### PR TITLE
fix(catalog): add operation name to resilience telemetry and explicit stale cache fallback

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogRepository.cs
@@ -139,12 +139,19 @@ public class CatalogRepository : ICatalogRepository
 
     public async Task RefreshSalesData(CancellationToken ct)
     {
-        CachedSalesData = await _resilienceService.ExecuteWithResilienceAsync(
-            async (cancellationToken) => await _salesClient.GetAsync(
-                _timeProvider.GetUtcNow().Date.AddDays(-1 * _options.Value.SalesHistoryDays),
-                _timeProvider.GetUtcNow().Date,
-                cancellationToken: cancellationToken),
-            "RefreshSalesData", ct);
+        try
+        {
+            CachedSalesData = await _resilienceService.ExecuteWithResilienceAsync(
+                async (cancellationToken) => await _salesClient.GetAsync(
+                    _timeProvider.GetUtcNow().Date.AddDays(-1 * _options.Value.SalesHistoryDays),
+                    _timeProvider.GetUtcNow().Date,
+                    cancellationToken: cancellationToken),
+                "RefreshSalesData", ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "RefreshSalesData failed after all retries — retaining stale cache. Items in cache: {Count}", CachedSalesData.Count);
+        }
     }
 
     public async Task RefreshAttributesData(CancellationToken ct)

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogResilienceService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogResilienceService.cs
@@ -68,8 +68,8 @@ public class CatalogResilienceService : ICatalogResilienceService
                 UseJitter = true,
                 OnRetry = args =>
                 {
-                    _logger.LogWarning("Retrying operation. Attempt {AttemptNumber} of {MaxRetryAttempts}. Exception: {Exception}",
-                        args.AttemptNumber + 1, 3, args.Outcome.Exception?.Message);
+                    _logger.LogWarning("Retrying operation '{OperationName}'. Attempt {AttemptNumber} of {MaxRetryAttempts}. Exception: {Exception}",
+                        args.Context.OperationKey, args.AttemptNumber + 1, 3, args.Outcome.Exception?.Message);
                     return ValueTask.CompletedTask;
                 }
             })
@@ -85,17 +85,20 @@ public class CatalogResilienceService : ICatalogResilienceService
                 BreakDuration = TimeSpan.FromSeconds(30), // How long to keep circuit open
                 OnOpened = args =>
                 {
-                    _logger.LogWarning("Circuit breaker opened due to {Exception}", args.Outcome.Exception?.Message);
+                    _logger.LogWarning("Circuit breaker opened for '{OperationName}' due to {Exception}",
+                        args.Context.OperationKey, args.Outcome.Exception?.Message);
                     return ValueTask.CompletedTask;
                 },
                 OnClosed = args =>
                 {
-                    _logger.LogInformation("Circuit breaker closed - service is healthy again");
+                    _logger.LogInformation("Circuit breaker closed for '{OperationName}' - service is healthy again",
+                        args.Context.OperationKey);
                     return ValueTask.CompletedTask;
                 },
                 OnHalfOpened = args =>
                 {
-                    _logger.LogInformation("Circuit breaker half-opened - testing service health");
+                    _logger.LogInformation("Circuit breaker half-opened for '{OperationName}' - testing service health",
+                        args.Context.OperationKey);
                     return ValueTask.CompletedTask;
                 }
             })

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogRepositoryCacheOptimizationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/CatalogRepositoryCacheOptimizationTests.cs
@@ -430,4 +430,39 @@ public class CatalogRepositoryCacheOptimizationTests
         var currentCache = _cache.Get<List<CatalogAggregate>>("CatalogData_Current");
         currentCache.Should().NotBeNull();
     }
+
+    [Fact]
+    public async Task RefreshSalesData_WhenResilienceServiceThrows_RetainsStaleCacheAndLogsWarning()
+    {
+        // Arrange - pre-populate the cache to simulate previously loaded data
+        var staleRecords = new List<CatalogSaleRecord> { new CatalogSaleRecord { ProductCode = "STALE001" } };
+        _cache.Set("CachedSalesData", staleRecords);
+
+        // Configure resilience mock to throw for the IList<CatalogSaleRecord> call made by RefreshSalesData
+        _resilienceServiceMock
+            .Setup(x => x.ExecuteWithResilienceAsync(
+                It.IsAny<Func<CancellationToken, Task<IList<CatalogSaleRecord>>>>(),
+                "RefreshSalesData",
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("External service is temporarily unavailable"));
+
+        // Act - should NOT throw; stale fallback should be retained
+        await _repository.RefreshSalesData(CancellationToken.None);
+
+        // Assert - stale records are still in the cache
+        var cached = _cache.Get<List<CatalogSaleRecord>>("CachedSalesData");
+        cached.Should().NotBeNull();
+        cached!.Should().HaveCount(1);
+        cached.First().ProductCode.Should().Be("STALE001");
+
+        // Verify warning was logged about retaining stale cache
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("retaining stale cache")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogResilienceServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogResilienceServiceTests.cs
@@ -57,12 +57,12 @@ public class CatalogResilienceServiceTests
         result.Should().Be(expectedResult);
         attemptCount.Should().Be(2); // First attempt failed, second succeeded
 
-        // Verify retry warning was logged
+        // Verify retry warning was logged with operation name
         _loggerMock.Verify(
             x => x.Log(
                 LogLevel.Warning,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Retrying operation")),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Retrying operation") && v.ToString()!.Contains(operationName)),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);


### PR DESCRIPTION
## Summary

Fixes #582 — SocketException spike where FlexiBee sales query timing out via `CatalogResilienceService` was impossible to attribute to a specific endpoint in App Insights.

• **`CatalogResilienceService`**: added `args.Context.OperationKey` to all retry and circuit-breaker log messages so App Insights traces now show which FlexiBee operation (e.g. `RefreshSalesData`) triggered the spike
• **`CatalogRepository.RefreshSalesData`**: wrapped the resilience call in an explicit try/catch — stale cache is now retained with a structured `LogWarning` (items count included) instead of silently bubbling to the scheduler's generic error handler

## Test plan

- [x] `CatalogResilienceServiceTests.ExecuteWithResilienceAsync_OperationThrowsHttpRequestException_RetriesAndSucceeds` — asserts operation name appears in retry log
- [x] `CatalogRepositoryCacheOptimizationTests.RefreshSalesData_WhenResilienceServiceThrows_RetainsStaleCacheAndLogsWarning` — new test; verifies stale cache retained and warning logged
- [x] All 2164 unit tests in `Anela.Heblo.Tests` pass
- [x] All 769 FE tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)