### PR TITLE
fix: use SQL GROUP BY aggregation for transport box summary (#621)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxSummary/GetTransportBoxSummaryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxSummary/GetTransportBoxSummaryHandler.cs
@@ -14,28 +14,20 @@ public class GetTransportBoxSummaryHandler : IRequestHandler<GetTransportBoxSumm
 
     public async Task<GetTransportBoxSummaryResponse> Handle(GetTransportBoxSummaryRequest request, CancellationToken cancellationToken)
     {
-        var result = await _repository.GetPagedListAsync(
-            skip: 0,
-            take: int.MaxValue, // Get all for summary
+        var stateSummary = await _repository.GetStateSummaryAsync(
             code: request.Code,
-            state: null, // Don't filter by state for summary
             productCode: request.ProductCode,
-            sortBy: null,
-            sortDescending: false
-        );
+            cancellationToken: cancellationToken);
 
-        var allBoxes = result.items;
-        var totalBoxes = allBoxes.Count;
-        var activeBoxes = allBoxes.Count(b => b.State != TransportBoxState.Closed);
+        var totalBoxes = stateSummary.Values.Sum();
+        var activeBoxes = stateSummary
+            .Where(kv => kv.Key != TransportBoxState.Closed)
+            .Sum(kv => kv.Value);
 
-        var stateCounts = new Dictionary<string, int>();
-
-        // Count boxes by state
-        foreach (var state in Enum.GetValues<TransportBoxState>())
-        {
-            var count = allBoxes.Count(b => b.State == state);
-            stateCounts[state.ToString()] = count;
-        }
+        var stateCounts = Enum.GetValues<TransportBoxState>()
+            .ToDictionary(
+                state => state.ToString(),
+                state => stateSummary.GetValueOrDefault(state, 0));
 
         return new GetTransportBoxSummaryResponse
         {

--- a/backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/ITransportBoxRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Logistics/Transport/ITransportBoxRepository.cs
@@ -26,4 +26,9 @@ public interface ITransportBoxRepository : IRepository<TransportBox, int>
         CancellationToken cancellationToken = default);
 
     Task<IList<TransportBox>> GetReceivedBoxesAsync(CancellationToken cancellationToken = default);
+
+    Task<Dictionary<TransportBoxState, int>> GetStateSummaryAsync(
+        string? code = null,
+        string? productCode = null,
+        CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Persistence/Logistics/TransportBoxes/TransportBoxRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Logistics/TransportBoxes/TransportBoxRepository.cs
@@ -165,4 +165,29 @@ public class TransportBoxRepository : BaseRepository<TransportBox, int>, ITransp
 
         return receivedBoxes;
     }
+
+    public async Task<Dictionary<TransportBoxState, int>> GetStateSummaryAsync(
+        string? code = null,
+        string? productCode = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = DbSet.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(code))
+        {
+            query = query.Where(x => x.Code != null && x.Code.ToUpper().Contains(code.ToUpper()));
+        }
+
+        if (!string.IsNullOrWhiteSpace(productCode))
+        {
+            query = query.Where(x => x.Items.Any(item => item.ProductCode != null && item.ProductCode.ToUpper().Contains(productCode.ToUpper())));
+        }
+
+        var counts = await query
+            .GroupBy(x => x.State)
+            .Select(g => new { State = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        return counts.ToDictionary(x => x.State, x => x.Count);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxSummaryHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxSummaryHandlerTests.cs
@@ -1,0 +1,108 @@
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxSummary;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Logistics.Transport;
+
+public class GetTransportBoxSummaryHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly GetTransportBoxSummaryHandler _handler;
+
+    public GetTransportBoxSummaryHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _handler = new GetTransportBoxSummaryHandler(_repositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsTotalsFromSqlAggregation()
+    {
+        // Arrange
+        var summary = new Dictionary<TransportBoxState, int>
+        {
+            { TransportBoxState.New, 2 },
+            { TransportBoxState.Opened, 3 },
+            { TransportBoxState.InTransit, 1 },
+            { TransportBoxState.Closed, 4 },
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetStateSummaryAsync(null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(summary);
+
+        // Act
+        var result = await _handler.Handle(new GetTransportBoxSummaryRequest(), CancellationToken.None);
+
+        // Assert
+        result.TotalBoxes.Should().Be(10);
+        result.ActiveBoxes.Should().Be(6); // New + Opened + InTransit
+        result.StatesCounts["New"].Should().Be(2);
+        result.StatesCounts["Opened"].Should().Be(3);
+        result.StatesCounts["InTransit"].Should().Be(1);
+        result.StatesCounts["Closed"].Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Handle_StatesMissingFromDb_DefaultToZero()
+    {
+        // Arrange — only some states present in DB
+        var summary = new Dictionary<TransportBoxState, int>
+        {
+            { TransportBoxState.Opened, 5 },
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetStateSummaryAsync(null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(summary);
+
+        // Act
+        var result = await _handler.Handle(new GetTransportBoxSummaryRequest(), CancellationToken.None);
+
+        // Assert
+        result.TotalBoxes.Should().Be(5);
+        result.ActiveBoxes.Should().Be(5);
+        result.StatesCounts["Closed"].Should().Be(0);
+        result.StatesCounts["New"].Should().Be(0);
+        result.StatesCounts.Should().ContainKeys(
+            Enum.GetValues<TransportBoxState>().Select(s => s.ToString()));
+    }
+
+    [Fact]
+    public async Task Handle_ForwardsFiltersToRepository()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetStateSummaryAsync("B001", "PROD1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<TransportBoxState, int> { { TransportBoxState.Opened, 1 } });
+
+        var request = new GetTransportBoxSummaryRequest { Code = "B001", ProductCode = "PROD1" };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.GetStateSummaryAsync("B001", "PROD1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyDb_ReturnsAllZeros()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetStateSummaryAsync(null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<TransportBoxState, int>());
+
+        // Act
+        var result = await _handler.Handle(new GetTransportBoxSummaryRequest(), CancellationToken.None);
+
+        // Assert
+        result.TotalBoxes.Should().Be(0);
+        result.ActiveBoxes.Should().Be(0);
+        result.StatesCounts.Values.Should().AllBeEquivalentTo(0);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #621

Replaces the full table scan in `GetTransportBoxSummaryHandler` with a dedicated `GetStateSummaryAsync` repository method that executes a single `GROUP BY State` SQL query.

**Before:** `GetPagedListAsync(take: int.MaxValue)` loaded every row into memory, then LINQ counted per-state — causing ~5s response times on large tables.

**After:** A single SQL aggregation returns `{ State, Count }` pairs, keeping the response time constant regardless of table size.

## Changes

- `ITransportBoxRepository` — new `GetStateSummaryAsync(code?, productCode?, ct)` method
- `TransportBoxRepository` — EF Core `GroupBy/Select` implementation (translated to `SELECT State, COUNT(*) FROM ... GROUP BY State`)
- `GetTransportBoxSummaryHandler` — refactored to call `GetStateSummaryAsync`; all enum states appear in response (defaults to 0)
- `GetTransportBoxSummaryHandlerTests` — 4 unit tests: totals, missing states default to zero, filter forwarding, empty DB

## Test plan

- [x] `dotnet test` — 2167 passed (7 pre-existing Docker-dependent integration test failures, unrelated)
- [x] `npm test -- --watchAll=false` — 82 suites, 769 passed
