### PR TITLE
feat(shoptet-invoices): Task 3 — BillingMethodMapper with unit tests

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/BillingMethodMapper.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/BillingMethodMapper.cs
@@ -1,0 +1,41 @@
+using Anela.Heblo.Domain.Features.Invoices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+
+public class BillingMethodMapper
+{
+    private static readonly Dictionary<string, BillingMethod> CodeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["bankTransfer"] = BillingMethod.BankTransfer,
+        ["cash"] = BillingMethod.Cash,
+        ["cashOnDelivery"] = BillingMethod.CoD,
+        ["creditCard"] = BillingMethod.CreditCard,
+        ["comgate"] = BillingMethod.Comgate,
+    };
+
+    private readonly ILogger<BillingMethodMapper> _logger;
+
+    public BillingMethodMapper(ILogger<BillingMethodMapper> logger)
+    {
+        _logger = logger;
+    }
+
+    public BillingMethodMapper() : this(NullLogger<BillingMethodMapper>.Instance)
+    {
+    }
+
+    public BillingMethod Map(string? shoptetCode)
+    {
+        if (string.IsNullOrEmpty(shoptetCode) || !CodeMap.TryGetValue(shoptetCode, out var method))
+        {
+            if (!string.IsNullOrEmpty(shoptetCode))
+                _logger.LogWarning(
+                    "Unknown Shoptet billingMethod code '{Code}' — defaulting to BankTransfer. Add to BillingMethodMapper.Map.",
+                    shoptetCode);
+            return BillingMethod.BankTransfer;
+        }
+        return method;
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/IssuedInvoices/BillingMethodMapperTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/IssuedInvoices/BillingMethodMapperTests.cs
@@ -1,0 +1,40 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+using Anela.Heblo.Domain.Features.Invoices;
+using FluentAssertions;
+
+namespace Anela.Heblo.Adapters.Shoptet.Tests.IssuedInvoices;
+
+public class BillingMethodMapperTests
+{
+    private readonly BillingMethodMapper _sut = new();
+
+    [Theory]
+    [InlineData("bankTransfer", BillingMethod.BankTransfer)]
+    [InlineData("cash", BillingMethod.Cash)]
+    [InlineData("cashOnDelivery", BillingMethod.CoD)]
+    [InlineData("creditCard", BillingMethod.CreditCard)]
+    [InlineData("comgate", BillingMethod.Comgate)]
+    public void Map_KnownCodes_ReturnCorrectEnum(string shoptetCode, BillingMethod expected)
+    {
+        _sut.Map(shoptetCode).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("BANKTRANSFER", BillingMethod.BankTransfer)]
+    [InlineData("CashOnDelivery", BillingMethod.CoD)]
+    [InlineData("CREDITCARD", BillingMethod.CreditCard)]
+    public void Map_KnownCodes_AreCaseInsensitive(string shoptetCode, BillingMethod expected)
+    {
+        _sut.Map(shoptetCode).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("unknownPaymentMethod")]
+    public void Map_UnknownOrNullCode_ReturnsBankTransferDefault(string? shoptetCode)
+    {
+        _sut.Map(shoptetCode).Should().Be(BillingMethod.BankTransfer,
+            "Default matches Playwright's PaymentMethodResolver fallback");
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `BillingMethodMapper` mapping Shoptet `billingMethod` codes to `BillingMethod` enum
- Case-insensitive dictionary; defaults to `BankTransfer` for null/empty/unknown (matches Playwright fallback)
- Warns on unknown non-empty codes
- 11 unit tests covering all known codes, case-insensitivity, and fallback paths

Closes #551. Part of epic #547.

## Test plan
- dotnet build — 0 errors
- dotnet test (non-integration) — 2315 pass
- npm test -- --watchAll=false — 769 FE tests pass, 5 skipped