### PR TITLE
fix(kb): replace existing archive file on name conflict during ingestion

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/GraphOneDriveService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/GraphOneDriveService.cs
@@ -88,14 +88,15 @@ public class GraphOneDriveService : IOneDriveService
         var resolver = new GraphFolderResolver(client, token, _cache, _logger);
         var folderItemId = await resolver.GetOrCreateFolderIdAsync(driveId, archivedPath, ct);
 
-        var body = JsonSerializer.Serialize(new
+        // @microsoft.graph.conflictBehavior=replace: replace any existing file with the same name
+        // in the archive folder. Without this, Graph returns 409 Conflict and the file stays in
+        // the inbox indefinitely (exception is swallowed by the ingestion job's catch block).
+        var bodyObj = new Dictionary<string, object>
         {
-            parentReference = new
-            {
-                driveId,
-                id = folderItemId
-            }
-        });
+            ["parentReference"] = new { driveId, id = folderItemId },
+            ["@microsoft.graph.conflictBehavior"] = "replace"
+        };
+        var body = JsonSerializer.Serialize(bodyObj);
 
         var url = $"{GraphApiHelpers.GraphBaseUrl}/drives/{Uri.EscapeDataString(driveId)}/items/{fileId}";
         var request = GraphApiHelpers.CreateRequest(HttpMethod.Patch, url, token);


### PR DESCRIPTION
## Summary
- `MoveToArchivedAsync` was missing `@microsoft.graph.conflictBehavior=replace` in the PATCH body
- When a file with the same name already existed in the archive folder, the Graph API returned 409 Conflict
- That exception was caught by the ingestion job's generic `catch (Exception ex)` block, logged as "Failed to index", and the file was never moved — causing it to be reprocessed indefinitely on every job run

## Fix
Added `"@microsoft.graph.conflictBehavior": "replace"` to the PATCH request body in `GraphOneDriveService.MoveToArchivedAsync`. The key requires OData annotation syntax (`@microsoft.graph.conflictBehavior`) which can't be expressed in a C# anonymous object, so switched to `Dictionary<string, object>` for the body.

## Test Plan
- [ ] Upload a document to the KB inbox
- [ ] Let the ingestion job process it (it moves it to archive)
- [ ] Upload the same document again to the inbox
- [ ] Verify the second run completes without error and the file in archive is replaced