### PR TITLE
test: replace NSubstitute with Moq in testing framework

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+++ b/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/test/Anela.Heblo.Tests/Features/FinancialOverviewTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FinancialOverviewTests.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
+using Moq;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features;
@@ -18,11 +18,11 @@ public class FinancialOverviewTests : IClassFixture<WebApplicationFactory<Progra
 {
     private readonly WebApplicationFactory<Program> _factory;
     private readonly HttpClient _client;
-    private readonly ILedgerService _mockLedgerService;
+    private readonly Mock<ILedgerService> _mockLedgerService;
 
     public FinancialOverviewTests(WebApplicationFactory<Program> factory)
     {
-        _mockLedgerService = Substitute.For<ILedgerService>();
+        _mockLedgerService = new Mock<ILedgerService>();
 
         _factory = factory.WithWebHostBuilder(builder =>
         {
@@ -41,7 +41,7 @@ public class FinancialOverviewTests : IClassFixture<WebApplicationFactory<Progra
                 {
                     services.Remove(descriptor);
                 }
-                services.AddSingleton(_mockLedgerService);
+                services.AddSingleton(_mockLedgerService.Object);
             });
         });
 
@@ -84,14 +84,15 @@ public class FinancialOverviewTests : IClassFixture<WebApplicationFactory<Progra
             }
         };
 
-        _mockLedgerService.GetLedgerItems(
-            Arg.Any<DateTime>(),
-            Arg.Any<DateTime>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<IEnumerable<string>>(),
-            Arg.Any<string>(),
-            Arg.Any<CancellationToken>())
-            .Returns(testData);
+        _mockLedgerService
+            .Setup(x => x.GetLedgerItems(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testData);
     }
 
     [Fact]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Replaced NSubstitute with Moq in FinancialOverviewTests.cs for consistent testing framework usage
- Removed NSubstitute package dependency from test project  
- All tests continue to pass with Moq implementation

## Changes Made
- **Updated mock creation**: Changed from `Substitute.For<ILedgerService>()` to `new Mock<ILedgerService>()`
- **Updated mock setup syntax**: Changed from `Substitute.Arg.Any` to `Mock.Setup with It.IsAny`
- **Fixed async return methods**: Changed from `Returns()` to `ReturnsAsync()` for async methods
- **Removed package dependency**: Eliminated NSubstitute package reference from `Anela.Heblo.Tests.csproj`

## Test Results
✅ All backend tests pass  
✅ Code formatting validates successfully  
✅ No breaking changes to existing functionality

## Motivation
- Standardizes the entire project on Moq, AutoFixture, and FluentAssertions as requested in issue #63
- Eliminates mixed mocking framework usage which could cause confusion
- Follows established patterns used throughout the rest of the test suite

Closes #63

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)