### PR TITLE
fix(storage): use overwrite:true in UploadAsync to prevent 409 on re-upload

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
@@ -78,15 +78,12 @@ public class AzureBlobStorageService : IBlobStorageService
             var containerClient = await GetOrCreateContainerAsync(containerName, cancellationToken);
             var blobClient = containerClient.GetBlobClient(blobName);
 
-            var blobHttpHeaders = new BlobHttpHeaders
+            await blobClient.UploadAsync(stream, overwrite: true, cancellationToken);
+
+            await blobClient.SetHttpHeadersAsync(new BlobHttpHeaders
             {
                 ContentType = contentType
-            };
-
-            await blobClient.UploadAsync(stream, new BlobUploadOptions
-            {
-                HttpHeaders = blobHttpHeaders
-            }, cancellationToken);
+            }, cancellationToken: cancellationToken);
 
             var blobUrl = blobClient.Uri.ToString();
             _logger.LogInformation("Successfully uploaded blob: {BlobUrl}", blobUrl);

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
@@ -109,9 +109,15 @@ public class AzureBlobStorageServiceTests
         mockBlobClient.Setup(x => x.Uri).Returns(new Uri(expectedBlobUrl));
         mockBlobClient.Setup(x => x.UploadAsync(
             It.IsAny<Stream>(),
-            It.IsAny<BlobUploadOptions>(),
+            It.IsAny<bool>(),
             It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContentInfo>>()));
+
+        mockBlobClient.Setup(x => x.SetHttpHeadersAsync(
+            It.IsAny<BlobHttpHeaders>(),
+            It.IsAny<BlobRequestConditions>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobInfo>>()));
 
         mockContainerClient.Setup(x => x.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
         mockContainerClient.Setup(x => x.CreateIfNotExistsAsync(
@@ -147,9 +153,15 @@ public class AzureBlobStorageServiceTests
         mockBlobClient.Setup(x => x.Uri).Returns(new Uri(expectedBlobUrl));
         mockBlobClient.Setup(x => x.UploadAsync(
             It.IsAny<Stream>(),
-            It.IsAny<BlobUploadOptions>(),
+            It.IsAny<bool>(),
             It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContentInfo>>()));
+
+        mockBlobClient.Setup(x => x.SetHttpHeadersAsync(
+            It.IsAny<BlobHttpHeaders>(),
+            It.IsAny<BlobRequestConditions>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobInfo>>()));
 
         mockContainerClient.Setup(x => x.GetBlobClient(blobName)).Returns(mockBlobClient.Object);
         mockContainerClient.Setup(x => x.CreateIfNotExistsAsync(
@@ -167,7 +179,59 @@ public class AzureBlobStorageServiceTests
         Assert.Equal(expectedBlobUrl, result);
         mockBlobClient.Verify(x => x.UploadAsync(
             It.IsAny<Stream>(),
-            It.Is<BlobUploadOptions>(opts => opts.HttpHeaders.ContentType == contentType),
+            true,
+            It.IsAny<CancellationToken>()), Times.Once);
+        mockBlobClient.Verify(x => x.SetHttpHeadersAsync(
+            It.Is<BlobHttpHeaders>(h => h.ContentType == contentType),
+            It.IsAny<BlobRequestConditions>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadAsync_BlobAlreadyExists_ShouldOverwriteWithoutConflict()
+    {
+        // Arrange — verifies Overwrite = true is passed so a second upload of the same blob does not throw 409
+        var content = "Updated file content";
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var containerName = "documents";
+        var blobName = "existing.txt";
+        var contentType = "text/plain";
+
+        var mockContainerClient = new Mock<BlobContainerClient>();
+        var mockBlobClient = new Mock<BlobClient>();
+        var expectedBlobUrl = $"https://testaccount.blob.core.windows.net/{containerName}/{blobName}";
+
+        mockBlobClient.Setup(x => x.Uri).Returns(new Uri(expectedBlobUrl));
+        mockBlobClient
+            .Setup(x => x.UploadAsync(
+                It.IsAny<Stream>(),
+                It.Is<bool>(b => b == true),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContentInfo>>()));
+
+        mockBlobClient.Setup(x => x.SetHttpHeadersAsync(
+            It.IsAny<BlobHttpHeaders>(),
+            It.IsAny<BlobRequestConditions>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobInfo>>()));
+
+        mockContainerClient.Setup(x => x.GetBlobClient(blobName)).Returns(mockBlobClient.Object);
+        mockContainerClient.Setup(x => x.CreateIfNotExistsAsync(
+            It.IsAny<PublicAccessType>(),
+            It.IsAny<IDictionary<string, string>>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContainerInfo>>()));
+
+        _mockBlobServiceClient.Setup(x => x.GetBlobContainerClient(containerName)).Returns(mockContainerClient.Object);
+
+        // Act — should not throw (overwrite:true prevents 409)
+        var result = await _service.UploadAsync(stream, containerName, blobName, contentType);
+
+        // Assert
+        Assert.Equal(expectedBlobUrl, result);
+        mockBlobClient.Verify(x => x.UploadAsync(
+            It.IsAny<Stream>(),
+            true,
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -312,7 +376,7 @@ public class AzureBlobStorageServiceTests
 
         mockBlobClient.Setup(x => x.UploadAsync(
             It.IsAny<Stream>(),
-            It.IsAny<BlobUploadOptions>(),
+            It.IsAny<bool>(),
             It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Storage error"));
 


### PR DESCRIPTION
## Summary

Fixes #481

`AzureBlobStorageService.UploadAsync` was calling `BlobClient.UploadAsync` without the overwrite flag, causing HTTP 409 Conflict errors when a blob with the same name already existed in the container.

## Changes

- **`AzureBlobStorageService.cs`**: Replaced `BlobUploadOptions { HttpHeaders = ... }` call with a two-step approach:
  1. `UploadAsync(stream, overwrite: true, ct)` — explicitly suppresses the `If-None-Match: *` header that causes 409
  2. `SetHttpHeadersAsync(new BlobHttpHeaders { ContentType = contentType }, ct)` — sets content-type after upload

- **`AzureBlobStorageServiceTests.cs`**: Updated all four affected test setups/verifications to use the `(Stream, bool, CancellationToken)` overload and added `SetHttpHeadersAsync` mocking.

## Notes

`BlobUploadOptions` does not expose an `Overwrite` property in `Azure.Storage.Blobs` 12.25.0, so the explicit `bool overwrite` overload is used instead — consistent with how `AzureBlobPrintQueueSink` already uploads.

## Test Results

- 2000 tests pass
- 6 pre-existing failures (Docker/TestContainers not available in CI, Shoptet integration tests require external services) — unrelated to this change