### PR TITLE
fix(e2e): replace waitForResponse race condition with DOM-based wait in stock operations tests

### DIFF
--- a/frontend/test/e2e/helpers/stock-operations-test-helpers.ts
+++ b/frontend/test/e2e/helpers/stock-operations-test-helpers.ts
@@ -11,10 +11,15 @@ const UI_LABELS = {
 } as const;
 
 /**
- * Wait for stock operations table to update after filter/sort changes
+ * Wait for stock operations table to update after filter/sort changes.
+ * Uses DOM-based wait to avoid race conditions with page.waitForResponse,
+ * which only catches API responses registered BEFORE the request fires.
  */
 export async function waitForTableUpdate(page: Page): Promise<void> {
-  await waitForSearchResults(page, { endpoint: '/api/StockUpOperations' });
+  // Wait for either the data table or the empty-state message to appear
+  await expect(
+    page.locator('table').or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
+  ).toBeVisible({ timeout: 15000 });
 }
 
 /**


### PR DESCRIPTION
## Root cause

`waitForTableUpdate` used `page.waitForResponse('/api/StockUpOperations')` which registers a response listener **after** the navigation/filter action has already fired the API request. When the response arrives before the listener is registered (a race), the promise never resolves and the test times out.

16 stock operations E2E tests were failing because of this:
- `filters.spec.ts` — H, I, J, K suites
- `navigation.spec.ts` — all tests
- `panel.spec.ts` — L and M suites (via `beforeEach`)

## Fix

Replace the API-intercept approach with a DOM-based wait:

```ts
// Before (broken — race condition):
export async function waitForTableUpdate(page: Page): Promise<void> {
  await waitForSearchResults(page, { endpoint: '/api/StockUpOperations' });
}

// After (reliable — waits for UI to reflect current state):
export async function waitForTableUpdate(page: Page): Promise<void> {
  await expect(
    page.locator('table').or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
  ).toBeVisible({ timeout: 15000 });
}
```

Waiting for either the data `<table>` or the empty-state `<h3>Žádné výsledky</h3>` to be visible is timing-safe — it works whether the response arrived before or after the wait call.