### PR TITLE
fix: distinguish FlexiBee timeout vs caller cancellation in Flexi adapters

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureHistoryClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureHistoryClient.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.Manufacture;
+using Microsoft.Extensions.Logging;
 using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
 using Rem.FlexiBeeSDK.Model.Products.StockMovement;
 
@@ -7,21 +8,43 @@ namespace Anela.Heblo.Adapters.Flexi.Manufacture;
 public class FlexiManufactureHistoryClient : IManufactureHistoryClient
 {
     private readonly IStockItemsMovementClient _stockItemsMovementClient;
+    private readonly ILogger<FlexiManufactureHistoryClient> _logger;
 
     private const int ManufactureDocumentTypeId = 56;
 
     public FlexiManufactureHistoryClient(
-        IStockItemsMovementClient stockItemsMovementClient
-    )
+        IStockItemsMovementClient stockItemsMovementClient,
+        ILogger<FlexiManufactureHistoryClient> logger)
     {
         _stockItemsMovementClient = stockItemsMovementClient;
+        _logger = logger;
     }
 
 
     public async Task<List<ManufactureHistoryRecord>> GetHistoryAsync(DateTime dateFrom, DateTime dateTo, string? productCode = null,
         CancellationToken cancellationToken = default)
     {
-        var movements = await _stockItemsMovementClient.GetAsync(dateFrom, dateTo, StockMovementDirection.In, documentTypeId: ManufactureDocumentTypeId, cancellationToken: cancellationToken);
+        IReadOnlyList<StockItemMovementFlexiDto> movements;
+        try
+        {
+            movements = await _stockItemsMovementClient.GetAsync(dateFrom, dateTo, StockMovementDirection.In, documentTypeId: ManufactureDocumentTypeId, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex,
+                "FlexiBee uzivatelsky-dotaz request timed out (internal HttpClient timeout). " +
+                "DateFrom: {DateFrom}, DateTo: {DateTo}",
+                dateFrom, dateTo);
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation(
+                "FlexiBee uzivatelsky-dotaz request was canceled by the caller (client abort). " +
+                "DateFrom: {DateFrom}, DateTo: {DateTo}",
+                dateFrom, dateTo);
+            throw;
+        }
 
         var query = movements.AsQueryable();
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Stock/FlexiStockClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Stock/FlexiStockClient.cs
@@ -64,6 +64,22 @@ public class FlexiStockClient : IErpStockClient
                 warehouseId, date);
             throw;
         }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex,
+                "FlexiBee stav-skladu-k-datu request timed out (internal HttpClient timeout). " +
+                "WarehouseId: {WarehouseId}, Date: {Date}",
+                warehouseId, date);
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation(
+                "FlexiBee stav-skladu-k-datu request was canceled by the caller (client abort). " +
+                "WarehouseId: {WarehouseId}, Date: {Date}",
+                warehouseId, date);
+            throw;
+        }
     }
 
     private Task<IReadOnlyList<ErpStock>> ListByWarehouse(int warehouseId, ProductType productType,
@@ -89,6 +105,22 @@ public class FlexiStockClient : IErpStockClient
         {
             _logger.LogError(ex,
                 "FlexiBee stav-skladu-k-datu returned 501 NotImplemented — endpoint may be disabled or unsupported on this instance. " +
+                "WarehouseId: {WarehouseId}, ProductTypes: {ProductTypes}",
+                warehouseId, string.Join(", ", productTypes));
+            throw;
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex,
+                "FlexiBee stav-skladu-k-datu request timed out (internal HttpClient timeout). " +
+                "WarehouseId: {WarehouseId}, ProductTypes: {ProductTypes}",
+                warehouseId, string.Join(", ", productTypes));
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation(
+                "FlexiBee stav-skladu-k-datu request was canceled by the caller (client abort). " +
                 "WarehouseId: {WarehouseId}, ProductTypes: {ProductTypes}",
                 warehouseId, string.Join(", ", productTypes));
             throw;

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs
@@ -1,0 +1,80 @@
+using Anela.Heblo.Adapters.Flexi.Manufacture;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
+using Rem.FlexiBeeSDK.Model.Products.StockMovement;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Manufacture;
+
+public class FlexiManufactureHistoryClientTests
+{
+    private readonly Mock<IStockItemsMovementClient> _mockMovementClient;
+    private readonly Mock<ILogger<FlexiManufactureHistoryClient>> _mockLogger;
+    private readonly FlexiManufactureHistoryClient _client;
+
+    public FlexiManufactureHistoryClientTests()
+    {
+        _mockMovementClient = new Mock<IStockItemsMovementClient>();
+        _mockLogger = new Mock<ILogger<FlexiManufactureHistoryClient>>();
+
+        _client = new FlexiManufactureHistoryClient(
+            _mockMovementClient.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_WhenInternalTimeoutCancels_LogsWarningAndRethrows()
+    {
+        // Arrange — HttpClient internal timeout (not caller's token)
+        var timeoutCts = new CancellationTokenSource();
+        var timeoutException = new TaskCanceledException("HttpClient timeout", null, timeoutCts.Token);
+        await timeoutCts.CancelAsync();
+
+        _mockMovementClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<StockMovementDirection>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(timeoutException);
+
+        // Act — caller's token is NOT canceled
+        var act = async () => await _client.GetHistoryAsync(DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, cancellationToken: CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("timed out")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_WhenCallerCancels_LogsInformationAndRethrows()
+    {
+        // Arrange — caller cancels via their own token
+        using var callerCts = new CancellationTokenSource();
+        var canceledException = new TaskCanceledException("Caller canceled", null, callerCts.Token);
+        await callerCts.CancelAsync();
+
+        _mockMovementClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<StockMovementDirection>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(canceledException);
+
+        // Act — same token is canceled
+        var act = async () => await _client.GetHistoryAsync(DateTime.UtcNow.AddDays(-7), DateTime.UtcNow, cancellationToken: callerCts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("canceled by the caller")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Stock/FlexiStockClientTests.cs
@@ -75,4 +75,112 @@ public class FlexiStockClientTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.AtLeastOnce);
     }
+
+    [Fact]
+    public async Task StockToDateAsync_WhenInternalTimeoutCancels_LogsWarningAndRethrows()
+    {
+        // Arrange — timeout fires from HttpClient's own CTS, not from our token
+        var timeoutCts = new CancellationTokenSource();
+        var timeoutException = new TaskCanceledException("HttpClient timeout", null, timeoutCts.Token);
+        await timeoutCts.CancelAsync();
+
+        _mockStockClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(timeoutException);
+
+        // Act — caller's token is NOT canceled
+        var act = async () => await _client.StockToDateAsync(DateTime.UtcNow, warehouseId: 5, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("timed out")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task StockToDateAsync_WhenCallerCancels_LogsInformationAndRethrows()
+    {
+        // Arrange — caller cancels via their own token
+        using var callerCts = new CancellationTokenSource();
+        var canceledException = new TaskCanceledException("Caller canceled", null, callerCts.Token);
+        await callerCts.CancelAsync();
+
+        _mockStockClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(canceledException);
+
+        // Act — same token is canceled
+        var act = async () => await _client.StockToDateAsync(DateTime.UtcNow, warehouseId: 5, callerCts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("canceled by the caller")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenInternalTimeoutCancels_LogsWarningAndRethrows()
+    {
+        // Arrange — HttpClient internal timeout (not caller's token)
+        var timeoutCts = new CancellationTokenSource();
+        var timeoutException = new TaskCanceledException("HttpClient timeout", null, timeoutCts.Token);
+        await timeoutCts.CancelAsync();
+
+        _mockStockClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(timeoutException);
+
+        // Act
+        var act = async () => await _client.ListAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("timed out")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ListAsync_WhenCallerCancels_LogsInformationAndRethrows()
+    {
+        // Arrange
+        using var callerCts = new CancellationTokenSource();
+        var canceledException = new TaskCanceledException("Caller canceled", null, callerCts.Token);
+        await callerCts.CancelAsync();
+
+        _mockStockClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(canceledException);
+
+        // Act
+        var act = async () => await _client.ListAsync(callerCts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("canceled by the caller")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #676 — App Insights was logging noisy `OperationCanceledException` entries for FlexiBee HTTP calls without distinguishing between:
- *Internal HttpClient timeouts* (own timeout CTS fired, caller token NOT canceled) → now logged as `Warning`
- *Caller-abort cancellations* (client disconnected, request canceled upstream) → now logged as `Information`

### Changes

- `FlexiStockClient` — added `OperationCanceledException` catch blocks in `StockToDateAsync` and private `ListByWarehouse` (`stav-skladu-k-datu` endpoint)
- `FlexiManufactureHistoryClient` — injected `ILogger<>`, added try/catch around `GetAsync` (`uzivatelsky-dotaz` endpoint)

### Tests

- 4 new unit tests in `FlexiStockClientTests` (timeout + caller-cancel for both `StockToDateAsync` and `ListAsync`)
- 2 new unit tests in `FlexiManufactureHistoryClientTests` (timeout + caller-cancel)
- All 8 unit tests pass ✅
- All 82 FE test suites pass ✅

## Test plan

- [ ] Review catch block logic: `when (!cancellationToken.IsCancellationRequested)` → Warning; else → Information
- [ ] Verify no regression in existing tests
- [ ] Check App Insights after deploy to confirm reduced noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)