### PR TITLE
feat(manufacture): Phase 4 - persistence migration + GetErpDocumentItemsAsync (#541)

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -767,6 +767,42 @@ public class FlexiManufactureClient : IManufactureClient
             .ToList();
     }
 
+    public async Task<List<ManufactureErpDocumentItem>> GetErpDocumentItemsAsync(string documentCode, int? documentTypeId = null, CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow().DateTime;
+        var dateFrom = now.AddYears(-5);
+        var dateTo = now.AddDays(1);
+
+        var items = await _stockMovementClient.GetAsync(
+            dateFrom,
+            dateTo,
+            documentCode: documentCode,
+            documentTypeId: documentTypeId,
+            cancellationToken: cancellationToken);
+
+        return items.Select(item => new ManufactureErpDocumentItem
+        {
+            ProductCode = item.ProductCode,
+            ProductName = item.Name,
+            Amount = item.Amount,
+            LotNumber = string.IsNullOrEmpty(item.Batch) ? null : item.Batch,
+            ExpirationDate = ParseExpiration(item.Expiration),
+        }).ToList();
+    }
+
+    private static DateOnly? ParseExpiration(string? expiration)
+    {
+        if (string.IsNullOrEmpty(expiration))
+            return null;
+
+        if (DateOnly.TryParse(expiration, out var date))
+            return date;
+
+        if (DateTime.TryParse(expiration, out var dateTime))
+            return DateOnly.FromDateTime(dateTime);
+
+        return null;
+    }
 
     private static IssuedOrderItemFlexiDto MapToFlexiItem(SubmitManufactureClientItem item,
         SubmitManufactureClientRequest request)

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureClient.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureClient.cs
@@ -9,4 +9,6 @@ public interface IManufactureClient
     Task<ManufactureTemplate?> GetManufactureTemplateAsync(string id, CancellationToken cancellationToken = default);
     Task<List<ManufactureTemplate>> FindByIngredientAsync(string ingredientCode, CancellationToken cancellationToken = default);
     Task<List<ProductPart>> GetSetPartsAsync(string setProductCode, CancellationToken cancellationToken = default);
+
+    Task<List<ManufactureErpDocumentItem>> GetErpDocumentItemsAsync(string documentCode, int? documentTypeId = null, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureErpDocumentItem.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureErpDocumentItem.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Domain.Features.Manufacture;
+
+public class ManufactureErpDocumentItem
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public double Amount { get; set; }
+    public string? Unit { get; set; }
+    public string? LotNumber { get; set; }
+    public DateOnly? ExpirationDate { get; set; }
+}

--- a/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderConfiguration.cs
@@ -73,6 +73,41 @@ public class ManufactureOrderConfiguration : IEntityTypeConfiguration<Manufactur
             .IsRequired(false)
             .AsUtcTimestamp();
 
+        builder.Property(x => x.FlexiDocMaterialIssueForSemiProduct)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocMaterialIssueForSemiProductDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocSemiProductReceipt)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocSemiProductReceiptDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocSemiProductIssueForProduct)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocSemiProductIssueForProductDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocMaterialIssueForProduct)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocMaterialIssueForProductDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocProductReceipt)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocProductReceiptDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
         builder.Property(x => x.WeightWithinTolerance)
             .IsRequired(false);
 

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410183927_AddManufactureOrderFlexiDocNumbers")]
+    partial class AddManufactureOrderFlexiDocNumbers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddManufactureOrderFlexiDocNumbers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForSemiProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForSemiProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
@@ -1187,4 +1187,135 @@ public class FlexiManufactureClientTests
     }
 
     #endregion
+
+    #region GetErpDocumentItemsAsync Tests
+
+    [Fact]
+    public async Task GetErpDocumentItemsAsync_MapsFlexiItems_ReturnsCorrectLotAndExpiration()
+    {
+        // Arrange
+        const string documentCode = "V-VYDEJ-2026-000123";
+        var expirationDate = new DateTime(2027, 6, 30);
+
+        var flexiItem = new StockItemMovementFlexiDto
+        {
+            Name = "Bisabolol",
+            Amount = 5.5,
+            Batch = "LOT-2026-001",
+            Expiration = expirationDate.ToString("yyyy-MM-dd"),
+            Items = new List<StockItemProductFlexiDto>
+            {
+                new StockItemProductFlexiDto { Code = "AKL001" }
+            },
+            DocumentList = new List<StockItemDocumentFlexiDto>
+            {
+                new StockItemDocumentFlexiDto { DocumentCode = documentCode }
+            },
+            StoreList = new List<StockItemStoreFlexiDto>
+            {
+                new StockItemStoreFlexiDto()
+            }
+        };
+
+        _mockStockMovementClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<StockMovementDirection>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                documentCode,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto> { flexiItem });
+
+        // Act
+        var result = await _client.GetErpDocumentItemsAsync(documentCode);
+
+        // Assert
+        Assert.Single(result);
+        var item = result[0];
+        Assert.Equal("AKL001", item.ProductCode);
+        Assert.Equal("Bisabolol", item.ProductName);
+        Assert.Equal(5.5, item.Amount);
+        Assert.Equal("LOT-2026-001", item.LotNumber);
+        Assert.Equal(new DateOnly(2027, 6, 30), item.ExpirationDate);
+    }
+
+    [Fact]
+    public async Task GetErpDocumentItemsAsync_NullBatchAndExpiration_ReturnsNullLotAndExpiration()
+    {
+        // Arrange
+        const string documentCode = "V-PRIJEM-2026-000456";
+
+        var flexiItem = new StockItemMovementFlexiDto
+        {
+            Name = "Glycerol 99%",
+            Amount = 10.0,
+            Batch = null,
+            Expiration = null,
+            Items = new List<StockItemProductFlexiDto>
+            {
+                new StockItemProductFlexiDto { Code = "AKL007" }
+            },
+            DocumentList = new List<StockItemDocumentFlexiDto>
+            {
+                new StockItemDocumentFlexiDto { DocumentCode = documentCode }
+            },
+            StoreList = new List<StockItemStoreFlexiDto>
+            {
+                new StockItemStoreFlexiDto()
+            }
+        };
+
+        _mockStockMovementClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<StockMovementDirection>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                documentCode,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto> { flexiItem });
+
+        // Act
+        var result = await _client.GetErpDocumentItemsAsync(documentCode);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Null(result[0].LotNumber);
+        Assert.Null(result[0].ExpirationDate);
+    }
+
+    [Fact]
+    public async Task GetErpDocumentItemsAsync_EmptyResult_ReturnsEmptyList()
+    {
+        // Arrange
+        const string documentCode = "V-VYDEJ-2026-000999";
+
+        _mockStockMovementClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<StockMovementDirection>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                documentCode,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto>());
+
+        // Act
+        var result = await _client.GetErpDocumentItemsAsync(documentCode);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Add 10 EF Core property mappings to `ManufactureOrderConfiguration` for the 5 FlexiDoc string columns and 5 timestamp columns
- Generate `AddManufactureOrderFlexiDocNumbers` migration — aligns the 5 date columns from `timestamp with time zone` (created in Phase 3) to `timestamp` per project convention
- Create `ManufactureErpDocumentItem` domain DTO (`ProductCode`, `ProductName`, `Amount`, `Unit`, `LotNumber`, `ExpirationDate`)
- Add `IManufactureClient.GetErpDocumentItemsAsync(documentCode, documentTypeId?, ct)` interface method
- Implement in `FlexiManufactureClient`: uses 5-year date range, delegates to `IStockItemsMovementClient.GetAsync` filtered by `documentCode`, maps `Batch→LotNumber` and parses `Expiration` string → `DateOnly?`

## Test plan

- [x] 3 new unit tests in `FlexiManufactureClientTests` — lot/expiration mapping, null batch/expiration, empty result
- [x] All 2170 backend tests pass (`dotnet test --filter FullyQualifiedName!~Integration`)
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet build` — no errors

Closes #541
Part of #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)