### PR TITLE
fix(persistence): add Npgsql KeepAlive and connection lifetime settings to prune stale pool connections

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -52,6 +52,14 @@ public static class PersistenceModule
                 dataSourceBuilder.ConnectionStringBuilder.MaxPoolSize = maxPoolSize.Value;
             }
 
+            // Prune stale connections left over after a DB restart or maintenance window.
+            // Without these settings the pool holds dead sockets until the caller hits a
+            // SocketException (observed spike: 112 SocketExceptions in 24 h, 6.1× the
+            // 7-day average, coinciding with a pg_terminate_backend / server restart).
+            dataSourceBuilder.ConnectionStringBuilder.KeepAlive = 30;              // TCP keepalive every 30 s
+            dataSourceBuilder.ConnectionStringBuilder.ConnectionIdleLifetime = 120; // retire idle connections after 2 min
+            dataSourceBuilder.ConnectionStringBuilder.ConnectionLifetime = 600;     // retire any connection older than 10 min
+
             dataSourceBuilder.UseVector();
             dataSource = dataSourceBuilder.Build();
             services.AddSingleton(dataSource); // Register for DI-managed disposal


### PR DESCRIPTION
## Problem

A 6.1× spike in `System.Net.Sockets.SocketException` (`Failed to connect to postgres:5432`) was observed on 2026-04-20 — 112 exceptions in 24 h against a 7-day average of 18.4/day. The spike coincided with elevated `Npgsql.PostgresException` (`57P01: terminating connection due to administrator command`), confirming the PostgreSQL server restarted and the connection pool retained dead sockets.

## Root cause

`PersistenceModule.cs` built the `NpgsqlDataSource` singleton with no TCP keepalive or connection lifetime settings. After a DB restart, pooled connections stay alive in the pool until a caller tries to use one — at which point the dead socket throws `SocketException`.

## Fix

Three settings added to `NpgsqlDataSourceBuilder` before `Build()`:

| Setting | Value | Purpose |
|---|---|---|
| `KeepAlive` | 30 s | TCP keepalive probes; OS closes dead connections before callers hit them |
| `ConnectionIdleLifetime` | 120 s | Pool removes connections idle > 2 min |
| `ConnectionLifetime` | 600 s | Pool retires any connection older than 10 min |

## Testing

- BE unit tests: ✅ 2162 passed, 0 failed (Docker integration tests skipped — environment has no Docker)
- FE tests: ✅ 769 passed, 5 skipped

Closes #680