### PR TITLE
feat(manufacture): Manufacture Protocol PDF generation (Phases 5-7)

### DIFF
--- a/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+++ b/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
@@ -28,6 +28,7 @@
         <PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
         <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.14.1" />
         <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.8" />
+        <PackageReference Include="QuestPDF" Version="2024.3.4" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
         <PackageReference Include="NSwag.AspNetCore" Version="14.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/backend/src/Anela.Heblo.API/Controllers/ManufactureOrderController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/ManufactureOrderController.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOrders;
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOrder;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CreateManufactureOrder;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrder;
@@ -296,6 +297,24 @@ public class ManufactureOrderController : BaseApiController
 
         var response = await _mediator.Send(request);
         return HandleResponse(response);
+    }
+
+    /// <summary>
+    /// Generate manufacture protocol PDF for a completed order
+    /// </summary>
+    [HttpGet("{id}/protocol.pdf")]
+    public async Task<IActionResult> GetProtocolPdf(int id)
+    {
+        var request = new GetManufactureProtocolRequest { Id = id };
+        try
+        {
+            var response = await _mediator.Send(request);
+            return File(response.PdfBytes, "application/pdf", response.FileName);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     /// <summary>

--- a/backend/src/Anela.Heblo.API/Controllers/ManufactureOrderController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/ManufactureOrderController.cs
@@ -303,12 +303,12 @@ public class ManufactureOrderController : BaseApiController
     /// Generate manufacture protocol PDF for a completed order
     /// </summary>
     [HttpGet("{id}/protocol.pdf")]
-    public async Task<IActionResult> GetProtocolPdf(int id)
+    public async Task<IActionResult> GetProtocolPdf(int id, CancellationToken cancellationToken)
     {
         var request = new GetManufactureProtocolRequest { Id = id };
         try
         {
-            var response = await _mediator.Send(request);
+            var response = await _mediator.Send(request, cancellationToken);
             return File(response.PdfBytes, "application/pdf", response.FileName);
         }
         catch (InvalidOperationException ex)

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -18,7 +18,9 @@ using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.Cups;
 using Anela.Heblo.Adapters.Cups.Features.ExpeditionList;
 using Anela.Heblo.API.Features.ExpeditionList;
+using Anela.Heblo.API.PDFPrints;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 
 namespace Anela.Heblo.API.Extensions;
 
@@ -115,6 +117,9 @@ public static class ServiceCollectionExtensions
             logging.ResponseBodyLogLimit = 4096;
         });
         services.AddHttpLoggingInterceptor<SuppressHealthHttpLogging>();
+
+        // PDF renderer — lives in API layer because QuestPDF is not a dependency of Application layer
+        services.AddScoped<IManufactureProtocolRenderer, QuestPdfManufactureProtocolRenderer>();
 
         // Note: Application services are now registered in vertical slice modules
         // This method is kept for backward compatibility and other cross-cutting concerns

--- a/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
+++ b/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
@@ -138,7 +138,7 @@ public class ManufactureProtocolDocument : IDocument
                         {
                             t.DefaultTextStyle(x => x.FontSize(10));
                             t.Span($"{erpDoc.DocumentCode}").Bold();
-                            t.Span($"  –  {erpDoc.DocumentLabel}").FontColor(Colors.Grey.Darken1);
+                            t.Span($"  –  {erpDoc.DocumentType}").FontColor(Colors.Grey.Darken1);
                         });
 
                         col.Item().PaddingTop(4);

--- a/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
+++ b/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
@@ -1,0 +1,228 @@
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace Anela.Heblo.API.PDFPrints;
+
+public class ManufactureProtocolDocument : IDocument
+{
+    static ManufactureProtocolDocument()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    private readonly ManufactureProtocolData _data;
+
+    public ManufactureProtocolDocument(ManufactureProtocolData data)
+    {
+        _data = data;
+    }
+
+    public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+
+    public DocumentSettings GetSettings() => DocumentSettings.Default;
+
+    public void Compose(IDocumentContainer container)
+    {
+        container.Page(page =>
+        {
+            page.Size(PageSizes.A4);
+            page.Margin(1.5f, Unit.Centimetre);
+            page.DefaultTextStyle(x => x.FontSize(9));
+
+            page.Header().Column(header =>
+            {
+                header.Item().Text(_data.OrderNumber).FontSize(16).Bold();
+                header.Item().Text($"Vygenerováno: {_data.GeneratedAt:dd.MM.yyyy HH:mm}").FontSize(8).FontColor(Colors.Grey.Darken1);
+                header.Item().PaddingTop(4).LineHorizontal(1f).LineColor(Colors.Grey.Lighten1);
+            });
+
+            page.Content().PaddingTop(8).Column(col =>
+            {
+                // Basic info row
+                col.Item().Row(row =>
+                {
+                    row.RelativeItem().Column(c =>
+                    {
+                        c.Item().Text(t =>
+                        {
+                            t.Span("Odpovědná osoba: ").Bold();
+                            t.Span(_data.ResponsiblePerson ?? "—");
+                        });
+                    });
+
+                    row.RelativeItem().Column(c =>
+                    {
+                        c.Item().Text(t =>
+                        {
+                            t.Span("Plánované datum: ").Bold();
+                            t.Span(_data.PlannedDate.ToString("dd.MM.yyyy"));
+                        });
+                    });
+                });
+
+                col.Item().PaddingTop(10);
+
+                // Semi-product section
+                if (_data.SemiProduct != null)
+                {
+                    col.Item().Text("Polotovar").FontSize(11).Bold();
+                    col.Item().PaddingTop(4);
+
+                    col.Item().Table(table =>
+                    {
+                        table.ColumnsDefinition(cols =>
+                        {
+                            cols.RelativeColumn(2);   // Kód
+                            cols.RelativeColumn(4);   // Název
+                            cols.RelativeColumn(2);   // Skutečné množství
+                            cols.RelativeColumn(2);   // Šarže
+                            cols.RelativeColumn(2);   // Expirace
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Element(HeaderCell).Text("Kód").Bold();
+                            header.Cell().Element(HeaderCell).Text("Název").Bold();
+                            header.Cell().Element(HeaderCell).Text("Skut. množství").Bold();
+                            header.Cell().Element(HeaderCell).Text("Šarže").Bold();
+                            header.Cell().Element(HeaderCell).Text("Expirace").Bold();
+                        });
+
+                        var sp = _data.SemiProduct;
+                        table.Cell().Element(DataCell).Text(sp.ProductCode);
+                        table.Cell().Element(DataCell).Text(sp.ProductName);
+                        table.Cell().Element(DataCell).Text(sp.ActualQuantity?.ToString("0.###") ?? "—");
+                        table.Cell().Element(DataCell).Text(sp.LotNumber ?? "—");
+                        table.Cell().Element(DataCell).Text(sp.ExpirationDate?.ToString("dd.MM.yyyy") ?? "—");
+                    });
+
+                    col.Item().PaddingTop(10);
+                }
+
+                // Products table
+                col.Item().Text("Výrobky").FontSize(11).Bold();
+                col.Item().PaddingTop(4);
+
+                col.Item().Table(table =>
+                {
+                    table.ColumnsDefinition(cols =>
+                    {
+                        cols.RelativeColumn(2);   // Kód
+                        cols.RelativeColumn(6);   // Název
+                        cols.RelativeColumn(2);   // Skutečné množství
+                    });
+
+                    table.Header(header =>
+                    {
+                        header.Cell().Element(HeaderCell).Text("Kód").Bold();
+                        header.Cell().Element(HeaderCell).Text("Název").Bold();
+                        header.Cell().Element(HeaderCell).Text("Skut. množství").Bold();
+                    });
+
+                    foreach (var product in _data.Products)
+                    {
+                        table.Cell().Element(DataCell).Text(product.ProductCode);
+                        table.Cell().Element(DataCell).Text(product.ProductName);
+                        table.Cell().Element(DataCell).Text(product.ActualQuantity?.ToString("0.###") ?? "—");
+                    }
+                });
+
+                col.Item().PaddingTop(10);
+
+                // ERP documents section
+                if (_data.ErpDocuments.Count > 0)
+                {
+                    col.Item().Text("ABRA Flexi doklady a spotřeba").FontSize(11).Bold();
+
+                    foreach (var erpDoc in _data.ErpDocuments)
+                    {
+                        col.Item().PaddingTop(8);
+                        col.Item().Text(t =>
+                        {
+                            t.DefaultTextStyle(x => x.FontSize(10));
+                            t.Span($"{erpDoc.DocumentCode}").Bold();
+                            t.Span($"  –  {erpDoc.DocumentLabel}").FontColor(Colors.Grey.Darken1);
+                        });
+
+                        col.Item().PaddingTop(4);
+
+                        col.Item().Table(table =>
+                        {
+                            table.ColumnsDefinition(cols =>
+                            {
+                                cols.RelativeColumn(2);   // Kód
+                                cols.RelativeColumn(4);   // Název
+                                cols.RelativeColumn(1.5f); // Množství
+                                cols.RelativeColumn(1.5f); // Jednotka
+                                cols.RelativeColumn(2);   // Šarže
+                                cols.RelativeColumn(2);   // Expirace
+                            });
+
+                            table.Header(header =>
+                            {
+                                header.Cell().Element(HeaderCell).Text("Kód").Bold();
+                                header.Cell().Element(HeaderCell).Text("Název").Bold();
+                                header.Cell().Element(HeaderCell).Text("Množství").Bold();
+                                header.Cell().Element(HeaderCell).Text("Jednotka").Bold();
+                                header.Cell().Element(HeaderCell).Text("Šarže").Bold();
+                                header.Cell().Element(HeaderCell).Text("Expirace").Bold();
+                            });
+
+                            foreach (var item in erpDoc.Items)
+                            {
+                                table.Cell().Element(DataCell).Text(item.ProductCode);
+                                table.Cell().Element(DataCell).Text(item.ProductName);
+                                table.Cell().Element(DataCell).Text(item.Amount.ToString("0.###"));
+                                table.Cell().Element(DataCell).Text(item.Unit ?? "—");
+                                table.Cell().Element(DataCell).Text(item.LotNumber ?? "—");
+                                table.Cell().Element(DataCell).Text(item.ExpirationDate?.ToString("dd.MM.yyyy") ?? "—");
+                            }
+                        });
+                    }
+
+                    col.Item().PaddingTop(10);
+                }
+
+                // Notes section
+                if (_data.Notes.Count > 0)
+                {
+                    col.Item().Text("Poznámky").FontSize(11).Bold();
+                    col.Item().PaddingTop(4);
+
+                    foreach (var note in _data.Notes)
+                    {
+                        col.Item().PaddingTop(4).Column(noteCol =>
+                        {
+                            noteCol.Item().Text(t =>
+                            {
+                                t.Span(note.Text);
+                            });
+                            noteCol.Item().Text(
+                                $"{note.CreatedAt:dd.MM.yyyy HH:mm}  –  {note.CreatedByUser}")
+                                .FontSize(8).FontColor(Colors.Grey.Darken1);
+                        });
+                    }
+                }
+            });
+
+            page.Footer().AlignCenter().Text(t =>
+            {
+                t.DefaultTextStyle(x => x.FontSize(8).FontColor(Colors.Grey.Darken1));
+                t.Span("Strana ");
+                t.CurrentPageNumber();
+                t.Span(" z ");
+                t.TotalPages();
+            });
+        });
+    }
+
+    private static IContainer HeaderCell(IContainer c) =>
+        c.Border(0.5f).BorderColor(Colors.Grey.Lighten1)
+         .Background(Colors.Grey.Lighten3)
+         .Padding(3);
+
+    private static IContainer DataCell(IContainer c) =>
+        c.Border(0.5f).BorderColor(Colors.Grey.Lighten1).Padding(3);
+}

--- a/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
+++ b/backend/src/Anela.Heblo.API/PDFPrints/ManufactureProtocolDocument.cs
@@ -7,11 +7,6 @@ namespace Anela.Heblo.API.PDFPrints;
 
 public class ManufactureProtocolDocument : IDocument
 {
-    static ManufactureProtocolDocument()
-    {
-        QuestPDF.Settings.License = LicenseType.Community;
-    }
-
     private readonly ManufactureProtocolData _data;
 
     public ManufactureProtocolDocument(ManufactureProtocolData data)

--- a/backend/src/Anela.Heblo.API/PDFPrints/QuestPdfManufactureProtocolRenderer.cs
+++ b/backend/src/Anela.Heblo.API/PDFPrints/QuestPdfManufactureProtocolRenderer.cs
@@ -1,0 +1,12 @@
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+using QuestPDF.Fluent;
+
+namespace Anela.Heblo.API.PDFPrints;
+
+public class QuestPdfManufactureProtocolRenderer : IManufactureProtocolRenderer
+{
+    public byte[] Render(ManufactureProtocolData data)
+    {
+        return new ManufactureProtocolDocument(data).GeneratePdf();
+    }
+}

--- a/backend/src/Anela.Heblo.API/PDFPrints/QuestPdfManufactureProtocolRenderer.cs
+++ b/backend/src/Anela.Heblo.API/PDFPrints/QuestPdfManufactureProtocolRenderer.cs
@@ -1,10 +1,16 @@
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
 using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
 
 namespace Anela.Heblo.API.PDFPrints;
 
 public class QuestPdfManufactureProtocolRenderer : IManufactureProtocolRenderer
 {
+    static QuestPdfManufactureProtocolRenderer()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
     public byte[] Render(ManufactureProtocolData data)
     {
         return new ManufactureProtocolDocument(data).GeneratePdf();

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolHandler.cs
@@ -38,6 +38,7 @@ public class GetManufactureProtocolHandler : IRequestHandler<GetManufactureProto
         {
             OrderNumber = order.OrderNumber,
             CreatedDate = order.CreatedDate,
+            PlannedDate = order.PlannedDate,
             CompletedAt = order.StateChangedAt,
             ResponsiblePerson = order.ResponsiblePerson,
             ManufactureType = order.ManufactureType,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/GetManufactureProtocolResponse.cs
@@ -5,5 +5,14 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufacturePr
 public class GetManufactureProtocolResponse : BaseResponse
 {
     public byte[] PdfBytes { get; set; } = Array.Empty<byte>();
-    public string FileName { get; set; } = null!;
+    public string FileName { get; set; } = string.Empty;
+
+    public GetManufactureProtocolResponse() : base()
+    {
+    }
+
+    public GetManufactureProtocolResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters)
+    {
+    }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/ManufactureProtocolData.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureProtocol/ManufactureProtocolData.cs
@@ -6,6 +6,7 @@ public class ManufactureProtocolData
 {
     public string OrderNumber { get; set; } = null!;
     public DateTime CreatedDate { get; set; }
+    public DateOnly PlannedDate { get; set; }
     public DateTime? CompletedAt { get; set; }
     public string? ResponsiblePerson { get; set; }
     public ManufactureType ManufactureType { get; set; }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderControllerProtocolTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderControllerProtocolTests.cs
@@ -1,0 +1,107 @@
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Manufacture.Services;
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture;
+
+public class ManufactureOrderControllerProtocolTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly ManufactureOrderController _controller;
+
+    public ManufactureOrderControllerProtocolTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        var configMock = new Mock<IConfiguration>();
+        var serviceMock = new Mock<IManufactureOrderApplicationService>();
+
+        _controller = new ManufactureOrderController(_mediatorMock.Object, configMock.Object, serviceMock.Object);
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.RequestServices = serviceProvider;
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+    }
+
+    [Fact]
+    public async Task GetProtocolPdf_Should_Return_FileResult_With_Pdf_ContentType()
+    {
+        // Arrange
+        var orderId = 42;
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D }; // %PDF-
+        var fileName = "ManufactureProtocol-MO-2024-042.pdf";
+
+        _mediatorMock
+            .Setup(m => m.Send(It.Is<GetManufactureProtocolRequest>(r => r.Id == orderId), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetManufactureProtocolResponse
+            {
+                PdfBytes = pdfBytes,
+                FileName = fileName,
+            });
+
+        // Act
+        var result = await _controller.GetProtocolPdf(orderId);
+
+        // Assert
+        var fileResult = result.Should().BeOfType<FileContentResult>().Subject;
+        fileResult.ContentType.Should().Be("application/pdf");
+        fileResult.FileDownloadName.Should().Be(fileName);
+        fileResult.FileContents.Should().BeEquivalentTo(pdfBytes);
+
+        _mediatorMock.Verify(
+            m => m.Send(It.Is<GetManufactureProtocolRequest>(r => r.Id == orderId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProtocolPdf_Should_Return_BadRequest_When_Order_Not_Completed()
+    {
+        // Arrange
+        var orderId = 1;
+        var errorMessage = "Manufacture order MO-2024-001 must be completed before generating a protocol. Current state: Planned.";
+
+        _mediatorMock
+            .Setup(m => m.Send(It.Is<GetManufactureProtocolRequest>(r => r.Id == orderId), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(errorMessage));
+
+        // Act
+        var result = await _controller.GetProtocolPdf(orderId);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var body = badRequest.Value.Should().BeAssignableTo<object>().Subject;
+        body.ToString().Should().Contain("message");
+
+        _mediatorMock.Verify(
+            m => m.Send(It.Is<GetManufactureProtocolRequest>(r => r.Id == orderId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProtocolPdf_Should_Return_BadRequest_When_Order_Not_Found()
+    {
+        // Arrange
+        var orderId = 999;
+
+        _mediatorMock
+            .Setup(m => m.Send(It.Is<GetManufactureProtocolRequest>(r => r.Id == orderId), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException($"Manufacture order with id {orderId} was not found."));
+
+        // Act
+        var result = await _controller.GetProtocolPdf(orderId);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderControllerProtocolTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureOrderControllerProtocolTests.cs
@@ -51,7 +51,7 @@ public class ManufactureOrderControllerProtocolTests
             });
 
         // Act
-        var result = await _controller.GetProtocolPdf(orderId);
+        var result = await _controller.GetProtocolPdf(orderId, CancellationToken.None);
 
         // Assert
         var fileResult = result.Should().BeOfType<FileContentResult>().Subject;
@@ -76,12 +76,13 @@ public class ManufactureOrderControllerProtocolTests
             .ThrowsAsync(new InvalidOperationException(errorMessage));
 
         // Act
-        var result = await _controller.GetProtocolPdf(orderId);
+        var result = await _controller.GetProtocolPdf(orderId, CancellationToken.None);
 
         // Assert
         var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        var body = badRequest.Value.Should().BeAssignableTo<object>().Subject;
-        body.ToString().Should().Contain("message");
+        var body = badRequest.Value;
+        var message = body!.GetType().GetProperty("message")?.GetValue(body) as string;
+        message.Should().Be(errorMessage);
 
         _mediatorMock.Verify(
             m => m.Send(It.Is<GetManufactureProtocolRequest>(r => r.Id == orderId), It.IsAny<CancellationToken>()),
@@ -99,7 +100,7 @@ public class ManufactureOrderControllerProtocolTests
             .ThrowsAsync(new InvalidOperationException($"Manufacture order with id {orderId} was not found."));
 
         // Act
-        var result = await _controller.GetProtocolPdf(orderId);
+        var result = await _controller.GetProtocolPdf(orderId, CancellationToken.None);
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>();

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureProtocolRendererSmokeTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureProtocolRendererSmokeTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.API.PDFPrints;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+using Anela.Heblo.Domain.Features.Manufacture;
 using FluentAssertions;
 using Xunit;
 
@@ -43,10 +44,10 @@ public class ManufactureProtocolRendererSmokeTests
                 new ManufactureProtocolErpDocument
                 {
                     DocumentCode = "VYD001",
-                    DocumentLabel = "Výdej materiálu pro polotovar",
-                    Items = new List<ManufactureErpDocumentItemDto>
+                    DocumentType = "Výdej materiálu pro polotovar",
+                    Items = new List<ManufactureErpDocumentItem>
                     {
-                        new ManufactureErpDocumentItemDto
+                        new ManufactureErpDocumentItem
                         {
                             ProductCode = "MAT001",
                             ProductName = "Materiál A",

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureProtocolRendererSmokeTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ManufactureProtocolRendererSmokeTests.cs
@@ -1,0 +1,100 @@
+using Anela.Heblo.API.PDFPrints;
+using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture;
+
+/// <summary>
+/// Smoke test that verifies the renderer produces valid PDF bytes.
+/// Does not test layout details — just confirms the magic bytes are correct.
+/// </summary>
+public class ManufactureProtocolRendererSmokeTests
+{
+    [Fact]
+    public void Render_ReturnsValidPdfBytes()
+    {
+        var renderer = new QuestPdfManufactureProtocolRenderer();
+        var data = new ManufactureProtocolData
+        {
+            OrderNumber = "MO-2024-001",
+            GeneratedAt = new DateTime(2024, 6, 1, 12, 0, 0, DateTimeKind.Utc),
+            ResponsiblePerson = "test@anela.cz",
+            PlannedDate = new DateOnly(2024, 6, 15),
+            SemiProduct = new ManufactureProtocolSemiProduct
+            {
+                ProductCode = "SEMI001",
+                ProductName = "Testovací polotovar",
+                ActualQuantity = 500m,
+                LotNumber = "LOT-001",
+                ExpirationDate = new DateOnly(2025, 6, 15),
+            },
+            Products = new List<ManufactureProtocolProduct>
+            {
+                new ManufactureProtocolProduct
+                {
+                    ProductCode = "PROD001",
+                    ProductName = "Testovací výrobek",
+                    ActualQuantity = 100m,
+                },
+            },
+            ErpDocuments = new List<ManufactureProtocolErpDocument>
+            {
+                new ManufactureProtocolErpDocument
+                {
+                    DocumentCode = "VYD001",
+                    DocumentLabel = "Výdej materiálu pro polotovar",
+                    Items = new List<ManufactureErpDocumentItemDto>
+                    {
+                        new ManufactureErpDocumentItemDto
+                        {
+                            ProductCode = "MAT001",
+                            ProductName = "Materiál A",
+                            Amount = 50.0,
+                            Unit = "kg",
+                            LotNumber = "LOT-MAT-001",
+                            ExpirationDate = new DateOnly(2025, 12, 31),
+                        },
+                    },
+                },
+            },
+            Notes = new List<ManufactureProtocolNote>
+            {
+                new ManufactureProtocolNote
+                {
+                    Text = "Testovací poznámka",
+                    CreatedAt = new DateTime(2024, 6, 1, 10, 0, 0, DateTimeKind.Utc),
+                    CreatedByUser = "user@anela.cz",
+                },
+            },
+        };
+
+        var bytes = renderer.Render(data);
+
+        bytes.Should().NotBeNullOrEmpty();
+        bytes[0].Should().Be(0x25); // %
+        bytes[1].Should().Be(0x50); // P
+        bytes[2].Should().Be(0x44); // D
+        bytes[3].Should().Be(0x46); // F
+    }
+
+    [Fact]
+    public void Render_WithMinimalData_ReturnsValidPdfBytes()
+    {
+        var renderer = new QuestPdfManufactureProtocolRenderer();
+        var data = new ManufactureProtocolData
+        {
+            OrderNumber = "MO-2024-999",
+            GeneratedAt = DateTime.UtcNow,
+            PlannedDate = DateOnly.FromDateTime(DateTime.Today),
+        };
+
+        var bytes = renderer.Render(data);
+
+        bytes.Should().NotBeNullOrEmpty();
+        bytes[0].Should().Be(0x25); // %
+        bytes[1].Should().Be(0x50); // P
+        bytes[2].Should().Be(0x44); // D
+        bytes[3].Should().Be(0x46); // F
+    }
+}

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -4411,7 +4411,7 @@ export class ApiClient {
         return Promise.resolve<CalculateBatchPlanResponse>(null as any);
     }
 
-    manufactureOrder_GetOrders(state: ManufactureOrderState | null | undefined, dateFrom: Date | null | undefined, dateTo: Date | null | undefined, responsiblePerson: string | null | undefined, orderNumber: string | null | undefined, productCode: string | null | undefined, erpDocumentNumber: string | null | undefined, manualActionRequired: boolean | null | undefined): Promise<GetManufactureOrdersResponse> {
+    manufactureOrder_GetOrders(state: ManufactureOrderState | null | undefined, dateFrom: Date | null | undefined, dateTo: Date | null | undefined, responsiblePerson: string | null | undefined, orderNumber: string | null | undefined, productCode: string | null | undefined, erpDocumentNumber: string | null | undefined, manualActionRequired: boolean | null | undefined, lotNumber: string | null | undefined, pageNumber: number | undefined, pageSize: number | undefined): Promise<GetManufactureOrdersResponse> {
         let url_ = this.baseUrl + "/api/ManufactureOrder?";
         if (state !== undefined && state !== null)
             url_ += "State=" + encodeURIComponent("" + state) + "&";
@@ -4429,6 +4429,16 @@ export class ApiClient {
             url_ += "ErpDocumentNumber=" + encodeURIComponent("" + erpDocumentNumber) + "&";
         if (manualActionRequired !== undefined && manualActionRequired !== null)
             url_ += "ManualActionRequired=" + encodeURIComponent("" + manualActionRequired) + "&";
+        if (lotNumber !== undefined && lotNumber !== null)
+            url_ += "LotNumber=" + encodeURIComponent("" + lotNumber) + "&";
+        if (pageNumber === null)
+            throw new Error("The parameter 'pageNumber' cannot be null.");
+        else if (pageNumber !== undefined)
+            url_ += "PageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "PageSize=" + encodeURIComponent("" + pageSize) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -4852,6 +4862,47 @@ export class ApiClient {
             });
         }
         return Promise.resolve<ResolveManualActionResponse>(null as any);
+    }
+
+    manufactureOrder_GetProtocolPdf(id: number): Promise<FileResponse> {
+        let url_ = this.baseUrl + "/api/ManufactureOrder/{id}/protocol.pdf";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/octet-stream"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processManufactureOrder_GetProtocolPdf(_response);
+        });
+    }
+
+    protected processManufactureOrder_GetProtocolPdf(response: Response): Promise<FileResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200 || status === 206) {
+            const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
+            let fileNameMatch = contentDisposition ? /filename\*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+            let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
+            if (fileName) {
+                fileName = decodeURIComponent(fileName);
+            } else {
+                fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+                fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+            }
+            return response.blob().then(blob => { return { fileName: fileName, data: blob, status: status, headers: _headers }; });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FileResponse>(null as any);
     }
 
     manufactureOrder_UpdateOrderSchedule(id: number, request: UpdateManufactureOrderScheduleRequest): Promise<UpdateManufactureOrderScheduleResponse> {
@@ -15965,6 +16016,10 @@ export interface IProductSizeConstraint {
 
 export class GetManufactureOrdersResponse extends BaseResponse implements IGetManufactureOrdersResponse {
     orders?: ManufactureOrderDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
 
     constructor(data?: IGetManufactureOrdersResponse) {
         super(data);
@@ -15978,6 +16033,10 @@ export class GetManufactureOrdersResponse extends BaseResponse implements IGetMa
                 for (let item of _data["orders"])
                     this.orders!.push(ManufactureOrderDto.fromJS(item));
             }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+            this.totalPages = _data["totalPages"];
         }
     }
 
@@ -15995,6 +16054,10 @@ export class GetManufactureOrdersResponse extends BaseResponse implements IGetMa
             for (let item of this.orders)
                 data["orders"].push(item.toJSON());
         }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        data["totalPages"] = this.totalPages;
         super.toJSON(data);
         return data;
     }
@@ -16002,6 +16065,10 @@ export class GetManufactureOrdersResponse extends BaseResponse implements IGetMa
 
 export interface IGetManufactureOrdersResponse extends IBaseResponse {
     orders?: ManufactureOrderDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
 }
 
 export class ManufactureOrderDto implements IManufactureOrderDto {
@@ -17039,6 +17106,11 @@ export class UpdateManufactureOrderStatusRequest implements IUpdateManufactureOr
     discardRedisueDocumentCode?: string | undefined;
     weightWithinTolerance?: boolean | undefined;
     weightDifference?: number | undefined;
+    flexiDocMaterialIssueForSemiProduct?: string | undefined;
+    flexiDocSemiProductReceipt?: string | undefined;
+    flexiDocSemiProductIssueForProduct?: string | undefined;
+    flexiDocMaterialIssueForProduct?: string | undefined;
+    flexiDocProductReceipt?: string | undefined;
 
     constructor(data?: IUpdateManufactureOrderStatusRequest) {
         if (data) {
@@ -17061,6 +17133,11 @@ export class UpdateManufactureOrderStatusRequest implements IUpdateManufactureOr
             this.discardRedisueDocumentCode = _data["discardRedisueDocumentCode"];
             this.weightWithinTolerance = _data["weightWithinTolerance"];
             this.weightDifference = _data["weightDifference"];
+            this.flexiDocMaterialIssueForSemiProduct = _data["flexiDocMaterialIssueForSemiProduct"];
+            this.flexiDocSemiProductReceipt = _data["flexiDocSemiProductReceipt"];
+            this.flexiDocSemiProductIssueForProduct = _data["flexiDocSemiProductIssueForProduct"];
+            this.flexiDocMaterialIssueForProduct = _data["flexiDocMaterialIssueForProduct"];
+            this.flexiDocProductReceipt = _data["flexiDocProductReceipt"];
         }
     }
 
@@ -17083,6 +17160,11 @@ export class UpdateManufactureOrderStatusRequest implements IUpdateManufactureOr
         data["discardRedisueDocumentCode"] = this.discardRedisueDocumentCode;
         data["weightWithinTolerance"] = this.weightWithinTolerance;
         data["weightDifference"] = this.weightDifference;
+        data["flexiDocMaterialIssueForSemiProduct"] = this.flexiDocMaterialIssueForSemiProduct;
+        data["flexiDocSemiProductReceipt"] = this.flexiDocSemiProductReceipt;
+        data["flexiDocSemiProductIssueForProduct"] = this.flexiDocSemiProductIssueForProduct;
+        data["flexiDocMaterialIssueForProduct"] = this.flexiDocMaterialIssueForProduct;
+        data["flexiDocProductReceipt"] = this.flexiDocProductReceipt;
         return data;
     }
 }
@@ -17098,6 +17180,11 @@ export interface IUpdateManufactureOrderStatusRequest {
     discardRedisueDocumentCode?: string | undefined;
     weightWithinTolerance?: boolean | undefined;
     weightDifference?: number | undefined;
+    flexiDocMaterialIssueForSemiProduct?: string | undefined;
+    flexiDocSemiProductReceipt?: string | undefined;
+    flexiDocSemiProductIssueForProduct?: string | undefined;
+    flexiDocMaterialIssueForProduct?: string | undefined;
+    flexiDocProductReceipt?: string | undefined;
 }
 
 export class ConfirmSemiProductManufactureResponse extends BaseResponse implements IConfirmSemiProductManufactureResponse {

--- a/frontend/src/api/hooks/__tests__/useOpenManufactureProtocol.test.ts
+++ b/frontend/src/api/hooks/__tests__/useOpenManufactureProtocol.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, act } from '@testing-library/react';
+import { useOpenManufactureProtocol } from '../useManufactureOrders';
+import { getAuthenticatedApiClient } from '../../client';
+
+jest.mock('../../client');
+const mockGetAuthenticatedApiClient = getAuthenticatedApiClient as jest.MockedFunction<
+  typeof getAuthenticatedApiClient
+>;
+
+describe('useOpenManufactureProtocol', () => {
+  let mockFetch: jest.Mock;
+  let mockApiClient: any;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    mockApiClient = {
+      baseUrl: 'http://localhost:5001',
+      http: { fetch: mockFetch },
+    };
+    mockGetAuthenticatedApiClient.mockReturnValue(mockApiClient);
+
+    URL.createObjectURL = jest.fn().mockReturnValue('blob:mock-url');
+    URL.revokeObjectURL = jest.fn();
+    window.open = jest.fn();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  test('calls the correct URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(new Blob(['pdf'], { type: 'application/pdf' })),
+    });
+
+    const { result } = renderHook(() => useOpenManufactureProtocol());
+
+    await act(async () => {
+      await result.current.openProtocol(42);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5001/api/manufactureorder/42/protocol.pdf',
+      { method: 'GET' }
+    );
+  });
+
+  test('opens the blob URL in a new tab', async () => {
+    const mockBlob = new Blob(['pdf'], { type: 'application/pdf' });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(mockBlob),
+    });
+
+    const { result } = renderHook(() => useOpenManufactureProtocol());
+
+    await act(async () => {
+      await result.current.openProtocol(42);
+    });
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+    expect(window.open).toHaveBeenCalledWith('blob:mock-url', '_blank', 'noopener,noreferrer');
+  });
+
+  test('schedules URL revocation after 10 seconds', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockResolvedValueOnce(new Blob(['pdf'])),
+    });
+
+    const { result } = renderHook(() => useOpenManufactureProtocol());
+
+    await act(async () => {
+      await result.current.openProtocol(42);
+    });
+
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  test('sets isLoading to true during fetch and false after', async () => {
+    let resolveBlob: (b: Blob) => void;
+    const blobPromise = new Promise<Blob>((res) => { resolveBlob = res; });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      blob: jest.fn().mockReturnValueOnce(blobPromise),
+    });
+
+    const { result } = renderHook(() => useOpenManufactureProtocol());
+
+    expect(result.current.isLoading).toBe(false);
+
+    const openPromise = act(async () => {
+      await result.current.openProtocol(42);
+    });
+
+    resolveBlob!(new Blob(['pdf']));
+    await openPromise;
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('sets error when HTTP response is not ok', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const { result } = renderHook(() => useOpenManufactureProtocol());
+
+    await act(async () => {
+      await result.current.openProtocol(99);
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error?.message).toBe('HTTP error! status: 404');
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  test('sets error when fetch throws', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    const { result } = renderHook(() => useOpenManufactureProtocol());
+
+    await act(async () => {
+      await result.current.openProtocol(1);
+    });
+
+    expect(result.current.error?.message).toBe('Network failure');
+  });
+});

--- a/frontend/src/api/hooks/useManufactureOrders.ts
+++ b/frontend/src/api/hooks/useManufactureOrders.ts
@@ -427,7 +427,9 @@ export const useOpenManufactureProtocol = () => {
       window.open(blobUrl, '_blank', 'noopener,noreferrer');
       setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
     } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error('Failed to open manufacture protocol PDF:', error);
+      setError(error);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/api/hooks/useManufactureOrders.ts
+++ b/frontend/src/api/hooks/useManufactureOrders.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
 import { ApiClient as GeneratedApiClient } from "../generated/api-client";
@@ -405,3 +406,32 @@ export const useUpdateManufactureOrderSchedule = () => {
 export const useCreateManufactureOrder = useCreateManufactureOrderMutation;
 export const useUpdateManufactureOrder = useUpdateManufactureOrderMutation;
 export const useUpdateManufactureOrderStatus = useUpdateManufactureOrderStatusMutation;
+
+export const useOpenManufactureProtocol = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const openProtocol = async (orderId: number) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const apiClient = getAuthenticatedApiClient();
+      const relativeUrl = `/api/manufactureorder/${orderId}/protocol.pdf`;
+      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+      const response = await (apiClient as any).http.fetch(fullUrl, { method: 'GET' });
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { openProtocol, isLoading, error };
+};

--- a/frontend/src/components/manufacture/detail/DetailActionButtons.tsx
+++ b/frontend/src/components/manufacture/detail/DetailActionButtons.tsx
@@ -6,6 +6,7 @@ import {
   XCircle,
   Loader2,
   Calculator,
+  Printer,
 } from "lucide-react";
 import { ManufactureOrderState } from "../../../api/generated/api-client";
 
@@ -16,8 +17,10 @@ interface DetailActionButtonsProps {
   onClose: () => void;
   onSave: () => void;
   onBatchCalculator?: () => void;
+  onPrintProtocol?: () => void;
   isUpdateLoading: boolean;
   isDuplicateLoading: boolean;
+  isPrintingProtocol?: boolean;
 }
 
 export const DetailActionButtons: React.FC<DetailActionButtonsProps> = ({
@@ -27,8 +30,10 @@ export const DetailActionButtons: React.FC<DetailActionButtonsProps> = ({
   onClose,
   onSave,
   onBatchCalculator,
+  onPrintProtocol,
   isUpdateLoading,
   isDuplicateLoading,
+  isPrintingProtocol,
 }) => {
   return (
     <div className="border-t border-gray-200 p-3 flex-shrink-0">
@@ -76,6 +81,23 @@ export const DetailActionButtons: React.FC<DetailActionButtonsProps> = ({
             >
               <Calculator className="h-4 w-4 mr-1" />
               Kalkulačka dávek
+            </button>
+          )}
+
+          {/* Print Protocol button – only for Completed orders */}
+          {order && order.state === ManufactureOrderState.Completed && onPrintProtocol && (
+            <button
+              onClick={onPrintProtocol}
+              disabled={isPrintingProtocol}
+              className="flex items-center px-4 py-2 bg-sky-600 text-white rounded-lg hover:bg-sky-700 transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Tisknout protokol výroby"
+            >
+              {isPrintingProtocol ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <Printer className="h-4 w-4 mr-1" />
+              )}
+              Tisk protokolu
             </button>
           )}
         </div>

--- a/frontend/src/components/manufacture/detail/__tests__/DetailActionButtons.test.tsx
+++ b/frontend/src/components/manufacture/detail/__tests__/DetailActionButtons.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DetailActionButtons } from '../DetailActionButtons';
+import { ManufactureOrderState } from '../../../../api/generated/api-client';
+
+const baseProps = {
+  onCancel: jest.fn(),
+  onDuplicate: jest.fn(),
+  onClose: jest.fn(),
+  onSave: jest.fn(),
+  isUpdateLoading: false,
+  isDuplicateLoading: false,
+};
+
+describe('DetailActionButtons', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('does NOT render Tisk protokolu button when order is not Completed', () => {
+    const order = { state: ManufactureOrderState.Planned };
+    const onPrintProtocol = jest.fn();
+
+    render(
+      <DetailActionButtons
+        {...baseProps}
+        order={order}
+        onPrintProtocol={onPrintProtocol}
+      />
+    );
+
+    expect(screen.queryByText('Tisk protokolu')).not.toBeInTheDocument();
+  });
+
+  test('does NOT render Tisk protokolu button when order is Draft', () => {
+    const order = { state: ManufactureOrderState.Draft };
+    const onPrintProtocol = jest.fn();
+
+    render(
+      <DetailActionButtons
+        {...baseProps}
+        order={order}
+        onPrintProtocol={onPrintProtocol}
+      />
+    );
+
+    expect(screen.queryByText('Tisk protokolu')).not.toBeInTheDocument();
+  });
+
+  test('renders Tisk protokolu button when order state is Completed', () => {
+    const order = { state: ManufactureOrderState.Completed };
+    const onPrintProtocol = jest.fn();
+
+    render(
+      <DetailActionButtons
+        {...baseProps}
+        order={order}
+        onPrintProtocol={onPrintProtocol}
+      />
+    );
+
+    expect(screen.getByText('Tisk protokolu')).toBeInTheDocument();
+  });
+
+  test('calls onPrintProtocol when Tisk protokolu button is clicked', () => {
+    const order = { state: ManufactureOrderState.Completed };
+    const onPrintProtocol = jest.fn();
+
+    render(
+      <DetailActionButtons
+        {...baseProps}
+        order={order}
+        onPrintProtocol={onPrintProtocol}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Tisk protokolu'));
+    expect(onPrintProtocol).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT render Tisk protokolu button when onPrintProtocol is not provided', () => {
+    const order = { state: ManufactureOrderState.Completed };
+
+    render(
+      <DetailActionButtons
+        {...baseProps}
+        order={order}
+      />
+    );
+
+    expect(screen.queryByText('Tisk protokolu')).not.toBeInTheDocument();
+  });
+
+  test('Tisk protokolu button is disabled when isPrintingProtocol is true', () => {
+    const order = { state: ManufactureOrderState.Completed };
+    const onPrintProtocol = jest.fn();
+
+    render(
+      <DetailActionButtons
+        {...baseProps}
+        order={order}
+        onPrintProtocol={onPrintProtocol}
+        isPrintingProtocol={true}
+      />
+    );
+
+    const button = screen.getByTitle('Tisknout protokol výroby');
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx
@@ -18,6 +18,7 @@ import {
   useConfirmSemiProductManufacture,
   useConfirmProductCompletion,
   useDuplicateManufactureOrder,
+  useOpenManufactureProtocol,
 } from "../../../api/hooks/useManufactureOrders";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -106,6 +107,9 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
   } = useManufactureOrderDetailQuery(orderId || 0);
 
   const order = orderData?.order;
+
+  // Protocol PDF hook
+  const { openProtocol, isLoading: isProtocolLoading } = useOpenManufactureProtocol();
 
   // Mutations
   const updateOrderMutation = useUpdateManufactureOrder();
@@ -689,8 +693,10 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
         onClose={handleCloseWithWeekNavigation}
         onSave={handleSave}
         onBatchCalculator={handleGoToBatchCalculator}
+        onPrintProtocol={() => openProtocol(orderId)}
         isUpdateLoading={updateOrderMutation.isPending}
         isDuplicateLoading={duplicateOrderMutation.isPending}
+        isPrintingProtocol={isProtocolLoading}
       />
 
       <ConfirmationDialogs

--- a/frontend/src/components/manufacture/pages/__tests__/ManufactureOrderDetail.autoCalculation.test.tsx
+++ b/frontend/src/components/manufacture/pages/__tests__/ManufactureOrderDetail.autoCalculation.test.tsx
@@ -42,6 +42,7 @@ jest.mock("../../../../api/hooks/useManufactureOrders", () => ({
   useConfirmSemiProductManufacture: () => mockUseConfirmSemiProductManufacture(),
   useConfirmProductCompletion: () => mockUseConfirmProductCompletion(),
   useDuplicateManufactureOrder: () => mockUseDuplicateManufactureOrder(),
+  useOpenManufactureProtocol: () => ({ openProtocol: jest.fn(), isLoading: false, error: null }),
 }));
 
 // Mock react-router-dom navigate

--- a/frontend/test/e2e/manufacturing/protocol.spec.ts
+++ b/frontend/test/e2e/manufacturing/protocol.spec.ts
@@ -1,88 +1,70 @@
 import { test, expect } from '@playwright/test';
 import { navigateToApp } from '../helpers/e2e-auth-helper';
 
+async function navigateToManufactureOrders(page: import('@playwright/test').Page) {
+  await navigateToApp(page);
+  await page.getByRole('button', { name: 'Výroba' }).click();
+  await page.getByRole('link', { name: 'Zakázky' }).click();
+  await page.waitForLoadState('domcontentloaded');
+}
+
+async function findAndClickRowByState(
+  page: import('@playwright/test').Page,
+  statePattern: RegExp,
+  maxRows: number = 5,
+): Promise<boolean> {
+  const rows = page.locator('tr').filter({ hasText: /MO-/ });
+  const count = await rows.count();
+  const limit = Math.min(count, maxRows);
+
+  for (let i = 0; i < limit; i++) {
+    const row = rows.nth(i);
+    const text = await row.textContent();
+    if (statePattern.test(text ?? '')) {
+      await row.click();
+      await page.waitForLoadState('domcontentloaded');
+      return true;
+    }
+  }
+
+  return false;
+}
+
 test.describe('Manufacture Protocol PDF', () => {
   test('should show Tisk protokolu button for a completed order and open PDF', async ({
     page,
     context,
   }) => {
-    await navigateToApp(page);
+    await navigateToManufactureOrders(page);
 
-    // Navigate to manufacturing orders list and filter by Completed state
-    await page.goto('/manufacturing/orders');
-    await page.waitForLoadState('networkidle');
-
-    // Apply Completed filter – the filter dropdown label may vary; try common selectors
-    const stateSelect = page.locator('select').first();
-    if (await stateSelect.isVisible()) {
-      await stateSelect.selectOption('Completed');
-      await page.waitForLoadState('networkidle');
-    }
-
-    // Find a row that contains the Completed state badge
-    const completedRow = page
-      .locator('tr, [role="row"]')
-      .filter({ hasText: /Completed|Dokončeno/i })
-      .first();
-
-    const rowCount = await completedRow.count();
-    if (rowCount === 0) {
+    const found = await findAndClickRowByState(page, /Completed|Dokončeno/i);
+    if (!found) {
       throw new Error(
-        'Test data missing: No completed manufacture order found in staging. ' +
-          'Create at least one completed manufacture order first.'
+        'Test data missing: No completed manufacture order found in the first 5 rows on staging. ' +
+          'Create at least one completed manufacture order first.',
       );
     }
 
-    // Click the row to open the detail
-    await completedRow.click();
-    await page.waitForLoadState('networkidle');
-
-    // Verify "Tisk protokolu" button is visible in the detail panel/page
     const printButton = page.getByTitle('Tisknout protokol výroby');
     await expect(printButton).toBeVisible({ timeout: 10000 });
 
-    // Click the button and wait for a new tab/popup to open
-    const [newPage] = await Promise.all([
-      context.waitForEvent('page'),
-      printButton.click(),
-    ]);
+    const [newPage] = await Promise.all([context.waitForEvent('page'), printButton.click()]);
 
-    // The new tab should open with a blob URL
     await newPage.waitForLoadState();
-    const newPageUrl = newPage.url();
-    expect(newPageUrl).toMatch(/^blob:/);
+    expect(newPage.url()).toMatch(/^blob:/);
   });
 
   test('should NOT show Tisk protokolu button for a non-completed order', async ({ page }) => {
-    await navigateToApp(page);
+    await navigateToManufactureOrders(page);
 
-    await page.goto('/manufacturing/orders');
-    await page.waitForLoadState('networkidle');
-
-    // Filter for Draft orders
-    const stateSelect = page.locator('select').first();
-    if (await stateSelect.isVisible()) {
-      await stateSelect.selectOption('Draft');
-      await page.waitForLoadState('networkidle');
-    }
-
-    const draftRow = page
-      .locator('tr, [role="row"]')
-      .filter({ hasText: /Draft|Návrh/i })
-      .first();
-
-    const rowCount = await draftRow.count();
-    if (rowCount === 0) {
+    const found = await findAndClickRowByState(page, /Draft|Návrh|Planned|Plánováno/i);
+    if (!found) {
       throw new Error(
-        'Test data missing: No draft manufacture order found in staging. ' +
-          'Create at least one draft manufacture order first.'
+        'Test data missing: No non-completed manufacture order found in the first 5 rows on staging. ' +
+          'Create at least one order in Draft or Planned state first.',
       );
     }
 
-    await draftRow.click();
-    await page.waitForLoadState('networkidle');
-
-    // "Tisk protokolu" must not be present for a non-completed order
     const printButton = page.getByTitle('Tisknout protokol výroby');
     await expect(printButton).not.toBeVisible({ timeout: 5000 });
   });

--- a/frontend/test/e2e/manufacturing/protocol.spec.ts
+++ b/frontend/test/e2e/manufacturing/protocol.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { navigateToApp } from '../helpers/e2e-auth-helper';
+
+test.describe('Manufacture Protocol PDF', () => {
+  test('should show Tisk protokolu button for a completed order and open PDF', async ({
+    page,
+    context,
+  }) => {
+    await navigateToApp(page);
+
+    // Navigate to manufacturing orders list and filter by Completed state
+    await page.goto('/manufacturing/orders');
+    await page.waitForLoadState('networkidle');
+
+    // Apply Completed filter – the filter dropdown label may vary; try common selectors
+    const stateSelect = page.locator('select').first();
+    if (await stateSelect.isVisible()) {
+      await stateSelect.selectOption('Completed');
+      await page.waitForLoadState('networkidle');
+    }
+
+    // Find a row that contains the Completed state badge
+    const completedRow = page
+      .locator('tr, [role="row"]')
+      .filter({ hasText: /Completed|Dokončeno/i })
+      .first();
+
+    const rowCount = await completedRow.count();
+    if (rowCount === 0) {
+      throw new Error(
+        'Test data missing: No completed manufacture order found in staging. ' +
+          'Create at least one completed manufacture order first.'
+      );
+    }
+
+    // Click the row to open the detail
+    await completedRow.click();
+    await page.waitForLoadState('networkidle');
+
+    // Verify "Tisk protokolu" button is visible in the detail panel/page
+    const printButton = page.getByTitle('Tisknout protokol výroby');
+    await expect(printButton).toBeVisible({ timeout: 10000 });
+
+    // Click the button and wait for a new tab/popup to open
+    const [newPage] = await Promise.all([
+      context.waitForEvent('page'),
+      printButton.click(),
+    ]);
+
+    // The new tab should open with a blob URL
+    await newPage.waitForLoadState();
+    const newPageUrl = newPage.url();
+    expect(newPageUrl).toMatch(/^blob:/);
+  });
+
+  test('should NOT show Tisk protokolu button for a non-completed order', async ({ page }) => {
+    await navigateToApp(page);
+
+    await page.goto('/manufacturing/orders');
+    await page.waitForLoadState('networkidle');
+
+    // Filter for Draft orders
+    const stateSelect = page.locator('select').first();
+    if (await stateSelect.isVisible()) {
+      await stateSelect.selectOption('Draft');
+      await page.waitForLoadState('networkidle');
+    }
+
+    const draftRow = page
+      .locator('tr, [role="row"]')
+      .filter({ hasText: /Draft|Návrh/i })
+      .first();
+
+    const rowCount = await draftRow.count();
+    if (rowCount === 0) {
+      throw new Error(
+        'Test data missing: No draft manufacture order found in staging. ' +
+          'Create at least one draft manufacture order first.'
+      );
+    }
+
+    await draftRow.click();
+    await page.waitForLoadState('networkidle');
+
+    // "Tisk protokolu" must not be present for a non-completed order
+    const printButton = page.getByTitle('Tisknout protokol výroby');
+    await expect(printButton).not.toBeVisible({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #542, #543, #544 — part of Epic #537.

- **Phase 5**: `GetManufactureProtocol` MediatR use case — loads completed order, fetches consumed materials from all 5 Flexi stock documents in parallel, assembles `ManufactureProtocolData`
- **Phase 6**: `ManufactureProtocolDocument` (QuestPDF A4) + `QuestPdfManufactureProtocolRenderer`, `GET /api/manufactureorder/{id}/protocol.pdf` endpoint
- **Phase 7**: `useOpenManufactureProtocol` hook + "Tisk protokolu" button in `DetailActionButtons` (visible only on Completed orders), Playwright E2E smoke test

## Architecture

- `IManufactureProtocolRenderer` abstraction keeps QuestPDF out of the Application layer
- Handler fetches ERP document items via `Task.WhenAll` (parallel Flexi calls)
- Frontend uses blob-download pattern (matches `ExpeditionListArchivePage`)
- Button gated on `ManufactureOrderState.Completed`

## Test Plan

- [ ] `dotnet test` — 2063 backend tests passing (5 new: handler + renderer smoke + controller)
- [ ] `npm test` — 761 frontend tests passing (12 new: hook + button visibility)
- [ ] E2E: `./scripts/run-playwright-tests.sh manufacturing` — `protocol.spec.ts` validates blob URL opens for completed order
- [ ] Manual: Open completed order → click "Tisk protokolu" → PDF opens in new tab with order metadata + consumed materials from Flexi

🤖 Generated with [Claude Code](https://claude.ai/claude-code)