### PR TITLE
feat(data-quality): add domain model — DqtRun, InvoiceDqtResult entities and enums

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRun.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRun.cs
@@ -1,0 +1,50 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public class DqtRun : Entity<Guid>
+{
+    public DqtTestType TestType { get; private set; }
+    public DateOnly DateFrom { get; private set; }
+    public DateOnly DateTo { get; private set; }
+    public DqtRunStatus Status { get; private set; }
+    public DateTime StartedAt { get; private set; }
+    public DateTime? CompletedAt { get; private set; }
+    public DqtTriggerType TriggerType { get; private set; }
+    public int TotalChecked { get; private set; }
+    public int TotalMismatches { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public List<InvoiceDqtResult> Results { get; private set; } = new();
+
+    private DqtRun() { } // EF Core
+
+    public static DqtRun Start(DqtTestType testType, DateOnly dateFrom, DateOnly dateTo, DqtTriggerType triggerType)
+    {
+        return new DqtRun
+        {
+            Id = Guid.NewGuid(),
+            TestType = testType,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+            Status = DqtRunStatus.Running,
+            StartedAt = DateTime.UtcNow,
+            TriggerType = triggerType
+        };
+    }
+
+    public void Complete(int totalChecked, int totalMismatches)
+    {
+        Status = DqtRunStatus.Completed;
+        CompletedAt = DateTime.UtcNow;
+        TotalChecked = totalChecked;
+        TotalMismatches = totalMismatches;
+    }
+
+    public void Fail(string errorMessage)
+    {
+        Status = DqtRunStatus.Failed;
+        CompletedAt = DateTime.UtcNow;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRunStatus.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRunStatus.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtRunStatus
+{
+    Running = 1,
+    Completed = 2,
+    Failed = 3
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtTestType
+{
+    IssuedInvoiceComparison = 1
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTriggerType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTriggerType.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtTriggerType
+{
+    Scheduled = 1,
+    Manual = 2
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/IDqtRunRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/IDqtRunRepository.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Xcc.Persistance;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public interface IDqtRunRepository : IRepository<DqtRun, Guid>
+{
+    Task<DqtRun?> GetLatestByTestTypeAsync(DqtTestType testType, CancellationToken cancellationToken = default);
+    Task<(List<DqtRun> Items, int TotalCount)> GetPaginatedAsync(
+        DqtTestType? testType,
+        DqtRunStatus? status,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+    Task<DqtRun?> GetWithResultsAsync(Guid id, int resultPage, int resultPageSize, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceDqtResult.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceDqtResult.cs
@@ -1,0 +1,35 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public class InvoiceDqtResult : Entity<Guid>
+{
+    public Guid DqtRunId { get; private set; }
+    public string InvoiceCode { get; private set; } = string.Empty;
+    public InvoiceMismatchType MismatchType { get; private set; }
+    public string? ShoptetValue { get; private set; }
+    public string? FlexiValue { get; private set; }
+    public string? Details { get; private set; }
+
+    private InvoiceDqtResult() { } // EF Core
+
+    public static InvoiceDqtResult Create(
+        Guid dqtRunId,
+        string invoiceCode,
+        InvoiceMismatchType mismatchType,
+        string? shoptetValue,
+        string? flexiValue,
+        string? details)
+    {
+        return new InvoiceDqtResult
+        {
+            Id = Guid.NewGuid(),
+            DqtRunId = dqtRunId,
+            InvoiceCode = invoiceCode,
+            MismatchType = mismatchType,
+            ShoptetValue = shoptetValue,
+            FlexiValue = flexiValue,
+            Details = details
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+[Flags]
+public enum InvoiceMismatchType
+{
+    None = 0,
+    MissingInFlexi = 1,
+    MissingInShoptet = 2,
+    TotalWithVatDiffers = 4,
+    TotalWithoutVatDiffers = 8,
+    ItemsDiffer = 16
+}


### PR DESCRIPTION
## Summary
- Add DqtRun entity with Start/Complete/Fail lifecycle methods
- Add InvoiceDqtResult entity for per-invoice comparison results  
- Add enums: DqtTestType, DqtRunStatus, DqtTriggerType, InvoiceMismatchType (flags)
- Add IDqtRunRepository interface with paginated query methods

## Test plan
- [x] `dotnet build` succeeds (0 errors)
- [x] All 2198 BE tests pass
- [x] Frontend build succeeds
- [x] `dotnet format` clean

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)