### PR TITLE
feat(shoptet-invoices): add ShoptetApiInvoiceSource implementing IIssuedInvoiceSource

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/HebloShoptetAdapterModule.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/HebloShoptetAdapterModule.cs
@@ -29,7 +29,7 @@ public static class ShoptetAdapterServiceCollectionExtensions
 
         services.AddHttpClient();
         services.AddSingleton<IIssuedInvoiceParser, XmlIssuedInvoiceParser>();
-        services.AddSingleton<IIssuedInvoiceSource, ShoptetPlaywrightInvoiceSource>();
+        services.AddSingleton<ShoptetPlaywrightInvoiceSource>();
 
         // Register invoice mapping resolvers
         services.AddSingleton<IPaymentMethodResolver, PaymentMethodResolver>();

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/IShoptetInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/IShoptetInvoiceClient.cs
@@ -1,0 +1,13 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public interface IShoptetInvoiceClient
+{
+    Task<IReadOnlyList<ShoptetInvoiceDto>> ListInvoicesAsync(
+        DateTime? dateFrom,
+        DateTime? dateTo,
+        CancellationToken ct = default);
+
+    Task<ShoptetInvoiceDto?> GetInvoiceAsync(string code, CancellationToken ct = default);
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetApiInvoiceSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetApiInvoiceSource.cs
@@ -1,0 +1,75 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+using Anela.Heblo.Domain.Features.Invoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public class ShoptetApiInvoiceSource : IIssuedInvoiceSource
+{
+    private readonly IShoptetInvoiceClient _client;
+    private readonly ShoptetInvoiceMapper _mapper;
+    private readonly ILogger<ShoptetApiInvoiceSource> _logger;
+
+    public ShoptetApiInvoiceSource(
+        IShoptetInvoiceClient client,
+        ShoptetInvoiceMapper mapper,
+        ILogger<ShoptetApiInvoiceSource> logger)
+    {
+        _client = client;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<List<IssuedInvoiceDetailBatch>> GetAllAsync(IssuedInvoiceSourceQuery query)
+    {
+        var ct = CancellationToken.None;
+
+        IReadOnlyList<ShoptetInvoiceDto> invoices;
+
+        if (query.QueryByInvoice)
+        {
+            var single = await _client.GetInvoiceAsync(query.InvoiceId!, ct);
+            invoices = single != null
+                ? new[] { single }
+                : Array.Empty<ShoptetInvoiceDto>();
+        }
+        else
+        {
+            invoices = await _client.ListInvoicesAsync(query.DateFrom, query.DateTo, ct);
+        }
+
+        var total = invoices.Count;
+
+        var filtered = invoices
+            .Where(i => string.Equals(
+                i.Price?.CurrencyCode,
+                query.Currency,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        _logger.LogInformation(
+            "ShoptetApiInvoiceSource fetched {Total} invoices, {Filtered} match currency {Currency}",
+            total,
+            filtered.Count,
+            query.Currency);
+
+        var details = filtered
+            .Select(i => _mapper.Map(i))
+            .ToList();
+
+        var batch = new IssuedInvoiceDetailBatch
+        {
+            BatchId = query.RequestId,
+            Invoices = details,
+        };
+
+        return new List<IssuedInvoiceDetailBatch> { batch };
+    }
+
+    public Task CommitAsync(IssuedInvoiceDetailBatch batch, string? commitMessage = default)
+        => Task.CompletedTask;
+
+    public Task FailAsync(IssuedInvoiceDetailBatch batch, string? errorMessage = default)
+        => Task.CompletedTask;
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/ShoptetInvoiceClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+
+public class ShoptetInvoiceClient : IShoptetInvoiceClient
+{
+    private readonly HttpClient _http;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public ShoptetInvoiceClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<IReadOnlyList<ShoptetInvoiceDto>> ListInvoicesAsync(
+        DateTime? dateFrom,
+        DateTime? dateTo,
+        CancellationToken ct = default)
+    {
+        var result = new List<ShoptetInvoiceDto>();
+        var page = 1;
+
+        while (true)
+        {
+            var url = BuildListUrl(dateFrom, dateTo, page);
+            var response = await _http.GetAsync(url, ct);
+            response.EnsureSuccessStatusCode();
+
+            var data = await response.Content.ReadFromJsonAsync<InvoiceListResponse>(JsonOptions, ct);
+            if (data == null)
+                break;
+
+            result.AddRange(data.Data.Invoices);
+
+            if (data.Data.Paginator.Page >= data.Data.Paginator.PageCount)
+                break;
+
+            page++;
+        }
+
+        return result;
+    }
+
+    public async Task<ShoptetInvoiceDto?> GetInvoiceAsync(string code, CancellationToken ct = default)
+    {
+        var response = await _http.GetAsync($"/api/invoices/{Uri.EscapeDataString(code)}", ct);
+        response.EnsureSuccessStatusCode();
+
+        var data = await response.Content.ReadFromJsonAsync<InvoiceDetailResponse>(JsonOptions, ct);
+        return data?.Data?.Invoice;
+    }
+
+    private static string BuildListUrl(DateTime? dateFrom, DateTime? dateTo, int page)
+    {
+        var from = (dateFrom ?? DateTime.UtcNow.AddDays(-1)).ToString("s") + "Z";
+        var to = (dateTo ?? DateTime.UtcNow).ToString("s") + "Z";
+        return $"/api/invoices?creationTimeFrom={Uri.EscapeDataString(from)}&creationTimeTo={Uri.EscapeDataString(to)}&page={page}&itemsPerPage=50";
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using Anela.Heblo.Adapters.ShoptetApi.Expedition;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
 using Anela.Heblo.Adapters.ShoptetApi.Stock;
 using Anela.Heblo.Application.Features.ShoptetOrders;
@@ -39,10 +41,22 @@ public static class ShoptetApiAdapterServiceCollectionExtensions
             client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
         });
 
+        services.AddHttpClient<IShoptetInvoiceClient, ShoptetInvoiceClient>((sp, client) =>
+        {
+            var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+            client.BaseAddress = new Uri(settings.BaseUrl);
+            client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+        });
+
         services.Configure<ShoptetStockClientOptions>(
             configuration.GetSection(ShoptetStockClientOptions.SettingsKey));
 
         services.AddTransient<IPickingListSource, ShoptetApiExpeditionListSource>();
+
+        services.AddSingleton<BillingMethodMapper>();
+        services.AddSingleton<ShippingMethodMapper>();
+        services.AddSingleton<ShoptetInvoiceMapper>();
+        services.AddSingleton<ShoptetApiInvoiceSource>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -5,10 +5,13 @@ using Anela.Heblo.Adapters.Comgate;
 using Anela.Heblo.Adapters.Flexi;
 using Anela.Heblo.Adapters.OpenAI;
 using Anela.Heblo.Adapters.Shoptet;
+using Anela.Heblo.Adapters.Shoptet.Playwright;
 using Anela.Heblo.Adapters.ShoptetApi;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
 using Anela.Heblo.API.Extensions;
 using Anela.Heblo.API.MCP;
 using Anela.Heblo.Application;
+using Anela.Heblo.Domain.Features.Invoices;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Xcc;
 using Anela.Heblo.Xcc.Services.Dashboard;
@@ -59,6 +62,20 @@ public partial class Program
         builder.Services.AddAnthropicAdapter(builder.Configuration);
         builder.Services.AddOpenAiAdapter(builder.Configuration);
         builder.Services.AddSendGridAdapter(builder.Configuration);
+
+        // Bind IIssuedInvoiceSource to the implementation selected by Invoices:Source config flag.
+        // Valid values: "RestApi" | "Playwright" (default)
+        var invoicesSource = builder.Configuration["Invoices:Source"] ?? "Playwright";
+        if (string.Equals(invoicesSource, "RestApi", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.Services.AddSingleton<IIssuedInvoiceSource>(
+                sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+        }
+        else
+        {
+            builder.Services.AddSingleton<IIssuedInvoiceSource>(
+                sp => sp.GetRequiredService<ShoptetPlaywrightInvoiceSource>());
+        }
 
         // Print queue sink — valid values: "FileSystem" (default), "AzureBlob", "Cups", "Combined"
         builder.Services.AddPrintQueueSink(builder.Configuration);

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -189,6 +189,9 @@
   "Hangfire": {
     "SchedulerEnabled": false
   },
+  "Invoices": {
+    "Source": "Playwright"
+  },
   "InvoiceImport": {
     "MinimumDailyThreshold": 10,
     "DefaultDaysBack": 30

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20493,7 +20493,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
Fixes #554

Part of epic #547 — Shoptet REST Invoice Adapter

## Changes
- Added `ShoptetApiInvoiceSource` implementing `IIssuedInvoiceSource`
- Supports both single-invoice (`QueryByInvoice`) and date-range list modes
- Filters by currency code (case-insensitive)
- `CommitAsync`/`FailAsync` are no-ops matching Playwright adapter behaviour
- Cherry-picked Task 2 (`ShoptetInvoiceClient` + `IShoptetInvoiceClient`) from `feat/550-shoptet-invoice-client` as it was not yet in `feat/553-shoptet-invoice-mapper`

**Branch based on `feat/553-shoptet-invoice-mapper`** (includes Tasks 2–5 as dependencies)