### PR TITLE
fix: reset pagination to page 1 when catalog sort changes

### DIFF
--- a/frontend/src/components/pages/CatalogList.tsx
+++ b/frontend/src/components/pages/CatalogList.tsx
@@ -164,6 +164,7 @@ const CatalogList: React.FC = () => {
       setSortBy(column);
       setSortDescending(false);
     }
+    setPageNumber(1); // Reset to page 1 when sort changes
     // React Query will automatically refetch when sortBy or sortDescending changes
   };
 


### PR DESCRIPTION
## Summary

Fixes pagination reset when changing catalog sort order.

**Bug**: When users were on page 2+ of catalog results and changed sort order by clicking a column header, they remained on the current page instead of being taken to page 1 to see the beginning of newly sorted results.

**Fix**: Added `setPageNumber(1)` to the `handleSort` function in `CatalogList.tsx`, aligning sort behavior with other state changes (filters, page size, product type) which already reset pagination correctly.

## Changes

- Modified `frontend/src/components/pages/CatalogList.tsx:167` - Added `setPageNumber(1)` call in `handleSort` function

## Test Plan

- ✅ Frontend tests: 67 test suites passed (642 tests)
- ✅ Backend tests: 1635 tests passed
- ✅ Changed file linting: No errors
- 📋 E2E test coverage: `catalog-sorting-with-filters.spec.ts:283` validates this behavior (runs nightly against staging)

## User Impact

Users will now see the first page of results when changing sort order, preventing them from missing important data at the beginning of sorted lists.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)