### PR TITLE
fix(mcp): add diagnostics middleware for GET /mcp 404 spike (#599)

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Hangfire;
 using Anela.Heblo.API.Infrastructure.Hangfire;
 using Microsoft.AspNetCore.HttpLogging;
 using Anela.Heblo.API.Infrastructure.Authentication;
+using Anela.Heblo.API.MCP;
 using ModelContextProtocol.AspNetCore;
 
 namespace Anela.Heblo.API.Extensions;
@@ -111,6 +112,10 @@ public static class ApplicationBuilderExtensions
 
         app.MapControllers();
 
+        // MCP diagnostics — logs structured context for GET /mcp 404 responses to
+        // aid investigation of session-resumption failures (issue #599).
+        app.UseMiddleware<McpDiagnosticsMiddleware>();
+
         // MCP server endpoint — requires authentication (Microsoft Entra ID)
         app.MapMcp("/mcp").RequireAuthorization();
 
@@ -181,11 +186,18 @@ public static class ApplicationBuilderExtensions
                     }
                 };
 
-                // IMPORTANT: Configure SPA to NOT intercept API routes
+                // IMPORTANT: Configure SPA to NOT intercept API or MCP routes
                 spa.ApplicationBuilder.UseRouting();
                 spa.ApplicationBuilder.UseEndpoints(endpoints =>
                 {
                     endpoints.Map("/api/{**catch-all}", context =>
+                    {
+                        context.Response.StatusCode = 404;
+                        return Task.CompletedTask;
+                    });
+                    // Prevent SPA from serving index.html for MCP sub-paths (e.g. /mcp/sse)
+                    // that are not handled by MapMcp but must not fall through to the SPA.
+                    endpoints.Map("/mcp/{**catch-all}", context =>
                     {
                         context.Response.StatusCode = 404;
                         return Task.CompletedTask;

--- a/backend/src/Anela.Heblo.API/MCP/McpDiagnosticsMiddleware.cs
+++ b/backend/src/Anela.Heblo.API/MCP/McpDiagnosticsMiddleware.cs
@@ -1,0 +1,56 @@
+namespace Anela.Heblo.API.MCP;
+
+/// <summary>
+/// Middleware that logs structured diagnostics for MCP endpoint 404 responses.
+/// Captures session ID, User-Agent, and Accept header to aid investigation of
+/// client session-resumption failures and probe traffic spikes (issue #599).
+/// </summary>
+public class McpDiagnosticsMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<McpDiagnosticsMiddleware> _logger;
+
+    public McpDiagnosticsMiddleware(RequestDelegate next, ILogger<McpDiagnosticsMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await _next(context);
+
+        if (!IsMcpGetRequest(context) || context.Response.StatusCode != 404)
+            return;
+
+        var sessionId = context.Request.Query["sessionId"].FirstOrDefault();
+        var userAgent = context.Request.Headers.UserAgent.FirstOrDefault() ?? "unknown";
+        var acceptHeader = context.Request.Headers.Accept.ToString();
+        var path = context.Request.Path.Value;
+
+        if (sessionId is not null)
+        {
+            _logger.LogWarning(
+                "MCP session resumption failed (404) — session not found on server. " +
+                "SessionIdPrefix: {SessionIdPrefix}, UserAgent: {UserAgent}, Accept: {Accept}",
+                TruncateId(sessionId),
+                userAgent,
+                acceptHeader);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "MCP GET returned 404. Path: {Path}, UserAgent: {UserAgent}, Accept: {Accept}",
+                path,
+                userAgent,
+                acceptHeader);
+        }
+    }
+
+    private static bool IsMcpGetRequest(HttpContext context)
+        => context.Request.Method == HttpMethods.Get
+           && context.Request.Path.StartsWithSegments("/mcp");
+
+    internal static string TruncateId(string id)
+        => id.Length > 8 ? id[..8] + "***" : "***";
+}

--- a/backend/test/Anela.Heblo.Tests/MCP/McpDiagnosticsMiddlewareTests.cs
+++ b/backend/test/Anela.Heblo.Tests/MCP/McpDiagnosticsMiddlewareTests.cs
@@ -1,0 +1,180 @@
+using Anela.Heblo.API.MCP;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.MCP;
+
+public class McpDiagnosticsMiddlewareTests
+{
+    private readonly Mock<ILogger<McpDiagnosticsMiddleware>> _loggerMock;
+
+    public McpDiagnosticsMiddlewareTests()
+    {
+        _loggerMock = new Mock<ILogger<McpDiagnosticsMiddleware>>();
+    }
+
+    private McpDiagnosticsMiddleware CreateMiddleware(RequestDelegate next)
+        => new(next, _loggerMock.Object);
+
+    [Fact]
+    public async Task InvokeAsync_NonMcpPath_DoesNotLog()
+    {
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 404;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("GET", "/api/other", 404);
+
+        await middleware.InvokeAsync(context);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_McpGet200_DoesNotLog()
+    {
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("GET", "/mcp", 200);
+
+        await middleware.InvokeAsync(context);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_McpPost404_DoesNotLog()
+    {
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 404;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("POST", "/mcp", 404);
+
+        await middleware.InvokeAsync(context);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_McpGet404WithSessionId_LogsWarningWithTruncatedId()
+    {
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 404;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("GET", "/mcp", 404, sessionId: "abc123def456");
+
+        await middleware.InvokeAsync(context);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("session resumption failed")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_McpGet404WithoutSessionId_LogsWarningWithPath()
+    {
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 404;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("GET", "/mcp", 404);
+
+        await middleware.InvokeAsync(context);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("GET returned 404")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_McpSubPath404_LogsWarning()
+    {
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 404;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("GET", "/mcp/sse", 404);
+
+        await middleware.InvokeAsync(context);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData("abc123def456", "abc123de***")]
+    [InlineData("short", "***")]
+    [InlineData("exactly8!", "exactly8***")]
+    public void TruncateId_ReturnsExpectedResult(string input, string expected)
+    {
+        McpDiagnosticsMiddleware.TruncateId(input).Should().Be(expected);
+    }
+
+    private static DefaultHttpContext CreateContext(
+        string method, string path, int statusCode, string? sessionId = null)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = method;
+        context.Request.Path = path;
+        if (sessionId is not null)
+            context.Request.QueryString = new QueryString($"?sessionId={sessionId}");
+        context.Response.StatusCode = statusCode;
+        return context;
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the GET /mcp 404 spike reported in issue #599.

## Changes

- **`McpDiagnosticsMiddleware`** — new middleware that intercepts GET /mcp responses after the next delegate runs and logs a structured `Warning` when status is 404:
  - If `?sessionId=` is present: logs `"MCP session resumption failed (404) — session not found on server"` with truncated session ID prefix, User-Agent, Accept
  - Otherwise: logs `"MCP GET returned 404"` with path, User-Agent, Accept
  - Registered before `app.MapMcp("/mcp")` in the pipeline
- **SPA fallback fix** — `ConfigureSpaFallback` now explicitly returns 404 for `/mcp/{**catch-all}` sub-paths, preventing the SPA from serving `index.html` for unhandled MCP sub-paths like `/mcp/sse`
- **9 unit tests** covering all branches: non-MCP path (no log), GET 200 (no log), POST 404 (no log), GET 404 with sessionId (warning with truncated ID), GET 404 without sessionId (warning with path), sub-path 404 (warning), and `TruncateId` edge cases

## Test plan

- [x] `dotnet test` — 2179 passed, 7 pre-existing Docker/Testcontainers failures (no Docker in CI sandbox, same count as main)
- [x] `npm test -- --watchAll=false` — 769 passed, 5 skipped, 0 failed
- [x] All 9 new `McpDiagnosticsMiddlewareTests` pass

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)