### PR TITLE
fix(mcp): catch transient stream exceptions in SearchDocumentsHandler (#598)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SearchDocuments/SearchDocumentsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SearchDocuments/SearchDocumentsHandler.cs
@@ -36,11 +36,38 @@ public class SearchDocumentsHandler : IRequestHandler<SearchDocumentsRequest, Se
             ? await ExpandQueryAsync(request.Query, cancellationToken)
             : request.Query;
 
-        var embeddings = await _embeddingGenerator.GenerateAsync(
-            [queryToEmbed],
-            cancellationToken: cancellationToken);
-        var queryEmbedding = embeddings[0].Vector.ToArray();
-        var results = await _repository.SearchSimilarAsync(queryEmbedding, request.TopK, cancellationToken);
+        float[] queryEmbedding;
+        try
+        {
+            var embeddings = await _embeddingGenerator.GenerateAsync(
+                [queryToEmbed],
+                cancellationToken: cancellationToken);
+            queryEmbedding = embeddings[0].Vector.ToArray();
+        }
+        catch (Exception ex) when (ex is IOException or HttpRequestException or TimeoutException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Transient embedding failure for query '{Query}' — exceptionType: {ExceptionType}, innerExceptionType: {InnerExceptionType}",
+                request.Query,
+                ex.GetType().Name,
+                ex.InnerException?.GetType().Name ?? "none");
+            return new SearchDocumentsResponse();
+        }
+
+        List<(KnowledgeBaseChunk Chunk, double Score)> results;
+        try
+        {
+            results = await _repository.SearchSimilarAsync(queryEmbedding, request.TopK, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or HttpRequestException or TimeoutException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Transient vector DB failure during SearchSimilarAsync for query '{Query}' — exceptionType: {ExceptionType}, innerExceptionType: {InnerExceptionType}",
+                request.Query,
+                ex.GetType().Name,
+                ex.InnerException?.GetType().Name ?? "none");
+            return new SearchDocumentsResponse();
+        }
 
         var above = results.Where(r => r.Score >= _options.MinSimilarityScore).ToList();
         var belowCount = results.Count - above.Count;

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
@@ -251,4 +251,107 @@ public class SearchDocumentsHandlerTests
 
         Assert.Equal(rawQuery, capturedEmbeddingInput);
     }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(TaskCanceledException))]
+    public async Task Handle_EmbeddingGeneratorThrowsTransientException_ReturnsEmptyResponse(Type exceptionType)
+    {
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "Exception while reading from stream")!;
+        _embeddingGenerator
+            .Setup(s => s.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                default))
+            .ThrowsAsync(exception);
+
+        var result = await CreateHandler().Handle(
+            new SearchDocumentsRequest { Query = "test query", TopK = 5 },
+            default);
+
+        Assert.Empty(result.Chunks);
+        Assert.Equal(0, result.BelowThresholdCount);
+        _repository.Verify(
+            r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(TaskCanceledException))]
+    public async Task Handle_EmbeddingGeneratorThrowsTransientException_LogsWarningWithExceptionType(Type exceptionType)
+    {
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "stream error")!;
+        _embeddingGenerator
+            .Setup(s => s.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                default))
+            .ThrowsAsync(exception);
+
+        await CreateHandler().Handle(
+            new SearchDocumentsRequest { Query = "test query", TopK = 5 },
+            default);
+
+        _logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Transient embedding failure")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(TaskCanceledException))]
+    public async Task Handle_RepositoryThrowsTransientException_ReturnsEmptyResponse(Type exceptionType)
+    {
+        SetupEmbeddingGenerator();
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "stream error from pgvector")!;
+        _repository
+            .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), default))
+            .ThrowsAsync(exception);
+
+        var result = await CreateHandler().Handle(
+            new SearchDocumentsRequest { Query = "test query", TopK = 5 },
+            default);
+
+        Assert.Empty(result.Chunks);
+        Assert.Equal(0, result.BelowThresholdCount);
+    }
+
+    [Theory]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(TaskCanceledException))]
+    public async Task Handle_RepositoryThrowsTransientException_LogsWarningWithExceptionType(Type exceptionType)
+    {
+        SetupEmbeddingGenerator();
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "stream error from pgvector")!;
+        _repository
+            .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), default))
+            .ThrowsAsync(exception);
+
+        await CreateHandler().Handle(
+            new SearchDocumentsRequest { Query = "test query", TopK = 5 },
+            default);
+
+        _logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Transient vector DB failure")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
## Problem

`SearchDocumentsHandler.Handle()` did not catch transient stream exceptions thrown by:
- `IEmbeddingGenerator.GenerateAsync` (Azure OpenAI embedding calls)
- `IKnowledgeBaseRepository.SearchSimilarAsync` (pgvector queries)

These exceptions propagated up to `KnowledgeBaseTools`, where they were caught and re-thrown as `McpException`, causing a 4× spike above the baseline error rate observed in production (#598).

## Solution

Wrapped both calls in targeted `try/catch` with an exception filter for the four transient types: `IOException`, `HttpRequestException`, `TimeoutException`, `TaskCanceledException`.

On transient failure the handler now returns a graceful empty `SearchDocumentsResponse()` instead of propagating, preventing the McpException spike.

Added structured logging with `exceptionType` and `innerExceptionType` fields to distinguish embedding generator failures from vector DB stream failures in telemetry.

## Test coverage

Added 4 × 2 Theory-based unit tests (parameterised across all 4 exception types):
- `Handle_EmbeddingGeneratorThrowsTransientException_ReturnsEmptyResponse`
- `Handle_EmbeddingGeneratorThrowsTransientException_LogsWarningWithExceptionType`
- `Handle_RepositoryThrowsTransientException_ReturnsEmptyResponse`
- `Handle_RepositoryThrowsTransientException_LogsWarningWithExceptionType`

All 2 139 unit tests pass. Integration tests (requiring Docker / FlexiBee creds) are pre-existing failures unrelated to this change.

Closes #598
