### PR TITLE
test(bank): add regression guard for ShoptetPayImportJob account name (#480)

### DIFF
--- a/backend/test/Anela.Heblo.Tests/Features/Bank/ShoptetPayImportJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/ShoptetPayImportJobTests.cs
@@ -1,0 +1,60 @@
+using Anela.Heblo.Application.Features.Bank.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Bank;
+
+public class ShoptetPayImportJobTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
+
+    private ShoptetPayImportJob CreateJob()
+    {
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync("daily-shoptetpay-czk-import", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ImportBankStatementResponse { Statements = [] });
+
+        return new ShoptetPayImportJob(
+            _mediator.Object,
+            NullLogger<ShoptetPayImportJob>.Instance,
+            _statusChecker.Object);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SendsRequestWithCorrectAccountName_ShoptetPay()
+    {
+        var job = CreateJob();
+
+        await job.ExecuteAsync();
+
+        _mediator.Verify(m => m.Send(
+            It.Is<ImportBankStatementRequest>(r => r.AccountName == "ShoptetPay-CZK"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenJobDisabled_DoesNotCallMediator()
+    {
+        _statusChecker
+            .Setup(s => s.IsJobEnabledAsync("daily-shoptetpay-czk-import", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var job = new ShoptetPayImportJob(
+            _mediator.Object,
+            NullLogger<ShoptetPayImportJob>.Instance,
+            _statusChecker.Object);
+
+        await job.ExecuteAsync();
+
+        _mediator.Verify(m => m.Send(It.IsAny<ImportBankStatementRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

- Investigated issue #480: `ShoptetPayImportJob` reportedly using wrong account name `"ShoptetPay-CZK"` not found in production config
- Root cause was a **production config drift** — `appsettings.json` and job code both correctly use `"ShoptetPay-CZK"`, and the production env var override (`BankAccounts__Accounts__2__Name = ShoptetPay-CZK`) is already in place
- No code change needed; adding regression tests to guard against future drift

## Changes

- Added `ShoptetPayImportJobTests.cs` with two tests:
  - Verifies the job sends `ImportBankStatementRequest` with account name `"ShoptetPay-CZK"`
  - Verifies the job skips MediatR when disabled via `IRecurringJobStatusChecker`

## Test plan

- [x] New unit tests pass (`Passed: 2`)
- [x] Full backend test suite passes (`Passed: 2007`)
- [x] `dotnet format` reports no violations

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)