### PR TITLE
feat(campaigns): Frontend Campaign Dashboard page (#633)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import RecurringJobsPage from "./pages/RecurringJobsPage";
 import KnowledgeBasePage from "./pages/KnowledgeBasePage";
 import KnowledgeBaseFeedbackPage from "./pages/KnowledgeBaseFeedbackPage";
 import ExpeditionListArchivePage from "./pages/ExpeditionListArchivePage";
+import CampaignsPage from "./components/pages/Campaigns/CampaignsPage";
 import AuthGuard from "./components/auth/AuthGuard";
 import { StatusBar } from "./components/StatusBar";
 import { loadConfig, Config } from "./config/runtimeConfig";
@@ -457,6 +458,10 @@ function App() {
                         <Route
                           path="/knowledge-base/feedback"
                           element={<KnowledgeBaseFeedbackPage />}
+                        />
+                        <Route
+                          path="/campaigns"
+                          element={<CampaignsPage />}
                         />
                       </Routes>
                     </Layout>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   ExternalLink,
   FileText,
   Database,
+  TrendingUp,
 } from "lucide-react";
 import UserProfile from "../auth/UserProfile";
 import { useAuth } from "../../auth/useAuth";
@@ -294,6 +295,15 @@ const Sidebar: React.FC<SidebarProps> = ({
         ...(hasRole('knowledge_base_manager')
           ? [{ id: 'kb-feedback', name: 'Feedback', href: '/knowledge-base/feedback' }]
           : []),
+      ],
+    },
+    {
+      id: 'marketing',
+      name: 'Marketing',
+      icon: TrendingUp,
+      type: 'section' as const,
+      items: [
+        { id: 'campaigns', name: 'Campaigns', href: '/campaigns' },
       ],
     },
   ];

--- a/frontend/src/components/pages/Campaigns/CampaignAdSetRow.tsx
+++ b/frontend/src/components/pages/Campaigns/CampaignAdSetRow.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { AdSetDetail } from '../../../hooks/useCampaignDetail';
+
+interface CampaignAdSetRowProps {
+  adSet: AdSetDetail;
+}
+
+const formatCurrency = (v: number) =>
+  new Intl.NumberFormat('cs-CZ', { style: 'currency', currency: 'CZK', maximumFractionDigits: 0 }).format(v);
+
+const formatNumber = (v: number) =>
+  new Intl.NumberFormat('cs-CZ').format(v);
+
+export const CampaignAdSetRow: React.FC<CampaignAdSetRowProps> = ({ adSet }) => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <>
+      <tr
+        className="bg-gray-50 cursor-pointer hover:bg-gray-100"
+        onClick={() => setExpanded(e => !e)}
+      >
+        <td className="px-4 py-2 pl-8 text-sm font-medium text-gray-700" colSpan={2}>
+          {expanded ? '▾' : '▸'} {adSet.name}
+        </td>
+        <td className="px-4 py-2 text-sm text-gray-500">{adSet.status}</td>
+        <td className="px-4 py-2 text-sm text-gray-500" colSpan={5}>
+          {adSet.ads.length} ads
+        </td>
+      </tr>
+      {expanded &&
+        adSet.ads.map(ad => (
+          <tr key={ad.id} className="bg-gray-50/50">
+            <td className="px-4 py-2 pl-12 text-sm text-gray-600" colSpan={2}>
+              {ad.creativePreviewUrl ? (
+                <a
+                  href={ad.creativePreviewUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  {ad.name}
+                </a>
+              ) : (
+                ad.name
+              )}
+            </td>
+            <td className="px-4 py-2 text-xs text-gray-400">{ad.status}</td>
+            <td className="px-4 py-2 text-sm text-right">{formatCurrency(ad.spend)}</td>
+            <td className="px-4 py-2 text-sm text-right">{formatNumber(ad.impressions)}</td>
+            <td className="px-4 py-2 text-sm text-right">{formatNumber(ad.clicks)}</td>
+            <td className="px-4 py-2 text-sm text-right">{ad.conversions}</td>
+            <td className="px-4 py-2 text-sm text-right">—</td>
+          </tr>
+        ))}
+    </>
+  );
+};

--- a/frontend/src/components/pages/Campaigns/CampaignSpendChart.tsx
+++ b/frontend/src/components/pages/Campaigns/CampaignSpendChart.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { DailySpend } from '../../../hooks/useCampaignDashboard';
+
+interface CampaignSpendChartProps {
+  data: DailySpend[];
+  isLoading: boolean;
+}
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('cs-CZ', { style: 'currency', currency: 'CZK', maximumFractionDigits: 0 }).format(value);
+
+export const CampaignSpendChart: React.FC<CampaignSpendChartProps> = ({
+  data,
+  isLoading,
+}) => {
+  if (isLoading) {
+    return <div className="h-64 bg-gray-100 rounded animate-pulse" />;
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <h3 className="text-sm font-medium text-gray-700 mb-4">Spend Over Time</h3>
+      <ResponsiveContainer width="100%" height={240}>
+        <LineChart data={data} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 11 }}
+            tickFormatter={(d: string) => d.slice(5)}
+          />
+          <YAxis tick={{ fontSize: 11 }} tickFormatter={formatCurrency} width={80} />
+          <Tooltip formatter={(value: number) => formatCurrency(value)} />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="metaSpend"
+            name="Meta"
+            stroke="#1877f2"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="googleSpend"
+            name="Google"
+            stroke="#ea4335"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/frontend/src/components/pages/Campaigns/CampaignSummaryCard.tsx
+++ b/frontend/src/components/pages/Campaigns/CampaignSummaryCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface CampaignSummaryCardProps {
+  title: string;
+  value: string;
+  isLoading: boolean;
+}
+
+export const CampaignSummaryCard: React.FC<CampaignSummaryCardProps> = ({
+  title,
+  value,
+  isLoading,
+}) => {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 flex flex-col gap-1">
+      <span className="text-sm text-gray-500 font-medium">{title}</span>
+      {isLoading ? (
+        <div className="h-8 bg-gray-100 rounded animate-pulse" />
+      ) : (
+        <span className="text-2xl font-bold text-gray-900">{value}</span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/pages/Campaigns/CampaignTable.tsx
+++ b/frontend/src/components/pages/Campaigns/CampaignTable.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { CampaignSummary } from '../../../hooks/useCampaignList';
+import { useCampaignDetail } from '../../../hooks/useCampaignDetail';
+import { CampaignAdSetRow } from './CampaignAdSetRow';
+
+interface CampaignTableProps {
+  campaigns: CampaignSummary[];
+  isLoading: boolean;
+  from: string;
+  to: string;
+  sortBy: keyof CampaignSummary;
+  sortDesc: boolean;
+  onSort: (col: keyof CampaignSummary) => void;
+}
+
+const formatCurrency = (v: number) =>
+  new Intl.NumberFormat('cs-CZ', { style: 'currency', currency: 'CZK', maximumFractionDigits: 0 }).format(v);
+
+const formatNumber = (v: number) =>
+  new Intl.NumberFormat('cs-CZ').format(v);
+
+const SortableHeader: React.FC<{
+  col: keyof CampaignSummary;
+  label: string;
+  sortBy: keyof CampaignSummary;
+  sortDesc: boolean;
+  onSort: (col: keyof CampaignSummary) => void;
+  align?: 'left' | 'right';
+}> = ({ col, label, sortBy, sortDesc, onSort, align = 'left' }) => (
+  <th
+    className={`px-4 py-3 text-xs font-medium text-gray-500 uppercase cursor-pointer hover:bg-gray-50 select-none text-${align}`}
+    onClick={() => onSort(col)}
+  >
+    {label} {sortBy === col ? (sortDesc ? '↓' : '↑') : ''}
+  </th>
+);
+
+const PlatformBadge: React.FC<{ platform: string }> = ({ platform }) => (
+  <span
+    className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+      platform === 'Meta'
+        ? 'bg-blue-100 text-blue-700'
+        : 'bg-red-100 text-red-700'
+    }`}
+  >
+    {platform}
+  </span>
+);
+
+export const CampaignTable: React.FC<CampaignTableProps> = ({
+  campaigns,
+  isLoading,
+  from,
+  to,
+  sortBy,
+  sortDesc,
+  onSort,
+}) => {
+  const [expandedIds, setExpandedIds] = React.useState<Set<string>>(new Set());
+  const { details, loadingIds, fetchDetail } = useCampaignDetail();
+
+  const toggleExpanded = (id: string) => {
+    const next = new Set(expandedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+      fetchDetail(id, from, to);
+    }
+    setExpandedIds(next);
+  };
+
+  if (isLoading) {
+    return <div className="h-48 bg-gray-100 rounded animate-pulse" />;
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 border-b border-gray-200">
+          <tr>
+            <SortableHeader col="name" label="Campaign" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} />
+            <SortableHeader col="platform" label="Platform" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} />
+            <SortableHeader col="status" label="Status" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} />
+            <SortableHeader col="spend" label="Spend" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} align="right" />
+            <SortableHeader col="impressions" label="Impressions" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} align="right" />
+            <SortableHeader col="clicks" label="Clicks" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} align="right" />
+            <SortableHeader col="conversions" label="Conv." sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} align="right" />
+            <SortableHeader col="roas" label="ROAS" sortBy={sortBy} sortDesc={sortDesc} onSort={onSort} align="right" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {campaigns.map(c => (
+            <React.Fragment key={c.id}>
+              <tr
+                className="hover:bg-gray-50 cursor-pointer"
+                onClick={() => toggleExpanded(c.id)}
+              >
+                <td className="px-4 py-3 font-medium text-gray-900">
+                  {expandedIds.has(c.id) ? '▾' : '▸'} {c.name}
+                </td>
+                <td className="px-4 py-3">
+                  <PlatformBadge platform={c.platform} />
+                </td>
+                <td className="px-4 py-3 text-gray-500">{c.status}</td>
+                <td className="px-4 py-3 text-right">{formatCurrency(c.spend)}</td>
+                <td className="px-4 py-3 text-right">{formatNumber(c.impressions)}</td>
+                <td className="px-4 py-3 text-right">{formatNumber(c.clicks)}</td>
+                <td className="px-4 py-3 text-right">{c.conversions}</td>
+                <td className="px-4 py-3 text-right">{c.roas.toFixed(2)}×</td>
+              </tr>
+              {expandedIds.has(c.id) && (
+                loadingIds.has(c.id)
+                  ? (
+                    <tr>
+                      <td colSpan={8} className="px-4 py-2 text-sm text-gray-400">Loading...</td>
+                    </tr>
+                  )
+                  : details[c.id]?.adSets.map(adSet => (
+                    <CampaignAdSetRow key={adSet.id} adSet={adSet} />
+                  ))
+              )}
+            </React.Fragment>
+          ))}
+          {campaigns.length === 0 && (
+            <tr>
+              <td colSpan={8} className="px-4 py-8 text-center text-gray-400">
+                No campaigns found for the selected period.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/frontend/src/components/pages/Campaigns/CampaignsPage.tsx
+++ b/frontend/src/components/pages/Campaigns/CampaignsPage.tsx
@@ -1,0 +1,159 @@
+import React, { useState, useMemo } from 'react';
+import { CampaignSummaryCard } from './CampaignSummaryCard';
+import { CampaignSpendChart } from './CampaignSpendChart';
+import { CampaignTable } from './CampaignTable';
+import { useCampaignDashboard, AdPlatformFilter } from '../../../hooks/useCampaignDashboard';
+import { useCampaignList, CampaignSummary } from '../../../hooks/useCampaignList';
+
+const today = new Date();
+const defaultTo = today.toISOString().slice(0, 10);
+const defaultFrom = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+const formatCurrency = (v: number) =>
+  new Intl.NumberFormat('cs-CZ', { style: 'currency', currency: 'CZK', maximumFractionDigits: 0 }).format(v);
+
+export const CampaignsPage: React.FC = () => {
+  const [from, setFrom] = useState(defaultFrom);
+  const [to, setTo] = useState(defaultTo);
+  const [platformFilter, setPlatformFilter] = useState<AdPlatformFilter>(undefined);
+  const [fromInput, setFromInput] = useState(defaultFrom);
+  const [toInput, setToInput] = useState(defaultTo);
+  const [sortBy, setSortBy] = useState<keyof CampaignSummary>('spend');
+  const [sortDesc, setSortDesc] = useState(true);
+
+  const dashboard = useCampaignDashboard(from, to, platformFilter);
+  const campaignList = useCampaignList(from, to, platformFilter);
+
+  const sortedCampaigns = useMemo(() => {
+    return [...campaignList.campaigns].sort((a, b) => {
+      const aVal = a[sortBy];
+      const bVal = b[sortBy];
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return sortDesc ? bVal - aVal : aVal - bVal;
+      }
+      return sortDesc
+        ? String(bVal).localeCompare(String(aVal))
+        : String(aVal).localeCompare(String(bVal));
+    });
+  }, [campaignList.campaigns, sortBy, sortDesc]);
+
+  const handleSort = (col: keyof CampaignSummary) => {
+    if (sortBy === col) {
+      setSortDesc(d => !d);
+    } else {
+      setSortBy(col);
+      setSortDesc(true);
+    }
+  };
+
+  const handleApplyFilters = () => {
+    setFrom(fromInput);
+    setTo(toInput);
+  };
+
+  const handleClearFilters = () => {
+    setFromInput(defaultFrom);
+    setToInput(defaultTo);
+    setFrom(defaultFrom);
+    setTo(defaultTo);
+    setPlatformFilter(undefined);
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-gray-900">Campaigns</h1>
+      </div>
+
+      {/* Filter Bar */}
+      <div className="flex flex-wrap items-center gap-3 bg-white rounded-lg border border-gray-200 p-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-gray-600">From</label>
+          <input
+            type="date"
+            value={fromInput}
+            onChange={e => setFromInput(e.target.value)}
+            className="border border-gray-300 rounded px-2 py-1 text-sm"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-gray-600">To</label>
+          <input
+            type="date"
+            value={toInput}
+            onChange={e => setToInput(e.target.value)}
+            className="border border-gray-300 rounded px-2 py-1 text-sm"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-gray-600">Platform</label>
+          <select
+            value={platformFilter ?? ''}
+            onChange={e => setPlatformFilter((e.target.value as AdPlatformFilter) || undefined)}
+            className="border border-gray-300 rounded px-2 py-1 text-sm"
+          >
+            <option value="">All</option>
+            <option value="Meta">Meta</option>
+            <option value="Google">Google</option>
+          </select>
+        </div>
+        <button
+          onClick={handleApplyFilters}
+          className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
+        >
+          Apply
+        </button>
+        <button
+          onClick={handleClearFilters}
+          className="px-3 py-1.5 bg-white border border-gray-300 text-sm rounded hover:bg-gray-50"
+        >
+          Clear
+        </button>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <CampaignSummaryCard
+          title="Total Spend"
+          value={dashboard.data ? formatCurrency(dashboard.data.totalSpend) : '—'}
+          isLoading={dashboard.isLoading}
+        />
+        <CampaignSummaryCard
+          title="Total Conversions"
+          value={dashboard.data ? String(dashboard.data.totalConversions) : '—'}
+          isLoading={dashboard.isLoading}
+        />
+        <CampaignSummaryCard
+          title="Avg ROAS"
+          value={dashboard.data ? `${dashboard.data.avgRoas.toFixed(2)}×` : '—'}
+          isLoading={dashboard.isLoading}
+        />
+        <CampaignSummaryCard
+          title="Avg CPC"
+          value={dashboard.data ? formatCurrency(dashboard.data.avgCpc) : '—'}
+          isLoading={dashboard.isLoading}
+        />
+      </div>
+
+      {/* Spend Chart */}
+      <CampaignSpendChart
+        data={dashboard.data?.spendOverTime ?? []}
+        isLoading={dashboard.isLoading}
+      />
+
+      {/* Campaign Table */}
+      <CampaignTable
+        campaigns={sortedCampaigns}
+        isLoading={campaignList.isLoading}
+        from={from}
+        to={to}
+        sortBy={sortBy}
+        sortDesc={sortDesc}
+        onSort={handleSort}
+      />
+    </div>
+  );
+};
+
+export default CampaignsPage;

--- a/frontend/src/hooks/useCampaignDashboard.ts
+++ b/frontend/src/hooks/useCampaignDashboard.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getAuthenticatedApiClient } from '../api/client';
+
+export interface DailySpend {
+  date: string;
+  metaSpend: number;
+  googleSpend: number;
+}
+
+export interface CampaignDashboard {
+  totalSpend: number;
+  totalConversions: number;
+  avgRoas: number;
+  avgCpc: number;
+  spendOverTime: DailySpend[];
+}
+
+export type AdPlatformFilter = 'Meta' | 'Google' | undefined;
+
+export function useCampaignDashboard(
+  from: string,
+  to: string,
+  platform: AdPlatformFilter
+) {
+  const [data, setData] = useState<CampaignDashboard | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDashboard = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const apiClient = await getAuthenticatedApiClient();
+      const params = new URLSearchParams({ from, to });
+      if (platform) params.append('platform', platform);
+
+      const relativeUrl = `/api/campaigns/dashboard?${params.toString()}`;
+      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+      const response = await (apiClient as any).http.fetch(fullUrl, { method: 'GET' });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const json = await response.json();
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load dashboard');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [from, to, platform]);
+
+  useEffect(() => {
+    fetchDashboard();
+  }, [fetchDashboard]);
+
+  return { data, isLoading, error, refetch: fetchDashboard };
+}

--- a/frontend/src/hooks/useCampaignDetail.ts
+++ b/frontend/src/hooks/useCampaignDetail.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from 'react';
+import { getAuthenticatedApiClient } from '../api/client';
+
+export interface AdDetail {
+  id: string;
+  name: string;
+  status: string;
+  creativePreviewUrl?: string;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+}
+
+export interface AdSetDetail {
+  id: string;
+  name: string;
+  status: string;
+  ads: AdDetail[];
+}
+
+export interface CampaignDetail {
+  id: string;
+  name: string;
+  platform: 'Meta' | 'Google';
+  status: string;
+  adSets: AdSetDetail[];
+}
+
+export function useCampaignDetail() {
+  const [details, setDetails] = useState<Record<string, CampaignDetail>>({});
+  const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+
+  const fetchDetail = useCallback(async (campaignId: string, from: string, to: string) => {
+    if (details[campaignId]) return; // already loaded
+
+    setLoadingIds(prev => new Set(prev).add(campaignId));
+
+    try {
+      const apiClient = await getAuthenticatedApiClient();
+      const params = new URLSearchParams({ from, to });
+      const relativeUrl = `/api/campaigns/${campaignId}?${params.toString()}`;
+      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+      const response = await (apiClient as any).http.fetch(fullUrl, { method: 'GET' });
+
+      if (!response.ok) return;
+
+      const json: CampaignDetail = await response.json();
+      setDetails(prev => ({ ...prev, [campaignId]: json }));
+    } finally {
+      setLoadingIds(prev => {
+        const next = new Set(prev);
+        next.delete(campaignId);
+        return next;
+      });
+    }
+  }, [details]);
+
+  return { details, loadingIds, fetchDetail };
+}

--- a/frontend/src/hooks/useCampaignList.ts
+++ b/frontend/src/hooks/useCampaignList.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getAuthenticatedApiClient } from '../api/client';
+import { AdPlatformFilter } from './useCampaignDashboard';
+
+export interface CampaignSummary {
+  id: string;
+  name: string;
+  platform: 'Meta' | 'Google';
+  status: string;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  roas: number;
+}
+
+export function useCampaignList(
+  from: string,
+  to: string,
+  platform: AdPlatformFilter
+) {
+  const [campaigns, setCampaigns] = useState<CampaignSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCampaigns = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const apiClient = await getAuthenticatedApiClient();
+      const params = new URLSearchParams({ from, to });
+      if (platform) params.append('platform', platform);
+
+      const relativeUrl = `/api/campaigns?${params.toString()}`;
+      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+      const response = await (apiClient as any).http.fetch(fullUrl, { method: 'GET' });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const json = await response.json();
+      setCampaigns(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load campaigns');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [from, to, platform]);
+
+  useEffect(() => {
+    fetchCampaigns();
+  }, [fetchCampaigns]);
+
+  return { campaigns, isLoading, error, refetch: fetchCampaigns };
+}


### PR DESCRIPTION
## Summary

- Adds `/campaigns` route with full Campaign Dashboard page
- 4 summary cards: Total Spend, Total Conversions, Avg ROAS, Avg CPC
- Spend-over-time line chart (Meta + Google, CZK locale)
- Sortable/filterable campaign table with date range + platform filter
- Expandable rows: campaign → ad set → individual ads with creative preview links
- Marketing section added to sidebar navigation

## Hooks

- `useCampaignDashboard` — fetches `/api/campaigns/dashboard`
- `useCampaignList` — fetches `/api/campaigns`
- `useCampaignDetail` — lazy-loads `/api/campaigns/{id}` with caching

## Tests

All 769 existing tests pass. No TypeScript errors in source files.

Closes #633