### PR TITLE
fix(dashboard): add per-tile timeout to prevent slow tile from blocking response

### DIFF
--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardOptions.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardOptions.cs
@@ -5,4 +5,10 @@ public class DashboardOptions
     public const string SectionName = "Dashboard";
 
     public int MaxConcurrentTileLoads { get; set; } = 4;
+
+    /// <summary>
+    /// Maximum seconds to wait for a single tile's data to load before returning an error tile.
+    /// Prevents one slow tile from blocking the entire dashboard response.
+    /// </summary>
+    public int TileLoadTimeoutSeconds { get; set; } = 5;
 }

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardService.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardService.cs
@@ -152,8 +152,34 @@ public class DashboardService : IDashboardService
                         return;
                     }
 
-                    // Load data using registry method that manages scope properly
-                    var data = await _tileRegistry.GetTileDataAsync(tileSettings.TileId, tileParameters);
+                    // Load data using registry method that manages scope properly.
+                    // Apply a per-tile timeout so a single slow tile cannot block the entire response.
+                    using var timeoutCts = new CancellationTokenSource(
+                        TimeSpan.FromSeconds(_dashboardOptions.TileLoadTimeoutSeconds));
+
+                    var loadTask = _tileRegistry.GetTileDataAsync(tileSettings.TileId, tileParameters);
+                    var completedTask = await Task.WhenAny(
+                        loadTask,
+                        Task.Delay(Timeout.Infinite, timeoutCts.Token));
+
+                    if (completedTask != loadTask)
+                    {
+                        // Tile timed out — degrade gracefully instead of blocking the whole response
+                        results.Add((index, new TileData
+                        {
+                            TileId = tileSettings.TileId,
+                            Title = "Error",
+                            Description = $"Tile '{tileSettings.TileId}' timed out after {_dashboardOptions.TileLoadTimeoutSeconds}s",
+                            Size = TileSize.Small,
+                            Category = TileCategory.Error,
+                            Data = new { Error = "Tile load timed out" }
+                        }));
+                        return;
+                    }
+
+                    // Cancel the delay task to release timer resources
+                    await timeoutCts.CancelAsync();
+                    var data = await loadTask;
 
                     results.Add((index, new TileData
                     {

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/DashboardServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/DashboardServiceTests.cs
@@ -259,6 +259,93 @@ public class DashboardServiceTests
     }
 
     [Fact]
+    public async Task GetTileDataAsync_WhenTileExceedsTimeout_ShouldReturnErrorTile()
+    {
+        // Arrange
+        var userId = "user123";
+        var userSettings = CreateUserSettingsWithVisibleTiles(userId);
+        var mockTile = CreateMockTileWithData("tile1");
+
+        _settingsRepositoryMock
+            .Setup(x => x.GetByUserIdAsync(userId))
+            .ReturnsAsync(userSettings);
+
+        _tileRegistryMock
+            .Setup(x => x.GetAvailableTiles())
+            .Returns(new List<ITile>());
+
+        _tileRegistryMock
+            .Setup(x => x.GetTile("tile1"))
+            .Returns(mockTile);
+
+        // Simulate a slow tile load (longer than the configured timeout)
+        _tileRegistryMock
+            .Setup(x => x.GetTileDataAsync("tile1", It.IsAny<Dictionary<string, string>?>()))
+            .Returns(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(60)); // far longer than any test timeout
+                return (object?)new { };
+            });
+
+        // Use a 1-second timeout for the test
+        var options = Options.Create(new DashboardOptions { TileLoadTimeoutSeconds = 1 });
+        var service = new DashboardService(_tileRegistryMock.Object, _settingsRepositoryMock.Object, options);
+
+        // Act
+        var result = await service.GetTileDataAsync(userId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+
+        var errorTile = result.First();
+        errorTile.TileId.Should().Be("tile1");
+        errorTile.Title.Should().Be("Error");
+        errorTile.Category.Should().Be(TileCategory.Error);
+        errorTile.Description.Should().Contain("timed out");
+    }
+
+    [Fact]
+    public async Task GetTileDataAsync_WhenTileLoadCompletesBeforeTimeout_ShouldReturnTileData()
+    {
+        // Arrange
+        var userId = "user123";
+        var userSettings = CreateUserSettingsWithVisibleTiles(userId);
+        var mockTile = CreateMockTileWithData("tile1");
+
+        _settingsRepositoryMock
+            .Setup(x => x.GetByUserIdAsync(userId))
+            .ReturnsAsync(userSettings);
+
+        _tileRegistryMock
+            .Setup(x => x.GetAvailableTiles())
+            .Returns(new List<ITile>());
+
+        _tileRegistryMock
+            .Setup(x => x.GetTile("tile1"))
+            .Returns(mockTile);
+
+        _tileRegistryMock
+            .Setup(x => x.GetTileDataAsync("tile1", It.IsAny<Dictionary<string, string>?>()))
+            .ReturnsAsync(new { Status = "Active" });
+
+        // Use a generous timeout so the fast load completes well within it
+        var options = Options.Create(new DashboardOptions { TileLoadTimeoutSeconds = 30 });
+        var service = new DashboardService(_tileRegistryMock.Object, _settingsRepositoryMock.Object, options);
+
+        // Act
+        var result = await service.GetTileDataAsync(userId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+
+        var tile = result.First();
+        tile.Title.Should().Be("Test Tile");
+        tile.Category.Should().NotBe(TileCategory.Error);
+    }
+
+    [Fact]
     public async Task GetTileDataAsync_WhenTileDataLoadingThrows_ShouldReturnErrorTile()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Closes #623

The dashboard endpoint could take 7-8 seconds when any single tile had a slow data load, because `Parallel.ForEachAsync` still waits for all tasks to complete before returning.

### Changes

- Added `TileLoadTimeoutSeconds` option to `DashboardOptions` (default: **5 s**, configurable via `Dashboard:TileLoadTimeoutSeconds` in appsettings)
- Applied a per-tile timeout in `DashboardService.GetTileDataAsync` using the `Task.WhenAny` pattern — if a tile exceeds the timeout it degrades gracefully to an error tile, so the rest of the dashboard is unaffected
- Added two unit tests covering the timeout and the happy-path (completes within timeout)

### Why Task.WhenAny instead of CancellationToken propagation

`ITileRegistry.GetTileDataAsync` does not accept a `CancellationToken`, so cancellation cannot propagate into the tile load. `Task.WhenAny` with a `Task.Delay` sentinel achieves the same timeout semantics without requiring interface changes.

## Test plan

- [x] All 75 Dashboard unit tests pass
- [x] All 2165 unit tests in `Anela.Heblo.Tests` pass (7 pre-existing Docker-required integration test failures unchanged)
- [x] All 769 frontend tests pass
- [x] New test `GetTileDataAsync_WhenTileExceedsTimeout_ShouldReturnErrorTile` verifies slow tile returns error tile
- [x] New test `GetTileDataAsync_WhenTileLoadCompletesBeforeTimeout_ShouldReturnTileData` verifies fast tile returns normal data

🤖 Generated with [Claude Code](https://claude.com/claude-code)