### PR TITLE
feat: sales multiplier for Manufacturing Stock Analysis (#391)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs
@@ -64,7 +64,7 @@ public class GetManufacturingStockAnalysisHandler : IRequestHandler<GetManufactu
 
         // 3. Analyze all items for summary calculation
         var allAnalysisItems = finishedProducts
-            .Select(item => AnalyzeManufacturingStockItem(item, fromDate, toDate))
+            .Select(item => AnalyzeManufacturingStockItem(item, fromDate, toDate, request.SalesMultiplier))
             .ToList();
 
         var productFamilies = allAnalysisItems
@@ -98,13 +98,14 @@ public class GetManufacturingStockAnalysisHandler : IRequestHandler<GetManufactu
         };
     }
 
-    private ManufacturingStockItemDto AnalyzeManufacturingStockItem(CatalogAggregate item, DateTime fromDate, DateTime toDate)
+    private ManufacturingStockItemDto AnalyzeManufacturingStockItem(CatalogAggregate item, DateTime fromDate, DateTime toDate, double salesMultiplier = 1.0)
     {
         // Calculate daily sales rate using domain service
         var dailySalesRate = _consumptionCalculator.CalculateDailySalesRate(item.SalesHistory, fromDate, toDate);
+        dailySalesRate *= salesMultiplier;
 
         // Calculate total sales in period for display
-        var salesInPeriod = item.GetTotalSold(fromDate, toDate);
+        var salesInPeriod = item.GetTotalSold(fromDate, toDate) * salesMultiplier;
 
         // Calculate stock days available using domain service - now includes reserve stock
         var stockDaysAvailable = _consumptionCalculator.CalculateStockDaysAvailable(item.Stock.Total, dailySalesRate);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisRequest.cs
@@ -41,6 +41,12 @@ public class GetManufacturingStockAnalysisRequest : IRequest<GetManufacturingSto
     public ManufacturingStockSortBy SortBy { get; set; } = ManufacturingStockSortBy.StockDaysAvailable;
 
     public bool SortDescending { get; set; } = false;
+
+    /// <summary>
+    /// Multiplier applied to daily sales rate for demand forecasting.
+    /// Range: 0.1 to 3.0, default 1.0.
+    /// </summary>
+    public double SalesMultiplier { get; set; } = 1.0;
 }
 
 public enum TimePeriodFilter

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/GetManufacturingStockAnalysisRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/GetManufacturingStockAnalysisRequestValidator.cs
@@ -50,5 +50,10 @@ public class GetManufacturingStockAnalysisRequestValidator : AbstractValidator<G
                 .MaximumLength(50)
                 .WithMessage("ProductFamily cannot exceed 50 characters");
         });
+
+        // SalesMultiplier validation
+        RuleFor(x => x.SalesMultiplier)
+            .InclusiveBetween(0.1, 3.0)
+            .WithMessage("SalesMultiplier must be between 0.1 and 3.0");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufacturingStockAnalysisHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufacturingStockAnalysisHandlerTests.cs
@@ -293,4 +293,114 @@ public class GetManufacturingStockAnalysisHandlerTests
             Times.Once,
             "Should call CalculateStockDaysAvailable with total stock including reserve");
     }
+
+    [Fact]
+    public async Task Handle_SalesMultiplierDefault_PassesUnmodifiedDailyRateToCalculations()
+    {
+        // Arrange
+        var request = new GetManufacturingStockAnalysisRequest
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SalesMultiplier = 1.0
+        };
+
+        var catalogItems = CreateTestCatalogItems();
+
+        _timePeriodCalculatorMock.Setup(x => x.CalculateTimePeriod(It.IsAny<TimePeriodFilter>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .Returns((DateTime.Today.AddDays(-30), DateTime.Today));
+
+        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(catalogItems);
+
+        double capturedDailyRate = 0;
+
+        _consumptionCalculatorMock.Setup(x => x.CalculateDailySalesRate(It.IsAny<List<CatalogSaleRecord>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(5.0);
+
+        _consumptionCalculatorMock.Setup(x => x.CalculateStockDaysAvailable(It.IsAny<decimal>(), It.IsAny<double>()))
+            .Callback<decimal, double>((stock, rate) => capturedDailyRate = rate)
+            .Returns(20.0);
+
+        _severityCalculatorMock.Setup(x => x.CalculateOverstockPercentage(It.IsAny<double>(), It.IsAny<int>())).Returns(0.0);
+        _severityCalculatorMock.Setup(x => x.CalculateSeverity(It.IsAny<CatalogAggregate>(), It.IsAny<double>(), It.IsAny<double>())).Returns(ManufacturingStockSeverity.Adequate);
+        _productionAnalyzerMock.Setup(x => x.IsInActiveProduction(It.IsAny<IEnumerable<ManufactureHistoryRecord>>(), It.IsAny<int>())).Returns(false);
+        _mapperMock.Setup(x => x.MapToDto(It.IsAny<CatalogAggregate>(), It.IsAny<ManufacturingStockSeverity>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>()))
+            .Returns(new ManufacturingStockItemDto { Code = "PRD001" });
+        _filterServiceMock.Setup(x => x.FilterItems(It.IsAny<List<ManufacturingStockItemDto>>(), It.IsAny<GetManufacturingStockAnalysisRequest>()))
+            .Returns((List<ManufacturingStockItemDto> items, GetManufacturingStockAnalysisRequest req) => items);
+        _filterServiceMock.Setup(x => x.SortItems(It.IsAny<List<ManufacturingStockItemDto>>(), It.IsAny<ManufacturingStockSortBy>(), It.IsAny<bool>()))
+            .Returns((List<ManufacturingStockItemDto> items, ManufacturingStockSortBy sortBy, bool desc) => items);
+        _filterServiceMock.Setup(x => x.CalculateSummary(It.IsAny<List<ManufacturingStockItemDto>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<List<string>>()))
+            .Returns(new ManufacturingStockSummaryDto());
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - multiplier of 1.0 should not change the daily rate (5.0 * 1.0 = 5.0)
+        capturedDailyRate.Should().Be(5.0, "SalesMultiplier=1.0 should not alter the daily sales rate");
+    }
+
+    [Fact]
+    public async Task Handle_SalesMultiplierTwo_DoublesDailyRateAndSalesInPeriod()
+    {
+        // Arrange
+        var request = new GetManufacturingStockAnalysisRequest
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SalesMultiplier = 2.0
+        };
+
+        var catalogItems = new List<CatalogAggregate>
+        {
+            new CatalogAggregate
+            {
+                ProductCode = "PRD001",
+                ProductName = "Product 1",
+                Type = ProductType.Product,
+                Stock = new StockData { Erp = 100m },
+                Properties = new CatalogProperties { OptimalStockDaysSetup = 30 }
+            }
+        };
+
+        _timePeriodCalculatorMock.Setup(x => x.CalculateTimePeriod(It.IsAny<TimePeriodFilter>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .Returns((DateTime.Today.AddDays(-30), DateTime.Today));
+
+        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(catalogItems);
+
+        double capturedDailyRate = 0;
+
+        _consumptionCalculatorMock.Setup(x => x.CalculateDailySalesRate(It.IsAny<List<CatalogSaleRecord>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(5.0);
+
+        _consumptionCalculatorMock.Setup(x => x.CalculateStockDaysAvailable(It.IsAny<decimal>(), It.IsAny<double>()))
+            .Callback<decimal, double>((stock, rate) => capturedDailyRate = rate)
+            .Returns(10.0);
+
+        _severityCalculatorMock.Setup(x => x.CalculateOverstockPercentage(It.IsAny<double>(), It.IsAny<int>())).Returns(0.0);
+        _severityCalculatorMock.Setup(x => x.CalculateSeverity(It.IsAny<CatalogAggregate>(), It.IsAny<double>(), It.IsAny<double>())).Returns(ManufacturingStockSeverity.Critical);
+        _productionAnalyzerMock.Setup(x => x.IsInActiveProduction(It.IsAny<IEnumerable<ManufactureHistoryRecord>>(), It.IsAny<int>())).Returns(false);
+        _mapperMock.Setup(x => x.MapToDto(It.IsAny<CatalogAggregate>(), It.IsAny<ManufacturingStockSeverity>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<double>(), It.IsAny<bool>()))
+            .Returns(new ManufacturingStockItemDto { Code = "PRD001" });
+        _filterServiceMock.Setup(x => x.FilterItems(It.IsAny<List<ManufacturingStockItemDto>>(), It.IsAny<GetManufacturingStockAnalysisRequest>()))
+            .Returns((List<ManufacturingStockItemDto> items, GetManufacturingStockAnalysisRequest req) => items);
+        _filterServiceMock.Setup(x => x.SortItems(It.IsAny<List<ManufacturingStockItemDto>>(), It.IsAny<ManufacturingStockSortBy>(), It.IsAny<bool>()))
+            .Returns((List<ManufacturingStockItemDto> items, ManufacturingStockSortBy sortBy, bool desc) => items);
+        _filterServiceMock.Setup(x => x.CalculateSummary(It.IsAny<List<ManufacturingStockItemDto>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<List<string>>()))
+            .Returns(new ManufacturingStockSummaryDto());
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert - multiplier of 2.0 should double the rate from 5.0 to 10.0
+        capturedDailyRate.Should().Be(10.0, "SalesMultiplier=2.0 should double the daily sales rate (5.0 * 2.0 = 10.0)");
+
+        // Verify CalculateStockDaysAvailable was called with the doubled rate
+        _consumptionCalculatorMock.Verify(
+            x => x.CalculateStockDaysAvailable(It.IsAny<decimal>(), 10.0),
+            Times.Once,
+            "Should call CalculateStockDaysAvailable with doubled rate");
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufacturingStockAnalysisRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufacturingStockAnalysisRequestValidatorTests.cs
@@ -314,4 +314,64 @@ public class GetManufacturingStockAnalysisRequestValidatorTests
     }
 
     #endregion
+
+    #region SalesMultiplier Tests
+
+    [Fact]
+    public void SalesMultiplier_WhenDefault_ShouldNotHaveValidationError()
+    {
+        // Arrange
+        var request = new GetManufacturingStockAnalysisRequest { SalesMultiplier = 1.0 };
+
+        // Act & Assert
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.SalesMultiplier);
+    }
+
+    [Theory]
+    [InlineData(0.1)]
+    [InlineData(1.0)]
+    [InlineData(1.5)]
+    [InlineData(3.0)]
+    public void SalesMultiplier_WhenWithinRange_ShouldNotHaveValidationError(double multiplier)
+    {
+        // Arrange
+        var request = new GetManufacturingStockAnalysisRequest { SalesMultiplier = multiplier };
+
+        // Act & Assert
+        var result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.SalesMultiplier);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(0.09)]
+    public void SalesMultiplier_WhenBelowMinimum_ShouldHaveValidationError(double multiplier)
+    {
+        // Arrange
+        var request = new GetManufacturingStockAnalysisRequest { SalesMultiplier = multiplier };
+
+        // Act & Assert
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.SalesMultiplier)
+            .WithErrorMessage("SalesMultiplier must be between 0.1 and 3.0");
+    }
+
+    [Theory]
+    [InlineData(3.1)]
+    [InlineData(5.0)]
+    [InlineData(10.0)]
+    public void SalesMultiplier_WhenAboveMaximum_ShouldHaveValidationError(double multiplier)
+    {
+        // Arrange
+        var request = new GetManufacturingStockAnalysisRequest { SalesMultiplier = multiplier };
+
+        // Act & Assert
+        var result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.SalesMultiplier)
+            .WithErrorMessage("SalesMultiplier must be between 0.1 and 3.0");
+    }
+
+    #endregion
 }

--- a/frontend/src/api/hooks/useManufacturingStockAnalysis.ts
+++ b/frontend/src/api/hooks/useManufacturingStockAnalysis.ts
@@ -16,6 +16,7 @@ export interface GetManufacturingStockAnalysisRequest {
   pageSize?: number;
   sortBy?: ManufacturingStockSortBy;
   sortDescending?: boolean;
+  salesMultiplier?: number;
 }
 
 export enum TimePeriodFilter {
@@ -142,6 +143,8 @@ export const useManufacturingStockAnalysisQuery = (
       if (request.sortBy) params.append("sortBy", request.sortBy);
       if (request.sortDescending !== undefined)
         params.append("sortDescending", request.sortDescending.toString());
+      if (request.salesMultiplier !== undefined && request.salesMultiplier !== 1.0)
+        params.append("salesMultiplier", request.salesMultiplier.toString());
 
       const queryString = params.toString();
       const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}${queryString ? `?${queryString}` : ""}`;

--- a/frontend/src/components/pages/ManufacturingStockAnalysis.tsx
+++ b/frontend/src/components/pages/ManufacturingStockAnalysis.tsx
@@ -34,6 +34,27 @@ import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 import { usePlanningList } from "../../contexts/PlanningListContext";
 import PlanningListPanel from "../common/PlanningListPanel";
 
+const SALES_MULTIPLIER_COOKIE = "manufacturing-stock-sales-multiplier";
+
+const getCookie = (name: string): string | null => {
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`));
+  return match ? match.split("=")[1] : null;
+};
+
+const setCookie = (name: string, value: string): void => {
+  document.cookie = `${name}=${value}; path=/; max-age=31536000`;
+};
+
+const readSalesMultiplierCookie = (): number => {
+  const raw = getCookie(SALES_MULTIPLIER_COOKIE);
+  if (raw === null) return 1.0;
+  const parsed = parseFloat(raw);
+  if (isNaN(parsed) || parsed < 0.1 || parsed > 3.0) return 1.0;
+  return parsed;
+};
+
 const ManufacturingStockAnalysis: React.FC = () => {
   // State for filters
   const [filters, setFilters] = useState<GetManufacturingStockAnalysisRequest>({
@@ -48,6 +69,7 @@ const ManufacturingStockAnalysis: React.FC = () => {
     pageSize: 20,
     sortBy: ManufacturingStockSortBy.OverstockPercentage,
     sortDescending: false,
+    salesMultiplier: readSalesMultiplierCookie(),
   });
 
   // State for product detail modal
@@ -88,6 +110,17 @@ const ManufacturingStockAnalysis: React.FC = () => {
     newFilters: Partial<GetManufacturingStockAnalysisRequest>,
   ) => {
     setFilters((prev) => ({ ...prev, ...newFilters, pageNumber: 1 }));
+  };
+
+  // Handler for sales multiplier change
+  const handleSalesMultiplierChange = (delta: number) => {
+    setFilters((prev) => {
+      const current = prev.salesMultiplier ?? 1.0;
+      const next = Math.round((current + delta) * 10) / 10;
+      const clamped = Math.min(3.0, Math.max(0.1, next));
+      setCookie(SALES_MULTIPLIER_COOKIE, clamped.toString());
+      return { ...prev, salesMultiplier: clamped, pageNumber: 1 };
+    });
   };
 
   // Handler for pagination
@@ -736,6 +769,43 @@ const ManufacturingStockAnalysis: React.FC = () => {
                   </div>
                 </>
               )}
+
+              {/* Sales multiplier control - always visible */}
+              <div
+                className="flex items-center border border-gray-300 rounded-md shadow-sm bg-white"
+                title="Násobitel denních prodejů pro simulaci poptávky"
+              >
+                <button
+                  onClick={() => handleSalesMultiplierChange(-0.1)}
+                  disabled={(filters.salesMultiplier ?? 1.0) <= 0.1}
+                  className="px-1.5 py-1 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-40 rounded-l-md"
+                  aria-label="Snížit násobitel"
+                >
+                  −
+                </button>
+                <span
+                  className={`px-1.5 py-1 text-xs min-w-[2.5rem] text-center ${
+                    (filters.salesMultiplier ?? 1.0) !== 1.0
+                      ? "text-indigo-600 font-semibold"
+                      : "text-gray-700"
+                  }`}
+                  title={
+                    (filters.salesMultiplier ?? 1.0) !== 1.0
+                      ? "Prodejní násobitel aktivní"
+                      : undefined
+                  }
+                >
+                  {((filters.salesMultiplier ?? 1.0).toFixed(1))}x
+                </span>
+                <button
+                  onClick={() => handleSalesMultiplierChange(0.1)}
+                  disabled={(filters.salesMultiplier ?? 1.0) >= 3.0}
+                  className="px-1.5 py-1 text-xs text-gray-700 hover:bg-gray-50 disabled:opacity-40 rounded-r-md"
+                  aria-label="Zvýšit násobitel"
+                >
+                  +
+                </button>
+              </div>
 
               {/* Action buttons - always visible */}
               <button

--- a/frontend/src/components/pages/__tests__/ManufacturingStockAnalysis.test.tsx
+++ b/frontend/src/components/pages/__tests__/ManufacturingStockAnalysis.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -392,5 +392,120 @@ describe("ManufacturingStockAnalysis", () => {
     expect(screen.getByText("Test Product 1")).toBeInTheDocument(); // Product name
     expect(screen.getByText("PROD002")).toBeInTheDocument(); // Product code
     expect(screen.getByText("Test Product 2")).toBeInTheDocument(); // Product name
+  });
+
+  it("renders sales multiplier control with default value 1.0x", () => {
+    // Clear cookie to ensure default
+    document.cookie =
+      "manufacturing-stock-sales-multiplier=; max-age=0; path=/";
+
+    mockUseManufacturingStockAnalysisQuery.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<ManufacturingStockAnalysis />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("1.0x")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /snížit násobitel/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /zvýšit násobitel/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("increases sales multiplier when plus button is clicked", () => {
+    document.cookie =
+      "manufacturing-stock-sales-multiplier=; max-age=0; path=/";
+
+    mockUseManufacturingStockAnalysisQuery.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<ManufacturingStockAnalysis />, { wrapper: createWrapper() });
+
+    const plusButton = screen.getByRole("button", { name: /zvýšit násobitel/i });
+    fireEvent.click(plusButton);
+
+    expect(screen.getByText("1.1x")).toBeInTheDocument();
+  });
+
+  it("decreases sales multiplier when minus button is clicked", () => {
+    document.cookie =
+      "manufacturing-stock-sales-multiplier=2.0; path=/; max-age=31536000";
+
+    mockUseManufacturingStockAnalysisQuery.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<ManufacturingStockAnalysis />, { wrapper: createWrapper() });
+
+    const minusButton = screen.getByRole("button", {
+      name: /snížit násobitel/i,
+    });
+    fireEvent.click(minusButton);
+
+    expect(screen.getByText("1.9x")).toBeInTheDocument();
+  });
+
+  it("disables minus button at minimum value 0.1", () => {
+    document.cookie =
+      "manufacturing-stock-sales-multiplier=0.1; path=/; max-age=31536000";
+
+    mockUseManufacturingStockAnalysisQuery.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<ManufacturingStockAnalysis />, { wrapper: createWrapper() });
+
+    const minusButton = screen.getByRole("button", {
+      name: /snížit násobitel/i,
+    });
+    expect(minusButton).toBeDisabled();
+  });
+
+  it("disables plus button at maximum value 3.0", () => {
+    document.cookie =
+      "manufacturing-stock-sales-multiplier=3.0; path=/; max-age=31536000";
+
+    mockUseManufacturingStockAnalysisQuery.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<ManufacturingStockAnalysis />, { wrapper: createWrapper() });
+
+    const plusButton = screen.getByRole("button", { name: /zvýšit násobitel/i });
+    expect(plusButton).toBeDisabled();
+  });
+
+  it("reads initial sales multiplier from cookie", () => {
+    document.cookie =
+      "manufacturing-stock-sales-multiplier=1.5; path=/; max-age=31536000";
+
+    mockUseManufacturingStockAnalysisQuery.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<ManufacturingStockAnalysis />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("1.5x")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Implements issue #391 — adds a **sales multiplier** parameter to the Manufacturing Stock Analysis page ("Řízení zásob výrobků") that scales the `dailySalesRate` before all downstream calculations, enabling demand forecasting scenarios.

- Add `SalesMultiplier` request property (default `1.0`, range `0.1–3.0`, step `0.1`)
- Applied **server-side** so all derived values (stockDaysAvailable, overstockPercentage, severity, summary counts) are correctly recalculated
- Persisted in browser cookie (`manufacturing-stock-sales-multiplier`, 1-year expiry)

## Changes

### Backend
- `GetManufacturingStockAnalysisRequest.cs` — Add `SalesMultiplier` property (default `1.0`)
- `GetManufacturingStockAnalysisRequestValidator.cs` — Add FluentValidation `InclusiveBetween(0.1, 3.0)` rule
- `GetManufacturingStockAnalysisHandler.cs` — Multiply `dailySalesRate` and `salesInPeriod` by `SalesMultiplier` before downstream calculations

### Frontend
- `useManufacturingStockAnalysis.ts` — Add `salesMultiplier` to request interface and query params (skipped when `1.0`)
- `ManufacturingStockAnalysis.tsx` — Add `[ − ] 1.0x [ + ]` control to action bar with cookie read/write; indigo highlight when value ≠ 1.0

### Tests
- **13 new BE tests**: Validator range tests (valid/invalid boundaries), handler multiplier logic (default=no change, 2.0=doubles rate)
- **6 new FE tests**: Control renders with default `1.0x`, `+` increments, `−` decrements, bounds disable buttons, reads initial value from cookie

## Test plan
- [ ] `dotnet test` — 1688 passed (13 new), 0 failed
- [ ] `npm test -- --testPathPattern=ManufacturingStockAnalysis` — 28 passed (6 new), 0 failed
- [ ] No lint errors in changed files
- [ ] Multiplier control visible left of Obnovit button
- [ ] Value persists across page reload (cookie)
- [ ] API called with `salesMultiplier` param when value ≠ 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)