### PR TITLE
fix(e2e): narrow waitForTableUpdate selector to data tbody rows to avoid matching layout tables

### DIFF
--- a/frontend/test/e2e/helpers/stock-operations-test-helpers.ts
+++ b/frontend/test/e2e/helpers/stock-operations-test-helpers.ts
@@ -14,11 +14,15 @@ const UI_LABELS = {
  * Wait for stock operations table to update after filter/sort changes.
  * Uses DOM-based wait to avoid race conditions with page.waitForResponse,
  * which only catches API responses registered BEFORE the request fires.
+ *
+ * Waits for at least one data row (tbody tr) to be visible, or for the
+ * empty-state message to appear. Using 'tbody tr' instead of 'table' avoids
+ * matching layout/filter tables that may be present before the data table loads.
  */
 export async function waitForTableUpdate(page: Page): Promise<void> {
-  // Wait for either the data table or the empty-state message to appear
+  // Wait for either at least one data row or the empty-state message to appear
   await expect(
-    page.locator('table').or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
+    page.locator('tbody tr').first().or(page.locator('h3').filter({ hasText: 'Žádné výsledky' }))
   ).toBeVisible({ timeout: 15000 });
 }
 


### PR DESCRIPTION
Fixes #511

Narrows `waitForTableUpdate` selector from `page.locator("table")` (which matched any table on the page including layout/filter tables) to `page.locator("tbody tr").first()` so it only resolves when the actual data table has at least one row visible.

This prevents the test from proceeding before the data table is ready, fixing the `should display loading state during data fetch` timeout.