### PR TITLE
feat(manufacture): allow direct semiproduct amount as sellable output

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs
@@ -358,6 +358,10 @@ public class BatchPlanningService : IBatchPlanningService
 
         var availableVolume = request.TotalWeightToUse ?? (request.MmqMultiplier ?? 1.0) * semiproduct.MinimalManufactureQuantity;
 
+        // Subtract reserved direct semiproduct output from available volume
+        var directSemiproductAmount = request.DirectSemiproductAmount ?? 0;
+        availableVolume -= directSemiproductAmount;
+
         // 2. Find all products that use this semiproduct
         var productTemplates = await _manufactureClient.FindByIngredientAsync(request.ProductCode, cancellationToken);
         if (productTemplates.Count == 0)
@@ -382,6 +386,9 @@ public class BatchPlanningService : IBatchPlanningService
 
         // 4. Apply optimization algorithm based on control mode
         var response = ApplyOptimization(batchPlanItems, request, availableVolume, semiproduct);
+
+        // Echo the direct semiproduct amount back in the response
+        response.DirectSemiproductAmount = directSemiproductAmount;
 
         return response;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs
@@ -25,6 +25,12 @@ public class ResidueDistributionCalculator : IResidueDistributionCalculator
 
         var actualSemiProduct = order.SemiProduct.ActualQuantity ?? order.SemiProduct.PlannedQuantity;
 
+        // Subtract grams that exit as direct semiproduct output (virtual row where ProductCode == SemiProduct.ProductCode)
+        var directRowGrams = order.Products
+            .Where(p => p.ProductCode == order.SemiProduct.ProductCode)
+            .Sum(p => p.ActualQuantity ?? p.PlannedQuantity);
+        var effectiveActual = actualSemiProduct - directRowGrams;
+
         var productData = await BuildProductDataAsync(order, cancellationToken);
         if (productData.Count == 0)
             return new ResidueDistribution { IsWithinAllowedThreshold = true };
@@ -34,17 +40,17 @@ public class ResidueDistributionCalculator : IResidueDistributionCalculator
         var semiProductCatalog = await _catalogRepository.GetByIdAsync(order.SemiProduct.ProductCode, cancellationToken);
         var allowedResiduePercentage = semiProductCatalog?.Properties.AllowedResiduePercentage ?? 0;
 
-        var difference = actualSemiProduct - totalTheoretical;
+        var difference = effectiveActual - totalTheoretical;
         var differencePercentage = totalTheoretical > 0
             ? (double)Math.Abs(difference) / (double)totalTheoretical * 100
             : 0;
         var isWithinThreshold = differencePercentage <= allowedResiduePercentage;
 
-        var distributions = ComputeDistributions(productData, actualSemiProduct, totalTheoretical);
+        var distributions = ComputeDistributions(productData, effectiveActual, totalTheoretical);
 
         return new ResidueDistribution
         {
-            ActualSemiProductQuantity = actualSemiProduct,
+            ActualSemiProductQuantity = effectiveActual,
             TheoreticalConsumption = totalTheoretical,
             Difference = difference,
             DifferencePercentage = differencePercentage,
@@ -62,6 +68,10 @@ public class ResidueDistributionCalculator : IResidueDistributionCalculator
 
         foreach (var product in order.Products)
         {
+            // Skip direct semiproduct output rows — they have no manufacture template
+            if (product.ProductCode == order.SemiProduct?.ProductCode)
+                continue;
+
             var actualPieces = product.ActualQuantity ?? product.PlannedQuantity;
             if (actualPieces <= 0)
                 continue;

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflow.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflow.cs
@@ -149,6 +149,7 @@ public class ConfirmProductCompletionWorkflow : IConfirmProductCompletionWorkflo
         var semiProduct = order.SemiProduct;
         var manufactureName = _nameBuilder.Build(order, ErpManufactureType.Product);
         var items = order.Products
+            .Where(p => p.ProductCode != semiProduct.ProductCode)
             .Select(p => new SubmitManufactureRequestItem
             {
                 ProductCode = p.ProductCode,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanRequest.cs
@@ -25,6 +25,9 @@ public class CalculateBatchPlanRequest : IRequest<CalculateBatchPlanResponse>
     // Product size constraints
     public List<ProductSizeConstraint> ProductConstraints { get; set; } = new();
 
+    // Optional: grams of semiproduct to reserve as direct sellable output (MultiPhase only)
+    public double? DirectSemiproductAmount { get; set; }
+
     // Manufacturing type - set internally by handler
     public ManufactureType? ManufactureType { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanResponse.cs
@@ -13,6 +13,9 @@ public class CalculateBatchPlanResponse : BaseResponse
     public double TotalVolumeAvailable { get; set; }
     public ManufactureType ManufactureType { get; set; }
 
+    // Grams reserved as direct semiproduct output (echoed from request)
+    public double DirectSemiproductAmount { get; set; }
+
     public CalculateBatchPlanResponse() : base() { }
 
     public CalculateBatchPlanResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null) : base(errorCode, parameters) { }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
@@ -116,6 +116,24 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
         }
 
 
+        // Append virtual direct semiproduct output row when applicable
+        if (request.ManufactureType == ManufactureType.MultiPhase
+            && request.DirectSemiproductAmount is > 0
+            && order.SemiProduct != null)
+        {
+            var directRow = new ManufactureOrderProduct
+            {
+                ProductCode = order.SemiProduct.ProductCode,
+                ProductName = order.SemiProduct.ProductName,
+                SemiProductCode = order.SemiProduct.ProductCode,
+                PlannedQuantity = (decimal)request.DirectSemiproductAmount.Value,
+                ActualQuantity = (decimal)request.DirectSemiproductAmount.Value,
+                ExpirationDate = expirationDate,
+                LotNumber = lotNumber,
+            };
+            order.Products.Add(directRow);
+        }
+
         // Save the order
         var createdOrder = await _repository.AddOrderAsync(order, cancellationToken);
 

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderRequest.cs
@@ -29,6 +29,9 @@ public class CreateManufactureOrderRequest : IRequest<CreateManufactureOrderResp
     public string? ResponsiblePerson { get; set; }
 
     public ManufactureType ManufactureType { get; set; } = ManufactureType.MultiPhase;
+
+    // Optional: grams of semiproduct to reserve as direct sellable output (MultiPhase only)
+    public double? DirectSemiproductAmount { get; set; }
 }
 
 public class CreateManufactureOrderProductRequest

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchPlanRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Validators/CalculateBatchPlanRequestValidator.cs
@@ -52,6 +52,11 @@ public class CalculateBatchPlanRequestValidator : AbstractValidator<CalculateBat
 
         RuleForEach(x => x.ProductConstraints)
             .SetValidator(new ProductSizeConstraintValidator());
+
+        RuleFor(x => x.DirectSemiproductAmount)
+            .GreaterThan(0)
+            .When(x => x.DirectSemiproductAmount.HasValue)
+            .WithMessage("Direct semiproduct amount must be greater than 0.");
     }
 }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/BatchPlanningServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/BatchPlanningServiceTests.cs
@@ -303,6 +303,62 @@ public class BatchPlanningServiceTests
         Assert.Equal(125, fixedProduct2.TotalVolumeRequired);
     }
 
+    [Fact]
+    public async Task CalculateBatchPlan_WithDirectSemiproductAmount_ReducesAvailableVolume()
+    {
+        // Arrange
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.0,
+            DirectSemiproductAmount = 200, // Reserve 200g as direct output
+            FromDate = DateTime.Now.AddDays(-30),
+            ToDate = DateTime.Now
+        };
+
+        var semiproduct = CreateSemiproduct("SEMI001", 1000); // MMQ = 1000g
+        var templates = CreateManufactureTemplates();
+        var products = CreateProducts();
+
+        SetupRepositoryMocks(semiproduct, templates, products);
+
+        // Act
+        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        // Available volume for optimization = MMQ (1000) - direct amount (200) = 800
+        Assert.Equal(200, result.DirectSemiproductAmount);
+        Assert.True(result.TotalVolumeAvailable <= 800, $"Available volume should be at most 800 but was {result.TotalVolumeAvailable}");
+    }
+
+    [Fact]
+    public async Task CalculateBatchPlan_WithoutDirectSemiproductAmount_EchoesZero()
+    {
+        // Arrange
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.0,
+            DirectSemiproductAmount = null
+        };
+
+        var semiproduct = CreateSemiproduct("SEMI001", 1000);
+        var templates = CreateManufactureTemplates();
+        var products = CreateProducts();
+
+        SetupRepositoryMocks(semiproduct, templates, products);
+
+        // Act
+        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(0, result.DirectSemiproductAmount);
+    }
+
     private CatalogAggregate CreateSemiproduct(string code, double stock)
     {
         return new CatalogAggregate

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanRequestValidatorTests.cs
@@ -252,4 +252,64 @@ public class CalculateBatchPlanRequestValidatorTests
         // Assert
         result.ShouldHaveValidationErrorFor("ProductConstraints[0].FixedQuantity");
     }
+
+    [Fact]
+    public void Validate_DirectSemiproductAmount_NotSet_PassesValidation()
+    {
+        // Arrange
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.5,
+            DirectSemiproductAmount = null
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.DirectSemiproductAmount);
+    }
+
+    [Fact]
+    public void Validate_DirectSemiproductAmount_PositiveValue_PassesValidation()
+    {
+        // Arrange
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.5,
+            DirectSemiproductAmount = 500.0
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.DirectSemiproductAmount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100.5)]
+    public void Validate_DirectSemiproductAmount_ZeroOrNegative_FailsValidation(double amount)
+    {
+        // Arrange
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.5,
+            DirectSemiproductAmount = amount
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.DirectSemiproductAmount);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
@@ -414,6 +414,111 @@ public class CreateManufactureOrderHandlerTests
             .WithMessage("Order number generation failed");
     }
 
+    [Fact]
+    public async Task Handle_WithDirectSemiproductAmount_ShouldAppendDirectRow()
+    {
+        var request = CreateValidRequest();
+        request.ManufactureType = ManufactureType.MultiPhase;
+        request.DirectSemiproductAmount = 250.0;
+
+        ManufactureOrder? capturedOrder = null;
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GeneratedOrderNumber);
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                capturedOrder = order;
+                order.Id = 1;
+                return order;
+            });
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        capturedOrder.Should().NotBeNull();
+        // 1 regular product + 1 direct row
+        capturedOrder!.Products.Should().HaveCount(2);
+
+        var directRow = capturedOrder.Products.First(p => p.ProductCode == ValidProductCode);
+        directRow.ProductCode.Should().Be(ValidProductCode);
+        directRow.SemiProductCode.Should().Be(ValidProductCode);
+        directRow.PlannedQuantity.Should().Be(250.0m);
+        directRow.ActualQuantity.Should().Be(250.0m);
+    }
+
+    [Fact]
+    public async Task Handle_WithNullDirectSemiproductAmount_ShouldNotAppendDirectRow()
+    {
+        var request = CreateValidRequest();
+        request.ManufactureType = ManufactureType.MultiPhase;
+        request.DirectSemiproductAmount = null;
+
+        ManufactureOrder? capturedOrder = null;
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GeneratedOrderNumber);
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                capturedOrder = order;
+                order.Id = 1;
+                return order;
+            });
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        capturedOrder.Should().NotBeNull();
+        capturedOrder!.Products.Should().HaveCount(1);
+        capturedOrder.Products.Should().NotContain(p => p.ProductCode == ValidProductCode);
+    }
+
+    [Fact]
+    public async Task Handle_SinglePhase_WithDirectSemiproductAmount_ShouldNotAppendDirectRow()
+    {
+        var request = CreateValidRequest();
+        request.ManufactureType = ManufactureType.SinglePhase;
+        request.DirectSemiproductAmount = 250.0;
+
+        ManufactureOrder? capturedOrder = null;
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidProductCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateValidCatalogItem());
+
+        _repositoryMock
+            .Setup(x => x.GenerateOrderNumberAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(GeneratedOrderNumber);
+
+        _repositoryMock
+            .Setup(x => x.AddOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                capturedOrder = order;
+                order.Id = 1;
+                return order;
+            });
+
+        await _handler.Handle(request, CancellationToken.None);
+
+        capturedOrder.Should().NotBeNull();
+        // Only the regular product — no direct row for SinglePhase
+        capturedOrder!.Products.Should().HaveCount(1);
+    }
+
     private static CreateManufactureOrderRequest CreateValidRequest()
     {
         return new CreateManufactureOrderRequest

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ResidueDistributionCalculatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ResidueDistributionCalculatorTests.cs
@@ -270,6 +270,115 @@ public class ResidueDistributionCalculatorTests
         productA.AdjustedGramsPerUnit.Should().Be(productA.AdjustedConsumption / productA.ActualPieces);
     }
 
+    [Fact]
+    public async Task CalculateAsync_WithDirectRow_SubtractsDirectGramsBeforeDistribution()
+    {
+        // actualSemiProduct = 4500g, direct row = 500g → effectiveActual = 4000g
+        // Product A: 30 × 100g = 3000g, Product B: 80 × 10g = 800g → theoretical = 3800g
+        // difference = 4000 - 3800 = 200g → 5.26% < 10%
+        var products = new[]
+        {
+            (ProductCodeA, "Product A", pieces: 30m, gramsPerUnit: 100.0),
+            (ProductCodeB, "Product B", pieces: 80m, gramsPerUnit: 10.0)
+        };
+        SetupTemplatesForProducts(products);
+        SetupCatalogWithThreshold(SemiProductCode, allowedResiduePercentage: 10.0);
+
+        var order = new UpdateManufactureOrderDto
+        {
+            SemiProduct = new UpdateManufactureOrderSemiProductDto
+            {
+                ProductCode = SemiProductCode,
+                ProductName = "Semi Product",
+                PlannedQuantity = 4500m,
+                ActualQuantity = 4500m
+            },
+            Products = new List<UpdateManufactureOrderProductDto>
+            {
+                // direct semiproduct output row
+                new UpdateManufactureOrderProductDto
+                {
+                    ProductCode = SemiProductCode,
+                    ProductName = "Semi Product",
+                    SemiProductCode = SemiProductCode,
+                    PlannedQuantity = 500m,
+                    ActualQuantity = 500m
+                },
+                new UpdateManufactureOrderProductDto
+                {
+                    ProductCode = ProductCodeA,
+                    ProductName = "Product A",
+                    SemiProductCode = SemiProductCode,
+                    PlannedQuantity = 30m,
+                    ActualQuantity = 30m
+                },
+                new UpdateManufactureOrderProductDto
+                {
+                    ProductCode = ProductCodeB,
+                    ProductName = "Product B",
+                    SemiProductCode = SemiProductCode,
+                    PlannedQuantity = 80m,
+                    ActualQuantity = 80m
+                }
+            }
+        };
+
+        var result = await _calculator.CalculateAsync(order);
+
+        result.IsWithinAllowedThreshold.Should().BeTrue();
+        result.ActualSemiProductQuantity.Should().Be(4000m);  // 4500 - 500 direct
+        result.TheoreticalConsumption.Should().Be(3800m);
+        result.Difference.Should().Be(200m);
+        result.Products.Should().HaveCount(2);
+        result.Products.Sum(p => p.AdjustedConsumption).Should().Be(4000m);
+
+        // Direct row must not appear in distributions
+        result.Products.Should().NotContain(p => p.ProductCode == SemiProductCode);
+
+        // GetManufactureTemplateAsync must NOT be called for the direct row
+        _manufactureClientMock.Verify(
+            x => x.GetManufactureTemplateAsync(SemiProductCode, It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CalculateAsync_WithDirectRow_NoOtherProducts_ReturnsWithinThreshold()
+    {
+        // All non-semiproduct products have quantity 0; only direct row remains → should short-circuit
+        SetupCatalogWithThreshold(SemiProductCode, allowedResiduePercentage: 10.0);
+
+        var order = new UpdateManufactureOrderDto
+        {
+            SemiProduct = new UpdateManufactureOrderSemiProductDto
+            {
+                ProductCode = SemiProductCode,
+                ProductName = "Semi Product",
+                PlannedQuantity = 1000m,
+                ActualQuantity = 1000m
+            },
+            Products = new List<UpdateManufactureOrderProductDto>
+            {
+                new UpdateManufactureOrderProductDto
+                {
+                    ProductCode = SemiProductCode,
+                    ProductName = "Semi Product",
+                    SemiProductCode = SemiProductCode,
+                    PlannedQuantity = 1000m,
+                    ActualQuantity = 1000m
+                }
+            }
+        };
+
+        var result = await _calculator.CalculateAsync(order);
+
+        // all products are direct row → early return
+        result.IsWithinAllowedThreshold.Should().BeTrue();
+        result.Products.Should().BeEmpty();
+        _manufactureClientMock.Verify(
+            x => x.GetManufactureTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // ---- Helpers ----
 
     private UpdateManufactureOrderDto BuildOrder(

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflowTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflowTests.cs
@@ -445,6 +445,86 @@ public class ConfirmProductCompletionWorkflowTests
         capturedStatusRequest.ManualActionRequired.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenDirectRowPresent_ExcludesItFromErpSubmitItems()
+    {
+        // Arrange — order has one regular product AND a direct-row (ProductCode == SemiProduct.ProductCode)
+        var productQuantities = new Dictionary<int, decimal> { { 1, 5.0m }, { 2, 500.0m } };
+        var distribution = CreateDistributionWithinThreshold();
+        var submitResponse = CreateSuccessfulSubmitManufactureResponse("ERP_PRODUCT_999");
+        var updateStatusResponse = CreateSuccessfulUpdateStatusResponse();
+
+        var orderWithDirectRow = new UpdateManufactureOrderResponse
+        {
+            Success = true,
+            Order = new UpdateManufactureOrderDto
+            {
+                OrderNumber = "MO-2024-DIRECT",
+                SemiProduct = new UpdateManufactureOrderSemiProductDto
+                {
+                    ProductCode = "SP001001",
+                    ProductName = "Semi Product 1",
+                    ActualQuantity = 10500m,
+                    PlannedQuantity = 10500m,
+                    LotNumber = "LOT-DIRECT",
+                    ExpirationDate = DateOnly.FromDateTime(DateTime.Today.AddDays(30)),
+                },
+                Products = new List<UpdateManufactureOrderProductDto>
+                {
+                    // Regular product
+                    new UpdateManufactureOrderProductDto
+                    {
+                        ProductCode = "P001",
+                        ProductName = "Product 1",
+                        ActualQuantity = 5.0m,
+                        PlannedQuantity = 5.0m,
+                    },
+                    // Direct semiproduct output row — same code as SemiProduct
+                    new UpdateManufactureOrderProductDto
+                    {
+                        ProductCode = "SP001001",
+                        ProductName = "Semi Product 1",
+                        ActualQuantity = 500m,
+                        PlannedQuantity = 500m,
+                    },
+                },
+            },
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateManufactureOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orderWithDirectRow);
+
+        SubmitManufactureRequest? capturedSubmit = null;
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<SubmitManufactureRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<SubmitManufactureResponse>, CancellationToken>(
+                (r, _) => capturedSubmit = (SubmitManufactureRequest)r)
+            .ReturnsAsync(submitResponse);
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateManufactureOrderStatusRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updateStatusResponse);
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateBoMIngredientAmountRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateBoMIngredientAmountResponse { Success = true });
+
+        _residueCalculatorMock
+            .Setup(x => x.CalculateAsync(It.IsAny<UpdateManufactureOrderDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(distribution);
+
+        // Act
+        var result = await _workflow.ExecuteAsync(ValidOrderId, productQuantities, false, ValidChangeReason, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        capturedSubmit.Should().NotBeNull();
+        capturedSubmit!.Items.Should().HaveCount(1);
+        capturedSubmit.Items.Should().Contain(i => i.ProductCode == "P001");
+        capturedSubmit.Items.Should().NotContain(i => i.ProductCode == "SP001001");
+    }
+
     #region Helper Methods
 
     private void SetupMediatorResponses(

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -15616,6 +15616,7 @@ export class CalculateBatchPlanResponse extends BaseResponse implements ICalcula
     totalVolumeUsed?: number;
     totalVolumeAvailable?: number;
     manufactureType?: ManufactureType;
+    directSemiproductAmount?: number | undefined;
 
     constructor(data?: ICalculateBatchPlanResponse) {
         super(data);
@@ -15635,6 +15636,7 @@ export class CalculateBatchPlanResponse extends BaseResponse implements ICalcula
             this.totalVolumeUsed = _data["totalVolumeUsed"];
             this.totalVolumeAvailable = _data["totalVolumeAvailable"];
             this.manufactureType = _data["manufactureType"];
+            this.directSemiproductAmount = _data["directSemiproductAmount"];
         }
     }
 
@@ -15658,6 +15660,7 @@ export class CalculateBatchPlanResponse extends BaseResponse implements ICalcula
         data["totalVolumeUsed"] = this.totalVolumeUsed;
         data["totalVolumeAvailable"] = this.totalVolumeAvailable;
         data["manufactureType"] = this.manufactureType;
+        data["directSemiproductAmount"] = this.directSemiproductAmount;
         super.toJSON(data);
         return data;
     }
@@ -15671,6 +15674,7 @@ export interface ICalculateBatchPlanResponse extends IBaseResponse {
     totalVolumeUsed?: number;
     totalVolumeAvailable?: number;
     manufactureType?: ManufactureType;
+    directSemiproductAmount?: number | undefined;
 }
 
 export class SemiproductInfoDto implements ISemiproductInfoDto {
@@ -15906,6 +15910,7 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
     targetDaysCoverage?: number | undefined;
     productConstraints?: ProductSizeConstraint[];
     manufactureType?: ManufactureType | undefined;
+    directSemiproductAmount?: number | undefined;
 
     constructor(data?: ICalculateBatchPlanRequest) {
         if (data) {
@@ -15932,6 +15937,7 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
                     this.productConstraints!.push(ProductSizeConstraint.fromJS(item));
             }
             this.manufactureType = _data["manufactureType"];
+            this.directSemiproductAmount = _data["directSemiproductAmount"];
         }
     }
 
@@ -15958,6 +15964,7 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
                 data["productConstraints"].push(item.toJSON());
         }
         data["manufactureType"] = this.manufactureType;
+        data["directSemiproductAmount"] = this.directSemiproductAmount;
         return data;
     }
 }
@@ -15973,6 +15980,7 @@ export interface ICalculateBatchPlanRequest {
     targetDaysCoverage?: number | undefined;
     productConstraints?: ProductSizeConstraint[];
     manufactureType?: ManufactureType | undefined;
+    directSemiproductAmount?: number | undefined;
 }
 
 export class ProductSizeConstraint implements IProductSizeConstraint {
@@ -16512,6 +16520,7 @@ export class CreateManufactureOrderRequest implements ICreateManufactureOrderReq
     plannedDate!: Date;
     responsiblePerson?: string | undefined;
     manufactureType?: ManufactureType;
+    directSemiproductAmount?: number | undefined;
 
     constructor(data?: ICreateManufactureOrderRequest) {
         if (data) {
@@ -16537,6 +16546,7 @@ export class CreateManufactureOrderRequest implements ICreateManufactureOrderReq
             this.plannedDate = _data["plannedDate"] ? new Date(_data["plannedDate"].toString()) : <any>undefined;
             this.responsiblePerson = _data["responsiblePerson"];
             this.manufactureType = _data["manufactureType"];
+            this.directSemiproductAmount = _data["directSemiproductAmount"];
         }
     }
 
@@ -16562,6 +16572,7 @@ export class CreateManufactureOrderRequest implements ICreateManufactureOrderReq
         data["plannedDate"] = this.plannedDate ? formatDate(this.plannedDate) : <any>undefined;
         data["responsiblePerson"] = this.responsiblePerson;
         data["manufactureType"] = this.manufactureType;
+        data["directSemiproductAmount"] = this.directSemiproductAmount;
         return data;
     }
 }
@@ -16576,6 +16587,7 @@ export interface ICreateManufactureOrderRequest {
     plannedDate: Date;
     responsiblePerson?: string | undefined;
     manufactureType?: ManufactureType;
+    directSemiproductAmount?: number | undefined;
 }
 
 export class CreateManufactureOrderProductRequest implements ICreateManufactureOrderProductRequest {

--- a/frontend/src/components/manufacture/detail/ConfirmationDialogs.tsx
+++ b/frontend/src/components/manufacture/detail/ConfirmationDialogs.tsx
@@ -194,6 +194,7 @@ export const ConfirmationDialogs: React.FC<ConfirmationDialogsProps> = ({
             productName: product.productName || "",
             plannedQuantity: product.plannedQuantity || 0
           }))}
+          semiProductCode={order.semiProduct?.productCode}
           isLoading={isProductCompletionLoading}
           distributionPreview={distributionPreview}
           onConfirmDistribution={onConfirmDistribution}

--- a/frontend/src/components/manufacture/detail/ProductsDataGrid.tsx
+++ b/frontend/src/components/manufacture/detail/ProductsDataGrid.tsx
@@ -32,24 +32,35 @@ export const ProductsDataGrid: React.FC<ProductsDataGridProps> = ({
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {order.products.map((product: any, index: number) => (
-                <tr key={index} className="hover:bg-gray-50">
+              {order.products.map((product: any, index: number) => {
+                const isDirectRow = product.productCode === order.semiProduct?.productCode;
+                const unit = isDirectRow ? "g" : "ks";
+                return (
+                <tr key={index} className={isDirectRow ? "hover:bg-amber-50 bg-amber-50/40" : "hover:bg-gray-50"}>
                   <td className="px-4 py-3 text-sm font-medium text-gray-900">
                     {product.productCode || "-"}
+                    {isDirectRow && (
+                      <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
+                        přímý
+                      </span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-700">
                     {product.productName || "-"}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-700">
                     {canEditFields ? (
-                      <input
-                        type="number"
-                        value={editableProductQuantities[index] || ""}
-                        onChange={(e) => onProductQuantityChange(index, e.target.value)}
-                        className="w-20 px-2 py-1 border border-gray-300 rounded text-center"
-                        min="0"
-                        step="1"
-                      />
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="number"
+                          value={editableProductQuantities[index] || ""}
+                          onChange={(e) => onProductQuantityChange(index, e.target.value)}
+                          className="w-20 px-2 py-1 border border-gray-300 rounded text-center"
+                          min="0"
+                          step="1"
+                        />
+                        <span className="text-xs text-gray-500">{unit}</span>
+                      </div>
                     ) : (
                       <div>
                         {(() => {
@@ -59,16 +70,16 @@ export const ProductsDataGrid: React.FC<ProductsDataGridProps> = ({
                           if (hasActual && hasPlanned && product.actualQuantity !== product.plannedQuantity) {
                             return (
                               <>
-                                {product.actualQuantity}
+                                {product.actualQuantity} {unit}
                                 <span className="text-xs text-gray-500 ml-1">
-                                  (plán: {product.plannedQuantity})
+                                  (plán: {product.plannedQuantity} {unit})
                                 </span>
                               </>
                             );
                           } else if (hasActual) {
-                            return product.actualQuantity;
+                            return <>{product.actualQuantity} {unit}</>;
                           } else if (hasPlanned) {
-                            return product.plannedQuantity;
+                            return <>{product.plannedQuantity} {unit}</>;
                           } else {
                             return "-";
                           }
@@ -77,7 +88,8 @@ export const ProductsDataGrid: React.FC<ProductsDataGridProps> = ({
                     )}
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/components/modals/ConfirmProductCompletionModal.tsx
+++ b/frontend/src/components/modals/ConfirmProductCompletionModal.tsx
@@ -19,6 +19,7 @@ interface ConfirmProductCompletionModalProps {
   onSubmit: (request: ConfirmProductCompletionRequest) => Promise<void>;
   orderId: number;
   products: ProductQuantityData[];
+  semiProductCode?: string;
   isLoading?: boolean;
   distributionPreview?: ResidueDistributionDto;
   onConfirmDistribution: () => Promise<void>;
@@ -31,6 +32,7 @@ const ConfirmProductCompletionModal: React.FC<ConfirmProductCompletionModalProps
   onSubmit,
   orderId,
   products,
+  semiProductCode,
   isLoading = false,
   distributionPreview,
   onConfirmDistribution,
@@ -261,15 +263,25 @@ const ConfirmProductCompletionModal: React.FC<ConfirmProductCompletionModalProps
 
           {/* Products */}
           <div className="space-y-2">
-            {products.map((product) => (
-              <div key={product.id} className="border border-gray-200 rounded-lg p-3">
+            {products.map((product) => {
+              const isDirectRow = semiProductCode != null && product.productCode === semiProductCode;
+              const unit = isDirectRow ? "g" : "ks";
+              return (
+              <div key={product.id} className={`border rounded-lg p-3 ${isDirectRow ? "border-amber-300 bg-amber-50/40" : "border-gray-200"}`}>
                 <div className="flex items-center justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <h4 className="font-medium text-gray-900 truncate text-sm">{product.productName}</h4>
+                    <div className="flex items-center gap-2">
+                      <h4 className="font-medium text-gray-900 truncate text-sm">{product.productName}</h4>
+                      {isDirectRow && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
+                          přímý
+                        </span>
+                      )}
+                    </div>
                     <div className="flex items-center gap-3 mt-1">
                       <p className="text-xs text-gray-600">{product.productCode}</p>
                       <p className="text-xs text-gray-500">
-                        Plánované: <span className="font-medium">{product.plannedQuantity}</span>
+                        Plánované: <span className="font-medium">{product.plannedQuantity} {unit}</span>
                       </p>
                     </div>
                   </div>
@@ -292,10 +304,12 @@ const ConfirmProductCompletionModal: React.FC<ConfirmProductCompletionModalProps
                       disabled={isLoading}
                       required
                     />
+                    <span className="text-xs text-gray-500">{unit}</span>
                   </div>
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
 
           {/* Error Message */}

--- a/frontend/src/components/pages/ManufactureBatchPlanning.tsx
+++ b/frontend/src/components/pages/ManufactureBatchPlanning.tsx
@@ -60,6 +60,9 @@ const BatchPlanningCalculator: React.FC = () => {
   
   // State to track if recalculation is needed
   const [needsRecalculation, setNeedsRecalculation] = useState(false);
+
+  // Direct semiproduct amount (grams to reserve as sellable bulk output)
+  const [directSemiproductAmount, setDirectSemiproductAmount] = useState<number | null>(null);
   
   // Mutation
   const batchPlanMutation = useBatchPlanningMutation();
@@ -308,6 +311,10 @@ const BatchPlanningCalculator: React.FC = () => {
         break;
     }
 
+    if (directSemiproductAmount != null && directSemiproductAmount > 0) {
+      requestData.directSemiproductAmount = directSemiproductAmount;
+    }
+
     const request = new CalculateBatchPlanRequest(requestData);
     batchPlanMutation.mutate(request);
     setNeedsRecalculation(false); // Clear the flag after calculation
@@ -345,6 +352,10 @@ const BatchPlanningCalculator: React.FC = () => {
         break;
     }
 
+    if (directSemiproductAmount != null && directSemiproductAmount > 0) {
+      requestData.directSemiproductAmount = directSemiproductAmount;
+    }
+
     const request = new CalculateBatchPlanRequest(requestData);
     batchPlanMutation.mutate(request);
     setNeedsRecalculation(false); // Clear the flag after calculation
@@ -360,6 +371,7 @@ const BatchPlanningCalculator: React.FC = () => {
     setControlMode(BatchPlanControlMode.MmqMultiplier); // Reset to default mode
     // Clear constraints when changing product
     setProductConstraints(new Map());
+    setDirectSemiproductAmount(null);
     setNeedsRecalculation(false); // Clear recalculation flag when selecting new product
     
     // Auto-trigger calculation immediately after product selection
@@ -476,7 +488,8 @@ const BatchPlanningCalculator: React.FC = () => {
         })),
         plannedDate: plannedDate,
         responsiblePerson: undefined,
-        manufactureType: response.manufactureType
+        manufactureType: response.manufactureType,
+        directSemiproductAmount: directSemiproductAmount != null && directSemiproductAmount > 0 ? directSemiproductAmount : undefined
       });
 
       const orderResponse = await createOrderMutation.mutateAsync(orderRequest);
@@ -785,12 +798,35 @@ const BatchPlanningCalculator: React.FC = () => {
                         </button>
                       </div>
                     </div>
+
+                    {/* Direct semiproduct amount input */}
+                    <div className="flex items-center gap-3">
+                      <label className="text-sm font-medium text-gray-700 whitespace-nowrap">
+                        Přímý výstup (g):
+                      </label>
+                      <input
+                        type="number"
+                        min="0"
+                        step="1"
+                        value={directSemiproductAmount ?? ""}
+                        onChange={(e) => {
+                          const val = e.target.value === "" ? null : Number(e.target.value);
+                          setDirectSemiproductAmount(val);
+                          setNeedsRecalculation(true);
+                        }}
+                        placeholder="Volitelně"
+                        className="w-28 px-3 py-2 text-sm border border-gray-300 bg-white text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 text-center"
+                      />
+                      <span className="text-xs text-gray-500">
+                        Množství polotovaru prodávaného přímo jako výstup (bez dalšího zpracování)
+                      </span>
+                    </div>
                   </div>
                 )}
               </div>
             </div>
 
-            
+
 
             {/* Product Grid - Only show if semiproduct is selected */}
             {selectedSemiproduct && (


### PR DESCRIPTION
## Summary

Implements Issue #546 — allows a portion of the semiproduct batch to be reserved as a direct sellable output (bulk grams sold without further processing), alongside the normal finished product variants.

### Backend changes
- `CalculateBatchPlanRequest` — new `DirectSemiproductAmount` (nullable double)
- `CalculateBatchPlanResponse` — echoes back `DirectSemiproductAmount`
- `CalculateBatchPlanRequestValidator` — validates amount > 0 when provided
- `BatchPlanningService` — subtracts direct amount from available volume before distributing to product variants
- `CreateManufactureOrderRequest` — new `DirectSemiproductAmount` (nullable double)
- `CreateManufactureOrderHandler` — appends a virtual ManufactureOrderProduct row (ProductCode == SemiProduct.ProductCode) when amount > 0 for MultiPhase orders
- `ResidueDistributionCalculator` — subtracts direct row grams as effectiveActual; skips direct rows in BuildProductDataAsync
- `ConfirmProductCompletionWorkflow` — excludes direct product row from ERP submission items

### Frontend changes
- `api-client.ts` — manually added `directSemiproductAmount` to three generated types
- `ManufactureBatchPlanning.tsx` — new Přímý výstup (g) input; wired into both calculate functions and order creation
- `ProductsDataGrid.tsx` — direct rows highlighted amber with přímý badge and g unit label
- `ConfirmProductCompletionModal.tsx` — same amber highlight + badge + unit label in confirmation modal
- `ConfirmationDialogs.tsx` — passes semiProductCode prop to the modal

### Tests
- 410+ lines of new unit tests covering all backend paths
- All 2240 backend unit tests pass (7 pre-existing Docker failures unaffected)
- All 769 frontend tests pass

Closes #546