### PR TITLE
feat(shoptet-invoices): DI wiring and Invoices:Source config flag (#555)

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/HebloShoptetAdapterModule.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/HebloShoptetAdapterModule.cs
@@ -29,7 +29,7 @@ public static class ShoptetAdapterServiceCollectionExtensions
 
         services.AddHttpClient();
         services.AddSingleton<IIssuedInvoiceParser, XmlIssuedInvoiceParser>();
-        services.AddSingleton<IIssuedInvoiceSource, ShoptetPlaywrightInvoiceSource>();
+        services.AddSingleton<ShoptetPlaywrightInvoiceSource>();
 
         // Register invoice mapping resolvers
         services.AddSingleton<IPaymentMethodResolver, PaymentMethodResolver>();

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using Anela.Heblo.Adapters.ShoptetApi.Expedition;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
 using Anela.Heblo.Adapters.ShoptetApi.Orders;
 using Anela.Heblo.Adapters.ShoptetApi.Stock;
 using Anela.Heblo.Application.Features.ShoptetOrders;
@@ -39,10 +41,22 @@ public static class ShoptetApiAdapterServiceCollectionExtensions
             client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
         });
 
+        services.AddHttpClient<IShoptetInvoiceClient, ShoptetInvoiceClient>((sp, client) =>
+        {
+            var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+            client.BaseAddress = new Uri(settings.BaseUrl);
+            client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+        });
+
         services.Configure<ShoptetStockClientOptions>(
             configuration.GetSection(ShoptetStockClientOptions.SettingsKey));
 
         services.AddTransient<IPickingListSource, ShoptetApiExpeditionListSource>();
+
+        services.AddSingleton<BillingMethodMapper>();
+        services.AddSingleton<ShippingMethodMapper>();
+        services.AddSingleton<ShoptetInvoiceMapper>();
+        services.AddSingleton<ShoptetApiInvoiceSource>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -5,10 +5,13 @@ using Anela.Heblo.Adapters.Comgate;
 using Anela.Heblo.Adapters.Flexi;
 using Anela.Heblo.Adapters.OpenAI;
 using Anela.Heblo.Adapters.Shoptet;
+using Anela.Heblo.Adapters.Shoptet.Playwright;
 using Anela.Heblo.Adapters.ShoptetApi;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
 using Anela.Heblo.API.Extensions;
 using Anela.Heblo.API.MCP;
 using Anela.Heblo.Application;
+using Anela.Heblo.Domain.Features.Invoices;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Xcc;
 using Anela.Heblo.Xcc.Services.Dashboard;
@@ -59,6 +62,20 @@ public partial class Program
         builder.Services.AddAnthropicAdapter(builder.Configuration);
         builder.Services.AddOpenAiAdapter(builder.Configuration);
         builder.Services.AddSendGridAdapter(builder.Configuration);
+
+        // Bind IIssuedInvoiceSource to the implementation selected by Invoices:Source config flag.
+        // Valid values: "RestApi" | "Playwright" (default)
+        var invoicesSource = builder.Configuration["Invoices:Source"] ?? "Playwright";
+        if (string.Equals(invoicesSource, "RestApi", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.Services.AddSingleton<IIssuedInvoiceSource>(
+                sp => sp.GetRequiredService<ShoptetApiInvoiceSource>());
+        }
+        else
+        {
+            builder.Services.AddSingleton<IIssuedInvoiceSource>(
+                sp => sp.GetRequiredService<ShoptetPlaywrightInvoiceSource>());
+        }
 
         // Print queue sink — valid values: "FileSystem" (default), "AzureBlob", "Cups", "Combined"
         builder.Services.AddPrintQueueSink(builder.Configuration);

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -189,6 +189,9 @@
   "Hangfire": {
     "SchedulerEnabled": false
   },
+  "Invoices": {
+    "Source": "Playwright"
+  },
   "InvoiceImport": {
     "MinimumDailyThreshold": 10,
     "DefaultDaysBack": 30


### PR DESCRIPTION
## Summary

- Register `ShoptetApiInvoiceSource`, `ShoptetInvoiceMapper`, `BillingMethodMapper`, `ShippingMethodMapper`, and `IShoptetInvoiceClient` in `ShoptetApiAdapterServiceCollectionExtensions`
- Decouple `IIssuedInvoiceSource` binding from `HebloShoptetAdapterModule` — it no longer registers the interface, only the concrete `ShoptetPlaywrightInvoiceSource`
- Add config-driven `IIssuedInvoiceSource` binding in `Program.cs` controlled by `Invoices:Source` (`Playwright` | `RestApi`, default: `Playwright`)
- Add `"Invoices": { "Source": "Playwright" }` to `appsettings.json`

## Test plan

- [x] `dotnet build` passes with 0 warnings, 0 errors
- [x] `dotnet test` — 2141 passed, 7 failed (all pre-existing Docker integration tests unrelated to these changes)
- [ ] Switch `Invoices:Source` to `RestApi` in user secrets and verify invoice import uses the REST API path
- [ ] Switch back to `Playwright` and verify Playwright invoice source is used

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)