### PR TITLE
feat(marketing-invoices): Google Ads transaction fetching adapter (#608)

### DIFF
--- a/Anela.Heblo.sln
+++ b/Anela.Heblo.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.Shopte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.MetaAds", "backend\src\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj", "{714E577E-6254-4CD5-83CE-B4C9367A175A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Anela.Heblo.Adapters.GoogleAds", "backend\src\Adapters\Anela.Heblo.Adapters.GoogleAds\Anela.Heblo.Adapters.GoogleAds.csproj", "{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -293,6 +295,18 @@ Global
 		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x64.Build.0 = Release|Any CPU
 		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x86.ActiveCfg = Release|Any CPU
 		{714E577E-6254-4CD5-83CE-B4C9367A175A}.Release|x86.Build.0 = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x64.Build.0 = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Debug|x86.Build.0 = Debug|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x64.ActiveCfg = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x64.Build.0 = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x86.ActiveCfg = Release|Any CPU
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -320,5 +334,6 @@ Global
 		{B0098688-4986-4F6C-97B8-19A16808EDDA} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{E54D4978-CE79-4415-BA6B-E1B1C3C71169} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 		{714E577E-6254-4CD5-83CE-B4C9367A175A} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
+		{8B4F9B02-E1EB-4642-9402-CFBB115B0BDC} = {4B6F17C3-0A57-487A-BE8C-1808B40EC604}
 	EndGlobalSection
 EndGlobal

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Anela.Heblo.Adapters.GoogleAds</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Ads.GoogleAds" Version="21.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Anela.Heblo.Tests" />
+  </ItemGroup>
+</Project>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsAdapterServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public static class GoogleAdsAdapterServiceCollectionExtensions
+{
+    public static IServiceCollection AddGoogleAdsAdapter(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<GoogleAdsSettings>(configuration.GetSection(GoogleAdsSettings.ConfigurationKey));
+        services.AddScoped<IAccountBudgetFetcher, SdkAccountBudgetFetcher>();
+        services.AddScoped<GoogleAdsTransactionSource>(sp =>
+            new GoogleAdsTransactionSource(
+                sp.GetRequiredService<IAccountBudgetFetcher>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<GoogleAdsTransactionSource>>()));
+        services.AddScoped<IRecurringJob, GoogleAdsInvoiceImportJob>();
+        return services;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsInvoiceImportJob.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsInvoiceImportJob.cs
@@ -1,0 +1,70 @@
+using Anela.Heblo.Application.Features.MarketingInvoices.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public class GoogleAdsInvoiceImportJob : IRecurringJob
+{
+    private readonly GoogleAdsTransactionSource _source;
+    private readonly IImportedMarketingTransactionRepository _repository;
+    private readonly ILogger<MarketingInvoiceImportService> _importLogger;
+    private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILogger<GoogleAdsInvoiceImportJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "google-ads-invoice-import",
+        DisplayName = "Google Ads Invoice Import",
+        Description = "Fetches billing transactions from Google Ads API via account_budget GAQL queries (7-day lookback)",
+        CronExpression = "15 6,18 * * *",
+        DefaultIsEnabled = true,
+    };
+
+    public GoogleAdsInvoiceImportJob(
+        GoogleAdsTransactionSource source,
+        IImportedMarketingTransactionRepository repository,
+        ILogger<MarketingInvoiceImportService> importLogger,
+        IRecurringJobStatusChecker statusChecker,
+        ILogger<GoogleAdsInvoiceImportJob> logger)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _importLogger = importLogger ?? throw new ArgumentNullException(nameof(importLogger));
+        _statusChecker = statusChecker ?? throw new ArgumentNullException(nameof(statusChecker));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await _statusChecker.IsJobEnabledAsync(Metadata.JobName))
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping execution.", Metadata.JobName);
+            return;
+        }
+
+        try
+        {
+            _logger.LogInformation("Starting {JobName}", Metadata.JobName);
+
+            var to = DateTime.UtcNow;
+            var from = to.AddDays(-7);
+
+            var service = new MarketingInvoiceImportService(_source, _repository, _importLogger);
+            var result = await service.ImportAsync(from, to, cancellationToken);
+
+            _logger.LogInformation(
+                "{JobName} completed. Imported={Imported}, Skipped={Skipped}, Failed={Failed}",
+                Metadata.JobName,
+                result.Imported,
+                result.Skipped,
+                result.Failed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "{JobName} failed", Metadata.JobName);
+            throw;
+        }
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsSettings.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsSettings.cs
@@ -1,0 +1,21 @@
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public class GoogleAdsSettings
+{
+    public const string ConfigurationKey = "GoogleAds";
+
+    /// <summary>Google Ads customer ID (no dashes), e.g. "1234567890".</summary>
+    public string CustomerId { get; set; } = string.Empty;
+
+    /// <summary>Developer token from Google Ads API Center. Store in secrets.json / Key Vault.</summary>
+    public string DeveloperToken { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 client ID from GCP project. Store in secrets.json / Key Vault.</summary>
+    public string OAuth2ClientId { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 client secret from GCP project. Store in secrets.json / Key Vault.</summary>
+    public string OAuth2ClientSecret { get; set; } = string.Empty;
+
+    /// <summary>OAuth2 refresh token for the Google Ads account. Store in secrets.json / Key Vault.</summary>
+    public string OAuth2RefreshToken { get; set; } = string.Empty;
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+public class GoogleAdsTransactionSource : IMarketingTransactionSource
+{
+    private readonly IAccountBudgetFetcher _fetcher;
+    private readonly ILogger<GoogleAdsTransactionSource> _logger;
+
+    public string Platform => "GoogleAds";
+
+    internal GoogleAdsTransactionSource(
+        IAccountBudgetFetcher fetcher,
+        ILogger<GoogleAdsTransactionSource> logger)
+    {
+        _fetcher = fetcher ?? throw new ArgumentNullException(nameof(fetcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<List<MarketingTransaction>> GetTransactionsAsync(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "GoogleAds: fetching account budgets from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
+            from,
+            to);
+
+        var rows = await _fetcher.FetchAsync(from, to, ct);
+
+        var transactions = rows.Select(r => new MarketingTransaction
+        {
+            TransactionId = r.Id,
+            Platform = Platform,
+            Amount = r.AmountServedMicros / 1_000_000m,
+            TransactionDate = r.StartDate,
+            Currency = r.CurrencyCode,
+            Description = r.Name ?? "Google Ads billing period",
+            RawData = JsonSerializer.Serialize(r),
+        }).ToList();
+
+        _logger.LogInformation("GoogleAds: fetched {Count} account budgets", transactions.Count);
+
+        return transactions;
+    }
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/IAccountBudgetFetcher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/IAccountBudgetFetcher.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+/// <summary>Abstracts Google Ads SDK GAQL execution for testability.</summary>
+internal interface IAccountBudgetFetcher
+{
+    Task<IReadOnlyList<RawAccountBudget>> FetchAsync(DateTime from, DateTime to, CancellationToken ct);
+}

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/RawAccountBudget.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/RawAccountBudget.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+/// <summary>Raw data returned from the Google Ads account_budget GAQL query.</summary>
+internal sealed record RawAccountBudget(
+    string Id,
+    string? Name,
+    DateTime StartDate,
+    long AmountServedMicros,
+    string CurrencyCode);

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/SdkAccountBudgetFetcher.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/SdkAccountBudgetFetcher.cs
@@ -1,0 +1,92 @@
+using Google.Ads.GoogleAds;
+using Google.Ads.GoogleAds.Config;
+using Google.Ads.GoogleAds.Lib;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Adapters.GoogleAds;
+
+internal sealed class SdkAccountBudgetFetcher : IAccountBudgetFetcher
+{
+    private readonly IOptionsMonitor<GoogleAdsSettings> _settings;
+    private readonly ILogger<SdkAccountBudgetFetcher> _logger;
+
+    public SdkAccountBudgetFetcher(
+        IOptionsMonitor<GoogleAdsSettings> settings,
+        ILogger<SdkAccountBudgetFetcher> logger)
+    {
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<RawAccountBudget>> FetchAsync(DateTime from, DateTime to, CancellationToken ct)
+    {
+        var s = _settings.CurrentValue;
+        var customerId = s.CustomerId.Replace("-", "");
+
+        var config = new GoogleAdsConfig
+        {
+            DeveloperToken = s.DeveloperToken,
+            OAuth2ClientId = s.OAuth2ClientId,
+            OAuth2ClientSecret = s.OAuth2ClientSecret,
+            OAuth2RefreshToken = s.OAuth2RefreshToken,
+            LoginCustomerId = customerId,
+        };
+
+        var client = new GoogleAdsClient(config);
+        var service = client.GetService(Services.V18.GoogleAdsService);
+
+        var fromStr = from.ToString("yyyy-MM-dd");
+        var toStr = to.ToString("yyyy-MM-dd");
+
+        var query = $"""
+            SELECT
+                account_budget.id,
+                account_budget.name,
+                account_budget.approved_start_date_time,
+                account_budget.amount_served_micros,
+                customer.currency_code
+            FROM account_budget
+            WHERE account_budget.status = 'APPROVED'
+              AND account_budget.approved_start_date_time >= '{fromStr} 00:00:00'
+              AND account_budget.approved_start_date_time <= '{toStr} 23:59:59'
+            """;
+
+        _logger.LogDebug("GoogleAds: executing GAQL query for account_budget from {From} to {To}", fromStr, toStr);
+
+        var results = new List<RawAccountBudget>();
+
+        using var stream = service.SearchStream(customerId, query);
+        var responseStream = stream.GetResponseStream();
+
+        while (await responseStream.MoveNextAsync(ct))
+        {
+            var response = responseStream.Current;
+
+            foreach (var row in response.Results)
+            {
+                var ab = row.AccountBudget;
+                if (ab is null)
+                {
+                    continue;
+                }
+
+                if (!DateTime.TryParse(ab.ApprovedStartDateTime, out var startDate))
+                {
+                    continue;
+                }
+
+                var currencyCode = row.Customer?.CurrencyCode ?? string.Empty;
+
+                results.Add(new RawAccountBudget(
+                    ab.Id.ToString(),
+                    string.IsNullOrEmpty(ab.Name) ? null : ab.Name,
+                    startDate.ToUniversalTime(),
+                    ab.AmountServedMicros,
+                    currencyCode));
+            }
+        }
+
+        return results;
+    }
+}

--- a/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+++ b/backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
@@ -48,6 +48,7 @@
         <ProjectReference Include="../Anela.Heblo.Application/Anela.Heblo.Application.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Comgate\Anela.Heblo.Adapters.Comgate.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.MetaAds\Anela.Heblo.Adapters.MetaAds.csproj" />
+        <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.GoogleAds\Anela.Heblo.Adapters.GoogleAds.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Flexi\Anela.Heblo.Adapters.Flexi.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.Shoptet\Anela.Heblo.Adapters.Shoptet.csproj" />
         <ProjectReference Include="..\Adapters\Anela.Heblo.Adapters.ShoptetApi\Anela.Heblo.Adapters.ShoptetApi.csproj" />

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Adapters.Anthropic;
 using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.SendGrid;
 using Anela.Heblo.Adapters.Comgate;
+using Anela.Heblo.Adapters.GoogleAds;
 using Anela.Heblo.Adapters.MetaAds;
 using Anela.Heblo.Adapters.Flexi;
 using Anela.Heblo.Adapters.OpenAI;
@@ -58,6 +59,7 @@ public partial class Program
         builder.Services.AddShoptetPayAdapter(builder.Configuration);
         builder.Services.AddComgateAdapter(builder.Configuration);
         builder.Services.AddMetaAdsAdapter(builder.Configuration);
+        builder.Services.AddGoogleAdsAdapter(builder.Configuration);
         builder.Services.AddAnthropicAdapter(builder.Configuration);
         builder.Services.AddOpenAiAdapter(builder.Configuration);
         builder.Services.AddSendGridAdapter(builder.Configuration);

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -67,6 +67,13 @@
     "AdAccountId": "act_XXXXXXXXX",
     "ApiVersion": "v21.0"
   },
+  "GoogleAds": {
+    "CustomerId": "XXX-XXX-XXXX",
+    "DeveloperToken": "-- stored in secrets.json --",
+    "OAuth2ClientId": "-- stored in secrets.json --",
+    "OAuth2ClientSecret": "-- stored in secrets.json --",
+    "OAuth2RefreshToken": "-- stored in secrets.json --"
+  },
   "Shoptet": {
     "Token": "xxxxxxxx",
     "StockId": 1

--- a/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
@@ -1,0 +1,105 @@
+using Anela.Heblo.Adapters.GoogleAds;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Adapters.GoogleAds;
+
+public class GoogleAdsTransactionSourceTests
+{
+    private static GoogleAdsTransactionSource CreateSource(IReadOnlyList<RawAccountBudget> rows)
+        => new(new FakeAccountBudgetFetcher(rows), NullLogger<GoogleAdsTransactionSource>.Instance);
+
+    [Fact]
+    public async Task GetTransactionsAsync_ValidRows_MapsFieldsCorrectly()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var source = CreateSource([new("budget-001", "Spring Campaign Budget", startDate, 15_000_000L, "CZK")]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            startDate.AddDays(-1), startDate.AddDays(1), CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        var tx = transactions[0];
+        tx.TransactionId.Should().Be("budget-001");
+        tx.Platform.Should().Be("GoogleAds");
+        tx.Amount.Should().Be(15m); // 15_000_000 micros / 1_000_000
+        tx.Currency.Should().Be("CZK");
+        tx.Description.Should().Be("Spring Campaign Budget");
+        tx.TransactionDate.Should().Be(startDate);
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_AmountConversion_MicrosToDecimal()
+    {
+        // Arrange
+        var source = CreateSource([new("budget-002", null, DateTime.UtcNow.AddDays(-1), 1_234_567L, "CZK")]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(1);
+        transactions[0].Amount.Should().Be(1.234567m); // exact micros conversion
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_NullName_UsesDefaultDescription()
+    {
+        // Arrange
+        var source = CreateSource([new("budget-003", null, DateTime.UtcNow.AddDays(-1), 5_000_000L, "CZK")]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions[0].Description.Should().Be("Google Ads billing period");
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_EmptyResponse_ReturnsEmptyList()
+    {
+        // Arrange
+        var source = CreateSource([]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTransactionsAsync_MultipleRows_AllMapped()
+    {
+        // Arrange
+        var source = CreateSource(
+        [
+            new("budget-010", "Budget A", DateTime.UtcNow.AddDays(-5), 10_000_000L, "CZK"),
+            new("budget-011", "Budget B", DateTime.UtcNow.AddDays(-3), 20_000_000L, "CZK"),
+            new("budget-012", "Budget C", DateTime.UtcNow.AddDays(-1), 30_000_000L, "CZK"),
+        ]);
+
+        // Act
+        var transactions = await source.GetTransactionsAsync(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, CancellationToken.None);
+
+        // Assert
+        transactions.Should().HaveCount(3);
+        transactions.Select(t => t.TransactionId).Should().Contain(["budget-010", "budget-011", "budget-012"]);
+        transactions.Select(t => t.Amount).Should().Contain([10m, 20m, 30m]);
+    }
+}
+
+/// <summary>Test double that returns a fixed list of account budget rows.</summary>
+file sealed class FakeAccountBudgetFetcher(IReadOnlyList<RawAccountBudget> rows) : IAccountBudgetFetcher
+{
+    public Task<IReadOnlyList<RawAccountBudget>> FetchAsync(DateTime from, DateTime to, CancellationToken ct)
+        => Task.FromResult(rows);
+}


### PR DESCRIPTION
## Summary

- Adds `Anela.Heblo.Adapters.GoogleAds` project with `GoogleAdsTransactionSource` implementing `IMarketingTransactionSource`
- Uses Google Ads API `account_budget` GAQL resource (auto-pay accounts don't have invoice endpoint)
- Converts cost from micros to decimal (÷ 1,000,000)
- `GoogleAdsInvoiceImportJob` implements `IRecurringJob`, runs at 6:15 AM and 6:15 PM Prague time with 7-day lookback (offset from Meta Ads job at 6:00)
- Internal `IAccountBudgetFetcher` abstraction keeps the SDK gRPC layer out of unit tests
- 5 unit tests covering field mapping, micros conversion, null name fallback, empty response, multiple rows

## Key SDK findings

- `LoginCustomerId` is `string` (not `long`) in `GoogleAdsConfig`
- `account_budget` rows don't have a direct `currency_code` field — currency comes from a customer JOIN; modelled via a `CurrencyCode` field on `RawAccountBudget` populated from the GAQL result
- SDK V18 used (latest stable at time of implementation)

## Test plan

- [x] `dotnet build Anela.Heblo.sln` — 0 errors
- [x] `dotnet test Anela.Heblo.sln` — 2225 tests pass (5 new GoogleAds tests)
- [x] `dotnet format` — no violations

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)