### PR TITLE
perf(manufacture): add configurable ERP timeout for Flexi HTTP calls

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -161,6 +161,9 @@
   "Dashboard": {
     "MaxConcurrentTileLoads": 4
   },
+  "ManufactureErp": {
+    "ErpTimeoutSeconds": 60
+  },
   "ManufactureAnalysis": {
     "DefaultMonthsBack": 12,
     "MaxMonthsBack": 60,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Configuration/ManufactureErpOptions.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Application.Features.Manufacture.Configuration;
+
+/// <summary>
+/// Configuration options for Manufacture ERP integration (FlexiBee).
+/// </summary>
+public class ManufactureErpOptions
+{
+    /// <summary>
+    /// Maximum number of seconds to wait for a single Flexi ERP call before timing out.
+    /// Defaults to 60 seconds. Set to 0 to disable the application-level timeout.
+    /// </summary>
+    public int ErpTimeoutSeconds { get; set; } = 60;
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
@@ -24,6 +24,11 @@ public static class ManufactureModule
             configuration.GetSection("ManufactureAnalysis").Bind(options);
         });
 
+        services.Configure<ManufactureErpOptions>(options =>
+        {
+            configuration.GetSection("ManufactureErp").Bind(options);
+        });
+
         // Register domain services for manufacturing stock analysis
         services.AddScoped<ITimePeriodCalculator, TimePeriodCalculator>();
         services.AddScoped<IConsumptionRateCalculator, ConsumptionRateCalculator>();

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufacture/SubmitManufactureHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufacture/SubmitManufactureHandler.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Manufacture.Configuration;
 using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Manufacture;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufacture;
 
@@ -13,19 +16,22 @@ public class SubmitManufactureHandler : IRequestHandler<SubmitManufactureRequest
     private readonly IManufactureErrorTransformer _errorTransformer;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<SubmitManufactureHandler> _logger;
+    private readonly ManufactureErpOptions _erpOptions;
 
     public SubmitManufactureHandler(
         IManufactureClient manufactureClient,
         IManufactureOrderRepository repository,
         IManufactureErrorTransformer errorTransformer,
         TimeProvider timeProvider,
-        ILogger<SubmitManufactureHandler> logger)
+        ILogger<SubmitManufactureHandler> logger,
+        IOptions<ManufactureErpOptions> erpOptions)
     {
         _manufactureClient = manufactureClient;
         _repository = repository;
         _errorTransformer = errorTransformer;
         _timeProvider = timeProvider;
         _logger = logger;
+        _erpOptions = erpOptions.Value;
     }
 
     public async Task<SubmitManufactureResponse> Handle(
@@ -34,8 +40,16 @@ public class SubmitManufactureHandler : IRequestHandler<SubmitManufactureRequest
     {
         try
         {
+            using var cts = CreateLinkedCts(cancellationToken);
+
+            var sw = Stopwatch.StartNew();
             var clientResponse = await _manufactureClient.SubmitManufactureAsync(
-                request.ToClientRequest(), cancellationToken);
+                request.ToClientRequest(), cts.Token);
+            sw.Stop();
+
+            _logger.LogInformation(
+                "Flexi ERP SubmitManufacture completed in {ElapsedMs}ms for order {ManufactureOrderNumber}",
+                sw.ElapsedMilliseconds, request.ManufactureOrderNumber);
 
             _logger.LogInformation("Successfully created manufacture {ManufactureId} for order {ManufactureOrderId}",
                 clientResponse.ManufactureId, request.ManufactureOrderNumber);
@@ -60,6 +74,14 @@ public class SubmitManufactureHandler : IRequestHandler<SubmitManufactureRequest
                 UserMessage = _errorTransformer.Transform(ex)
             };
         }
+    }
+
+    private CancellationTokenSource CreateLinkedCts(CancellationToken cancellationToken)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_erpOptions.ErpTimeoutSeconds > 0)
+            cts.CancelAfter(TimeSpan.FromSeconds(_erpOptions.ErpTimeoutSeconds));
+        return cts;
     }
 
     private async Task PersistDocCodesAsync(

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureHandlerTests.cs
@@ -1,9 +1,11 @@
+using Anela.Heblo.Application.Features.Manufacture.Configuration;
 using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufacture;
 using Anela.Heblo.Domain.Features.Manufacture;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -24,7 +26,8 @@ public class SubmitManufactureHandlerTests
             _repositoryMock.Object,
             _transformerMock.Object,
             TimeProvider.System,
-            _loggerMock.Object);
+            _loggerMock.Object,
+            Options.Create(new ManufactureErpOptions()));
     }
 
     [Fact]
@@ -179,6 +182,59 @@ public class SubmitManufactureHandlerTests
         // Assert
         capturedClientRequest.Should().NotBeNull();
         capturedClientRequest!.ValidateIngredientStock.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenErpTimesOut_PropagatesOperationCanceledException()
+    {
+        // Arrange — simulate Flexi taking longer than the configured timeout.
+        // Use a very short timeout (1 ms) so the test doesn't actually wait.
+        var handlerWithShortTimeout = new SubmitManufactureHandler(
+            _clientMock.Object,
+            _repositoryMock.Object,
+            _transformerMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            Options.Create(new ManufactureErpOptions { ErpTimeoutSeconds = 1 }));
+
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(async (SubmitManufactureClientRequest _, CancellationToken ct) =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), ct);
+                return new SubmitManufactureClientResponse { ManufactureId = "NEVER" };
+            });
+
+        // Act
+        var act = async () => await handlerWithShortTimeout.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert — the timeout CTS cancels, which propagates as OperationCanceledException
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _transformerMock.Verify(t => t.Transform(It.IsAny<Exception>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenTimeoutDisabled_DoesNotApplyCancelAfter()
+    {
+        // Arrange — ErpTimeoutSeconds = 0 means no application-level timeout.
+        var handlerNoTimeout = new SubmitManufactureHandler(
+            _clientMock.Object,
+            _repositoryMock.Object,
+            _transformerMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            Options.Create(new ManufactureErpOptions { ErpTimeoutSeconds = 0 }));
+
+        _clientMock
+            .Setup(c => c.SubmitManufactureAsync(It.IsAny<SubmitManufactureClientRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubmitManufactureClientResponse { ManufactureId = "MAN-NOTIMEOUT" });
+
+        // Act
+        var result = await handlerNoTimeout.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert — call succeeds; no timeout was enforced
+        result.Success.Should().BeTrue();
+        result.ManufactureId.Should().Be("MAN-NOTIMEOUT");
     }
 
     private static SubmitManufactureRequest BuildRequest() => new()


### PR DESCRIPTION
Closes #601

## Problem

Flexi ERP HTTP calls (`SubmitManufactureAsync`) had no application-level timeout. When FlexiBee was slow or unresponsive, requests blocked indefinitely, contributing to the observed avg 12.5 s (`ConfirmSemiProductManufacture`) and 8.8 s (`ConfirmProductCompletion`) response times reported in #601.

The FlexiBee SDK (`AddFlexiBee`) does not expose an HTTP client timeout option.

## Solution

Enforce a timeout at the MediatR handler level using a linked `CancellationTokenSource` with `CancelAfter`.

## Changes

- *New* `ManufactureErpOptions` — `ErpTimeoutSeconds` (default 60 s, 0 = disabled)
- *Updated* `ManufactureModule` — registers options from `ManufactureErp` config section
- *Updated* `appsettings.json` — adds `"ManufactureErp": { "ErpTimeoutSeconds": 60 }`
- *Updated* `SubmitManufactureHandler` — wraps ERP call with linked CTS + Stopwatch duration logging
- *Updated* `SubmitManufactureHandlerTests` — two new tests: timeout propagation, disabled-timeout success path

## Behaviour

| Scenario | Result |
|---|---|
| ERP responds within timeout | Success, duration logged in ms |
| ERP exceeds timeout | `OperationCanceledException` propagates |
| `ErpTimeoutSeconds = 0` | No application-level timeout (opt-out) |
| User cancels request | `OperationCanceledException` propagates (unchanged) |

## Test results

- BE unit tests: 2172 passed
- FE tests: 82 suites, 769 passed