### PR TITLE
fix(e2e): fix clearAllFilters race condition in invoice classification history tests

### DIFF
--- a/frontend/test/e2e/helpers/classification-history-helpers.ts
+++ b/frontend/test/e2e/helpers/classification-history-helpers.ts
@@ -86,7 +86,12 @@ export async function applyFilters(
 export async function clearAllFilters(page: Page): Promise<void> {
   const inputs = getFilterInputs(page);
   await inputs.clearButton.click();
-  await page.waitForLoadState('networkidle'); // Wait for clear to complete
+  // ClassificationHistoryPage.clearFilters uses setTimeout(() => refetch(), 0) so the
+  // refetch API call is deferred one event-loop tick. waitForLoadState('networkidle')
+  // can resolve in that gap — before the request has even started — causing the test
+  // to proceed with stale data. A small pause lets the deferred refetch fire first.
+  await page.waitForTimeout(100);
+  await page.waitForLoadState('networkidle');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes race condition in `clearAllFilters` helper used by invoice classification E2E tests
- `ClassificationHistoryPage.clearFilters()` defers its `refetch()` call via `setTimeout(..., 0)` to let React batch state resets first
- `page.waitForLoadState("networkidle")` was resolving in the one-event-loop gap between the `setState` calls and the deferred `refetch()`, causing tests to proceed with stale table data
- Fix: insert a 100ms pause after clicking "Vymazat" so the deferred refetch fires before `networkidle` is checked

## Test plan

- [ ] Run `invoice-classification-history-filters.spec.ts` nightly regression — all filter clear tests should pass consistently
- [ ] Verify no flakiness in tests that call `clearAllFilters` followed by row count assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)