### PR TITLE
feat(marketing): Task 2 — Persistence layer (EF configs, repository, migration)

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
@@ -85,6 +86,11 @@ public class ApplicationDbContext : DbContext
 
     // Marketing Invoices module
     public DbSet<ImportedMarketingTransaction> ImportedMarketingTransactions { get; set; } = null!;
+
+    // Marketing Calendar module
+    public DbSet<MarketingAction> MarketingActions { get; set; } = null!;
+    public DbSet<MarketingActionProduct> MarketingActionProducts { get; set; } = null!;
+    public DbSet<MarketingActionFolderLink> MarketingActionFolderLinks { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionConfiguration.cs
@@ -1,0 +1,99 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionConfiguration : IEntityTypeConfiguration<MarketingAction>
+    {
+        public void Configure(EntityTypeBuilder<MarketingAction> builder)
+        {
+            builder.ToTable("MarketingActions", "public");
+
+            builder.HasKey(x => x.Id);
+
+            builder.Property(x => x.Title)
+                .HasMaxLength(200)
+                .IsRequired();
+
+            builder.Property(x => x.Description)
+                .HasMaxLength(5000)
+                .IsRequired(false);
+
+            builder.Property(x => x.ActionType)
+                .IsRequired();
+
+            builder.Property(x => x.StartDate)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.EndDate)
+                .IsRequired(false)
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.CreatedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.ModifiedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.CreatedByUserId)
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Property(x => x.CreatedByUsername)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.ModifiedByUserId)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.ModifiedByUsername)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.DeletedAt)
+                .IsRequired(false)
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.DeletedByUserId)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.DeletedByUsername)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            // Soft delete filter
+            builder.HasQueryFilter(x => !x.IsDeleted);
+
+            // Indexes for performance
+            builder.HasIndex(x => x.StartDate)
+                .HasDatabaseName("IX_MarketingActions_StartDate");
+
+            builder.HasIndex(x => x.EndDate)
+                .HasDatabaseName("IX_MarketingActions_EndDate");
+
+            builder.HasIndex(x => new { x.IsDeleted, x.StartDate, x.EndDate })
+                .HasDatabaseName("IX_MarketingActions_IsDeleted_StartDate_EndDate");
+
+            builder.HasIndex(x => x.ActionType)
+                .HasDatabaseName("IX_MarketingActions_ActionType");
+
+            // Navigation properties
+            builder.HasMany(x => x.ProductAssociations)
+                .WithOne(x => x.MarketingAction)
+                .HasForeignKey(x => x.MarketingActionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(x => x.FolderLinks)
+                .WithOne(x => x.MarketingAction)
+                .HasForeignKey(x => x.MarketingActionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionFolderLinkConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionFolderLinkConfiguration.cs
@@ -1,0 +1,33 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionFolderLinkConfiguration : IEntityTypeConfiguration<MarketingActionFolderLink>
+    {
+        public void Configure(EntityTypeBuilder<MarketingActionFolderLink> builder)
+        {
+            builder.ToTable("MarketingActionFolderLinks", "public");
+
+            // Composite primary key
+            builder.HasKey(x => new { x.MarketingActionId, x.FolderKey });
+
+            builder.Property(x => x.FolderKey)
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Property(x => x.FolderType)
+                .IsRequired();
+
+            builder.Property(x => x.CreatedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            // Index for marketing action lookups
+            builder.HasIndex(x => x.MarketingActionId)
+                .HasDatabaseName("IX_MarketingActionFolderLinks_MarketingActionId");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionProductConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionProductConfiguration.cs
@@ -1,0 +1,30 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionProductConfiguration : IEntityTypeConfiguration<MarketingActionProduct>
+    {
+        public void Configure(EntityTypeBuilder<MarketingActionProduct> builder)
+        {
+            builder.ToTable("MarketingActionProducts", "public");
+
+            // Composite primary key
+            builder.HasKey(x => new { x.MarketingActionId, x.ProductCodePrefix });
+
+            builder.Property(x => x.ProductCodePrefix)
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(x => x.CreatedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            // Index for product code prefix lookups
+            builder.HasIndex(x => x.ProductCodePrefix)
+                .HasDatabaseName("IX_MarketingActionProducts_ProductCodePrefix");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
@@ -1,0 +1,131 @@
+using Anela.Heblo.Domain.Features.Journal;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionRepository : BaseRepository<MarketingAction, int>, IMarketingActionRepository
+    {
+        private readonly ILogger<MarketingActionRepository> _logger;
+
+        public MarketingActionRepository(ApplicationDbContext context, ILogger<MarketingActionRepository> logger)
+            : base(context)
+        {
+            _logger = logger;
+        }
+
+        public override async Task<MarketingAction?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        {
+            return await Context.Set<MarketingAction>()
+                .Include(x => x.ProductAssociations)
+                .Include(x => x.FolderLinks)
+                .FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted, cancellationToken);
+        }
+
+        public async Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default)
+        {
+            var entity = await GetByIdAsync(id, cancellationToken);
+            if (entity != null)
+            {
+                entity.SoftDelete(userId, username);
+                await UpdateAsync(entity, cancellationToken);
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        public async Task<PagedResult<MarketingAction>> GetPagedAsync(
+            MarketingActionQueryCriteria criteria,
+            CancellationToken cancellationToken = default)
+        {
+            var query = Context.Set<MarketingAction>()
+                .Include(x => x.ProductAssociations)
+                .Include(x => x.FolderLinks)
+                .AsQueryable();
+
+            if (!criteria.IncludeDeleted)
+            {
+                query = query.Where(x => !x.IsDeleted);
+            }
+
+            // Text search
+            if (!string.IsNullOrWhiteSpace(criteria.SearchTerm))
+            {
+                var searchTerm = criteria.SearchTerm.Trim().ToLower();
+                query = query.Where(x =>
+                    x.Title.ToLower().Contains(searchTerm) ||
+                    (x.Description != null && x.Description.ToLower().Contains(searchTerm)));
+            }
+
+            // Action type filter
+            if (criteria.ActionType.HasValue)
+            {
+                query = query.Where(x => x.ActionType == criteria.ActionType.Value);
+            }
+
+            // Date range filters
+            if (criteria.StartDateFrom.HasValue)
+            {
+                query = query.Where(x => x.StartDate >= criteria.StartDateFrom.Value);
+            }
+
+            if (criteria.StartDateTo.HasValue)
+            {
+                query = query.Where(x => x.StartDate <= criteria.StartDateTo.Value);
+            }
+
+            if (criteria.EndDateFrom.HasValue)
+            {
+                query = query.Where(x => x.EndDate.HasValue && x.EndDate >= criteria.EndDateFrom.Value);
+            }
+
+            if (criteria.EndDateTo.HasValue)
+            {
+                query = query.Where(x => x.EndDate.HasValue && x.EndDate <= criteria.EndDateTo.Value);
+            }
+
+            // Product code prefix filter
+            if (!string.IsNullOrWhiteSpace(criteria.ProductCodePrefix))
+            {
+                var prefix = criteria.ProductCodePrefix.Trim();
+                query = query.Where(x => x.ProductAssociations
+                    .Any(pa => prefix.StartsWith(pa.ProductCodePrefix)));
+            }
+
+            // Default sort: newest first by StartDate
+            query = query.OrderByDescending(x => x.StartDate)
+                .ThenByDescending(x => x.CreatedAt);
+
+            var totalCount = await query.CountAsync(cancellationToken);
+
+            var items = await query
+                .Skip((criteria.PageNumber - 1) * criteria.PageSize)
+                .Take(criteria.PageSize)
+                .ToListAsync(cancellationToken);
+
+            return new PagedResult<MarketingAction>
+            {
+                Items = items,
+                TotalCount = totalCount,
+                PageNumber = criteria.PageNumber,
+                PageSize = criteria.PageSize
+            };
+        }
+
+        public async Task<List<MarketingAction>> GetForCalendarAsync(
+            DateTime from,
+            DateTime to,
+            CancellationToken cancellationToken = default)
+        {
+            return await Context.Set<MarketingAction>()
+                .Include(x => x.ProductAssociations)
+                .Include(x => x.FolderLinks)
+                .Where(x => !x.IsDeleted &&
+                    x.StartDate <= to &&
+                    (!x.EndDate.HasValue || x.EndDate >= from))
+                .OrderBy(x => x.StartDate)
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424095051_AddMarketingCalendar")]
+    partial class AddMarketingCalendar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMarketingCalendar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MarketingActions",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(5000)", maxLength: 5000, nullable: true),
+                    ActionType = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    CreatedByUsername = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ModifiedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ModifiedByUsername = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp", nullable: true),
+                    DeletedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    DeletedByUsername = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingActions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MarketingActionFolderLinks",
+                schema: "public",
+                columns: table => new
+                {
+                    MarketingActionId = table.Column<int>(type: "integer", nullable: false),
+                    FolderKey = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    FolderType = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingActionFolderLinks", x => new { x.MarketingActionId, x.FolderKey });
+                    table.ForeignKey(
+                        name: "FK_MarketingActionFolderLinks_MarketingActions_MarketingAction~",
+                        column: x => x.MarketingActionId,
+                        principalSchema: "public",
+                        principalTable: "MarketingActions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MarketingActionProducts",
+                schema: "public",
+                columns: table => new
+                {
+                    MarketingActionId = table.Column<int>(type: "integer", nullable: false),
+                    ProductCodePrefix = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingActionProducts", x => new { x.MarketingActionId, x.ProductCodePrefix });
+                    table.ForeignKey(
+                        name: "FK_MarketingActionProducts_MarketingActions_MarketingActionId",
+                        column: x => x.MarketingActionId,
+                        principalSchema: "public",
+                        principalTable: "MarketingActions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActionFolderLinks_MarketingActionId",
+                schema: "public",
+                table: "MarketingActionFolderLinks",
+                column: "MarketingActionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActionProducts_ProductCodePrefix",
+                schema: "public",
+                table: "MarketingActionProducts",
+                column: "ProductCodePrefix");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_ActionType",
+                schema: "public",
+                table: "MarketingActions",
+                column: "ActionType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_EndDate",
+                schema: "public",
+                table: "MarketingActions",
+                column: "EndDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_IsDeleted_StartDate_EndDate",
+                schema: "public",
+                table: "MarketingActions",
+                columns: new[] { "IsDeleted", "StartDate", "EndDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_StartDate",
+                schema: "public",
+                table: "MarketingActions",
+                column: "StartDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MarketingActionFolderLinks",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "MarketingActionProducts",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "MarketingActions",
+                schema: "public");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -1,6 +1,8 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Marketing;
 using Anela.Heblo.Persistence.GridLayouts;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
@@ -121,6 +123,9 @@ public static class PersistenceModule
 
         // Grid Layouts repositories
         services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
+
+        // Marketing Calendar repositories
+        services.AddScoped<IMarketingActionRepository, MarketingActionRepository>();
 
         return services;
     }


### PR DESCRIPTION
## Summary

- `MarketingActionConfiguration` — EF config with soft-delete query filter and 4 indexes
- `MarketingActionProductConfiguration` — composite PK join entity config
- `MarketingActionFolderLinkConfiguration`
- `MarketingActionRepository` — paged list with date/text/product filters, calendar range query, soft-delete
- `ApplicationDbContext` — 3 new DbSets
- `AddMarketingCalendar` EF migration — creates `MarketingActions`, `MarketingActionProducts`, `MarketingActionFolderLinks` tables

Depends on #731. Part of epic #730.

Closes #732