### PR TITLE
fix(invoices): log error when FlexiBee rejects invoice with HTTP 400

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiIssuedInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiIssuedInvoiceClient.cs
@@ -43,6 +43,8 @@ public class FlexiIssuedInvoiceClient : Anela.Heblo.Domain.Features.Invoices.IIs
 
             if (!flexiResult.IsSuccess)
             {
+                _logger.LogDebug("FlexiBee HTTP 400 response payload for invoice {InvoiceCode}: {Payload}",
+                    invoiceDetail.Code, JsonSerializer.Serialize(flexiResult));
                 throw new ApplicationException(flexiResult.GetErrorMessage());
             }
         }

--- a/backend/src/Anela.Heblo.Application/Features/Invoices/Services/InvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Invoices/Services/InvoiceImportService.cs
@@ -103,6 +103,7 @@ public class InvoiceImportService : IInvoiceImportService
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "FlexiBee rejected invoice {InvoiceCode}: {Error}", transformedInvoice.Code, ex.Message);
                 invoice.SyncFailed(transformedInvoice, ex.Message);
             }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Invoices/InvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Invoices/InvoiceImportServiceTests.cs
@@ -166,6 +166,47 @@ public class InvoiceImportServiceTests
     }
 
     [Fact]
+    public async Task ImportInvoicesAsync_WhenFlexiBeeRejectsInvoice_LogsErrorWithInvoiceCodeAndMessage()
+    {
+        // Arrange
+        var query = new IssuedInvoiceSourceQuery { RequestId = "test-flexi-400" };
+        var invoiceDetail = CreateTestInvoiceDetail("INV-FLEXI-400");
+        var batch = CreateTestBatch("batch-1", invoiceDetail);
+        var invoice = CreateTestIssuedInvoice("INV-FLEXI-400");
+        var flexiError = new ApplicationException("Pole 'kod' je povinné.");
+
+        _mockInvoiceSource.Setup(x => x.GetAllAsync(query))
+            .ReturnsAsync(new List<IssuedInvoiceDetailBatch> { batch });
+        _mockRepository.Setup(x => x.GetByIdAsync("INV-FLEXI-400", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IssuedInvoice?)null);
+        _mockMapper.Setup(x => x.Map<IssuedInvoiceDetail, IssuedInvoice>(invoiceDetail))
+            .Returns(invoice);
+        _mockInvoiceClient.Setup(x => x.SaveAsync(invoiceDetail, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(flexiError);
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<IssuedInvoice>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IssuedInvoice i, CancellationToken c) => i);
+        _mockRepository.Setup(x => x.UpdateAsync(It.IsAny<IssuedInvoice>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        await _service.ImportInvoicesAsync("test-description", query);
+
+        // Assert — LogError must be called with the invoice code and the FlexiBee error message
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("INV-FLEXI-400") &&
+                    v.ToString()!.Contains("Pole 'kod' je povinné.")),
+                flexiError,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ImportInvoicesAsync_WithTransformations_AppliesAllTransformations()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Fixes #620

HTTP 400 responses from FlexiBee were silently swallowed — the inner `catch` in `InvoiceImportService.ExecuteImportInvoice` called `invoice.SyncFailed()` but never logged the error, making it impossible to trace which invoices failed and why.

## Changes

- **`InvoiceImportService`**: Added `_logger.LogError` in the inner catch block so FlexiBee rejection errors are always visible in structured logs with the invoice code and error message.
- **`FlexiIssuedInvoiceClient`**: Added `_logger.LogDebug` of the serialized FlexiBee response payload before throwing on HTTP 400, to aid diagnosis.
- **Tests**: Added `ImportInvoicesAsync_WhenFlexiBeeRejectsInvoice_LogsErrorWithInvoiceCodeAndMessage` verifying the logger is called with the invoice code and error message on FlexiBee rejection.

## Test plan

- [x] All 8 `InvoiceImportServiceTests` pass
- [x] All 2164 unit tests pass (7 pre-existing integration test failures unrelated to this change — require DB/live credentials)
- [x] All 769 FE tests pass