### PR TITLE
fix(storage): cache container existence to eliminate 409 dependency noise

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/Services/AzureBlobStorageService.cs
@@ -1,7 +1,7 @@
+using System.Collections.Concurrent;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Anela.Heblo.Domain.Features.FileStorage;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.FileStorage.Services;
@@ -14,6 +14,7 @@ public class AzureBlobStorageService : IBlobStorageService
     private readonly BlobServiceClient _blobServiceClient;
     private readonly HttpClient _httpClient;
     private readonly ILogger<AzureBlobStorageService> _logger;
+    private readonly ConcurrentDictionary<string, bool> _containerExists = new();
 
     public AzureBlobStorageService(
         BlobServiceClient blobServiceClient,
@@ -229,7 +230,11 @@ public class AzureBlobStorageService : IBlobStorageService
     private async Task<BlobContainerClient> GetOrCreateContainerAsync(string containerName, CancellationToken cancellationToken = default)
     {
         var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
-        await containerClient.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+        if (_containerExists.TryAdd(containerName, true))
+        {
+            await containerClient.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+        }
+
         return containerClient;
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/AzureBlobStorageServiceTests.cs
@@ -339,6 +339,87 @@ public class AzureBlobStorageServiceTests
     }
 
     [Fact]
+    public async Task UploadAsync_CalledMultipleTimes_ShouldCallCreateIfNotExistsOnlyOnce()
+    {
+        // Arrange — fresh instance so _containerExists cache is empty
+        var mockBlobServiceClient = new Mock<BlobServiceClient>();
+        var mockLogger = new Mock<ILogger<AzureBlobStorageService>>();
+        var service = new AzureBlobStorageService(
+            mockBlobServiceClient.Object,
+            new HttpClient(),
+            mockLogger.Object);
+
+        var containerName = "documents";
+        var mockContainerClient = new Mock<BlobContainerClient>();
+        var mockBlobClient = new Mock<BlobClient>();
+
+        mockBlobClient.Setup(x => x.Uri).Returns(new Uri($"https://test.blob.core.windows.net/{containerName}/file.txt"));
+        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContentInfo>>()));
+        mockContainerClient.Setup(x => x.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
+        mockContainerClient.Setup(x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContainerInfo>>()));
+        mockBlobServiceClient.Setup(x => x.GetBlobContainerClient(containerName)).Returns(mockContainerClient.Object);
+
+        // Act — upload 3 times to the same container
+        await service.UploadAsync(new MemoryStream(new byte[] { 1 }), containerName, "file1.txt", "text/plain");
+        await service.UploadAsync(new MemoryStream(new byte[] { 2 }), containerName, "file2.txt", "text/plain");
+        await service.UploadAsync(new MemoryStream(new byte[] { 3 }), containerName, "file3.txt", "text/plain");
+
+        // Assert — CreateIfNotExistsAsync called exactly once despite 3 uploads
+        mockContainerClient.Verify(
+            x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UploadAsync_DifferentContainers_ShouldCallCreateIfNotExistsOncePerContainer()
+    {
+        // Arrange — fresh instance so _containerExists cache is empty
+        var mockBlobServiceClient = new Mock<BlobServiceClient>();
+        var mockLogger = new Mock<ILogger<AzureBlobStorageService>>();
+        var service = new AzureBlobStorageService(
+            mockBlobServiceClient.Object,
+            new HttpClient(),
+            mockLogger.Object);
+
+        var containerA = "container-a";
+        var containerB = "container-b";
+
+        var mockContainerClientA = new Mock<BlobContainerClient>();
+        var mockContainerClientB = new Mock<BlobContainerClient>();
+        var mockBlobClient = new Mock<BlobClient>();
+
+        mockBlobClient.Setup(x => x.Uri).Returns(new Uri("https://test.blob.core.windows.net/container-a/file.txt"));
+        mockBlobClient.Setup(x => x.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContentInfo>>()));
+
+        foreach (var mock in new[] { mockContainerClientA, mockContainerClientB })
+        {
+            mock.Setup(x => x.GetBlobClient(It.IsAny<string>())).Returns(mockBlobClient.Object);
+            mock.Setup(x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Mock.Of<Azure.Response<BlobContainerInfo>>()));
+        }
+
+        mockBlobServiceClient.Setup(x => x.GetBlobContainerClient(containerA)).Returns(mockContainerClientA.Object);
+        mockBlobServiceClient.Setup(x => x.GetBlobContainerClient(containerB)).Returns(mockContainerClientB.Object);
+
+        // Act — upload twice to container A and twice to container B
+        await service.UploadAsync(new MemoryStream(new byte[] { 1 }), containerA, "a1.txt", "text/plain");
+        await service.UploadAsync(new MemoryStream(new byte[] { 2 }), containerA, "a2.txt", "text/plain");
+        await service.UploadAsync(new MemoryStream(new byte[] { 3 }), containerB, "b1.txt", "text/plain");
+        await service.UploadAsync(new MemoryStream(new byte[] { 4 }), containerB, "b2.txt", "text/plain");
+
+        // Assert — each container gets exactly one CreateIfNotExistsAsync call
+        mockContainerClientA.Verify(
+            x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        mockContainerClientB.Verify(
+            x => x.CreateIfNotExistsAsync(It.IsAny<PublicAccessType>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<BlobContainerEncryptionScopeOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task UploadAsync_BlobStorageException_ShouldThrow()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- `CreateIfNotExistsAsync` was called on every `UploadAsync` invocation, causing Azure to return HTTP 409 for existing containers
- App Insights traced each 409 as a failed dependency (20+ noise failures/day per issue #505)
- Fix: `ConcurrentDictionary<string, bool> _containerExists` field caches confirmed containers, so `CreateIfNotExistsAsync` is called at most **once per container per service lifetime**

## Test plan
- [x] 2 new unit tests added: `UploadAsync_CalledMultipleTimes_ShouldCallCreateIfNotExistsOnlyOnce` and `UploadAsync_DifferentContainers_ShouldCallCreateIfNotExistsOncePerContainer`
- [x] All 2085 backend tests pass (+ 8 pre-existing integration skips)
- [x] All 756 frontend Jest tests pass
- [x] `dotnet format --verify-no-changes` clean

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)