### PR TITLE
fix(kb): align feedback score scale to 1-5

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SubmitFeedback/SubmitFeedbackRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SubmitFeedback/SubmitFeedbackRequest.cs
@@ -8,10 +8,10 @@ public class SubmitFeedbackRequest : IRequest<SubmitFeedbackResponse>
 {
     public Guid LogId { get; set; }
 
-    [Range(1, 10)]
+    [Range(1, 5)]
     public int PrecisionScore { get; set; }
 
-    [Range(1, 10)]
+    [Range(1, 5)]
     public int StyleScore { get; set; }
 
     public string? Comment { get; set; }

--- a/frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx
+++ b/frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx
@@ -52,7 +52,7 @@ const SourceAccordion: React.FC<SourceAccordionProps> = ({ sources, onViewSource
   );
 };
 
-const SCORES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const SCORES = [1, 2, 3, 4, 5];
 
 const ScoreRow: React.FC<{
   label: string;


### PR DESCRIPTION
## Summary
- Changed feedback input scores from 1-10 to 1-5 in `KnowledgeBaseSearchAskTab`
- Updated backend validation `[Range(1, 10)]` → `[Range(1, 5)]` for both `PrecisionScore` and `StyleScore`
- Display components (`FeedbackTable`, `FeedbackDetailModal`) were already using 1-5 scale

## Test Plan
- [ ] Submit feedback and verify only scores 1-5 are selectable
- [ ] Verify backend rejects scores outside 1-5 range
- [ ] Verify feedback table and detail modal display scores correctly