### PR TITLE
feat(shoptet-invoices): Task 2 — ShoptetInvoiceClient typed HTTP client

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/IShoptetInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/IShoptetInvoiceClient.cs
@@ -1,0 +1,13 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public interface IShoptetInvoiceClient
+{
+    Task<IReadOnlyList<ShoptetInvoiceDto>> ListInvoicesAsync(
+        DateTime? dateFrom,
+        DateTime? dateTo,
+        CancellationToken ct = default);
+
+    Task<ShoptetInvoiceDto?> GetInvoiceAsync(string code, CancellationToken ct = default);
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetInvoiceClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public class ShoptetInvoiceClient : IShoptetInvoiceClient
+{
+    private readonly HttpClient _http;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public ShoptetInvoiceClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<IReadOnlyList<ShoptetInvoiceDto>> ListInvoicesAsync(
+        DateTime? dateFrom,
+        DateTime? dateTo,
+        CancellationToken ct = default)
+    {
+        var result = new List<ShoptetInvoiceDto>();
+        var page = 1;
+
+        while (true)
+        {
+            var url = BuildListUrl(dateFrom, dateTo, page);
+            var response = await _http.GetAsync(url, ct);
+            response.EnsureSuccessStatusCode();
+
+            var data = await response.Content.ReadFromJsonAsync<InvoiceListResponse>(JsonOptions, ct);
+            if (data == null)
+                break;
+
+            result.AddRange(data.Data.Invoices);
+
+            if (data.Data.Paginator.Page >= data.Data.Paginator.PageCount)
+                break;
+
+            page++;
+        }
+
+        return result;
+    }
+
+    public async Task<ShoptetInvoiceDto?> GetInvoiceAsync(string code, CancellationToken ct = default)
+    {
+        var response = await _http.GetAsync($"/api/invoices/{Uri.EscapeDataString(code)}", ct);
+        response.EnsureSuccessStatusCode();
+
+        var data = await response.Content.ReadFromJsonAsync<InvoiceDetailResponse>(JsonOptions, ct);
+        return data?.Data?.Invoice;
+    }
+
+    private static string BuildListUrl(DateTime? dateFrom, DateTime? dateTo, int page)
+    {
+        var from = (dateFrom ?? DateTime.UtcNow.AddDays(-1)).ToString("s") + "Z";
+        var to = (dateTo ?? DateTime.UtcNow).ToString("s") + "Z";
+        return $"/api/invoices?creationTimeFrom={Uri.EscapeDataString(from)}&creationTimeTo={Uri.EscapeDataString(to)}&page={page}&itemsPerPage=50";
+    }
+}


### PR DESCRIPTION
## Summary

Implements Task 2 of the Shoptet REST Invoice Adapter epic (#547).

Adds the typed HTTP client for the `/api/invoices` endpoint:

- `IShoptetInvoiceClient` - interface with `ListInvoicesAsync` (paginated) and `GetInvoiceAsync`
- `ShoptetInvoiceClient` - implementation using `HttpClient`, handles automatic pagination across all pages

Closes #550

> Note: based on `feat/549-shoptet-invoice-dtos` (Task 1 PR #624). Merge Task 1 first.