### PR TITLE
feat(marketing): Task 3 — Application layer (contracts, handlers, module)

### DIFF
--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -16,6 +16,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.Purchase;
 using Anela.Heblo.Application.Features.FinancialOverview;
 using Anela.Heblo.Application.Features.Journal;
+using Anela.Heblo.Application.Features.Marketing;
 using Anela.Heblo.Application.Features.Logistics;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture;
 using Anela.Heblo.Application.Features.Manufacture;
@@ -56,6 +57,7 @@ public static class ApplicationModule
         services.AddPurchaseModule();
         services.AddFinancialOverviewModule(configuration);
         services.AddJournalModule();
+        services.AddMarketingModule();
         services.AddManufactureModule(configuration);
         services.AddTransportModule();
         services.AddGiftPackageManufactureModule();

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/CreateMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/CreateMarketingActionRequest.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class CreateMarketingActionRequest : IRequest<CreateMarketingActionResponse>
+    {
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = null!;
+
+        [MaxLength(5000)]
+        public string? Description { get; set; }
+
+        [Required]
+        public MarketingActionType ActionType { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        public List<string>? AssociatedProducts { get; set; }
+        public List<CreateFolderLinkRequest>? FolderLinks { get; set; }
+
+        public class CreateFolderLinkRequest
+        {
+            [Required]
+            [MaxLength(100)]
+            public string FolderKey { get; set; } = null!;
+
+            [Required]
+            public MarketingFolderType FolderType { get; set; }
+        }
+    }
+
+    public class CreateMarketingActionResponse : BaseResponse
+    {
+        public int Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string Message { get; set; } = "Marketing action created successfully";
+
+        public CreateMarketingActionResponse() : base() { }
+
+        public CreateMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/DeleteMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/DeleteMarketingActionRequest.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class DeleteMarketingActionRequest : IRequest<DeleteMarketingActionResponse>
+    {
+        public int Id { get; set; }
+    }
+
+    public class DeleteMarketingActionResponse : BaseResponse
+    {
+        public int Id { get; set; }
+        public string Message { get; set; } = "Marketing action deleted successfully";
+
+        public DeleteMarketingActionResponse() : base() { }
+
+        public DeleteMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionRequest.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class GetMarketingActionRequest : IRequest<GetMarketingActionResponse>
+    {
+        public int Id { get; set; }
+    }
+
+    public class GetMarketingActionResponse : BaseResponse
+    {
+        public MarketingActionDto? Action { get; set; }
+
+        public GetMarketingActionResponse() : base() { }
+
+        public GetMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionsRequest.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class GetMarketingActionsRequest : IRequest<GetMarketingActionsResponse>
+    {
+        public int PageNumber { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+        public string? SearchTerm { get; set; }
+        public string? ProductCodePrefix { get; set; }
+        public DateTime? StartDateFrom { get; set; }
+        public DateTime? StartDateTo { get; set; }
+        public DateTime? EndDateFrom { get; set; }
+        public DateTime? EndDateTo { get; set; }
+        public bool IncludeDeleted { get; set; } = false;
+    }
+
+    public class GetMarketingActionsResponse : BaseResponse
+    {
+        public List<MarketingActionDto> Actions { get; set; } = new();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages { get; set; }
+        public bool HasNextPage { get; set; }
+        public bool HasPreviousPage { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingCalendarRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingCalendarRequest.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class GetMarketingCalendarRequest : IRequest<GetMarketingCalendarResponse>
+    {
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+    }
+
+    public class GetMarketingCalendarResponse : BaseResponse
+    {
+        public List<MarketingActionCalendarDto> Actions { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionCalendarDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionCalendarDto.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class MarketingActionCalendarDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = null!;
+        public string ActionType { get; set; } = null!;
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public List<string> AssociatedProducts { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionDto.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class MarketingActionDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = null!;
+        public string? Description { get; set; }
+        public string ActionType { get; set; } = null!;
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<MarketingActionFolderLinkDto> FolderLinks { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionFolderLinkDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionFolderLinkDto.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class MarketingActionFolderLinkDto
+    {
+        public string FolderKey { get; set; } = null!;
+        public string FolderType { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/UpdateMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/UpdateMarketingActionRequest.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class UpdateMarketingActionRequest : IRequest<UpdateMarketingActionResponse>
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = null!;
+
+        [MaxLength(5000)]
+        public string? Description { get; set; }
+
+        [Required]
+        public MarketingActionType ActionType { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        public List<string>? AssociatedProducts { get; set; }
+        public List<CreateMarketingActionRequest.CreateFolderLinkRequest>? FolderLinks { get; set; }
+    }
+
+    public class UpdateMarketingActionResponse : BaseResponse
+    {
+        public int Id { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string Message { get; set; } = "Marketing action updated successfully";
+
+        public UpdateMarketingActionResponse() : base() { }
+
+        public UpdateMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
@@ -1,0 +1,16 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Marketing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Marketing
+{
+    public static class MarketingModule
+    {
+        public static IServiceCollection AddMarketingModule(this IServiceCollection services)
+        {
+            services.AddScoped<IMarketingActionRepository, MarketingActionRepository>();
+            // MediatR handlers are auto-registered by assembly scan
+            return services;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction
+{
+    public class CreateMarketingActionHandler : IRequestHandler<CreateMarketingActionRequest, CreateMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<CreateMarketingActionHandler> _logger;
+
+        public CreateMarketingActionHandler(
+            IMarketingActionRepository repository,
+            ICurrentUserService currentUserService,
+            ILogger<CreateMarketingActionHandler> logger)
+        {
+            _repository = repository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<CreateMarketingActionResponse> Handle(
+            CreateMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            if (!currentUser.IsAuthenticated || string.IsNullOrEmpty(currentUser.Id))
+            {
+                return new CreateMarketingActionResponse(ErrorCodes.UnauthorizedMarketingAccess, new Dictionary<string, string>
+                {
+                    { "resource", "marketing_action" },
+                });
+            }
+
+            var now = DateTime.UtcNow;
+
+            var action = new MarketingAction
+            {
+                Title = request.Title.Trim(),
+                Description = request.Description?.Trim(),
+                ActionType = request.ActionType,
+                StartDate = request.StartDate,
+                EndDate = request.EndDate,
+                CreatedAt = now,
+                ModifiedAt = now,
+                CreatedByUserId = currentUser.Id,
+                CreatedByUsername = currentUser.Name ?? "Unknown User",
+            };
+
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var product in request.AssociatedProducts.Distinct())
+                {
+                    action.AssociateWithProduct(product);
+                }
+            }
+
+            if (request.FolderLinks?.Any() == true)
+            {
+                foreach (var link in request.FolderLinks)
+                {
+                    action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);
+                }
+            }
+
+            var created = await _repository.AddAsync(action, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "MarketingAction {ActionId} created by user {UserId}",
+                created.Id,
+                currentUser.Id);
+
+            return new CreateMarketingActionResponse
+            {
+                Id = created.Id,
+                CreatedAt = created.CreatedAt,
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAction
+{
+    public class DeleteMarketingActionHandler : IRequestHandler<DeleteMarketingActionRequest, DeleteMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<DeleteMarketingActionHandler> _logger;
+
+        public DeleteMarketingActionHandler(
+            IMarketingActionRepository repository,
+            ICurrentUserService currentUserService,
+            ILogger<DeleteMarketingActionHandler> logger)
+        {
+            _repository = repository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<DeleteMarketingActionResponse> Handle(
+            DeleteMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            if (!currentUser.IsAuthenticated || string.IsNullOrEmpty(currentUser.Id))
+            {
+                return new DeleteMarketingActionResponse(ErrorCodes.UnauthorizedMarketingAccess, new Dictionary<string, string>
+                {
+                    { "resource", "marketing_action" },
+                });
+            }
+
+            var action = await _repository.GetByIdAsync(request.Id, cancellationToken);
+            if (action == null)
+            {
+                return new DeleteMarketingActionResponse(ErrorCodes.MarketingActionNotFound, new Dictionary<string, string>
+                {
+                    { "actionId", request.Id.ToString() },
+                });
+            }
+
+            await _repository.DeleteSoftAsync(request.Id, currentUser.Id, currentUser.Name ?? "Unknown User", cancellationToken);
+
+            _logger.LogInformation(
+                "MarketingAction {ActionId} deleted by user {UserId}",
+                request.Id,
+                currentUser.Id);
+
+            return new DeleteMarketingActionResponse { Id = request.Id };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingAction/GetMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingAction/GetMarketingActionHandler.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingActions;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingAction
+{
+    public class GetMarketingActionHandler : IRequestHandler<GetMarketingActionRequest, GetMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+
+        public GetMarketingActionHandler(IMarketingActionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetMarketingActionResponse> Handle(
+            GetMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var action = await _repository.GetByIdAsync(request.Id, cancellationToken);
+            if (action == null)
+            {
+                return new GetMarketingActionResponse(ErrorCodes.MarketingActionNotFound, new Dictionary<string, string>
+                {
+                    { "actionId", request.Id.ToString() },
+                });
+            }
+
+            return new GetMarketingActionResponse
+            {
+                Action = GetMarketingActionsHandler.MapToDto(action),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingActions/GetMarketingActionsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingActions/GetMarketingActionsHandler.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingActions
+{
+    public class GetMarketingActionsHandler : IRequestHandler<GetMarketingActionsRequest, GetMarketingActionsResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+
+        public GetMarketingActionsHandler(IMarketingActionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetMarketingActionsResponse> Handle(
+            GetMarketingActionsRequest request,
+            CancellationToken cancellationToken)
+        {
+            var criteria = new MarketingActionQueryCriteria
+            {
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize,
+                SearchTerm = request.SearchTerm,
+                ProductCodePrefix = request.ProductCodePrefix,
+                StartDateFrom = request.StartDateFrom,
+                StartDateTo = request.StartDateTo,
+                EndDateFrom = request.EndDateFrom,
+                EndDateTo = request.EndDateTo,
+                IncludeDeleted = request.IncludeDeleted,
+            };
+
+            var result = await _repository.GetPagedAsync(criteria, cancellationToken);
+
+            return new GetMarketingActionsResponse
+            {
+                Actions = result.Items.Select(MapToDto).ToList(),
+                TotalCount = result.TotalCount,
+                PageNumber = result.PageNumber,
+                PageSize = result.PageSize,
+                TotalPages = (int)Math.Ceiling((double)result.TotalCount / result.PageSize),
+                HasNextPage = result.PageNumber * result.PageSize < result.TotalCount,
+                HasPreviousPage = result.PageNumber > 1,
+            };
+        }
+
+        internal static MarketingActionDto MapToDto(MarketingAction action) =>
+            new()
+            {
+                Id = action.Id,
+                Title = action.Title,
+                Description = action.Description,
+                ActionType = action.ActionType.ToString(),
+                StartDate = action.StartDate,
+                EndDate = action.EndDate,
+                CreatedAt = action.CreatedAt,
+                ModifiedAt = action.ModifiedAt,
+                CreatedByUserId = action.CreatedByUserId,
+                CreatedByUsername = action.CreatedByUsername,
+                ModifiedByUserId = action.ModifiedByUserId,
+                ModifiedByUsername = action.ModifiedByUsername,
+                AssociatedProducts = action.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                FolderLinks = action.FolderLinks
+                    .Select(fl => new MarketingActionFolderLinkDto
+                    {
+                        FolderKey = fl.FolderKey,
+                        FolderType = fl.FolderType.ToString(),
+                    })
+                    .ToList(),
+            };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingCalendar/GetMarketingCalendarHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingCalendar/GetMarketingCalendarHandler.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingCalendar
+{
+    public class GetMarketingCalendarHandler : IRequestHandler<GetMarketingCalendarRequest, GetMarketingCalendarResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+
+        public GetMarketingCalendarHandler(IMarketingActionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetMarketingCalendarResponse> Handle(
+            GetMarketingCalendarRequest request,
+            CancellationToken cancellationToken)
+        {
+            var actions = await _repository.GetForCalendarAsync(
+                request.StartDate,
+                request.EndDate,
+                cancellationToken);
+
+            return new GetMarketingCalendarResponse
+            {
+                Actions = actions.Select(a => new MarketingActionCalendarDto
+                {
+                    Id = a.Id,
+                    Title = a.Title,
+                    ActionType = a.ActionType.ToString(),
+                    StartDate = a.StartDate,
+                    EndDate = a.EndDate,
+                    AssociatedProducts = a.ProductAssociations
+                        .Select(pa => pa.ProductCodePrefix)
+                        .Distinct()
+                        .ToList(),
+                }).ToList(),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAction
+{
+    public class UpdateMarketingActionHandler : IRequestHandler<UpdateMarketingActionRequest, UpdateMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<UpdateMarketingActionHandler> _logger;
+
+        public UpdateMarketingActionHandler(
+            IMarketingActionRepository repository,
+            ICurrentUserService currentUserService,
+            ILogger<UpdateMarketingActionHandler> logger)
+        {
+            _repository = repository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<UpdateMarketingActionResponse> Handle(
+            UpdateMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            if (!currentUser.IsAuthenticated || string.IsNullOrEmpty(currentUser.Id))
+            {
+                return new UpdateMarketingActionResponse(ErrorCodes.UnauthorizedMarketingAccess, new Dictionary<string, string>
+                {
+                    { "resource", "marketing_action" },
+                });
+            }
+
+            var action = await _repository.GetByIdAsync(request.Id, cancellationToken);
+            if (action == null)
+            {
+                return new UpdateMarketingActionResponse(ErrorCodes.MarketingActionNotFound, new Dictionary<string, string>
+                {
+                    { "actionId", request.Id.ToString() },
+                });
+            }
+
+            var now = DateTime.UtcNow;
+
+            action.Title = request.Title.Trim();
+            action.Description = request.Description?.Trim();
+            action.ActionType = request.ActionType;
+            action.StartDate = request.StartDate;
+            action.EndDate = request.EndDate;
+            action.ModifiedAt = now;
+            action.ModifiedByUserId = currentUser.Id;
+            action.ModifiedByUsername = currentUser.Name ?? "Unknown User";
+
+            // Replace product associations
+            action.ProductAssociations.Clear();
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var product in request.AssociatedProducts.Distinct())
+                {
+                    action.AssociateWithProduct(product);
+                }
+            }
+
+            // Replace folder links
+            action.FolderLinks.Clear();
+            if (request.FolderLinks?.Any() == true)
+            {
+                foreach (var link in request.FolderLinks)
+                {
+                    action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);
+                }
+            }
+
+            await _repository.UpdateAsync(action, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "MarketingAction {ActionId} updated by user {UserId}",
+                action.Id,
+                currentUser.Id);
+
+            return new UpdateMarketingActionResponse
+            {
+                Id = action.Id,
+                ModifiedAt = action.ModifiedAt,
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -218,6 +218,12 @@ public enum ErrorCodes
     [HttpStatusCode(HttpStatusCode.NotFound)]
     ShoptetOrderNotFound = 2102,
 
+    // Marketing Calendar errors (23XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    MarketingActionNotFound = 2301,
+    [HttpStatusCode(HttpStatusCode.Forbidden)]
+    UnauthorizedMarketingAccess = 2302,
+
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
     ExternalServiceError = 9001,

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -1,8 +1,6 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
-using Anela.Heblo.Domain.Features.Marketing;
-using Anela.Heblo.Persistence.Marketing;
 using Anela.Heblo.Persistence.GridLayouts;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.InvoiceClassification;
@@ -123,9 +121,6 @@ public static class PersistenceModule
 
         // Grid Layouts repositories
         services.AddScoped<IGridLayoutRepository, GridLayoutRepository>();
-
-        // Marketing Calendar repositories
-        services.AddScoped<IMarketingActionRepository, MarketingActionRepository>();
 
         return services;
     }

--- a/backend/test/Anela.Heblo.Tests/ErrorHandlingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ErrorHandlingTests.cs
@@ -84,6 +84,7 @@ public class ErrorHandlingTests
         var backgroundJobsErrors = errorCodes.Where(code => code >= 1900 && code < 2000).ToList(); // 19XX range
         var knowledgeBaseErrors = errorCodes.Where(code => code >= 2000 && code < 2100).ToList(); // 20XX range
         var shoptetOrdersErrors = errorCodes.Where(code => code >= 2100 && code < 2200).ToList(); // 21XX range
+        var marketingErrors = errorCodes.Where(code => code >= 2300 && code < 2400).ToList(); // 23XX range
         var externalServiceErrors = errorCodes.Where(code => code >= 9000 && code < 9100).ToList(); // 90XX range
 
         // Ensure we have some errors in the expected categories
@@ -98,6 +99,7 @@ public class ErrorHandlingTests
         Assert.True(backgroundJobsErrors.Count > 0, "Should have background jobs errors in 19XX range");
         Assert.True(knowledgeBaseErrors.Count > 0, "Should have knowledge base errors in 20XX range");
         Assert.True(shoptetOrdersErrors.Count > 0, "Should have Shoptet orders errors in 21XX range");
+        Assert.True(marketingErrors.Count > 0, "Should have Marketing Calendar errors in 23XX range");
         Assert.True(externalServiceErrors.Count > 0, "Should have external service errors in 90XX range");
 
         // Ensure all error codes fall into defined module ranges
@@ -105,7 +107,7 @@ public class ErrorHandlingTests
                               manufactureErrors.Count + catalogErrors.Count + transportErrors.Count +
                               configErrors.Count + journalErrors.Count + analyticsErrors.Count +
                               fileStorageErrors.Count + backgroundJobsErrors.Count + knowledgeBaseErrors.Count +
-                              shoptetOrdersErrors.Count + externalServiceErrors.Count;
+                              shoptetOrdersErrors.Count + marketingErrors.Count + externalServiceErrors.Count;
 
         Assert.Equal(errorCodes.Count, categorizedCount);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Marketing;
+
+public class CreateMarketingActionHandlerTests
+{
+    private readonly Mock<IMarketingActionRepository> _repositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ILogger<CreateMarketingActionHandler>> _loggerMock;
+    private readonly CreateMarketingActionHandler _handler;
+
+    public CreateMarketingActionHandlerTests()
+    {
+        _repositoryMock = new Mock<IMarketingActionRepository>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _loggerMock = new Mock<ILogger<CreateMarketingActionHandler>>();
+        _handler = new CreateMarketingActionHandler(
+            _repositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserNotAuthenticated_ShouldReturnUnauthorizedError()
+    {
+        // Arrange
+        var request = new CreateMarketingActionRequest
+        {
+            Title = "Summer Campaign",
+            ActionType = MarketingActionType.Campaign,
+            StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(Id: null, Name: null, Email: null, IsAuthenticated: false));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.UnauthorizedMarketingAccess);
+        result.Params.Should().ContainKey("resource");
+    }
+
+    [Fact]
+    public async Task Handle_WhenValidRequest_ShouldCreateActionSuccessfully()
+    {
+        // Arrange
+        var request = new CreateMarketingActionRequest
+        {
+            Title = "Summer Campaign",
+            ActionType = MarketingActionType.Event,
+            StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc),
+            AssociatedProducts = new List<string> { "TON001" },
+        };
+
+        var currentUser = new CurrentUser(
+            Id: "user123",
+            Name: "Test User",
+            Email: "test@example.com",
+            IsAuthenticated: true);
+
+        var createdAction = new MarketingAction
+        {
+            Id = 42,
+            Title = request.Title,
+            ActionType = request.ActionType,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            CreatedAt = DateTime.UtcNow,
+            CreatedByUserId = currentUser.Id!,
+        };
+
+        _currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(currentUser);
+        _repositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdAction);
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Id.Should().Be(42);
+        result.ErrorCode.Should().BeNull();
+
+        _repositoryMock.Verify(x => x.AddAsync(
+            It.Is<MarketingAction>(a =>
+                a.Title == "Summer Campaign" &&
+                a.ActionType == MarketingActionType.Event &&
+                a.CreatedByUserId == "user123"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _repositoryMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/GetMarketingCalendarHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/GetMarketingCalendarHandlerTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingCalendar;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Marketing;
+
+public class GetMarketingCalendarHandlerTests
+{
+    private readonly Mock<IMarketingActionRepository> _repositoryMock;
+    private readonly GetMarketingCalendarHandler _handler;
+
+    public GetMarketingCalendarHandlerTests()
+    {
+        _repositoryMock = new Mock<IMarketingActionRepository>();
+        _handler = new GetMarketingCalendarHandler(_repositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenActionsExist_ShouldReturnMappedCalendarDtos()
+    {
+        // Arrange
+        var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        var actions = new List<MarketingAction>
+        {
+            new()
+            {
+                Id = 1,
+                Title = "June Launch",
+                ActionType = MarketingActionType.Event,
+                StartDate = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc),
+                ProductAssociations = new List<MarketingActionProduct>
+                {
+                    new() { ProductCodePrefix = "TON001" },
+                },
+            },
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetForCalendarAsync(start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(actions);
+
+        var request = new GetMarketingCalendarRequest { StartDate = start, EndDate = end };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Actions.Should().HaveCount(1);
+        result.Actions[0].Id.Should().Be(1);
+        result.Actions[0].Title.Should().Be("June Launch");
+        result.Actions[0].ActionType.Should().Be("Event");
+        result.Actions[0].AssociatedProducts.Should().ContainSingle("TON001");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoActionsExist_ShouldReturnEmptyList()
+    {
+        // Arrange
+        var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        _repositoryMock
+            .Setup(x => x.GetForCalendarAsync(start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingAction>());
+
+        var request = new GetMarketingCalendarRequest { StartDate = start, EndDate = end };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Actions.Should().BeEmpty();
+    }
+}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -198,6 +198,10 @@ const resources = {
         ShoptetOrderInvalidSourceState: "Objednávku nelze zablokovat – není ve povoleném stavu",
         ShoptetOrderNotFound: "Objednávka nebyla nalezena",
 
+        // Marketing Calendar module errors
+        MarketingActionNotFound: "Marketingová akce nebyla nalezena",
+        UnauthorizedMarketingAccess: "Nemáte oprávnění k této marketingové akci",
+
         // External Service errors
         ExternalServiceError: "Chyba externí služby",
         FlexiApiError: "Chyba ABRA Flexi API",


### PR DESCRIPTION
## Summary

- 9 contract files: DTOs (`MarketingActionDto`, `MarketingActionCalendarDto`, `MarketingActionFolderLinkDto`) + request/response pairs for all 6 use cases
- 6 MediatR handlers: Get list, Get single, Get calendar, Create, Update, Delete
- `MarketingModule.cs` — DI registration (moved from PersistenceModule)
- 2 new error codes: `MarketingActionNotFound` (2301), `UnauthorizedMarketingAccess` (2302)
- Czech i18n translations for new error codes
- Unit tests for Create and GetCalendar handlers (4 tests total)
- `ErrorHandlingTests` updated with 23XX Marketing range

**Adaptations from spec to actual domain:**
- Used `StartDate`/`EndDate` (DateTime) instead of spec`s `DateFrom`/`DateTo` (DateOnly) — domain from #731 uses DateTime
- Used `Description` instead of spec`s `Detail` — domain field name
- `MarketingActionFolderLinkDto` uses `FolderKey` instead of `Path`/`Label`/`Id` — actual domain has composite PK on (MarketingActionId, FolderKey)
- `GetMarketingCalendarRequest` uses `DateTime` (not `DateOnly`) to match `IMarketingActionRepository.GetForCalendarAsync`
- `GetMarketingActionsRequest` uses criteria field names matching actual `MarketingActionQueryCriteria`
- Enum value `Campaign` used in tests instead of spec`s `SocialMedia` (not in actual enum)

Depends on #731, #732. Part of epic #730.

Closes #733