### PR TITLE
feat(dqt): add invoice comparison service with unit tests (#698)

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiIssuedInvoiceClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Invoices/FlexiIssuedInvoiceClient.cs
@@ -80,4 +80,9 @@ public class FlexiIssuedInvoiceClient : Anela.Heblo.Domain.Features.Invoices.IIs
             throw;
         }
     }
+
+    public Task<List<IssuedInvoiceDetail>> GetAllAsync(DateOnly from, DateOnly to, CancellationToken ct)
+    {
+        throw new NotImplementedException("GetAllAsync is blocked on FlexiBee SDK support.");
+    }
 }

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/IInvoiceDqtComparer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/IInvoiceDqtComparer.cs
@@ -1,0 +1,23 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+
+namespace Anela.Heblo.Application.Features.DataQuality.Services;
+
+public interface IInvoiceDqtComparer
+{
+    Task<InvoiceDqtComparisonResult> CompareAsync(DateOnly from, DateOnly to, CancellationToken ct = default);
+}
+
+public class InvoiceDqtComparisonResult
+{
+    public List<InvoiceDqtMismatch> Mismatches { get; init; } = new();
+    public int TotalChecked { get; init; }
+}
+
+public class InvoiceDqtMismatch
+{
+    public string InvoiceCode { get; init; } = string.Empty;
+    public InvoiceMismatchType MismatchType { get; init; }
+    public string? ShoptetValue { get; init; }
+    public string? FlexiValue { get; init; }
+    public string? Details { get; init; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/InvoiceDqtComparer.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/Services/InvoiceDqtComparer.cs
@@ -1,0 +1,148 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Domain.Features.Invoices;
+
+namespace Anela.Heblo.Application.Features.DataQuality.Services;
+
+public class InvoiceDqtComparer : IInvoiceDqtComparer
+{
+    private const decimal Tolerance = 0.02m;
+
+    private readonly IIssuedInvoiceSource _shoptetSource;
+    private readonly IIssuedInvoiceClient _flexiClient;
+
+    public InvoiceDqtComparer(IIssuedInvoiceSource shoptetSource, IIssuedInvoiceClient flexiClient)
+    {
+        _shoptetSource = shoptetSource;
+        _flexiClient = flexiClient;
+    }
+
+    public async Task<InvoiceDqtComparisonResult> CompareAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
+    {
+        var shoptetQuery = new IssuedInvoiceSourceQuery
+        {
+            RequestId = $"dqt-{from:yyyy-MM-dd}-{to:yyyy-MM-dd}",
+            DateFrom = from.ToDateTime(TimeOnly.MinValue),
+            DateTo = to.ToDateTime(TimeOnly.MinValue)
+        };
+
+        var shoptetBatches = await _shoptetSource.GetAllAsync(shoptetQuery, ct);
+        var shoptetInvoices = shoptetBatches.SelectMany(b => b.Invoices).ToList();
+
+        var flexiInvoices = await _flexiClient.GetAllAsync(from, to, ct);
+
+        var shoptetByCode = shoptetInvoices.ToDictionary(i => i.Code);
+        var flexiByCode = flexiInvoices.ToDictionary(i => i.Code);
+
+        var allCodes = shoptetByCode.Keys.Union(flexiByCode.Keys).ToHashSet();
+        var mismatches = new List<InvoiceDqtMismatch>();
+
+        foreach (var code in allCodes)
+        {
+            var inShoptet = shoptetByCode.TryGetValue(code, out var shoptetInvoice);
+            var inFlexi = flexiByCode.TryGetValue(code, out var flexiInvoice);
+
+            if (inShoptet && !inFlexi)
+            {
+                mismatches.Add(new InvoiceDqtMismatch
+                {
+                    InvoiceCode = code,
+                    MismatchType = InvoiceMismatchType.MissingInFlexi
+                });
+                continue;
+            }
+
+            if (!inShoptet && inFlexi)
+            {
+                mismatches.Add(new InvoiceDqtMismatch
+                {
+                    InvoiceCode = code,
+                    MismatchType = InvoiceMismatchType.MissingInShoptet
+                });
+                continue;
+            }
+
+            // Both exist — compare
+            var flags = InvoiceMismatchType.None;
+            string? shoptetVal = null;
+            string? flexiVal = null;
+            string? details = null;
+
+            if (Math.Abs(shoptetInvoice!.Price.TotalWithVat - flexiInvoice!.Price.TotalWithVat) > Tolerance)
+            {
+                flags |= InvoiceMismatchType.TotalWithVatDiffers;
+                shoptetVal = shoptetInvoice.Price.TotalWithVat.ToString("F2");
+                flexiVal = flexiInvoice.Price.TotalWithVat.ToString("F2");
+            }
+
+            if (Math.Abs(shoptetInvoice.Price.TotalWithoutVat - flexiInvoice.Price.TotalWithoutVat) > Tolerance)
+            {
+                flags |= InvoiceMismatchType.TotalWithoutVatDiffers;
+                shoptetVal ??= shoptetInvoice.Price.TotalWithoutVat.ToString("F2");
+                flexiVal ??= flexiInvoice.Price.TotalWithoutVat.ToString("F2");
+            }
+
+            var itemDiff = CompareItems(shoptetInvoice.Items, flexiInvoice.Items);
+            if (itemDiff != null)
+            {
+                flags |= InvoiceMismatchType.ItemsDiffer;
+                details = itemDiff;
+            }
+
+            if (flags != InvoiceMismatchType.None)
+            {
+                mismatches.Add(new InvoiceDqtMismatch
+                {
+                    InvoiceCode = code,
+                    MismatchType = flags,
+                    ShoptetValue = shoptetVal,
+                    FlexiValue = flexiVal,
+                    Details = details
+                });
+            }
+        }
+
+        return new InvoiceDqtComparisonResult
+        {
+            Mismatches = mismatches,
+            TotalChecked = allCodes.Count
+        };
+    }
+
+    private static string? CompareItems(List<IssuedInvoiceDetailItem> shoptetItems, List<IssuedInvoiceDetailItem> flexiItems)
+    {
+        var shoptetByCode = shoptetItems.ToDictionary(i => i.Code);
+        var flexiByCode = flexiItems.ToDictionary(i => i.Code);
+        var allCodes = shoptetByCode.Keys.Union(flexiByCode.Keys);
+
+        var diffs = new List<string>();
+
+        foreach (var code in allCodes)
+        {
+            var inShoptet = shoptetByCode.TryGetValue(code, out var sItem);
+            var inFlexi = flexiByCode.TryGetValue(code, out var fItem);
+
+            if (inShoptet && !inFlexi)
+            {
+                diffs.Add($"Item {code}: missing in Flexi");
+                continue;
+            }
+
+            if (!inShoptet && inFlexi)
+            {
+                diffs.Add($"Item {code}: missing in Shoptet");
+                continue;
+            }
+
+            if (sItem!.Amount != fItem!.Amount)
+                diffs.Add($"Item {code}: Amount shoptet={sItem.Amount} flexi={fItem.Amount}");
+
+            if (Math.Abs(sItem.ItemPrice.WithVat - fItem.ItemPrice.WithVat) > Tolerance)
+                diffs.Add($"Item {code}: WithVat shoptet={sItem.ItemPrice.WithVat:F2} flexi={fItem.ItemPrice.WithVat:F2}");
+
+            if (Math.Abs(sItem.ItemPrice.WithoutVat - fItem.ItemPrice.WithoutVat) > Tolerance)
+                diffs.Add($"Item {code}: WithoutVat shoptet={sItem.ItemPrice.WithoutVat:F2} flexi={fItem.ItemPrice.WithoutVat:F2}");
+        }
+
+        return diffs.Count > 0 ? string.Join("; ", diffs) : null;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRun.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRun.cs
@@ -1,0 +1,50 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public class DqtRun : Entity<Guid>
+{
+    public DqtTestType TestType { get; private set; }
+    public DateOnly DateFrom { get; private set; }
+    public DateOnly DateTo { get; private set; }
+    public DqtRunStatus Status { get; private set; }
+    public DateTime StartedAt { get; private set; }
+    public DateTime? CompletedAt { get; private set; }
+    public DqtTriggerType TriggerType { get; private set; }
+    public int TotalChecked { get; private set; }
+    public int TotalMismatches { get; private set; }
+    public string? ErrorMessage { get; private set; }
+
+    public List<InvoiceDqtResult> Results { get; private set; } = new();
+
+    private DqtRun() { } // EF Core
+
+    public static DqtRun Start(DqtTestType testType, DateOnly dateFrom, DateOnly dateTo, DqtTriggerType triggerType)
+    {
+        return new DqtRun
+        {
+            Id = Guid.NewGuid(),
+            TestType = testType,
+            DateFrom = dateFrom,
+            DateTo = dateTo,
+            Status = DqtRunStatus.Running,
+            StartedAt = DateTime.UtcNow,
+            TriggerType = triggerType
+        };
+    }
+
+    public void Complete(int totalChecked, int totalMismatches)
+    {
+        Status = DqtRunStatus.Completed;
+        CompletedAt = DateTime.UtcNow;
+        TotalChecked = totalChecked;
+        TotalMismatches = totalMismatches;
+    }
+
+    public void Fail(string errorMessage)
+    {
+        Status = DqtRunStatus.Failed;
+        CompletedAt = DateTime.UtcNow;
+        ErrorMessage = errorMessage;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRunStatus.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtRunStatus.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtRunStatus
+{
+    Running = 1,
+    Completed = 2,
+    Failed = 3
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTestType.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtTestType
+{
+    IssuedInvoiceComparison = 1
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTriggerType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/DqtTriggerType.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public enum DqtTriggerType
+{
+    Scheduled = 1,
+    Manual = 2
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/IDqtRunRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/IDqtRunRepository.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Xcc.Persistance;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public interface IDqtRunRepository : IRepository<DqtRun, Guid>
+{
+    Task<DqtRun?> GetLatestByTestTypeAsync(DqtTestType testType, CancellationToken cancellationToken = default);
+    Task<(List<DqtRun> Items, int TotalCount)> GetPaginatedAsync(
+        DqtTestType? testType,
+        DqtRunStatus? status,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+    Task<DqtRun?> GetWithResultsAsync(Guid id, int resultPage, int resultPageSize, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceDqtResult.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceDqtResult.cs
@@ -1,0 +1,35 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+public class InvoiceDqtResult : Entity<Guid>
+{
+    public Guid DqtRunId { get; private set; }
+    public string InvoiceCode { get; private set; } = string.Empty;
+    public InvoiceMismatchType MismatchType { get; private set; }
+    public string? ShoptetValue { get; private set; }
+    public string? FlexiValue { get; private set; }
+    public string? Details { get; private set; }
+
+    private InvoiceDqtResult() { } // EF Core
+
+    public static InvoiceDqtResult Create(
+        Guid dqtRunId,
+        string invoiceCode,
+        InvoiceMismatchType mismatchType,
+        string? shoptetValue,
+        string? flexiValue,
+        string? details)
+    {
+        return new InvoiceDqtResult
+        {
+            Id = Guid.NewGuid(),
+            DqtRunId = dqtRunId,
+            InvoiceCode = invoiceCode,
+            MismatchType = mismatchType,
+            ShoptetValue = shoptetValue,
+            FlexiValue = flexiValue,
+            Details = details
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/DataQuality/InvoiceMismatchType.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Domain.Features.DataQuality;
+
+[Flags]
+public enum InvoiceMismatchType
+{
+    None = 0,
+    MissingInFlexi = 1,
+    MissingInShoptet = 2,
+    TotalWithVatDiffers = 4,
+    TotalWithoutVatDiffers = 8,
+    ItemsDiffer = 16
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Invoices/IIssuedInvoiceClient.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Invoices/IIssuedInvoiceClient.cs
@@ -7,6 +7,7 @@ public interface IIssuedInvoiceClient
 {
     Task<string?> SaveAsync(IssuedInvoiceDetail invoiceDetail, CancellationToken cancellationToken = default);
     Task<IssuedInvoiceDetail> GetAsync(string invoiceId, CancellationToken cancellationToken = default);
+    Task<List<IssuedInvoiceDetail>> GetAllAsync(DateOnly from, DateOnly to, CancellationToken ct);
 }
 
 

--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
@@ -85,6 +86,10 @@ public class ApplicationDbContext : DbContext
 
     // Marketing Invoices module
     public DbSet<ImportedMarketingTransaction> ImportedMarketingTransactions { get; set; } = null!;
+
+    // Data Quality module
+    public DbSet<DqtRun> DqtRuns { get; set; } = null!;
+    public DbSet<InvoiceDqtResult> InvoiceDqtResults { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunConfiguration.cs
@@ -1,0 +1,70 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.DataQuality;
+
+public class DqtRunConfiguration : IEntityTypeConfiguration<DqtRun>
+{
+    public void Configure(EntityTypeBuilder<DqtRun> builder)
+    {
+        builder.ToTable("dqt_runs");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.TestType)
+            .HasColumnName("test_type")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.DateFrom)
+            .HasColumnName("date_from")
+            .IsRequired();
+
+        builder.Property(e => e.DateTo)
+            .HasColumnName("date_to")
+            .IsRequired();
+
+        builder.Property(e => e.Status)
+            .HasColumnName("status")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.StartedAt)
+            .HasColumnName("started_at")
+            .HasColumnType("timestamp without time zone")
+            .IsRequired();
+
+        builder.Property(e => e.CompletedAt)
+            .HasColumnName("completed_at")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.TriggerType)
+            .HasColumnName("trigger_type")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.TotalChecked)
+            .HasColumnName("total_checked")
+            .IsRequired();
+
+        builder.Property(e => e.TotalMismatches)
+            .HasColumnName("total_mismatches")
+            .IsRequired();
+
+        builder.Property(e => e.ErrorMessage)
+            .HasColumnName("error_message");
+
+        builder.HasMany(e => e.Results)
+            .WithOne()
+            .HasForeignKey(e => e.DqtRunId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => new { e.TestType, e.StartedAt })
+            .HasDatabaseName("IX_dqt_runs_test_type_started_at");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunRepository.cs
@@ -1,0 +1,73 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.DataQuality;
+
+public class DqtRunRepository : BaseRepository<DqtRun, Guid>, IDqtRunRepository
+{
+    public DqtRunRepository(ApplicationDbContext context) : base(context)
+    {
+    }
+
+    public async Task<DqtRun?> GetLatestByTestTypeAsync(DqtTestType testType, CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Where(r => r.TestType == testType)
+            .OrderByDescending(r => r.StartedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<(List<DqtRun> Items, int TotalCount)> GetPaginatedAsync(
+        DqtTestType? testType,
+        DqtRunStatus? status,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var query = DbSet.AsQueryable();
+
+        if (testType.HasValue)
+        {
+            query = query.Where(r => r.TestType == testType.Value);
+        }
+
+        if (status.HasValue)
+        {
+            query = query.Where(r => r.Status == status.Value);
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(r => r.StartedAt)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public async Task<DqtRun?> GetWithResultsAsync(Guid id, int resultPage, int resultPageSize, CancellationToken cancellationToken = default)
+    {
+        var run = await DbSet
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+
+        if (run == null)
+        {
+            return null;
+        }
+
+        var results = await Context.Set<InvoiceDqtResult>()
+            .Where(r => r.DqtRunId == id)
+            .OrderBy(r => r.InvoiceCode)
+            .Skip((resultPage - 1) * resultPageSize)
+            .Take(resultPageSize)
+            .ToListAsync(cancellationToken);
+
+        run.Results.Clear();
+        run.Results.AddRange(results);
+
+        return run;
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/DataQuality/InvoiceDqtResultConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/DataQuality/InvoiceDqtResultConfiguration.cs
@@ -1,0 +1,48 @@
+using Anela.Heblo.Domain.Features.DataQuality;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.DataQuality;
+
+public class InvoiceDqtResultConfiguration : IEntityTypeConfiguration<InvoiceDqtResult>
+{
+    public void Configure(EntityTypeBuilder<InvoiceDqtResult> builder)
+    {
+        builder.ToTable("invoice_dqt_results");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.DqtRunId)
+            .HasColumnName("dqt_run_id")
+            .IsRequired();
+
+        builder.Property(e => e.InvoiceCode)
+            .HasColumnName("invoice_code")
+            .IsRequired();
+
+        builder.Property(e => e.MismatchType)
+            .HasColumnName("mismatch_type")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.ShoptetValue)
+            .HasColumnName("shoptet_value");
+
+        builder.Property(e => e.FlexiValue)
+            .HasColumnName("flexi_value");
+
+        builder.Property(e => e.Details)
+            .HasColumnName("details")
+            .HasMaxLength(4000);
+
+        builder.HasIndex(e => e.DqtRunId)
+            .HasDatabaseName("IX_invoice_dqt_results_dqt_run_id");
+
+        builder.HasIndex(e => e.InvoiceCode)
+            .HasDatabaseName("IX_invoice_dqt_results_invoice_code");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Persistence.GridLayouts;
@@ -6,6 +7,7 @@ using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Persistence.BackgroundJobs;
+using Anela.Heblo.Persistence.DataQuality;
 using Anela.Heblo.Persistence.Catalog.Stock;
 using Anela.Heblo.Persistence.Dashboard;
 using Anela.Heblo.Persistence.Features.Bank;
@@ -107,6 +109,9 @@ public static class PersistenceModule
 
         // Grid Layouts repositories
         services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
+
+        // Data Quality repositories
+        services.AddScoped<IDqtRunRepository, DqtRunRepository>();
 
         return services;
     }

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/InvoiceDqtComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/InvoiceDqtComparerTests.cs
@@ -1,0 +1,219 @@
+using Anela.Heblo.Application.Features.DataQuality.Services;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Domain.Features.Invoices;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.DataQuality;
+
+public class InvoiceDqtComparerTests
+{
+    private readonly Mock<IIssuedInvoiceSource> _sourceMock = new();
+    private readonly Mock<IIssuedInvoiceClient> _clientMock = new();
+    private readonly InvoiceDqtComparer _sut;
+
+    private static readonly DateOnly From = new(2026, 1, 1);
+    private static readonly DateOnly To = new(2026, 1, 31);
+
+    public InvoiceDqtComparerTests()
+    {
+        _sut = new InvoiceDqtComparer(_sourceMock.Object, _clientMock.Object);
+    }
+
+    private void SetupShoptet(params IssuedInvoiceDetail[] invoices)
+    {
+        var batch = new IssuedInvoiceDetailBatch { Invoices = invoices.ToList() };
+        _sourceMock.Setup(s => s.GetAllAsync(It.IsAny<IssuedInvoiceSourceQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<IssuedInvoiceDetailBatch> { batch });
+    }
+
+    private void SetupFlexi(params IssuedInvoiceDetail[] invoices)
+    {
+        _clientMock.Setup(c => c.GetAllAsync(From, To, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invoices.ToList());
+    }
+
+    private static IssuedInvoiceDetail MakeInvoice(string code, decimal totalWithVat = 100m, decimal totalWithoutVat = 80m, List<IssuedInvoiceDetailItem>? items = null)
+    {
+        return new IssuedInvoiceDetail
+        {
+            Code = code,
+            Price = new InvoicePrice { TotalWithVat = totalWithVat, TotalWithoutVat = totalWithoutVat },
+            Items = items ?? new List<IssuedInvoiceDetailItem>()
+        };
+    }
+
+    private static IssuedInvoiceDetailItem MakeItem(string code, decimal amount = 1m, decimal withVat = 100m, decimal withoutVat = 80m)
+    {
+        return new IssuedInvoiceDetailItem
+        {
+            Code = code,
+            Name = code,
+            VariantName = string.Empty,
+            AmountUnit = "ks",
+            Amount = amount,
+            ItemPrice = new InvoicePrice { WithVat = withVat, WithoutVat = withoutVat },
+            BuyPrice = new InvoicePrice()
+        };
+    }
+
+    [Fact]
+    public async Task BothEmpty_ReturnsZeroCheckedZeroMismatches()
+    {
+        SetupShoptet();
+        SetupFlexi();
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Equal(0, result.TotalChecked);
+        Assert.Empty(result.Mismatches);
+    }
+
+    [Fact]
+    public async Task InvoiceInShoptetOnly_FlagsMissingInFlexi()
+    {
+        SetupShoptet(MakeInvoice("INV-001"));
+        SetupFlexi();
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.Equal("INV-001", result.Mismatches[0].InvoiceCode);
+        Assert.Equal(InvoiceMismatchType.MissingInFlexi, result.Mismatches[0].MismatchType);
+    }
+
+    [Fact]
+    public async Task InvoiceInFlexiOnly_FlagsMissingInShoptet()
+    {
+        SetupShoptet();
+        SetupFlexi(MakeInvoice("INV-002"));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.Equal("INV-002", result.Mismatches[0].InvoiceCode);
+        Assert.Equal(InvoiceMismatchType.MissingInShoptet, result.Mismatches[0].MismatchType);
+    }
+
+    [Fact]
+    public async Task MatchingInvoices_ReturnsZeroMismatches()
+    {
+        var inv = MakeInvoice("INV-003");
+        SetupShoptet(inv);
+        SetupFlexi(MakeInvoice("INV-003"));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Equal(1, result.TotalChecked);
+        Assert.Empty(result.Mismatches);
+    }
+
+    [Fact]
+    public async Task WithinTolerance_NoMismatch()
+    {
+        SetupShoptet(MakeInvoice("INV-004", totalWithVat: 100.00m, totalWithoutVat: 80.00m));
+        SetupFlexi(MakeInvoice("INV-004", totalWithVat: 100.01m, totalWithoutVat: 80.02m));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Empty(result.Mismatches);
+    }
+
+    [Fact]
+    public async Task WithVatDiffers_FlagsTotalWithVatDiffers()
+    {
+        SetupShoptet(MakeInvoice("INV-005", totalWithVat: 100.00m));
+        SetupFlexi(MakeInvoice("INV-005", totalWithVat: 110.00m));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.True(result.Mismatches[0].MismatchType.HasFlag(InvoiceMismatchType.TotalWithVatDiffers));
+    }
+
+    [Fact]
+    public async Task WithoutVatDiffers_FlagsTotalWithoutVatDiffers()
+    {
+        SetupShoptet(MakeInvoice("INV-006", totalWithoutVat: 80.00m));
+        SetupFlexi(MakeInvoice("INV-006", totalWithoutVat: 90.00m));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.True(result.Mismatches[0].MismatchType.HasFlag(InvoiceMismatchType.TotalWithoutVatDiffers));
+    }
+
+    [Fact]
+    public async Task ItemsDiffer_ByProductCode()
+    {
+        var shoptetItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-A"), MakeItem("PROD-B") };
+        var flexiItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-A") };
+
+        SetupShoptet(MakeInvoice("INV-007", items: shoptetItems));
+        SetupFlexi(MakeInvoice("INV-007", items: flexiItems));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.True(result.Mismatches[0].MismatchType.HasFlag(InvoiceMismatchType.ItemsDiffer));
+        Assert.Contains("PROD-B", result.Mismatches[0].Details);
+    }
+
+    [Fact]
+    public async Task ItemsDiffer_ByAmount()
+    {
+        var shoptetItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-C", amount: 2m) };
+        var flexiItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-C", amount: 3m) };
+
+        SetupShoptet(MakeInvoice("INV-008", items: shoptetItems));
+        SetupFlexi(MakeInvoice("INV-008", items: flexiItems));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.True(result.Mismatches[0].MismatchType.HasFlag(InvoiceMismatchType.ItemsDiffer));
+        Assert.Contains("Amount", result.Mismatches[0].Details);
+    }
+
+    [Fact]
+    public async Task ItemPriceDiffers()
+    {
+        var shoptetItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-D", withVat: 50m) };
+        var flexiItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-D", withVat: 60m) };
+
+        SetupShoptet(MakeInvoice("INV-009", items: shoptetItems));
+        SetupFlexi(MakeInvoice("INV-009", items: flexiItems));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Single(result.Mismatches);
+        Assert.True(result.Mismatches[0].MismatchType.HasFlag(InvoiceMismatchType.ItemsDiffer));
+        Assert.Contains("WithVat", result.Mismatches[0].Details);
+    }
+
+    [Fact]
+    public async Task MultipleIssues_CombinesFlags()
+    {
+        // INV-010: missing in Flexi
+        // INV-011: total mismatch + item diff
+        var shoptetItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-X", withVat: 50m) };
+        var flexiItems = new List<IssuedInvoiceDetailItem> { MakeItem("PROD-X", withVat: 60m) };
+
+        SetupShoptet(
+            MakeInvoice("INV-010"),
+            MakeInvoice("INV-011", totalWithVat: 100m, items: shoptetItems));
+        SetupFlexi(
+            MakeInvoice("INV-011", totalWithVat: 200m, items: flexiItems));
+
+        var result = await _sut.CompareAsync(From, To);
+
+        Assert.Equal(2, result.TotalChecked);
+        Assert.Equal(2, result.Mismatches.Count);
+
+        var missing = result.Mismatches.Single(m => m.InvoiceCode == "INV-010");
+        Assert.Equal(InvoiceMismatchType.MissingInFlexi, missing.MismatchType);
+
+        var combined = result.Mismatches.Single(m => m.InvoiceCode == "INV-011");
+        Assert.True(combined.MismatchType.HasFlag(InvoiceMismatchType.TotalWithVatDiffers));
+        Assert.True(combined.MismatchType.HasFlag(InvoiceMismatchType.ItemsDiffer));
+    }
+}


### PR DESCRIPTION
## Summary

Implements DQT #3 — Invoice Comparison Service.

- Adds `GetAllAsync(DateOnly from, DateOnly to, CancellationToken ct)` to `IIssuedInvoiceClient`
- Adds `NotImplementedException` stub in `FlexiIssuedInvoiceClient` (blocked on FlexiBee SDK)
- Creates `IInvoiceDqtComparer` interface with `InvoiceDqtComparisonResult` and `InvoiceDqtMismatch` types
- Implements `InvoiceDqtComparer` with ±0.02 tolerance, flag-based mismatch detection, and item-level diffing
- 11 unit tests covering all scenarios: missing in either system, price tolerance, combined flags, item diffs by code/amount/price

## Test plan

- [x] `BothEmpty_ReturnsZeroCheckedZeroMismatches`
- [x] `InvoiceInShoptetOnly_FlagsMissingInFlexi`
- [x] `InvoiceInFlexiOnly_FlagsMissingInShoptet`
- [x] `MatchingInvoices_ReturnsZeroMismatches`
- [x] `WithinTolerance_NoMismatch`
- [x] `WithVatDiffers_FlagsTotalWithVatDiffers`
- [x] `WithoutVatDiffers_FlagsTotalWithoutVatDiffers`
- [x] `ItemsDiffer_ByProductCode`
- [x] `ItemsDiffer_ByAmount`
- [x] `ItemPriceDiffers`
- [x] `MultipleIssues_CombinesFlags`

All 11 unit tests pass. Integration test failures in the full suite are pre-existing (require external credentials/DB) and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)