### PR TITLE
feat(shoptet-invoices): Task 1 — Invoice Response DTOs

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/InvoiceListResponse.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/InvoiceListResponse.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class InvoiceListResponse
+{
+    [JsonPropertyName("data")]
+    public InvoiceListData Data { get; set; } = new();
+}
+
+public class InvoiceListData
+{
+    [JsonPropertyName("invoices")]
+    public List<ShoptetInvoiceDto> Invoices { get; set; } = new();
+
+    [JsonPropertyName("paginator")]
+    public InvoicePaginator Paginator { get; set; } = new();
+}
+
+public class InvoicePaginator
+{
+    [JsonPropertyName("totalCount")]
+    public int TotalCount { get; set; }
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+
+    [JsonPropertyName("pageCount")]
+    public int PageCount { get; set; }
+}
+
+public class InvoiceDetailResponse
+{
+    [JsonPropertyName("data")]
+    public InvoiceDetailData Data { get; set; } = new();
+}
+
+public class InvoiceDetailData
+{
+    [JsonPropertyName("invoice")]
+    public ShoptetInvoiceDto Invoice { get; set; } = new();
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetBillingMethodDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetBillingMethodDto.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+/// <summary>
+/// Billing/payment method as returned in the invoice response.
+/// Shoptet REST API returns { "id": int, "name": "..." }.
+/// </summary>
+public class ShoptetBillingMethodDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceAddressDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceAddressDto.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+/// <summary>
+/// Shared address DTO used for both billingAddress and deliveryAddress on invoices.
+/// The fields companyId, taxId, vatId, and vatIdValidationStatus are only present
+/// on billingAddress — they are absent (null) on deliveryAddress.
+/// </summary>
+public class ShoptetInvoiceAddressDto
+{
+    [JsonPropertyName("company")]
+    public string? Company { get; set; }
+
+    [JsonPropertyName("fullName")]
+    public string? FullName { get; set; }
+
+    [JsonPropertyName("street")]
+    public string? Street { get; set; }
+
+    [JsonPropertyName("houseNumber")]
+    public string? HouseNumber { get; set; }
+
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
+
+    [JsonPropertyName("zip")]
+    public string? Zip { get; set; }
+
+    [JsonPropertyName("countryCode")]
+    public string? CountryCode { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("companyId")]
+    public string? CompanyId { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("taxId")]
+    public string? TaxId { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("vatId")]
+    public string? VatId { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("vatIdValidationStatus")]
+    public string? VatIdValidationStatus { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceDto.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoiceDto
+{
+    [JsonPropertyName("code")]
+    public string Code { get; set; } = null!;
+
+    /// <summary>Order code this invoice belongs to.</summary>
+    [JsonPropertyName("orderCode")]
+    public string? OrderCode { get; set; }
+
+    /// <summary>Variable symbol (payment reference). Returned as a number by the API.</summary>
+    [JsonPropertyName("varSymbol")]
+    public long? VarSymbol { get; set; }
+
+    /// <summary>ISO 8601 datetime string, e.g. "2024-06-01T10:00:00"</summary>
+    [JsonPropertyName("creationTime")]
+    public string? CreationTime { get; set; }
+
+    [JsonPropertyName("billingMethod")]
+    public ShoptetBillingMethodDto? BillingMethod { get; set; }
+
+    [JsonPropertyName("billingAddress")]
+    public ShoptetInvoiceAddressDto? BillingAddress { get; set; }
+
+    [JsonPropertyName("deliveryAddress")]
+    public ShoptetInvoiceAddressDto? DeliveryAddress { get; set; }
+
+    [JsonPropertyName("items")]
+    public List<ShoptetInvoiceItemDto> Items { get; set; } = new();
+
+    [JsonPropertyName("price")]
+    public ShoptetInvoicePriceDto? Price { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceItemDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceItemDto.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoiceItemDto
+{
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Quantity as a string, e.g. "2.00"</summary>
+    [JsonPropertyName("amount")]
+    public string? Amount { get; set; }
+
+    [JsonPropertyName("amountUnit")]
+    public string? AmountUnit { get; set; }
+
+    /// <summary>Total price for the line item (amount × unitPrice).</summary>
+    [JsonPropertyName("itemPrice")]
+    public ShoptetInvoiceUnitPriceDto? ItemPrice { get; set; }
+
+    /// <summary>Unit price for a single piece.</summary>
+    [JsonPropertyName("unitPrice")]
+    public ShoptetInvoiceUnitPriceDto? UnitPrice { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoicePriceDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoicePriceDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoicePriceDto
+{
+    [JsonPropertyName("withVat")]
+    public string? WithVat { get; set; }
+
+    [JsonPropertyName("withoutVat")]
+    public string? WithoutVat { get; set; }
+
+    [JsonPropertyName("toPay")]
+    public string? ToPay { get; set; }
+
+    [JsonPropertyName("vat")]
+    public string? Vat { get; set; }
+
+    [JsonPropertyName("currencyCode")]
+    public string? CurrencyCode { get; set; }
+
+    [JsonPropertyName("exchangeRate")]
+    public decimal? ExchangeRate { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceUnitPriceDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceUnitPriceDto.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoiceUnitPriceDto
+{
+    [JsonPropertyName("withVat")]
+    public string? WithVat { get; set; }
+
+    [JsonPropertyName("withoutVat")]
+    public string? WithoutVat { get; set; }
+
+    [JsonPropertyName("vat")]
+    public string? Vat { get; set; }
+
+    /// <summary>VAT rate as a percentage number, e.g. 21.0</summary>
+    [JsonPropertyName("vatRate")]
+    public decimal? VatRate { get; set; }
+}


### PR DESCRIPTION
## Summary

Implements Issue #549 — Task 1 of Epic #547 (Shoptet Invoice Integration).

Adds 7 C# DTO classes for deserializing the Shoptet Issued Invoices API responses:

- `ShoptetInvoiceDto` — main invoice object
- `ShoptetInvoiceItemDto` — line item
- `ShoptetInvoiceUnitPriceDto` — item-level price (withVat/withoutVat/vat as strings, vatRate as decimal)
- `ShoptetInvoicePriceDto` — invoice-level price summary
- `ShoptetInvoiceAddressDto` — shared billing/delivery address
- `ShoptetBillingMethodDto` — payment method (id + name)
- `InvoiceListResponse` / `InvoiceDetailResponse` — API envelope wrappers with paginator

All classes use `System.Text.Json` with `[JsonPropertyName]` attributes following existing adapter patterns.

## Test plan
- [x] `dotnet build` — succeeds with no new errors
- [x] `dotnet test` — same pre-existing failures as `main` (infrastructure-dependent integration tests requiring Docker/credentials); all 2193 unit tests pass
- [x] `npm test -- --watchAll=false` — 82 suites, 769 tests passed, 5 skipped

Closes #549