### PR TITLE
fix(e2e): fix race condition in applyFilters causing zero-row result

### DIFF
--- a/frontend/test/e2e/helpers/classification-history-helpers.ts
+++ b/frontend/test/e2e/helpers/classification-history-helpers.ts
@@ -76,8 +76,26 @@ export async function applyFilters(
     await inputs.companyName.fill(filters.companyName);
   }
 
+  // Register response waiter BEFORE clicking to avoid missing the response.
+  // (US-002 pattern: page.waitForResponse must be registered before the action that
+  // triggers the request, or the response may arrive before the waiter is set up.)
+  const responsePromise = page.waitForResponse(
+    resp => resp.url().includes('/api/InvoiceClassification/history') && resp.status() === 200,
+    { timeout: 15000 }
+  );
+
   await inputs.filterButton.click();
-  await page.waitForLoadState('networkidle'); // Wait for filter application
+
+  // Wait for the API response to arrive.
+  await responsePromise;
+
+  // After the response arrives, React re-renders. Wait for the DOM to reflect the new
+  // state: either table rows or the no-records message (component renders one or the other
+  // once isLoading becomes false).
+  await page.waitForSelector(
+    'table tbody tr, :text("Nebyly nalezeny žádné záznamy")',
+    { timeout: 15000 }
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #513

- Replace `waitForLoadState('networkidle')` with the US-002 `waitForResponse` + `waitForSelector` pattern in the `applyFilters` E2E helper
- Register `page.waitForResponse` for `/api/InvoiceClassification/history` **before** clicking the filter button so the response is never missed
- After awaiting the response, wait for the DOM to show either table rows or the no-records message, ensuring React has finished re-rendering

## Root cause

`networkidle` resolved after the network response arrived but before React committed its DOM update. `getRowCount()` therefore read the table during a transient empty/loading state and returned 0, causing the test `should apply all four filters together` to fail with 0 rows.

The same race condition pattern was documented in `wait-helpers.ts` (US-002 analysis) for the catalog text-search tests.

## Test plan

- [ ] E2E test `should apply all four filters together` passes on staging
- [ ] All other classification history filter E2E tests remain green
- [ ] FE unit tests: 769 passed, 0 failed