### PR TITLE
perf: add missing DB indexes for KnowledgeBase queries

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseChunkConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseChunkConfiguration.cs
@@ -31,5 +31,8 @@ public class KnowledgeBaseChunkConfiguration : IEntityTypeConfiguration<Knowledg
         builder.Ignore(e => e.Embedding);
 
         builder.HasIndex(e => e.DocumentId);
+
+        builder.HasIndex(e => new { e.DocumentId, e.ChunkIndex })
+            .HasDatabaseName("ix_knowledgebase_chunks_document_chunk");
     }
 }

--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs
@@ -58,5 +58,8 @@ public class KnowledgeBaseDocumentConfiguration : IEntityTypeConfiguration<Knowl
             .IsUnique();
 
         builder.HasIndex(e => e.Status);
+
+        builder.HasIndex(e => e.ContentType)
+            .HasDatabaseName("ix_knowledgebase_documents_contenttype");
     }
 }

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260421120000_AddKnowledgeBaseChunkIndexes.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260421120000_AddKnowledgeBaseChunkIndexes.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKnowledgeBaseChunkIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_knowledgebase_chunks_document_chunk",
+                schema: "dbo",
+                table: "KnowledgeBaseChunks",
+                columns: new[] { "DocumentId", "ChunkIndex" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_knowledgebase_documents_contenttype",
+                schema: "dbo",
+                table: "KnowledgeBaseDocuments",
+                column: "ContentType");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_knowledgebase_chunks_document_chunk",
+                schema: "dbo",
+                table: "KnowledgeBaseChunks");
+
+            migrationBuilder.DropIndex(
+                name: "ix_knowledgebase_documents_contenttype",
+                schema: "dbo",
+                table: "KnowledgeBaseDocuments");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -787,6 +787,9 @@ namespace Anela.Heblo.Persistence.Migrations
 
                     b.HasIndex("DocumentId");
 
+                    b.HasIndex("DocumentId", "ChunkIndex")
+                        .HasDatabaseName("ix_knowledgebase_chunks_document_chunk");
+
                     b.ToTable("KnowledgeBaseChunks", "dbo");
                 });
 
@@ -841,6 +844,9 @@ namespace Anela.Heblo.Persistence.Migrations
                         .IsUnique();
 
                     b.HasIndex("Status");
+
+                    b.HasIndex("ContentType")
+                        .HasDatabaseName("ix_knowledgebase_documents_contenttype");
 
                     b.ToTable("KnowledgeBaseDocuments", "dbo");
                 });


### PR DESCRIPTION
## Summary

Fixes #668

Adds two missing DB indexes that were causing slow KnowledgeBase queries:

- **(DocumentId, ChunkIndex) composite index on `KnowledgeBaseChunks`** — speeds up `GetFirstChunkIdsByDocumentIdsAsync` which groups by DocumentId and orders by ChunkIndex (~5.5s → fast)
- **ContentType index on `KnowledgeBaseDocuments`** — speeds up `GetDistinctContentTypesAsync` which queries distinct content types (~4.2s → fast)

## Changes

- `KnowledgeBaseChunkConfiguration.cs` — added composite index
- `KnowledgeBaseDocumentConfiguration.cs` — added ContentType index
- Migration `20260421120000_AddKnowledgeBaseChunkIndexes.cs` — creates both indexes
- `ApplicationDbContextModelSnapshot.cs` — updated to reflect new indexes

## Tests

- BE: 2162 unit tests passing (7 integration tests require Docker, skipped in sandbox)
- FE: 769 tests passing, 5 skipped