### PR TITLE
fix: add automatic Git tag creation after successful Docker build

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -324,6 +324,25 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "You can approve both at once, or approve them at different times." >> $GITHUB_STEP_SUMMARY
 
+      - name: 🏷️ Create and Push Git Tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "🏷️ Creating Git tag: $VERSION"
+
+          # Configure Git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create tag
+          git tag -a "$VERSION" -m "Release $VERSION"
+
+          # Push tag to repository
+          git push origin "$VERSION"
+
+          echo "✅ Git tag $VERSION created and pushed successfully!"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Deploy to Staging - MANUAL APPROVAL REQUIRED
   deploy-staging:
     name: 🚀 Deploy to Staging


### PR DESCRIPTION
## Summary

- Adds automatic Git tag creation step to `ci-main-branch.yml` workflow
- Tag is created after successful Docker image build
- Tag is pushed back to repository using `GITHUB_TOKEN`
- Resolves issue where GitVersion couldn't track version progress

## Problem

GitVersion was calculating the same version (v3.22.0) on every build because:
1. Last Git tag was `v3.21.13`
2. GitVersion counted commits since that tag and calculated `v3.22.0`
3. Tag wasn't created in repository
4. Next build started from `v3.21.13` again → same version calculated

## Solution

Added new workflow step that:
- Creates Git tag with GitVersion calculated version
- Pushes tag back to repository
- Runs after successful Docker build
- Runs before deployment jobs

## Impact

- ✅ Version numbers will now increment correctly with conventional commits
- ✅ Each build creates a new tag for future reference
- ✅ GitVersion can track version history properly
- ✅ No manual tagging required

## Test Plan

- [ ] Merge this PR to main
- [ ] Verify new tag is created in repository (should be v3.23.0)
- [ ] Next feat commit should increment to v3.24.0
- [ ] Verify tags are visible in repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)