### PR TITLE
feat: begin migration to FluentAssertions in test suite (#62)

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/SafeMarginCalculatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/SafeMarginCalculatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Anela.Heblo.Application.Features.Catalog.Services;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -128,7 +129,7 @@ public class SafeMarginCalculatorTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        Assert.Equal(expectedMargin, result.Margin.Value, 2); // Allow small rounding differences
+        result.Margin.Value.Should().BeApproximately(expectedMargin, 0.01m); // Allow small rounding differences
         Assert.Null(result.ErrorMessage);
         Assert.Null(result.Exception);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ManufactureSeverityCalculatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ManufactureSeverityCalculatorTests.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Application.Features.Manufacture.Model;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -220,7 +221,7 @@ public class ManufactureSeverityCalculatorTests
         var result = _calculator.CalculateOverstockPercentage(stockDaysAvailable, optimalStockDaysSetup);
 
         // Assert
-        Assert.Equal(expectedPercentage, result, precision: 2);
+        result.Should().BeApproximately(expectedPercentage, 0.01);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ProductionActivityAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -161,7 +162,7 @@ public class ProductionActivityAnalyzerTests
         var result = _analyzer.CalculateAverageProductionFrequency(manufactureHistory, analysisMonths: 12);
 
         // Assert
-        Assert.Equal(11.666666666666666, result, precision: 10);
+        result.Should().BeApproximately(11.666666666666666, 0.0000000001);
     }
 
     [Fact]


### PR DESCRIPTION
Addresses issue #62: Use FluentAssertions instead of Assert

## Summary
- Added FluentAssertions using directive to selected test files
- Replaced precision-based `Assert.Equal` calls with `Should().BeApproximately()`
- Targeted initial conversion of SafeMarginCalculatorTests, ManufactureSeverityCalculatorTests, and ProductionActivityAnalyzerTests
- Maintained backward compatibility with existing Assert statements

## Changes Made
- **SafeMarginCalculatorTests**: Added FluentAssertions and converted decimal precision assertions
- **ManufactureSeverityCalculatorTests**: Added FluentAssertions and converted percentage calculations  
- **ProductionActivityAnalyzerTests**: Added FluentAssertions and converted frequency calculations

## Test Plan
- [x] All targeted tests pass with FluentAssertions syntax
- [x] No regression in existing Assert-based tests
- [x] Formatting validation passes

This is a gradual migration approach that demonstrates the conversion pattern while maintaining full backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)