### PR TITLE
chore(#405): add memory/ directory for cross-session knowledge accumulation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,3 +423,14 @@ See `docs/development/setup.md` for detailed development commands and setup inst
 - Backend follows Clean Architecture with Vertical Slice organization
 - To run Playwright tests: Always use `./scripts/run-playwright-tests.sh` script
 - Validate builds before claiming completion
+
+## Memory
+
+Cross-session knowledge lives in `memory/`. Read relevant files at the start of each session. Write new learnings, decisions, and patterns during the session.
+
+- `memory/decisions/` — architectural and library choices with reasoning
+- `memory/patterns/` — confirmed implementation patterns for this codebase
+- `memory/gotchas/` — bugs, edge cases, and hard-won lessons
+- `memory/context/` — current project state, active work, pending decisions
+
+Update `memory/context/state.md` at the end of significant sessions with: current branch, what was completed, what is pending, any blockers.

--- a/memory/context/state.md
+++ b/memory/context/state.md
@@ -1,0 +1,30 @@
+# Project State
+
+_Update this file at the end of significant sessions._
+
+## Project Summary
+
+**Anela Heblo** — cosmetics company workspace app. Monorepo: .NET 8 backend + React frontend. Single Docker image deployed to Azure Web App for Containers.
+
+## Active Branches (as of 2026-03-29)
+
+- `main` — stable, production
+- `feat/444-shoptet-hydration` — Shoptet test environment hydration feature (in progress)
+- `feat/405-memory-directory` — this memory directory implementation
+
+## Recently Completed
+
+- Shoptet test environment hydration (issue #444): added `SHOPTET_HYDRATE` env var gate, Rider launch profile, non-hardcoded storage
+- MCP server: 15 tools across Catalog, Manufacturing, Batch Planning, Knowledge Base
+
+## Pending / Known Issues
+
+- Memory directory (issue #405): adding cross-session knowledge accumulation — this PR
+- Database migrations are manual (not automated in deployment)
+
+## Key Infrastructure Notes
+
+- CI runs: frontend Jest + backend .NET tests on PR
+- Nightly: full Playwright E2E against staging
+- OpenAPI TypeScript client auto-generated on `dotnet build`
+- Secrets managed via local `secrets.json` (never `dotnet user-secrets set`)

--- a/memory/decisions/clean-architecture-vertical-slice.md
+++ b/memory/decisions/clean-architecture-vertical-slice.md
@@ -1,0 +1,11 @@
+# Decision: Clean Architecture with Vertical Slice Organization
+
+**Decision:** Use Clean Architecture but organize by feature (vertical slice), not by layer.
+
+**Why:** Avoids the "horizontal layer" problem where a single feature's code is scattered across layers. Each feature owns its full stack — domain, application, persistence, API — making features self-contained and easier to reason about.
+
+**How to apply:**
+- New features go in `Domain/Features/{Feature}/`, `Application/Features/{Feature}/UseCases/`, `Persistence/{Feature}/`, `API/Controllers/`
+- Each feature has its own `{Feature}Module.cs` for DI registration
+- MediatR pattern: Controller → IMediator.Send(Request) → Handler → Response
+- See `docs/architecture/filesystem.md` for directory placement rules

--- a/memory/decisions/dto-classes-not-records.md
+++ b/memory/decisions/dto-classes-not-records.md
@@ -1,0 +1,10 @@
+# Decision: Use Classes (not Records) for API DTOs
+
+**Decision:** All MediatR request/response types exposed via API endpoints must be C# classes with properties, not records.
+
+**Why:** OpenAPI generators (used for TypeScript client auto-generation on build) have issues with C# records — parameter order in constructors causes unreliable schema generation. This broke the frontend API client.
+
+**How to apply:**
+- `[Required]`, `[JsonPropertyName]` and other validation attributes on class properties
+- Internal domain objects that are never exposed through the API can still use records
+- Applies to all `*Request` and `*Response` types in `Application/Features/*/UseCases/`

--- a/memory/decisions/single-docker-image-deployment.md
+++ b/memory/decisions/single-docker-image-deployment.md
@@ -1,0 +1,11 @@
+# Decision: Single Docker Image Deployment
+
+**Decision:** Backend (.NET) and frontend (React) are packaged into a single Docker image and deployed to Azure Web App for Containers.
+
+**Why:** Simplifies deployment — no separate frontend CDN or static hosting needed. The .NET API serves the React SPA directly. Single image means single deployment unit.
+
+**How to apply:**
+- React build output is embedded into the .NET API container at build time
+- Azure Web App for Containers hosts the single image
+- All Docker images pushed to Docker Hub
+- See `docs/architecture/application_infrastructure.md` for CI/CD details

--- a/memory/gotchas/api-client-must-use-absolute-urls.md
+++ b/memory/gotchas/api-client-must-use-absolute-urls.md
@@ -1,0 +1,17 @@
+# Gotcha: API Client Must Use Absolute URLs
+
+**Problem:** Using relative URLs (e.g., `/api/catalog`) in frontend API hooks causes requests to hit the frontend dev server (port 3000) instead of the backend (port 5001).
+
+**Root cause:** The generated API client has a `baseUrl` property. Relative URLs bypass it and go to the current browser origin, which is the Vite dev server in development.
+
+**Fix:**
+```typescript
+// Wrong — hits wrong port:
+const response = await (apiClient as any).http.fetch(`/api/catalog`, { method: 'GET' });
+
+// Correct — uses baseUrl from client config:
+const fullUrl = `${(apiClient as any).baseUrl}/api/catalog`;
+const response = await (apiClient as any).http.fetch(fullUrl, { method: 'GET' });
+```
+
+Always get the API client via `getAuthenticatedApiClient()` and use its `baseUrl`.

--- a/memory/gotchas/dto-records-break-openapi-generation.md
+++ b/memory/gotchas/dto-records-break-openapi-generation.md
@@ -1,0 +1,21 @@
+# Gotcha: C# Records Break OpenAPI Client Generation
+
+**Problem:** Using C# records for API request/response DTOs causes the OpenAPI generator to produce incorrect TypeScript client code — parameter order in the generated constructors is unreliable.
+
+**Root cause:** OpenAPI generators treat record primary constructors differently from class properties. The schema generation is not deterministic with records.
+
+**Fix:** Always use classes with properties for any DTO that flows through the API:
+```csharp
+// Wrong:
+public record GetCatalogRequest(string Code, int Page);
+
+// Correct:
+public class GetCatalogRequest
+{
+    [Required]
+    public string Code { get; set; } = string.Empty;
+    public int Page { get; set; }
+}
+```
+
+Internal types (never serialized to/from API) can still use records.

--- a/memory/gotchas/e2e-auth-navigatetoapp-vs-createe2eauthsession.md
+++ b/memory/gotchas/e2e-auth-navigatetoapp-vs-createe2eauthsession.md
@@ -1,0 +1,16 @@
+# Gotcha: E2E Auth — navigateToApp() vs createE2EAuthSession()
+
+**Problem:** Using `createE2EAuthSession()` alone leaves the frontend session missing, causing the Microsoft Entra ID login screen to appear mid-test and failing the test silently.
+
+**Root cause:** `createE2EAuthSession()` only creates the backend service principal token. The frontend also needs session cookies and sessionStorage set (including the E2E flag). `navigateToApp()` does all of this.
+
+**Fix:**
+```typescript
+// Always do this:
+await navigateToApp(page);
+
+// Never rely solely on this:
+await createE2EAuthSession(page); // missing frontend session
+```
+
+**Where this burned us:** Every new E2E test written before this rule was documented would hit the Microsoft login screen on CI.

--- a/memory/gotchas/secrets-json-not-user-secrets-set.md
+++ b/memory/gotchas/secrets-json-not-user-secrets-set.md
@@ -1,0 +1,13 @@
+# Gotcha: Edit secrets.json Directly, Never Use dotnet user-secrets set
+
+**Problem:** Using `dotnet user-secrets set` commands to configure secrets produces incorrect output or fails silently when run in a monorepo with multiple projects.
+
+**Fix:** Always open and edit `secrets.json` directly in the correct project's user secrets directory:
+```bash
+# Find the path:
+cat backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj | grep UserSecretsId
+# Then edit:
+# ~/.microsoft/usersecrets/{UserSecretsId}/secrets.json
+```
+
+**Why this matters:** `dotnet user-secrets set` picks the wrong project in some contexts, silently writing to the wrong `secrets.json`.

--- a/memory/patterns/e2e-test-structure.md
+++ b/memory/patterns/e2e-test-structure.md
@@ -1,0 +1,41 @@
+# Pattern: E2E Test Structure
+
+E2E tests use Playwright and run against the **staging** environment (https://heblo.stg.anela.cz).
+
+## Directory Layout
+
+```
+frontend/test/e2e/
+├── helpers/        # Shared utilities (e2e-auth-helper.ts, etc.)
+├── fixtures/       # Test data (test-data.ts)
+├── catalog/        # Catalog module tests
+├── issued-invoices/
+├── stock-operations/
+├── transport/
+├── manufacturing/
+└── core/           # Dashboard, navigation, auth
+```
+
+## Authentication (CRITICAL)
+
+Always use `navigateToApp()` for full auth setup:
+```typescript
+import { navigateToApp } from '../helpers/e2e-auth-helper';
+test.beforeEach(async ({ page }) => {
+  await navigateToApp(page);
+  await page.goto('/your-page');
+});
+```
+
+Never use `createE2EAuthSession()` alone — it only sets up the backend session, missing the frontend session, which causes the Microsoft login screen.
+
+## Test Data
+
+Use fixtures from `frontend/test/e2e/fixtures/test-data.ts`. Tests must **fail** (not skip) when expected data is missing — throw a clear error message.
+
+## Running Tests
+
+```bash
+./scripts/run-playwright-tests.sh           # All modules
+./scripts/run-playwright-tests.sh catalog   # Specific module
+```

--- a/memory/patterns/mcp-tool-pattern.md
+++ b/memory/patterns/mcp-tool-pattern.md
@@ -1,0 +1,31 @@
+# Pattern: Adding an MCP Tool
+
+MCP tools are thin wrappers around MediatR handlers. They live in `backend/src/Anela.Heblo.API/MCP/Tools/`.
+
+## Structure
+
+```csharp
+[McpServerToolType]
+public class MyFeatureTool
+{
+    private readonly IMediator _mediator;
+
+    public MyFeatureTool(IMediator mediator) => _mediator = mediator;
+
+    [McpServerTool]
+    [Description("What this tool does")]
+    public async Task<string> ToolName(
+        [Description("param description")] string param)
+    {
+        var result = await _mediator.Send(new MyRequest { Param = param });
+        return JsonSerializer.Serialize(result);
+    }
+}
+```
+
+## Rules
+- Errors: throw `McpException` (from `ModelContextProtocol` namespace)
+- Return `Task<string>` with JSON-serialized response
+- Register in `McpModule.cs` via `.WithTools<MyFeatureTool>()`
+- Tests go in `backend/test/Anela.Heblo.Tests/MCP/Tools/` — see existing tests for patterns
+- Authentication is handled by existing Microsoft Entra ID middleware (no extra work needed)

--- a/memory/patterns/new-feature-checklist.md
+++ b/memory/patterns/new-feature-checklist.md
@@ -1,0 +1,18 @@
+# Pattern: Creating a New Backend Feature
+
+Follow this order every time a new feature is added:
+
+1. **Domain** — define entity and repository interface in `Domain/Features/{Feature}/`
+2. **Application** — create MediatR handler in `Application/Features/{Feature}/UseCases/{Action}{Entity}Handler.cs`
+   - Request and Response must be **classes** (not records) — see `decisions/dto-classes-not-records.md`
+3. **Persistence** — create EF Core entity configuration in `Persistence/{Feature}/`
+4. **API** — create controller in `API/Controllers/{Feature}Controller.cs`
+   - Route: `/api/{controller}` (REST convention)
+   - Controller calls `IMediator.Send(request)`
+5. **Registration** — update `{Feature}Module.cs` and `PersistenceModule.cs`
+
+## Naming
+- Controller: `{Feature}Controller`
+- Handler: `{Action}{Entity}Handler`
+- Request/Response: `{Action}{Entity}Request` / `{Action}{Entity}Response`
+- DTO: `{Entity}Dto`


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements #405 — adds a `memory/` directory so Claude Code sessions accumulate context over time instead of starting cold.

- **`memory/decisions/`** — architectural choices with reasoning (vertical slice, DTO classes not records, single Docker image)
- **`memory/patterns/`** — confirmed implementation patterns (new feature checklist, MCP tool pattern, E2E test structure)
- **`memory/gotchas/`** — hard-won lessons (E2E auth setup, absolute API URLs, records vs classes, secrets.json editing)
- **`memory/context/state.md`** — current project state snapshot (active branches, pending work)

Also adds a `## Memory` section at the bottom of `CLAUDE.md` instructing Claude to read/write the memory directory during sessions.

## Test plan

- [ ] Verify `memory/` directory structure matches issue spec (`decisions/`, `patterns/`, `gotchas/`, `context/`)
- [ ] Verify `CLAUDE.md` has new Memory section with correct directory descriptions
- [ ] Verify seed files contain accurate, non-duplicated content from existing `CLAUDE.md` and docs
- [ ] Verify `memory/` is not listed in `.gitignore` (it should be committed, not ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)