### PR TITLE
feat(data-quality): add EF Core persistence — DqtRun configs, repository

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRun.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRun.cs
@@ -1,0 +1,50 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public class DqtRun : Entity<Guid>
+{
+    public DqtTestType TestType { get; private set; }
+    public DateOnly DateFrom { get; private set; }
+    public DateOnly DateTo { get; private set; }
+    public DqtRunStatus Status { get; private set; }
+    public DateTime StartedAt { get; private set; }
+    public DateTime? CompletedAt { get; private set; }
+    public DqtTriggerType TriggerType { get; private set; }
+    public int TotalChecked { get; private set; }
+    public int TotalMismatches { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public List<InvoiceDqtResult> Results { get; private set; } = new();
+
+    private DqtRun() { } // EF Core
+
+    public static DqtRun Start(DqtTestType testType, DateOnly dateFrom, DateOnly dateTo, DqtTriggerType triggerType)
+    {
+        return new DqtRun
+        {
+            Id = Guid.NewGuid(),
+            TestType = testType,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+            Status = DqtRunStatus.Running,
+            StartedAt = DateTime.UtcNow,
+            TriggerType = triggerType
+        };
+    }
+
+    public void Complete(int totalChecked, int totalMismatches)
+    {
+        Status = DqtRunStatus.Completed;
+        CompletedAt = DateTime.UtcNow;
+        TotalChecked = totalChecked;
+        TotalMismatches = totalMismatches;
+    }
+
+    public void Fail(string errorMessage)
+    {
+        Status = DqtRunStatus.Failed;
+        CompletedAt = DateTime.UtcNow;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRunStatus.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRunStatus.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtRunStatus
+{
+    Running = 1,
+    Completed = 2,
+    Failed = 3
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtTestType
+{
+    IssuedInvoiceComparison = 1
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTriggerType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTriggerType.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtTriggerType
+{
+    Scheduled = 1,
+    Manual = 2
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/IDqtRunRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/IDqtRunRepository.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Xcc.Persistance;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public interface IDqtRunRepository : IRepository<DqtRun, Guid>
+{
+    Task<DqtRun?> GetLatestByTestTypeAsync(DqtTestType testType, CancellationToken cancellationToken = default);
+    Task<(List<DqtRun> Items, int TotalCount)> GetPaginatedAsync(
+        DqtTestType? testType,
+        DqtRunStatus? status,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+    Task<DqtRun?> GetWithResultsAsync(Guid id, int resultPage, int resultPageSize, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceDqtResult.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceDqtResult.cs
@@ -1,0 +1,35 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public class InvoiceDqtResult : Entity<Guid>
+{
+    public Guid DqtRunId { get; private set; }
+    public string InvoiceCode { get; private set; } = string.Empty;
+    public InvoiceMismatchType MismatchType { get; private set; }
+    public string? ShoptetValue { get; private set; }
+    public string? FlexiValue { get; private set; }
+    public string? Details { get; private set; }
+
+    private InvoiceDqtResult() { } // EF Core
+
+    public static InvoiceDqtResult Create(
+        Guid dqtRunId,
+        string invoiceCode,
+        InvoiceMismatchType mismatchType,
+        string? shoptetValue,
+        string? flexiValue,
+        string? details)
+    {
+        return new InvoiceDqtResult
+        {
+            Id = Guid.NewGuid(),
+            DqtRunId = dqtRunId,
+            InvoiceCode = invoiceCode,
+            MismatchType = mismatchType,
+            ShoptetValue = shoptetValue,
+            FlexiValue = flexiValue,
+            Details = details
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+[Flags]
+public enum InvoiceMismatchType
+{
+    None = 0,
+    MissingInFlexi = 1,
+    MissingInShoptet = 2,
+    TotalWithVatDiffers = 4,
+    TotalWithoutVatDiffers = 8,
+    ItemsDiffer = 16
+}

--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
@@ -85,6 +86,10 @@ public class ApplicationDbContext : DbContext
 
     // Marketing Invoices module
     public DbSet<ImportedMarketingTransaction> ImportedMarketingTransactions { get; set; } = null!;
+
+    // Data Quality module
+    public DbSet<DqtRun> DqtRuns { get; set; } = null!;
+    public DbSet<InvoiceDqtResult> InvoiceDqtResults { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunConfiguration.cs
@@ -1,0 +1,70 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.DataQuality;
+
+public class DqtRunConfiguration : IEntityTypeConfiguration<DqtRun>
+{
+    public void Configure(EntityTypeBuilder<DqtRun> builder)
+    {
+        builder.ToTable("dqt_runs");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.TestType)
+            .HasColumnName("test_type")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.DateFrom)
+            .HasColumnName("date_from")
+            .IsRequired();
+
+        builder.Property(e => e.DateTo)
+            .HasColumnName("date_to")
+            .IsRequired();
+
+        builder.Property(e => e.Status)
+            .HasColumnName("status")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.StartedAt)
+            .HasColumnName("started_at")
+            .HasColumnType("timestamp without time zone")
+            .IsRequired();
+
+        builder.Property(e => e.CompletedAt)
+            .HasColumnName("completed_at")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.TriggerType)
+            .HasColumnName("trigger_type")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.TotalChecked)
+            .HasColumnName("total_checked")
+            .IsRequired();
+
+        builder.Property(e => e.TotalMismatches)
+            .HasColumnName("total_mismatches")
+            .IsRequired();
+
+        builder.Property(e => e.ErrorMessage)
+            .HasColumnName("error_message");
+
+        builder.HasMany(e => e.Results)
+            .WithOne()
+            .HasForeignKey(e => e.DqtRunId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => new { e.TestType, e.StartedAt })
+            .HasDatabaseName("IX_dqt_runs_test_type_started_at");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunRepository.cs
@@ -1,0 +1,73 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.DataQuality;
+
+public class DqtRunRepository : BaseRepository<DqtRun, Guid>, IDqtRunRepository
+{
+    public DqtRunRepository(ApplicationDbContext context) : base(context)
+    {
+    }
+
+    public async Task<DqtRun?> GetLatestByTestTypeAsync(DqtTestType testType, CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Where(r => r.TestType == testType)
+            .OrderByDescending(r => r.StartedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<(List<DqtRun> Items, int TotalCount)> GetPaginatedAsync(
+        DqtTestType? testType,
+        DqtRunStatus? status,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var query = DbSet.AsQueryable();
+
+        if (testType.HasValue)
+        {
+            query = query.Where(r => r.TestType == testType.Value);
+        }
+
+        if (status.HasValue)
+        {
+            query = query.Where(r => r.Status == status.Value);
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(r => r.StartedAt)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public async Task<DqtRun?> GetWithResultsAsync(Guid id, int resultPage, int resultPageSize, CancellationToken cancellationToken = default)
+    {
+        var run = await DbSet
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+
+        if (run == null)
+        {
+            return null;
+        }
+
+        var results = await Context.Set<InvoiceDqtResult>()
+            .Where(r => r.DqtRunId == id)
+            .OrderBy(r => r.InvoiceCode)
+            .Skip((resultPage - 1) * resultPageSize)
+            .Take(resultPageSize)
+            .ToListAsync(cancellationToken);
+
+        run.Results.Clear();
+        run.Results.AddRange(results);
+
+        return run;
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/DataQuality/InvoiceDqtResultConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/DataQuality/InvoiceDqtResultConfiguration.cs
@@ -1,0 +1,48 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.DataQuality;
+
+public class InvoiceDqtResultConfiguration : IEntityTypeConfiguration<InvoiceDqtResult>
+{
+    public void Configure(EntityTypeBuilder<InvoiceDqtResult> builder)
+    {
+        builder.ToTable("invoice_dqt_results");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.DqtRunId)
+            .HasColumnName("dqt_run_id")
+            .IsRequired();
+
+        builder.Property(e => e.InvoiceCode)
+            .HasColumnName("invoice_code")
+            .IsRequired();
+
+        builder.Property(e => e.MismatchType)
+            .HasColumnName("mismatch_type")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.ShoptetValue)
+            .HasColumnName("shoptet_value");
+
+        builder.Property(e => e.FlexiValue)
+            .HasColumnName("flexi_value");
+
+        builder.Property(e => e.Details)
+            .HasColumnName("details")
+            .HasMaxLength(4000);
+
+        builder.HasIndex(e => e.DqtRunId)
+            .HasDatabaseName("IX_invoice_dqt_results_dqt_run_id");
+
+        builder.HasIndex(e => e.InvoiceCode)
+            .HasDatabaseName("IX_invoice_dqt_results_invoice_code");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Persistence.GridLayouts;
@@ -6,6 +7,7 @@ using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Persistence.BackgroundJobs;
+using Anela.Heblo.Persistence.DataQuality;
 using Anela.Heblo.Persistence.Catalog.Stock;
 using Anela.Heblo.Persistence.Dashboard;
 using Anela.Heblo.Persistence.Features.Bank;
@@ -107,6 +109,9 @@ public static class PersistenceModule
 
         // Grid Layouts repositories
         services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
+
+        // Data Quality repositories
+        services.AddScoped<IDqtRunRepository, DqtRunRepository>();
 
         return services;
     }


### PR DESCRIPTION
## Summary

- **DqtRunConfiguration**: maps `DqtRun` to `dqt_runs` table with snake_case columns, enum-as-int conversions for `TestType`/`Status`/`TriggerType`, `timestamp without time zone` for datetime columns, and cascade delete to `InvoiceDqtResult`
- **InvoiceDqtResultConfiguration**: maps `InvoiceDqtResult` to `invoice_dqt_results`, stores `[Flags]` `InvoiceMismatchType` enum as int (preserves bitmask), indexes on `dqt_run_id` and `invoice_code`
- **DqtRunRepository**: extends `BaseRepository<DqtRun, Guid>`, implements `IDqtRunRepository` with paginated queries and a separate paginated results loader
- **ApplicationDbContext**: adds `DbSet<DqtRun>` and `DbSet<InvoiceDqtResult>`
- **PersistenceModule**: registers `IDqtRunRepository → DqtRunRepository` in DI

## Test plan

- [x] `dotnet build Anela.Heblo.sln` — 0 errors
- [x] `dotnet format --verify-no-changes` — no formatting violations
- [x] `dotnet test` — 2205 passed, 0 failed

Closes #697
Part of epic #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)