### PR TITLE
fix(financial-overview): fix current-year start date + add current-month toggle

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/FinancialOverviewController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/FinancialOverviewController.cs
@@ -25,13 +25,15 @@ public class FinancialOverviewController : ControllerBase
     public async Task<IActionResult> GetFinancialOverview(
         [FromQuery] int? months = 6,
         [FromQuery] bool includeStockData = true,
-        [FromQuery] List<string>? excludedDepartments = null)
+        [FromQuery] List<string>? excludedDepartments = null,
+        [FromQuery] bool includeCurrentMonth = false)
     {
         var request = new GetFinancialOverviewRequest
         {
             Months = months,
             IncludeStockData = includeStockData,
-            ExcludedDepartments = excludedDepartments
+            ExcludedDepartments = excludedDepartments,
+            IncludeCurrentMonth = includeCurrentMonth
         };
         var response = await _mediator.Send(request);
 

--- a/backend/src/Anela.Heblo.Application/Features/FinancialOverview/GetFinancialOverviewHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FinancialOverview/GetFinancialOverviewHandler.cs
@@ -29,6 +29,7 @@ public class GetFinancialOverviewHandler : IRequestHandler<GetFinancialOverviewR
             months,
             request.IncludeStockData,
             request.ExcludedDepartments,
+            request.IncludeCurrentMonth,
             cancellationToken);
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/FinancialOverview/GetFinancialOverviewRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FinancialOverview/GetFinancialOverviewRequest.cs
@@ -17,4 +17,10 @@ public class GetFinancialOverviewRequest : IRequest<GetFinancialOverviewResponse
     /// When populated, a real-time calculation is performed with in-memory department filtering.
     /// </summary>
     public List<string>? ExcludedDepartments { get; set; }
+
+    /// <summary>
+    /// When true, includes the current (incomplete) month in the data.
+    /// Bypasses cache and uses real-time calculation.
+    /// </summary>
+    public bool IncludeCurrentMonth { get; set; } = false;
 }

--- a/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
@@ -39,19 +39,24 @@ public class FinancialAnalysisService : IFinancialAnalysisService
         int months,
         bool includeStockData,
         IReadOnlyList<string>? excludedDepartments = null,
+        bool includeCurrentMonth = false,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Fetching financial overview for {Months} months, IncludeStock={IncludeStock}, ExcludedDepartments={ExcludedDepartments}",
-            months, includeStockData, excludedDepartments?.Count ?? 0);
+        _logger.LogInformation("Fetching financial overview for {Months} months, IncludeStock={IncludeStock}, ExcludedDepartments={ExcludedDepartments}, IncludeCurrentMonth={IncludeCurrentMonth}",
+            months, includeStockData, excludedDepartments?.Count ?? 0, includeCurrentMonth);
 
-        // When departments are excluded, we must use real-time calculation because
-        // the cache stores pre-aggregated totals that cannot be filtered by department.
-        if (excludedDepartments is { Count: > 0 })
+        // When departments are excluded or current month is requested, use real-time calculation.
+        // The cache stores pre-aggregated totals per completed month and cannot handle these cases.
+        if (excludedDepartments is { Count: > 0 } || includeCurrentMonth)
         {
-            _logger.LogInformation("Department filter active ({Count} excluded), bypassing cache for real-time calculation",
-                excludedDepartments.Count);
+            if (excludedDepartments is { Count: > 0 })
+                _logger.LogInformation("Department filter active ({Count} excluded), bypassing cache for real-time calculation",
+                    excludedDepartments.Count);
 
-            return await GetFinancialOverviewRealTimeAsync(months, includeStockData, excludedDepartments, cancellationToken);
+            if (includeCurrentMonth)
+                _logger.LogInformation("Current month requested, bypassing cache for real-time calculation");
+
+            return await GetFinancialOverviewRealTimeAsync(months, includeStockData, excludedDepartments, includeCurrentMonth, cancellationToken);
         }
 
         try
@@ -61,7 +66,7 @@ public class FinancialAnalysisService : IFinancialAnalysisService
             if (cacheStatus.CachedMonthsCount == 0)
             {
                 _logger.LogInformation("Cache is empty, using real-time calculation");
-                return await GetFinancialOverviewRealTimeAsync(months, includeStockData, null, cancellationToken);
+                return await GetFinancialOverviewRealTimeAsync(months, includeStockData, null, false, cancellationToken);
             }
 
             var cachedResponse = GetCachedFinancialOverview(months, includeStockData);
@@ -76,7 +81,7 @@ public class FinancialAnalysisService : IFinancialAnalysisService
             _logger.LogWarning(ex, "Failed to get cached financial data, falling back to real-time calculation");
 
             // Fallback to real-time calculation if cache fails
-            return await GetFinancialOverviewRealTimeAsync(months, includeStockData, null, cancellationToken);
+            return await GetFinancialOverviewRealTimeAsync(months, includeStockData, null, false, cancellationToken);
         }
     }
 
@@ -316,11 +321,14 @@ public class FinancialAnalysisService : IFinancialAnalysisService
         int months,
         bool includeStockData,
         IReadOnlyList<string>? excludedDepartments,
+        bool includeCurrentMonth,
         CancellationToken cancellationToken)
     {
-        // Set endDate to last day of previous month (exclude current month)
         var now = DateTime.UtcNow;
-        var endDate = new DateTime(now.Year, now.Month, 1).AddDays(-1);
+        // When including current month, use today as end date; otherwise last day of previous month
+        var endDate = includeCurrentMonth
+            ? now.Date
+            : new DateTime(now.Year, now.Month, 1).AddDays(-1);
 
         // Calculate startDate - go back the requested number of months from the end date
         var startDate = endDate.AddMonths(-months + 1);

--- a/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/IFinancialAnalysisService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/IFinancialAnalysisService.cs
@@ -4,13 +4,14 @@ public interface IFinancialAnalysisService
 {
     /// <summary>
     /// Gets financial overview data, preferably from cache.
-    /// When <paramref name="excludedDepartments"/> is null or empty, the cached path is used.
-    /// When populated, a real-time calculation is performed with department filtering applied.
+    /// When <paramref name="excludedDepartments"/> is null or empty and <paramref name="includeCurrentMonth"/> is false,
+    /// the cached path is used. Otherwise, a real-time calculation is performed.
     /// </summary>
     Task<GetFinancialOverviewResponse> GetFinancialOverviewAsync(
         int months,
         bool includeStockData,
         IReadOnlyList<string>? excludedDepartments = null,
+        bool includeCurrentMonth = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/backend/test/Anela.Heblo.Tests/Application/FinancialOverview/GetFinancialOverviewHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/FinancialOverview/GetFinancialOverviewHandlerTests.cs
@@ -46,7 +46,7 @@ public class GetFinancialOverviewHandlerTests
             Summary = new FinancialSummaryDto()
         };
 
-        _financialAnalysisServiceMock.Setup(x => x.GetFinancialOverviewAsync(6, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+        _financialAnalysisServiceMock.Setup(x => x.GetFinancialOverviewAsync(6, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
         // Act
@@ -54,7 +54,7 @@ public class GetFinancialOverviewHandlerTests
 
         // Assert
         result.Data.Count.Should().Be(6);
-        _financialAnalysisServiceMock.Verify(x => x.GetFinancialOverviewAsync(6, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _financialAnalysisServiceMock.Verify(x => x.GetFinancialOverviewAsync(6, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -69,14 +69,14 @@ public class GetFinancialOverviewHandlerTests
             Summary = new FinancialSummaryDto()
         };
 
-        _financialAnalysisServiceMock.Setup(x => x.GetFinancialOverviewAsync(3, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+        _financialAnalysisServiceMock.Setup(x => x.GetFinancialOverviewAsync(3, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
-        _financialAnalysisServiceMock.Verify(x => x.GetFinancialOverviewAsync(3, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _financialAnalysisServiceMock.Verify(x => x.GetFinancialOverviewAsync(3, false, It.IsAny<IReadOnlyList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -102,6 +102,7 @@ public class GetFinancialOverviewHandlerTests
                 6,
                 false,
                 It.Is<IReadOnlyList<string>>(d => d.Count == 2 && d.Contains("Marketing") && d.Contains("Sales")),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
@@ -115,6 +116,7 @@ public class GetFinancialOverviewHandlerTests
                 6,
                 false,
                 It.Is<IReadOnlyList<string>>(d => d.Count == 2 && d.Contains("Marketing") && d.Contains("Sales")),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -145,7 +147,7 @@ public class GetFinancialOverviewHandlerTests
             }
         };
 
-        _financialAnalysisServiceMock.Setup(x => x.GetFinancialOverviewAsync(3, true, It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+        _financialAnalysisServiceMock.Setup(x => x.GetFinancialOverviewAsync(3, true, It.IsAny<IReadOnlyList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
         // Act
@@ -154,7 +156,7 @@ public class GetFinancialOverviewHandlerTests
         // Assert
         result.Summary.StockSummary.Should().NotBeNull();
         result.Summary.StockSummary.TotalStockValueChange.Should().Be(100m);
-        _financialAnalysisServiceMock.Verify(x => x.GetFinancialOverviewAsync(3, true, It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _financialAnalysisServiceMock.Verify(x => x.GetFinancialOverviewAsync(3, true, It.IsAny<IReadOnlyList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
 
         // Verify stock data was included in response
         var monthWithStock = result.Data.FirstOrDefault(d => d.StockChanges != null);

--- a/frontend/src/api/hooks/useFinancialOverview.ts
+++ b/frontend/src/api/hooks/useFinancialOverview.ts
@@ -21,14 +21,16 @@ export const useFinancialOverviewQuery = (
   months: number = 6,
   includeStockData: boolean = true,
   excludedDepartments: string[] = [],
+  includeCurrentMonth: boolean = false,
 ) => {
   return useQuery<GetFinancialOverviewResponse, Error>({
-    queryKey: [...QUERY_KEYS.financialOverview, months, includeStockData, excludedDepartments],
+    queryKey: [...QUERY_KEYS.financialOverview, months, includeStockData, excludedDepartments, includeCurrentMonth],
     queryFn: async () => {
       const apiClient = getAuthenticatedApiClient();
       const params = new URLSearchParams();
       params.set('months', String(months));
       params.set('includeStockData', String(includeStockData));
+      params.set('includeCurrentMonth', String(includeCurrentMonth));
       excludedDepartments.forEach(d => params.append('excludedDepartments', d));
       const relativeUrl = `/api/FinancialOverview?${params.toString()}`;
       const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;

--- a/frontend/src/components/pages/FinancialOverview.tsx
+++ b/frontend/src/components/pages/FinancialOverview.tsx
@@ -25,6 +25,7 @@ const FinancialOverview: React.FC = () => {
   const [selectedPeriod, setSelectedPeriod] =
     useState<PeriodType>("current-year");
   const [includeStockData, setIncludeStockData] = useState<boolean>(true);
+  const [includeCurrentMonth, setIncludeCurrentMonth] = useState<boolean>(false);
   const [excludedDepartments, setExcludedDepartments] = useState<string[]>([]);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const initialDefaultsSet = React.useRef(false);
@@ -47,14 +48,19 @@ const FinancialOverview: React.FC = () => {
     }
   }, [departments]);
 
-  // Convert period type to months for API call
+  // Convert period type to months for API call.
+  // For "current-year" periods, we count completed months only (now.getMonth() = 0-indexed).
+  // The +1 for includeCurrentMonth is handled by the backend via the includeCurrentMonth flag,
+  // but we still need to pass the correct total month count.
   const getMonthsFromPeriod = (period: PeriodType): number => {
     const now = new Date();
+    const currentMonthOffset = includeCurrentMonth ? 1 : 0;
     switch (period) {
       case "current-year":
-        return now.getMonth() + 1; // Months from January to current month
+        // now.getMonth() is 0-indexed: 0=Jan, 3=Apr → completed months = getMonth()
+        return now.getMonth() + currentMonthOffset;
       case "current-and-previous-year":
-        return now.getMonth() + 1 + 12; // Current year months + 12 previous months
+        return now.getMonth() + currentMonthOffset + 12;
       case "last-6-months":
         return 6;
       case "last-13-months":
@@ -71,6 +77,7 @@ const FinancialOverview: React.FC = () => {
     months,
     includeStockData,
     excludedDepartments,
+    includeCurrentMonth,
   );
 
   const formatCurrency = (amount: number) => {
@@ -320,21 +327,39 @@ const FinancialOverview: React.FC = () => {
               >
                 Zobrazení dat:
               </label>
-              <div className="flex items-center">
-                <input
-                  id="stock-toggle"
-                  type="checkbox"
-                  checked={includeStockData}
-                  onChange={(e) => setIncludeStockData(e.target.checked)}
-                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
-                />
-                <label
-                  htmlFor="stock-toggle"
-                  className="ml-2 block text-sm text-gray-900 flex items-center"
-                >
-                  <Package className="w-4 h-4 mr-1" />
-                  Zahrnout skladová data
-                </label>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center">
+                  <input
+                    id="stock-toggle"
+                    type="checkbox"
+                    checked={includeStockData}
+                    onChange={(e) => setIncludeStockData(e.target.checked)}
+                    className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                  />
+                  <label
+                    htmlFor="stock-toggle"
+                    className="ml-2 block text-sm text-gray-900 flex items-center"
+                  >
+                    <Package className="w-4 h-4 mr-1" />
+                    Zahrnout skladová data
+                  </label>
+                </div>
+                <div className="flex items-center">
+                  <input
+                    id="current-month-toggle"
+                    type="checkbox"
+                    checked={includeCurrentMonth}
+                    onChange={(e) => setIncludeCurrentMonth(e.target.checked)}
+                    className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                  />
+                  <label
+                    htmlFor="current-month-toggle"
+                    className="ml-2 block text-sm text-gray-900 flex items-center"
+                  >
+                    <Calendar className="w-4 h-4 mr-1" />
+                    Zobrazit aktuální měsíc
+                  </label>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

- **Bug fix**: \"Aktuální rok\" was showing December of the previous year. Root cause: `getMonthsFromPeriod` returned `now.getMonth() + 1` (e.g. `4` for April), causing the backend to compute `startDate = December 2025` instead of January. Fixed to `now.getMonth()` so only completed months are counted.
- **New feature**: Added \"Zobrazit aktuální měsíc\" checkbox. When checked, the current (incomplete) month is included in the chart and table. Backend bypasses cache and sets `endDate = today` instead of end of previous month.

## Test plan

- [ ] Open Finanční přehled, select \"Aktuální rok\" — chart should start from January, not December
- [ ] Check \"Zobrazit aktuální měsíc\" — current month appears in the chart with partial data
- [ ] Uncheck — current month disappears again
- [ ] All other period types (6/13/26 months, current+previous year) work as before
- [ ] Backend tests pass: `dotnet test --filter FinancialOverview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)