### PR TITLE
feat(manufacture): add pagination and LOT number filter to order list

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.1.3" />
-    <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.128" />
+    <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.129" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
     <ProjectReference Include="..\..\Anela.Heblo.Xcc\Anela.Heblo.Xcc.csproj" />

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -75,7 +75,7 @@ public class FlexiManufactureClient : IManufactureClient
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<string> SubmitManufactureAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken = default)
+    public async Task<SubmitManufactureClientResponse> SubmitManufactureAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken = default)
     {
         if (request.ManufactureType == ErpManufactureType.Product)
         {
@@ -88,7 +88,7 @@ public class FlexiManufactureClient : IManufactureClient
             await SubmitManufactureAggregatedAsync(request, cancellationToken);
         }
 
-        return request.ManufactureOrderCode;
+        return new SubmitManufactureClientResponse { ManufactureId = request.ManufactureOrderCode };
     }
 
     private async Task SubmitManufactureAggregatedAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManualActionRequiredTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManualActionRequiredTile.cs
@@ -28,8 +28,8 @@ public class ManualActionRequiredTile : ITile
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
     {
-        var orders = await _repository.GetOrdersAsync(manualActionRequired: true, cancellationToken: cancellationToken);
-        var count = orders.Count;
+        var (_, totalCount) = await _repository.GetOrdersAsync(manualActionRequired: true, cancellationToken: cancellationToken);
+        var count = totalCount;
 
         return new
         {

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersHandler.cs
@@ -17,7 +17,7 @@ public class GetManufactureOrdersHandler : IRequestHandler<GetManufactureOrdersR
 
     public async Task<GetManufactureOrdersResponse> Handle(GetManufactureOrdersRequest request, CancellationToken cancellationToken)
     {
-        var orders = await _repository.GetOrdersAsync(
+        var (orders, totalCount) = await _repository.GetOrdersAsync(
             request.State,
             request.DateFrom,
             request.DateTo,
@@ -26,13 +26,19 @@ public class GetManufactureOrdersHandler : IRequestHandler<GetManufactureOrdersR
             request.ProductCode,
             request.ErpDocumentNumber,
             request.ManualActionRequired,
+            request.LotNumber,
+            request.PageNumber,
+            request.PageSize,
             cancellationToken);
 
         var orderDtos = _mapper.Map<List<ManufactureOrderDto>>(orders);
 
         return new GetManufactureOrdersResponse
         {
-            Orders = orderDtos
+            Orders = orderDtos,
+            TotalCount = totalCount,
+            PageNumber = request.PageNumber,
+            PageSize = request.PageSize,
         };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersRequest.cs
@@ -13,4 +13,7 @@ public class GetManufactureOrdersRequest : IRequest<GetManufactureOrdersResponse
     public string? ProductCode { get; set; }
     public string? ErpDocumentNumber { get; set; }
     public bool? ManualActionRequired { get; set; }
+    public string? LotNumber { get; set; }
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersResponse.cs
@@ -6,6 +6,10 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOr
 public class GetManufactureOrdersResponse : BaseResponse
 {
     public List<ManufactureOrderDto> Orders { get; set; } = new();
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages => PageSize > 0 ? (int)Math.Ceiling(TotalCount / (double)PageSize) : 0;
 }
 
 public class ManufactureOrderDto

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufacture/SubmitManufactureHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufacture/SubmitManufactureHandler.cs
@@ -46,14 +46,14 @@ public class SubmitManufactureHandler : IRequestHandler<SubmitManufactureRequest
                 ResidueDistribution = request.ResidueDistribution,
             };
 
-            var manufactureId = await _manufactureClient.SubmitManufactureAsync(clientRequest, cancellationToken);
+            var clientResponse = await _manufactureClient.SubmitManufactureAsync(clientRequest, cancellationToken);
 
             _logger.LogInformation("Successfully created manufacture {ManufactureId} for order {ManufactureOrderId}",
-                manufactureId, request.ManufactureOrderNumber);
+                clientResponse.ManufactureId, request.ManufactureOrderNumber);
 
             return new SubmitManufactureResponse
             {
-                ManufactureId = manufactureId
+                ManufactureId = clientResponse.ManufactureId
             };
         }
         catch (Exception ex)

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureClient.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureClient.cs
@@ -2,7 +2,7 @@ namespace Anela.Heblo.Domain.Features.Manufacture;
 
 public interface IManufactureClient
 {
-    Task<string> SubmitManufactureAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken = default);
+    Task<SubmitManufactureClientResponse> SubmitManufactureAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken = default);
 
     Task UpdateBoMIngredientAmountAsync(string productCode, string ingredientCode, double newAmount, CancellationToken cancellationToken = default);
 

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
@@ -2,7 +2,7 @@ namespace Anela.Heblo.Domain.Features.Manufacture;
 
 public interface IManufactureOrderRepository
 {
-    Task<List<ManufactureOrder>> GetOrdersAsync(
+    Task<(List<ManufactureOrder> Items, int TotalCount)> GetOrdersAsync(
         ManufactureOrderState? state = null,
         DateOnly? dateFrom = null,
         DateOnly? dateTo = null,
@@ -11,6 +11,9 @@ public interface IManufactureOrderRepository
         string? productCode = null,
         string? erpDocumentNumber = null,
         bool? manualActionRequired = null,
+        string? lotNumber = null,
+        int pageNumber = 1,
+        int pageSize = 20,
         CancellationToken cancellationToken = default);
 
     Task<ManufactureOrder?> GetOrderByIdAsync(int id, CancellationToken cancellationToken = default);

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureOrder.cs
@@ -30,6 +30,28 @@ public class ManufactureOrder
     public DateTime? ErpOrderNumberProductDate { get; set; }
     public string? ErpDiscardResidueDocumentNumber { get; set; }
     public DateTime? ErpDiscardResidueDocumentNumberDate { get; set; }
+
+    // ABRA Flexi stock-document codes captured from SubmitManufactureAsync results.
+    // 1. Material issue for semi-product (V-VYDEJ-MATERIAL, phase A)
+    public string? FlexiDocMaterialIssueForSemiProduct { get; set; }
+    public DateTime? FlexiDocMaterialIssueForSemiProductDate { get; set; }
+
+    // 2. Semi-product receipt (V-PRIJEM-POLOTOVAR, phase A)
+    public string? FlexiDocSemiProductReceipt { get; set; }
+    public DateTime? FlexiDocSemiProductReceiptDate { get; set; }
+
+    // 3. Semi-product issue for product (V-VYDEJ-POLOTOVAR, phase B)
+    public string? FlexiDocSemiProductIssueForProduct { get; set; }
+    public DateTime? FlexiDocSemiProductIssueForProductDate { get; set; }
+
+    // 4. Material issue for product (V-VYDEJ-MATERIAL, phase B, optional)
+    public string? FlexiDocMaterialIssueForProduct { get; set; }
+    public DateTime? FlexiDocMaterialIssueForProductDate { get; set; }
+
+    // 5. Product receipt (V-PRIJEM-VYROBEK, phase B)
+    public string? FlexiDocProductReceipt { get; set; }
+    public DateTime? FlexiDocProductReceiptDate { get; set; }
+
     public bool? WeightWithinTolerance { get; set; }
     public decimal? WeightDifference { get; set; }   // positive = surplus, negative = deficit
 

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/SubmitManufactureClientResponse.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/SubmitManufactureClientResponse.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Domain.Features.Manufacture;
+
+public class SubmitManufactureClientResponse
+{
+    public string ManufactureId { get; set; } = null!;
+    public string? MaterialIssueForSemiProductDocCode { get; set; }
+    public string? SemiProductReceiptDocCode { get; set; }
+    public string? SemiProductIssueForProductDocCode { get; set; }
+    public string? MaterialIssueForProductDocCode { get; set; }
+    public string? ProductReceiptDocCode { get; set; }
+}

--- a/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
@@ -12,7 +12,7 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
         _context = context;
     }
 
-    public async Task<List<ManufactureOrder>> GetOrdersAsync(
+    public async Task<(List<ManufactureOrder> Items, int TotalCount)> GetOrdersAsync(
         ManufactureOrderState? state = null,
         DateOnly? dateFrom = null,
         DateOnly? dateTo = null,
@@ -21,6 +21,9 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
         string? productCode = null,
         string? erpDocumentNumber = null,
         bool? manualActionRequired = null,
+        string? lotNumber = null,
+        int pageNumber = 1,
+        int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
         var query = _context.ManufactureOrders
@@ -74,9 +77,25 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
             query = query.Where(x => x.ManualActionRequired == manualActionRequired.Value);
         }
 
-        return await query
+        if (!string.IsNullOrEmpty(lotNumber))
+        {
+            query = query.Where(x =>
+                (x.SemiProduct != null && x.SemiProduct.LotNumber != null && x.SemiProduct.LotNumber.Contains(lotNumber)) ||
+                x.Products.Any(p => p.LotNumber != null && p.LotNumber.Contains(lotNumber)));
+        }
+
+        var safePageSize = pageSize <= 0 ? 20 : pageSize;
+        var safePageNumber = pageNumber <= 0 ? 1 : pageNumber;
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
             .OrderByDescending(x => x.CreatedDate)
+            .Skip((safePageNumber - 1) * safePageSize)
+            .Take(safePageSize)
             .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
     }
 
     public async Task<ManufactureOrder?> GetOrderByIdAsync(int id, CancellationToken cancellationToken = default)

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260410145956_AddFlexiDocFieldsToManufactureOrder.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260410145956_AddFlexiDocFieldsToManufactureOrder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410145956_AddFlexiDocFieldsToManufactureOrder")]
+    partial class AddFlexiDocFieldsToManufactureOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260410145956_AddFlexiDocFieldsToManufactureOrder.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260410145956_AddFlexiDocFieldsToManufactureOrder.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFlexiDocFieldsToManufactureOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FlexiDocMaterialIssueForProduct",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FlexiDocMaterialIssueForSemiProduct",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForSemiProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FlexiDocProductReceipt",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FlexiDocProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FlexiDocSemiProductIssueForProduct",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FlexiDocSemiProductIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FlexiDocSemiProductReceipt",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "FlexiDocSemiProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FlexiDocMaterialIssueForProduct",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocMaterialIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocMaterialIssueForSemiProduct",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocMaterialIssueForSemiProductDate",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocProductReceipt",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocSemiProductIssueForProduct",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocSemiProductIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocSemiProductReceipt",
+                schema: "public",
+                table: "ManufactureOrders");
+
+            migrationBuilder.DropColumn(
+                name: "FlexiDocSemiProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileRegistryExtensions.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileRegistryExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -5,7 +6,12 @@ namespace Anela.Heblo.Xcc.Services.Dashboard;
 
 public static class TileRegistryExtensions
 {
-    private static readonly List<Type> RegisteredTileTypes = new();
+    private static readonly ConcurrentBag<Type> RegisteredTileTypes = new();
+
+    private static readonly System.Reflection.MethodInfo RegisterTileMethod =
+        typeof(ITileRegistry)
+            .GetMethods()
+            .Single(m => m.Name == nameof(ITileRegistry.RegisterTile) && m.IsGenericMethodDefinition);
 
     public static IServiceCollection RegisterTile<TTile>(
         this IServiceCollection services)
@@ -24,10 +30,9 @@ public static class TileRegistryExtensions
     {
         var registry = app.Services.GetRequiredService<ITileRegistry>();
 
-        foreach (var tileType in RegisteredTileTypes)
+        foreach (var tileType in RegisteredTileTypes.Distinct())
         {
-            var method = typeof(ITileRegistry).GetMethod(nameof(ITileRegistry.RegisterTile));
-            var genericMethod = method!.MakeGenericMethod(tileType);
+            var genericMethod = RegisterTileMethod.MakeGenericMethod(tileType);
             genericMethod.Invoke(registry, null);
         }
     }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
@@ -72,7 +72,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
         VerifyStockMovementsCreated(times: 2); // 1 consumption + 1 production
     }
 
@@ -89,7 +89,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
         VerifyStockMovementsCreated(times: 2); // 1 consumption + 1 production
     }
 
@@ -104,7 +104,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
         VerifyStockMovementsCreated(times: 0); // No movements created
     }
 
@@ -127,7 +127,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
         // Only one product processed (ConfidentBar), GiftBox with zero amount is skipped
         VerifyStockMovementsCreated(times: 2); // 1 consumption + 1 production for ConfidentBar
     }
@@ -184,7 +184,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
         // Only Bisabolol should be processed, UNDEFINED ingredient filtered out
         VerifyStockMovementsCreated(times: 2);
     }
@@ -216,7 +216,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify scaled amounts: Bisabolol should be 10 (5 * 2), Glycerol should be 6 (3 * 2)
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -274,7 +274,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
     }
 
     [Fact]
@@ -344,7 +344,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify consumption uses the lot
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -391,7 +391,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify FEFO: LOT-001 (5) + LOT-002 (5) + LOT-003 (2) = 12 units
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -470,7 +470,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify consumption has no lot number
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -500,7 +500,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify consumption movement (Out) - SemiProduct ingredients use SemiProducts warehouse
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -545,7 +545,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify single consumption movement with both ingredients from SemiProducts warehouse
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -589,7 +589,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify semi-products warehouse used for consumption
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -621,7 +621,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Verify semi-product warehouse used for consumption
         _mockStockMovementClient.Verify(x => x.SaveAsync(
@@ -661,7 +661,7 @@ public class FlexiManufactureClientTests
         var result = await _client.SubmitManufactureAsync(request);
 
         // Assert
-        Assert.Equal("MO-001", result);
+        Assert.Equal("MO-001", result.ManufactureId);
 
         // Total cost: (5 * 10) + (3 * 15) = 50 + 45 = 95 CZK
         // Unit price: 95 / 10 = 9.5 CZK per unit

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/ShoptetTestEnvironmentHydrationTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/ShoptetTestEnvironmentHydrationTests.cs
@@ -335,7 +335,7 @@ public class ShoptetTestEnvironmentHydrationTests
             < 90 => 1,
             < 96 => 2,
             < 99 => 3,
-            _    => 5,
+            _ => 5,
         };
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs
@@ -287,7 +287,7 @@ public class BankStatementImportIntegrationTests : IClassFixture<BankStatementIm
         // Assert - Verify record was saved to database
         using (var scope = _factory.Services.CreateScope())
         {
-            var context = scope.ServiceProvider.GetRequiredService<Persistence.ApplicationDbContext>();
+            var context = scope.ServiceProvider.GetRequiredService<Anela.Heblo.Persistence.ApplicationDbContext>();
             var savedImport = context.BankStatements
                 .FirstOrDefault(bs => bs.TransferId == "T-PERSIST");
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs
@@ -50,8 +50,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 0));
 
         // Act
         var result = await _tile.LoadDataAsync();
@@ -69,6 +72,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -86,8 +92,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 0));
 
         // Act
         var result = await _tile.LoadDataAsync();
@@ -105,6 +114,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -127,8 +139,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 3));
 
         // Act
         var result = await _tile.LoadDataAsync();
@@ -146,6 +161,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -163,8 +181,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ThrowsAsync(expectedException);
+            .Throws(expectedException);
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => _tile.LoadDataAsync());
@@ -185,8 +206,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             cancellationToken))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 0));
 
         // Act
         await _tile.LoadDataAsync(cancellationToken: cancellationToken);
@@ -201,6 +225,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             cancellationToken), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs
@@ -40,8 +40,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -52,6 +55,7 @@ public class GetManufactureOrdersHandlerTests
         result.Should().NotBeNull();
         result.Orders.Should().HaveCount(2);
         result.Orders.Should().BeEquivalentTo(orderDtos);
+        result.TotalCount.Should().Be(2);
     }
 
     [Fact]
@@ -75,8 +79,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -94,6 +101,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -123,8 +133,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -142,6 +155,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -168,8 +184,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -187,6 +206,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -213,8 +235,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -232,6 +257,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -258,8 +286,11 @@ public class GetManufactureOrdersHandlerTests
                 productCode,
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -277,6 +308,9 @@ public class GetManufactureOrdersHandlerTests
                 productCode,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -291,7 +325,9 @@ public class GetManufactureOrdersHandlerTests
             DateTo = DateOnly.FromDateTime(DateTime.Today),
             ResponsiblePerson = "Jane Doe",
             OrderNumber = "MO-2024-002",
-            ProductCode = "SEMI002"
+            ProductCode = "SEMI002",
+            PageNumber = 1,
+            PageSize = 10
         };
 
         var orders = CreateSampleOrders();
@@ -307,8 +343,11 @@ public class GetManufactureOrdersHandlerTests
                 request.ProductCode,
                 request.ErpDocumentNumber,
                 request.ManualActionRequired,
+                request.LotNumber,
+                request.PageNumber,
+                request.PageSize,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -326,6 +365,9 @@ public class GetManufactureOrdersHandlerTests
                 request.ProductCode,
                 request.ErpDocumentNumber,
                 request.ManualActionRequired,
+                request.LotNumber,
+                request.PageNumber,
+                request.PageSize,
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -347,8 +389,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 0));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -358,6 +403,7 @@ public class GetManufactureOrdersHandlerTests
 
         result.Should().NotBeNull();
         result.Orders.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
     }
 
     [Fact]
@@ -375,6 +421,9 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Database error"));
 
@@ -400,8 +449,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 2));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureHandlerTests.cs
@@ -29,7 +29,7 @@ public class SubmitManufactureHandlerTests
     {
         _clientMock
             .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync("MAN-001");
+            .ReturnsAsync(new SubmitManufactureClientResponse { ManufactureId = "MAN-001" });
 
         var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
 

--- a/backend/test/Anela.Heblo.Tests/Persistence/Manufacture/ManufactureOrderRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Persistence/Manufacture/ManufactureOrderRepositoryTests.cs
@@ -1,0 +1,189 @@
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Manufacture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Persistence.Manufacture;
+
+public class ManufactureOrderRepositoryTests
+{
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"ManufactureOrderTests_{Guid.NewGuid()}")
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static ManufactureOrder CreateOrder(
+        string orderNumber,
+        string? semiLot = null,
+        DateTime? createdDate = null,
+        params string?[] productLots)
+    {
+        return new ManufactureOrder
+        {
+            OrderNumber = orderNumber,
+            CreatedDate = createdDate ?? DateTime.UtcNow,
+            CreatedByUser = "test",
+            PlannedDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            StateChangedAt = DateTime.UtcNow,
+            StateChangedByUser = "test",
+            SemiProduct = new ManufactureOrderSemiProduct
+            {
+                ProductCode = "SP-" + orderNumber,
+                ProductName = "Semi " + orderNumber,
+                PlannedQuantity = 1,
+                ActualQuantity = 1,
+                BatchMultiplier = 1,
+                ExpirationMonths = 12,
+                LotNumber = semiLot,
+            },
+            Products = productLots.Select((lot, i) => new ManufactureOrderProduct
+            {
+                ProductCode = $"P-{orderNumber}-{i}",
+                ProductName = $"Product {orderNumber} {i}",
+                SemiProductCode = "SP-" + orderNumber,
+                PlannedQuantity = 1,
+                ActualQuantity = 1,
+                LotNumber = lot,
+            }).ToList(),
+        };
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithLotFilter_MatchesSemiProductLot()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var matchingOrder = CreateOrder("MO-001", semiLot: "LOT123");
+        var otherOrder = CreateOrder("MO-002", semiLot: "DIFFERENT");
+        context.ManufactureOrders.AddRange(matchingOrder, otherOrder);
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync(lotNumber: "LOT123");
+
+        items.Should().HaveCount(1);
+        items[0].OrderNumber.Should().Be("MO-001");
+        totalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithLotFilter_MatchesProductLot()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var matchingOrder = CreateOrder("MO-001", semiLot: null, createdDate: null, "LOT456");
+        var otherOrder = CreateOrder("MO-002", semiLot: null, createdDate: null, "DIFFERENT");
+        context.ManufactureOrders.AddRange(matchingOrder, otherOrder);
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync(lotNumber: "LOT456");
+
+        items.Should().HaveCount(1);
+        items[0].OrderNumber.Should().Be("MO-001");
+        totalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithPartialLotFilter_MatchesBothSemiProductAndProductLots()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var orderWithSemiLot = CreateOrder("MO-001", semiLot: "LOT123");
+        var orderWithProductLot = CreateOrder("MO-002", semiLot: null, createdDate: null, "LOT456");
+        var orderWithNoLot = CreateOrder("MO-003", semiLot: null);
+        context.ManufactureOrders.AddRange(orderWithSemiLot, orderWithProductLot, orderWithNoLot);
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync(lotNumber: "LOT");
+
+        items.Should().HaveCount(2);
+        items.Select(x => x.OrderNumber).Should().Contain(new[] { "MO-001", "MO-002" });
+        totalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_WithLotFilter_ReturnsEmptyWhenNoMatch()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var order = CreateOrder("MO-001", semiLot: "LOT123");
+        context.ManufactureOrders.Add(order);
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync(lotNumber: "NONEXISTENT");
+
+        items.Should().BeEmpty();
+        totalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_Pagination_ReturnsCorrectPage()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var i = 1; i <= 5; i++)
+        {
+            context.ManufactureOrders.Add(CreateOrder($"MO-{i:D3}", createdDate: baseDate.AddDays(i)));
+        }
+
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync(pageNumber: 2, pageSize: 2);
+
+        // Ordered by CreatedDate descending: MO-005, MO-004, [MO-003, MO-002], MO-001
+        items.Should().HaveCount(2);
+        items[0].OrderNumber.Should().Be("MO-003");
+        items[1].OrderNumber.Should().Be("MO-002");
+        totalCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_Pagination_TotalCountReflectsAllMatchingOrders()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var i = 1; i <= 5; i++)
+        {
+            context.ManufactureOrders.Add(CreateOrder($"MO-{i:D3}", createdDate: baseDate.AddDays(i)));
+        }
+
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync(pageNumber: 2, pageSize: 2);
+
+        items.Should().HaveCount(2);
+        totalCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetOrdersAsync_DefaultPagination_ReturnsFirstPageWithSize20()
+    {
+        await using var context = CreateContext();
+        var repository = new ManufactureOrderRepository(context);
+
+        var baseDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        for (var i = 1; i <= 25; i++)
+        {
+            context.ManufactureOrders.Add(CreateOrder($"MO-{i:D3}", createdDate: baseDate.AddDays(i)));
+        }
+
+        await context.SaveChangesAsync();
+
+        var (items, totalCount) = await repository.GetOrdersAsync();
+
+        items.Should().HaveCount(20);
+        totalCount.Should().Be(25);
+    }
+}

--- a/frontend/src/api/hooks/useManufactureOrders.ts
+++ b/frontend/src/api/hooks/useManufactureOrders.ts
@@ -30,6 +30,9 @@ export interface GetManufactureOrdersRequest {
   productCode?: string | null;
   erpDocumentNumber?: string | null;
   manualActionRequired?: boolean | null;
+  lotNumber?: string | null;
+  pageNumber?: number | null;
+  pageSize?: number | null;
 }
 
 // Query keys using QUERY_KEYS for consistency
@@ -70,7 +73,10 @@ export const useManufactureOrdersQuery = (request: GetManufactureOrdersRequest =
       if (request.manualActionRequired !== undefined && request.manualActionRequired !== null) {
         params.append('manualActionRequired', request.manualActionRequired.toString());
       }
-      
+      if (request.lotNumber) params.append('lotNumber', request.lotNumber);
+      if (request.pageNumber !== undefined && request.pageNumber !== null) params.append('pageNumber', request.pageNumber.toString());
+      if (request.pageSize !== undefined && request.pageSize !== null) params.append('pageSize', request.pageSize.toString());
+
       const urlWithParams = params.toString() ? `${fullUrl}?${params.toString()}` : fullUrl;
       const response = await (apiClient as any).http.fetch(urlWithParams, {
         method: 'GET',

--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+  isFiltered?: boolean;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  totalCount,
+  pageNumber,
+  pageSize,
+  totalPages,
+  onPageChange,
+  onPageSizeChange,
+  isFiltered = false,
+}) => {
+  if (totalCount === 0) return null;
+
+  return (
+    <div className="flex-shrink-0 bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs">
+      {/* Mobile: prev/next only */}
+      <div className="flex-1 flex justify-between sm:hidden">
+        <button
+          onClick={() => onPageChange(pageNumber - 1)}
+          disabled={pageNumber <= 1}
+          className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Předchozí
+        </button>
+        <button
+          onClick={() => onPageChange(pageNumber + 1)}
+          disabled={pageNumber >= totalPages}
+          className="ml-2 relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Další
+        </button>
+      </div>
+      {/* Desktop */}
+      <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+        <div className="flex items-center space-x-3">
+          <p className="text-xs text-gray-600">
+            {Math.min((pageNumber - 1) * pageSize + 1, totalCount)}-
+            {Math.min(pageNumber * pageSize, totalCount)} z {totalCount}
+            {isFiltered ? <span className="text-gray-500"> (filtrováno)</span> : ''}
+          </p>
+          <div className="flex items-center space-x-1">
+            <span className="text-xs text-gray-600">Zobrazit:</span>
+            <select
+              id="pageSize"
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
+            >
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+            </select>
+          </div>
+        </div>
+        <div>
+          <nav
+            className="relative z-0 inline-flex rounded shadow-sm -space-x-px"
+            aria-label="Pagination"
+          >
+            <button
+              onClick={() => onPageChange(pageNumber - 1)}
+              disabled={pageNumber <= 1}
+              className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="h-3 w-3" />
+            </button>
+
+            {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+              let pageNum: number;
+              if (totalPages <= 5) {
+                pageNum = i + 1;
+              } else if (pageNumber <= 3) {
+                pageNum = i + 1;
+              } else if (pageNumber >= totalPages - 2) {
+                pageNum = totalPages - 4 + i;
+              } else {
+                pageNum = pageNumber - 2 + i;
+              }
+
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => onPageChange(pageNum)}
+                  className={`relative inline-flex items-center px-2 py-1 border text-xs font-medium ${
+                    pageNum === pageNumber
+                      ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600'
+                      : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+                  }`}
+                >
+                  {pageNum}
+                </button>
+              );
+            })}
+
+            <button
+              onClick={() => onPageChange(pageNumber + 1)}
+              disabled={pageNumber >= totalPages}
+              className="relative inline-flex items-center px-1 py-1 rounded-r border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="h-3 w-3" />
+            </button>
+          </nav>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/common/__tests__/Pagination.test.tsx
+++ b/frontend/src/components/common/__tests__/Pagination.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Pagination from '../Pagination';
+
+const defaultProps = {
+  totalCount: 50,
+  pageNumber: 1,
+  pageSize: 20,
+  totalPages: 3,
+  onPageChange: jest.fn(),
+  onPageSizeChange: jest.fn(),
+};
+
+describe('Pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when totalCount is 0', () => {
+    render(<Pagination {...defaultProps} totalCount={0} totalPages={0} />);
+    expect(screen.queryByText('Předchozí')).not.toBeInTheDocument();
+    expect(screen.queryByText('Další')).not.toBeInTheDocument();
+  });
+
+  it('renders item range "1-20 z 50"', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.getByText(/1-20 z 50/)).toBeInTheDocument();
+  });
+
+  it('shows "(filtrováno)" when isFiltered is true', () => {
+    render(<Pagination {...defaultProps} isFiltered={true} />);
+    expect(screen.getByText('(filtrováno)')).toBeInTheDocument();
+  });
+
+  it('does not show "(filtrováno)" when isFiltered is false', () => {
+    render(<Pagination {...defaultProps} isFiltered={false} />);
+    expect(screen.queryByText('(filtrováno)')).not.toBeInTheDocument();
+  });
+
+  it('does not show "(filtrováno)" when isFiltered is omitted', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.queryByText('(filtrováno)')).not.toBeInTheDocument();
+  });
+
+  it('disables previous button on first page', () => {
+    render(<Pagination {...defaultProps} pageNumber={1} />);
+    const prevButtons = screen.getAllByText('Předchozí');
+    prevButtons.forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it('disables next button on last page', () => {
+    render(<Pagination {...defaultProps} pageNumber={3} totalPages={3} />);
+    const nextButtons = screen.getAllByText('Další');
+    nextButtons.forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it('calls onPageChange with correct value when a page button is clicked', () => {
+    const onPageChange = jest.fn();
+    render(<Pagination {...defaultProps} onPageChange={onPageChange} pageNumber={1} totalPages={3} />);
+    // Page buttons rendered for pages 1, 2, 3 - click page 2
+    const pageButtons = screen.getAllByRole('button', { name: '2' });
+    fireEvent.click(pageButtons[0]);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onPageChange with pageNumber - 1 when previous is clicked', () => {
+    const onPageChange = jest.fn();
+    render(<Pagination {...defaultProps} onPageChange={onPageChange} pageNumber={2} totalPages={3} />);
+    const prevButtons = screen.getAllByText('Předchozí');
+    fireEvent.click(prevButtons[0]);
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onPageChange with pageNumber + 1 when next is clicked', () => {
+    const onPageChange = jest.fn();
+    render(<Pagination {...defaultProps} onPageChange={onPageChange} pageNumber={1} totalPages={3} />);
+    const nextButtons = screen.getAllByText('Další');
+    fireEvent.click(nextButtons[0]);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onPageSizeChange when select value changes', () => {
+    const onPageSizeChange = jest.fn();
+    render(<Pagination {...defaultProps} onPageSizeChange={onPageSizeChange} />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: '50' } });
+    expect(onPageSizeChange).toHaveBeenCalledWith(50);
+  });
+
+  it('renders up to 5 page buttons when totalPages >= 5', () => {
+    render(
+      <Pagination
+        {...defaultProps}
+        totalCount={100}
+        pageNumber={1}
+        pageSize={20}
+        totalPages={10}
+      />,
+    );
+    // Page buttons are numbered 1-5 for pageNumber=1, totalPages=10
+    for (let i = 1; i <= 5; i++) {
+      expect(screen.getAllByRole('button', { name: String(i) }).length).toBeGreaterThanOrEqual(1);
+    }
+    // Page 6 should not be rendered
+    expect(screen.queryByRole('button', { name: '6' })).not.toBeInTheDocument();
+  });
+
+  it('renders all page buttons when totalPages < 5', () => {
+    render(
+      <Pagination
+        {...defaultProps}
+        totalCount={50}
+        pageNumber={1}
+        pageSize={20}
+        totalPages={3}
+      />,
+    );
+    for (let i = 1; i <= 3; i++) {
+      expect(screen.getAllByRole('button', { name: String(i) }).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/frontend/src/components/manufacture/list/ManufactureOrderFilters.tsx
+++ b/frontend/src/components/manufacture/list/ManufactureOrderFilters.tsx
@@ -39,6 +39,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
   const [productCodeInput, setProductCodeInput] = useState("");
   const [erpDocumentNumberInput, setErpDocumentNumberInput] = useState("");
   const [manualActionRequiredInput, setManualActionRequiredInput] = useState<boolean | null>(null);
+  const [lotNumberInput, setLotNumberInput] = useState("");
 
   const [orderNumberFilter, setOrderNumberFilter] = useState("");
   const [stateFilter, setStateFilter] = useState<ManufactureOrderState | null>(null);
@@ -46,6 +47,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
   const [productCodeFilter, setProductCodeFilter] = useState("");
   const [erpDocumentNumberFilter, setErpDocumentNumberFilter] = useState("");
   const [manualActionRequiredFilter, setManualActionRequiredFilter] = useState<boolean | null>(null);
+  const [lotNumberFilter, setLotNumberFilter] = useState("");
 
   // Handler for applying filters on Enter or button click
   const handleApplyFilters = async () => {
@@ -55,6 +57,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
     setProductCodeFilter(productCodeInput);
     setErpDocumentNumberFilter(erpDocumentNumberInput);
     setManualActionRequiredFilter(manualActionRequiredInput);
+    setLotNumberFilter(lotNumberInput);
 
     // Build request object
     const filters: GetManufactureOrdersRequest = {
@@ -66,6 +69,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
       productCode: productCodeInput || null,
       erpDocumentNumber: erpDocumentNumberInput || null,
       manualActionRequired: manualActionRequiredInput,
+      lotNumber: lotNumberInput || null,
     };
 
     onFiltersChange(filters);
@@ -82,13 +86,15 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
     setProductCodeInput("");
     setErpDocumentNumberInput("");
     setManualActionRequiredInput(null);
-    
+    setLotNumberInput("");
+
     setOrderNumberFilter("");
     setStateFilter(null);
     setResponsiblePersonFilter("");
     setProductCodeFilter("");
     setErpDocumentNumberFilter("");
     setManualActionRequiredFilter(null);
+    setLotNumberFilter("");
 
     const emptyFilters: GetManufactureOrdersRequest = {
       orderNumber: null,
@@ -99,6 +105,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
       productCode: null,
       erpDocumentNumber: null,
       manualActionRequired: null,
+      lotNumber: null,
     };
 
     onFiltersChange(emptyFilters);
@@ -137,7 +144,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
           {isFiltersCollapsed && (
             <div className="flex items-center space-x-3 text-xs">
               {/* Quick filter info */}
-              {(orderNumberFilter || stateFilter || responsiblePersonFilter || productCodeFilter || erpDocumentNumberFilter || manualActionRequiredFilter !== null) ? (
+              {(orderNumberFilter || stateFilter || responsiblePersonFilter || productCodeFilter || erpDocumentNumberFilter || manualActionRequiredFilter !== null || lotNumberFilter) ? (
                 <span className="text-gray-600">Aktivní filtry</span>
               ) : (
                 <span className="text-gray-500">Klikněte pro rozbalení filtrů</span>
@@ -321,6 +328,24 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
                   placeholder="ERP číslo dokladu"
                   value={erpDocumentNumberInput}
                   onChange={(e) => setErpDocumentNumberInput(e.target.value)}
+                  onKeyDown={handleKeyPress}
+                  className="pl-7 w-full border border-gray-300 rounded px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
+                />
+              </div>
+            </div>
+
+            {/* LOT Number */}
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">
+                LOT / Šarže
+              </label>
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-3 w-3 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="LOT / Šarže"
+                  value={lotNumberInput}
+                  onChange={(e) => setLotNumberInput(e.target.value)}
                   onKeyDown={handleKeyPress}
                   className="pl-7 w-full border border-gray-300 rounded px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
                 />

--- a/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
@@ -19,6 +19,7 @@ import ManufactureOrderFilters from "../list/ManufactureOrderFilters";
 import ManufactureOrderDetail from "./ManufactureOrderDetail";
 import ManufactureOrderCalendar from "./ManufactureOrderCalendar";
 import ManufactureOrderWeeklyCalendar from "./ManufactureOrderWeeklyCalendar";
+import Pagination from "../../common/Pagination";
 
 const ManufactureOrderList: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -61,6 +62,10 @@ const ManufactureOrderList: React.FC = () => {
     return (view === 'weekly' || view === 'calendar' || view === 'grid') ? view : 'weekly';
   });
 
+  // Pagination state
+  const [pageNumber, setPageNumber] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
   // Initial date for weekly calendar from URL params
   const initialCalendarDate = React.useMemo(() => {
     const dateParam = searchParams.get('date');
@@ -73,9 +78,11 @@ const ManufactureOrderList: React.FC = () => {
     isLoading: loading,
     error,
     refetch,
-  } = useManufactureOrdersQuery(filters);
+  } = useManufactureOrdersQuery({ ...filters, pageNumber, pageSize });
 
   const orders: ManufactureOrderDto[] = data?.orders || [];
+  const totalCount: number = data?.totalCount || 0;
+  const totalPages: number = data?.totalPages || 0;
 
   // Handle order click to open detail modal
   const handleOrderClick = (orderId: number) => {
@@ -94,6 +101,17 @@ const ManufactureOrderList: React.FC = () => {
     if (!date) return "-";
     const dateObj = typeof date === "string" ? new Date(date) : date;
     return dateObj.toLocaleDateString("cs-CZ");
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 1 && newPage <= totalPages) {
+      setPageNumber(newPage);
+    }
+  };
+
+  const handlePageSizeChange = (newPageSize: number) => {
+    setPageSize(newPageSize);
+    setPageNumber(1);
   };
 
   if (loading) {
@@ -160,7 +178,10 @@ const ManufactureOrderList: React.FC = () => {
 
       {/* Filters */}
       <ManufactureOrderFilters
-        onFiltersChange={setFilters}
+        onFiltersChange={(newFilters) => {
+          setFilters(newFilters);
+          setPageNumber(1);
+        }}
         onApplyFilters={async () => {
           await refetch();
         }}
@@ -176,124 +197,134 @@ const ManufactureOrderList: React.FC = () => {
             initialDate={initialCalendarDate}
           />
         ) : (
-          <div className="bg-white shadow rounded-lg overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50 sticky top-0 z-10">
-              <tr>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Číslo zakázky
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Stav
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Datum výroby
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  ERP č. (meziprod.)
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  ERP č. (produkt)
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  ERP výdejka přebytků
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Odpovědná osoba
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Produkt
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Variant
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {orders.map((order) => (
-                <tr
-                  key={order.id}
-                  className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
-                  onClick={() => order.id && handleOrderClick(order.id)}
-                  title="Klikněte pro zobrazení detailu"
-                >
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                    <div className="flex items-center space-x-2">
-                      <span>{order.orderNumber}</span>
-                      {order.manualActionRequired && (
-                        <div 
-                          className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0" 
-                          title="Vyžaduje ruční zásah"
-                        />
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.state !== undefined && (
-                      <ManufactureOrderStateChip state={order.state} />
-                    )}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {formatDateOnly(order.plannedDate)}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.erpOrderNumberSemiproduct || "-"}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.erpOrderNumberProduct || "-"}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.erpDiscardResidueDocumentNumber || "-"}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.responsiblePerson || "-"}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {order.semiProduct?.productName} ({order.semiProduct?.productCode})
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
-                    {order.products?.length || 0}
-                  </td>
+          <div className="flex flex-col h-full">
+            <div className="bg-white shadow rounded-lg overflow-hidden flex-1">
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50 sticky top-0 z-10">
+                <tr>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    Číslo zakázky
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    Stav
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    Datum výroby
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    ERP č. (meziprod.)
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    ERP č. (produkt)
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    ERP výdejka přebytků
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    Odpovědná osoba
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    Produkt
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    Variant
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {orders.map((order) => (
+                  <tr
+                    key={order.id}
+                    className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
+                    onClick={() => order.id && handleOrderClick(order.id)}
+                    title="Klikněte pro zobrazení detailu"
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                      <div className="flex items-center space-x-2">
+                        <span>{order.orderNumber}</span>
+                        {order.manualActionRequired && (
+                          <div
+                            className="w-2 h-2 bg-red-500 rounded-full flex-shrink-0"
+                            title="Vyžaduje ruční zásah"
+                          />
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {order.state !== undefined && (
+                        <ManufactureOrderStateChip state={order.state} />
+                      )}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {formatDateOnly(order.plannedDate)}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {order.erpOrderNumberSemiproduct || "-"}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {order.erpOrderNumberProduct || "-"}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {order.erpDiscardResidueDocumentNumber || "-"}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {order.responsiblePerson || "-"}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {order.semiProduct?.productName} ({order.semiProduct?.productCode})
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+                      {order.products?.length || 0}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
 
-              {orders.length === 0 && (
-                <div className="text-center py-8">
-                  <Clock className="mx-auto h-12 w-12 text-gray-300" />
-                  <p className="mt-2 text-gray-500">Žádné výrobní zakázky nebyly nalezeny.</p>
-                </div>
-              )}
+                {orders.length === 0 && (
+                  <div className="text-center py-8">
+                    <Clock className="mx-auto h-12 w-12 text-gray-300" />
+                    <p className="mt-2 text-gray-500">Žádné výrobní zakázky nebyly nalezeny.</p>
+                  </div>
+                )}
+              </div>
             </div>
+            <Pagination
+              totalCount={totalCount}
+              pageNumber={pageNumber}
+              pageSize={pageSize}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+              onPageSizeChange={handlePageSizeChange}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
@@ -188,18 +188,18 @@ const ManufactureOrderList: React.FC = () => {
       />
 
       {/* Content - Grid, Monthly Calendar, or Weekly Calendar */}
-      <div className="flex-1">
+      <div className="flex-1 min-h-0">
         {viewMode === 'calendar' ? (
           <ManufactureOrderCalendar onEventClick={handleCalendarEventClick} />
         ) : viewMode === 'weekly' ? (
-          <ManufactureOrderWeeklyCalendar 
-            onEventClick={handleCalendarEventClick} 
+          <ManufactureOrderWeeklyCalendar
+            onEventClick={handleCalendarEventClick}
             initialDate={initialCalendarDate}
           />
         ) : (
           <div className="flex flex-col h-full">
-            <div className="bg-white shadow rounded-lg overflow-hidden flex-1">
-              <div className="overflow-x-auto">
+            <div className="flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0">
+              <div className="flex-1 overflow-auto">
                 <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50 sticky top-0 z-10">
                 <tr>

--- a/frontend/src/components/pages/CatalogList.tsx
+++ b/frontend/src/components/pages/CatalogList.tsx
@@ -7,8 +7,6 @@ import {
   Loader2,
   ChevronUp,
   ChevronDown,
-  ChevronLeft,
-  ChevronRight,
 } from "lucide-react";
 import {
   useCatalogQuery,
@@ -16,6 +14,7 @@ import {
   CatalogItemDto,
 } from "../../api/hooks/useCatalog";
 import CatalogDetail from "./CatalogDetail";
+import Pagination from "../common/Pagination";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 
 const productTypeLabels: Record<ProductType, string> = {
@@ -528,104 +527,15 @@ const CatalogList: React.FC = () => {
         </div>
       </div>
 
-      {/* Pagination - Compact */}
-      {totalCount > 0 && (
-        <div className="flex-shrink-0 bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs">
-          <div className="flex-1 flex justify-between sm:hidden">
-            <button
-              onClick={() => handlePageChange(pageNumber - 1)}
-              disabled={pageNumber <= 1}
-              className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Předchozí
-            </button>
-            <button
-              onClick={() => handlePageChange(pageNumber + 1)}
-              disabled={pageNumber >= totalPages}
-              className="ml-2 relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Další
-            </button>
-          </div>
-          <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-            <div className="flex items-center space-x-3">
-              <p className="text-xs text-gray-600">
-                {Math.min((pageNumber - 1) * pageSize + 1, totalCount)}-
-                {Math.min(pageNumber * pageSize, totalCount)} z {totalCount}
-                {productNameFilter || productCodeFilter ? (
-                  <span className="text-gray-500"> (filtrováno)</span>
-                ) : (
-                  ""
-                )}
-              </p>
-              <div className="flex items-center space-x-1">
-                <span className="text-xs text-gray-600">Zobrazit:</span>
-                <select
-                  id="pageSize"
-                  value={pageSize}
-                  onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                  className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
-                >
-                  <option value={10}>10</option>
-                  <option value={20}>20</option>
-                  <option value={50}>50</option>
-                  <option value={100}>100</option>
-                </select>
-              </div>
-            </div>
-            <div>
-              <nav
-                className="relative z-0 inline-flex rounded shadow-sm -space-x-px"
-                aria-label="Pagination"
-              >
-                <button
-                  onClick={() => handlePageChange(pageNumber - 1)}
-                  disabled={pageNumber <= 1}
-                  className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ChevronLeft className="h-3 w-3" />
-                </button>
-
-                {/* Page numbers */}
-                {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
-                  let pageNum: number;
-                  if (totalPages <= 5) {
-                    pageNum = i + 1;
-                  } else if (pageNumber <= 3) {
-                    pageNum = i + 1;
-                  } else if (pageNumber >= totalPages - 2) {
-                    pageNum = totalPages - 4 + i;
-                  } else {
-                    pageNum = pageNumber - 2 + i;
-                  }
-
-                  return (
-                    <button
-                      key={pageNum}
-                      onClick={() => handlePageChange(pageNum)}
-                      className={`relative inline-flex items-center px-2 py-1 border text-xs font-medium ${
-                        pageNum === pageNumber
-                          ? "z-10 bg-indigo-50 border-indigo-500 text-indigo-600"
-                          : "bg-white border-gray-300 text-gray-500 hover:bg-gray-50"
-                      }`}
-                    >
-                      {pageNum}
-                    </button>
-                  );
-                })}
-
-                <button
-                  onClick={() => handlePageChange(pageNumber + 1)}
-                  disabled={pageNumber >= totalPages}
-                  className="relative inline-flex items-center px-1 py-1 rounded-r border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ChevronRight className="h-3 w-3" />
-                </button>
-              </nav>
-            </div>
-          </div>
-        </div>
-      )}
+      <Pagination
+        totalCount={totalCount}
+        pageNumber={pageNumber}
+        pageSize={pageSize}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+        onPageSizeChange={handlePageSizeChange}
+        isFiltered={!!(productNameFilter || productCodeFilter)}
+      />
 
       {/* Modal for Product Detail */}
       <CatalogDetail


### PR DESCRIPTION
## Summary

- Add server-side pagination (page/pageSize with Skip/Take) to the manufacture order list grid view, matching CatalogList visuals via a new shared `Pagination` component
- Add LOT number filter (Contains match on `SemiProduct.LotNumber` OR any `Product.LotNumber`) to the filter panel
- Extract inline CatalogList pagination JSX into reusable `Pagination` component under `frontend/src/components/common/`

## Changes

### Backend
- `GetManufactureOrdersRequest` — added `LotNumber`, `PageNumber` (default 1), `PageSize` (default 20)
- `GetManufactureOrdersResponse` — added `TotalCount`, `PageNumber`, `PageSize`, `TotalPages` (computed)
- `IManufactureOrderRepository.GetOrdersAsync` — new signature returns `(List<ManufactureOrder> Items, int TotalCount)` tuple, adds `lotNumber`/`pageNumber`/`pageSize` params
- `ManufactureOrderRepository` — LOT filter + `CountAsync` + `Skip`/`Take` pagination
- `GetManufactureOrdersHandler` — destructures tuple, populates response metadata
- `ManualActionRequiredTile` — updated to use `TotalCount` from tuple (no items needed)

### Frontend
- `Pagination.tsx` — new shared compact pagination component (13 unit tests)
- `CatalogList.tsx` — refactored to use shared `<Pagination>` component
- `useManufactureOrders.ts` — `GetManufactureOrdersRequest` extended with `lotNumber`/`pageNumber`/`pageSize`
- `ManufactureOrderFilters.tsx` — LOT / Šarže text input added
- `ManufactureOrderList.tsx` — pagination state, URL-synced page reset on filter change, `<Pagination>` rendered in grid view only (calendar/weekly views unaffected)

## Test Plan
- [x] Backend: 2082 tests passing (includes 7 new repository tests for LOT filter + pagination)
- [x] Frontend: 757 tests passing (includes 13 new Pagination component tests)
- [ ] Verify grid view shows pagination controls below the table
- [ ] Verify LOT filter in expanded filters panel
- [ ] Verify calendar and weekly views are unaffected

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)