### PR TITLE
fix(catalog): reset pagination to page 1 when filters change

### DIFF
--- a/frontend/src/components/pages/CatalogList.tsx
+++ b/frontend/src/components/pages/CatalogList.tsx
@@ -215,12 +215,6 @@ const CatalogList: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
-  // Reset pagination when type filter changes
-  React.useEffect(() => {
-    setPageNumber(1);
-    // Refetch will be triggered automatically by the query dependency change
-  }, [productTypeFilter]);
-
   // Sync page number state from URL parameter changes (for external URL manipulation)
   React.useEffect(() => {
     const urlPageParam = searchParams.get("page");
@@ -231,7 +225,7 @@ const CatalogList: React.FC = () => {
     if (validPageNumber !== pageNumber) {
       setPageNumber(validPageNumber);
     }
-  }, [searchParams]);
+  }, [searchParams, pageNumber]);
 
   // Sync URL parameter with page number state
   React.useEffect(() => {
@@ -373,13 +367,14 @@ const CatalogList: React.FC = () => {
               <select
                 id="productType"
                 value={productTypeFilter}
-                onChange={(e) =>
+                onChange={(e) => {
                   setProductTypeFilter(
                     e.target.value === ""
                       ? ""
                       : (e.target.value as ProductType),
-                  )
-                }
+                  );
+                  setPageNumber(1); // Reset to first page when filter changes
+                }}
                 className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
               >
                 <option value="">Všechny typy</option>


### PR DESCRIPTION
## Summary
Fixes #320 - Catalog pagination now correctly resets to page 1 when any filter is changed.

## Problem
When a user was on page 2+ and changed any filter (product name, code, or type), the pagination did not reset to page 1. This resulted in users potentially seeing empty results or incorrect data after filtering.

**Example scenario:**
1. User navigates to page 2 of catalog
2. User applies filter "Krém" to product name
3. ❌ **Before:** User remains on page 2, potentially seeing no results
4. ✅ **After:** User is automatically taken to page 1 with filtered results

## Root Cause
The `productTypeFilter` dropdown onChange handler did not call `setPageNumber(1)` when the filter value changed. There was a separate `useEffect` attempting to handle this (lines 218-222), but it ran after the component re-render, causing race conditions.

## Solution
- Modified `productTypeFilter` onChange handler to immediately call `setPageNumber(1)` when the filter changes
- Removed duplicate `useEffect` that was trying to reset pagination for type filter changes
- Fixed React Hook exhaustive-deps linting warning

## Changes Made
**File:** `frontend/src/components/pages/CatalogList.tsx`
- Added `setPageNumber(1)` call in productTypeFilter onChange handler (line 383)
- Removed duplicate useEffect for productTypeFilter pagination reset (lines 218-222)
- Fixed exhaustive-deps warning by adding `pageNumber` to dependency array (line 228)

## Behavior After Fix
When user changes any filter:
1. ✅ Product name filter (via "Filtrovat" button) → resets to page 1 (already working)
2. ✅ Product code filter (via "Filtrovat" button) → resets to page 1 (already working)
3. ✅ Product type filter (dropdown selection) → resets to page 1 (**NOW FIXED**)
4. ✅ Clear filters button → resets to page 1 (already working)

## Testing Completed
- ✅ All frontend Jest tests passing (625 tests, 0 failures)
- ✅ Frontend build successful with no compilation errors
- ✅ No new linting errors introduced
- ⏳ E2E test `catalog-combined-filters.spec.ts:152` will be verified after PR deployment to staging

## Test Plan
Once this PR is deployed to staging, the following E2E test should pass:
- **Test file:** `frontend/test/e2e/catalog-combined-filters.spec.ts:152`
- **Test name:** `should reset page to 1 when any filter changes`
- **Expected outcome:** Test navigates to page 2, applies filter, verifies pagination resets to 1

## Related Issues
- Closes #320
- Related to #319 (filter clearing pagination reset - already fixed)

---

🤖 Generated with Claude Code