### PR TITLE
fix: catch PostgresException in GridLayouts handlers to prevent unhandled 500 errors

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
@@ -35,7 +35,9 @@ public class GridLayoutsController : BaseApiController
     public async Task<ActionResult> Save(string gridKey, [FromBody] SaveGridLayoutRequest body)
     {
         body.GridKey = gridKey;
-        await _mediator.Send(body);
+        var response = await _mediator.Send(body);
+        if (!response.Success)
+            return StatusCode(500, response);
         return Ok();
     }
 
@@ -43,7 +45,9 @@ public class GridLayoutsController : BaseApiController
     public async Task<ActionResult> Reset(string gridKey)
     {
         var request = new ResetGridLayoutRequest { GridKey = gridKey };
-        await _mediator.Send(request);
+        var response = await _mediator.Send(request);
+        if (!response.Success)
+            return StatusCode(500, response);
         return Ok();
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
@@ -3,6 +3,8 @@ using Anela.Heblo.Application.Features.GridLayouts.Contracts;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
+using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
 
@@ -10,11 +12,13 @@ public class GetGridLayoutHandler : IRequestHandler<GetGridLayoutRequest, GetGri
 {
     private readonly IGridLayoutRepository _repository;
     private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<GetGridLayoutHandler> _logger;
 
-    public GetGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService)
+    public GetGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService, ILogger<GetGridLayoutHandler> logger)
     {
         _repository = repository;
         _currentUserService = currentUserService;
+        _logger = logger;
     }
 
     public async Task<GetGridLayoutResponse> Handle(GetGridLayoutRequest request, CancellationToken cancellationToken)
@@ -23,17 +27,28 @@ public class GetGridLayoutHandler : IRequestHandler<GetGridLayoutRequest, GetGri
         var userId = user.Id ?? user.Email
             ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
 
-        var entity = await _repository.GetAsync(userId, request.GridKey, cancellationToken);
-
-        if (entity is null)
+        try
         {
+            var entity = await _repository.GetAsync(userId, request.GridKey, cancellationToken);
+
+            if (entity is null)
+            {
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
+            var dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto();
+            dto.GridKey = entity.GridKey;
+            dto.LastModified = entity.LastModified;
+
+            return new GetGridLayoutResponse { Layout = dto };
+        }
+        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        {
+            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
+            _logger.LogError(ex,
+                "Database error reading GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, pgEx?.SqlState);
             return new GetGridLayoutResponse { Layout = null };
         }
-
-        var dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto();
-        dto.GridKey = entity.GridKey;
-        dto.LastModified = entity.LastModified;
-
-        return new GetGridLayoutResponse { Layout = dto };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs
@@ -1,6 +1,9 @@
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
+using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
 
@@ -8,11 +11,13 @@ public class ResetGridLayoutHandler : IRequestHandler<ResetGridLayoutRequest, Re
 {
     private readonly IGridLayoutRepository _repository;
     private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<ResetGridLayoutHandler> _logger;
 
-    public ResetGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService)
+    public ResetGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService, ILogger<ResetGridLayoutHandler> logger)
     {
         _repository = repository;
         _currentUserService = currentUserService;
+        _logger = logger;
     }
 
     public async Task<ResetGridLayoutResponse> Handle(ResetGridLayoutRequest request, CancellationToken cancellationToken)
@@ -21,8 +26,18 @@ public class ResetGridLayoutHandler : IRequestHandler<ResetGridLayoutRequest, Re
         var userId = user.Id ?? user.Email
             ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
 
-        await _repository.DeleteAsync(userId, request.GridKey, cancellationToken);
-
-        return new ResetGridLayoutResponse();
+        try
+        {
+            await _repository.DeleteAsync(userId, request.GridKey, cancellationToken);
+            return new ResetGridLayoutResponse();
+        }
+        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        {
+            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
+            _logger.LogError(ex,
+                "Database error resetting GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, pgEx?.SqlState);
+            return new ResetGridLayoutResponse(ErrorCodes.DatabaseError);
+        }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutResponse.cs
@@ -2,4 +2,9 @@ using Anela.Heblo.Application.Shared;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
 
-public class ResetGridLayoutResponse : BaseResponse { }
+public class ResetGridLayoutResponse : BaseResponse
+{
+    public ResetGridLayoutResponse() : base() { }
+
+    public ResetGridLayoutResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs
@@ -1,8 +1,11 @@
 using System.Text.Json;
 using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
+using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
 
@@ -10,11 +13,13 @@ public class SaveGridLayoutHandler : IRequestHandler<SaveGridLayoutRequest, Save
 {
     private readonly IGridLayoutRepository _repository;
     private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<SaveGridLayoutHandler> _logger;
 
-    public SaveGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService)
+    public SaveGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService, ILogger<SaveGridLayoutHandler> logger)
     {
         _repository = repository;
         _currentUserService = currentUserService;
+        _logger = logger;
     }
 
     public async Task<SaveGridLayoutResponse> Handle(SaveGridLayoutRequest request, CancellationToken cancellationToken)
@@ -30,8 +35,19 @@ public class SaveGridLayoutHandler : IRequestHandler<SaveGridLayoutRequest, Save
         };
 
         var json = JsonSerializer.Serialize(payload);
-        await _repository.UpsertAsync(userId, request.GridKey, json, cancellationToken);
 
-        return new SaveGridLayoutResponse();
+        try
+        {
+            await _repository.UpsertAsync(userId, request.GridKey, json, cancellationToken);
+            return new SaveGridLayoutResponse();
+        }
+        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        {
+            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
+            _logger.LogError(ex,
+                "Database error saving GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, pgEx?.SqlState);
+            return new SaveGridLayoutResponse(ErrorCodes.DatabaseError);
+        }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutResponse.cs
@@ -2,4 +2,9 @@ using Anela.Heblo.Application.Shared;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
 
-public class SaveGridLayoutResponse : BaseResponse { }
+public class SaveGridLayoutResponse : BaseResponse
+{
+    public SaveGridLayoutResponse() : base() { }
+
+    public SaveGridLayoutResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
@@ -3,7 +3,9 @@ using Anela.Heblo.Application.Features.GridLayouts.Contracts;
 using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.GridLayouts;
@@ -12,9 +14,10 @@ public class GetGridLayoutHandlerTests
 {
     private readonly Mock<IGridLayoutRepository> _repositoryMock = new();
     private readonly Mock<ICurrentUserService> _currentUserMock = new();
+    private readonly Mock<ILogger<GetGridLayoutHandler>> _loggerMock = new();
 
     private GetGridLayoutHandler CreateHandler() =>
-        new(_repositoryMock.Object, _currentUserMock.Object);
+        new(_repositoryMock.Object, _currentUserMock.Object, _loggerMock.Object);
 
     [Fact]
     public async Task Handle_WhenNoSavedLayout_ReturnsNull()
@@ -51,5 +54,27 @@ public class GetGridLayoutHandlerTests
         Assert.Single(response.Layout!.Columns);
         Assert.Equal("col1", response.Layout.Columns[0].Id);
         Assert.Equal(120, response.Layout.Columns[0].Width);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDatabaseThrows_ReturnsNullLayoutAndLogsError()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock
+            .Setup(x => x.GetAsync("user-1", "test-grid", default))
+            .ThrowsAsync(new NpgsqlException("relation \"GridLayouts\" does not exist"));
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error reading GridLayout")),
+                It.IsAny<NpgsqlException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs
@@ -1,7 +1,10 @@
 using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.GridLayouts;
@@ -10,9 +13,10 @@ public class ResetGridLayoutHandlerTests
 {
     private readonly Mock<IGridLayoutRepository> _repositoryMock = new();
     private readonly Mock<ICurrentUserService> _currentUserMock = new();
+    private readonly Mock<ILogger<ResetGridLayoutHandler>> _loggerMock = new();
 
     private ResetGridLayoutHandler CreateHandler() =>
-        new(_repositoryMock.Object, _currentUserMock.Object);
+        new(_repositoryMock.Object, _currentUserMock.Object, _loggerMock.Object);
 
     [Fact]
     public async Task Handle_CallsDeleteWithCorrectUserAndGrid()
@@ -24,5 +28,28 @@ public class ResetGridLayoutHandlerTests
         await handler.Handle(new ResetGridLayoutRequest { GridKey = "test-grid" }, default);
 
         _repositoryMock.Verify(x => x.DeleteAsync("user-1", "test-grid", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDatabaseThrows_ReturnsDatabaseErrorAndLogsError()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock
+            .Setup(x => x.DeleteAsync("user-1", "test-grid", default))
+            .ThrowsAsync(new NpgsqlException("relation \"GridLayouts\" does not exist"));
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new ResetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.DatabaseError, response.ErrorCode);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error resetting GridLayout")),
+                It.IsAny<NpgsqlException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs
@@ -1,9 +1,12 @@
 using System.Text.Json;
 using Anela.Heblo.Application.Features.GridLayouts.Contracts;
 using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.GridLayouts;
@@ -12,9 +15,10 @@ public class SaveGridLayoutHandlerTests
 {
     private readonly Mock<IGridLayoutRepository> _repositoryMock = new();
     private readonly Mock<ICurrentUserService> _currentUserMock = new();
+    private readonly Mock<ILogger<SaveGridLayoutHandler>> _loggerMock = new();
 
     private SaveGridLayoutHandler CreateHandler() =>
-        new(_repositoryMock.Object, _currentUserMock.Object);
+        new(_repositoryMock.Object, _currentUserMock.Object, _loggerMock.Object);
 
     [Fact]
     public async Task Handle_CallsUpsertWithSerializedColumns()
@@ -44,5 +48,30 @@ public class SaveGridLayoutHandlerTests
         Assert.NotNull(capturedJson);
         var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(capturedJson!);
         Assert.True(parsed!.ContainsKey("columns"));
+    }
+
+    [Fact]
+    public async Task Handle_WhenDatabaseThrows_ReturnsDatabaseErrorAndLogsError()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock
+            .Setup(x => x.UpsertAsync("user-1", "test-grid", It.IsAny<string>(), default))
+            .ThrowsAsync(new NpgsqlException("relation \"GridLayouts\" does not exist"));
+
+        var request = new SaveGridLayoutRequest { GridKey = "test-grid", Columns = new List<GridColumnStateDto>() };
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(request, default);
+
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.DatabaseError, response.ErrorCode);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error saving GridLayout")),
+                It.IsAny<NpgsqlException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }


### PR DESCRIPTION
## Problem

Issue #530: When the `GridLayouts` migration has not been applied to the database yet, all three GridLayouts endpoints throw an unhandled `PostgresException` (`42P01: relation "GridLayouts" does not exist`), resulting in elevated 500 errors in production.

The existing `PostgresExceptionLoggingInterceptor` only covers EF Core `SaveChanges` writes — it does **not** catch exceptions from read queries.

## Solution

- Added `ILogger<T>` injection to all three handlers (`GetGridLayout`, `SaveGridLayout`, `ResetGridLayout`)
- Added `catch (Exception ex) when (ex is PostgresException or NpgsqlException)` in each handler
- **Get**: Returns `null` layout on DB error (graceful degradation — frontend falls back to defaults)
- **Save / Reset**: Returns `ErrorCodes.DatabaseError`, controller returns HTTP 500 with error body
- Logs include `userId`, `gridKey`, and `SqlState` for easier diagnosis
- Added constructor overloads to `SaveGridLayoutResponse` and `ResetGridLayoutResponse`
- Updated `GridLayoutsController` Save/Reset to check `response.Success`

## Tests

Added unit tests for the DB error path in all three handlers. All 2108 unit tests pass. FE: 769/774 tests pass (5 skipped).

Closes #530