### PR TITLE
fix(flexi): log error and rethrow on 501 from BoM and stav-skladu-k-datu

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -6,6 +6,8 @@ using Rem.FlexiBeeSDK.Client;
 using Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
 using Rem.FlexiBeeSDK.Client.Clients.Products.BoM;
 using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
+using Rem.FlexiBeeSDK.Model;
+using System.Net;
 
 namespace Anela.Heblo.Adapters.Flexi.Manufacture;
 
@@ -166,7 +168,18 @@ internal class FlexiManufactureClient : IManufactureClient
 
     public async Task UpdateBoMIngredientAmountAsync(string productCode, string ingredientCode, double newAmount, CancellationToken cancellationToken = default)
     {
-        await _bomClient.UpdateIngredientAmountAsync(productCode, ingredientCode, newAmount, cancellationToken);
+        try
+        {
+            await _bomClient.UpdateIngredientAmountAsync(productCode, ingredientCode, newAmount, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotImplemented)
+        {
+            _logger.LogError(ex,
+                "FlexiBee kusovnik returned 501 NotImplemented while updating BoM ingredient amount — " +
+                "endpoint may be disabled or unsupported on this instance. ProductCode: {ProductCode}, IngredientCode: {IngredientCode}",
+                productCode, ingredientCode);
+            throw;
+        }
     }
 
     public async Task<ManufactureTemplate?> GetManufactureTemplateAsync(string id, CancellationToken cancellationToken = default)
@@ -176,7 +189,19 @@ internal class FlexiManufactureClient : IManufactureClient
 
     public async Task<List<ManufactureTemplate>> FindByIngredientAsync(string ingredientCode, CancellationToken cancellationToken)
     {
-        var templates = await _bomClient.GetByIngredientAsync(ingredientCode, cancellationToken);
+        IEnumerable<BoMItemFlexiDto> templates;
+        try
+        {
+            templates = await _bomClient.GetByIngredientAsync(ingredientCode, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotImplemented)
+        {
+            _logger.LogError(ex,
+                "FlexiBee kusovnik returned 501 NotImplemented while fetching BoM by ingredient — " +
+                "endpoint may be disabled or unsupported on this instance. IngredientCode: {IngredientCode}",
+                ingredientCode);
+            throw;
+        }
 
         return templates
                 .Select(s => new ManufactureTemplate()

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureTemplateService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureTemplateService.cs
@@ -2,8 +2,10 @@ using Anela.Heblo.Adapters.Flexi.Stock;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Manufacture;
+using Microsoft.Extensions.Logging;
 using Rem.FlexiBeeSDK.Client.Clients.Products.BoM;
 using Rem.FlexiBeeSDK.Model;
+using System.Net;
 
 namespace Anela.Heblo.Adapters.Flexi.Manufacture.Internal;
 
@@ -12,20 +14,35 @@ internal sealed class FlexiManufactureTemplateService : IFlexiManufactureTemplat
     private readonly IBoMClient _bomClient;
     private readonly IErpStockClient _stockClient;
     private readonly TimeProvider _timeProvider;
+    private readonly ILogger<FlexiManufactureTemplateService> _logger;
 
     public FlexiManufactureTemplateService(
         IBoMClient bomClient,
         IErpStockClient stockClient,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ILogger<FlexiManufactureTemplateService> logger)
     {
         _bomClient = bomClient ?? throw new ArgumentNullException(nameof(bomClient));
         _stockClient = stockClient ?? throw new ArgumentNullException(nameof(stockClient));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<ManufactureTemplate?> GetManufactureTemplateAsync(string productCode, CancellationToken cancellationToken = default)
     {
-        var bom = await _bomClient.GetAsync(productCode, cancellationToken);
+        IEnumerable<BoMItemFlexiDto> bom;
+        try
+        {
+            bom = await _bomClient.GetAsync(productCode, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotImplemented)
+        {
+            _logger.LogError(ex,
+                "FlexiBee kusovnik returned 501 NotImplemented while fetching BoM template — " +
+                "endpoint may be disabled or unsupported on this instance. ProductCode: {ProductCode}",
+                productCode);
+            throw;
+        }
 
         var header = bom.SingleOrDefault(s => s.Level == 1);
         if (header == null)

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Products/FlexiProductClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Products/FlexiProductClient.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Domain.Features.Catalog.Products;
 using Microsoft.Extensions.Logging;
 using Rem.FlexiBeeSDK.Client.Clients.Products.BoM;
+using System.Net;
 
 namespace Anela.Heblo.Adapters.Flexi.Products;
 
@@ -25,7 +26,19 @@ public class FlexiProductClient : IProductWeightClient
         _logger.LogDebug("Starting weight recalculation for product {ProductCode}", productCode);
 
         // 1. Get BOM data for the product
-        var weight = await _bomClient.GetBomWeight(productCode, cancellationToken);
+        double? weight;
+        try
+        {
+            weight = (await _bomClient.GetBomWeight(productCode, cancellationToken))?.NetWeight;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotImplemented)
+        {
+            _logger.LogError(ex,
+                "FlexiBee kusovnik returned 501 NotImplemented while fetching BoM weight — " +
+                "endpoint may be disabled or unsupported on this instance. ProductCode: {ProductCode}",
+                productCode);
+            throw;
+        }
 
         if (weight == null)
         {
@@ -36,7 +49,7 @@ public class FlexiProductClient : IProductWeightClient
         var request = new PriceListFlexiDto()
         {
             ProductCode = productCode,
-            Weight = weight.NetWeight,
+            Weight = weight.Value,
         };
 
         var result = await _priceListClient.SaveAsync(request, cancellationToken);

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Stock/FlexiStockClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Stock/FlexiStockClient.cs
@@ -1,7 +1,9 @@
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using AutoMapper;
+using Microsoft.Extensions.Logging;
 using Rem.FlexiBeeSDK.Client.Clients.Products.StockToDate;
+using System.Net;
 
 namespace Anela.Heblo.Adapters.Flexi.Stock;
 
@@ -14,12 +16,18 @@ public class FlexiStockClient : IErpStockClient
     private readonly IStockToDateClient _stockClient;
     private readonly TimeProvider _timeProvider;
     private readonly IMapper _mapper;
+    private readonly ILogger<FlexiStockClient> _logger;
 
-    public FlexiStockClient(IStockToDateClient stockClient, TimeProvider timeProvider, IMapper mapper)
+    public FlexiStockClient(
+        IStockToDateClient stockClient,
+        TimeProvider timeProvider,
+        IMapper mapper,
+        ILogger<FlexiStockClient> logger)
     {
         _stockClient = stockClient;
         _timeProvider = timeProvider;
         _mapper = mapper;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<IReadOnlyList<ErpStock>> ListAsync(CancellationToken cancellationToken)
@@ -40,12 +48,22 @@ public class FlexiStockClient : IErpStockClient
     public async Task<IReadOnlyList<ErpStock>> StockToDateAsync(DateTime date, int warehouseId,
         CancellationToken cancellationToken)
     {
-        // Map store code to warehouse ID
-        var stockToDate = await _stockClient
-            .GetAsync(date, warehouseId: warehouseId, cancellationToken: cancellationToken);
+        try
+        {
+            var stockToDate = await _stockClient
+                .GetAsync(date, warehouseId: warehouseId, cancellationToken: cancellationToken);
 
-        var stock = _mapper.Map<List<ErpStock>>(stockToDate);
-        return stock;
+            var stock = _mapper.Map<List<ErpStock>>(stockToDate);
+            return stock;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotImplemented)
+        {
+            _logger.LogError(ex,
+                "FlexiBee stav-skladu-k-datu returned 501 NotImplemented — endpoint may be disabled or unsupported on this instance. " +
+                "WarehouseId: {WarehouseId}, Date: {Date}",
+                warehouseId, date);
+            throw;
+        }
     }
 
     private Task<IReadOnlyList<ErpStock>> ListByWarehouse(int warehouseId, ProductType productType,
@@ -57,20 +75,23 @@ public class FlexiStockClient : IErpStockClient
     private async Task<IReadOnlyList<ErpStock>> ListByWarehouse(int warehouseId, ProductType[] productTypes,
         CancellationToken cancellationToken)
     {
-        var startTime = DateTime.UtcNow;
-        var parameters = new Dictionary<string, object>
+        try
         {
-            ["warehouseId"] = warehouseId,
-            ["productTypes"] = string.Join(", ", productTypes),
-            ["date"] = _timeProvider.GetUtcNow().Date
-        };
+            var stockToDate = await _stockClient
+                .GetAsync(_timeProvider.GetUtcNow().Date, warehouseId: warehouseId, cancellationToken: cancellationToken);
 
-        var stockToDate = await _stockClient
-            .GetAsync(_timeProvider.GetUtcNow().Date, warehouseId: warehouseId, cancellationToken: cancellationToken);
-
-        var productTypeIds = productTypes.Select(i => (int?)i).ToList();
-        var filteredStockToDate = stockToDate.Where(w => productTypeIds.Contains(w.ProductTypeId));
-        var stock = _mapper.Map<List<ErpStock>>(filteredStockToDate);
-        return stock;
+            var productTypeIds = productTypes.Select(i => (int?)i).ToList();
+            var filteredStockToDate = stockToDate.Where(w => productTypeIds.Contains(w.ProductTypeId));
+            var stock = _mapper.Map<List<ErpStock>>(filteredStockToDate);
+            return stock;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotImplemented)
+        {
+            _logger.LogError(ex,
+                "FlexiBee stav-skladu-k-datu returned 501 NotImplemented — endpoint may be disabled or unsupported on this instance. " +
+                "WarehouseId: {WarehouseId}, ProductTypes: {ProductTypes}",
+                warehouseId, string.Join(", ", productTypes));
+            throw;
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClient501Tests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClient501Tests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using Anela.Heblo.Adapters.Flexi.Manufacture;
+using Anela.Heblo.Adapters.Flexi.Manufacture.Internal;
+using Anela.Heblo.Domain.Features.Catalog.Lots;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rem.FlexiBeeSDK.Client;
+using Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
+using Rem.FlexiBeeSDK.Client.Clients.Products.BoM;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Manufacture;
+
+public class FlexiManufactureClient501Tests
+{
+    private readonly Mock<IBoMClient> _mockBomClient;
+    private readonly Mock<ILogger<FlexiManufactureClient>> _mockLogger;
+    private readonly FlexiManufactureClient _client;
+
+    public FlexiManufactureClient501Tests()
+    {
+        _mockBomClient = new Mock<IBoMClient>();
+        _mockLogger = new Mock<ILogger<FlexiManufactureClient>>();
+        var mockTemplateService = new Mock<IFlexiManufactureTemplateService>();
+        var mockStockClient = new Mock<IErpStockClient>();
+        var mockStockMovementClient = new Mock<IStockItemsMovementClient>();
+        var mockProductSetsClient = new Mock<IProductSetsClient>();
+        var mockLotsClient = new Mock<ILotsClient>();
+
+        var movementService = new FlexiManufactureDocumentService(
+            mockStockClient.Object,
+            mockStockMovementClient.Object);
+
+        _client = new FlexiManufactureClient(
+            _mockBomClient.Object,
+            mockProductSetsClient.Object,
+            _mockLogger.Object,
+            mockTemplateService.Object,
+            new FefoConsumptionAllocator(),
+            new FlexiIngredientRequirementAggregator(mockTemplateService.Object),
+            new FlexiIngredientStockValidator(mockStockClient.Object, TimeProvider.System),
+            new FlexiLotLoader(mockLotsClient.Object),
+            movementService,
+            mockStockMovementClient.Object,
+            TimeProvider.System);
+    }
+
+    [Fact]
+    public async Task UpdateBoMIngredientAmountAsync_When501Returned_LogsErrorAndRethrows()
+    {
+        // Arrange
+        var exception = new HttpRequestException("NotImplemented", null, HttpStatusCode.NotImplemented);
+        _mockBomClient
+            .Setup(x => x.UpdateIngredientAmountAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var act = async () => await _client.UpdateBoMIngredientAmountAsync("PROD-001", "ING-001", 5.0, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("501") && v.ToString()!.Contains("kusovnik")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FindByIngredientAsync_When501Returned_LogsErrorAndRethrows()
+    {
+        // Arrange
+        var exception = new HttpRequestException("NotImplemented", null, HttpStatusCode.NotImplemented);
+        _mockBomClient
+            .Setup(x => x.GetByIngredientAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var act = async () => await _client.FindByIngredientAsync("ING-001", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("501") && v.ToString()!.Contains("kusovnik")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/Internal/FlexiManufactureTemplateServiceTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/Internal/FlexiManufactureTemplateServiceTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using Anela.Heblo.Adapters.Flexi.Manufacture.Internal;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.BoM;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Manufacture.Internal;
+
+public class FlexiManufactureTemplateServiceTests
+{
+    private readonly Mock<IBoMClient> _mockBomClient;
+    private readonly Mock<IErpStockClient> _mockStockClient;
+    private readonly Mock<ILogger<FlexiManufactureTemplateService>> _mockLogger;
+    private readonly FlexiManufactureTemplateService _service;
+
+    public FlexiManufactureTemplateServiceTests()
+    {
+        _mockBomClient = new Mock<IBoMClient>();
+        _mockStockClient = new Mock<IErpStockClient>();
+        _mockLogger = new Mock<ILogger<FlexiManufactureTemplateService>>();
+
+        _service = new FlexiManufactureTemplateService(
+            _mockBomClient.Object,
+            _mockStockClient.Object,
+            TimeProvider.System,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetManufactureTemplateAsync_When501Returned_LogsErrorAndRethrows()
+    {
+        // Arrange
+        var exception = new HttpRequestException("NotImplemented", null, HttpStatusCode.NotImplemented);
+        _mockBomClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var act = async () => await _service.GetManufactureTemplateAsync("PROD-001", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("501") && v.ToString()!.Contains("kusovnik")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Products/FlexiProductClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Products/FlexiProductClientTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using Anela.Heblo.Adapters.Flexi.Products;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.BoM;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Products;
+
+public class FlexiProductClientTests
+{
+    private readonly Mock<IBoMClient> _mockBomClient;
+    private readonly Mock<IPriceListClient> _mockPriceListClient;
+    private readonly Mock<ILogger<FlexiProductClient>> _mockLogger;
+    private readonly FlexiProductClient _client;
+
+    public FlexiProductClientTests()
+    {
+        _mockBomClient = new Mock<IBoMClient>();
+        _mockPriceListClient = new Mock<IPriceListClient>();
+        _mockLogger = new Mock<ILogger<FlexiProductClient>>();
+
+        _client = new FlexiProductClient(
+            _mockBomClient.Object,
+            _mockPriceListClient.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task RefreshProductWeight_When501Returned_LogsErrorAndRethrows()
+    {
+        // Arrange
+        var exception = new HttpRequestException("NotImplemented", null, HttpStatusCode.NotImplemented);
+        _mockBomClient
+            .Setup(x => x.GetBomWeight(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var act = async () => await _client.RefreshProductWeight("PROD-001", CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("501") && v.ToString()!.Contains("kusovnik")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockClientTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using Anela.Heblo.Adapters.Flexi.Stock;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockToDate;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Stock;
+
+public class FlexiStockClientTests
+{
+    private readonly Mock<IStockToDateClient> _mockStockClient;
+    private readonly Mock<ILogger<FlexiStockClient>> _mockLogger;
+    private readonly FlexiStockClient _client;
+
+    public FlexiStockClientTests()
+    {
+        _mockStockClient = new Mock<IStockToDateClient>();
+        _mockLogger = new Mock<ILogger<FlexiStockClient>>();
+        var mockMapper = new Mock<IMapper>();
+
+        _client = new FlexiStockClient(
+            _mockStockClient.Object,
+            TimeProvider.System,
+            mockMapper.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task StockToDateAsync_When501Returned_LogsErrorAndRethrows()
+    {
+        // Arrange
+        var exception = new HttpRequestException("NotImplemented", null, HttpStatusCode.NotImplemented);
+        _mockStockClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var act = async () => await _client.StockToDateAsync(DateTime.UtcNow, warehouseId: 5, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("501") && v.ToString()!.Contains("stav-skladu-k-datu")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ListAsync_When501ReturnedForWarehouse_LogsErrorAndRethrows()
+    {
+        // Arrange
+        var exception = new HttpRequestException("NotImplemented", null, HttpStatusCode.NotImplemented);
+        _mockStockClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var act = async () => await _client.ListAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("501") && v.ToString()!.Contains("stav-skladu-k-datu")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+}


### PR DESCRIPTION
## Summary

- FlexiBee returns HTTP 501 NotImplemented for `kusovnik` (BoM) and `stav-skladu-k-datu` endpoints on instances where they are disabled
- These errors were silently swallowed, making diagnosis very difficult
- Added `LogError` + re-throw in all four affected classes

## Changes

• `FlexiStockClient` — catch 501 in `StockToDateAsync` and `ListByWarehouse`, log with warehouseId context
• `FlexiProductClient` — catch 501 in `RefreshProductWeight`, log with productCode context
• `FlexiManufactureClient` — catch 501 in `UpdateBoMIngredientAmountAsync` and `FindByIngredientAsync`
• `FlexiManufactureTemplateService` — catch 501 in `GetManufactureTemplateAsync`, log with productCode context

## Tests

New unit test files covering 501 scenarios for all four classes:
• `FlexiStockClientTests` (2 tests)
• `FlexiProductClientTests` (1 test)
• `FlexiManufactureClient501Tests` (2 tests)
• `FlexiManufactureTemplateServiceTests` (1 test)

All 2247 BE tests pass + 769 FE tests pass.

Closes #515