### PR TITLE
refactor: remove custom Hangfire queue name, use built-in default (#433)

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/HangfireOptions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/HangfireOptions.cs
@@ -4,7 +4,6 @@ public class HangfireOptions
 {
     public static string ConfigurationKey => "Hangfire";
     public string SchemaName { get; set; } = "hangfire_heblo";
-    public string QueueName { get; set; } = "heblo";
     public bool SchedulerEnabled { get; set; } = false;
     public int WorkerCount { get; set; } = 1;
     public bool UseInMemoryStorage { get; set; } = false;

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -283,12 +283,9 @@ public static class ServiceCollectionExtensions
                 }));
         }
 
-        // Always add Hangfire server with Heblo queue - NEVER allow fallback to Default queue
         services.AddHangfireServer(options =>
         {
-            // Configure server options - ALWAYS only process Heblo queue
             options.WorkerCount = hangfireOptions.WorkerCount;
-            options.Queues = new[] { hangfireOptions.QueueName };
         });
 
         // Register Hangfire dashboard authorization filter

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireBackgroundWorker.cs
@@ -1,53 +1,43 @@
 using System.Linq.Expressions;
-using Anela.Heblo.API.Extensions;
 using Anela.Heblo.Xcc.Services;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage;
-using Microsoft.Extensions.Options;
 using System.ComponentModel;
 
 namespace Anela.Heblo.API.Infrastructure.Hangfire;
 
 public class HangfireBackgroundWorker : IBackgroundWorker
 {
-    private readonly string _queueName;
-
-    public HangfireBackgroundWorker(IOptions<HangfireOptions> hangfireOptions)
-    {
-        _queueName = hangfireOptions.Value.QueueName;
-    }
     public string Enqueue<T>(Expression<Func<T, Task>> methodCall)
     {
-        return BackgroundJob.Enqueue(_queueName, methodCall);
+        return BackgroundJob.Enqueue(methodCall);
     }
 
     public string Enqueue<T>(Expression<Action<T>> methodCall)
     {
-        return BackgroundJob.Enqueue(_queueName, methodCall);
+        return BackgroundJob.Enqueue(methodCall);
     }
-
-
 
     public string Schedule<T>(Expression<Func<T, Task>> methodCall, TimeSpan delay)
     {
-        return BackgroundJob.Schedule(_queueName, methodCall, delay);
+        return BackgroundJob.Schedule(methodCall, delay);
     }
 
     public string Schedule<T>(Expression<Action<T>> methodCall, TimeSpan delay)
     {
-        return BackgroundJob.Schedule(_queueName, methodCall, delay);
+        return BackgroundJob.Schedule(methodCall, delay);
     }
 
     public string Schedule<T>(Expression<Func<T, Task>> methodCall, DateTimeOffset enqueueAt)
     {
-        return BackgroundJob.Schedule(_queueName, methodCall, enqueueAt);
+        return BackgroundJob.Schedule(methodCall, enqueueAt);
     }
 
     public string Schedule<T>(Expression<Action<T>> methodCall, DateTimeOffset enqueueAt)
     {
-        return BackgroundJob.Schedule(_queueName, methodCall, enqueueAt);
+        return BackgroundJob.Schedule(methodCall, enqueueAt);
     }
 
     public IList<BackgroundJobInfo> GetPendingJobs()
@@ -55,12 +45,11 @@ public class HangfireBackgroundWorker : IBackgroundWorker
         using var connection = JobStorage.Current.GetConnection();
         var monitoring = JobStorage.Current.GetMonitoringApi();
 
-        var enqueuedJobs = monitoring.EnqueuedJobs(_queueName, 0, int.MaxValue);
+        var enqueuedJobs = monitoring.EnqueuedJobs("default", 0, int.MaxValue);
         var scheduledJobs = monitoring.ScheduledJobs(0, int.MaxValue);
 
         var result = new List<BackgroundJobInfo>();
 
-        // Add enqueued jobs from the specific queue
         foreach (var job in enqueuedJobs)
         {
             result.Add(new BackgroundJobInfo
@@ -69,28 +58,23 @@ public class HangfireBackgroundWorker : IBackgroundWorker
                 JobName = GetJobDisplayName(job.Key, job.Value.Job),
                 State = "Enqueued",
                 CreatedAt = job.Value.EnqueuedAt,
-                Queue = _queueName
+                Queue = "default"
             });
         }
 
-        // Add scheduled jobs that belong to our queue
         foreach (var job in scheduledJobs)
         {
             var jobDetails = connection.GetJobData(job.Key);
             if (jobDetails?.Job != null)
             {
-                var jobQueue = jobDetails.Job.Queue ?? "default";
-                if (jobQueue == _queueName)
+                result.Add(new BackgroundJobInfo
                 {
-                    result.Add(new BackgroundJobInfo
-                    {
-                        Id = job.Key,
-                        JobName = GetJobDisplayName(job.Key, job.Value.Job),
-                        State = "Scheduled",
-                        CreatedAt = job.Value.EnqueueAt,
-                        Queue = jobQueue
-                    });
-                }
+                    Id = job.Key,
+                    JobName = GetJobDisplayName(job.Key, job.Value.Job),
+                    State = "Scheduled",
+                    CreatedAt = job.Value.EnqueueAt,
+                    Queue = jobDetails.Job.Queue ?? "default"
+                });
             }
         }
 
@@ -106,25 +90,20 @@ public class HangfireBackgroundWorker : IBackgroundWorker
 
         foreach (var job in processingJobs)
         {
-            // Check if this job belongs to our queue by examining the job data
             using var connection = JobStorage.Current.GetConnection();
             var jobDetails = connection.GetJobData(job.Key);
 
             if (jobDetails?.Job != null)
             {
-                var jobQueue = jobDetails.Job.Queue ?? "default";
-                if (jobQueue == _queueName)
+                result.Add(new BackgroundJobInfo
                 {
-                    result.Add(new BackgroundJobInfo
-                    {
-                        Id = job.Key,
-                        JobName = GetJobDisplayName(job.Key, job.Value.Job),
-                        State = "Processing",
-                        CreatedAt = jobDetails.CreatedAt,
-                        StartedAt = job.Value.StartedAt,
-                        Queue = jobQueue
-                    });
-                }
+                    Id = job.Key,
+                    JobName = GetJobDisplayName(job.Key, job.Value.Job),
+                    State = "Processing",
+                    CreatedAt = jobDetails.CreatedAt,
+                    StartedAt = job.Value.StartedAt,
+                    Queue = jobDetails.Job.Queue ?? "default"
+                });
             }
         }
 
@@ -141,13 +120,6 @@ public class HangfireBackgroundWorker : IBackgroundWorker
             if (jobDetails?.Job == null)
                 return null;
 
-            var jobQueue = jobDetails.Job.Queue ?? "default";
-
-            // Only return jobs from our queue
-            if (jobQueue != _queueName)
-                return null;
-
-            // Determine job state by checking various job states
             var state = GetJobState(connection, jobId);
 
             return new BackgroundJobInfo
@@ -157,12 +129,11 @@ public class HangfireBackgroundWorker : IBackgroundWorker
                 State = state,
                 CreatedAt = jobDetails.CreatedAt,
                 StartedAt = GetJobStartedAt(connection, jobId),
-                Queue = jobQueue
+                Queue = jobDetails.Job.Queue ?? "default"
             };
         }
         catch (Exception)
         {
-            // If Hangfire monitoring fails, return null gracefully
             return null;
         }
     }
@@ -177,7 +148,6 @@ public class HangfireBackgroundWorker : IBackgroundWorker
     {
         try
         {
-            // Try to get job details and check for processing state time
             var monitoring = JobStorage.Current.GetMonitoringApi();
             var processingJobs = monitoring.ProcessingJobs(0, int.MaxValue);
 
@@ -198,7 +168,6 @@ public class HangfireBackgroundWorker : IBackgroundWorker
         if (job?.Method?.Name == null)
             return "Unknown Job";
 
-        // First try to get custom display name from job parameters
         try
         {
             using var connection = JobStorage.Current.GetConnection();
@@ -211,13 +180,11 @@ public class HangfireBackgroundWorker : IBackgroundWorker
             // Fall back if parameter retrieval fails
         }
 
-        // Use DisplayName attribute if available
         var displayNameAttribute = job.Method.GetCustomAttributes(typeof(System.ComponentModel.DisplayNameAttribute), false)
             .FirstOrDefault() as System.ComponentModel.DisplayNameAttribute;
 
         if (displayNameAttribute != null)
         {
-            // Replace placeholders with actual argument values
             var displayName = displayNameAttribute.DisplayName;
             for (int i = 0; i < job.Args.Count; i++)
             {
@@ -226,7 +193,6 @@ public class HangfireBackgroundWorker : IBackgroundWorker
             return displayName;
         }
 
-        // Fallback to method name with args
         var methodName = job.Method.Name;
 
         if (job.Args?.Count > 0)
@@ -236,15 +202,12 @@ public class HangfireBackgroundWorker : IBackgroundWorker
                 if (arg == null)
                     return "null";
 
-                // For strings, show them in quotes
                 if (arg is string stringArg)
                     return $"\"{stringArg}\"";
 
-                // For primitives, show their string representation
                 if (arg.GetType().IsPrimitive || arg is decimal || arg is DateTime || arg is DateTimeOffset)
                     return arg.ToString();
 
-                // For complex objects, show their type name
                 return $"<{arg.GetType().Name}>";
             }));
 

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
@@ -75,12 +75,11 @@ public class RecurringJobDiscoveryService : IHostedService
                     {
                         metadata.JobName,
                         metadata.CronExpression,
-                        metadata.TimeZoneId,
-                        metadata.QueueName
+                        metadata.TimeZoneId
                     });
 
-                    _logger.LogInformation("Registered recurring job: {JobName} ({JobType}) with schedule {Cron} in queue {Queue}",
-                        metadata.JobName, jobType.Name, metadata.CronExpression, metadata.QueueName);
+                    _logger.LogInformation("Registered recurring job: {JobName} ({JobType}) with schedule {Cron}",
+                        metadata.JobName, jobType.Name, metadata.CronExpression);
                 }
                 catch (Exception ex)
                 {
@@ -116,14 +115,12 @@ public class RecurringJobDiscoveryService : IHostedService
     private static void RegisterRecurringJobInternal<TJob>(
         string jobName,
         string cronExpression,
-        string timeZoneId,
-        string queueName) where TJob : IRecurringJob
+        string timeZoneId) where TJob : IRecurringJob
     {
         RecurringJob.AddOrUpdate<TJob>(
             jobName,
             job => job.ExecuteAsync(default),
             cronExpression,
-            TimeZoneInfo.FindSystemTimeZoneById(timeZoneId),
-            queueName);
+            TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobEnqueuer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobEnqueuer.cs
@@ -2,7 +2,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Hangfire;
-using Hangfire.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
@@ -62,14 +61,11 @@ public class HangfireJobEnqueuer : IHangfireJobEnqueuer
         // Create lambda: (TJob job) => job.ExecuteAsync(cancellationToken)
         var lambda = CreateExecutionExpression(jobType, executeMethod, cancellationToken);
 
-        // Get queue name from job metadata
-        var queueName = job.Metadata.QueueName;
-
         // Invoke our wrapper method which calls Hangfire API via injected client
-        var jobId = (string?)genericMethod.Invoke(this, new object[] { queueName, lambda });
+        var jobId = (string?)genericMethod.Invoke(this, new object[] { lambda });
 
-        _logger.LogInformation("Job {JobType} enqueued to queue '{QueueName}' with Hangfire job ID: {JobId}",
-            jobType.Name, queueName, jobId);
+        _logger.LogInformation("Job {JobType} enqueued with Hangfire job ID: {JobId}",
+            jobType.Name, jobId);
 
         return jobId;
     }
@@ -78,29 +74,14 @@ public class HangfireJobEnqueuer : IHangfireJobEnqueuer
     /// Internal generic wrapper method that calls IBackgroundJobClient.Enqueue API.
     /// This provides design-time validation that the Hangfire API exists and has correct signature.
     /// If Hangfire API changes, we'll get a compile error instead of runtime failure.
-    /// Handles both storage types: PostgreSQL (supports queue parameter) and MemoryStorage (does not).
     /// </summary>
     /// <typeparam name="T">The job type (must implement IRecurringJob)</typeparam>
-    /// <param name="queueName">Queue name from job metadata</param>
     /// <param name="methodCall">Expression representing the job execution</param>
     /// <returns>Hangfire job ID</returns>
-    private string EnqueueJobInternal<T>(string queueName, Expression<Func<T, Task>> methodCall)
+    private string EnqueueJobInternal<T>(Expression<Func<T, Task>> methodCall)
         where T : IRecurringJob
     {
-        // Check if current storage supports queue property (PostgreSQL does, MemoryStorage doesn't)
-        var supportsQueueProperty = JobStorage.Current.HasFeature(JobStorageFeatures.JobQueueProperty);
-
-        if (supportsQueueProperty)
-        {
-            // Production: PostgreSQL storage - use queue parameter
-            return _backgroundJobClient.Enqueue(queueName, methodCall);
-        }
-        else
-        {
-            // Tests: MemoryStorage - cannot use queue parameter, uses default queue
-            // MemoryStorage throws NotSupportedException if queue parameter is provided
-            return _backgroundJobClient.Enqueue(methodCall);
-        }
+        return _backgroundJobClient.Enqueue(methodCall);
     }
 
     /// <summary>

--- a/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs
@@ -31,11 +31,6 @@ public class RecurringJobMetadata
     public bool DefaultIsEnabled { get; init; } = true;
 
     /// <summary>
-    /// Queue name for job execution
-    /// </summary>
-    public string QueueName { get; init; } = "heblo";
-
-    /// <summary>
     /// Timezone for cron expression (defaults to Europe/Prague)
     /// </summary>
     public string TimeZoneId { get; init; } = "Europe/Prague";

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobEnqueuerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobEnqueuerTests.cs
@@ -74,16 +74,10 @@ public class HangfireJobEnqueuerTests
     [Fact]
     public void EnqueueJob_WithValidJob_UsesMetadataCorrectly()
     {
-        // Queue name from metadata is passed to HangfireJobEnqueuer.
-        // For PostgreSQL (production), jobs are enqueued to the specified queue.
-        // For MemoryStorage (tests), queue parameter is ignored due to storage limitations.
-
         // Arrange
         var testJob = new TestRecurringJob();
 
         // Act & Assert
-        // Verify job has queue metadata defined
-        testJob.Metadata.QueueName.Should().Be("test");
         testJob.Metadata.JobName.Should().Be("test-job");
     }
 
@@ -102,14 +96,11 @@ public class HangfireJobEnqueuerTests
         Assert.True(enqueueInternalMethod.IsGenericMethodDefinition);
         Assert.Equal(typeof(string), enqueueInternalMethod.ReturnType);
 
-        // Verify it has 2 parameters: string queueName, Expression<Func<T, Task>> methodCall
-        // Queue name parameter added to support PostgreSQL storage (production) while maintaining MemoryStorage compatibility (tests)
+        // Verify it has 1 parameter: Expression<Func<T, Task>> methodCall
         var parameters = enqueueInternalMethod.GetParameters();
-        Assert.Equal(2, parameters.Length);
-        Assert.Equal("queueName", parameters[0].Name);
-        Assert.Equal(typeof(string), parameters[0].ParameterType);
-        Assert.Equal("methodCall", parameters[1].Name);
-        Assert.True(parameters[1].ParameterType.IsGenericType);
+        Assert.Single(parameters);
+        Assert.Equal("methodCall", parameters[0].Name);
+        Assert.True(parameters[0].ParameterType.IsGenericType);
 
         // Verify generic constraint: where T : IRecurringJob
         var genericConstraints = enqueueInternalMethod.GetGenericArguments()[0].GetGenericParameterConstraints();
@@ -159,29 +150,6 @@ public class HangfireJobEnqueuerTests
             Description = "A test job for unit testing",
             CronExpression = "0 0 * * *",
             DefaultIsEnabled = true,
-            QueueName = "test",
-            TimeZoneId = "Europe/Prague"
-        };
-
-        public Task ExecuteAsync(CancellationToken cancellationToken)
-        {
-            return Task.CompletedTask;
-        }
-    }
-
-    /// <summary>
-    /// Test job with custom queue name
-    /// </summary>
-    private class TestRecurringJobWithCustomQueue : IRecurringJob
-    {
-        public RecurringJobMetadata Metadata => new RecurringJobMetadata
-        {
-            JobName = "custom-queue-job",
-            DisplayName = "Custom Queue Job",
-            Description = "A job with custom queue",
-            CronExpression = "0 0 * * *",
-            DefaultIsEnabled = true,
-            QueueName = "custom-queue",
             TimeZoneId = "Europe/Prague"
         };
 

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobDiscoveryServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobDiscoveryServiceTests.cs
@@ -42,8 +42,7 @@ public class RecurringJobDiscoveryServiceTests : IDisposable
         // Arrange
         var hangfireOptions = Options.Create(new HangfireOptions
         {
-            SchedulerEnabled = true,
-            QueueName = "test-queue"
+            SchedulerEnabled = true
         });
 
         var service = new RecurringJobDiscoveryService(
@@ -74,8 +73,7 @@ public class RecurringJobDiscoveryServiceTests : IDisposable
         // Arrange
         var hangfireOptions = Options.Create(new HangfireOptions
         {
-            SchedulerEnabled = false,
-            QueueName = "test-queue"
+            SchedulerEnabled = false
         });
 
         var service = new RecurringJobDiscoveryService(


### PR DESCRIPTION
Resolves #433

Removes the custom `heblo` Hangfire queue name throughout the codebase, switching to Hangfire's built-in `default` queue.

## Changes

- `HangfireOptions` - removed `QueueName` property
- `RecurringJobMetadata` - removed `QueueName` property
- `ServiceCollectionExtensions` - removed explicit `Queues` assignment
- `HangfireBackgroundWorker` - removed `_queueName` field
- `HangfireJobEnqueuer` - simplified to use no-queue-param overload; removed storage-type branching
- `RecurringJobDiscoveryService` - simplified to use 4-param `AddOrUpdate` (no queue param)
- Tests updated accordingly

## Why

Hangfire routes to `default` queue when no queue is specified, working uniformly for both PostgreSQL and MemoryStorage. The custom queue name added unnecessary complexity.

@claude