### PR TITLE
fix(manufacture): round semiproduct consumption amounts to avoid floating-point overflow

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -534,12 +534,13 @@ public class FlexiManufactureClient : IManufactureClient
                 // Track cost per manufactured product
                 productCosts[consumptionItem.SourceProductCode] += unitPrice * consumptionItem.Amount;
 
+                var amount = Math.Round(consumptionItem.Amount, 6);
                 stockMovementItems.Add(new StockItemsMovementUpsertRequestItemFlexiDto
                 {
                     ProductCode = consumptionItem.ProductCode,
                     ProductName = consumptionItem.ProductName,
-                    Amount = consumptionItem.Amount,
-                    AmountIssued = consumptionItem.Amount,
+                    Amount = amount,
+                    AmountIssued = amount,
                     LotNumber = consumptionItem.LotNumber,
                     Expiration = consumptionItem.Expiration?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
                     UnitPrice = unitPrice,

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -396,14 +396,15 @@ public class FlexiManufactureClient : IManufactureClient
             {
                 var stockItem = stockItems.FirstOrDefault(s => s.ProductCode == consumptionItem.ProductCode);
                 var unitPrice = stockItem != null ? (double)stockItem.Price : 0;
-                totalConsumptionCost += unitPrice * consumptionItem.Amount;
+                var amount = Math.Round(consumptionItem.Amount, 4);
+                totalConsumptionCost += unitPrice * amount;
 
                 stockMovementItems.Add(new StockItemsMovementUpsertRequestItemFlexiDto
                 {
                     ProductCode = consumptionItem.ProductCode,
                     ProductName = consumptionItem.ProductName,
-                    Amount = consumptionItem.Amount,
-                    AmountIssued = consumptionItem.Amount,
+                    Amount = amount,
+                    AmountIssued = amount,
                     LotNumber = consumptionItem.LotNumber,
                     Expiration = consumptionItem.Expiration?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
                     UnitPrice = unitPrice
@@ -534,7 +535,7 @@ public class FlexiManufactureClient : IManufactureClient
                 // Track cost per manufactured product
                 productCosts[consumptionItem.SourceProductCode] += unitPrice * consumptionItem.Amount;
 
-                var amount = Math.Round(consumptionItem.Amount, 6);
+                var amount = Math.Round(consumptionItem.Amount, 4);
                 stockMovementItems.Add(new StockItemsMovementUpsertRequestItemFlexiDto
                 {
                     ProductCode = consumptionItem.ProductCode,


### PR DESCRIPTION
## Summary
- Casting `decimal` `AdjustedConsumption` values to `double` introduces floating-point errors (~1e-13) that accumulate across FEFO lot allocations
- This caused Flexi to reject the stock movement document because the total consumed amount (e.g. `5800.0000000000009`) slightly exceeded available stock (`5800.0`)
- Fix: round amounts to 6 decimal places when building `StockItemsMovementUpsertRequestItemFlexiDto`, preserving all meaningful precision while eliminating double-precision noise

## Test Plan
- [ ] All 2063 backend tests pass
- [ ] All 744 frontend tests pass
- [ ] Verify manufacture submission with residue distribution no longer fails with floating-point overflow on Flexi

🤖 Generated with [Claude Code](https://claude.com/claude-code)