### PR TITLE
feat(manufacture): add server-side pagination + LOT filter to order list (#545)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManualActionRequiredTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManualActionRequiredTile.cs
@@ -28,8 +28,7 @@ public class ManualActionRequiredTile : ITile
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
     {
-        var orders = await _repository.GetOrdersAsync(manualActionRequired: true, cancellationToken: cancellationToken);
-        var count = orders.Count;
+        var (_, count) = await _repository.GetOrdersAsync(manualActionRequired: true, pageSize: 1, cancellationToken: cancellationToken);
 
         return new
         {

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersHandler.cs
@@ -17,7 +17,7 @@ public class GetManufactureOrdersHandler : IRequestHandler<GetManufactureOrdersR
 
     public async Task<GetManufactureOrdersResponse> Handle(GetManufactureOrdersRequest request, CancellationToken cancellationToken)
     {
-        var orders = await _repository.GetOrdersAsync(
+        var (orders, totalCount) = await _repository.GetOrdersAsync(
             request.State,
             request.DateFrom,
             request.DateTo,
@@ -26,13 +26,19 @@ public class GetManufactureOrdersHandler : IRequestHandler<GetManufactureOrdersR
             request.ProductCode,
             request.ErpDocumentNumber,
             request.ManualActionRequired,
+            request.LotNumber,
+            request.PageNumber,
+            request.PageSize,
             cancellationToken);
 
         var orderDtos = _mapper.Map<List<ManufactureOrderDto>>(orders);
 
         return new GetManufactureOrdersResponse
         {
-            Orders = orderDtos
+            Orders = orderDtos,
+            TotalCount = totalCount,
+            PageNumber = request.PageNumber,
+            PageSize = request.PageSize,
         };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersRequest.cs
@@ -13,4 +13,7 @@ public class GetManufactureOrdersRequest : IRequest<GetManufactureOrdersResponse
     public string? ProductCode { get; set; }
     public string? ErpDocumentNumber { get; set; }
     public bool? ManualActionRequired { get; set; }
+    public string? LotNumber { get; set; }
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOrders/GetManufactureOrdersResponse.cs
@@ -6,6 +6,10 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOr
 public class GetManufactureOrdersResponse : BaseResponse
 {
     public List<ManufactureOrderDto> Orders { get; set; } = new();
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages => PageSize > 0 ? (int)Math.Ceiling(TotalCount / (double)PageSize) : 0;
 }
 
 public class ManufactureOrderDto

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureOrderRepository.cs
@@ -2,7 +2,7 @@ namespace Anela.Heblo.Domain.Features.Manufacture;
 
 public interface IManufactureOrderRepository
 {
-    Task<List<ManufactureOrder>> GetOrdersAsync(
+    Task<(List<ManufactureOrder> Items, int TotalCount)> GetOrdersAsync(
         ManufactureOrderState? state = null,
         DateOnly? dateFrom = null,
         DateOnly? dateTo = null,
@@ -11,6 +11,9 @@ public interface IManufactureOrderRepository
         string? productCode = null,
         string? erpDocumentNumber = null,
         bool? manualActionRequired = null,
+        string? lotNumber = null,
+        int pageNumber = 1,
+        int pageSize = 20,
         CancellationToken cancellationToken = default);
 
     Task<ManufactureOrder?> GetOrderByIdAsync(int id, CancellationToken cancellationToken = default);

--- a/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderRepository.cs
@@ -12,7 +12,7 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
         _context = context;
     }
 
-    public async Task<List<ManufactureOrder>> GetOrdersAsync(
+    public async Task<(List<ManufactureOrder> Items, int TotalCount)> GetOrdersAsync(
         ManufactureOrderState? state = null,
         DateOnly? dateFrom = null,
         DateOnly? dateTo = null,
@@ -21,6 +21,9 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
         string? productCode = null,
         string? erpDocumentNumber = null,
         bool? manualActionRequired = null,
+        string? lotNumber = null,
+        int pageNumber = 1,
+        int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
         var query = _context.ManufactureOrders
@@ -74,9 +77,25 @@ public class ManufactureOrderRepository : IManufactureOrderRepository
             query = query.Where(x => x.ManualActionRequired == manualActionRequired.Value);
         }
 
-        return await query
+        if (!string.IsNullOrEmpty(lotNumber))
+        {
+            query = query.Where(x =>
+                (x.SemiProduct != null && x.SemiProduct.LotNumber != null && x.SemiProduct.LotNumber.Contains(lotNumber)) ||
+                x.Products.Any(p => p.LotNumber != null && p.LotNumber.Contains(lotNumber)));
+        }
+
+        var safePageSize = pageSize <= 0 ? 20 : pageSize;
+        var safePageNumber = pageNumber <= 0 ? 1 : pageNumber;
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
             .OrderByDescending(x => x.CreatedDate)
+            .Skip((safePageNumber - 1) * safePageSize)
+            .Take(safePageSize)
             .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
     }
 
     public async Task<ManufactureOrder?> GetOrderByIdAsync(int id, CancellationToken cancellationToken = default)

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs
@@ -40,7 +40,6 @@ public class ManualActionRequiredTileTests
     public async Task LoadDataAsync_WithNoOrders_ShouldReturnZeroCount()
     {
         // Arrange
-        var orders = new List<ManufactureOrder>();
         _mockRepository.Setup(x => x.GetOrdersAsync(
             It.IsAny<ManufactureOrderState?>(),
             It.IsAny<DateOnly?>(),
@@ -50,8 +49,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((new List<ManufactureOrder>(), 0));
 
         // Act
         var result = await _tile.LoadDataAsync();
@@ -69,6 +71,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -76,7 +81,6 @@ public class ManualActionRequiredTileTests
     public async Task LoadDataAsync_WithOrdersButNoManualAction_ShouldReturnZeroCount()
     {
         // Arrange
-        var orders = new List<ManufactureOrder>();  // Repository returns empty list when manualActionRequired=true
         _mockRepository.Setup(x => x.GetOrdersAsync(
             It.IsAny<ManufactureOrderState?>(),
             It.IsAny<DateOnly?>(),
@@ -86,8 +90,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((new List<ManufactureOrder>(), 0));
 
         // Act
         var result = await _tile.LoadDataAsync();
@@ -105,6 +112,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -127,8 +137,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         // Act
         var result = await _tile.LoadDataAsync();
@@ -146,6 +159,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -163,6 +179,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             It.IsAny<CancellationToken>()))
             .ThrowsAsync(expectedException);
 
@@ -175,7 +194,6 @@ public class ManualActionRequiredTileTests
     {
         // Arrange
         var cancellationToken = new CancellationToken();
-        var orders = new List<ManufactureOrder>();
         _mockRepository.Setup(x => x.GetOrdersAsync(
             It.IsAny<ManufactureOrderState?>(),
             It.IsAny<DateOnly?>(),
@@ -185,8 +203,11 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             cancellationToken))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((new List<ManufactureOrder>(), 0));
 
         // Act
         await _tile.LoadDataAsync(cancellationToken: cancellationToken);
@@ -201,6 +222,9 @@ public class ManualActionRequiredTileTests
             It.IsAny<string?>(),
             It.IsAny<string?>(),
             true,
+            It.IsAny<string?>(),
+            It.IsAny<int>(),
+            It.IsAny<int>(),
             cancellationToken), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOrdersHandlerTests.cs
@@ -40,8 +40,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -75,8 +78,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -94,6 +100,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -123,8 +132,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -142,6 +154,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -168,8 +183,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -187,6 +205,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -213,8 +234,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -232,6 +256,9 @@ public class GetManufactureOrdersHandlerTests
                 null,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -258,8 +285,11 @@ public class GetManufactureOrdersHandlerTests
                 productCode,
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -277,6 +307,9 @@ public class GetManufactureOrdersHandlerTests
                 productCode,
                 null,
                 null,
+                null,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -307,8 +340,11 @@ public class GetManufactureOrdersHandlerTests
                 request.ProductCode,
                 request.ErpDocumentNumber,
                 request.ManualActionRequired,
+                request.LotNumber,
+                request.PageNumber,
+                request.PageSize,
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -326,6 +362,9 @@ public class GetManufactureOrdersHandlerTests
                 request.ProductCode,
                 request.ErpDocumentNumber,
                 request.ManualActionRequired,
+                request.LotNumber,
+                request.PageNumber,
+                request.PageSize,
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -347,8 +386,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, 0));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))
@@ -375,6 +417,9 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Database error"));
 
@@ -400,8 +445,11 @@ public class GetManufactureOrdersHandlerTests
                 It.IsAny<string?>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(orders);
+            .ReturnsAsync((orders, orders.Count));
 
         _mapperMock
             .Setup(x => x.Map<List<ManufactureOrderDto>>(orders))

--- a/frontend/src/api/hooks/useManufactureOrders.ts
+++ b/frontend/src/api/hooks/useManufactureOrders.ts
@@ -30,6 +30,9 @@ export interface GetManufactureOrdersRequest {
   productCode?: string | null;
   erpDocumentNumber?: string | null;
   manualActionRequired?: boolean | null;
+  lotNumber?: string | null;
+  pageNumber?: number | null;
+  pageSize?: number | null;
 }
 
 // Query keys using QUERY_KEYS for consistency
@@ -70,7 +73,10 @@ export const useManufactureOrdersQuery = (request: GetManufactureOrdersRequest =
       if (request.manualActionRequired !== undefined && request.manualActionRequired !== null) {
         params.append('manualActionRequired', request.manualActionRequired.toString());
       }
-      
+      if (request.lotNumber) params.append('lotNumber', request.lotNumber);
+      if (request.pageNumber !== undefined && request.pageNumber !== null) params.append('pageNumber', request.pageNumber.toString());
+      if (request.pageSize !== undefined && request.pageSize !== null) params.append('pageSize', request.pageSize.toString());
+
       const urlWithParams = params.toString() ? `${fullUrl}?${params.toString()}` : fullUrl;
       const response = await (apiClient as any).http.fetch(urlWithParams, {
         method: 'GET',

--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+  isFiltered?: boolean;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  totalCount,
+  pageNumber,
+  pageSize,
+  totalPages,
+  onPageChange,
+  onPageSizeChange,
+  isFiltered = false,
+}) => {
+  if (totalCount === 0) return null;
+
+  return (
+    <div className="flex-shrink-0 bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs">
+      {/* Mobile: prev/next only */}
+      <div className="flex-1 flex justify-between sm:hidden">
+        <button
+          onClick={() => onPageChange(pageNumber - 1)}
+          disabled={pageNumber <= 1}
+          className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Předchozí
+        </button>
+        <button
+          onClick={() => onPageChange(pageNumber + 1)}
+          disabled={pageNumber >= totalPages}
+          className="ml-2 relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Další
+        </button>
+      </div>
+      {/* Desktop */}
+      <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+        <div className="flex items-center space-x-3">
+          <p className="text-xs text-gray-600">
+            {Math.min((pageNumber - 1) * pageSize + 1, totalCount)}-
+            {Math.min(pageNumber * pageSize, totalCount)} z {totalCount}
+            {isFiltered ? <span className="text-gray-500"> (filtrováno)</span> : ''}
+          </p>
+          <div className="flex items-center space-x-1">
+            <span className="text-xs text-gray-600">Zobrazit:</span>
+            <select
+              id="pageSize"
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
+            >
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+            </select>
+          </div>
+        </div>
+        <div>
+          <nav
+            className="relative z-0 inline-flex rounded shadow-sm -space-x-px"
+            aria-label="Pagination"
+          >
+            <button
+              onClick={() => onPageChange(pageNumber - 1)}
+              disabled={pageNumber <= 1}
+              className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="h-3 w-3" />
+            </button>
+
+            {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+              let pageNum: number;
+              if (totalPages <= 5) {
+                pageNum = i + 1;
+              } else if (pageNumber <= 3) {
+                pageNum = i + 1;
+              } else if (pageNumber >= totalPages - 2) {
+                pageNum = totalPages - 4 + i;
+              } else {
+                pageNum = pageNumber - 2 + i;
+              }
+
+              return (
+                <button
+                  key={pageNum}
+                  onClick={() => onPageChange(pageNum)}
+                  className={`relative inline-flex items-center px-2 py-1 border text-xs font-medium ${
+                    pageNum === pageNumber
+                      ? 'z-10 bg-indigo-50 border-indigo-500 text-indigo-600'
+                      : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+                  }`}
+                >
+                  {pageNum}
+                </button>
+              );
+            })}
+
+            <button
+              onClick={() => onPageChange(pageNumber + 1)}
+              disabled={pageNumber >= totalPages}
+              className="relative inline-flex items-center px-1 py-1 rounded-r border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="h-3 w-3" />
+            </button>
+          </nav>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/manufacture/list/ManufactureOrderFilters.tsx
+++ b/frontend/src/components/manufacture/list/ManufactureOrderFilters.tsx
@@ -39,6 +39,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
   const [productCodeInput, setProductCodeInput] = useState("");
   const [erpDocumentNumberInput, setErpDocumentNumberInput] = useState("");
   const [manualActionRequiredInput, setManualActionRequiredInput] = useState<boolean | null>(null);
+  const [lotNumberInput, setLotNumberInput] = useState("");
 
   const [orderNumberFilter, setOrderNumberFilter] = useState("");
   const [stateFilter, setStateFilter] = useState<ManufactureOrderState | null>(null);
@@ -46,6 +47,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
   const [productCodeFilter, setProductCodeFilter] = useState("");
   const [erpDocumentNumberFilter, setErpDocumentNumberFilter] = useState("");
   const [manualActionRequiredFilter, setManualActionRequiredFilter] = useState<boolean | null>(null);
+  const [lotNumberFilter, setLotNumberFilter] = useState("");
 
   // Handler for applying filters on Enter or button click
   const handleApplyFilters = async () => {
@@ -55,6 +57,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
     setProductCodeFilter(productCodeInput);
     setErpDocumentNumberFilter(erpDocumentNumberInput);
     setManualActionRequiredFilter(manualActionRequiredInput);
+    setLotNumberFilter(lotNumberInput);
 
     // Build request object
     const filters: GetManufactureOrdersRequest = {
@@ -66,6 +69,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
       productCode: productCodeInput || null,
       erpDocumentNumber: erpDocumentNumberInput || null,
       manualActionRequired: manualActionRequiredInput,
+      lotNumber: lotNumberInput || null,
     };
 
     onFiltersChange(filters);
@@ -82,13 +86,15 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
     setProductCodeInput("");
     setErpDocumentNumberInput("");
     setManualActionRequiredInput(null);
-    
+    setLotNumberInput("");
+
     setOrderNumberFilter("");
     setStateFilter(null);
     setResponsiblePersonFilter("");
     setProductCodeFilter("");
     setErpDocumentNumberFilter("");
     setManualActionRequiredFilter(null);
+    setLotNumberFilter("");
 
     const emptyFilters: GetManufactureOrdersRequest = {
       orderNumber: null,
@@ -99,6 +105,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
       productCode: null,
       erpDocumentNumber: null,
       manualActionRequired: null,
+      lotNumber: null,
     };
 
     onFiltersChange(emptyFilters);
@@ -137,7 +144,7 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
           {isFiltersCollapsed && (
             <div className="flex items-center space-x-3 text-xs">
               {/* Quick filter info */}
-              {(orderNumberFilter || stateFilter || responsiblePersonFilter || productCodeFilter || erpDocumentNumberFilter || manualActionRequiredFilter !== null) ? (
+              {(orderNumberFilter || stateFilter || responsiblePersonFilter || productCodeFilter || erpDocumentNumberFilter || manualActionRequiredFilter !== null || lotNumberFilter) ? (
                 <span className="text-gray-600">Aktivní filtry</span>
               ) : (
                 <span className="text-gray-500">Klikněte pro rozbalení filtrů</span>
@@ -321,6 +328,24 @@ const ManufactureOrderFilters: React.FC<ManufactureOrderFiltersProps> = ({
                   placeholder="ERP číslo dokladu"
                   value={erpDocumentNumberInput}
                   onChange={(e) => setErpDocumentNumberInput(e.target.value)}
+                  onKeyDown={handleKeyPress}
+                  className="pl-7 w-full border border-gray-300 rounded px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
+                />
+              </div>
+            </div>
+
+            {/* LOT Number */}
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">
+                LOT / Šarže
+              </label>
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-3 w-3 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="LOT / Šarže"
+                  value={lotNumberInput}
+                  onChange={(e) => setLotNumberInput(e.target.value)}
                   onKeyDown={handleKeyPress}
                   className="pl-7 w-full border border-gray-300 rounded px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
                 />

--- a/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
@@ -19,6 +19,7 @@ import ManufactureOrderFilters from "../list/ManufactureOrderFilters";
 import ManufactureOrderDetail from "./ManufactureOrderDetail";
 import ManufactureOrderCalendar from "./ManufactureOrderCalendar";
 import ManufactureOrderWeeklyCalendar from "./ManufactureOrderWeeklyCalendar";
+import Pagination from "../../common/Pagination";
 
 const ManufactureOrderList: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -61,6 +62,10 @@ const ManufactureOrderList: React.FC = () => {
     return (view === 'weekly' || view === 'calendar' || view === 'grid') ? view : 'weekly';
   });
 
+  // Pagination state
+  const [pageNumber, setPageNumber] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
   // Initial date for weekly calendar from URL params
   const initialCalendarDate = React.useMemo(() => {
     const dateParam = searchParams.get('date');
@@ -73,9 +78,11 @@ const ManufactureOrderList: React.FC = () => {
     isLoading: loading,
     error,
     refetch,
-  } = useManufactureOrdersQuery(filters);
+  } = useManufactureOrdersQuery({ ...filters, pageNumber, pageSize });
 
   const orders: ManufactureOrderDto[] = data?.orders || [];
+  const totalCount: number = data?.totalCount || 0;
+  const totalPages: number = data?.totalPages || 0;
 
   // Handle order click to open detail modal
   const handleOrderClick = (orderId: number) => {
@@ -94,6 +101,17 @@ const ManufactureOrderList: React.FC = () => {
     if (!date) return "-";
     const dateObj = typeof date === "string" ? new Date(date) : date;
     return dateObj.toLocaleDateString("cs-CZ");
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 1 && newPage <= totalPages) {
+      setPageNumber(newPage);
+    }
+  };
+
+  const handlePageSizeChange = (newPageSize: number) => {
+    setPageSize(newPageSize);
+    setPageNumber(1);
   };
 
   if (loading) {
@@ -160,25 +178,29 @@ const ManufactureOrderList: React.FC = () => {
 
       {/* Filters */}
       <ManufactureOrderFilters
-        onFiltersChange={setFilters}
+        onFiltersChange={(newFilters) => {
+          setFilters(newFilters);
+          setPageNumber(1);
+        }}
         onApplyFilters={async () => {
           await refetch();
         }}
       />
 
       {/* Content - Grid, Monthly Calendar, or Weekly Calendar */}
-      <div className="flex-1">
+      <div className="flex-1 min-h-0">
         {viewMode === 'calendar' ? (
           <ManufactureOrderCalendar onEventClick={handleCalendarEventClick} />
         ) : viewMode === 'weekly' ? (
-          <ManufactureOrderWeeklyCalendar 
-            onEventClick={handleCalendarEventClick} 
+          <ManufactureOrderWeeklyCalendar
+            onEventClick={handleCalendarEventClick}
             initialDate={initialCalendarDate}
           />
         ) : (
-          <div className="bg-white shadow rounded-lg overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
+          <div className="flex flex-col h-full">
+            <div className="flex-1 bg-white shadow rounded-lg overflow-hidden flex flex-col min-h-0">
+              <div className="flex-1 overflow-auto">
+                <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50 sticky top-0 z-10">
               <tr>
                 <th
@@ -285,15 +307,24 @@ const ManufactureOrderList: React.FC = () => {
                 </tr>
               ))}
             </tbody>
-          </table>
+                </table>
 
-              {orders.length === 0 && (
-                <div className="text-center py-8">
-                  <Clock className="mx-auto h-12 w-12 text-gray-300" />
-                  <p className="mt-2 text-gray-500">Žádné výrobní zakázky nebyly nalezeny.</p>
-                </div>
-              )}
+                {orders.length === 0 && (
+                  <div className="text-center py-8">
+                    <Clock className="mx-auto h-12 w-12 text-gray-300" />
+                    <p className="mt-2 text-gray-500">Žádné výrobní zakázky nebyly nalezeny.</p>
+                  </div>
+                )}
+              </div>
             </div>
+            <Pagination
+              totalCount={totalCount}
+              pageNumber={pageNumber}
+              pageSize={pageSize}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+              onPageSizeChange={handlePageSizeChange}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/components/pages/CatalogList.tsx
+++ b/frontend/src/components/pages/CatalogList.tsx
@@ -7,8 +7,6 @@ import {
   Loader2,
   ChevronUp,
   ChevronDown,
-  ChevronLeft,
-  ChevronRight,
 } from "lucide-react";
 import {
   useCatalogQuery,
@@ -16,6 +14,7 @@ import {
   CatalogItemDto,
 } from "../../api/hooks/useCatalog";
 import CatalogDetail from "./CatalogDetail";
+import Pagination from "../common/Pagination";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 
 const productTypeLabels: Record<ProductType, string> = {
@@ -528,104 +527,15 @@ const CatalogList: React.FC = () => {
         </div>
       </div>
 
-      {/* Pagination - Compact */}
-      {totalCount > 0 && (
-        <div className="flex-shrink-0 bg-white px-3 py-2 flex items-center justify-between border-t border-gray-200 text-xs">
-          <div className="flex-1 flex justify-between sm:hidden">
-            <button
-              onClick={() => handlePageChange(pageNumber - 1)}
-              disabled={pageNumber <= 1}
-              className="relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Předchozí
-            </button>
-            <button
-              onClick={() => handlePageChange(pageNumber + 1)}
-              disabled={pageNumber >= totalPages}
-              className="ml-2 relative inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Další
-            </button>
-          </div>
-          <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-            <div className="flex items-center space-x-3">
-              <p className="text-xs text-gray-600">
-                {Math.min((pageNumber - 1) * pageSize + 1, totalCount)}-
-                {Math.min(pageNumber * pageSize, totalCount)} z {totalCount}
-                {productNameFilter || productCodeFilter ? (
-                  <span className="text-gray-500"> (filtrováno)</span>
-                ) : (
-                  ""
-                )}
-              </p>
-              <div className="flex items-center space-x-1">
-                <span className="text-xs text-gray-600">Zobrazit:</span>
-                <select
-                  id="pageSize"
-                  value={pageSize}
-                  onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                  className="border border-gray-300 rounded px-1 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-transparent"
-                >
-                  <option value={10}>10</option>
-                  <option value={20}>20</option>
-                  <option value={50}>50</option>
-                  <option value={100}>100</option>
-                </select>
-              </div>
-            </div>
-            <div>
-              <nav
-                className="relative z-0 inline-flex rounded shadow-sm -space-x-px"
-                aria-label="Pagination"
-              >
-                <button
-                  onClick={() => handlePageChange(pageNumber - 1)}
-                  disabled={pageNumber <= 1}
-                  className="relative inline-flex items-center px-1 py-1 rounded-l border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ChevronLeft className="h-3 w-3" />
-                </button>
-
-                {/* Page numbers */}
-                {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
-                  let pageNum: number;
-                  if (totalPages <= 5) {
-                    pageNum = i + 1;
-                  } else if (pageNumber <= 3) {
-                    pageNum = i + 1;
-                  } else if (pageNumber >= totalPages - 2) {
-                    pageNum = totalPages - 4 + i;
-                  } else {
-                    pageNum = pageNumber - 2 + i;
-                  }
-
-                  return (
-                    <button
-                      key={pageNum}
-                      onClick={() => handlePageChange(pageNum)}
-                      className={`relative inline-flex items-center px-2 py-1 border text-xs font-medium ${
-                        pageNum === pageNumber
-                          ? "z-10 bg-indigo-50 border-indigo-500 text-indigo-600"
-                          : "bg-white border-gray-300 text-gray-500 hover:bg-gray-50"
-                      }`}
-                    >
-                      {pageNum}
-                    </button>
-                  );
-                })}
-
-                <button
-                  onClick={() => handlePageChange(pageNumber + 1)}
-                  disabled={pageNumber >= totalPages}
-                  className="relative inline-flex items-center px-1 py-1 rounded-r border border-gray-300 bg-white text-xs font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ChevronRight className="h-3 w-3" />
-                </button>
-              </nav>
-            </div>
-          </div>
-        </div>
-      )}
+      <Pagination
+        totalCount={totalCount}
+        pageNumber={pageNumber}
+        pageSize={pageSize}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+        onPageSizeChange={handlePageSizeChange}
+        isFiltered={!!(productNameFilter || productCodeFilter)}
+      />
 
       {/* Modal for Product Detail */}
       <CatalogDetail


### PR DESCRIPTION
## Summary

- Add server-side pagination (`pageNumber`, `pageSize`) and LOT/Šarže filter to manufacture order list
- Extract shared `Pagination` component and refactor `CatalogList` to use it
- Reset page to 1 on filter change

## Changes

**Backend:**
- `IManufactureOrderRepository` — `GetOrdersAsync` returns `(Items, TotalCount)` tuple, adds `lotNumber`/`pageNumber`/`pageSize` params
- `ManufactureOrderRepository` — LOT filter on `SemiProduct.LotNumber` and `Product.LotNumber`, COUNT + paged query
- `GetManufactureOrdersRequest` — adds `LotNumber`, `PageNumber`, `PageSize`
- `GetManufactureOrdersResponse` — adds `TotalCount`, `PageNumber`, `PageSize`, `TotalPages`

**Frontend:**
- `Pagination.tsx` — new shared pagination component (mobile + desktop)
- `ManufactureOrderFilters.tsx` — adds LOT/Šarže input field
- `ManufactureOrderList.tsx` — wires pagination state, resets on filter change
- `CatalogList.tsx` — replaces inline pagination with shared `Pagination` component
- `useManufactureOrders.ts` — adds `lotNumber`, `pageNumber`, `pageSize` to request interface

## Test plan

- [ ] Manufacture order list shows 20 items per page by default
- [ ] Page navigation works correctly
- [ ] Changing page size works and resets to page 1
- [ ] LOT filter returns only orders matching the entered lot number
- [ ] Changing filters resets to page 1
- [ ] CatalogList pagination still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)