### PR TITLE
feat(manufacture): Phase 5 - GetManufactureProtocol use case (#542)

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -767,6 +767,42 @@ public class FlexiManufactureClient : IManufactureClient
             .ToList();
     }
 
+    public async Task<List<ManufactureErpDocumentItem>> GetErpDocumentItemsAsync(string documentCode, int? documentTypeId = null, CancellationToken cancellationToken = default)
+    {
+        var now = _timeProvider.GetUtcNow().DateTime;
+        var dateFrom = now.AddYears(-5);
+        var dateTo = now.AddDays(1);
+
+        var items = await _stockMovementClient.GetAsync(
+            dateFrom,
+            dateTo,
+            documentCode: documentCode,
+            documentTypeId: documentTypeId,
+            cancellationToken: cancellationToken);
+
+        return items.Select(item => new ManufactureErpDocumentItem
+        {
+            ProductCode = item.ProductCode,
+            ProductName = item.Name,
+            Amount = item.Amount,
+            LotNumber = string.IsNullOrEmpty(item.Batch) ? null : item.Batch,
+            ExpirationDate = ParseExpiration(item.Expiration),
+        }).ToList();
+    }
+
+    private static DateOnly? ParseExpiration(string? expiration)
+    {
+        if (string.IsNullOrEmpty(expiration))
+            return null;
+
+        if (DateOnly.TryParse(expiration, out var date))
+            return date;
+
+        if (DateTime.TryParse(expiration, out var dateTime))
+            return DateOnly.FromDateTime(dateTime);
+
+        return null;
+    }
 
     private static IssuedOrderItemFlexiDto MapToFlexiItem(SubmitManufactureClientItem item,
         SubmitManufactureClientRequest request)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Application.Features.Manufacture.Configuration;
 using Anela.Heblo.Application.Features.Manufacture.DashboardTiles;
 using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
 using Anela.Heblo.Application.Features.Manufacture.Services;
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Persistence.Manufacture;
 using Anela.Heblo.Xcc.Services.Dashboard;
@@ -46,6 +47,9 @@ public static class ManufactureModule
         services.RegisterTile<TodayProductionTile>();
         services.RegisterTile<NextDayProductionTile>();
         services.RegisterTile<ManualActionRequiredTile>();
+
+        // Register protocol renderer placeholder (replaced by QuestPdfManufactureProtocolRenderer in Phase 6)
+        services.AddScoped<IManufactureProtocolRenderer, NotImplementedManufactureProtocolRenderer>();
 
         // Register manufacture error transformation
         services.Scan(scan => scan

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolHandler.cs
@@ -1,0 +1,112 @@
+using Anela.Heblo.Domain.Features.Manufacture;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+
+public class GetManufactureProtocolHandler : IRequestHandler<GetManufactureProtocolRequest, GetManufactureProtocolResponse>
+{
+    private readonly IManufactureOrderRepository _repository;
+    private readonly IManufactureClient _manufactureClient;
+    private readonly IManufactureProtocolRenderer _renderer;
+
+    public GetManufactureProtocolHandler(
+        IManufactureOrderRepository repository,
+        IManufactureClient manufactureClient,
+        IManufactureProtocolRenderer renderer)
+    {
+        _repository = repository;
+        _manufactureClient = manufactureClient;
+        _renderer = renderer;
+    }
+
+    public async Task<GetManufactureProtocolResponse> Handle(
+        GetManufactureProtocolRequest request,
+        CancellationToken cancellationToken)
+    {
+        var order = await _repository.GetOrderByIdAsync(request.Id, cancellationToken)
+                    ?? throw new InvalidOperationException($"Manufacture order {request.Id} not found.");
+
+        if (order.State != ManufactureOrderState.Completed)
+        {
+            throw new InvalidOperationException(
+                $"Manufacture order {order.OrderNumber} is not completed; cannot generate protocol.");
+        }
+
+        var erpDocuments = await BuildErpDocumentsAsync(order, cancellationToken);
+
+        var data = new ManufactureProtocolData
+        {
+            OrderNumber = order.OrderNumber,
+            CreatedDate = order.CreatedDate,
+            CompletedAt = order.StateChangedAt,
+            ResponsiblePerson = order.ResponsiblePerson,
+            ManufactureType = order.ManufactureType,
+            SemiProduct = order.SemiProduct == null
+                ? null
+                : new ManufactureProtocolSemiProduct
+                {
+                    ProductCode = order.SemiProduct.ProductCode,
+                    ProductName = order.SemiProduct.ProductName,
+                    PlannedQuantity = order.SemiProduct.PlannedQuantity,
+                    ActualQuantity = order.SemiProduct.ActualQuantity,
+                    LotNumber = order.SemiProduct.LotNumber,
+                    ExpirationDate = order.SemiProduct.ExpirationDate,
+                },
+            Products = order.Products.Select(p => new ManufactureProtocolProduct
+            {
+                ProductCode = p.ProductCode,
+                ProductName = p.ProductName,
+                PlannedQuantity = p.PlannedQuantity,
+                ActualQuantity = p.ActualQuantity,
+                LotNumber = p.LotNumber,
+                ExpirationDate = p.ExpirationDate,
+            }).ToList(),
+            ErpDocuments = erpDocuments,
+            Notes = order.Notes.Select(n => new ManufactureProtocolNote
+            {
+                CreatedAt = n.CreatedAt,
+                CreatedByUser = n.CreatedByUser,
+                Text = n.Text,
+            }).ToList(),
+            GeneratedAt = DateTime.UtcNow,
+        };
+
+        var pdfBytes = _renderer.Render(data);
+
+        return new GetManufactureProtocolResponse
+        {
+            PdfBytes = pdfBytes,
+            FileName = $"ManufactureProtocol-{order.OrderNumber}.pdf",
+        };
+    }
+
+    private async Task<List<ManufactureProtocolErpDocument>> BuildErpDocumentsAsync(
+        ManufactureOrder order,
+        CancellationToken cancellationToken)
+    {
+        var lookups = new List<(string Label, string? Code, DateTime? Date)>
+        {
+            ("Výdej materiálu (polotovar)", order.FlexiDocMaterialIssueForSemiProduct, order.FlexiDocMaterialIssueForSemiProductDate),
+            ("Příjem polotovaru", order.FlexiDocSemiProductReceipt, order.FlexiDocSemiProductReceiptDate),
+            ("Výdej polotovaru (výrobek)", order.FlexiDocSemiProductIssueForProduct, order.FlexiDocSemiProductIssueForProductDate),
+            ("Výdej materiálu (výrobek)", order.FlexiDocMaterialIssueForProduct, order.FlexiDocMaterialIssueForProductDate),
+            ("Příjem výrobku", order.FlexiDocProductReceipt, order.FlexiDocProductReceiptDate),
+        };
+
+        var populated = lookups.Where(l => !string.IsNullOrEmpty(l.Code)).ToList();
+
+        var itemTasks = populated
+            .Select(l => _manufactureClient.GetErpDocumentItemsAsync(l.Code!, cancellationToken: cancellationToken))
+            .ToList();
+
+        var itemResults = await Task.WhenAll(itemTasks);
+
+        return populated.Select((l, idx) => new ManufactureProtocolErpDocument
+        {
+            DocumentType = l.Label,
+            DocumentCode = l.Code!,
+            DocumentDate = l.Date,
+            Items = itemResults[idx].ToList(),
+        }).ToList();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolRequest.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+
+public class GetManufactureProtocolRequest : IRequest<GetManufactureProtocolResponse>
+{
+    public int Id { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolResponse.cs
@@ -1,0 +1,9 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+
+public class GetManufactureProtocolResponse : BaseResponse
+{
+    public byte[] PdfBytes { get; set; } = Array.Empty<byte>();
+    public string FileName { get; set; } = null!;
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/IManufactureProtocolRenderer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/IManufactureProtocolRenderer.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+
+public interface IManufactureProtocolRenderer
+{
+    byte[] Render(ManufactureProtocolData data);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/ManufactureProtocolData.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/ManufactureProtocolData.cs
@@ -1,0 +1,55 @@
+using Anela.Heblo.Domain.Features.Manufacture;
+
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+
+public class ManufactureProtocolData
+{
+    public string OrderNumber { get; set; } = null!;
+    public DateTime CreatedDate { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public string? ResponsiblePerson { get; set; }
+    public ManufactureType ManufactureType { get; set; }
+
+    public ManufactureProtocolSemiProduct? SemiProduct { get; set; }
+    public List<ManufactureProtocolProduct> Products { get; set; } = new();
+
+    public List<ManufactureProtocolErpDocument> ErpDocuments { get; set; } = new();
+    public List<ManufactureProtocolNote> Notes { get; set; } = new();
+
+    public DateTime GeneratedAt { get; set; }
+}
+
+public class ManufactureProtocolSemiProduct
+{
+    public string ProductCode { get; set; } = null!;
+    public string ProductName { get; set; } = null!;
+    public decimal PlannedQuantity { get; set; }
+    public decimal? ActualQuantity { get; set; }
+    public string? LotNumber { get; set; }
+    public DateOnly? ExpirationDate { get; set; }
+}
+
+public class ManufactureProtocolProduct
+{
+    public string ProductCode { get; set; } = null!;
+    public string ProductName { get; set; } = null!;
+    public decimal PlannedQuantity { get; set; }
+    public decimal? ActualQuantity { get; set; }
+    public string? LotNumber { get; set; }
+    public DateOnly? ExpirationDate { get; set; }
+}
+
+public class ManufactureProtocolErpDocument
+{
+    public string DocumentType { get; set; } = null!;
+    public string DocumentCode { get; set; } = null!;
+    public DateTime? DocumentDate { get; set; }
+    public List<ManufactureErpDocumentItem> Items { get; set; } = new();
+}
+
+public class ManufactureProtocolNote
+{
+    public DateTime CreatedAt { get; set; }
+    public string CreatedByUser { get; set; } = null!;
+    public string Text { get; set; } = null!;
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/NotImplementedManufactureProtocolRenderer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/NotImplementedManufactureProtocolRenderer.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+
+/// <summary>
+/// Placeholder renderer registered until Phase 6 installs the real QuestPDF implementation.
+/// </summary>
+internal sealed class NotImplementedManufactureProtocolRenderer : IManufactureProtocolRenderer
+{
+    public byte[] Render(ManufactureProtocolData data)
+    {
+        throw new NotImplementedException(
+            "PDF rendering is not yet implemented. Register QuestPdfManufactureProtocolRenderer from the API project.");
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureClient.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureClient.cs
@@ -9,4 +9,6 @@ public interface IManufactureClient
     Task<ManufactureTemplate?> GetManufactureTemplateAsync(string id, CancellationToken cancellationToken = default);
     Task<List<ManufactureTemplate>> FindByIngredientAsync(string ingredientCode, CancellationToken cancellationToken = default);
     Task<List<ProductPart>> GetSetPartsAsync(string setProductCode, CancellationToken cancellationToken = default);
+
+    Task<List<ManufactureErpDocumentItem>> GetErpDocumentItemsAsync(string documentCode, int? documentTypeId = null, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureErpDocumentItem.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/ManufactureErpDocumentItem.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Domain.Features.Manufacture;
+
+public class ManufactureErpDocumentItem
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public double Amount { get; set; }
+    public string? Unit { get; set; }
+    public string? LotNumber { get; set; }
+    public DateOnly? ExpirationDate { get; set; }
+}

--- a/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Manufacture/ManufactureOrderConfiguration.cs
@@ -73,6 +73,41 @@ public class ManufactureOrderConfiguration : IEntityTypeConfiguration<Manufactur
             .IsRequired(false)
             .AsUtcTimestamp();
 
+        builder.Property(x => x.FlexiDocMaterialIssueForSemiProduct)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocMaterialIssueForSemiProductDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocSemiProductReceipt)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocSemiProductReceiptDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocSemiProductIssueForProduct)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocSemiProductIssueForProductDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocMaterialIssueForProduct)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocMaterialIssueForProductDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
+        builder.Property(x => x.FlexiDocProductReceipt)
+            .IsRequired(false);
+
+        builder.Property(x => x.FlexiDocProductReceiptDate)
+            .IsRequired(false)
+            .AsUtcTimestamp();
+
         builder.Property(x => x.WeightWithinTolerance)
             .IsRequired(false);
 

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410183927_AddManufactureOrderFlexiDocNumbers")]
+    partial class AddManufactureOrderFlexiDocNumbers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260410183927_AddManufactureOrderFlexiDocNumbers.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddManufactureOrderFlexiDocNumbers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForSemiProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocSemiProductIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocProductReceiptDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForSemiProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "FlexiDocMaterialIssueForProductDate",
+                schema: "public",
+                table: "ManufactureOrders",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp",
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
@@ -1187,4 +1187,135 @@ public class FlexiManufactureClientTests
     }
 
     #endregion
+
+    #region GetErpDocumentItemsAsync Tests
+
+    [Fact]
+    public async Task GetErpDocumentItemsAsync_MapsFlexiItems_ReturnsCorrectLotAndExpiration()
+    {
+        // Arrange
+        const string documentCode = "V-VYDEJ-2026-000123";
+        var expirationDate = new DateTime(2027, 6, 30);
+
+        var flexiItem = new StockItemMovementFlexiDto
+        {
+            Name = "Bisabolol",
+            Amount = 5.5,
+            Batch = "LOT-2026-001",
+            Expiration = expirationDate.ToString("yyyy-MM-dd"),
+            Items = new List<StockItemProductFlexiDto>
+            {
+                new StockItemProductFlexiDto { Code = "AKL001" }
+            },
+            DocumentList = new List<StockItemDocumentFlexiDto>
+            {
+                new StockItemDocumentFlexiDto { DocumentCode = documentCode }
+            },
+            StoreList = new List<StockItemStoreFlexiDto>
+            {
+                new StockItemStoreFlexiDto()
+            }
+        };
+
+        _mockStockMovementClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<StockMovementDirection>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                documentCode,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto> { flexiItem });
+
+        // Act
+        var result = await _client.GetErpDocumentItemsAsync(documentCode);
+
+        // Assert
+        Assert.Single(result);
+        var item = result[0];
+        Assert.Equal("AKL001", item.ProductCode);
+        Assert.Equal("Bisabolol", item.ProductName);
+        Assert.Equal(5.5, item.Amount);
+        Assert.Equal("LOT-2026-001", item.LotNumber);
+        Assert.Equal(new DateOnly(2027, 6, 30), item.ExpirationDate);
+    }
+
+    [Fact]
+    public async Task GetErpDocumentItemsAsync_NullBatchAndExpiration_ReturnsNullLotAndExpiration()
+    {
+        // Arrange
+        const string documentCode = "V-PRIJEM-2026-000456";
+
+        var flexiItem = new StockItemMovementFlexiDto
+        {
+            Name = "Glycerol 99%",
+            Amount = 10.0,
+            Batch = null,
+            Expiration = null,
+            Items = new List<StockItemProductFlexiDto>
+            {
+                new StockItemProductFlexiDto { Code = "AKL007" }
+            },
+            DocumentList = new List<StockItemDocumentFlexiDto>
+            {
+                new StockItemDocumentFlexiDto { DocumentCode = documentCode }
+            },
+            StoreList = new List<StockItemStoreFlexiDto>
+            {
+                new StockItemStoreFlexiDto()
+            }
+        };
+
+        _mockStockMovementClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<StockMovementDirection>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                documentCode,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto> { flexiItem });
+
+        // Act
+        var result = await _client.GetErpDocumentItemsAsync(documentCode);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Null(result[0].LotNumber);
+        Assert.Null(result[0].ExpirationDate);
+    }
+
+    [Fact]
+    public async Task GetErpDocumentItemsAsync_EmptyResult_ReturnsEmptyList()
+    {
+        // Arrange
+        const string documentCode = "V-VYDEJ-2026-000999";
+
+        _mockStockMovementClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<StockMovementDirection>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                documentCode,
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto>());
+
+        // Act
+        var result = await _client.GetErpDocumentItemsAsync(documentCode);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    #endregion
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureProtocolHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureProtocolHandlerTests.cs
@@ -1,0 +1,207 @@
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+using Anela.Heblo.Domain.Features.Manufacture;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture;
+
+public class GetManufactureProtocolHandlerTests
+{
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock = new();
+    private readonly Mock<IManufactureClient> _flexiMock = new();
+    private readonly Mock<IManufactureProtocolRenderer> _rendererMock = new();
+    private readonly GetManufactureProtocolHandler _handler;
+
+    private static readonly byte[] PdfMagicBytes = new byte[] { 0x25, 0x50, 0x44, 0x46 };
+
+    public GetManufactureProtocolHandlerTests()
+    {
+        _handler = new GetManufactureProtocolHandler(
+            _repositoryMock.Object,
+            _flexiMock.Object,
+            _rendererMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NonCompletedOrder_Throws()
+    {
+        var order = new ManufactureOrder { Id = 1, State = ManufactureOrderState.Planned, OrderNumber = "MO-2026-001" };
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        Func<Task> act = () => _handler.Handle(new GetManufactureProtocolRequest { Id = 1 }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+                 .WithMessage("*completed*");
+    }
+
+    [Fact]
+    public async Task Handle_OrderNotFound_Throws()
+    {
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder?)null);
+
+        Func<Task> act = () => _handler.Handle(new GetManufactureProtocolRequest { Id = 999 }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+                 .WithMessage("*999*");
+    }
+
+    [Fact]
+    public async Task Handle_CompletedOrder_ReturnsPdfWithCorrectFileName()
+    {
+        var order = BuildCompletedOrder();
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _flexiMock
+            .Setup(x => x.GetErpDocumentItemsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureErpDocumentItem>());
+
+        _rendererMock
+            .Setup(r => r.Render(It.IsAny<ManufactureProtocolData>()))
+            .Returns(PdfMagicBytes);
+
+        var result = await _handler.Handle(new GetManufactureProtocolRequest { Id = 1 }, CancellationToken.None);
+
+        result.PdfBytes.Should().StartWith(PdfMagicBytes);
+        result.FileName.Should().Be("ManufactureProtocol-MO-2026-001.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_CompletedOrder_FetchesItemsForEachPopulatedFlexiDoc()
+    {
+        var order = BuildCompletedOrder();
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _flexiMock
+            .Setup(x => x.GetErpDocumentItemsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureErpDocumentItem>
+            {
+                new() { ProductCode = "CHEM-001", Amount = 5.0, LotNumber = "L001", ExpirationDate = new DateOnly(2027, 1, 1) }
+            });
+
+        _rendererMock
+            .Setup(r => r.Render(It.IsAny<ManufactureProtocolData>()))
+            .Returns(PdfMagicBytes);
+
+        await _handler.Handle(new GetManufactureProtocolRequest { Id = 1 }, CancellationToken.None);
+
+        // Order has 4 non-null FlexiDoc codes (MaterialIssueForProduct is null)
+        _flexiMock.Verify(
+            x => x.GetErpDocumentItemsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(4));
+    }
+
+    [Fact]
+    public async Task Handle_CompletedOrder_BuildsErpDocumentsWithCorrectLabels()
+    {
+        var order = BuildCompletedOrder();
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _flexiMock
+            .Setup(x => x.GetErpDocumentItemsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureErpDocumentItem>());
+
+        ManufactureProtocolData? capturedData = null;
+        _rendererMock
+            .Setup(r => r.Render(It.IsAny<ManufactureProtocolData>()))
+            .Callback<ManufactureProtocolData>(d => capturedData = d)
+            .Returns(PdfMagicBytes);
+
+        await _handler.Handle(new GetManufactureProtocolRequest { Id = 1 }, CancellationToken.None);
+
+        capturedData.Should().NotBeNull();
+        capturedData!.ErpDocuments.Should().HaveCount(4);
+        capturedData.ErpDocuments.Select(d => d.DocumentCode)
+            .Should().Contain(new[] { "V-MAT-001", "V-POL-001", "V-POL-OUT-001", "V-PROD-001" });
+    }
+
+    [Fact]
+    public async Task Handle_CompletedOrder_MapsOrderDataToProtocolData()
+    {
+        var order = BuildCompletedOrder();
+        _repositoryMock
+            .Setup(r => r.GetOrderByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _flexiMock
+            .Setup(x => x.GetErpDocumentItemsAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ManufactureErpDocumentItem>());
+
+        ManufactureProtocolData? capturedData = null;
+        _rendererMock
+            .Setup(r => r.Render(It.IsAny<ManufactureProtocolData>()))
+            .Callback<ManufactureProtocolData>(d => capturedData = d)
+            .Returns(PdfMagicBytes);
+
+        await _handler.Handle(new GetManufactureProtocolRequest { Id = 1 }, CancellationToken.None);
+
+        capturedData.Should().NotBeNull();
+        capturedData!.OrderNumber.Should().Be("MO-2026-001");
+        capturedData.ResponsiblePerson.Should().Be("Jana Nováková");
+        capturedData.SemiProduct.Should().NotBeNull();
+        capturedData.SemiProduct!.ProductCode.Should().Be("POL-001");
+        capturedData.SemiProduct.LotNumber.Should().Be("L20260402");
+        capturedData.Products.Should().HaveCount(1);
+        capturedData.Products[0].ProductCode.Should().Be("PRD-001");
+        capturedData.Notes.Should().HaveCount(1);
+        capturedData.Notes[0].Text.Should().Be("Test note");
+    }
+
+    private static ManufactureOrder BuildCompletedOrder()
+    {
+        return new ManufactureOrder
+        {
+            Id = 1,
+            OrderNumber = "MO-2026-001",
+            State = ManufactureOrderState.Completed,
+            CreatedDate = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            StateChangedAt = new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc),
+            ResponsiblePerson = "Jana Nováková",
+            ManufactureType = ManufactureType.MultiPhase,
+            SemiProduct = new ManufactureOrderSemiProduct
+            {
+                ProductCode = "POL-001",
+                ProductName = "Polotovar A",
+                PlannedQuantity = 10,
+                ActualQuantity = 9.8m,
+                LotNumber = "L20260402",
+                ExpirationDate = new DateOnly(2027, 4, 2),
+            },
+            Products = new List<ManufactureOrderProduct>
+            {
+                new()
+                {
+                    ProductCode = "PRD-001",
+                    ProductName = "Krém",
+                    PlannedQuantity = 50,
+                    ActualQuantity = 48,
+                    LotNumber = "L20260402A",
+                    ExpirationDate = new DateOnly(2027, 4, 2),
+                }
+            },
+            Notes = new List<ManufactureOrderNote>
+            {
+                new() { CreatedAt = DateTime.UtcNow, CreatedByUser = "Test User", Text = "Test note" }
+            },
+            FlexiDocMaterialIssueForSemiProduct = "V-MAT-001",
+            FlexiDocMaterialIssueForSemiProductDate = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            FlexiDocSemiProductReceipt = "V-POL-001",
+            FlexiDocSemiProductReceiptDate = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            FlexiDocSemiProductIssueForProduct = "V-POL-OUT-001",
+            FlexiDocSemiProductIssueForProductDate = new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc),
+            FlexiDocMaterialIssueForProduct = null, // Optional — not present in this order
+            FlexiDocProductReceipt = "V-PROD-001",
+            FlexiDocProductReceiptDate = new DateTime(2026, 4, 2, 0, 0, 0, DateTimeKind.Utc),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `GetManufactureProtocolRequest/Response` MediatR DTOs (classes, not records per project convention)
- Create `ManufactureProtocolData` DTO family (`ManufactureProtocolSemiProduct`, `ManufactureProtocolProduct`, `ManufactureProtocolErpDocument`, `ManufactureProtocolNote`) used by the PDF renderer
- Introduce `IManufactureProtocolRenderer` abstraction in Application layer — keeps handler unit-testable without QuestPDF dependency
- Implement `GetManufactureProtocolHandler`: validates `State == Completed`, builds 5 ERP-document lookup tuples, filters null codes, fetches items in parallel via `Task.WhenAll`, assembles `ManufactureProtocolData`, delegates rendering
- Register `NotImplementedManufactureProtocolRenderer` placeholder in `ManufactureModule` (replaced by `QuestPdfManufactureProtocolRenderer` in Phase 6)

## Test plan

- [x] 6 unit tests in `GetManufactureProtocolHandlerTests`: non-completed order throws, not-found throws, correct PDF filename, parallel fetch count matches populated FlexiDoc codes, ERP document labels/codes correct, full data mapping (semi-product, products, notes)
- [x] All 2,178 backend tests pass (`dotnet test --filter FullyQualifiedName!~Integration`)
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet build` — 0 errors

Closes #542
Part of #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)