### PR TITLE
fix(e2e): resolve staging environment authentication timeouts (#180)

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/ServicePrincipalTokenValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/Authentication/ServicePrincipalTokenValidatorTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
+using Anela.Heblo.API.Infrastructure.Authentication;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Tests for Service Principal Token Validator performance optimizations
+/// Validates caching behavior and timeout handling improvements
+/// </summary>
+public class ServicePrincipalTokenValidatorTests
+{
+    private readonly ILogger<ServicePrincipalTokenValidator> _logger;
+    private readonly IConfiguration _configuration;
+    private readonly IMemoryCache _cache;
+
+    public ServicePrincipalTokenValidatorTests()
+    {
+        _logger = NullLogger<ServicePrincipalTokenValidator>.Instance;
+        _cache = new MemoryCache(new MemoryCacheOptions());
+
+        // Create minimal configuration for testing
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            {"E2E:ExpectedClientId", "test-client-id"},
+            {"E2E:ExpectedTenantId", "test-tenant-id"}
+        });
+        _configuration = configBuilder.Build();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithValidToken_ShouldCacheResult()
+    {
+        // Arrange
+        var validator = new ServicePrincipalTokenValidator(_logger, _configuration, _cache);
+        var validToken = CreateValidTestToken();
+
+        // Act - First validation
+        var result1 = await validator.ValidateAsync(validToken);
+
+        // Act - Second validation (should use cache)
+        var result2 = await validator.ValidateAsync(validToken);
+
+        // Assert
+        Assert.True(result1);
+        Assert.True(result2);
+
+        // Verify cache contains the result
+        var tokenHash = validToken.GetHashCode().ToString();
+        var cacheKey = $"sptoken_{tokenHash}";
+        Assert.True(_cache.TryGetValue(cacheKey, out bool cachedValue));
+        Assert.True(cachedValue);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithInvalidToken_ShouldCacheFailureResult()
+    {
+        // Arrange
+        var validator = new ServicePrincipalTokenValidator(_logger, _configuration, _cache);
+        var invalidToken = "invalid-token";
+
+        // Act
+        var result = await validator.ValidateAsync(invalidToken);
+
+        // Assert
+        Assert.False(result);
+
+        // Verify failure is cached (for shorter duration)
+        var tokenHash = invalidToken.GetHashCode().ToString();
+        var cacheKey = $"sptoken_{tokenHash}";
+        Assert.True(_cache.TryGetValue(cacheKey, out bool cachedValue));
+        Assert.False(cachedValue);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithCachedResult_ShouldReturnCachedValue()
+    {
+        // Arrange
+        var validator = new ServicePrincipalTokenValidator(_logger, _configuration, _cache);
+        var token = "test-token";
+        var tokenHash = token.GetHashCode().ToString();
+        var cacheKey = $"sptoken_{tokenHash}";
+
+        // Pre-populate cache
+        _cache.Set(cacheKey, true, TimeSpan.FromMinutes(5));
+
+        // Act
+        var result = await validator.ValidateAsync(token);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TokenMissingRequiredClaims_ShouldReturnFalse()
+    {
+        // Arrange
+        var validator = new ServicePrincipalTokenValidator(_logger, _configuration, _cache);
+        var tokenWithoutClaims = CreateTokenWithoutRequiredClaims();
+
+        // Act
+        var result = await validator.ValidateAsync(tokenWithoutClaims);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ExpiredToken_ShouldReturnFalse()
+    {
+        // Arrange
+        var validator = new ServicePrincipalTokenValidator(_logger, _configuration, _cache);
+        var expiredToken = CreateExpiredTestToken();
+
+        // Act
+        var result = await validator.ValidateAsync(expiredToken);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TokenWithWrongClientId_ShouldReturnFalse()
+    {
+        // Arrange
+        var validator = new ServicePrincipalTokenValidator(_logger, _configuration, _cache);
+        var tokenWithWrongClientId = CreateTokenWithWrongClientId();
+
+        // Act
+        var result = await validator.ValidateAsync(tokenWithWrongClientId);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    private string CreateValidTestToken()
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+        {
+            Claims = new System.Collections.Generic.Dictionary<string, object>
+            {
+                ["appid"] = "test-client-id",
+                ["tid"] = "test-tenant-id",
+                ["iss"] = "https://login.microsoftonline.com/test-tenant-id/v2.0",
+                ["aud"] = "api://test-audience",
+                ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+            },
+            Expires = DateTime.UtcNow.AddHours(1)
+        };
+
+        var token = handler.CreateJwtSecurityToken(tokenDescriptor);
+        return handler.WriteToken(token);
+    }
+
+    private string CreateTokenWithoutRequiredClaims()
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+        {
+            Claims = new System.Collections.Generic.Dictionary<string, object>
+            {
+                ["iss"] = "https://login.microsoftonline.com/test-tenant-id/v2.0",
+                ["aud"] = "api://test-audience"
+                // Missing appid and tid claims
+            },
+            Expires = DateTime.UtcNow.AddHours(1)
+        };
+
+        var token = handler.CreateJwtSecurityToken(tokenDescriptor);
+        return handler.WriteToken(token);
+    }
+
+    private string CreateExpiredTestToken()
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var expiredTime = DateTime.UtcNow.AddHours(-1);
+        var notBeforeTime = DateTime.UtcNow.AddHours(-2); // NotBefore must be before Expires
+        var tokenDescriptor = new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+        {
+            Claims = new System.Collections.Generic.Dictionary<string, object>
+            {
+                ["appid"] = "test-client-id",
+                ["tid"] = "test-tenant-id",
+                ["iss"] = "https://login.microsoftonline.com/test-tenant-id/v2.0",
+                ["aud"] = "api://test-audience",
+                ["exp"] = ((DateTimeOffset)expiredTime).ToUnixTimeSeconds() // Expired 1 hour ago
+            },
+            Expires = expiredTime,
+            NotBefore = notBeforeTime
+        };
+
+        var token = handler.CreateJwtSecurityToken(tokenDescriptor);
+        return handler.WriteToken(token);
+    }
+
+    private string CreateTokenWithWrongClientId()
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+        {
+            Claims = new System.Collections.Generic.Dictionary<string, object>
+            {
+                ["appid"] = "wrong-client-id", // Different from expected
+                ["tid"] = "test-tenant-id",
+                ["iss"] = "https://login.microsoftonline.com/test-tenant-id/v2.0",
+                ["aud"] = "api://test-audience",
+                ["exp"] = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()
+            },
+            Expires = DateTime.UtcNow.AddHours(1)
+        };
+
+        var token = handler.CreateJwtSecurityToken(tokenDescriptor);
+        return handler.WriteToken(token);
+    }
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -54,19 +54,28 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     
-    /* Increase timeout for E2E test actions - increased for staging environment performance */
-    actionTimeout: 60000, // 60 seconds for actions
-    navigationTimeout: 60000, // 60 seconds for page navigation
+    /* Increased timeouts for staging environment performance issues */
+    actionTimeout: 90000, // 90 seconds for actions (increased from 60s)
+    navigationTimeout: 90000, // 90 seconds for page navigation (increased from 60s)
     
     /* Screenshot on failure */
     screenshot: 'only-on-failure',
     
     /* Video for failed tests */
     video: 'retain-on-failure',
+    
+    /* Configure browser context with optimal settings for staging */
+    launchOptions: {
+      // Reduce resource contention that might affect staging performance
+      args: ['--disable-dev-shm-usage', '--disable-extensions', '--no-sandbox']
+    }
   },
 
   /* Global test timeout for E2E - increased for staging environment performance */
-  timeout: 300000, // 5 minutes per test
+  timeout: 420000, // 7 minutes per test (increased from 5 minutes)
+  
+  /* Test file timeout - how long to wait for entire test file to complete */
+  globalTimeout: 1800000, // 30 minutes for entire test run
 
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
## Summary
- Add token caching to ServicePrincipalTokenValidator to eliminate redundant validations
- Implement exponential backoff with jitter for Azure AD token requests
- Add timeout protection with CancellationTokenSource to prevent hanging requests
- Increase Playwright test timeouts for staging environment performance compatibility
- Add comprehensive unit tests for token validator caching behavior

## Fixes
Closes #180

## Changes
### Backend Performance Optimizations
- **ServicePrincipalTokenValidator**: Added IMemoryCache for 5-minute token validation caching
- **E2ETestController**: Added 30-second timeout protection for token validation calls
- **Unit Tests**: Comprehensive test coverage for caching scenarios and edge cases

### Frontend Resilience Improvements  
- **e2e-auth-helper.ts**: Increased retry attempts (3→5) with exponential backoff and jitter
- **playwright.config.ts**: Extended timeouts (5→7 min per test, 60→90s actions) for staging performance

### Infrastructure Enhancements
- **Browser optimization**: Added Chrome args to reduce resource contention on staging
- **Error handling**: Enhanced logging and retry logic for better debugging

## Test Results
- ✅ Backend unit tests pass with new caching behavior validation
- ✅ Existing E2E tests maintain compatibility with increased timeouts
- ✅ Authentication flow optimized for staging environment performance

## Test plan
- [x] Run backend unit tests (`dotnet test`)
- [x] Run frontend tests (`npm test`) 
- [x] Run linters (`dotnet format`, `npm run lint`)
- [x] Verify E2E authentication improvements on staging environment
- [ ] Monitor staging E2E test success rates after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)