### PR TITLE
fix(block-order): use POST /api/orders/{code}/history for internal note

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/Model/UpdateNotesRequest.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/Model/UpdateNotesRequest.cs
@@ -2,14 +2,17 @@ using System.Text.Json.Serialization;
 
 namespace Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
 
-public class UpdateNotesRequest
+public class CreateOrderRemarkRequest
 {
     [JsonPropertyName("data")]
-    public UpdateNotesData Data { get; set; } = new();
+    public CreateOrderRemarkData Data { get; set; } = new();
 }
 
-public class UpdateNotesData
+public class CreateOrderRemarkData
 {
-    [JsonPropertyName("internalNote")]
-    public string InternalNote { get; set; } = string.Empty;
+    [JsonPropertyName("text")]
+    public string Text { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "system";
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetOrderClient.cs
@@ -120,21 +120,22 @@ public class ShoptetOrderClient : IShoptetOrderClient
     }
 
     /// <summary>
-    /// Set the internal note on an existing order.
+    /// Add a system remark to the order history (visible in admin under the History tab).
+    /// Uses POST /api/orders/{code}/history with type "system".
     /// </summary>
     public async Task SetInternalNoteAsync(string orderCode, string note, CancellationToken ct = default)
     {
-        var body = new UpdateNotesRequest
+        var body = new CreateOrderRemarkRequest
         {
-            Data = new UpdateNotesData { InternalNote = note },
+            Data = new CreateOrderRemarkData { Text = note, Type = "system" },
         };
 
-        var response = await _http.PatchAsJsonAsync($"/api/orders/{orderCode}/notes", body, JsonOptions, ct);
+        var response = await _http.PostAsJsonAsync($"/api/orders/{orderCode}/history", body, JsonOptions, ct);
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(ct);
             throw new HttpRequestException(
-                $"PATCH /api/orders/{orderCode}/notes returned {(int)response.StatusCode}: {errorBody}");
+                $"POST /api/orders/{orderCode}/history returned {(int)response.StatusCode}: {errorBody}");
         }
     }
 

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/BlockOrderProcessingIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/BlockOrderProcessingIntegrationTests.cs
@@ -1,0 +1,191 @@
+using Anela.Heblo.Adapters.ShoptetApi.Orders;
+using Anela.Heblo.Adapters.ShoptetApi.Orders.Model;
+using Anela.Heblo.Domain.Features.ShoptetOrders;
+using Anela.Heblo.Adapters.Shoptet.Tests.Integration.Infrastructure;
+using Anela.Heblo.Application.Features.ShoptetOrders;
+using Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing;
+using Anela.Heblo.Application.Shared;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit.Abstractions;
+
+namespace Anela.Heblo.Adapters.Shoptet.Tests.Integration;
+
+[Collection("ShoptetIntegration")]
+[Trait("Category", "Integration")]
+public class BlockOrderProcessingIntegrationTests
+{
+    private const int StatusNova = -1;
+    private const int StatusPoznamka = 35;
+    private const int StatusVyrizujeSe = -2;
+    private const int StatusBaliSe = 26;
+
+    private const string TestEmail = "block-order-test@heblo.test";
+
+    private readonly IConfiguration _configuration;
+    private readonly ShoptetOrderClient _client;
+    private readonly ILogger<BlockOrderProcessingHandler> _logger;
+    private readonly ITestOutputHelper _output;
+
+    public BlockOrderProcessingIntegrationTests(
+        ShoptetIntegrationTestFixture fixture,
+        ITestOutputHelper output)
+    {
+        _configuration = fixture.Configuration;
+        _client = (ShoptetOrderClient)fixture.ServiceProvider.GetRequiredService<IShoptetOrderClient>();
+        _logger = fixture.ServiceProvider.GetRequiredService<ILogger<BlockOrderProcessingHandler>>();
+        _output = output;
+    }
+
+    [Fact]
+    public async Task BlockOrder_Nova_Succeeds()
+    {
+        await RunTest("BLOCK-ORDER-TEST-NOVA", StatusNova, shouldSucceed: true);
+    }
+
+    [Fact]
+    public async Task BlockOrder_Poznamka_Succeeds()
+    {
+        await RunTest("BLOCK-ORDER-TEST-POZNAMKA", StatusPoznamka, shouldSucceed: true);
+    }
+
+    [Fact]
+    public async Task BlockOrder_VyrizujeSe_Succeeds()
+    {
+        await RunTest("BLOCK-ORDER-TEST-VYRIZI", StatusVyrizujeSe, shouldSucceed: true);
+    }
+
+    [Fact]
+    public async Task BlockOrder_BaliSe_IsRejectedWithInvalidSourceStateError()
+    {
+        await RunTest("BLOCK-ORDER-TEST-BALI", StatusBaliSe, shouldSucceed: false);
+    }
+
+    private async Task RunTest(string externalCode, int statusId, bool shouldSucceed)
+    {
+        if (Environment.GetEnvironmentVariable("SHOPTET_BLOCK_ORDER") != "1")
+            return;
+
+        AssertTestEnvironment(_configuration);
+
+        var blockedStatusId = _configuration.GetValue<int?>("ShoptetOrders:BlockedStatusId")
+            ?? throw new InvalidOperationException(
+                "Missing ShoptetOrders:BlockedStatusId in configuration. "
+                + "Add it to user secrets — use GET /api/eshop?include=orderStatuses to discover valid IDs.");
+
+        var handler = new BlockOrderProcessingHandler(
+            _client,
+            Options.Create(new ShoptetOrdersSettings
+            {
+                AllowedBlockSourceStateIds = [StatusNova, StatusPoznamka, StatusVyrizujeSe],
+                BlockedStatusId = blockedStatusId,
+            }),
+            _logger);
+
+        var ct = new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token;
+        var paymentGuid = _configuration["Shoptet:PaymentMethodGuid"]
+            ?? throw new InvalidOperationException("Missing Shoptet:PaymentMethodGuid in configuration.");
+        var shippingGuid = _configuration["Shoptet:ShippingGuidMap:21"]
+            ?? throw new InvalidOperationException("Missing Shoptet:ShippingGuidMap:21 in configuration.");
+
+        string? code = null;
+        try
+        {
+            code = await _client.CreateOrderAsync(BuildOrderRequest(externalCode, shippingGuid, paymentGuid), ct);
+            await _client.UpdateStatusAsync(code, statusId, ct);
+            _output.WriteLine($"CREATED  {externalCode} ({code}) → status {statusId}");
+
+            var result = await handler.Handle(
+                new BlockOrderProcessingRequest { OrderCode = code, Note = "Integration test block" },
+                ct);
+
+            if (shouldSucceed)
+            {
+                result.Success.Should().BeTrue(
+                    $"order in state {statusId} ({externalCode}) should be blockable");
+                _output.WriteLine($"BLOCKED  {externalCode} ({code}) ✓");
+            }
+            else
+            {
+                result.Success.Should().BeFalse(
+                    $"order in state {statusId} ({externalCode}) should not be blockable");
+                result.ErrorCode.Should().Be(ErrorCodes.ShoptetOrderInvalidSourceState);
+                _output.WriteLine($"REJECTED {externalCode} ({code}) ✓");
+            }
+        }
+        finally
+        {
+            if (code != null)
+            {
+                await _client.DeleteOrderAsync(code, ct);
+                _output.WriteLine($"DELETED  {code}");
+            }
+        }
+    }
+
+    private static CreateOrderRequest BuildOrderRequest(
+        string externalCode,
+        string shippingGuid,
+        string paymentGuid) =>
+        new()
+        {
+            Email = TestEmail,
+            Phone = "+420725191660",
+            ExternalCode = externalCode,
+            ShippingGuid = shippingGuid,
+            PaymentMethodGuid = paymentGuid,
+            Currency = new OrderCurrency { Code = "CZK" },
+            BillingAddress = new OrderAddress
+            {
+                FullName = "Test Heblo",
+                Street = "Testovaci 1",
+                City = "Praha",
+                Zip = "10000",
+            },
+            Items =
+            [
+                new OrderItem
+                {
+                    ItemType = "product",
+                    Code = "OCH001030",
+                    Name = "Test product",
+                    VatRate = "21",
+                    ItemPriceWithVat = "1.00",
+                    Amount = "1",
+                },
+                new OrderItem
+                {
+                    ItemType = "billing",
+                    Name = "Platba prevod",
+                    VatRate = "0",
+                    ItemPriceWithVat = "0.00",
+                    Amount = "1",
+                },
+                new OrderItem
+                {
+                    ItemType = "shipping",
+                    Name = "Zásilkovna (do ruky)",
+                    VatRate = "0",
+                    ItemPriceWithVat = "0.00",
+                    Amount = "1",
+                },
+            ],
+        };
+
+    private static void AssertTestEnvironment(IConfiguration config)
+    {
+        var isTest = config.GetValue<bool>("Shoptet:IsTestEnvironment");
+        if (!isTest)
+            throw new InvalidOperationException(
+                "Integration test must not run against live environment. "
+                + "Set Shoptet:IsTestEnvironment=true in test appsettings.json");
+
+        var baseUrl = config["Shoptet:BaseUrl"] ?? string.Empty;
+        if (baseUrl.Contains("anela", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                "Integration test refused: base URL contains 'anela' — this looks like the production store.");
+    }
+}

--- a/docs/integrations/shoptet-api.md
+++ b/docs/integrations/shoptet-api.md
@@ -42,6 +42,7 @@ These two are **completely unrelated** — do not confuse them.
 | `PATCH` | `/api/orders/{code}/head` | Update basic info (email, addresses) |
 | `PATCH` | `/api/orders/{code}/status` | Change status / mark paid / update payment method |
 | `PATCH` | `/api/orders/{code}/notes` | Update remarks and 6 custom fields |
+| `POST` | `/api/orders/{code}/history` | Add a remark to order history (type: `comment` or `system`) |
 | `PATCH` | `/api/orders/status-change` | Bulk status update for multiple orders |
 | `DELETE` | `/api/orders/{code}` | Delete order |
 | `POST` | `/api/orders/{code}/copy` | Duplicate order |
@@ -223,6 +224,7 @@ Location: `backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/`
 
 - **Seeding endpoint:** `POST /api/orders` — creates orders with minimal valid payload.
 - **Status update endpoint:** `PATCH /api/orders/{code}/status` — body shape `{"data":{"statusId":<int>}}`. Note: the property is `statusId` (flat integer), NOT `{"status":{"id":x}}` — verified against Shoptet OpenAPI spec (`additionalProperties: false` schema).
+- **Internal note / history remark:** `POST /api/orders/{code}/history` — body `{"data":{"text":"...","type":"system"}}`. The `type` field is either `"comment"` (visible to customer) or `"system"` (internal). `PATCH /api/orders/{code}/notes` is for updating the order's `remark` field and custom fields — it is NOT for writing history entries.
 - **Delete endpoint:** `DELETE /api/orders/{code}`.
 - **ExternalCode filter does NOT exist.** `GET /api/orders?externalCode={code}` returns 400 "Unsupported query parameters". There is no server-side filter by externalCode.
 - **ExternalCode is NOT in the list response.** `GET /api/orders` (paginated list) does NOT include the `externalCode` field for each order. The field is only available via `GET /api/orders/{code}` (single order detail). The list response DOES include `email`, which can be used as a pre-filter to narrow down candidates before fetching details.


### PR DESCRIPTION
## Summary

- `PATCH /api/orders/{code}/notes` updates the order's remark field — it does not write history entries and returns an error when used for that purpose
- Internal notes must be created via `POST /api/orders/{code}/history` with `type: "system"`
- Updated `ShoptetOrderClient.SetInternalNoteAsync` and renamed the request model from `UpdateNotesRequest` to `CreateOrderRemarkRequest` to match the actual endpoint
- Documented the finding in `docs/integrations/shoptet-api.md`

## Integration Tests

Added `BlockOrderProcessingIntegrationTests` with one test per order state:
- `BlockOrder_Nova_Succeeds` (status -1)
- `BlockOrder_Poznamka_Succeeds` (status 35)
- `BlockOrder_VyrizujeSe_Succeeds` (status -2)
- `BlockOrder_BaliSe_IsRejectedWithInvalidSourceStateError` (status 26)

Tests are guarded by `SHOPTET_BLOCK_ORDER=1` env var — they create real orders on the test store and clean up in `finally`.

## Test Plan
- [ ] Run `SHOPTET_BLOCK_ORDER=1 dotnet test ... --filter BlockOrderProcessingIntegrationTests` against test store and verify all 4 pass
- [ ] Call `PATCH /api/shoptet-orders/{code}/block` from Postman and verify the order history tab in Shoptet admin shows the system remark

🤖 Generated with [Claude Code](https://claude.com/claude-code)