### PR TITLE
feat(marketing): Task 1 — Domain entities + repository interface

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Domain.Features.Journal;
+using Anela.Heblo.Xcc.Persistance;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public interface IMarketingActionRepository : IRepository<MarketingAction, int>
+    {
+        Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default);
+
+        Task<PagedResult<MarketingAction>> GetPagedAsync(
+            MarketingActionQueryCriteria criteria,
+            CancellationToken cancellationToken = default);
+
+        Task<List<MarketingAction>> GetForCalendarAsync(
+            DateTime from,
+            DateTime to,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingAction : IEntity<int>
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = null!;
+
+        [MaxLength(5000)]
+        public string? Description { get; set; }
+
+        public MarketingActionType ActionType { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        [Required]
+        public DateTime CreatedAt { get; set; }
+
+        [Required]
+        public DateTime ModifiedAt { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string CreatedByUserId { get; set; } = null!;
+
+        [MaxLength(100)]
+        public string? CreatedByUsername { get; set; }
+
+        [MaxLength(100)]
+        public string? ModifiedByUserId { get; set; }
+
+        [MaxLength(100)]
+        public string? ModifiedByUsername { get; set; }
+
+        public bool IsDeleted { get; set; }
+        public DateTime? DeletedAt { get; set; }
+
+        [MaxLength(100)]
+        public string? DeletedByUserId { get; set; }
+
+        [MaxLength(100)]
+        public string? DeletedByUsername { get; set; }
+
+        // Navigation properties
+        public virtual ICollection<MarketingActionProduct> ProductAssociations { get; set; } = new List<MarketingActionProduct>();
+        public virtual ICollection<MarketingActionFolderLink> FolderLinks { get; set; } = new List<MarketingActionFolderLink>();
+
+        // Domain methods
+        public void AssociateWithProduct(string productCode)
+        {
+            if (string.IsNullOrWhiteSpace(productCode))
+                throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))
+                return;
+
+            ProductAssociations.Add(new MarketingActionProduct
+            {
+                MarketingActionId = Id,
+                ProductCodePrefix = productCode.Trim().ToUpperInvariant(),
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        public void LinkToFolder(string folderKey, MarketingFolderType folderType)
+        {
+            if (string.IsNullOrWhiteSpace(folderKey))
+                throw new ArgumentException("Folder key cannot be empty", nameof(folderKey));
+
+            if (FolderLinks.Any(fl => fl.FolderKey == folderKey))
+                return;
+
+            FolderLinks.Add(new MarketingActionFolderLink
+            {
+                MarketingActionId = Id,
+                FolderKey = folderKey.Trim(),
+                FolderType = folderType,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        public void SoftDelete(string userId, string username)
+        {
+            IsDeleted = true;
+            DeletedAt = DateTime.UtcNow;
+            DeletedByUserId = userId;
+            DeletedByUsername = username;
+            ModifiedAt = DateTime.UtcNow;
+            ModifiedByUserId = userId;
+            ModifiedByUsername = username;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionFolderLink.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionFolderLink.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingActionFolderLink
+    {
+        public int MarketingActionId { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string FolderKey { get; set; } = null!;
+
+        public MarketingFolderType FolderType { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        // Navigation properties
+        public virtual MarketingAction MarketingAction { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionProduct.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionProduct.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingActionProduct
+    {
+        public int MarketingActionId { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string ProductCodePrefix { get; set; } = null!;
+
+        public DateTime CreatedAt { get; set; }
+
+        // Navigation properties
+        public virtual MarketingAction MarketingAction { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionQueryCriteria.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionQueryCriteria.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingActionQueryCriteria
+    {
+        public int PageNumber { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+
+        public string? SearchTerm { get; set; }
+        public MarketingActionType? ActionType { get; set; }
+
+        public DateTime? StartDateFrom { get; set; }
+        public DateTime? StartDateTo { get; set; }
+
+        public DateTime? EndDateFrom { get; set; }
+        public DateTime? EndDateTo { get; set; }
+
+        public string? ProductCodePrefix { get; set; }
+
+        public bool IncludeDeleted { get; set; } = false;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionType.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public enum MarketingActionType
+    {
+        General = 0,
+        Promotion = 1,
+        Launch = 2,
+        Campaign = 3,
+        Event = 4,
+        Other = 99,
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingFolderType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingFolderType.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public enum MarketingFolderType
+    {
+        General = 0,
+        Seasonal = 1,
+        ProductLine = 2,
+        Campaign = 3,
+        Other = 99,
+    }
+}


### PR DESCRIPTION
## Summary

Creates the Domain layer for the Marketing Calendar feature:

- `MarketingAction` aggregate root (audit fields, soft-delete, product associations)
- `MarketingActionProduct` composite PK join entity
- `MarketingActionFolderLink`
- `MarketingActionType` and `MarketingFolderType` enums
- `IMarketingActionRepository` with `GetPagedAsync` and `GetForCalendarAsync`
- `MarketingActionQueryCriteria`

Part of epic #730.

Closes #731