### PR TITLE
fix(storage): register AzureBlobStorageService as Singleton (#583)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FileStorage/FileStorageModule.cs
@@ -27,8 +27,9 @@ public static class FileStorageModule
         // Register HTTP client for file downloads
         services.AddTransient<HttpClient>();
 
-        // Register blob storage service
-        services.AddTransient<IBlobStorageService, AzureBlobStorageService>();
+        // Register blob storage service as Singleton so the _containerExists cache survives across requests.
+        // BlobServiceClient is already Singleton and HttpClient is safe to reuse — no thread-safety concerns.
+        services.AddSingleton<IBlobStorageService, AzureBlobStorageService>();
 
         return services;
     }

--- a/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/FileStorage/FileStorageModuleTests.cs
@@ -1,0 +1,47 @@
+using Anela.Heblo.Application.Features.FileStorage;
+using Anela.Heblo.Domain.Features.FileStorage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.FileStorage;
+
+public class FileStorageModuleTests
+{
+    [Fact]
+    public void AddFileStorageModule_RegistersBlobStorageService_AsSingleton()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        var configuration = new ConfigurationBuilder().Build();
+
+        // Act
+        services.AddFileStorageModule(configuration);
+
+        // Assert — IBlobStorageService must be Singleton so _containerExists cache survives requests
+        var descriptor = services.Single(s => s.ServiceType == typeof(IBlobStorageService));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddFileStorageModule(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var first = provider.GetRequiredService<IBlobStorageService>();
+        var second = provider.GetRequiredService<IBlobStorageService>();
+
+        // Assert — same instance proves Singleton registration is working
+        Assert.Same(first, second);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #583 — Azure Blob 409 errors caused by `AzureBlobStorageService` being registered as `Transient`.

### Root cause

`AzureBlobStorageService` maintains a `ConcurrentDictionary<string, bool> _containerExists` to cache container existence and avoid calling `CreateIfNotExistsAsync` more than once per container. However, because it was registered with `AddTransient`, a **new instance** (with an empty dictionary) was created on every request — making the cache completely ineffective. Azure returns HTTP 409 Conflict when `CreateIfNotExistsAsync` is called on an already-existing container.

### Fix

Change `AddTransient` → `AddSingleton` for `IBlobStorageService` in `FileStorageModule.cs`. A single instance is created for the application lifetime, so the container-existence cache works as intended.

`BlobServiceClient` is already registered as Singleton and `HttpClient` is safe to reuse, so there are no thread-safety or lifetime concerns.

## Test plan

- [x] `FileStorageModuleTests.AddFileStorageModule_RegistersBlobStorageService_AsSingleton` — verifies `ServiceDescriptor.Lifetime == Singleton`
- [x] `FileStorageModuleTests.AddFileStorageModule_ResolvingBlobStorageServiceTwice_ReturnsSameInstance` — verifies same instance returned from DI container
- [x] All existing `AzureBlobStorageServiceTests` pass (62 tests, including caching-behaviour tests)
- [x] Full BE suite: 2165 tests passed (7 Docker-dependent integration tests skipped — pre-existing, unrelated to this change)
- [x] FE suite: 769 tests passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)