### PR TITLE
fix(dashboard): per-tile timeout and structured logging for GetTileData (#623)

### DIFF
--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardOptions.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardOptions.cs
@@ -5,4 +5,14 @@ public class DashboardOptions
     public const string SectionName = "Dashboard";
 
     public int MaxConcurrentTileLoads { get; set; } = 4;
+
+    /// <summary>
+    /// Seconds to wait for a single tile to load before returning an error tile instead of blocking.
+    /// </summary>
+    public int TileLoadTimeoutSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Log a warning when a tile load exceeds this many seconds.
+    /// </summary>
+    public double SlowTileWarningThresholdSeconds { get; set; } = 2.0;
 }

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardService.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/DashboardService.cs
@@ -1,6 +1,8 @@
 using Anela.Heblo.Xcc.Domain;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace Anela.Heblo.Xcc.Services.Dashboard;
 
@@ -9,16 +11,19 @@ public class DashboardService : IDashboardService
     private readonly ITileRegistry _tileRegistry;
     private readonly IUserDashboardSettingsRepository _settingsRepository;
     private readonly DashboardOptions _dashboardOptions;
+    private readonly ILogger<DashboardService> _logger;
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _userLocks = new();
 
     public DashboardService(
         ITileRegistry tileRegistry,
         IUserDashboardSettingsRepository settingsRepository,
-        IOptions<DashboardOptions> dashboardOptions)
+        IOptions<DashboardOptions> dashboardOptions,
+        ILogger<DashboardService> logger)
     {
         _tileRegistry = tileRegistry;
         _settingsRepository = settingsRepository;
         _dashboardOptions = dashboardOptions.Value;
+        _logger = logger;
     }
 
     private static SemaphoreSlim GetUserLock(string userId)
@@ -134,6 +139,7 @@ public class DashboardService : IDashboardService
             async (item, ct) =>
             {
                 var (tileSettings, index) = item;
+                var sw = Stopwatch.StartNew();
 
                 try
                 {
@@ -152,8 +158,42 @@ public class DashboardService : IDashboardService
                         return;
                     }
 
-                    // Load data using registry method that manages scope properly
-                    var data = await _tileRegistry.GetTileDataAsync(tileSettings.TileId, tileParameters);
+                    // Load data with a per-tile timeout to prevent one slow tile from blocking the entire dashboard
+                    var tileLoadTask = _tileRegistry.GetTileDataAsync(tileSettings.TileId, tileParameters);
+                    var timeoutTask = Task.Delay(TimeSpan.FromSeconds(_dashboardOptions.TileLoadTimeoutSeconds), ct);
+
+                    var completed = await Task.WhenAny(tileLoadTask, timeoutTask);
+                    sw.Stop();
+
+                    if (completed == timeoutTask)
+                    {
+                        _logger.LogWarning(
+                            "Tile {TileId} load timed out after {TimeoutSeconds}s",
+                            tileSettings.TileId,
+                            _dashboardOptions.TileLoadTimeoutSeconds);
+
+                        results.Add((index, new TileData
+                        {
+                            TileId = tileSettings.TileId,
+                            Title = "Error",
+                            Description = $"Tile '{tileSettings.TileId}' timed out",
+                            Size = TileSize.Small,
+                            Category = TileCategory.Error,
+                            Data = new { Error = "Tile load timed out" }
+                        }));
+                        return;
+                    }
+
+                    if (sw.Elapsed.TotalSeconds > _dashboardOptions.SlowTileWarningThresholdSeconds)
+                    {
+                        _logger.LogWarning(
+                            "Slow tile load: {TileId} took {ElapsedMs}ms (threshold: {ThresholdSeconds}s)",
+                            tileSettings.TileId,
+                            sw.ElapsedMilliseconds,
+                            _dashboardOptions.SlowTileWarningThresholdSeconds);
+                    }
+
+                    var data = await tileLoadTask;
 
                     results.Add((index, new TileData
                     {
@@ -166,11 +206,18 @@ public class DashboardService : IDashboardService
                         AutoShow = tile.AutoShow,
                         ComponentType = tile.ComponentType,
                         RequiredPermissions = tile.RequiredPermissions,
-                        Data = data
+                        Data = data ?? new { }
                     }));
                 }
                 catch (Exception ex)
                 {
+                    sw.Stop();
+                    _logger.LogError(
+                        ex,
+                        "Tile {TileId} threw an exception after {ElapsedMs}ms",
+                        tileSettings.TileId,
+                        sw.ElapsedMilliseconds);
+
                     results.Add((index, new TileData
                     {
                         TileId = tileSettings.TileId,

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/DashboardServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/DashboardServiceTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Xcc.Services.Dashboard;
 using Anela.Heblo.Xcc.Domain;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -11,14 +12,25 @@ public class DashboardServiceTests
 {
     private readonly Mock<ITileRegistry> _tileRegistryMock;
     private readonly Mock<IUserDashboardSettingsRepository> _settingsRepositoryMock;
+    private readonly Mock<ILogger<DashboardService>> _loggerMock;
     private readonly DashboardService _service;
 
     public DashboardServiceTests()
     {
         _tileRegistryMock = new Mock<ITileRegistry>();
         _settingsRepositoryMock = new Mock<IUserDashboardSettingsRepository>();
+        _loggerMock = new Mock<ILogger<DashboardService>>();
         var options = Options.Create(new DashboardOptions());
-        _service = new DashboardService(_tileRegistryMock.Object, _settingsRepositoryMock.Object, options);
+        _service = new DashboardService(_tileRegistryMock.Object, _settingsRepositoryMock.Object, options, _loggerMock.Object);
+    }
+
+    private DashboardService CreateServiceWithOptions(DashboardOptions options)
+    {
+        return new DashboardService(
+            _tileRegistryMock.Object,
+            _settingsRepositoryMock.Object,
+            Options.Create(options),
+            _loggerMock.Object);
     }
 
     [Fact]
@@ -294,6 +306,134 @@ public class DashboardServiceTests
         errorTile.Title.Should().Be("Error");
         errorTile.Category.Should().Be(TileCategory.Error);
         errorTile.Description.Should().Contain("Data loading failed");
+    }
+
+    [Fact]
+    public async Task GetTileDataAsync_WhenTileLoadExceedsTimeout_ShouldReturnErrorTile()
+    {
+        // Arrange
+        var userId = "user123";
+        var userSettings = CreateUserSettingsWithVisibleTiles(userId);
+        var mockTile = CreateMockTileWithData("tile1");
+
+        _settingsRepositoryMock
+            .Setup(x => x.GetByUserIdAsync(userId))
+            .ReturnsAsync(userSettings);
+
+        _tileRegistryMock
+            .Setup(x => x.GetAvailableTiles())
+            .Returns(new List<ITile>());
+
+        _tileRegistryMock
+            .Setup(x => x.GetTile("tile1"))
+            .Returns(mockTile);
+
+        // Simulate a tile that never finishes (hangs indefinitely)
+        _tileRegistryMock
+            .Setup(x => x.GetTileDataAsync("tile1", It.IsAny<Dictionary<string, string>?>()))
+            .Returns(Task.Delay(TimeSpan.FromSeconds(60)).ContinueWith(_ => (object?)null));
+
+        var service = CreateServiceWithOptions(new DashboardOptions
+        {
+            TileLoadTimeoutSeconds = 1,
+            SlowTileWarningThresholdSeconds = 0.5
+        });
+
+        // Act
+        var result = await service.GetTileDataAsync(userId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+
+        var errorTile = result.First();
+        errorTile.TileId.Should().Be("tile1");
+        errorTile.Title.Should().Be("Error");
+        errorTile.Category.Should().Be(TileCategory.Error);
+        errorTile.Description.Should().Contain("timed out");
+    }
+
+    [Fact]
+    public async Task GetTileDataAsync_WhenTileLoadExceedsTimeout_ShouldLogWarning()
+    {
+        // Arrange
+        var userId = "user123";
+        var userSettings = CreateUserSettingsWithVisibleTiles(userId);
+        var mockTile = CreateMockTileWithData("tile1");
+
+        _settingsRepositoryMock
+            .Setup(x => x.GetByUserIdAsync(userId))
+            .ReturnsAsync(userSettings);
+
+        _tileRegistryMock
+            .Setup(x => x.GetAvailableTiles())
+            .Returns(new List<ITile>());
+
+        _tileRegistryMock
+            .Setup(x => x.GetTile("tile1"))
+            .Returns(mockTile);
+
+        _tileRegistryMock
+            .Setup(x => x.GetTileDataAsync("tile1", It.IsAny<Dictionary<string, string>?>()))
+            .Returns(Task.Delay(TimeSpan.FromSeconds(60)).ContinueWith(_ => (object?)null));
+
+        var service = CreateServiceWithOptions(new DashboardOptions
+        {
+            TileLoadTimeoutSeconds = 1,
+            SlowTileWarningThresholdSeconds = 0.5
+        });
+
+        // Act
+        await service.GetTileDataAsync(userId);
+
+        // Assert: warning was logged for the timeout
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("tile1") && v.ToString()!.Contains("timed out")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTileDataAsync_WhenTileThrowsException_ShouldLogError()
+    {
+        // Arrange
+        var userId = "user123";
+        var userSettings = CreateUserSettingsWithVisibleTiles(userId);
+        var mockTile = CreateMockTileWithData("tile1");
+        var exception = new InvalidOperationException("Service unavailable");
+
+        _settingsRepositoryMock
+            .Setup(x => x.GetByUserIdAsync(userId))
+            .ReturnsAsync(userSettings);
+
+        _tileRegistryMock
+            .Setup(x => x.GetAvailableTiles())
+            .Returns(new List<ITile>());
+
+        _tileRegistryMock
+            .Setup(x => x.GetTile("tile1"))
+            .Returns(mockTile);
+
+        _tileRegistryMock
+            .Setup(x => x.GetTileDataAsync("tile1", It.IsAny<Dictionary<string, string>?>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        await _service.GetTileDataAsync(userId);
+
+        // Assert: error was logged with exception and tile ID
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("tile1")),
+                exception,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Dashboard `GetTileData` would block for 7-8 s when one tile was slow, because all tiles load in parallel but the response waits for the slowest one.

## Solution

- **Per-tile timeout** via `Task.WhenAny`: if a tile doesn’t finish within `TileLoadTimeoutSeconds` (default 5 s), it is replaced with an error tile immediately. The rest of the tiles are unaffected.
- **Slow-tile warning log**: tiles that finish but exceed `SlowTileWarningThresholdSeconds` (default 2 s) emit a `LogWarning` with tile ID and elapsed time.
- **Structured error logging**: exceptions now include tile ID and elapsed time.

## Changes

- `DashboardOptions` — two new config properties (`TileLoadTimeoutSeconds`, `SlowTileWarningThresholdSeconds`)
- `DashboardService` — `ILogger<DashboardService>` injected; `Task.WhenAny` timeout pattern added; `Stopwatch` tracking
- `DashboardServiceTests` — logger mock + 3 new test cases: timeout returns error tile, timeout logs warning, exception logs error

## Tests

- BE: 2173 unit tests passed (7 pre-existing Docker integration test failures, unrelated)
- FE: 82 suites, 769 tests passed

Closes #623