### PR TITLE
fix(tests): prevent flaky MediatR handler resolution via WebApp collection isolation (#393)

### DIFF
--- a/backend/test/Anela.Heblo.Tests/ApplicationStartupTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ApplicationStartupTests.cs
@@ -14,6 +14,7 @@ namespace Anela.Heblo.Tests;
 /// <summary>
 /// Integration tests to verify application startup and dependency resolution
 /// </summary>
+[Collection("WebApp")]
 public class ApplicationStartupTests : IClassFixture<HebloWebApplicationFactory>
 {
     private readonly HebloWebApplicationFactory _factory;

--- a/backend/test/Anela.Heblo.Tests/Common/BackgroundServicesConfigurationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Common/BackgroundServicesConfigurationTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Anela.Heblo.Tests.Common;
 
+[Collection("WebApp")]
 public class BackgroundServicesConfigurationTests : IClassFixture<HebloWebApplicationFactory>
 {
     private readonly HebloWebApplicationFactory _factory;

--- a/backend/test/Anela.Heblo.Tests/Common/WebAppTestCollection.cs
+++ b/backend/test/Anela.Heblo.Tests/Common/WebAppTestCollection.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace Anela.Heblo.Tests.Common;
+
+/// <summary>
+/// Collection definition for integration tests that share HebloWebApplicationFactory.
+///
+/// All test classes marked with [Collection("WebApp")] are forced to run sequentially
+/// (DisableParallelization = true). This prevents the race condition where one factory's
+/// IServiceProvider is disposed while another test class is still resolving services —
+/// the root cause of the intermittent ObjectDisposedException seen in
+/// ApplicationStartupTests.MediatR_Handler_Should_Be_Resolvable.
+///
+/// Each test class retains its own IClassFixture&lt;HebloWebApplicationFactory&gt; instance;
+/// sequential execution alone is sufficient to eliminate the disposal race condition.
+/// </summary>
+[CollectionDefinition("WebApp", DisableParallelization = true)]
+public class WebAppTestCollection
+{
+    // This class has no code, and is never created. Its purpose is simply
+    // to be the place to apply [CollectionDefinition].
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationEndpointTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationEndpointTests.cs
@@ -8,6 +8,7 @@ namespace Anela.Heblo.Tests.Features.Configuration;
 /// <summary>
 /// Integration tests for GetConfigurationEndpoint
 /// </summary>
+[Collection("WebApp")]
 public class GetConfigurationEndpointTests : IClassFixture<HebloWebApplicationFactory>
 {
     private readonly HebloWebApplicationFactory _factory;


### PR DESCRIPTION
## Summary

Fixes #393 — intermittent `ObjectDisposedException` in `ApplicationStartupTests.MediatR_Handler_Should_Be_Resolvable`.

## Root Cause

Three test classes each held an `IClassFixture<HebloWebApplicationFactory>` and ran **in parallel** (xUnit default behaviour). When one factory's `IServiceProvider` was disposed while another test class was still executing its 113+ `Theory` cases and calling `GetRequiredService()`, an `ObjectDisposedException` occurred intermittently:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'IServiceProvider'.
```

The affected classes were:
- `ApplicationStartupTests` (113+ theory cases for `MediatR_Handler_Should_Be_Resolvable`)
- `BackgroundServicesConfigurationTests`
- `GetConfigurationEndpointTests`

## Fix

Introduce a new `[CollectionDefinition("WebApp", DisableParallelization = true)]` and annotate all three classes with `[Collection("WebApp")]`. This forces **sequential** execution while each class retains its own factory instance, eliminating the disposal race condition without changing test isolation semantics.

This mirrors the existing `[Collection("Hangfire")]` pattern already used in the codebase for the same reason.

## Changes

- `Common/WebAppTestCollection.cs` — new collection definition (sequential, no shared fixture)
- `ApplicationStartupTests.cs` — added `[Collection("WebApp")]`
- `Common/BackgroundServicesConfigurationTests.cs` — added `[Collection("WebApp")]`
- `Features/Configuration/GetConfigurationEndpointTests.cs` — added `[Collection("WebApp")]`

## Test Results

- 1875 tests pass (0 failures introduced by this change)
- 3 pre-existing failures in `KnowledgeBaseRepositoryIntegrationTests` require Docker/Testcontainers (unavailable in CI sandbox)
- `ApplicationStartupTests` alone: 167 passed, 0 failed