### PR TITLE
perf(invoices): add missing indexes on IssuedInvoice table (#519)

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceConfiguration.cs
@@ -131,5 +131,14 @@ public class IssuedInvoiceConfiguration : IEntityTypeConfiguration<IssuedInvoice
 
         builder.HasIndex(e => e.LastSyncTime)
             .HasDatabaseName("IX_IssuedInvoice_LastSyncTime");
+
+        builder.HasIndex(e => e.IsSynced)
+            .HasDatabaseName("IX_IssuedInvoice_IsSynced");
+
+        builder.HasIndex(e => e.ErrorType)
+            .HasDatabaseName("IX_IssuedInvoice_ErrorType");
+
+        builder.HasIndex(e => e.CustomerName)
+            .HasDatabaseName("IX_IssuedInvoice_CustomerName");
     }
 }

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260412220436_AddIssuedInvoiceFilterIndexes.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260412220436_AddIssuedInvoiceFilterIndexes.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIssuedInvoiceFilterIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_IssuedInvoice_IsSynced",
+                schema: "dbo",
+                table: "IssuedInvoice",
+                column: "IsSynced");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IssuedInvoice_ErrorType",
+                schema: "dbo",
+                table: "IssuedInvoice",
+                column: "ErrorType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IssuedInvoice_CustomerName",
+                schema: "dbo",
+                table: "IssuedInvoice",
+                column: "CustomerName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_IssuedInvoice_IsSynced",
+                schema: "dbo",
+                table: "IssuedInvoice");
+
+            migrationBuilder.DropIndex(
+                name: "IX_IssuedInvoice_ErrorType",
+                schema: "dbo",
+                table: "IssuedInvoice");
+
+            migrationBuilder.DropIndex(
+                name: "IX_IssuedInvoice_CustomerName",
+                schema: "dbo",
+                table: "IssuedInvoice");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -567,6 +567,15 @@ namespace Anela.Heblo.Persistence.Migrations
                     b.HasIndex("LastSyncTime")
                         .HasDatabaseName("IX_IssuedInvoice_LastSyncTime");
 
+                    b.HasIndex("IsSynced")
+                        .HasDatabaseName("IX_IssuedInvoice_IsSynced");
+
+                    b.HasIndex("ErrorType")
+                        .HasDatabaseName("IX_IssuedInvoice_ErrorType");
+
+                    b.HasIndex("CustomerName")
+                        .HasDatabaseName("IX_IssuedInvoice_CustomerName");
+
                     b.ToTable("IssuedInvoice", "dbo");
                 });
 


### PR DESCRIPTION
## Summary

Closes #519

Adds B-tree indexes on the `IssuedInvoice` table to speed up filtered queries on the `GET /api/issued-invoices` endpoint:

- `IX_IssuedInvoice_IsSynced` — improves sync status filtering (`IsSynced = true/false`)
- `IX_IssuedInvoice_ErrorType` — improves error type filtering (`ErrorType IS NOT NULL`, specific error types)
- `IX_IssuedInvoice_CustomerName` — improves customer name lookups

### Changes
- `IssuedInvoiceConfiguration.cs` — declares 3 new indexes via EF Core fluent API
- New EF migration `20260412220436_AddIssuedInvoiceFilterIndexes.cs`
- Updated `ApplicationDbContextModelSnapshot.cs`

## Test plan
- [x] BE tests pass (`dotnet test`) — 2105 passed, 7 pre-existing failures (KnowledgeBase integration tests requiring PostgreSQL/pgvector)
- [x] FE tests pass (`npm test -- --watchAll=false`) — 769 passed, 5 skipped