### PR TITLE
fix(docker): upgrade Node.js from 18 to 20 in frontend build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builds React frontend and ASP.NET Core backend into single container
 
 # Stage 1: Build React Frontend
-FROM node:18-alpine AS frontend-build
+FROM node:20-alpine AS frontend-build
 WORKDIR /app/frontend
 
 # Accept build arguments for React environment variables


### PR DESCRIPTION
## Summary

- Upgrades Node.js from `node:18-alpine` to `node:20-alpine` in the frontend build stage of the Dockerfile

## Root Cause

Node.js v18 does not expose the Web Crypto API (`crypto`) as a global by default. `serialize-javascript` (a dependency of `css-minimizer-webpack-plugin`) calls `crypto.getRandomValues()` expecting it to be globally available, causing:

```
ReferenceError: crypto is not defined
    at generateUID (.../serialize-javascript/index.js:54:17)
```

Node.js v20 exposes `globalThis.crypto` by default, resolving the failure.

## Test plan

- [ ] Docker build completes successfully on CI
- [ ] Frontend build produces output in `wwwroot`
- [ ] Application starts and serves the React app correctly