### PR TITLE
fix: reduce McpException noise in App Insights (#531)

### DIFF
--- a/backend/src/Anela.Heblo.API/MCP/Tools/KnowledgeBaseTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/KnowledgeBaseTools.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.AskQuestion;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
@@ -12,10 +13,12 @@ namespace Anela.Heblo.API.MCP.Tools;
 public class KnowledgeBaseTools
 {
     private readonly IMediator _mediator;
+    private readonly ILogger<KnowledgeBaseTools> _logger;
 
-    public KnowledgeBaseTools(IMediator mediator)
+    public KnowledgeBaseTools(IMediator mediator, ILogger<KnowledgeBaseTools> logger)
     {
         _mediator = mediator;
+        _logger = logger;
     }
 
     [McpServerTool]
@@ -35,6 +38,7 @@ public class KnowledgeBaseTools
         }
         catch (Exception ex)
         {
+            _logger.LogWarning(ex, "MCP SearchKnowledgeBase failed for query '{Query}'", query);
             throw new McpException($"Failed to search knowledge base: {ex.Message}");
         }
     }
@@ -56,6 +60,7 @@ public class KnowledgeBaseTools
         }
         catch (Exception ex)
         {
+            _logger.LogWarning(ex, "MCP AskKnowledgeBase failed for question '{Question}'", question);
             throw new McpException($"Failed to answer question: {ex.Message}");
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SearchDocuments/SearchDocumentsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SearchDocuments/SearchDocumentsHandler.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using MediatR;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
@@ -11,17 +12,20 @@ public class SearchDocumentsHandler : IRequestHandler<SearchDocumentsRequest, Se
     private readonly IKnowledgeBaseRepository _repository;
     private readonly KnowledgeBaseOptions _options;
     private readonly IChatClient _chatClient;
+    private readonly ILogger<SearchDocumentsHandler> _logger;
 
     public SearchDocumentsHandler(
         IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
         IKnowledgeBaseRepository repository,
         IOptions<KnowledgeBaseOptions> options,
-        IChatClient chatClient)
+        IChatClient chatClient,
+        ILogger<SearchDocumentsHandler> logger)
     {
         _embeddingGenerator = embeddingGenerator;
         _repository = repository;
         _options = options.Value;
         _chatClient = chatClient;
+        _logger = logger;
     }
 
     public async Task<SearchDocumentsResponse> Handle(
@@ -64,7 +68,15 @@ public class SearchDocumentsHandler : IRequestHandler<SearchDocumentsRequest, Se
         };
 
         var chatOptions = new ChatOptions { ModelId = _options.QueryExpansionModel };
-        var response = await _chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
-        return string.IsNullOrWhiteSpace(response.Text) ? query : response.Text;
+        try
+        {
+            var response = await _chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
+            return string.IsNullOrWhiteSpace(response.Text) ? query : response.Text;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TimeoutException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "Query expansion failed for query '{Query}', falling back to raw query", query);
+            return query;
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -13,6 +14,7 @@ public class SearchDocumentsHandlerTests
     private readonly Mock<IEmbeddingGenerator<string, Embedding<float>>> _embeddingGenerator = new();
     private readonly Mock<IKnowledgeBaseRepository> _repository = new();
     private readonly Mock<IChatClient> _chatClient = new();
+    private readonly Mock<ILogger<SearchDocumentsHandler>> _logger = new();
 
     private SearchDocumentsHandler CreateHandler(double minScore = 0.60, bool queryExpansionEnabled = false)
     {
@@ -22,7 +24,7 @@ public class SearchDocumentsHandlerTests
             QueryExpansionEnabled = queryExpansionEnabled,
             QueryExpansionPrompt = "Expand:"
         });
-        return new SearchDocumentsHandler(_embeddingGenerator.Object, _repository.Object, options, _chatClient.Object);
+        return new SearchDocumentsHandler(_embeddingGenerator.Object, _repository.Object, options, _chatClient.Object, _logger.Object);
     }
 
     private void SetupEmbeddingGenerator()
@@ -177,6 +179,41 @@ public class SearchDocumentsHandlerTests
         _chatClient.Verify(
             c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions?>(), default),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_QueryExpansionEnabled_LlmThrowsTransientError_FallsBackToRawQuery()
+    {
+        const string rawQuery = "popraskane ruce?";
+        SetupEmbeddingGenerator();
+
+        _chatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                default))
+            .ThrowsAsync(new HttpRequestException("Exception while reading from stream"));
+
+        _repository
+            .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
+            .ReturnsAsync([]);
+
+        string? capturedEmbeddingInput = null;
+        _embeddingGenerator
+            .Setup(s => s.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                default))
+            .Callback<IEnumerable<string>, EmbeddingGenerationOptions?, CancellationToken>(
+                (texts, _, _) => capturedEmbeddingInput = texts.First())
+            .ReturnsAsync(new GeneratedEmbeddings<Embedding<float>>(
+                [new Embedding<float>(new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }))]));
+
+        await CreateHandler(queryExpansionEnabled: true).Handle(
+            new SearchDocumentsRequest { Query = rawQuery, TopK = 5 },
+            default);
+
+        Assert.Equal(rawQuery, capturedEmbeddingInput);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/MCP/Tools/KnowledgeBaseToolsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/MCP/Tools/KnowledgeBaseToolsTests.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.API.MCP.Tools;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.AskQuestion;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using Moq;
 using Xunit;
@@ -12,6 +13,9 @@ namespace Anela.Heblo.Tests.MCP.Tools;
 public class KnowledgeBaseToolsTests
 {
     private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<ILogger<KnowledgeBaseTools>> _logger = new();
+
+    private KnowledgeBaseTools CreateTools() => new(_mediator.Object, _logger.Object);
 
     [Fact]
     public async Task SearchKnowledgeBase_ShouldMapParametersCorrectly()
@@ -27,8 +31,7 @@ public class KnowledgeBaseToolsTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
-        var tools = new KnowledgeBaseTools(_mediator.Object);
-        var result = await tools.SearchKnowledgeBase("phenoxyethanol", 3);
+        var result = await CreateTools().SearchKnowledgeBase("phenoxyethanol", 3);
 
         var deserialized = JsonSerializer.Deserialize<SearchDocumentsResponse>(result);
         Assert.NotNull(deserialized);
@@ -51,8 +54,7 @@ public class KnowledgeBaseToolsTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
-        var tools = new KnowledgeBaseTools(_mediator.Object);
-        var result = await tools.AskKnowledgeBase("Max phenoxyethanol?");
+        var result = await CreateTools().AskKnowledgeBase("Max phenoxyethanol?");
 
         var deserialized = JsonSerializer.Deserialize<AskQuestionResponse>(result);
         Assert.NotNull(deserialized);
@@ -67,9 +69,58 @@ public class KnowledgeBaseToolsTests
             .Setup(m => m.Send(It.IsAny<SearchDocumentsRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("DB error"));
 
-        var tools = new KnowledgeBaseTools(_mediator.Object);
+        await Assert.ThrowsAsync<McpException>(() =>
+            CreateTools().SearchKnowledgeBase("query"));
+    }
+
+    [Fact]
+    public async Task SearchKnowledgeBase_ShouldLogWarning_WhenMediatorThrows()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<SearchDocumentsRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("stream error"));
 
         await Assert.ThrowsAsync<McpException>(() =>
-            tools.SearchKnowledgeBase("query"));
+            CreateTools().SearchKnowledgeBase("query"));
+
+        _logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("SearchKnowledgeBase")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AskKnowledgeBase_ShouldThrowMcpException_WhenMediatorThrows()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<AskQuestionRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("AI error"));
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            CreateTools().AskKnowledgeBase("question?"));
+    }
+
+    [Fact]
+    public async Task AskKnowledgeBase_ShouldLogWarning_WhenMediatorThrows()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<AskQuestionRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("AI error"));
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            CreateTools().AskKnowledgeBase("question?"));
+
+        _logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("AskKnowledgeBase")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #531 — elevated McpException exceptions in production Application Insights.

### Root cause

`KnowledgeBaseTools` wrapped all exceptions as `McpException` without logging them first, causing App Insights to track them as unhandled exceptions rather than handled warnings. When the Anthropic API timed out during query expansion in `SearchDocumentsHandler.ExpandQueryAsync`, the `TaskCanceledException` propagated all the way up as `McpException`.

### Changes

- *`KnowledgeBaseTools`* — inject `ILogger<KnowledgeBaseTools>` and emit `LogWarning` before re-throwing as `McpException`. App Insights will now track these as handled warnings, not unhandled exceptions.
- *`SearchDocumentsHandler`* — inject `ILogger<SearchDocumentsHandler>` and catch transient errors (`HttpRequestException`, `TimeoutException`, `TaskCanceledException`) in `ExpandQueryAsync`, falling back to the raw query. This prevents query expansion timeouts from propagating as `McpException` at all.

### Tests

Added 4 new unit tests:
- `SearchKnowledgeBase_ShouldLogWarning_WhenMediatorThrows`
- `AskKnowledgeBase_ShouldThrowMcpException_WhenMediatorThrows`
- `AskKnowledgeBase_ShouldLogWarning_WhenMediatorThrows`
- `Handle_QueryExpansionEnabled_LlmThrowsTransientError_FallsBackToRawQuery`

All 2109 unit tests pass (7 Docker-dependent integration test failures are pre-existing). All 769 frontend tests pass.