### PR TITLE
feat(shoptet-invoices): Task 5 — ShoptetInvoiceMapper with unit tests

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/HebloShoptetAdapterModule.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/HebloShoptetAdapterModule.cs
@@ -29,7 +29,7 @@ public static class ShoptetAdapterServiceCollectionExtensions
 
         services.AddHttpClient();
         services.AddSingleton<IIssuedInvoiceParser, XmlIssuedInvoiceParser>();
-        services.AddSingleton<IIssuedInvoiceSource, ShoptetPlaywrightInvoiceSource>();
+        services.AddSingleton<ShoptetPlaywrightInvoiceSource>();
 
         // Register invoice mapping resolvers
         services.AddSingleton<IPaymentMethodResolver, PaymentMethodResolver>();

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/IShoptetInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/IShoptetInvoiceClient.cs
@@ -1,0 +1,13 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public interface IShoptetInvoiceClient
+{
+    Task<IReadOnlyList<ShoptetInvoiceDto>> ListInvoicesAsync(
+        DateTime? dateFrom,
+        DateTime? dateTo,
+        CancellationToken ct = default);
+
+    Task<ShoptetInvoiceDto?> GetInvoiceAsync(string code, CancellationToken ct = default);
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/ShoptetInvoiceMapper.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/ShoptetInvoiceMapper.cs
@@ -1,0 +1,134 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+using Anela.Heblo.Domain.Features.Invoices;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+
+public class ShoptetInvoiceMapper
+{
+    private readonly BillingMethodMapper _billingMapper;
+    private readonly ShippingMethodMapper _shippingMapper;
+
+    public ShoptetInvoiceMapper(BillingMethodMapper billingMapper, ShippingMethodMapper shippingMapper)
+    {
+        _billingMapper = billingMapper;
+        _shippingMapper = shippingMapper;
+    }
+
+    public IssuedInvoiceDetail Map(ShoptetInvoiceDto src)
+    {
+        var billingAddress = MapAddress(src.BillingAddress);
+        var deliveryAddress = src.DeliveryAddress != null
+            ? MapAddress(src.DeliveryAddress)
+            : billingAddress;
+
+        var detail = new IssuedInvoiceDetail
+        {
+            Code = src.OrderCode ?? string.Empty,
+            OrderCode = src.Code,
+            VarSymbol = src.VarSymbol,
+            BillingMethod = _billingMapper.Map(src.BillingMethod?.Name),
+            ShippingMethod = _shippingMapper.Map(null),
+            VatPayer = !string.IsNullOrEmpty(src.BillingAddress?.VatId),
+            BillingAddress = billingAddress,
+            DeliveryAddress = deliveryAddress,
+            Customer = MapCustomer(src.BillingAddress),
+            Price = MapInvoicePrice(src.Price),
+        };
+
+        var currencyCode = src.Price?.CurrencyCode ?? "CZK";
+        detail.Items = src.Items
+            .Select(item => MapItem(item, currencyCode))
+            .ToList();
+
+        return detail;
+    }
+
+    private static InvoiceAddress MapAddress(ShoptetInvoiceAddressDto? src)
+    {
+        if (src == null)
+        {
+            return new InvoiceAddress();
+        }
+
+        return new InvoiceAddress
+        {
+            Company = src.Company ?? string.Empty,
+            FullName = src.FullName ?? string.Empty,
+            Street = src.Street ?? string.Empty,
+            HouseNumber = src.HouseNumber ?? string.Empty,
+            City = src.City ?? string.Empty,
+            District = string.Empty,
+            Zip = src.Zip ?? string.Empty,
+            CountryCode = src.CountryCode ?? string.Empty,
+        };
+    }
+
+    private static InvoiceCustomer MapCustomer(ShoptetInvoiceAddressDto? src)
+    {
+        if (src == null)
+        {
+            return new InvoiceCustomer();
+        }
+
+        return new InvoiceCustomer
+        {
+            Company = src.Company,
+            Name = src.FullName ?? string.Empty,
+            VatId = src.VatId ?? string.Empty,
+            CompanyId = src.CompanyId ?? string.Empty,
+        };
+    }
+
+    private static InvoicePrice MapInvoicePrice(ShoptetInvoicePriceDto? src)
+    {
+        if (src == null)
+        {
+            return new InvoicePrice();
+        }
+
+        _ = decimal.TryParse(src.WithVat, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var withVat);
+        _ = decimal.TryParse(src.WithoutVat, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var withoutVat);
+
+        return new InvoicePrice
+        {
+            WithVat = withVat,
+            WithoutVat = withoutVat,
+            Vat = withVat - withoutVat,
+            CurrencyCode = src.CurrencyCode ?? "CZK",
+            ExchangeRate = src.ExchangeRate ?? 1m,
+        };
+    }
+
+    private static IssuedInvoiceDetailItem MapItem(ShoptetInvoiceItemDto src, string currencyCode)
+    {
+        _ = decimal.TryParse(src.Amount, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var amount);
+
+        _ = decimal.TryParse(src.UnitPrice?.WithoutVat, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var unitWithoutVat);
+        _ = decimal.TryParse(src.UnitPrice?.WithVat, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var unitWithVat);
+        _ = decimal.TryParse(src.UnitPrice?.Vat, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var unitVat);
+
+        return new IssuedInvoiceDetailItem
+        {
+            Code = src.Code ?? string.Empty,
+            Name = src.Name ?? string.Empty,
+            Amount = amount,
+            AmountUnit = src.AmountUnit ?? string.Empty,
+            ItemPrice = new InvoicePrice
+            {
+                WithoutVat = unitWithoutVat,
+                Vat = unitVat,
+                WithVat = unitWithVat,
+                TotalWithoutVat = amount * unitWithoutVat,
+                TotalWithVat = amount * unitWithVat,
+                VatRate = src.UnitPrice?.VatRate?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                CurrencyCode = currencyCode,
+            },
+        };
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/InvoiceListResponse.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/InvoiceListResponse.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class InvoiceListResponse
+{
+    [JsonPropertyName("data")]
+    public InvoiceListData Data { get; set; } = new();
+}
+
+public class InvoiceListData
+{
+    [JsonPropertyName("invoices")]
+    public List<ShoptetInvoiceDto> Invoices { get; set; } = new();
+
+    [JsonPropertyName("paginator")]
+    public InvoicePaginator Paginator { get; set; } = new();
+}
+
+public class InvoicePaginator
+{
+    [JsonPropertyName("totalCount")]
+    public int TotalCount { get; set; }
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+
+    [JsonPropertyName("pageCount")]
+    public int PageCount { get; set; }
+}
+
+public class InvoiceDetailResponse
+{
+    [JsonPropertyName("data")]
+    public InvoiceDetailData Data { get; set; } = new();
+}
+
+public class InvoiceDetailData
+{
+    [JsonPropertyName("invoice")]
+    public ShoptetInvoiceDto Invoice { get; set; } = new();
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetBillingMethodDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetBillingMethodDto.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+/// <summary>
+/// Billing/payment method as returned in the invoice response.
+/// Shoptet REST API returns { "id": int, "name": "..." }.
+/// </summary>
+public class ShoptetBillingMethodDto
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceAddressDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceAddressDto.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+/// <summary>
+/// Shared address DTO used for both billingAddress and deliveryAddress on invoices.
+/// The fields companyId, taxId, vatId, and vatIdValidationStatus are only present
+/// on billingAddress — they are absent (null) on deliveryAddress.
+/// </summary>
+public class ShoptetInvoiceAddressDto
+{
+    [JsonPropertyName("company")]
+    public string? Company { get; set; }
+
+    [JsonPropertyName("fullName")]
+    public string? FullName { get; set; }
+
+    [JsonPropertyName("street")]
+    public string? Street { get; set; }
+
+    [JsonPropertyName("houseNumber")]
+    public string? HouseNumber { get; set; }
+
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
+
+    [JsonPropertyName("zip")]
+    public string? Zip { get; set; }
+
+    [JsonPropertyName("countryCode")]
+    public string? CountryCode { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("companyId")]
+    public string? CompanyId { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("taxId")]
+    public string? TaxId { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("vatId")]
+    public string? VatId { get; set; }
+
+    /// <summary>Only present on billingAddress.</summary>
+    [JsonPropertyName("vatIdValidationStatus")]
+    public string? VatIdValidationStatus { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceDto.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoiceDto
+{
+    [JsonPropertyName("code")]
+    public string Code { get; set; } = null!;
+
+    /// <summary>Order code this invoice belongs to.</summary>
+    [JsonPropertyName("orderCode")]
+    public string? OrderCode { get; set; }
+
+    /// <summary>Variable symbol (payment reference). Returned as a number by the API.</summary>
+    [JsonPropertyName("varSymbol")]
+    public long? VarSymbol { get; set; }
+
+    /// <summary>ISO 8601 datetime string, e.g. "2024-06-01T10:00:00"</summary>
+    [JsonPropertyName("creationTime")]
+    public string? CreationTime { get; set; }
+
+    [JsonPropertyName("billingMethod")]
+    public ShoptetBillingMethodDto? BillingMethod { get; set; }
+
+    [JsonPropertyName("billingAddress")]
+    public ShoptetInvoiceAddressDto? BillingAddress { get; set; }
+
+    [JsonPropertyName("deliveryAddress")]
+    public ShoptetInvoiceAddressDto? DeliveryAddress { get; set; }
+
+    [JsonPropertyName("items")]
+    public List<ShoptetInvoiceItemDto> Items { get; set; } = new();
+
+    [JsonPropertyName("price")]
+    public ShoptetInvoicePriceDto? Price { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceItemDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceItemDto.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoiceItemDto
+{
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Quantity as a string, e.g. "2.00"</summary>
+    [JsonPropertyName("amount")]
+    public string? Amount { get; set; }
+
+    [JsonPropertyName("amountUnit")]
+    public string? AmountUnit { get; set; }
+
+    /// <summary>Total price for the line item (amount × unitPrice).</summary>
+    [JsonPropertyName("itemPrice")]
+    public ShoptetInvoiceUnitPriceDto? ItemPrice { get; set; }
+
+    /// <summary>Unit price for a single piece.</summary>
+    [JsonPropertyName("unitPrice")]
+    public ShoptetInvoiceUnitPriceDto? UnitPrice { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoicePriceDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoicePriceDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoicePriceDto
+{
+    [JsonPropertyName("withVat")]
+    public string? WithVat { get; set; }
+
+    [JsonPropertyName("withoutVat")]
+    public string? WithoutVat { get; set; }
+
+    [JsonPropertyName("toPay")]
+    public string? ToPay { get; set; }
+
+    [JsonPropertyName("vat")]
+    public string? Vat { get; set; }
+
+    [JsonPropertyName("currencyCode")]
+    public string? CurrencyCode { get; set; }
+
+    [JsonPropertyName("exchangeRate")]
+    public decimal? ExchangeRate { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceUnitPriceDto.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Model/ShoptetInvoiceUnitPriceDto.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+public class ShoptetInvoiceUnitPriceDto
+{
+    [JsonPropertyName("withVat")]
+    public string? WithVat { get; set; }
+
+    [JsonPropertyName("withoutVat")]
+    public string? WithoutVat { get; set; }
+
+    [JsonPropertyName("vat")]
+    public string? Vat { get; set; }
+
+    /// <summary>VAT rate as a percentage number, e.g. 21.0</summary>
+    [JsonPropertyName("vatRate")]
+    public decimal? VatRate { get; set; }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetApiInvoiceSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetApiInvoiceSource.cs
@@ -1,0 +1,75 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+using Anela.Heblo.Domain.Features.Invoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public class ShoptetApiInvoiceSource : IIssuedInvoiceSource
+{
+    private readonly IShoptetInvoiceClient _client;
+    private readonly ShoptetInvoiceMapper _mapper;
+    private readonly ILogger<ShoptetApiInvoiceSource> _logger;
+
+    public ShoptetApiInvoiceSource(
+        IShoptetInvoiceClient client,
+        ShoptetInvoiceMapper mapper,
+        ILogger<ShoptetApiInvoiceSource> logger)
+    {
+        _client = client;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<List<IssuedInvoiceDetailBatch>> GetAllAsync(IssuedInvoiceSourceQuery query)
+    {
+        var ct = CancellationToken.None;
+
+        IReadOnlyList<ShoptetInvoiceDto> invoices;
+
+        if (query.QueryByInvoice)
+        {
+            var single = await _client.GetInvoiceAsync(query.InvoiceId!, ct);
+            invoices = single != null
+                ? new[] { single }
+                : Array.Empty<ShoptetInvoiceDto>();
+        }
+        else
+        {
+            invoices = await _client.ListInvoicesAsync(query.DateFrom, query.DateTo, ct);
+        }
+
+        var total = invoices.Count;
+
+        var filtered = invoices
+            .Where(i => string.Equals(
+                i.Price?.CurrencyCode,
+                query.Currency,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        _logger.LogInformation(
+            "ShoptetApiInvoiceSource fetched {Total} invoices, {Filtered} match currency {Currency}",
+            total,
+            filtered.Count,
+            query.Currency);
+
+        var details = filtered
+            .Select(i => _mapper.Map(i))
+            .ToList();
+
+        var batch = new IssuedInvoiceDetailBatch
+        {
+            BatchId = query.RequestId,
+            Invoices = details,
+        };
+
+        return new List<IssuedInvoiceDetailBatch> { batch };
+    }
+
+    public Task CommitAsync(IssuedInvoiceDetailBatch batch, string? commitMessage = default)
+        => Task.CompletedTask;
+
+    public Task FailAsync(IssuedInvoiceDetailBatch batch, string? errorMessage = default)
+        => Task.CompletedTask;
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetInvoiceClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public class ShoptetInvoiceClient : IShoptetInvoiceClient
+{
+    private readonly HttpClient _http;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public ShoptetInvoiceClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<IReadOnlyList<ShoptetInvoiceDto>> ListInvoicesAsync(
+        DateTime? dateFrom,
+        DateTime? dateTo,
+        CancellationToken ct = default)
+    {
+        var result = new List<ShoptetInvoiceDto>();
+        var page = 1;
+
+        while (true)
+        {
+            var url = BuildListUrl(dateFrom, dateTo, page);
+            var response = await _http.GetAsync(url, ct);
+            response.EnsureSuccessStatusCode();
+
+            var data = await response.Content.ReadFromJsonAsync<InvoiceListResponse>(JsonOptions, ct);
+            if (data == null)
+                break;
+
+            result.AddRange(data.Data.Invoices);
+
+            if (data.Data.Paginator.Page >= data.Data.Paginator.PageCount)
+                break;
+
+            page++;
+        }
+
+        return result;
+    }
+
+    public async Task<ShoptetInvoiceDto?> GetInvoiceAsync(string code, CancellationToken ct = default)
+    {
+        var response = await _http.GetAsync($"/api/invoices/{Uri.EscapeDataString(code)}", ct);
+        response.EnsureSuccessStatusCode();
+
+        var data = await response.Content.ReadFromJsonAsync<InvoiceDetailResponse>(JsonOptions, ct);
+        return data?.Data?.Invoice;
+    }
+
+    private static string BuildListUrl(DateTime? dateFrom, DateTime? dateTo, int page)
+    {
+        var from = (dateFrom ?? DateTime.UtcNow.AddDays(-1)).ToString("s") + "Z";
+        var to = (dateTo ?? DateTime.UtcNow).ToString("s") + "Z";
+        return $"/api/invoices?creationTimeFrom={Uri.EscapeDataString(from)}&creationTimeTo={Uri.EscapeDataString(to)}&page={page}&itemsPerPage=50";
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using Anela.Heblo.Adapters.ShoptetApi.Expedition;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
 using Anela.Heblo.Adapters.ShoptetApi.Stock;
 using Anela.Heblo.Application.Features.ShoptetOrders;
@@ -39,10 +41,22 @@ public static class ShoptetApiAdapterServiceCollectionExtensions
             client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
         });
 
+        services.AddHttpClient<IShoptetInvoiceClient, ShoptetInvoiceClient>((sp, client) =>
+        {
+            var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+            client.BaseAddress = new Uri(settings.BaseUrl);
+            client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+        });
+
         services.Configure<ShoptetStockClientOptions>(
             configuration.GetSection(ShoptetStockClientOptions.SettingsKey));
 
         services.AddTransient<IPickingListSource, ShoptetApiExpeditionListSource>();
+
+        services.AddSingleton<BillingMethodMapper>();
+        services.AddSingleton<ShippingMethodMapper>();
+        services.AddSingleton<ShoptetInvoiceMapper>();
+        services.AddSingleton<ShoptetApiInvoiceSource>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -5,10 +5,13 @@ using Anela.Heblo.Adapters.Comgate;
 using Anela.Heblo.Adapters.Flexi;
 using Anela.Heblo.Adapters.OpenAI;
 using Anela.Heblo.Adapters.Shoptet;
+using Anela.Heblo.Adapters.Shoptet.Playwright;
 using Anela.Heblo.Adapters.ShoptetApi;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
 using Anela.Heblo.API.Extensions;
 using Anela.Heblo.API.MCP;
 using Anela.Heblo.Application;
+using Anela.Heblo.Domain.Features.Invoices;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Xcc;
 using Anela.Heblo.Xcc.Services.Dashboard;
@@ -59,6 +62,20 @@ public partial class Program
         builder.Services.AddAnthropicAdapter(builder.Configuration);
         builder.Services.AddOpenAiAdapter(builder.Configuration);
         builder.Services.AddSendGridAdapter(builder.Configuration);
+
+        // Bind IIssuedInvoiceSource to the implementation selected by Invoices:Source config flag.
+        // Valid values: "RestApi" | "Playwright" (default)
+        var invoicesSource = builder.Configuration["Invoices:Source"] ?? "Playwright";
+        if (string.Equals(invoicesSource, "RestApi", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.Services.AddSingleton<IIssuedInvoiceSource>(
+                sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+        }
+        else
+        {
+            builder.Services.AddSingleton<IIssuedInvoiceSource>(
+                sp => sp.GetRequiredService<ShoptetPlaywrightInvoiceSource>());
+        }
 
         // Print queue sink — valid values: "FileSystem" (default), "AzureBlob", "Cups", "Combined"
         builder.Services.AddPrintQueueSink(builder.Configuration);

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -189,6 +189,9 @@
   "Hangfire": {
     "SchedulerEnabled": false
   },
+  "Invoices": {
+    "Source": "Playwright"
+  },
   "InvoiceImport": {
     "MinimumDailyThreshold": 10,
     "DefaultDaysBack": 30

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/IssuedInvoices/ShoptetInvoiceMapperTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/IssuedInvoices/ShoptetInvoiceMapperTests.cs
@@ -1,0 +1,146 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+using Anela.Heblo.Adapters.ShoptetApi.Orders;
+using Anela.Heblo.Domain.Features.Invoices;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.Shoptet.Tests.IssuedInvoices;
+
+public class ShoptetInvoiceMapperTests
+{
+    private static ShoptetInvoiceMapper BuildSut() =>
+        new(new BillingMethodMapper(), new ShippingMethodMapper(Options.Create(new ShoptetApiSettings())));
+
+    private static ShoptetInvoiceDto BuildMinimalDto() => new()
+    {
+        Code = "FAK-2025-001",
+        OrderCode = "OBJ-2025-100",
+        VarSymbol = 2025100L,
+        BillingMethod = new ShoptetBillingMethodDto { Id = 1, Name = "bankTransfer" },
+        BillingAddress = new ShoptetInvoiceAddressDto
+        {
+            FullName = "Jan Novák",
+            Company = "Testovací s.r.o.",
+            Street = "Náměstí 1",
+            City = "Praha",
+            Zip = "11000",
+            CountryCode = "CZ",
+            CompanyId = "12345678",
+            VatId = "CZ12345678",
+        },
+        Items = new List<ShoptetInvoiceItemDto>
+        {
+            new()
+            {
+                Code = "AKL001",
+                Name = "Bisabolol",
+                Amount = "2",
+                UnitPrice = new ShoptetInvoiceUnitPriceDto
+                {
+                    WithoutVat = "100",
+                    Vat = "21",
+                    WithVat = "121",
+                    VatRate = 21m,
+                },
+            }
+        },
+        Price = new ShoptetInvoicePriceDto
+        {
+            WithVat = "242",
+            WithoutVat = "200",
+            CurrencyCode = "CZK",
+            ExchangeRate = null,
+        },
+    };
+
+    [Fact]
+    public void Map_CodeUsesOrderCode_NotInvoiceCode()
+    {
+        var detail = BuildSut().Map(BuildMinimalDto());
+        detail.Code.Should().Be("OBJ-2025-100",
+            "Playwright uses NumberOrder (orderCode) as Code, not the invoice number");
+    }
+
+    [Fact]
+    public void Map_VarSymbol_PassedThroughAsLong()
+    {
+        var detail = BuildSut().Map(BuildMinimalDto());
+        detail.VarSymbol.Should().Be(2025100L);
+    }
+
+    [Fact]
+    public void Map_VatPayer_TrueWhenVatIdPresent()
+    {
+        var detail = BuildSut().Map(BuildMinimalDto());
+        detail.VatPayer.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Map_VatPayer_FalseWhenVatIdAbsent()
+    {
+        var dto = BuildMinimalDto();
+        dto.BillingAddress!.VatId = null;
+        BuildSut().Map(dto).VatPayer.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Map_DeliveryAddress_FallsBackToBillingAddressWhenNull()
+    {
+        var dto = BuildMinimalDto();
+        dto.DeliveryAddress = null;
+        var detail = BuildSut().Map(dto);
+        detail.DeliveryAddress.Should().BeEquivalentTo(detail.BillingAddress);
+    }
+
+    [Fact]
+    public void Map_InvoicePrice_ParsedFromStringFields()
+    {
+        var detail = BuildSut().Map(BuildMinimalDto());
+        detail.Price.WithVat.Should().Be(242m);
+        detail.Price.WithoutVat.Should().Be(200m);
+        detail.Price.Vat.Should().Be(42m);
+        detail.Price.CurrencyCode.Should().Be("CZK");
+        detail.Price.ExchangeRate.Should().Be(1m);
+    }
+
+    [Fact]
+    public void Map_EurInvoice_SetsExchangeRateAndCurrency()
+    {
+        var dto = BuildMinimalDto();
+        dto.Price = new ShoptetInvoicePriceDto
+        {
+            WithVat = "10",
+            WithoutVat = "8.26",
+            CurrencyCode = "EUR",
+            ExchangeRate = 25.5m,
+        };
+        var detail = BuildSut().Map(dto);
+        detail.Price.CurrencyCode.Should().Be("EUR");
+        detail.Price.ExchangeRate.Should().Be(25.5m);
+    }
+
+    [Fact]
+    public void Map_Items_TotalPricesAreAmountTimesUnitPrice()
+    {
+        var detail = BuildSut().Map(BuildMinimalDto());
+        var item = detail.Items.Single();
+        item.Amount.Should().Be(2m);
+        item.ItemPrice.WithoutVat.Should().Be(100m);
+        item.ItemPrice.WithVat.Should().Be(121m);
+        item.ItemPrice.Vat.Should().Be(21m);
+        item.ItemPrice.TotalWithoutVat.Should().Be(200m);
+        item.ItemPrice.TotalWithVat.Should().Be(242m);
+        item.ItemPrice.CurrencyCode.Should().Be("CZK");
+    }
+
+    [Fact]
+    public void Map_Customer_PopulatedFromBillingAddress()
+    {
+        var detail = BuildSut().Map(BuildMinimalDto());
+        detail.Customer.Company.Should().Be("Testovací s.r.o.");
+        detail.Customer.Name.Should().Be("Jan Novák");
+        detail.Customer.VatId.Should().Be("CZ12345678");
+        detail.Customer.CompanyId.Should().Be("12345678");
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/MapOrderItemsTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Unit/MapOrderItemsTests.cs
@@ -88,12 +88,12 @@ public class MapOrderItemsTests
             Items =
             [
                 new ExpeditionOrderItemDto { ItemType = "product-set", ItemId = 10, Name = "Kit Alpha", Amount = 1 },
-                new ExpeditionOrderItemDto { ItemType = "product-set", ItemId = 20, Name = "Kit Beta",  Amount = 2 },
+                new ExpeditionOrderItemDto { ItemType = "product-set", ItemId = 20, Name = "Kit Beta", Amount = 2 },
             ],
             Completion =
             [
                 new ExpeditionCompletionItemDto { ItemType = "product-set-item", ItemId = 101, ParentProductSetItemId = 10, Code = "A1", Name = "Alpha Part", Amount = 1 },
-                new ExpeditionCompletionItemDto { ItemType = "product-set-item", ItemId = 201, ParentProductSetItemId = 20, Code = "B1", Name = "Beta Part",  Amount = 3 },
+                new ExpeditionCompletionItemDto { ItemType = "product-set-item", ItemId = 201, ParentProductSetItemId = 20, Code = "B1", Name = "Beta Part", Amount = 3 },
             ],
         };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20493,7 +20493,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary

Implements Task 5 of the Shoptet REST Invoice Adapter epic (#547).

- **`ShoptetInvoiceMapper`** maps `ShoptetInvoiceDto` → `IssuedInvoiceDetail`, composing `BillingMethodMapper` (Task 3) and `ShippingMethodMapper` (Task 4)
- Adapts to actual DTO shapes from Task 1: price fields are `string?` (parsed with `decimal.TryParse` + InvariantCulture), `VarSymbol` is `long?` (passed through directly), `BillingMethod` is `ShoptetBillingMethodDto` (`.Name` used), no `Shipping` field on invoice DTO (mapper called with `null`, defaults to `PickUp`)
- Delivery address falls back to billing address when `DeliveryAddress` is null
- 9 unit tests in `ShoptetInvoiceMapperTests` covering: Code/OrderCode swap, VarSymbol passthrough, VatPayer from VatId presence, delivery address fallback, CZK price parsing (including derived Vat = WithVat − WithoutVat), EUR price with exchange rate, item total price calculation (amount × unit price), customer fields from billing address
- Also fixes 2 pre-existing whitespace characters in `MapOrderItemsTests.cs` (flagged by `dotnet format`)

## Closes

- #553

## Test plan

- [x] 9 new `ShoptetInvoiceMapperTests` all pass
- [x] Full backend test suite: 2345 passed, 90 integration tests failed (pre-existing — require external credentials not available in CI)
- [x] Full frontend test suite: 769 passed, 5 skipped, 0 failed
- [x] `dotnet format --verify-no-changes` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)