### PR TITLE
fix: use production API URL in Docker build

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -298,7 +298,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            REACT_APP_API_URL=https://heblo.stg.anela.cz
+            REACT_APP_API_URL=https://heblo.anela.cz
             REACT_APP_USE_MOCK_AUTH=false
             REACT_APP_AZURE_CLIENT_ID=${{ secrets.REACT_APP_AZURE_CLIENT_ID }}
             REACT_APP_AZURE_AUTHORITY=${{ secrets.REACT_APP_AZURE_AUTHORITY }}


### PR DESCRIPTION
## Problem

After CI/CD pipeline redesign in #281, the main branch workflow builds Docker images with **staging API URL** hardcoded in the frontend:

```yaml
REACT_APP_API_URL=https://heblo.stg.anela.cz  # ❌ Wrong for production!
```

**Impact:**
- Production environment (`https://heblo.anela.cz`) was calling **staging backend** (`https://heblo.stg.anela.cz`)
- Verified: `curl -s https://heblo.anela.cz/static/js/main.*.js` contains `heblo.stg.anela.cz`
- Production users were working with staging data
- Security and data consistency risk

## Root Cause

Before redesign:
- `ci.yml` built staging image with staging URL
- `deploy-production.yml` built **separate** production image with production URL

After redesign:
- Single workflow `ci-main-branch.yml` builds **one image** for both environments
- Image was incorrectly configured with staging URL
- Same image deployed to both staging and production

## Solution

Changed Docker build args in `ci-main-branch.yml`:

```diff
- REACT_APP_API_URL=https://heblo.stg.anela.cz
+ REACT_APP_API_URL=https://heblo.anela.cz
```

**Trade-off:**
- ✅ Production will now use correct production API
- ⚠️ Staging deployment will temporarily use production URL (known limitation for quick fix)
- 🔮 Future: Implement runtime configuration to avoid build-time URL hardcoding

## Verification

After merge and deployment, verify:
```bash
curl -s https://heblo.anela.cz/static/js/main.*.js | grep -o 'heblo\.[^"]*anela\.cz'
# Should return: heblo.anela.cz (not heblo.stg.anela.cz)
```

## Related

- Original redesign: #281
- Old workflows: `.github/workflows/ci.yml`, `.github/workflows/deploy-production.yml` (deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)