### PR TITLE
fix: use correct Azure credentials secret for production deployment

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -430,7 +430,7 @@ jobs:
       - name: 🔐 Azure Login
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_CREDENTIALS_PROD }}
 
       - name: 🚀 Deploy to Azure Web App (Production)
         id: deploy


### PR DESCRIPTION
The production deployment was failing with Azure login error because it was using AZURE_CREDENTIALS instead of AZURE_CREDENTIALS_PROD. This change aligns with the previous working deploy-production.yml workflow that used AZURE_CREDENTIALS_PROD.

Error: Using auth-type: SERVICE_PRINCIPAL. Not all values are present. Ensure 'client-id' and 'tenant-id' are supplied.

Changes:
- Updated production deployment job to use AZURE_CREDENTIALS_PROD secret
- Staging deployment continues to use AZURE_CREDENTIALS_TEST (unchanged)