### PR TITLE
feat(campaigns): domain entities, persistence layer, and EF migration (#629)

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/Ad.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/Ad.cs
@@ -1,0 +1,15 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public class Ad
+{
+    public Guid Id { get; set; }
+    public Guid AdSetId { get; set; }
+    public string PlatformAdId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public AdAdSet AdSet { get; set; } = null!;
+    public ICollection<AdDailyMetric> DailyMetrics { get; set; } = new List<AdDailyMetric>();
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdAdSet.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdAdSet.cs
@@ -1,0 +1,16 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public class AdAdSet
+{
+    public Guid Id { get; set; }
+    public Guid CampaignId { get; set; }
+    public string PlatformAdSetId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public decimal? DailyBudget { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public AdCampaign Campaign { get; set; } = null!;
+    public ICollection<Ad> Ads { get; set; } = new List<Ad>();
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdCampaign.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdCampaign.cs
@@ -1,0 +1,19 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public class AdCampaign
+{
+    public Guid Id { get; set; }
+    public AdPlatform Platform { get; set; }
+    public string PlatformCampaignId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public string? Objective { get; set; }
+    public decimal? DailyBudget { get; set; }
+    public decimal? LifetimeBudget { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public ICollection<AdAdSet> AdSets { get; set; } = new List<AdAdSet>();
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdDailyMetric.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdDailyMetric.cs
@@ -1,0 +1,24 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public class AdDailyMetric
+{
+    public Guid Id { get; set; }
+    public Guid AdId { get; set; }
+    public DateTime Date { get; set; }
+
+    // Core metrics
+    public long Impressions { get; set; }
+    public long Clicks { get; set; }
+    public decimal Spend { get; set; }
+    public decimal Revenue { get; set; }
+    public long Conversions { get; set; }
+
+    // Computed metrics
+    public decimal Ctr => Impressions > 0 ? (decimal)Clicks / Impressions * 100m : 0m;
+    public decimal Cpc => Clicks > 0 ? Spend / Clicks : 0m;
+    public decimal Roas => Spend > 0 ? Revenue / Spend : 0m;
+
+    public DateTime CreatedAt { get; set; }
+
+    public Ad Ad { get; set; } = null!;
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdPlatform.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdPlatform.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public enum AdPlatform
+{
+    Meta = 1,
+    Google = 2
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdSyncLog.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/AdSyncLog.cs
@@ -1,0 +1,39 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public class AdSyncLog
+{
+    public Guid Id { get; set; }
+    public AdPlatform Platform { get; set; }
+    public AdSyncStatus Status { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public int CampaignsSynced { get; set; }
+    public int AdSetsSynced { get; set; }
+    public int AdsSynced { get; set; }
+    public int MetricRowsSynced { get; set; }
+    public string? ErrorMessage { get; set; }
+
+    public void Complete(int campaigns, int adSets, int ads, int metricRows)
+    {
+        Status = AdSyncStatus.Success;
+        CompletedAt = DateTime.UtcNow;
+        CampaignsSynced = campaigns;
+        AdSetsSynced = adSets;
+        AdsSynced = ads;
+        MetricRowsSynced = metricRows;
+    }
+
+    public void Fail(string errorMessage)
+    {
+        Status = AdSyncStatus.Failed;
+        CompletedAt = DateTime.UtcNow;
+        ErrorMessage = errorMessage;
+    }
+}
+
+public enum AdSyncStatus
+{
+    Running = 0,
+    Success = 1,
+    Failed = 2
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/ICampaignRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/ICampaignRepository.cs
@@ -1,0 +1,18 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public interface ICampaignRepository
+{
+    // Upsert operations
+    Task UpsertCampaignAsync(AdCampaign campaign, CancellationToken ct = default);
+    Task UpsertAdSetAsync(AdAdSet adSet, CancellationToken ct = default);
+    Task UpsertAdAsync(Ad ad, CancellationToken ct = default);
+    Task UpsertDailyMetricAsync(AdDailyMetric metric, CancellationToken ct = default);
+
+    // Sync log
+    Task AddSyncLogAsync(AdSyncLog log, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+
+    // Query stubs (implemented in plan 4)
+    Task<List<AdCampaign>> GetCampaignsByPlatformAsync(AdPlatform platform, CancellationToken ct = default);
+    Task<List<AdDailyMetric>> GetMetricsByDateRangeAsync(DateTime from, DateTime to, CancellationToken ct = default);
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/IGoogleAdsClient.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/IGoogleAdsClient.cs
@@ -1,0 +1,48 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public interface IGoogleAdsClient
+{
+    Task<IReadOnlyList<GoogleCampaignDto>> GetCampaignsAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<GoogleAdGroupDto>> GetAdGroupsAsync(string campaignId, CancellationToken ct = default);
+    Task<IReadOnlyList<GoogleAdDto>> GetAdsAsync(string adGroupId, CancellationToken ct = default);
+    Task<IReadOnlyList<GoogleMetricDto>> GetMetricsAsync(string adId, DateTime since, DateTime until, CancellationToken ct = default);
+}
+
+public class GoogleCampaignDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public string? Objective { get; set; }
+    public decimal? DailyBudget { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+}
+
+public class GoogleAdGroupDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string CampaignId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public decimal? CpcBidMicros { get; set; }
+}
+
+public class GoogleAdDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string AdGroupId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+}
+
+public class GoogleMetricDto
+{
+    public string AdId { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public long Impressions { get; set; }
+    public long Clicks { get; set; }
+    public decimal CostMicros { get; set; }
+    public decimal ConversionsValue { get; set; }
+    public long Conversions { get; set; }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Campaigns/IMetaAdsClient.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Campaigns/IMetaAdsClient.cs
@@ -1,0 +1,49 @@
+namespace Anela.Heblo.Domain.Features.Campaigns;
+
+public interface IMetaAdsClient
+{
+    Task<IReadOnlyList<MetaCampaignDto>> GetCampaignsAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<MetaAdSetDto>> GetAdSetsAsync(string campaignId, CancellationToken ct = default);
+    Task<IReadOnlyList<MetaAdDto>> GetAdsAsync(string adSetId, CancellationToken ct = default);
+    Task<IReadOnlyList<MetaInsightDto>> GetInsightsAsync(string adId, DateTime since, DateTime until, CancellationToken ct = default);
+}
+
+public class MetaCampaignDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public string? Objective { get; set; }
+    public decimal? DailyBudget { get; set; }
+    public decimal? LifetimeBudget { get; set; }
+    public DateTime? StartTime { get; set; }
+    public DateTime? StopTime { get; set; }
+}
+
+public class MetaAdSetDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string CampaignId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+    public decimal? DailyBudget { get; set; }
+}
+
+public class MetaAdDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string AdSetId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Status { get; set; }
+}
+
+public class MetaInsightDto
+{
+    public string AdId { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public long Impressions { get; set; }
+    public long Clicks { get; set; }
+    public decimal Spend { get; set; }
+    public decimal Revenue { get; set; }
+    public long Conversions { get; set; }
+}

--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.Bank;
+using Anela.Heblo.Domain.Features.Campaigns;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -81,6 +82,13 @@ public class ApplicationDbContext : DbContext
 
     // Grid Layouts module
     public DbSet<GridLayout> GridLayouts { get; set; } = null!;
+
+    // Campaigns module
+    public DbSet<AdCampaign> AdCampaigns { get; set; } = null!;
+    public DbSet<AdAdSet> AdAdSets { get; set; } = null!;
+    public DbSet<Ad> Ads { get; set; } = null!;
+    public DbSet<AdDailyMetric> AdDailyMetrics { get; set; } = null!;
+    public DbSet<AdSyncLog> AdSyncLogs { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Anela.Heblo.Persistence/Campaigns/AdAdSetConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Campaigns/AdAdSetConfiguration.cs
@@ -1,0 +1,43 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Campaigns;
+
+public class AdAdSetConfiguration : IEntityTypeConfiguration<AdAdSet>
+{
+    public void Configure(EntityTypeBuilder<AdAdSet> builder)
+    {
+        builder.ToTable("AdAdSets", "dbo");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.PlatformAdSetId)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.HasIndex(e => e.PlatformAdSetId)
+            .IsUnique();
+
+        builder.Property(e => e.Name)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(e => e.Status)
+            .HasMaxLength(50);
+
+        builder.Property(e => e.DailyBudget)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(e => e.CreatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.UpdatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasMany(e => e.Ads)
+            .WithOne(e => e.AdSet)
+            .HasForeignKey(e => e.AdSetId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Campaigns/AdCampaignConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Campaigns/AdCampaignConfiguration.cs
@@ -1,0 +1,59 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Campaigns;
+
+public class AdCampaignConfiguration : IEntityTypeConfiguration<AdCampaign>
+{
+    public void Configure(EntityTypeBuilder<AdCampaign> builder)
+    {
+        builder.ToTable("AdCampaigns", "dbo");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Platform)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(e => e.PlatformCampaignId)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.HasIndex(e => new { e.Platform, e.PlatformCampaignId })
+            .IsUnique();
+
+        builder.Property(e => e.Name)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(e => e.Status)
+            .HasMaxLength(50);
+
+        builder.Property(e => e.Objective)
+            .HasMaxLength(100);
+
+        builder.Property(e => e.DailyBudget)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(e => e.LifetimeBudget)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(e => e.StartDate)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.EndDate)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.CreatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.UpdatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasMany(e => e.AdSets)
+            .WithOne(e => e.Campaign)
+            .HasForeignKey(e => e.CampaignId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Campaigns/AdConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Campaigns/AdConfiguration.cs
@@ -1,0 +1,40 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Campaigns;
+
+public class AdConfiguration : IEntityTypeConfiguration<Ad>
+{
+    public void Configure(EntityTypeBuilder<Ad> builder)
+    {
+        builder.ToTable("Ads", "dbo");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.PlatformAdId)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.HasIndex(e => e.PlatformAdId)
+            .IsUnique();
+
+        builder.Property(e => e.Name)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(e => e.Status)
+            .HasMaxLength(50);
+
+        builder.Property(e => e.CreatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.UpdatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasMany(e => e.DailyMetrics)
+            .WithOne(e => e.Ad)
+            .HasForeignKey(e => e.AdId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Campaigns/AdDailyMetricConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Campaigns/AdDailyMetricConfiguration.cs
@@ -1,0 +1,35 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Campaigns;
+
+public class AdDailyMetricConfiguration : IEntityTypeConfiguration<AdDailyMetric>
+{
+    public void Configure(EntityTypeBuilder<AdDailyMetric> builder)
+    {
+        builder.ToTable("AdDailyMetrics", "dbo");
+
+        builder.HasKey(e => e.Id);
+
+        builder.HasIndex(e => new { e.AdId, e.Date })
+            .IsUnique();
+
+        builder.Property(e => e.Date)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.Spend)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(e => e.Revenue)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(e => e.CreatedAt)
+            .HasColumnType("timestamp without time zone");
+
+        // Computed properties — not mapped to columns
+        builder.Ignore(e => e.Ctr);
+        builder.Ignore(e => e.Cpc);
+        builder.Ignore(e => e.Roas);
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Campaigns/AdSyncLogConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Campaigns/AdSyncLogConfiguration.cs
@@ -1,0 +1,34 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Campaigns;
+
+public class AdSyncLogConfiguration : IEntityTypeConfiguration<AdSyncLog>
+{
+    public void Configure(EntityTypeBuilder<AdSyncLog> builder)
+    {
+        builder.ToTable("AdSyncLogs", "dbo");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Platform)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(e => e.Status)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(e => e.StartedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.CompletedAt)
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.ErrorMessage)
+            .HasMaxLength(2000);
+
+        builder.HasIndex(e => new { e.Platform, e.StartedAt });
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Campaigns/CampaignRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Campaigns/CampaignRepository.cs
@@ -1,0 +1,126 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.Campaigns;
+
+public class CampaignRepository : ICampaignRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public CampaignRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task UpsertCampaignAsync(AdCampaign campaign, CancellationToken ct = default)
+    {
+        var existing = await _context.AdCampaigns
+            .FirstOrDefaultAsync(c => c.Platform == campaign.Platform && c.PlatformCampaignId == campaign.PlatformCampaignId, ct);
+
+        if (existing is null)
+        {
+            campaign.Id = Guid.NewGuid();
+            campaign.CreatedAt = DateTime.UtcNow;
+            campaign.UpdatedAt = DateTime.UtcNow;
+            _context.AdCampaigns.Add(campaign);
+        }
+        else
+        {
+            existing.Name = campaign.Name;
+            existing.Status = campaign.Status;
+            existing.Objective = campaign.Objective;
+            existing.DailyBudget = campaign.DailyBudget;
+            existing.LifetimeBudget = campaign.LifetimeBudget;
+            existing.StartDate = campaign.StartDate;
+            existing.EndDate = campaign.EndDate;
+            existing.UpdatedAt = DateTime.UtcNow;
+            campaign.Id = existing.Id;
+        }
+    }
+
+    public async Task UpsertAdSetAsync(AdAdSet adSet, CancellationToken ct = default)
+    {
+        var existing = await _context.AdAdSets
+            .FirstOrDefaultAsync(a => a.PlatformAdSetId == adSet.PlatformAdSetId, ct);
+
+        if (existing is null)
+        {
+            adSet.Id = Guid.NewGuid();
+            adSet.CreatedAt = DateTime.UtcNow;
+            adSet.UpdatedAt = DateTime.UtcNow;
+            _context.AdAdSets.Add(adSet);
+        }
+        else
+        {
+            existing.CampaignId = adSet.CampaignId;
+            existing.Name = adSet.Name;
+            existing.Status = adSet.Status;
+            existing.DailyBudget = adSet.DailyBudget;
+            existing.UpdatedAt = DateTime.UtcNow;
+            adSet.Id = existing.Id;
+        }
+    }
+
+    public async Task UpsertAdAsync(Ad ad, CancellationToken ct = default)
+    {
+        var existing = await _context.Ads
+            .FirstOrDefaultAsync(a => a.PlatformAdId == ad.PlatformAdId, ct);
+
+        if (existing is null)
+        {
+            ad.Id = Guid.NewGuid();
+            ad.CreatedAt = DateTime.UtcNow;
+            ad.UpdatedAt = DateTime.UtcNow;
+            _context.Ads.Add(ad);
+        }
+        else
+        {
+            existing.AdSetId = ad.AdSetId;
+            existing.Name = ad.Name;
+            existing.Status = ad.Status;
+            existing.UpdatedAt = DateTime.UtcNow;
+            ad.Id = existing.Id;
+        }
+    }
+
+    public async Task UpsertDailyMetricAsync(AdDailyMetric metric, CancellationToken ct = default)
+    {
+        var existing = await _context.AdDailyMetrics
+            .FirstOrDefaultAsync(m => m.AdId == metric.AdId && m.Date == metric.Date, ct);
+
+        if (existing is null)
+        {
+            metric.Id = Guid.NewGuid();
+            metric.CreatedAt = DateTime.UtcNow;
+            _context.AdDailyMetrics.Add(metric);
+        }
+        else
+        {
+            existing.Impressions = metric.Impressions;
+            existing.Clicks = metric.Clicks;
+            existing.Spend = metric.Spend;
+            existing.Revenue = metric.Revenue;
+            existing.Conversions = metric.Conversions;
+        }
+    }
+
+    public Task AddSyncLogAsync(AdSyncLog log, CancellationToken ct = default)
+    {
+        log.Id = Guid.NewGuid();
+        _context.AdSyncLogs.Add(log);
+        return Task.CompletedTask;
+    }
+
+    public Task SaveChangesAsync(CancellationToken ct = default)
+        => _context.SaveChangesAsync(ct);
+
+    public Task<List<AdCampaign>> GetCampaignsByPlatformAsync(AdPlatform platform, CancellationToken ct = default)
+        => _context.AdCampaigns
+            .Where(c => c.Platform == platform)
+            .ToListAsync(ct);
+
+    public Task<List<AdDailyMetric>> GetMetricsByDateRangeAsync(DateTime from, DateTime to, CancellationToken ct = default)
+        => _context.AdDailyMetrics
+            .Where(m => m.Date >= from && m.Date <= to)
+            .ToListAsync(ct);
+}

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260421031552_AddCampaigns.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260421031552_AddCampaigns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421031552_AddCampaigns")]
+    partial class AddCampaigns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260421031552_AddCampaigns.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260421031552_AddCampaigns.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCampaigns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AdCampaigns",
+                schema: "dbo",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Platform = table.Column<int>(type: "integer", nullable: false),
+                    PlatformCampaignId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Name = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Objective = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    DailyBudget = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    LifetimeBudget = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    StartDate = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    EndDate = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdCampaigns", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AdSyncLogs",
+                schema: "dbo",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Platform = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true),
+                    CampaignsSynced = table.Column<int>(type: "integer", nullable: false),
+                    AdSetsSynced = table.Column<int>(type: "integer", nullable: false),
+                    AdsSynced = table.Column<int>(type: "integer", nullable: false),
+                    MetricRowsSynced = table.Column<int>(type: "integer", nullable: false),
+                    ErrorMessage = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdSyncLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AdAdSets",
+                schema: "dbo",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CampaignId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlatformAdSetId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Name = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    DailyBudget = table.Column<decimal>(type: "numeric(18,2)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdAdSets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdAdSets_AdCampaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalSchema: "dbo",
+                        principalTable: "AdCampaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Ads",
+                schema: "dbo",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AdSetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlatformAdId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Name = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Ads", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Ads_AdAdSets_AdSetId",
+                        column: x => x.AdSetId,
+                        principalSchema: "dbo",
+                        principalTable: "AdAdSets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AdDailyMetrics",
+                schema: "dbo",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AdId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    Impressions = table.Column<long>(type: "bigint", nullable: false),
+                    Clicks = table.Column<long>(type: "bigint", nullable: false),
+                    Spend = table.Column<decimal>(type: "numeric(18,2)", nullable: false),
+                    Revenue = table.Column<decimal>(type: "numeric(18,2)", nullable: false),
+                    Conversions = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AdDailyMetrics", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AdDailyMetrics_Ads_AdId",
+                        column: x => x.AdId,
+                        principalSchema: "dbo",
+                        principalTable: "Ads",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdAdSets_CampaignId",
+                schema: "dbo",
+                table: "AdAdSets",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdAdSets_PlatformAdSetId",
+                schema: "dbo",
+                table: "AdAdSets",
+                column: "PlatformAdSetId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdCampaigns_Platform_PlatformCampaignId",
+                schema: "dbo",
+                table: "AdCampaigns",
+                columns: new[] { "Platform", "PlatformCampaignId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdDailyMetrics_AdId_Date",
+                schema: "dbo",
+                table: "AdDailyMetrics",
+                columns: new[] { "AdId", "Date" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ads_AdSetId",
+                schema: "dbo",
+                table: "Ads",
+                column: "AdSetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ads_PlatformAdId",
+                schema: "dbo",
+                table: "Ads",
+                column: "PlatformAdId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AdSyncLogs_Platform_StartedAt",
+                schema: "dbo",
+                table: "AdSyncLogs",
+                columns: new[] { "Platform", "StartedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AdDailyMetrics",
+                schema: "dbo");
+
+            migrationBuilder.DropTable(
+                name: "AdSyncLogs",
+                schema: "dbo");
+
+            migrationBuilder.DropTable(
+                name: "Ads",
+                schema: "dbo");
+
+            migrationBuilder.DropTable(
+                name: "AdAdSets",
+                schema: "dbo");
+
+            migrationBuilder.DropTable(
+                name: "AdCampaigns",
+                schema: "dbo");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -1,6 +1,8 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.Bank;
+using Anela.Heblo.Domain.Features.Campaigns;
 using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence.Campaigns;
 using Anela.Heblo.Persistence.GridLayouts;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
@@ -99,6 +101,9 @@ public static class PersistenceModule
 
         // Grid Layouts repositories
         services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
+
+        // Campaigns repositories
+        services.AddScoped<ICampaignRepository, CampaignRepository>();
 
         return services;
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Campaigns/AdDailyMetricTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Campaigns/AdDailyMetricTests.cs
@@ -1,0 +1,56 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Campaigns;
+
+public class AdDailyMetricTests
+{
+    [Fact]
+    public void Ctr_WhenImpressionsAreZero_ReturnsZero()
+    {
+        var metric = new AdDailyMetric { Impressions = 0, Clicks = 0 };
+
+        metric.Ctr.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Ctr_WhenImpressionsArePositive_ReturnsClicksPercentage()
+    {
+        var metric = new AdDailyMetric { Impressions = 1000, Clicks = 50 };
+
+        metric.Ctr.Should().Be(5m);
+    }
+
+    [Fact]
+    public void Cpc_WhenClicksAreZero_ReturnsZero()
+    {
+        var metric = new AdDailyMetric { Clicks = 0, Spend = 100m };
+
+        metric.Cpc.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Cpc_WhenClicksArePositive_ReturnsSpendPerClick()
+    {
+        var metric = new AdDailyMetric { Clicks = 10, Spend = 50m };
+
+        metric.Cpc.Should().Be(5m);
+    }
+
+    [Fact]
+    public void Roas_WhenSpendIsZero_ReturnsZero()
+    {
+        var metric = new AdDailyMetric { Spend = 0m, Revenue = 200m };
+
+        metric.Roas.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Roas_WhenSpendIsPositive_ReturnsRevenueOverSpend()
+    {
+        var metric = new AdDailyMetric { Spend = 100m, Revenue = 400m };
+
+        metric.Roas.Should().Be(4m);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Campaigns/AdSyncLogTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Campaigns/AdSyncLogTests.cs
@@ -1,0 +1,75 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Campaigns;
+
+public class AdSyncLogTests
+{
+    [Fact]
+    public void Complete_SetsStatusToSuccess()
+    {
+        var log = new AdSyncLog { Status = AdSyncStatus.Running };
+
+        log.Complete(campaigns: 5, adSets: 10, ads: 20, metricRows: 100);
+
+        log.Status.Should().Be(AdSyncStatus.Success);
+    }
+
+    [Fact]
+    public void Complete_SetsCounters()
+    {
+        var log = new AdSyncLog { Status = AdSyncStatus.Running };
+
+        log.Complete(campaigns: 3, adSets: 7, ads: 15, metricRows: 60);
+
+        log.CampaignsSynced.Should().Be(3);
+        log.AdSetsSynced.Should().Be(7);
+        log.AdsSynced.Should().Be(15);
+        log.MetricRowsSynced.Should().Be(60);
+    }
+
+    [Fact]
+    public void Complete_SetsCompletedAt()
+    {
+        var before = DateTime.UtcNow;
+        var log = new AdSyncLog { Status = AdSyncStatus.Running };
+
+        log.Complete(campaigns: 1, adSets: 1, ads: 1, metricRows: 1);
+
+        log.CompletedAt.Should().NotBeNull();
+        log.CompletedAt!.Value.Should().BeOnOrAfter(before);
+    }
+
+    [Fact]
+    public void Fail_SetsStatusToFailed()
+    {
+        var log = new AdSyncLog { Status = AdSyncStatus.Running };
+
+        log.Fail("Something went wrong");
+
+        log.Status.Should().Be(AdSyncStatus.Failed);
+    }
+
+    [Fact]
+    public void Fail_SetsErrorMessage()
+    {
+        var log = new AdSyncLog { Status = AdSyncStatus.Running };
+
+        log.Fail("Connection timeout");
+
+        log.ErrorMessage.Should().Be("Connection timeout");
+    }
+
+    [Fact]
+    public void Fail_SetsCompletedAt()
+    {
+        var before = DateTime.UtcNow;
+        var log = new AdSyncLog { Status = AdSyncStatus.Running };
+
+        log.Fail("error");
+
+        log.CompletedAt.Should().NotBeNull();
+        log.CompletedAt!.Value.Should().BeOnOrAfter(before);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Campaigns/CampaignRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Campaigns/CampaignRepositoryTests.cs
@@ -1,0 +1,228 @@
+using Anela.Heblo.Domain.Features.Campaigns;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Campaigns;
+
+public class CampaignRepositoryTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly CampaignRepository _repository;
+
+    public CampaignRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"CampaignTests_{Guid.NewGuid()}")
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new CampaignRepository(_context);
+    }
+
+    // --- UpsertCampaignAsync ---
+
+    [Fact]
+    public async Task UpsertCampaignAsync_WhenNew_AddsCampaign()
+    {
+        var campaign = new AdCampaign
+        {
+            Platform = AdPlatform.Meta,
+            PlatformCampaignId = "meta-001",
+            Name = "Test Campaign"
+        };
+
+        await _repository.UpsertCampaignAsync(campaign);
+        await _repository.SaveChangesAsync();
+
+        var saved = await _context.AdCampaigns.SingleAsync();
+        Assert.Equal("meta-001", saved.PlatformCampaignId);
+        Assert.Equal("Test Campaign", saved.Name);
+        Assert.NotEqual(Guid.Empty, saved.Id);
+    }
+
+    [Fact]
+    public async Task UpsertCampaignAsync_WhenExisting_UpdatesFields()
+    {
+        var campaign = new AdCampaign
+        {
+            Platform = AdPlatform.Meta,
+            PlatformCampaignId = "meta-001",
+            Name = "Original"
+        };
+        await _repository.UpsertCampaignAsync(campaign);
+        await _repository.SaveChangesAsync();
+
+        var update = new AdCampaign
+        {
+            Platform = AdPlatform.Meta,
+            PlatformCampaignId = "meta-001",
+            Name = "Updated",
+            Status = "PAUSED"
+        };
+        await _repository.UpsertCampaignAsync(update);
+        await _repository.SaveChangesAsync();
+
+        var campaigns = await _context.AdCampaigns.ToListAsync();
+        Assert.Single(campaigns);
+        Assert.Equal("Updated", campaigns[0].Name);
+        Assert.Equal("PAUSED", campaigns[0].Status);
+    }
+
+    // --- UpsertAdSetAsync ---
+
+    [Fact]
+    public async Task UpsertAdSetAsync_WhenNew_AddsAdSet()
+    {
+        var campaignId = Guid.NewGuid();
+        var adSet = new AdAdSet
+        {
+            CampaignId = campaignId,
+            PlatformAdSetId = "adset-001",
+            Name = "Test AdSet"
+        };
+
+        await _repository.UpsertAdSetAsync(adSet);
+        await _repository.SaveChangesAsync();
+
+        var saved = await _context.AdAdSets.SingleAsync();
+        Assert.Equal("adset-001", saved.PlatformAdSetId);
+        Assert.NotEqual(Guid.Empty, saved.Id);
+    }
+
+    [Fact]
+    public async Task UpsertAdSetAsync_WhenExisting_UpdatesFields()
+    {
+        var campaignId = Guid.NewGuid();
+        var adSet = new AdAdSet { CampaignId = campaignId, PlatformAdSetId = "adset-001", Name = "Original" };
+        await _repository.UpsertAdSetAsync(adSet);
+        await _repository.SaveChangesAsync();
+
+        var update = new AdAdSet { CampaignId = campaignId, PlatformAdSetId = "adset-001", Name = "Updated", Status = "PAUSED" };
+        await _repository.UpsertAdSetAsync(update);
+        await _repository.SaveChangesAsync();
+
+        var adSets = await _context.AdAdSets.ToListAsync();
+        Assert.Single(adSets);
+        Assert.Equal("Updated", adSets[0].Name);
+        Assert.Equal("PAUSED", adSets[0].Status);
+    }
+
+    // --- UpsertAdAsync ---
+
+    [Fact]
+    public async Task UpsertAdAsync_WhenNew_AddsAd()
+    {
+        var adSetId = Guid.NewGuid();
+        var ad = new Ad { AdSetId = adSetId, PlatformAdId = "ad-001", Name = "Test Ad" };
+
+        await _repository.UpsertAdAsync(ad);
+        await _repository.SaveChangesAsync();
+
+        var saved = await _context.Ads.SingleAsync();
+        Assert.Equal("ad-001", saved.PlatformAdId);
+        Assert.NotEqual(Guid.Empty, saved.Id);
+    }
+
+    // --- UpsertDailyMetricAsync ---
+
+    [Fact]
+    public async Task UpsertDailyMetricAsync_WhenNew_AddsMetric()
+    {
+        var adId = Guid.NewGuid();
+        var date = new DateTime(2025, 1, 1);
+        var metric = new AdDailyMetric { AdId = adId, Date = date, Impressions = 1000, Clicks = 50, Spend = 10m };
+
+        await _repository.UpsertDailyMetricAsync(metric);
+        await _repository.SaveChangesAsync();
+
+        var saved = await _context.AdDailyMetrics.SingleAsync();
+        Assert.Equal(adId, saved.AdId);
+        Assert.Equal(1000, saved.Impressions);
+    }
+
+    [Fact]
+    public async Task UpsertDailyMetricAsync_WhenExisting_UpdatesMetrics()
+    {
+        var adId = Guid.NewGuid();
+        var date = new DateTime(2025, 1, 1);
+        var metric = new AdDailyMetric { AdId = adId, Date = date, Impressions = 1000, Clicks = 50, Spend = 10m };
+        await _repository.UpsertDailyMetricAsync(metric);
+        await _repository.SaveChangesAsync();
+
+        var update = new AdDailyMetric { AdId = adId, Date = date, Impressions = 2000, Clicks = 100, Spend = 20m };
+        await _repository.UpsertDailyMetricAsync(update);
+        await _repository.SaveChangesAsync();
+
+        var metrics = await _context.AdDailyMetrics.ToListAsync();
+        Assert.Single(metrics);
+        Assert.Equal(2000, metrics[0].Impressions);
+        Assert.Equal(100, metrics[0].Clicks);
+    }
+
+    // --- AddSyncLogAsync ---
+
+    [Fact]
+    public async Task AddSyncLogAsync_AddsLog()
+    {
+        var log = new AdSyncLog
+        {
+            Platform = AdPlatform.Meta,
+            Status = AdSyncStatus.Running,
+            StartedAt = DateTime.UtcNow
+        };
+
+        await _repository.AddSyncLogAsync(log);
+        await _repository.SaveChangesAsync();
+
+        var saved = await _context.AdSyncLogs.SingleAsync();
+        Assert.Equal(AdPlatform.Meta, saved.Platform);
+        Assert.NotEqual(Guid.Empty, saved.Id);
+    }
+
+    // --- GetCampaignsByPlatformAsync ---
+
+    [Fact]
+    public async Task GetCampaignsByPlatformAsync_ReturnsOnlyMatchingPlatform()
+    {
+        var meta = new AdCampaign { Platform = AdPlatform.Meta, PlatformCampaignId = "m1", Name = "Meta Campaign" };
+        var google = new AdCampaign { Platform = AdPlatform.Google, PlatformCampaignId = "g1", Name = "Google Campaign" };
+        await _repository.UpsertCampaignAsync(meta);
+        await _repository.UpsertCampaignAsync(google);
+        await _repository.SaveChangesAsync();
+
+        var result = await _repository.GetCampaignsByPlatformAsync(AdPlatform.Meta);
+
+        Assert.Single(result);
+        Assert.Equal("Meta Campaign", result[0].Name);
+    }
+
+    // --- GetMetricsByDateRangeAsync ---
+
+    [Fact]
+    public async Task GetMetricsByDateRangeAsync_ReturnsOnlyMetricsInRange()
+    {
+        var adId = Guid.NewGuid();
+        var inRange1 = new AdDailyMetric { AdId = adId, Date = new DateTime(2025, 1, 10), Impressions = 100 };
+        var inRange2 = new AdDailyMetric { AdId = adId, Date = new DateTime(2025, 1, 15), Impressions = 200 };
+        var outOfRange = new AdDailyMetric { AdId = adId, Date = new DateTime(2025, 2, 1), Impressions = 300 };
+
+        await _repository.UpsertDailyMetricAsync(inRange1);
+        await _repository.UpsertDailyMetricAsync(inRange2);
+        await _repository.UpsertDailyMetricAsync(outOfRange);
+        await _repository.SaveChangesAsync();
+
+        var result = await _repository.GetMetricsByDateRangeAsync(
+            new DateTime(2025, 1, 1),
+            new DateTime(2025, 1, 31));
+
+        Assert.Equal(2, result.Count);
+        Assert.DoesNotContain(result, m => m.Impressions == 300);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Implements sub-issue #629 of Epic #628 (Campaign Data Integration — Facebook & Google Ads).

### Changes

**Domain layer** (`Anela.Heblo.Domain/Features/Campaigns/`)
- `AdCampaign`, `AdAdSet`, `Ad`, `AdDailyMetric`, `AdSyncLog` entities
- `AdPlatform` enum (Meta, GoogleAds)
- `ICampaignRepository` interface with upsert + query methods
- `IMetaAdsClient` and `IGoogleAdsClient` client interfaces
- `AdDailyMetric` computed properties: `Ctr`, `Cpc`, `Roas` (not persisted)
- `AdSyncLog.Complete()` / `Fail()` state-transition methods

**Persistence layer** (`Anela.Heblo.Persistence/Campaigns/`)
- EF configurations for all 5 entities with unique indexes and cascade deletes
- `CampaignRepository` with upsert logic (match by platform IDs) and query methods
- `AddCampaigns` EF migration — 5 tables in `dbo` schema
- `ApplicationDbContext` and `PersistenceModule` updated

**Tests** (`Anela.Heblo.Tests/Features/Campaigns/`)
- `AdDailyMetricTests` — computed property edge cases (zero-divide guards)
- `AdSyncLogTests` — state transition methods
- `CampaignRepositoryTests` — full upsert + query coverage using EF InMemory

## Test plan
- [x] `dotnet test` — 2184 passed, 7 pre-existing FlexiBee integration test failures (require external credentials, unrelated to this PR)
- [x] `npm test -- --watchAll=false` — 769 passed, 5 skipped, 82 suites

 Generated with Claude Code