### PR TITLE
feat(marketing-invoices): Meta Ads transaction fetching adapter (#607)

### DIFF
--- a/Anela.Heblo.sln
+++ b/Anela.Heblo.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Shopte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.MetaAds", "backend\src\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj", "{714E577E-6254-4CD5-83CE-B4C9367A175A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.GoogleAds", "backend\src\Adapters\Anela.Heblo.Adapters.GoogleAds\Anela.Heblo.Adapters.GoogleAds.csproj", "{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -293,6 +295,18 @@ Global
 		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x64.Build.0 = Release|Any CPU
 		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x86.ActiveCfg = Release|Any CPU
 		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x86.Build.0 = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x64.Build.0 = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x86.Build.0 = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x64.ActiveCfg = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x64.Build.0 = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x86.ActiveCfg = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -320,5 +334,6 @@ Global
 		{B0098688-4986-4F6C-97B8-19A16808EDDA} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{E54D4978-CE79-4415-BA6B-E1B1C3C71169} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{714E577E-6254-4CD5-83CE-B4C9367A175A} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 	EndGlobalSection
 EndGlobal

--- a/Anela.Heblo.sln
+++ b/Anela.Heblo.sln
@@ -53,6 +53,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.SendGr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.ShoptetApi", "backend\src\Adapters\Anela.Heblo.Adapters.ShoptetApi\Anela.Heblo.Adapters.ShoptetApi.csproj", "{E54D4978-CE79-4415-BA6B-E1B1C3C71169}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.MetaAds", "backend\src\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj", "{714E577E-6254-4CD5-83CE-B4C9367A175A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -279,6 +281,18 @@ Global
 		{E54D4978-CE79-4415-BA6B-E1B1C3C71169}.Release|x64.Build.0 = Release|Any CPU
 		{E54D4978-CE79-4415-BA6B-E1B1C3C71169}.Release|x86.ActiveCfg = Release|Any CPU
 		{E54D4978-CE79-4415-BA6B-E1B1C3C71169}.Release|x86.Build.0 = Release|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Debug|x64.Build.0 = Debug|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Debug|x86.Build.0 = Debug|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x64.ActiveCfg = Release|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x64.Build.0 = Release|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x86.ActiveCfg = Release|Any CPU
+		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -305,5 +319,6 @@ Global
 		{B30BD6DD-F8AC-4743-90F4-BBC504384A13} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{B0098688-4986-4F6C-97B8-19A16808EDDA} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{E54D4978-CE79-4415-BA6B-E1B1C3C71169} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+		{714E577E-6254-4CD5-83CE-B4C9367A175A} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 	EndGlobalSection
 EndGlobal

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Anela.Heblo.Adapters.GoogleAds</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Ads.GoogleAds" Version="21.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Anela.Heblo.Tests" />
+  </ItemGroup>
+</Project>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public static class GoogleAdsAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddGoogleAdsAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<GoogleAdsSettings>(configuration.GetSection(GoogleAdsSettings.ConfigurationKey));
+        services.AddScoped<IAccountBudgetFetcher, SdkAccountBudgetFetcher>();
+        services.AddScoped<GoogleAdsTransactionSource>(sp =>
+            new GoogleAdsTransactionSource(
+                sp.GetRequiredService<IAccountBudgetFetcher>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<GoogleAdsTransactionSource>>()));
+        services.AddScoped<IRecurringJob, GoogleAdsInvoiceImportJob>();
+        return services;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsInvoiceImportJob.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsInvoiceImportJob.cs
@@ -1,0 +1,70 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public class GoogleAdsInvoiceImportJob : IRecurringJob
+{
+    private readonly GoogleAdsTransactionSource _source;
+    private readonly IImportedMarketingTransactionRepository _repository;
+    private readonly ILogger<MarketingInvoiceImportService> _importLogger;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<GoogleAdsInvoiceImportJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "google-ads-invoice-import",
+        DisplayName = "Google Ads Invoice Import",
+        Description = "Fetches billing transactions from Google Ads API via account_budget GAQL queries (7-day lookback)",
+        CronExpression = "15 6,18 * * *",
+        DefaultIsEnabled = true,
+    };
+
+    public GoogleAdsInvoiceImportJob(
+        GoogleAdsTransactionSource source,
+        IImportedMarketingTransactionRepository repository,
+        ILogger<MarketingInvoiceImportService> importLogger,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<GoogleAdsInvoiceImportJob> logger)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _importLogger = importLogger ?? throw new ArgumentNullException(nameof(importLogger));
+        _statusChecker = statusChecker ?? throw new ArgumentNullException(nameof(statusChecker));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping execution.", Metadata.JobName);
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Starting {JobName}", Metadata.JobName);
+
+            var to = DateTime.UtcNow;
+            var from = to.AddDays(-7);
+
+            var service = new MarketingInvoiceImportService(_source, _repository, _importLogger);
+            var result = await service.ImportAsync(from, to, cancellationToken);
+
+            _logger.LogInformation(
+                "{JobName} completed. Imported={Imported}, Skipped={Skipped}, Failed={Failed}",
+                Metadata.JobName,
+                result.Imported,
+                result.Skipped,
+                result.Failed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{JobName} failed", Metadata.JobName);
+            throw;
+        }
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsSettings.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsSettings.cs
@@ -1,0 +1,21 @@
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public class GoogleAdsSettings
+{
+    public const string ConfigurationKey = "GoogleAds";
+
+    /// <summary>Google Ads customer ID (no dashes), e.g. "1234567890".</summary>
+    public string CustomerId { get; set; } = string.Empty;
+
+    /// <summary>Developer token from Google Ads API Center. Store in secrets.json / Key Vault.</summary>
+    public string DeveloperToken { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 client ID from GCP project. Store in secrets.json / Key Vault.</summary>
+    public string OAuth2ClientId { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 client secret from GCP project. Store in secrets.json / Key Vault.</summary>
+    public string OAuth2ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 refresh token for the Google Ads account. Store in secrets.json / Key Vault.</summary>
+    public string OAuth2RefreshToken { get; set; } = string.Empty;
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public class GoogleAdsTransactionSource : IMarketingTransactionSource
+{
+    private readonly IAccountBudgetFetcher _fetcher;
+    private readonly ILogger<GoogleAdsTransactionSource> _logger;
+
+    public string Platform => "GoogleAds";
+
+    internal GoogleAdsTransactionSource(
+        IAccountBudgetFetcher fetcher,
+        ILogger<GoogleAdsTransactionSource> logger)
+    {
+        _fetcher = fetcher ?? throw new ArgumentNullException(nameof(fetcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<List<MarketingTransaction>> GetTransactionsAsync(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "GoogleAds: fetching account budgets from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
+            from,
+            to);
+
+        var rows = await _fetcher.FetchAsync(from, to, ct);
+
+        var transactions = rows.Select(r => new MarketingTransaction
+        {
+            TransactionId = r.Id,
+            Platform = Platform,
+            Amount = r.AmountServedMicros / 1_000_000m,
+            TransactionDate = r.StartDate,
+            Currency = r.CurrencyCode,
+            Description = r.Name ?? "Google Ads billing period",
+            RawData = JsonSerializer.Serialize(r),
+        }).ToList();
+
+        _logger.LogInformation("GoogleAds: fetched {Count} account budgets", transactions.Count);
+
+        return transactions;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/IAccountBudgetFetcher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/IAccountBudgetFetcher.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+/// <summary>Abstracts Google Ads SDK GAQL execution for testability.</summary>
+internal interface IAccountBudgetFetcher
+{
+    Task<IReadOnlyList<RawAccountBudget>> FetchAsync(DateTime from, DateTime to, CancellationToken ct);
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/RawAccountBudget.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/RawAccountBudget.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+/// <summary>Raw data returned from the Google Ads account_budget GAQL query.</summary>
+internal sealed record RawAccountBudget(
+    string Id,
+    string? Name,
+    DateTime StartDate,
+    long AmountServedMicros,
+    string CurrencyCode);

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/SdkAccountBudgetFetcher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/SdkAccountBudgetFetcher.cs
@@ -1,0 +1,92 @@
+using Google.Ads.GoogleAds;
+using Google.Ads.GoogleAds.Config;
+using Google.Ads.GoogleAds.Lib;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+internal sealed class SdkAccountBudgetFetcher : IAccountBudgetFetcher
+{
+    private readonly IOptionsMonitor<GoogleAdsSettings> _settings;
+    private readonly ILogger<SdkAccountBudgetFetcher> _logger;
+
+    public SdkAccountBudgetFetcher(
+        IOptionsMonitor<GoogleAdsSettings> settings,
+        ILogger<SdkAccountBudgetFetcher> logger)
+    {
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<RawAccountBudget>> FetchAsync(DateTime from, DateTime to, CancellationToken ct)
+    {
+        var s = _settings.CurrentValue;
+        var customerId = s.CustomerId.Replace("-", "");
+
+        var config = new GoogleAdsConfig
+        {
+            DeveloperToken = s.DeveloperToken,
+            OAuth2ClientId = s.OAuth2ClientId,
+            OAuth2ClientSecret = s.OAuth2ClientSecret,
+            OAuth2RefreshToken = s.OAuth2RefreshToken,
+            LoginCustomerId = customerId,
+        };
+
+        var client = new GoogleAdsClient(config);
+        var service = client.GetService(Services.V18.GoogleAdsService);
+
+        var fromStr = from.ToString("yyyy-MM-dd");
+        var toStr = to.ToString("yyyy-MM-dd");
+
+        var query = $"""
+            SELECT
+                account_budget.id,
+                account_budget.name,
+                account_budget.approved_start_date_time,
+                account_budget.amount_served_micros,
+                customer.currency_code
+            FROM account_budget
+            WHERE account_budget.status = 'APPROVED'
+              AND account_budget.approved_start_date_time >= '{fromStr} 00:00:00'
+              AND account_budget.approved_start_date_time <= '{toStr} 23:59:59'
+            """;
+
+        _logger.LogDebug("GoogleAds: executing GAQL query for account_budget from {From} to {To}", fromStr, toStr);
+
+        var results = new List<RawAccountBudget>();
+
+        using var stream = service.SearchStream(customerId, query);
+        var responseStream = stream.GetResponseStream();
+
+        while (await responseStream.MoveNextAsync(ct))
+        {
+            var response = responseStream.Current;
+
+            foreach (var row in response.Results)
+            {
+                var ab = row.AccountBudget;
+                if (ab is null)
+                {
+                    continue;
+                }
+
+                if (!DateTime.TryParse(ab.ApprovedStartDateTime, out var startDate))
+                {
+                    continue;
+                }
+
+                var currencyCode = row.Customer?.CurrencyCode ?? string.Empty;
+
+                results.Add(new RawAccountBudget(
+                    ab.Id.ToString(),
+                    string.IsNullOrEmpty(ab.Name) ? null : ab.Name,
+                    startDate.ToUniversalTime(),
+                    ab.AmountServedMicros,
+                    currencyCode));
+            }
+        }
+
+        return results;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
@@ -14,4 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Anela.Heblo.Tests" />
+  </ItemGroup>
 </Project>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Anela.Heblo.Adapters.MetaAds</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Polly" Version="8.4.1" />
+    <PackageReference Include="Polly.Extensions" Version="8.4.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public static class MetaAdsAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddMetaAdsAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<MetaAdsSettings>(configuration.GetSection(MetaAdsSettings.ConfigurationKey));
+        services.AddHttpClient<MetaAdsTransactionSource>();
+        services.AddScoped<IRecurringJob, MetaAdsInvoiceImportJob>();
+        return services;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsInvoiceImportJob.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsInvoiceImportJob.cs
@@ -1,0 +1,67 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public class MetaAdsInvoiceImportJob : IRecurringJob
+{
+    private readonly MetaAdsTransactionSource _source;
+    private readonly IImportedMarketingTransactionRepository _repository;
+    private readonly ILogger<MarketingInvoiceImportService> _importLogger;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<MetaAdsInvoiceImportJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "meta-ads-invoice-import",
+        DisplayName = "Meta Ads Invoice Import",
+        Description = "Fetches billing transactions from Meta Ads Graph API (7-day lookback)",
+        CronExpression = "0 6,18 * * *", // 6 AM and 6 PM Prague time
+        DefaultIsEnabled = true,
+    };
+
+    public MetaAdsInvoiceImportJob(
+        MetaAdsTransactionSource source,
+        IImportedMarketingTransactionRepository repository,
+        ILogger<MarketingInvoiceImportService> importLogger,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<MetaAdsInvoiceImportJob> logger)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _importLogger = importLogger ?? throw new ArgumentNullException(nameof(importLogger));
+        _statusChecker = statusChecker ?? throw new ArgumentNullException(nameof(statusChecker));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping execution.", Metadata.JobName);
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Starting {JobName}", Metadata.JobName);
+
+            var to = DateTime.UtcNow;
+            var from = to.AddDays(-7);
+
+            var service = new MarketingInvoiceImportService(_source, _repository, _importLogger);
+            var result = await service.ImportAsync(from, to, cancellationToken);
+
+            _logger.LogInformation(
+                "{JobName} completed. Imported={Imported}, Skipped={Skipped}, Failed={Failed}",
+                Metadata.JobName, result.Imported, result.Skipped, result.Failed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{JobName} failed", Metadata.JobName);
+            throw;
+        }
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsSettings.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsSettings.cs
@@ -1,0 +1,15 @@
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public class MetaAdsSettings
+{
+    public const string ConfigurationKey = "MetaAds";
+
+    /// <summary>Ad account ID in the form "act_123456789".</summary>
+    public string AdAccountId { get; set; } = string.Empty;
+
+    /// <summary>System User token from Meta Business Manager. Store in secrets.json / Key Vault.</summary>
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>Graph API version, e.g. "v21.0".</summary>
+    public string ApiVersion { get; set; } = "v21.0";
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Retry;
+
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public class MetaAdsTransactionSource : IMarketingTransactionSource
+{
+    private readonly HttpClient _httpClient;
+    private readonly MetaAdsSettings _settings;
+    private readonly ILogger<MetaAdsTransactionSource> _logger;
+    private readonly ResiliencePipeline _pipeline;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public string Platform => "MetaAds";
+
+    public MetaAdsTransactionSource(
+        HttpClient httpClient,
+        IOptions<MetaAdsSettings> options,
+        ILogger<MetaAdsTransactionSource> logger,
+        ResiliencePipeline? pipeline = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _settings = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _pipeline = pipeline ?? BuildDefaultPipeline();
+    }
+
+    public async Task<List<MarketingTransaction>> GetTransactionsAsync(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        var results = new List<MarketingTransaction>();
+        var url = BuildInitialUrl();
+
+        _logger.LogInformation(
+            "MetaAds: fetching transactions for account {AccountId} from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
+            _settings.AdAccountId, from, to);
+
+        try
+        {
+            while (url is not null)
+            {
+                var page = await FetchPageAsync(url, ct);
+
+                foreach (var item in page.Data)
+                {
+                    var txDate = DateTimeOffset.FromUnixTimeSeconds(item.Time).UtcDateTime;
+
+                    if (txDate < from || txDate > to)
+                        continue;
+
+                    results.Add(new MarketingTransaction
+                    {
+                        TransactionId = item.Id,
+                        Platform = Platform,
+                        Amount = item.Amount / 100m,
+                        TransactionDate = txDate,
+                        Currency = item.Currency,
+                        Description = item.PaymentType,
+                        RawData = JsonSerializer.Serialize(item, JsonOptions),
+                    });
+                }
+
+                url = page.Paging?.Next;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(
+                ex,
+                "MetaAds: HTTP error fetching transactions for account {AccountId} from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}. StatusCode={StatusCode}",
+                _settings.AdAccountId, from, to, (int?)ex.StatusCode);
+            throw;
+        }
+
+        _logger.LogInformation(
+            "MetaAds: fetched {Count} transactions within date range", results.Count);
+
+        return results;
+    }
+
+    private async Task<MetaTransactionsResponse> FetchPageAsync(string url, CancellationToken ct)
+    {
+        _logger.LogDebug("MetaAds: GET {Url}", RedactToken(url));
+
+        return await _pipeline.ExecuteAsync(async innerCt =>
+        {
+            var response = await _httpClient.GetAsync(url, innerCt);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(innerCt);
+            return JsonSerializer.Deserialize<MetaTransactionsResponse>(json, JsonOptions)
+                   ?? throw new InvalidOperationException("MetaAds API returned null response body.");
+        }, ct);
+    }
+
+    private string BuildInitialUrl() =>
+        $"https://graph.facebook.com/{_settings.ApiVersion}/{_settings.AdAccountId}/transactions" +
+        $"?fields=id,time,amount,currency,payment_type" +
+        $"&access_token={_settings.AccessToken}";
+
+    private static string RedactToken(string url)
+    {
+        var idx = url.IndexOf("access_token=", StringComparison.Ordinal);
+        if (idx < 0) return url;
+        var end = url.IndexOf('&', idx);
+        return end < 0
+            ? url[..idx] + "access_token=***"
+            : url[..idx] + "access_token=***" + url[end..];
+    }
+
+    /// <summary>Production resilience pipeline: retry on HTTP 429 with exponential backoff.</summary>
+    internal static ResiliencePipeline BuildDefaultPipeline() =>
+        new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<HttpRequestException>(ex => ex.StatusCode == HttpStatusCode.TooManyRequests),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromSeconds(2),
+                BackoffType = DelayBackoffType.Exponential,
+                UseJitter = true,
+            })
+            .Build();
+
+    /// <summary>Zero-delay pipeline for unit tests.</summary>
+    internal static ResiliencePipeline BuildTestPipeline() =>
+        new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<HttpRequestException>(ex => ex.StatusCode == HttpStatusCode.TooManyRequests),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.Zero,
+            })
+            .Build();
+
+    // ── Internal deserialization models ──────────────────────────────────────
+
+    private sealed class MetaTransactionsResponse
+    {
+        [JsonPropertyName("data")]
+        public List<MetaTransactionItem> Data { get; set; } = [];
+
+        [JsonPropertyName("paging")]
+        public MetaPaging? Paging { get; set; }
+    }
+
+    private sealed class MetaTransactionItem
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("time")]
+        public long Time { get; set; }
+
+        /// <summary>Amount in cents (integer).</summary>
+        [JsonPropertyName("amount")]
+        public long Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; } = string.Empty;
+
+        [JsonPropertyName("payment_type")]
+        public string PaymentType { get; set; } = string.Empty;
+    }
+
+    private sealed class MetaPaging
+    {
+        [JsonPropertyName("next")]
+        public string? Next { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+++ b/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
@@ -48,6 +48,7 @@
         <ProjectReference Include="../Anela.Heblo.Application/Anela.Heblo.Application.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Comgate\Anela.Heblo.Adapters.Comgate.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
+        <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.GoogleAds\Anela.Heblo.Adapters.GoogleAds.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Flexi\Anela.Heblo.Adapters.Flexi.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Shoptet\Anela.Heblo.Adapters.Shoptet.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.ShoptetApi\Anela.Heblo.Adapters.ShoptetApi.csproj" />

--- a/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+++ b/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
@@ -47,6 +47,7 @@
     <ItemGroup>
         <ProjectReference Include="../Anela.Heblo.Application/Anela.Heblo.Application.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Comgate\Anela.Heblo.Adapters.Comgate.csproj" />
+        <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Flexi\Anela.Heblo.Adapters.Flexi.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Shoptet\Anela.Heblo.Adapters.Shoptet.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.ShoptetApi\Anela.Heblo.Adapters.ShoptetApi.csproj" />

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Adapters.Anthropic;
 using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.SendGrid;
 using Anela.Heblo.Adapters.Comgate;
+using Anela.Heblo.Adapters.GoogleAds;
 using Anela.Heblo.Adapters.MetaAds;
 using Anela.Heblo.Adapters.Flexi;
 using Anela.Heblo.Adapters.OpenAI;
@@ -58,6 +59,7 @@ public partial class Program
         builder.Services.AddShoptetPayAdapter(builder.Configuration);
         builder.Services.AddComgateAdapter(builder.Configuration);
         builder.Services.AddMetaAdsAdapter(builder.Configuration);
+        builder.Services.AddGoogleAdsAdapter(builder.Configuration);
         builder.Services.AddAnthropicAdapter(builder.Configuration);
         builder.Services.AddOpenAiAdapter(builder.Configuration);
         builder.Services.AddSendGridAdapter(builder.Configuration);

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Adapters.Anthropic;
 using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.SendGrid;
 using Anela.Heblo.Adapters.Comgate;
+using Anela.Heblo.Adapters.MetaAds;
 using Anela.Heblo.Adapters.Flexi;
 using Anela.Heblo.Adapters.OpenAI;
 using Anela.Heblo.Adapters.Shoptet;
@@ -56,6 +57,7 @@ public partial class Program
         builder.Services.AddShoptetApiAdapter(builder.Configuration);
         builder.Services.AddShoptetPayAdapter(builder.Configuration);
         builder.Services.AddComgateAdapter(builder.Configuration);
+        builder.Services.AddMetaAdsAdapter(builder.Configuration);
         builder.Services.AddAnthropicAdapter(builder.Configuration);
         builder.Services.AddOpenAiAdapter(builder.Configuration);
         builder.Services.AddSendGridAdapter(builder.Configuration);

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -67,6 +67,13 @@
     "AdAccountId": "act_XXXXXXXXX",
     "ApiVersion": "v21.0"
   },
+  "GoogleAds": {
+    "CustomerId": "XXX-XXX-XXXX",
+    "DeveloperToken": "-- stored in secrets.json --",
+    "OAuth2ClientId": "-- stored in secrets.json --",
+    "OAuth2ClientSecret": "-- stored in secrets.json --",
+    "OAuth2RefreshToken": "-- stored in secrets.json --"
+  },
   "Shoptet": {
     "Token": "xxxxxxxx",
     "StockId": 1

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -63,6 +63,10 @@
     "MerchantId": "xxxxxx",
     "Secret": "xxxxxxxx"
   },
+  "MetaAds": {
+    "AdAccountId": "act_XXXXXXXXX",
+    "ApiVersion": "v21.0"
+  },
   "Shoptet": {
     "Token": "xxxxxxxx",
     "StockId": 1

--- a/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
@@ -1,0 +1,105 @@
+using Anela.Heblo.Adapters.GoogleAds;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Adapters.GoogleAds;
+
+public class GoogleAdsTransactionSourceTests
+{
+    private static GoogleAdsTransactionSource CreateSource(IReadOnlyList<RawAccountBudget> rows)
+        => new(new FakeAccountBudgetFetcher(rows), NullLogger<GoogleAdsTransactionSource>.Instance);
+
+    [Fact]
+    public async Task GetTransactionsAsync_ValidRows_MapsFieldsCorrectly()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var source = CreateSource([new("budget-001", "Spring Campaign Budget", startDate, 15_000_000L, "CZK")]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            startDate.AddDays(-1), startDate.AddDays(1), CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        var tx = transactions[0];
+        tx.TransactionId.Should().Be("budget-001");
+        tx.Platform.Should().Be("GoogleAds");
+        tx.Amount.Should().Be(15m); // 15_000_000 micros / 1_000_000
+        tx.Currency.Should().Be("CZK");
+        tx.Description.Should().Be("Spring Campaign Budget");
+        tx.TransactionDate.Should().Be(startDate);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_AmountConversion_MicrosToDecimal()
+    {
+        // Arrange
+        var source = CreateSource([new("budget-002", null, DateTime.UtcNow.AddDays(-1), 1_234_567L, "CZK")]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        transactions[0].Amount.Should().Be(1.234567m); // exact micros conversion
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_NullName_UsesDefaultDescription()
+    {
+        // Arrange
+        var source = CreateSource([new("budget-003", null, DateTime.UtcNow.AddDays(-1), 5_000_000L, "CZK")]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions[0].Description.Should().Be("Google Ads billing period");
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_EmptyResponse_ReturnsEmptyList()
+    {
+        // Arrange
+        var source = CreateSource([]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_MultipleRows_AllMapped()
+    {
+        // Arrange
+        var source = CreateSource(
+        [
+            new("budget-010", "Budget A", DateTime.UtcNow.AddDays(-5), 10_000_000L, "CZK"),
+            new("budget-011", "Budget B", DateTime.UtcNow.AddDays(-3), 20_000_000L, "CZK"),
+            new("budget-012", "Budget C", DateTime.UtcNow.AddDays(-1), 30_000_000L, "CZK"),
+        ]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(3);
+        transactions.Select(t => t.TransactionId).Should().Contain(["budget-010", "budget-011", "budget-012"]);
+        transactions.Select(t => t.Amount).Should().Contain([10m, 20m, 30m]);
+    }
+}
+
+/// <summary>Test double that returns a fixed list of account budget rows.</summary>
+file sealed class FakeAccountBudgetFetcher(IReadOnlyList<RawAccountBudget> rows) : IAccountBudgetFetcher
+{
+    public Task<IReadOnlyList<RawAccountBudget>> FetchAsync(DateTime from, DateTime to, CancellationToken ct)
+        => Task.FromResult(rows);
+}

--- a/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
@@ -1,0 +1,233 @@
+using System.Net;
+using System.Text;
+using Anela.Heblo.Adapters.MetaAds;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Adapters.MetaAds;
+
+public class MetaAdsTransactionSourceTests
+{
+    private static MetaAdsTransactionSource CreateSource(
+        HttpMessageHandler handler,
+        MetaAdsSettings? settings = null)
+    {
+        settings ??= new MetaAdsSettings
+        {
+            AdAccountId = "act_123456789",
+            AccessToken = "test-token",
+            ApiVersion = "v21.0"
+        };
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.facebook.com/")
+        };
+
+        return new MetaAdsTransactionSource(
+            httpClient,
+            Options.Create(settings),
+            NullLogger<MetaAdsTransactionSource>.Instance);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_ValidResponse_ParsesFieldsCorrectly()
+    {
+        // Arrange
+        var json = """
+            {
+              "data": [
+                {
+                  "id": "TX-001",
+                  "time": 1744300800,
+                  "amount": 150000,
+                  "currency": "CZK",
+                  "payment_type": "THRESHOLD"
+                }
+              ],
+              "paging": {
+                "cursors": { "before": "abc", "after": "def" }
+              }
+            }
+            """;
+
+        var handler = new StaticResponseHandler(HttpStatusCode.OK, json);
+        var source = CreateSource(handler);
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        var tx = transactions[0];
+        tx.TransactionId.Should().Be("TX-001");
+        tx.Amount.Should().Be(1500.00m);
+        tx.Currency.Should().Be("CZK");
+        tx.Description.Should().Be("THRESHOLD");
+        tx.Platform.Should().Be("MetaAds");
+        tx.TransactionDate.Should().Be(DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_Amount_ConvertedFromCentsToDecimal()
+    {
+        // Arrange
+        var json = """
+            {
+              "data": [
+                {
+                  "id": "TX-002",
+                  "time": 1744300800,
+                  "amount": 150000,
+                  "currency": "CZK",
+                  "payment_type": "THRESHOLD"
+                }
+              ],
+              "paging": {}
+            }
+            """;
+
+        var handler = new StaticResponseHandler(HttpStatusCode.OK, json);
+        var source = CreateSource(handler);
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        transactions[0].Amount.Should().Be(1500.00m);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_Pagination_AllPagesCollected()
+    {
+        // Arrange — page 1 has paging.next, page 2 has none
+        var page1Json = """
+            {
+              "data": [
+                { "id": "TX-001", "time": 1744300800, "amount": 10000, "currency": "CZK", "payment_type": "THRESHOLD" }
+              ],
+              "paging": {
+                "next": "https://graph.facebook.com/v21.0/act_123456789/transactions?after=cursor1&access_token=test-token"
+              }
+            }
+            """;
+
+        var page2Json = """
+            {
+              "data": [
+                { "id": "TX-002", "time": 1744300800, "amount": 20000, "currency": "CZK", "payment_type": "THRESHOLD" }
+              ],
+              "paging": {
+                "cursors": { "before": "cursor1", "after": "cursor2" }
+              }
+            }
+            """;
+
+        var handler = new SequentialResponseHandler(
+            (HttpStatusCode.OK, page1Json),
+            (HttpStatusCode.OK, page2Json));
+
+        var source = CreateSource(handler);
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(2);
+        transactions.Select(t => t.TransactionId).Should().Contain(["TX-001", "TX-002"]);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_RateLimitRetry_SucceedsOnSecondAttempt()
+    {
+        // Arrange — first call returns 429, second returns 200 with a transaction
+        var successJson = """
+            {
+              "data": [
+                { "id": "TX-001", "time": 1744300800, "amount": 10000, "currency": "CZK", "payment_type": "THRESHOLD" }
+              ],
+              "paging": {}
+            }
+            """;
+
+        var handler = new SequentialResponseHandler(
+            (HttpStatusCode.TooManyRequests, "{}"),
+            (HttpStatusCode.OK, successJson));
+
+        // Build source with a fast-retry pipeline (no delay) for test speed
+        var settings = new MetaAdsSettings
+        {
+            AdAccountId = "act_123456789",
+            AccessToken = "test-token",
+            ApiVersion = "v21.0"
+        };
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.facebook.com/")
+        };
+
+        var source = new MetaAdsTransactionSource(
+            httpClient,
+            Options.Create(settings),
+            NullLogger<MetaAdsTransactionSource>.Instance,
+            MetaAdsTransactionSource.BuildTestPipeline());
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert — should succeed after retry, not throw
+        transactions.Should().HaveCount(1);
+        transactions[0].TransactionId.Should().Be("TX-001");
+    }
+}
+
+/// <summary>Always returns the same response.</summary>
+file sealed class StaticResponseHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        return Task.FromResult(response);
+    }
+}
+
+/// <summary>Returns responses in sequence; repeats the last one if exhausted.</summary>
+file sealed class SequentialResponseHandler : HttpMessageHandler
+{
+    private readonly Queue<(HttpStatusCode, string)> _responses;
+
+    public SequentialResponseHandler(params (HttpStatusCode, string)[] responses)
+    {
+        _responses = new Queue<(HttpStatusCode, string)>(responses);
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Dequeue until the last entry; keep the last for any additional calls.
+        var (status, body) = _responses.Count > 1 ? _responses.Dequeue() : _responses.Peek();
+        var response = new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        return Task.FromResult(response);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+++ b/backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.Anthropic\Anela.Heblo.Adapters.Anthropic.csproj" />
+    <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.Comgate\Anela.Heblo.Adapters.Comgate.csproj" />
     <ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.ShoptetApi\Anela.Heblo.Adapters.ShoptetApi.csproj" />
     <ProjectReference Include="..\..\src\Anela.Heblo.API\Anela.Heblo.API.csproj" />

--- a/docs/superpowers/plans/2026-04-15-meta-ads-adapter.md
+++ b/docs/superpowers/plans/2026-04-15-meta-ads-adapter.md
@@ -1,0 +1,858 @@
+# Meta Ads Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `Anela.Heblo.Adapters.MetaAds` — fetches billing transactions from Meta Graph API and persists them using the shared marketing invoice import core.
+
+**Architecture:** New .NET 8 class library adapter following the Comgate pattern (Polly for resilience). `MetaAdsTransactionSource` implements `IMarketingTransactionSource` and handles pagination + HTTP 429 retry. `MetaAdsInvoiceImportJob` instantiates `MarketingInvoiceImportService` directly with the concrete source (avoids future DI conflict with Google Ads).
+
+**Tech Stack:** .NET 8, Polly 8.x (retry on HTTP 429), `System.Text.Json`, `IHttpClientFactory`, `IRecurringJob` (Hangfire auto-discovery), xUnit + Moq + FluentAssertions.
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj` |
+| Create | `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsSettings.cs` |
+| Create | `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` |
+| Create | `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsInvoiceImportJob.cs` |
+| Create | `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs` |
+| Create | `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs` |
+| Modify | `Anela.Heblo.sln` — add new project |
+| Modify | `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` — add project reference |
+| Modify | `backend/src/Anela.Heblo.API/Program.cs` — register adapter |
+| Modify | `backend/src/Anela.Heblo.API/appsettings.json` — add MetaAds config stub |
+
+---
+
+## Task 1: Create adapter project and settings
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj`
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsSettings.cs`
+- Modify: `Anela.Heblo.sln`
+
+- [ ] **Step 1: Create the project directory and .csproj**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Anela.Heblo.Adapters.MetaAds</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Polly" Version="8.4.1" />
+    <PackageReference Include="Polly.Extensions" Version="8.4.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Anela.Heblo.Domain\Anela.Heblo.Domain.csproj" />
+    <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+- [ ] **Step 2: Add project to solution**
+
+Run from repo root (where `Anela.Heblo.sln` lives):
+
+```bash
+dotnet sln add backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+```
+
+Expected output: `Project 'backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj' added to the solution.`
+
+- [ ] **Step 3: Create MetaAdsSettings.cs**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsSettings.cs`:
+
+```csharp
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public class MetaAdsSettings
+{
+    public const string ConfigurationKey = "MetaAds";
+
+    /// <summary>Ad account ID in the form "act_123456789".</summary>
+    public string AdAccountId { get; set; } = string.Empty;
+
+    /// <summary>System User token from Meta Business Manager. Store in secrets.json / Key Vault.</summary>
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>Graph API version, e.g. "v21.0".</summary>
+    public string ApiVersion { get; set; } = "v21.0";
+}
+```
+
+- [ ] **Step 4: Verify the project builds**
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/ Anela.Heblo.sln
+git commit -m "feat(marketing-invoices): scaffold MetaAds adapter project and settings"
+```
+
+---
+
+## Task 2: Write tests for MetaAdsTransactionSource (TDD — red phase)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+
+- [ ] **Step 1: Add project reference to test project**
+
+In `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`, add inside the existing `<ItemGroup>` that contains other `<ProjectReference>` entries:
+
+```xml
+<ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
+```
+
+- [ ] **Step 2: Create the test file**
+
+Create `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs`:
+
+```csharp
+using System.Net;
+using System.Text;
+using Anela.Heblo.Adapters.MetaAds;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Adapters.MetaAds;
+
+public class MetaAdsTransactionSourceTests
+{
+    private static MetaAdsTransactionSource CreateSource(
+        HttpMessageHandler handler,
+        MetaAdsSettings? settings = null)
+    {
+        settings ??= new MetaAdsSettings
+        {
+            AdAccountId = "act_123456789",
+            AccessToken = "test-token",
+            ApiVersion = "v21.0"
+        };
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.facebook.com/")
+        };
+
+        return new MetaAdsTransactionSource(
+            httpClient,
+            Options.Create(settings),
+            NullLogger<MetaAdsTransactionSource>.Instance);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_ValidResponse_ParsesFieldsCorrectly()
+    {
+        // Arrange
+        var json = """
+            {
+              "data": [
+                {
+                  "id": "TX-001",
+                  "time": 1744300800,
+                  "amount": 150000,
+                  "currency": "CZK",
+                  "payment_type": "THRESHOLD"
+                }
+              ],
+              "paging": {
+                "cursors": { "before": "abc", "after": "def" }
+              }
+            }
+            """;
+
+        var handler = new StaticResponseHandler(HttpStatusCode.OK, json);
+        var source = CreateSource(handler);
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        var tx = transactions[0];
+        tx.TransactionId.Should().Be("TX-001");
+        tx.Amount.Should().Be(1500.00m);
+        tx.Currency.Should().Be("CZK");
+        tx.Description.Should().Be("THRESHOLD");
+        tx.Platform.Should().Be("MetaAds");
+        tx.TransactionDate.Should().Be(DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_Amount_ConvertedFromCentsToDecimal()
+    {
+        // Arrange
+        var json = """
+            {
+              "data": [
+                {
+                  "id": "TX-002",
+                  "time": 1744300800,
+                  "amount": 150000,
+                  "currency": "CZK",
+                  "payment_type": "THRESHOLD"
+                }
+              ],
+              "paging": {}
+            }
+            """;
+
+        var handler = new StaticResponseHandler(HttpStatusCode.OK, json);
+        var source = CreateSource(handler);
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        transactions[0].Amount.Should().Be(1500.00m);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_Pagination_AllPagesCollected()
+    {
+        // Arrange — page 1 has paging.next, page 2 has none
+        var page1Json = """
+            {
+              "data": [
+                { "id": "TX-001", "time": 1744300800, "amount": 10000, "currency": "CZK", "payment_type": "THRESHOLD" }
+              ],
+              "paging": {
+                "next": "https://graph.facebook.com/v21.0/act_123456789/transactions?after=cursor1&access_token=test-token"
+              }
+            }
+            """;
+
+        var page2Json = """
+            {
+              "data": [
+                { "id": "TX-002", "time": 1744300800, "amount": 20000, "currency": "CZK", "payment_type": "THRESHOLD" }
+              ],
+              "paging": {
+                "cursors": { "before": "cursor1", "after": "cursor2" }
+              }
+            }
+            """;
+
+        var handler = new SequentialResponseHandler(
+            (HttpStatusCode.OK, page1Json),
+            (HttpStatusCode.OK, page2Json));
+
+        var source = CreateSource(handler);
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(2);
+        transactions.Select(t => t.TransactionId).Should().Contain(["TX-001", "TX-002"]);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_RateLimitRetry_SucceedsOnSecondAttempt()
+    {
+        // Arrange — first call returns 429, second returns 200 with a transaction
+        var successJson = """
+            {
+              "data": [
+                { "id": "TX-001", "time": 1744300800, "amount": 10000, "currency": "CZK", "payment_type": "THRESHOLD" }
+              ],
+              "paging": {}
+            }
+            """;
+
+        var handler = new SequentialResponseHandler(
+            (HttpStatusCode.TooManyRequests, "{}"),
+            (HttpStatusCode.OK, successJson));
+
+        // Build source with a fast-retry pipeline (no delay) for test speed
+        var settings = new MetaAdsSettings
+        {
+            AdAccountId = "act_123456789",
+            AccessToken = "test-token",
+            ApiVersion = "v21.0"
+        };
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.facebook.com/")
+        };
+
+        var source = new MetaAdsTransactionSource(
+            httpClient,
+            Options.Create(settings),
+            NullLogger<MetaAdsTransactionSource>.Instance,
+            MetaAdsTransactionSource.BuildTestPipeline());
+
+        var from = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(-1);
+        var to = DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime.AddDays(1);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(from, to, CancellationToken.None);
+
+        // Assert — should succeed after retry, not throw
+        transactions.Should().HaveCount(1);
+        transactions[0].TransactionId.Should().Be("TX-001");
+    }
+}
+
+/// <summary>Always returns the same response.</summary>
+file sealed class StaticResponseHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        return Task.FromResult(response);
+    }
+}
+
+/// <summary>Returns responses in sequence; repeats the last one if exhausted.</summary>
+file sealed class SequentialResponseHandler : HttpMessageHandler
+{
+    private readonly Queue<(HttpStatusCode, string)> _responses;
+
+    public SequentialResponseHandler(params (HttpStatusCode, string)[] responses)
+    {
+        _responses = new Queue<(HttpStatusCode, string)>(responses);
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Dequeue until the last entry; keep the last for any additional calls.
+        var (status, body) = _responses.Count > 1 ? _responses.Dequeue() : _responses.Peek();
+        var response = new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        return Task.FromResult(response);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — verify they fail (red)**
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MetaAdsTransactionSourceTests" \
+  --no-build 2>&1 | tail -20
+```
+
+Expected: Compilation errors because `MetaAdsTransactionSource` doesn't exist yet. That's correct.
+
+- [ ] **Step 4: Commit tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/
+git commit -m "test(marketing-invoices): add MetaAdsTransactionSource unit tests (red)"
+```
+
+---
+
+## Task 3: Implement MetaAdsTransactionSource (green phase)
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs`
+
+- [ ] **Step 1: Create MetaAdsTransactionSource.cs**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs`:
+
+```csharp
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Retry;
+
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public class MetaAdsTransactionSource : IMarketingTransactionSource
+{
+    private readonly HttpClient _httpClient;
+    private readonly MetaAdsSettings _settings;
+    private readonly ILogger<MetaAdsTransactionSource> _logger;
+    private readonly ResiliencePipeline _pipeline;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public string Platform => "MetaAds";
+
+    public MetaAdsTransactionSource(
+        HttpClient httpClient,
+        IOptions<MetaAdsSettings> options,
+        ILogger<MetaAdsTransactionSource> logger,
+        ResiliencePipeline? pipeline = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _settings = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _pipeline = pipeline ?? BuildDefaultPipeline();
+    }
+
+    public async Task<List<MarketingTransaction>> GetTransactionsAsync(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        var results = new List<MarketingTransaction>();
+        var url = BuildInitialUrl();
+
+        _logger.LogInformation(
+            "MetaAds: fetching transactions for account {AccountId} from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
+            _settings.AdAccountId, from, to);
+
+        while (url is not null)
+        {
+            var page = await FetchPageAsync(url, ct);
+
+            foreach (var item in page.Data)
+            {
+                var txDate = DateTimeOffset.FromUnixTimeSeconds(item.Time).UtcDateTime;
+
+                if (txDate < from || txDate > to)
+                    continue;
+
+                results.Add(new MarketingTransaction
+                {
+                    TransactionId = item.Id,
+                    Platform = Platform,
+                    Amount = item.Amount / 100m,
+                    TransactionDate = txDate,
+                    Currency = item.Currency,
+                    Description = item.PaymentType,
+                    RawData = JsonSerializer.Serialize(item, JsonOptions),
+                });
+            }
+
+            url = page.Paging?.Next;
+        }
+
+        _logger.LogInformation(
+            "MetaAds: fetched {Count} transactions within date range", results.Count);
+
+        return results;
+    }
+
+    private async Task<MetaTransactionsResponse> FetchPageAsync(string url, CancellationToken ct)
+    {
+        _logger.LogDebug("MetaAds: GET {Url}", RedactToken(url));
+
+        return await _pipeline.ExecuteAsync(async innerCt =>
+        {
+            var response = await _httpClient.GetAsync(url, innerCt);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync(innerCt);
+            return JsonSerializer.Deserialize<MetaTransactionsResponse>(json, JsonOptions)
+                   ?? throw new InvalidOperationException("MetaAds API returned null response body.");
+        }, ct);
+    }
+
+    private string BuildInitialUrl() =>
+        $"https://graph.facebook.com/{_settings.ApiVersion}/{_settings.AdAccountId}/transactions" +
+        $"?fields=id,time,amount,currency,payment_type" +
+        $"&access_token={_settings.AccessToken}";
+
+    private static string RedactToken(string url)
+    {
+        var idx = url.IndexOf("access_token=", StringComparison.Ordinal);
+        if (idx < 0) return url;
+        var end = url.IndexOf('&', idx);
+        return end < 0
+            ? url[..idx] + "access_token=***"
+            : url[..idx] + "access_token=***" + url[end..];
+    }
+
+    /// <summary>Production resilience pipeline: retry on HTTP 429 with exponential backoff.</summary>
+    internal static ResiliencePipeline BuildDefaultPipeline() =>
+        new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<HttpRequestException>(ex => ex.StatusCode == HttpStatusCode.TooManyRequests),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromSeconds(2),
+                BackoffType = DelayBackoffType.Exponential,
+                UseJitter = true,
+            })
+            .Build();
+
+    /// <summary>Zero-delay pipeline for unit tests.</summary>
+    internal static ResiliencePipeline BuildTestPipeline() =>
+        new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<HttpRequestException>(ex => ex.StatusCode == HttpStatusCode.TooManyRequests),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.Zero,
+            })
+            .Build();
+
+    // ── Internal deserialization models ──────────────────────────────────────
+
+    private sealed class MetaTransactionsResponse
+    {
+        [JsonPropertyName("data")]
+        public List<MetaTransactionItem> Data { get; set; } = [];
+
+        [JsonPropertyName("paging")]
+        public MetaPaging? Paging { get; set; }
+    }
+
+    private sealed class MetaTransactionItem
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("time")]
+        public long Time { get; set; }
+
+        /// <summary>Amount in cents (integer).</summary>
+        [JsonPropertyName("amount")]
+        public long Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; } = string.Empty;
+
+        [JsonPropertyName("payment_type")]
+        public string PaymentType { get; set; } = string.Empty;
+    }
+
+    private sealed class MetaPaging
+    {
+        [JsonPropertyName("next")]
+        public string? Next { get; set; }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — verify they pass (green)**
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MetaAdsTransactionSourceTests"
+```
+
+Expected:
+```
+Passed!  - Failed: 0, Passed: 4, Skipped: 0
+```
+
+- [ ] **Step 3: Run dotnet format**
+
+```bash
+dotnet format backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+```
+
+Expected: exits with code 0, no output (or "Format complete").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
+git commit -m "feat(marketing-invoices): implement MetaAdsTransactionSource with Polly retry"
+```
+
+---
+
+## Task 4: Implement MetaAdsInvoiceImportJob
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsInvoiceImportJob.cs`
+
+- [ ] **Step 1: Create MetaAdsInvoiceImportJob.cs**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsInvoiceImportJob.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.MarketingInvoices.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public class MetaAdsInvoiceImportJob : IRecurringJob
+{
+    private readonly MetaAdsTransactionSource _source;
+    private readonly IImportedMarketingTransactionRepository _repository;
+    private readonly ILogger<MarketingInvoiceImportService> _importLogger;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<MetaAdsInvoiceImportJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "meta-ads-invoice-import",
+        DisplayName = "Meta Ads Invoice Import",
+        Description = "Fetches billing transactions from Meta Ads Graph API (7-day lookback)",
+        CronExpression = "0 6,18 * * *", // 6 AM and 6 PM Prague time
+        DefaultIsEnabled = true,
+    };
+
+    public MetaAdsInvoiceImportJob(
+        MetaAdsTransactionSource source,
+        IImportedMarketingTransactionRepository repository,
+        ILogger<MarketingInvoiceImportService> importLogger,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<MetaAdsInvoiceImportJob> logger)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _importLogger = importLogger ?? throw new ArgumentNullException(nameof(importLogger));
+        _statusChecker = statusChecker ?? throw new ArgumentNullException(nameof(statusChecker));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping execution.", Metadata.JobName);
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Starting {JobName}", Metadata.JobName);
+
+            var to = DateTime.UtcNow;
+            var from = to.AddDays(-7);
+
+            var service = new MarketingInvoiceImportService(_source, _repository, _importLogger);
+            var result = await service.ImportAsync(from, to, cancellationToken);
+
+            _logger.LogInformation(
+                "{JobName} completed. Imported={Imported}, Skipped={Skipped}, Failed={Failed}",
+                Metadata.JobName, result.Imported, result.Skipped, result.Failed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{JobName} failed", Metadata.JobName);
+            throw;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsInvoiceImportJob.cs
+git commit -m "feat(marketing-invoices): add MetaAdsInvoiceImportJob recurring job"
+```
+
+---
+
+## Task 5: Wire DI, configuration, and Program.cs
+
+**Files:**
+- Create: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs`
+- Modify: `backend/src/Anela.Heblo.API/Program.cs`
+- Modify: `backend/src/Anela.Heblo.API/appsettings.json`
+- Modify: `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj` (add project reference)
+
+- [ ] **Step 1: Create MetaAdsAdapterServiceCollectionExtensions.cs**
+
+Create `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsAdapterServiceCollectionExtensions.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.MetaAds;
+
+public static class MetaAdsAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddMetaAdsAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<MetaAdsSettings>(configuration.GetSection(MetaAdsSettings.ConfigurationKey));
+        services.AddHttpClient<MetaAdsTransactionSource>();
+        services.AddScoped<IRecurringJob, MetaAdsInvoiceImportJob>();
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Add project reference in API .csproj**
+
+Open `backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj` and add inside the `<ItemGroup>` block that contains other adapter `<ProjectReference>` entries:
+
+```xml
+<ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
+```
+
+- [ ] **Step 3: Register adapter in Program.cs**
+
+In `backend/src/Anela.Heblo.API/Program.cs`, add the using at the top:
+
+```csharp
+using Anela.Heblo.Adapters.MetaAds;
+```
+
+Then add the registration after `builder.Services.AddComgateAdapter(builder.Configuration);`:
+
+```csharp
+builder.Services.AddMetaAdsAdapter(builder.Configuration);
+```
+
+- [ ] **Step 4: Add config stub to appsettings.json**
+
+In `backend/src/Anela.Heblo.API/appsettings.json`, add after the `"Comgate"` block:
+
+```json
+"MetaAds": {
+  "AdAccountId": "act_XXXXXXXXX",
+  "ApiVersion": "v21.0"
+},
+```
+
+(`AccessToken` is intentionally omitted from `appsettings.json` — it goes in `secrets.json` / Key Vault only.)
+
+- [ ] **Step 5: Verify full solution build**
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 6: Run all backend tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: All previously passing tests still pass, plus the 4 new MetaAds tests.
+
+- [ ] **Step 7: Run dotnet format on changed projects**
+
+```bash
+dotnet format backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+dotnet format backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Expected: exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/ \
+        backend/src/Anela.Heblo.API/Program.cs \
+        backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj \
+        backend/src/Anela.Heblo.API/appsettings.json
+git commit -m "feat(marketing-invoices): wire MetaAds adapter into DI and configuration"
+```
+
+---
+
+## Task 6: Final verification and PR
+
+- [ ] **Step 1: Full solution build**
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo
+dotnet build
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` (warnings from other projects are pre-existing and acceptable).
+
+- [ ] **Step 2: Full test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: `Failed: 0` — all tests pass.
+
+- [ ] **Step 3: Final format check**
+
+```bash
+dotnet format --verify-no-changes
+```
+
+Expected: exits 0. If not, run `dotnet format` and re-commit.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/marketing-invoices-meta-ads
+```
+
+- [ ] **Step 5: Create PR**
+
+```bash
+gh pr create \
+  --title "feat(marketing-invoices): Meta Ads transaction fetching adapter (#607)" \
+  --body "## Summary
+- Adds \`Anela.Heblo.Adapters.MetaAds\` project
+- \`MetaAdsTransactionSource\` fetches billing transactions from Meta Graph API with pagination and HTTP 429 retry (Polly)
+- \`MetaAdsInvoiceImportJob\` runs at 6 AM / 6 PM Prague time with 7-day lookback
+- 4 unit tests covering parsing, amount conversion, pagination, and rate-limit retry
+- Closes #607
+
+## Test plan
+- [ ] \`dotnet build\` passes
+- [ ] \`dotnet test\` passes (4 new MetaAds tests + all existing tests)
+- [ ] \`dotnet format --verify-no-changes\` passes
+- [ ] Adapter registered in DI and \`appsettings.json\` has non-secret config stub
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --base feat/marketing-invoices-shared-core
+```
+
+Note: Base branch is `feat/marketing-invoices-shared-core` (not `main`) because this depends on the shared core from #606.

--- a/docs/superpowers/specs/2026-04-15-meta-ads-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-15-meta-ads-adapter-design.md
@@ -1,0 +1,196 @@
+# Design Spec: Meta Ads Transaction Fetching Adapter
+
+**Issue:** #607
+**Date:** 2026-04-15
+**Depends on:** #606 (shared core — `IMarketingTransactionSource`, `MarketingInvoiceImportService`, persistence)
+
+---
+
+## Summary
+
+Create `Anela.Heblo.Adapters.MetaAds` — a .NET 8 class library that fetches billing transaction data from Meta (Facebook) Ads Graph API and persists them via the shared marketing invoice import core.
+
+---
+
+## Architecture
+
+New project at `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/`, following the Comgate adapter pattern (Polly resilience) and ShoptetApi adapter pattern (project structure).
+
+**Key design decision:** `MarketingInvoiceImportService` is not registered in DI (the shared core module only registers the repository). `MetaAdsInvoiceImportJob` instantiates `MarketingInvoiceImportService` directly, injecting the concrete `MetaAdsTransactionSource`. This avoids DI conflicts when the Google Ads adapter is later registered with its own `IMarketingTransactionSource` implementation.
+
+---
+
+## Project Structure
+
+```
+backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/
+├── Anela.Heblo.Adapters.MetaAds.csproj
+├── MetaAdsSettings.cs
+├── MetaAdsTransactionSource.cs
+├── MetaAdsInvoiceImportJob.cs
+└── MetaAdsAdapterServiceCollectionExtensions.cs
+```
+
+---
+
+## Components
+
+### `Anela.Heblo.Adapters.MetaAds.csproj`
+
+- Target: `net8.0`, nullable enabled, implicit usings
+- Package references: `Microsoft.Extensions.Http`, `Microsoft.Extensions.Options.ConfigurationExtensions`, `Polly`, `Polly.Extensions`
+- Project references: `Anela.Heblo.Domain`, `Anela.Heblo.Application`
+
+### `MetaAdsSettings.cs`
+
+```csharp
+public class MetaAdsSettings
+{
+    public const string ConfigurationKey = "MetaAds";
+    public string AdAccountId { get; set; } = string.Empty;   // e.g. "act_123456789"
+    public string AccessToken { get; set; } = string.Empty;   // System User token — secrets.json / Key Vault
+    public string ApiVersion { get; set; } = "v21.0";
+}
+```
+
+Configuration in `appsettings.json` (non-secret values only):
+```json
+{
+  "MetaAds": {
+    "AdAccountId": "act_XXXXXXXXX",
+    "ApiVersion": "v21.0"
+  }
+}
+```
+`AccessToken` goes in `secrets.json` / Azure Key Vault only.
+
+### `MetaAdsTransactionSource.cs`
+
+Implements `IMarketingTransactionSource`.
+
+- `Platform` → `"MetaAds"`
+- Endpoint: `GET https://graph.facebook.com/{ApiVersion}/{AdAccountId}/transactions`
+- Query params: `fields=id,time,amount,currency,payment_type`, `access_token={token}`
+- Pagination: follow `paging.next` cursor URL until absent
+- Amount mapping: integer value from API (cents) → `decimal` by dividing by 100
+- `TransactionDate`: parsed from Unix timestamp in `time` field (`DateTimeOffset.FromUnixTimeSeconds`)
+- `Description`: populated from `payment_type` field (e.g., `"THRESHOLD"`)
+- `RawData`: set to the raw JSON object string for the transaction (not persisted, diagnostic only)
+- Client-side date filter: only return transactions where `TransactionDate >= from && TransactionDate <= to`
+
+**Resilience:** Polly `ResiliencePipeline` with retry on HTTP 429 (`TooManyRequests`):
+```
+MaxRetryAttempts = 3, Delay = 2s, BackoffType = Exponential, UseJitter = true
+```
+No circuit breaker (Meta is not on a critical payment path).
+
+**Error handling:** `HttpRequestException` for non-429, non-success responses propagates to the caller (the import service logs per-transaction errors).
+
+### `MetaAdsInvoiceImportJob.cs`
+
+Implements `IRecurringJob`.
+
+**Metadata:**
+```csharp
+JobName        = "meta-ads-invoice-import"
+DisplayName    = "Meta Ads Invoice Import"
+Description    = "Fetches billing transactions from Meta Ads Graph API (7-day lookback)"
+CronExpression = "0 6,18 * * *"   // 6 AM and 6 PM
+TimeZoneId     = "Europe/Prague"  (default from RecurringJobMetadata)
+DefaultIsEnabled = true
+```
+
+**Constructor injects:**
+- `MetaAdsTransactionSource source` (concrete — not via interface, avoids DI conflict)
+- `IImportedMarketingTransactionRepository repository`
+- `ILogger<MarketingInvoiceImportService> logger`
+- `IRecurringJobStatusChecker statusChecker`
+
+**`ExecuteAsync` logic:**
+1. Check `statusChecker.IsJobEnabledAsync` — return early if disabled
+2. Compute window: `from = DateTime.UtcNow.AddDays(-7)`, `to = DateTime.UtcNow`
+3. Instantiate `new MarketingInvoiceImportService(source, repository, logger)`
+4. Call `service.ImportAsync(from, to, cancellationToken)`
+5. Log result (Imported / Skipped / Failed counts)
+6. Rethrow unexpected exceptions after logging
+
+### `MetaAdsAdapterServiceCollectionExtensions.cs`
+
+```csharp
+public static IServiceCollection AddMetaAdsAdapter(
+    this IServiceCollection services,
+    IConfiguration configuration)
+{
+    services.Configure<MetaAdsSettings>(configuration.GetSection(MetaAdsSettings.ConfigurationKey));
+    services.AddHttpClient<MetaAdsTransactionSource>();
+    services.AddScoped<IRecurringJob, MetaAdsInvoiceImportJob>();
+    return services;
+}
+```
+
+### `Program.cs` change
+
+Add after `AddComgateAdapter`:
+```csharp
+builder.Services.AddMetaAdsAdapter(builder.Configuration);
+```
+
+### Solution file
+
+Add `Anela.Heblo.Adapters.MetaAds.csproj` to `backend/Anela.Heblo.sln`.
+
+### Test project
+
+Add project reference to `Anela.Heblo.Tests.csproj`:
+```xml
+<ProjectReference Include="..\..\src\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
+```
+
+---
+
+## API Response Shape
+
+```json
+{
+  "data": [
+    {
+      "id": "1234567890",
+      "time": 1744300800,
+      "amount": 150000,
+      "currency": "CZK",
+      "payment_type": "THRESHOLD"
+    }
+  ],
+  "paging": {
+    "cursors": { "before": "...", "after": "..." },
+    "next": "https://graph.facebook.com/..."
+  }
+}
+```
+
+The `next` field in `paging` is absent on the last page.
+
+---
+
+## Tests
+
+Location: `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs`
+
+| # | Test | Description |
+|---|------|-------------|
+| 1 | `GetTransactionsAsync_ValidResponse_ParsesFieldsCorrectly` | Single transaction in response → assert `TransactionId`, `Amount`, `TransactionDate`, `Currency`, `Description` mapped correctly |
+| 2 | `GetTransactionsAsync_Amount_ConvertedFromCentsToDecimal` | `amount: 150000` → `1500.00m` |
+| 3 | `GetTransactionsAsync_Pagination_AllPagesCollected` | First response has `paging.next`, second has none → transactions from both pages returned |
+| 4 | `GetTransactionsAsync_RateLimitRetry_SucceedsOnSecondAttempt` | First call returns HTTP 429, second returns 200 → result returned (not thrown) |
+
+Tests use `MockHttpMessageHandler` (manual `DelegatingHandler` pattern, no extra package needed).
+
+---
+
+## Out of Scope
+
+- Circuit breaker (Meta is not critical-path)
+- `Retry-After` header parsing (exponential backoff is sufficient)
+- Token expiry detection (monitor manually via Meta Business Manager alerts)
+- FlexiBee sync (future work, tracked in epic)
+- UI for viewing imported transactions (future work)


### PR DESCRIPTION
## Summary

- Adds `Anela.Heblo.Adapters.MetaAds` project
- `MetaAdsTransactionSource` fetches billing transactions from Meta Graph API with pagination and HTTP 429 retry (Polly exponential backoff, 3 retries)
- `MetaAdsInvoiceImportJob` runs at 6 AM / 6 PM Prague time with 7-day lookback window
- 4 unit tests covering: field parsing, amount conversion (cents→decimal), pagination, and rate-limit retry
- Closes #607

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (4 new MetaAds tests + all existing tests)
- [x] `dotnet format --verify-no-changes` passes
- [x] Adapter registered in DI and `appsettings.json` has non-secret config stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)