### PR TITLE
fix(stockup): prevent race condition causing missing document numbers

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/Playwright/Scenarios/StockUpScenario.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/Playwright/Scenarios/StockUpScenario.cs
@@ -151,6 +151,14 @@ public class StockUpScenario
         if (!_options.DryRun)
         {
             await page.ClickAsync("[data-testid='buttonAddItemsToStock']");
+
+            // CRITICAL FIX: Wait for operation to complete before closing browser
+            // Without this wait, browser closes immediately and Shoptet may not save documentNumber
+            // This prevents race condition where stock-up completes but without document number
+            _logger.LogDebug("Waiting for stock-up operation to complete for document {DocumentNumber}", request.StockUpId);
+            await page.WaitForLoadStateAsync(LoadState.NetworkIdle, new PageWaitForLoadStateOptions { Timeout = 30000 });
+
+            _logger.LogInformation("Stock-up operation completed for document {DocumentNumber}", request.StockUpId);
         }
         else
         {


### PR DESCRIPTION
## Summary

Fix critical race condition in StockUpScenario where stock-up operations would complete successfully but the documentNumber would not be saved to Shoptet.

This fixes the issue reported with GPM-000297 where gift package components were successfully de-stocked but the final package was added to Shoptet **without its document number** (GPM-000297-BAL0011M).

## Root Cause Analysis

**Problem Location:** `StockUpScenario.cs:153`

```csharp
await page.ClickAsync("[data-testid='buttonAddItemsToStock']");
// ❌ MISSING: No wait for operation completion
return new StockUpRecord(); // Browser closes immediately
```

**Race Condition Flow:**
1. DocumentNumber is filled: `GPM-000297-BAL0011M`
2. Products are added to form
3. Submit button is clicked
4. **Browser closes immediately** (using var playwright dispose)
5. **Shoptet's AJAX request is canceled** before server processes documentNumber
6. **Result:** Products added to stock but documentNumber is empty

**Evidence:**
- De-stocking components: ✅ Success (with document numbers)
- Stocking final package: ⚠️ Success but WITHOUT document number
- Both operations ran "approximately at the same time" → race condition

## Solution

Added `WaitForLoadStateAsync(LoadState.NetworkIdle)` after button click:

```csharp
await page.ClickAsync("[data-testid='buttonAddItemsToStock']");

// CRITICAL FIX: Wait for operation to complete before closing browser
await page.WaitForLoadStateAsync(LoadState.NetworkIdle, 
    new PageWaitForLoadStateOptions { Timeout = 30000 });

_logger.LogInformation("Stock-up operation completed for document {DocumentNumber}", 
    request.StockUpId);
```

**What This Does:**
- Waits for all network requests to complete (30s timeout)
- Ensures Shoptet server processes and saves the documentNumber
- Aligns with other working scenarios (e.g., `IssuedInvoiceExportScenario.cs:60`)

## Testing

- ✅ Backend build successful (0 errors, 408 warnings - existing)
- ✅ Code formatting validated (`dotnet format --verify-no-changes`)
- ⚠️ Manual testing required: Create gift package manufacture with GPM document number

## Test Plan

1. **Create Gift Package Manufacture:**
   - Navigate to Gift Package Manufacturing
   - Select a package (e.g., BAL0011M)
   - Manufacture 1 unit
   - Verify document number appears in Shoptet history

2. **Check Shoptet Stock History:**
   - Open Shoptet → Sklad → Historie
   - Search for document number (e.g., `GPM-000XXX-BAL0011M`)
   - Verify document is present with correct number

3. **Parallel Operations Test:**
   - Queue multiple stock operations quickly
   - Verify all document numbers are saved
   - Check no operations are missing document numbers

## Impact

**Fixes:**
- ✅ Missing document numbers in stock-up operations
- ✅ Race condition with parallel gift package manufacturing
- ✅ Inconsistent data between local DB and Shoptet

**Related Features:**
- Gift Package Manufacture (`docs/features/gift-package-manufacture.md`)
- Stock-Up Processing (`StockUpProcessingService.cs`)
- Background job processing of pending stock operations

## Related Issues

- Original issue: GPM-000297 components de-stocked correctly, but package added without document number
- Affects all stock-up operations processed via Playwright automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)