### PR TITLE
fix(db): cap Npgsql connection pool in Staging via MaxPoolSize config

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.Staging.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Staging.json
@@ -65,8 +65,12 @@
     "ManufactureHistoryDays": 100,
     "ManufactureCostHistoryDays": 100
   },
+  "Database": {
+    "MaxPoolSize": 10
+  },
   "Hangfire": {
-    "SchedulerEnabled": false
+    "SchedulerEnabled": false,
+    "ConnectionLimit": 5
   },
   "ExpeditionList": {
     "BlobContainerName": "expedition-lists-stg"

--- a/backend/test/Anela.Heblo.Tests/Persistence/PersistenceModuleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Persistence/PersistenceModuleTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Infrastructure;
@@ -86,6 +87,46 @@ public class PersistenceModuleTests
 
         // Assert
         context.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Regression test: Database:MaxPoolSize configuration must be applied to NpgsqlDataSource.
+    ///
+    /// Bug: appsettings.Staging.json was missing Database:MaxPoolSize, leaving the Npgsql
+    /// connection pool uncapped (default 100). Under load, the pool exhausted the PostgreSQL
+    /// server's max_connections, causing PostgresException 53300 (too_many_connections).
+    ///
+    /// Fix: Add Database:MaxPoolSize to all environment appsettings files, and verify the
+    /// config value is correctly wired into NpgsqlDataSourceBuilder.ConnectionStringBuilder.MaxPoolSize.
+    /// </summary>
+    [Fact]
+    public void AddPersistenceServices_WithMaxPoolSizeConfigured_AppliesItToNpgsqlDataSource()
+    {
+        // Arrange
+        const int configuredMaxPoolSize = 20;
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UseInMemoryDatabase"] = "false",
+                ["ConnectionStrings:Test"] = "Host=localhost;Database=test;Username=test;Password=test",
+                ["Database:MaxPoolSize"] = configuredMaxPoolSize.ToString()
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddPersistenceServices(configuration, new FakeHostEnvironment("Test"));
+
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var dataSource = provider.GetRequiredService<NpgsqlDataSource>();
+
+        // Assert
+        var csb = new NpgsqlConnectionStringBuilder(dataSource.ConnectionString);
+        csb.MaxPoolSize.Should().Be(configuredMaxPoolSize,
+            "Database:MaxPoolSize must be applied to NpgsqlDataSource to cap the connection pool " +
+            "and prevent PostgresException 53300 (too_many_connections)");
     }
 
     [Fact]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20493,7 +20493,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary

Fixes #591 — PostgresException 53300 spike caused by uncapped connection pool in Staging.

### Root cause
`appsettings.Staging.json` was missing `Database:MaxPoolSize`, so Npgsql used its default pool size of 100. Under load this exhausted PostgreSQL `max_connections` and caused `53300 too_many_connections` exceptions.

Production already had `MaxPoolSize: 15` configured correctly. Staging did not.

### Changes
- **`appsettings.Staging.json`**: Added `Database:MaxPoolSize = 10` and explicit `Hangfire:ConnectionLimit = 5`
- **`PersistenceModuleTests.cs`**: Added regression test verifying `Database:MaxPoolSize` config is wired into the `NpgsqlDataSource` singleton

### Test results
- All 4 `PersistenceModuleTests` pass
- Backend: 2164 unit tests pass (7 pre-existing Docker integration test failures, unrelated)
- Frontend: 769 tests pass