### PR TITLE
fix: add 5-minute request timeout to MCP SSE endpoint (#682)

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -88,6 +88,9 @@ public static class ApplicationBuilderExtensions
         app.UseAuthentication();
         app.UseAuthorization();
 
+        // Request timeouts middleware — must be after auth so timeout policies can be applied per-endpoint
+        app.UseRequestTimeouts();
+
         // Add Hangfire authentication middleware before Hangfire dashboard
         // This middleware handles redirects to login when user is not authenticated
         app.UseMiddleware<HangfireAuthenticationMiddleware>();
@@ -117,7 +120,10 @@ public static class ApplicationBuilderExtensions
         app.UseMiddleware<McpDiagnosticsMiddleware>();
 
         // MCP server endpoint — requires authentication (Microsoft Entra ID)
-        app.MapMcp("/mcp").RequireAuthorization();
+        // 5-minute session timeout terminates zombie SSE connections that linger after client disconnect.
+        app.MapMcp("/mcp")
+            .RequireAuthorization()
+            .WithRequestTimeout(TimeSpan.FromMinutes(5));
 
         // OAuth 2.0 authorization server metadata — required for MCP clients (e.g. Claude Desktop)
         // to discover the real authorization server (Microsoft Entra ID) instead of hitting the SPA fallback.

--- a/backend/src/Anela.Heblo.API/MCP/Tools/CatalogMcpTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/CatalogMcpTools.cs
@@ -36,7 +36,8 @@ public class CatalogMcpTools
         [Description("Page number for pagination (default: 1)")]
         int pageNumber = 1,
         [Description("Page size for pagination (default: 50, max: 100)")]
-        int pageSize = 50)
+        int pageSize = 50,
+        CancellationToken cancellationToken = default)
     {
         var request = new GetCatalogListRequest
         {
@@ -46,7 +47,7 @@ public class CatalogMcpTools
             PageSize = pageSize
         };
 
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
         return JsonSerializer.Serialize(response);
     }
 
@@ -55,7 +56,8 @@ public class CatalogMcpTools
         [Description("Product code (e.g., 'AKL001', 'SLU000001')")]
         string productCode,
         [Description("Number of months to look back for transaction history (default: 13)")]
-        int monthsBack = 13)
+        int monthsBack = 13,
+        CancellationToken cancellationToken = default)
     {
         var request = new GetCatalogDetailRequest
         {
@@ -63,7 +65,7 @@ public class CatalogMcpTools
             MonthsBack = monthsBack
         };
 
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -76,10 +78,11 @@ public class CatalogMcpTools
     [McpServerTool]
     public async Task<string> GetProductComposition(
         [Description("Product code (e.g., 'AKL001')")]
-        string productCode)
+        string productCode,
+        CancellationToken cancellationToken = default)
     {
         var request = new GetProductCompositionRequest { ProductCode = productCode };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -90,10 +93,10 @@ public class CatalogMcpTools
     }
 
     [McpServerTool]
-    public async Task<string> GetMaterialsForPurchase()
+    public async Task<string> GetMaterialsForPurchase(CancellationToken cancellationToken = default)
     {
         var request = new GetMaterialsForPurchaseRequest();
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
         return JsonSerializer.Serialize(response);
     }
 
@@ -104,7 +107,8 @@ public class CatalogMcpTools
         [Description("Maximum number of results to return (default: 20)")]
         int limit = 20,
         [Description("Filter by product types")]
-        ProductType[]? productTypes = null)
+        ProductType[]? productTypes = null,
+        CancellationToken cancellationToken = default)
     {
         var request = new GetCatalogListRequest
         {
@@ -114,17 +118,18 @@ public class CatalogMcpTools
             ProductTypes = productTypes
         };
 
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
         return JsonSerializer.Serialize(response);
     }
 
     [McpServerTool]
     public async Task<string> GetProductUsage(
         [Description("Product code (e.g., 'AKL001')")]
-        string productCode)
+        string productCode,
+        CancellationToken cancellationToken = default)
     {
         var request = new GetProductUsageRequest { ProductCode = productCode };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -135,10 +140,10 @@ public class CatalogMcpTools
     }
 
     [McpServerTool]
-    public async Task<string> GetWarehouseStatistics()
+    public async Task<string> GetWarehouseStatistics(CancellationToken cancellationToken = default)
     {
         var request = new GetWarehouseStatisticsRequest();
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
         return JsonSerializer.Serialize(response);
     }
 }

--- a/backend/src/Anela.Heblo.API/MCP/Tools/KnowledgeBaseTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/KnowledgeBaseTools.cs
@@ -25,7 +25,8 @@ public class KnowledgeBaseTools
     [Description("Search the knowledge base for relevant document chunks using semantic similarity. Returns raw chunks with source references.")]
     public async Task<string> SearchKnowledgeBase(
         [Description("Natural language search query")] string query,
-        [Description("Number of chunks to return (default: 5)")] int topK = 5)
+        [Description("Number of chunks to return (default: 5)")] int topK = 5,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -33,7 +34,7 @@ public class KnowledgeBaseTools
             {
                 Query = query,
                 TopK = topK
-            });
+            }, cancellationToken);
             return JsonSerializer.Serialize(result);
         }
         catch (Exception ex)
@@ -47,7 +48,8 @@ public class KnowledgeBaseTools
     [Description("Ask a question and get an AI-generated answer grounded in company documents. Returns a prose answer with cited sources.")]
     public async Task<string> AskKnowledgeBase(
         [Description("Question to answer using the knowledge base")] string question,
-        [Description("Number of context chunks to retrieve (default: 5)")] int topK = 5)
+        [Description("Number of context chunks to retrieve (default: 5)")] int topK = 5,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -55,7 +57,7 @@ public class KnowledgeBaseTools
             {
                 Question = question,
                 TopK = topK
-            });
+            }, cancellationToken);
             return JsonSerializer.Serialize(result);
         }
         catch (Exception ex)

--- a/backend/src/Anela.Heblo.API/MCP/Tools/ManufactureBatchMcpTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/ManufactureBatchMcpTools.cs
@@ -26,11 +26,12 @@ public class ManufactureBatchMcpTools
     [McpServerTool]
     public async Task<string> GetBatchTemplate(
         [Description("Product code to get batch template for")]
-        string productCode
+        string productCode,
+        CancellationToken cancellationToken = default
     )
     {
         var request = new CalculatedBatchSizeRequest { ProductCode = productCode };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -45,11 +46,12 @@ public class ManufactureBatchMcpTools
         [Description("Product code to calculate batch for")]
         string productCode,
         [Description("Desired batch size")]
-        double desiredBatchSize
+        double desiredBatchSize,
+        CancellationToken cancellationToken = default
     )
     {
         var request = new CalculatedBatchSizeRequest { ProductCode = productCode, DesiredBatchSize = desiredBatchSize };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -66,7 +68,8 @@ public class ManufactureBatchMcpTools
         [Description("Ingredient code to scale by")]
         string ingredientCode,
         [Description("Available quantity of the ingredient")]
-        double desiredIngredientAmount
+        double desiredIngredientAmount,
+        CancellationToken cancellationToken = default
     )
     {
         var request = new CalculateBatchByIngredientRequest
@@ -75,7 +78,7 @@ public class ManufactureBatchMcpTools
             IngredientCode = ingredientCode,
             DesiredIngredientAmount = desiredIngredientAmount
         };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -88,10 +91,11 @@ public class ManufactureBatchMcpTools
     [McpServerTool]
     public async Task<string> CalculateBatchPlan(
         [Description("Batch plan request with products and quantities")]
-        CalculateBatchPlanRequest request
+        CalculateBatchPlanRequest request,
+        CancellationToken cancellationToken = default
     )
     {
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {

--- a/backend/src/Anela.Heblo.API/MCP/Tools/ManufactureOrderMcpTools.cs
+++ b/backend/src/Anela.Heblo.API/MCP/Tools/ManufactureOrderMcpTools.cs
@@ -25,10 +25,10 @@ public class ManufactureOrderMcpTools
     }
 
     [McpServerTool]
-    public async Task<string> GetManufactureOrders()
+    public async Task<string> GetManufactureOrders(CancellationToken cancellationToken = default)
     {
         var request = new GetManufactureOrdersRequest();
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -41,11 +41,12 @@ public class ManufactureOrderMcpTools
     [McpServerTool]
     public async Task<string> GetManufactureOrder(
         [Description("Manufacture order ID")]
-        int id
+        int id,
+        CancellationToken cancellationToken = default
     )
     {
         var request = new GetManufactureOrderRequest { Id = id };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -56,10 +57,10 @@ public class ManufactureOrderMcpTools
     }
 
     [McpServerTool]
-    public async Task<string> GetCalendarView()
+    public async Task<string> GetCalendarView(CancellationToken cancellationToken = default)
     {
         var request = new GetCalendarViewRequest();
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {
@@ -72,11 +73,12 @@ public class ManufactureOrderMcpTools
     [McpServerTool]
     public async Task<string> GetResponsiblePersons(
         [Description("Microsoft Entra ID group ID for manufacture team")]
-        string groupId
+        string groupId,
+        CancellationToken cancellationToken = default
     )
     {
         var request = new GetGroupMembersRequest { GroupId = groupId };
-        var response = await _mediator.Send(request);
+        var response = await _mediator.Send(request, cancellationToken);
 
         if (!response.Success)
         {

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -66,6 +66,9 @@ public partial class Program
         // MCP server
         builder.Services.AddMcpServices();
 
+        // Request timeouts — required for .WithRequestTimeout() on MCP and other endpoints
+        builder.Services.AddRequestTimeouts();
+
         // Hangfire background jobs
         builder.Services.AddHangfireServices(builder.Configuration, builder.Environment);
         builder.Services.AddRecurringJobs(); // Register all IRecurringJob implementations and discovery service


### PR DESCRIPTION
## Summary

Fixes #682 — MCP SSE sessions were averaging 240 s with no timeout, leaving zombie connections open indefinitely.

### Changes

- **`Program.cs`**: Register `AddRequestTimeouts()` in DI
- **`ApplicationBuilderExtensions.cs`**: Add `UseRequestTimeouts()` middleware (after auth) and chain `.WithRequestTimeout(TimeSpan.FromMinutes(5))` on `MapMcp("/mcp")` so SSE sessions are terminated after 5 minutes of inactivity
- **MCP tool handlers** — propagate `CancellationToken` through all tool methods so in-flight mediator calls are cancelled when the session times out:
  - `CatalogMcpTools`
  - `ManufactureOrderMcpTools`
  - `ManufactureBatchMcpTools`
  - `KnowledgeBaseTools`

## Test plan

- [x] `dotnet test` — 2183 passed, 7 skipped (Docker integration tests, pre-existing infra issue unrelated to this change)
- [x] `npm test -- --watchAll=false` — 769 passed, 5 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)