### PR TITLE
fix(manufacture): optimistic state updates + preserve modal input on …

### DIFF
--- a/frontend/src/api/hooks/useManufactureOrders.ts
+++ b/frontend/src/api/hooks/useManufactureOrders.ts
@@ -154,19 +154,26 @@ export const useUpdateManufactureOrderStatusMutation = () => {
       const apiClient = getManufactureOrdersClient();
       return await apiClient.manufactureOrder_UpdateOrderStatus(request.id!, request);
     },
-    onSuccess: (data, variables) => {
-      // Invalidate and refetch manufacture orders
-      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.all });
-      
-      // Also invalidate specific order detail
-      queryClient.invalidateQueries({
-        queryKey: manufactureOrderKeys.detail(variables.id!),
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: manufactureOrderKeys.detail(variables.id!) });
+      const previousOrder = queryClient.getQueryData(manufactureOrderKeys.detail(variables.id!));
+      queryClient.setQueryData(manufactureOrderKeys.detail(variables.id!), (old: any) => {
+        if (!old) return old;
+        return { ...old, order: { ...old.order, state: variables.newState } };
       });
-
-      // Also invalidate all calendar queries (including those with date parameters)
+      return { previousOrder };
+    },
+    onError: (_err, variables, context: any) => {
+      if (context?.previousOrder) {
+        queryClient.setQueryData(manufactureOrderKeys.detail(variables.id!), context.previousOrder);
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.all });
+      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.detail(variables.id!) });
       queryClient.invalidateQueries({
         predicate: (query) => {
-          return query.queryKey.length >= 2 && 
+          return query.queryKey.length >= 2 &&
                  query.queryKey[0] === "manufacture-orders" &&
                  query.queryKey[1] === "calendar";
         },
@@ -243,27 +250,32 @@ export const useManufactureOrderCalendarQuery = (
 // Confirm semi-product manufacture mutation hook using generated API client
 export const useConfirmSemiProductManufacture = () => {
   const queryClient = useQueryClient();
-  
+
   return useMutation({
     mutationFn: async (request: ConfirmSemiProductManufactureRequest): Promise<ConfirmSemiProductManufactureResponse> => {
       const apiClient = getManufactureOrdersClient();
       return await apiClient.manufactureOrder_ConfirmSemiProductManufacture(request.id!, request);
     },
-    onSuccess: (data, variables) => {
-      // Invalidate and refetch manufacture orders
-      queryClient.invalidateQueries({
-        queryKey: manufactureOrderKeys.all,
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: manufactureOrderKeys.detail(variables.id!) });
+      const previousOrder = queryClient.getQueryData(manufactureOrderKeys.detail(variables.id!));
+      queryClient.setQueryData(manufactureOrderKeys.detail(variables.id!), (old: any) => {
+        if (!old) return old;
+        return { ...old, order: { ...old.order, state: ManufactureOrderState.SemiProductManufactured } };
       });
-      
-      // Also invalidate specific order detail
-      queryClient.invalidateQueries({
-        queryKey: manufactureOrderKeys.detail(variables.id!),
-      });
-
-      // Also invalidate all calendar queries (including those with date parameters)
+      return { previousOrder };
+    },
+    onError: (_err, variables, context: any) => {
+      if (context?.previousOrder) {
+        queryClient.setQueryData(manufactureOrderKeys.detail(variables.id!), context.previousOrder);
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.all });
+      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.detail(variables.id!) });
       queryClient.invalidateQueries({
         predicate: (query) => {
-          return query.queryKey.length >= 2 && 
+          return query.queryKey.length >= 2 &&
                  query.queryKey[0] === "manufacture-orders" &&
                  query.queryKey[1] === "calendar";
         },
@@ -275,27 +287,32 @@ export const useConfirmSemiProductManufacture = () => {
 // Confirm product completion mutation hook using generated API client
 export const useConfirmProductCompletion = () => {
   const queryClient = useQueryClient();
-  
+
   return useMutation({
     mutationFn: async (request: ConfirmProductCompletionRequest): Promise<ConfirmProductCompletionResponse> => {
       const apiClient = getManufactureOrdersClient();
       return await apiClient.manufactureOrder_ConfirmProductCompletion(request.id!, request);
     },
-    onSuccess: (data, variables) => {
-      // Invalidate and refetch manufacture orders
-      queryClient.invalidateQueries({
-        queryKey: manufactureOrderKeys.all,
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: manufactureOrderKeys.detail(variables.id!) });
+      const previousOrder = queryClient.getQueryData(manufactureOrderKeys.detail(variables.id!));
+      queryClient.setQueryData(manufactureOrderKeys.detail(variables.id!), (old: any) => {
+        if (!old) return old;
+        return { ...old, order: { ...old.order, state: ManufactureOrderState.Completed } };
       });
-      
-      // Also invalidate specific order detail
-      queryClient.invalidateQueries({
-        queryKey: manufactureOrderKeys.detail(variables.id!),
-      });
-
-      // Also invalidate all calendar queries (including those with date parameters)
+      return { previousOrder };
+    },
+    onError: (_err, variables, context: any) => {
+      if (context?.previousOrder) {
+        queryClient.setQueryData(manufactureOrderKeys.detail(variables.id!), context.previousOrder);
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.all });
+      queryClient.invalidateQueries({ queryKey: manufactureOrderKeys.detail(variables.id!) });
       queryClient.invalidateQueries({
         predicate: (query) => {
-          return query.queryKey.length >= 2 && 
+          return query.queryKey.length >= 2 &&
                  query.queryKey[0] === "manufacture-orders" &&
                  query.queryKey[1] === "calendar";
         },

--- a/frontend/src/components/modals/ConfirmProductCompletionModal.tsx
+++ b/frontend/src/components/modals/ConfirmProductCompletionModal.tsx
@@ -39,7 +39,10 @@ const ConfirmProductCompletionModal: React.FC<ConfirmProductCompletionModalProps
   const [actualQuantities, setActualQuantities] = useState<{ [key: number]: string }>({});
   const [error, setError] = useState<string>('');
 
-  // Initialize with planned quantities when modal opens
+  // Initialize with planned quantities when modal opens.
+  // Intentionally omit `products` from deps — re-renders caused by optimistic
+  // cache updates must not reset values the user has already entered.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (isOpen && products.length > 0) {
       const initialQuantities: { [key: number]: string } = {};
@@ -49,7 +52,7 @@ const ConfirmProductCompletionModal: React.FC<ConfirmProductCompletionModalProps
       setActualQuantities(initialQuantities);
       setError('');
     }
-  }, [isOpen, products]);
+  }, [isOpen]);
 
   const handleQuantityChange = (productId: number, value: string) => {
     setActualQuantities(prev => ({
@@ -87,10 +90,6 @@ const ConfirmProductCompletionModal: React.FC<ConfirmProductCompletionModalProps
       });
 
       await onSubmit(request);
-
-      // Reset form
-      setActualQuantities({});
-      setError('');
     } catch (err) {
       setError('Chyba při potvrzení množství produktů. Zkuste to prosím znovu.');
       console.error('Error confirming product completion:', err);

--- a/frontend/src/components/modals/ConfirmSemiProductQuantityModal.tsx
+++ b/frontend/src/components/modals/ConfirmSemiProductQuantityModal.tsx
@@ -24,13 +24,16 @@ const ConfirmSemiProductQuantityModal: React.FC<ConfirmSemiProductQuantityModalP
   const [actualQuantity, setActualQuantity] = useState<string>("");
   const [error, setError] = useState<string>("");
 
-  // Initialize with planned quantity when modal opens
+  // Initialize with planned quantity when modal opens.
+  // Intentionally omit `plannedQuantity` from deps — re-renders caused by
+  // optimistic cache updates must not reset a value the user has already entered.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (isOpen) {
       setActualQuantity(plannedQuantity.toString());
       setError("");
     }
-  }, [isOpen, plannedQuantity]);
+  }, [isOpen]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
…re-render

- Add onMutate optimistic cache update to all 3 state-change mutations (UpdateStatus, ConfirmSemiProduct, ConfirmProductCompletion) so the state badge changes instantly on click instead of waiting for refetch
- Add onError rollback and move invalidation to onSettled for consistency
- Fix ConfirmProductCompletionModal and ConfirmSemiProductQuantityModal resetting user-entered quantities on parent re-render: useEffect now only depends on [isOpen], not on data props that change from optimistic cache updates
- Fix ConfirmProductCompletionModal clearing actualQuantities after submit when distribution preview is shown; values are now preserved so "Zpět" returns a filled form

@claude