### PR TITLE
fix(shoptet): add EnsureSuccessStatusCode to prevent CsvHelper MissingFieldException on HTTP 500

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/Price/ShoptetPriceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/Price/ShoptetPriceClient.cs
@@ -23,26 +23,30 @@ public class ShoptetPriceClient : IProductPriceEshopClient
         List<ProductPriceEshop> priceList = new List<ProductPriceEshop>();
 
         using (HttpResponseMessage response = await _httpClient.GetAsync(_options.Value.ProductExportUrl, cancellationToken))
-        using (Stream csvStream = await response.Content.ReadAsStreamAsync(cancellationToken))
-        using (StreamReader reader = new StreamReader(csvStream, Encoding.GetEncoding("windows-1250")))
-        using (CsvReader csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ";" }))
         {
-            csv.Context.RegisterClassMap<ProductPriceImportMap>();
+            response.EnsureSuccessStatusCode();
 
-            // Read records and calculate PriceWithoutVat
-            var rawRecords = csv.GetRecords<ProductPriceImportRecord>().ToList();
-
-            foreach (var record in rawRecords)
+            using (Stream csvStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+            using (StreamReader reader = new StreamReader(csvStream, Encoding.GetEncoding("windows-1250")))
+            using (CsvReader csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ";" }))
             {
-                var product = new ProductPriceEshop
-                {
-                    ProductCode = record.ProductCode,
-                    PriceWithVat = record.PriceWithVat,
-                    PriceWithoutVat = (decimal)((double)(record.PriceWithVat ?? 0) / (double)((record?.PercentVat ?? 21) / 100 + 1)),
-                    PurchasePrice = record.PurchasePrice
-                };
+                csv.Context.RegisterClassMap<ProductPriceImportMap>();
 
-                priceList.Add(product);
+                // Read records and calculate PriceWithoutVat
+                var rawRecords = csv.GetRecords<ProductPriceImportRecord>().ToList();
+
+                foreach (var record in rawRecords)
+                {
+                    var product = new ProductPriceEshop
+                    {
+                        ProductCode = record.ProductCode,
+                        PriceWithVat = record.PriceWithVat,
+                        PriceWithoutVat = (decimal)((double)(record.PriceWithVat ?? 0) / (double)((record?.PercentVat ?? 21) / 100 + 1)),
+                        PurchasePrice = record.PurchasePrice
+                    };
+
+                    priceList.Add(product);
+                }
             }
         }
 
@@ -146,4 +150,3 @@ public class ShoptetPriceClient : IProductPriceEshopClient
         }
     }
 }
-

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/Stock/ShoptetStockClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/Stock/ShoptetStockClient.cs
@@ -35,12 +35,16 @@ public class ShoptetStockClient : IEshopStockClient
             List<EshopStock> stockDataList = new List<EshopStock>();
 
             using (HttpResponseMessage response = await _client.GetAsync(_options.Value.Url, cancellationToken))
-            using (Stream csvStream = await response.Content.ReadAsStreamAsync(cancellationToken))
-            using (StreamReader reader = new StreamReader(csvStream, Encoding.GetEncoding("windows-1250")))
-            using (CsvReader csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ";" }))
             {
-                csv.Context.RegisterClassMap<StockDataMap>();
-                stockDataList = csv.GetRecords<EshopStock>().ToList();
+                response.EnsureSuccessStatusCode();
+
+                using (Stream csvStream = await response.Content.ReadAsStreamAsync(cancellationToken))
+                using (StreamReader reader = new StreamReader(csvStream, Encoding.GetEncoding("windows-1250")))
+                using (CsvReader csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ";" }))
+                {
+                    csv.Context.RegisterClassMap<StockDataMap>();
+                    stockDataList = csv.GetRecords<EshopStock>().ToList();
+                }
             }
 
             return stockDataList;

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/ShoptetPriceClientHttp500Tests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/ShoptetPriceClientHttp500Tests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Text;
+using Anela.Heblo.Adapters.Shoptet.Price;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Shoptet.Tests.Unit;
+
+public class ShoptetPriceClientHttp500Tests
+{
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+    private readonly Mock<IOptions<ProductPriceOptions>> _mockOptions;
+    private readonly ShoptetPriceClient _client;
+
+    public ShoptetPriceClientHttp500Tests()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+        _mockOptions = new Mock<IOptions<ProductPriceOptions>>();
+
+        _mockOptions.Setup(o => o.Value).Returns(new ProductPriceOptions
+        {
+            ProductExportUrl = "https://test.com/export.csv"
+        });
+
+        _client = new ShoptetPriceClient(_httpClient, _mockOptions.Object);
+    }
+
+    private void SetupHttpResponse(HttpStatusCode statusCode, string body)
+    {
+        var responseMessage = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8)
+        };
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(responseMessage);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenServerReturns500_ThrowsHttpRequestException()
+    {
+        // Arrange – simulate Shoptet returning an HTML error page with HTTP 500
+        var htmlErrorBody = "<html><body><h1>Internal Server Error</h1></body></html>";
+        SetupHttpResponse(HttpStatusCode.InternalServerError, htmlErrorBody);
+
+        // Act
+        Func<Task> act = async () => await _client.GetAllAsync(CancellationToken.None);
+
+        // Assert – HttpRequestException must be thrown, NOT CsvHelper.MissingFieldException
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenServerReturns503_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var htmlErrorBody = "<html><body><h1>Service Unavailable</h1></body></html>";
+        SetupHttpResponse(HttpStatusCode.ServiceUnavailable, htmlErrorBody);
+
+        // Act
+        Func<Task> act = async () => await _client.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenServerReturns404_ThrowsHttpRequestException()
+    {
+        // Arrange
+        SetupHttpResponse(HttpStatusCode.NotFound, "Not Found");
+
+        // Act
+        Func<Task> act = async () => await _client.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenServerReturns200_DoesNotThrowHttpRequestException()
+    {
+        // Arrange – valid CSV response
+        var csvData = "CODE;PAIR;NAME;PRICE;PURCHASE;INCLUDING_VAT;PERCENT_VAT\n" +
+                      "PROD001;PAIR001;Product 1;120,00;80,00;true;20\n";
+
+        SetupHttpResponse(HttpStatusCode.OK, csvData);
+
+        // Act
+        Func<Task> act = async () => await _client.GetAllAsync(CancellationToken.None);
+
+        // Assert – no exception for a successful response
+        await act.Should().NotThrowAsync<HttpRequestException>();
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/ShoptetStockClientHttp500Tests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/ShoptetStockClientHttp500Tests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Text;
+using Anela.Heblo.Adapters.Shoptet.Stock;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Shoptet.Tests.Unit;
+
+public class ShoptetStockClientHttp500Tests
+{
+    private readonly Mock<HttpMessageHandler> _mockHttpMessageHandler;
+    private readonly HttpClient _httpClient;
+    private readonly Mock<IOptions<ShoptetStockClientOptions>> _mockOptions;
+    private readonly ShoptetStockClient _client;
+
+    public ShoptetStockClientHttp500Tests()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpMessageHandler.Object);
+        _mockOptions = new Mock<IOptions<ShoptetStockClientOptions>>();
+
+        _mockOptions.Setup(o => o.Value).Returns(new ShoptetStockClientOptions
+        {
+            Url = "https://test.com/stock-export.csv"
+        });
+
+        _client = new ShoptetStockClient(_httpClient, _mockOptions.Object);
+    }
+
+    private void SetupHttpResponse(HttpStatusCode statusCode, string body)
+    {
+        var responseMessage = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8)
+        };
+
+        _mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(responseMessage);
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenServerReturns500_ThrowsHttpRequestException()
+    {
+        // Arrange – simulate Shoptet returning an HTML error page with HTTP 500
+        var htmlErrorBody = "<html><body><h1>Internal Server Error</h1></body></html>";
+        SetupHttpResponse(HttpStatusCode.InternalServerError, htmlErrorBody);
+
+        // Act
+        Func<Task> act = async () => await _client.ListAsync(CancellationToken.None);
+
+        // Assert – HttpRequestException must be thrown, NOT CsvHelper.MissingFieldException
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenServerReturns503_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var htmlErrorBody = "<html><body><h1>Service Unavailable</h1></body></html>";
+        SetupHttpResponse(HttpStatusCode.ServiceUnavailable, htmlErrorBody);
+
+        // Act
+        Func<Task> act = async () => await _client.ListAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenServerReturns404_ThrowsHttpRequestException()
+    {
+        // Arrange
+        SetupHttpResponse(HttpStatusCode.NotFound, "Not Found");
+
+        // Act
+        Func<Task> act = async () => await _client.ListAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #504

Adds `response.EnsureSuccessStatusCode()` after `GetAsync` in `ShoptetPriceClient` and `ShoptetStockClient` to prevent CsvHelper from receiving HTML error pages as CSV input when the Shoptet export endpoint returns HTTP 500.

## Changes
- `ShoptetPriceClient.GetAllAsync`: Added HTTP status check before CSV parsing
- `ShoptetStockClient.ListAsync`: Added HTTP status check before CSV parsing
- Added unit tests for HTTP 500, 503, and 404 error handling in `ShoptetPriceClientHttp500Tests`
- Added unit tests for HTTP 500, 503, and 404 error handling in `ShoptetStockClientHttp500Tests`

## Testing
- All 30 unit tests pass (23 pre-existing + 7 new)
- New tests verify `HttpRequestException` is thrown (not `MissingFieldException`) when server returns 5xx/4xx
- Integration tests skipped (require live Shoptet credentials — expected in CI)

@claude