### PR TITLE
fix: expedition print - products with position first, unpositioned last

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
@@ -149,7 +149,8 @@ public class ExpeditionProtocolDocument : IDocument
                             first.StockCount,
                         };
                     })
-                    .OrderBy(x => x.WarehousePosition)
+                    .OrderBy(x => x.WarehousePosition == null)
+                    .ThenBy(x => x.WarehousePosition)
                     .ToList();
 
                 col.Item().Table(table =>


### PR DESCRIPTION
## Summary
- Changed ordering in expedition list print so products with a warehouse position are shown first, followed by products without a position
- Previously `OrderBy(WarehousePosition)` sorted nulls first; now `OrderBy(x => x.WarehousePosition == null).ThenBy(x => x.WarehousePosition)` pushes nulls to the end while preserving ascending order among positioned items

## Test plan
- [ ] Print an expedition list that contains products both with and without warehouse position
- [ ] Verify positioned products appear first in the printout, sorted by position ascending
- [ ] Verify products without a position appear at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)