### PR TITLE
fix(nav): move Kvalita dat into Automatizace + project skills + db table map

### DIFF
--- a/.claude/skills/backmerge-prs/SKILL.md
+++ b/.claude/skills/backmerge-prs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: backmerge-prs
+description: Merge the base/target branch back into each feature branch (backmerge). Use when the user says "backmerge PRs", "backmerge PR 717", "sync open PRs with base", or "merge base into feature branches". Without a PR number, walks all open PRs. With a PR number, targets that single PR. Skips merged/closed PRs, handles conflicts gracefully, prints a summary table, and restores the original branch when done.
+---
+
+# Backmerge PRs
+
+Merges each PR's base branch into its head branch (backmerge).
+
+## Usage
+
+```
+/backmerge-prs                      # all open PRs, each PR's base branch
+/backmerge-prs 717                  # single PR, its base branch
+/backmerge-prs --from main          # all open PRs, merge main into each head
+/backmerge-prs 717 --from main      # single PR, merge main into head
+```
+
+## Steps
+
+1. **Run the script** from the repo root:
+   ```bash
+   bash .claude/skills/backmerge-prs/scripts/backmerge_prs.sh [<pr_number>] [--from <branch>]
+   ```
+2. **Review summary table** — each PR shows `done`, `done (auto: N add/add)`, `skipped`, or `conflict: <files>`
+3. **For remaining conflict PRs** — resolve manually:
+   ```bash
+   git checkout <head-branch>
+   git merge origin/<branch>
+   # resolve conflicts
+   git add . && git commit && git push origin <head-branch>
+   ```
+
+## What the script does
+
+- `git fetch --all --prune` at start
+- No args → fetches all `--state open` PRs via `gh pr list`
+- One arg → fetches that specific PR via `gh pr view`
+- `--from <branch>` → overrides the merge source for every PR (default: each PR's own base branch)
+- Skips MERGED and CLOSED PRs automatically
+- Skips PRs where head branch equals the merge source
+- Checks out head branch, merges `origin/<source>` with `--no-edit`, pushes on success
+- On merge failure, attempts **auto-resolution** (see below) before giving up
+- Restores original branch at the end via `trap`
+
+## Auto-resolution logic
+
+After a failed merge, the script categorises conflicts:
+
+| Conflict type | Git status code | Action |
+|---------------|-----------------|--------|
+| Both branches added the same file | `AA` | `git checkout --theirs` (take base version), stage, commit, push |
+| Both branches modified the same file | `UU` | Abort merge, report for manual resolution |
+
+**Rule:** if the merge has only `AA` conflicts and zero `UU` conflicts, the script fully resolves and pushes automatically. Any `UU` conflict aborts the whole merge and leaves it for manual work.
+
+## Manual conflict resolution notes (Anela.Heblo)
+
+Common `UU` conflicts in this repo and how to resolve them:
+
+- **Program.cs / ApplicationModule.cs / ApplicationDbContext.cs** — keep both registrations (base added a new module/entity, head added another); manually merge both additions
+- **Migration files** (`Migrations/`) — each branch likely adds its own migration; keep both files, rename if timestamps clash
+- **OpenAPI client** (`frontend/src/api/`) — regenerated on build; take `--theirs` (base version) and let CI regenerate on merge
+
+After resolution:
+```bash
+git add <files>
+git commit
+git push origin <head-branch>
+```

--- a/.claude/skills/backmerge-prs/scripts/backmerge_prs.sh
+++ b/.claude/skills/backmerge-prs/scripts/backmerge_prs.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# backmerge_prs.sh [<pr_number>] [--from <branch>]
+# No args          → backmerge all open PRs using each PR's base branch
+# --from <branch>  → use <branch> as the merge source instead of each PR's base
+# <pr_number>      → limit to a single PR
+# Compatible with bash 3.2+ (macOS default)
+set -euo pipefail
+
+SPECIFIC_PR=
+FROM_BRANCH=
+
+# Parse args
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --from)
+      shift
+      FROM_BRANCH="${1:-}"
+      [ -z "$FROM_BRANCH" ] && { echo "Error: --from requires a branch name"; exit 1; }
+      ;;
+    -*)
+      echo "Unknown flag: $1"; exit 1 ;;
+    *)
+      SPECIFIC_PR="$1" ;;
+  esac
+  shift
+done
+
+ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Store results in a temp file (avoids associative arrays, works on bash 3.2)
+RESULTS_FILE=$(mktemp)
+
+cleanup() {
+  rm -f "$RESULTS_FILE"
+  git checkout "$ORIGINAL_BRANCH" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Fetching remote refs..."
+git fetch --all --prune -q
+
+# Fetch PR metadata
+if [ -n "$SPECIFIC_PR" ]; then
+  PR_JSON=$(gh pr view "$SPECIFIC_PR" \
+    --json number,title,headRefName,baseRefName,state \
+    | jq '[.]')
+else
+  PR_JSON=$(gh pr list --state open --limit 200 \
+    --json number,title,headRefName,baseRefName,state \
+    | jq 'sort_by(.number)')
+fi
+
+COUNT=$(echo "$PR_JSON" | jq 'length')
+
+if [ "$COUNT" -eq 0 ]; then
+  echo "No open PRs found."
+  exit 0
+fi
+
+LABEL="${SPECIFIC_PR:+PR #$SPECIFIC_PR}"
+LABEL="${LABEL:-all open PRs}"
+if [ -n "$FROM_BRANCH" ]; then
+  echo ""
+  echo "Found $COUNT PR(s) — $LABEL (merging from: $FROM_BRANCH)"
+else
+  echo ""
+  echo "Found $COUNT PR(s) — $LABEL"
+fi
+echo ""
+
+# Try to auto-resolve straightforward conflicts after a failed merge.
+# Returns 0 if all conflicts resolved and committed, 1 if manual work remains.
+try_auto_resolve() {
+  local HEAD="$1"
+  local MERGE_SOURCE="$2"
+
+  # Categorise conflicting files
+  local AA_FILES UU_FILES ALL_UNMERGED
+  AA_FILES=$(git status --short | awk '/^AA / {print $2}')
+  UU_FILES=$(git status --short | awk '/^UU / {print $2}')
+  ALL_UNMERGED=$(git diff --name-only --diff-filter=U)
+
+  if [ -z "$AA_FILES" ] && [ -z "$UU_FILES" ]; then
+    # Nothing to resolve (shouldn't happen, but be safe)
+    return 1
+  fi
+
+  if [ -n "$UU_FILES" ]; then
+    # Content conflicts require human judgment — bail out
+    git merge --abort 2>/dev/null || true
+    local conflict_list
+    conflict_list=$(echo "$ALL_UNMERGED" | tr '\n' ' ')
+    printf '%s\t%s\t%s\t%s\n' "$NUM" "$HEAD" "$MERGE_SOURCE" "conflict: $conflict_list" >> "$RESULTS_FILE"
+    echo "   ✗ Content conflict (manual): $UU_FILES"
+    return 1
+  fi
+
+  # Only add/add conflicts — take the base (--theirs) version for each
+  local count=0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    git checkout --theirs -- "$f"
+    git add "$f"
+    count=$((count + 1))
+  done <<< "$AA_FILES"
+
+  git commit --no-edit -q
+  git push origin "$HEAD" -q
+  echo "   ✓ Done (auto-resolved $count add/add conflict(s), took base version)"
+  printf '%s\t%s\t%s\t%s\n' "$NUM" "$HEAD" "$MERGE_SOURCE" "done (auto: $count add/add)" >> "$RESULTS_FILE"
+  return 0
+}
+
+# Process each PR in a single jq-driven loop
+while IFS=$'\t' read -r NUM HEAD BASE STATE; do
+  # Determine which branch to merge from
+  MERGE_SOURCE="${FROM_BRANCH:-$BASE}"
+
+  echo "── PR #$NUM: $HEAD ← $MERGE_SOURCE ($STATE)"
+
+  if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
+    echo "   ↷ Skipped ($STATE)"
+    printf '%s\t%s\t%s\t%s\n' "$NUM" "$HEAD" "$MERGE_SOURCE" "skipped ($STATE)" >> "$RESULTS_FILE"
+    continue
+  fi
+
+  # Skip if head branch is same as merge source
+  if [ "$HEAD" = "$MERGE_SOURCE" ]; then
+    echo "   ↷ Skipped (head == merge source)"
+    printf '%s\t%s\t%s\t%s\n' "$NUM" "$HEAD" "$MERGE_SOURCE" "skipped (same branch)" >> "$RESULTS_FILE"
+    continue
+  fi
+
+  # Checkout head branch
+  git checkout "$HEAD" -q 2>/dev/null || git checkout -b "$HEAD" "origin/$HEAD" -q
+  git pull origin "$HEAD" -q 2>/dev/null || true
+
+  # Attempt clean merge
+  if git merge "origin/$MERGE_SOURCE" --no-edit -q 2>/dev/null; then
+    git push origin "$HEAD" -q
+    echo "   ✓ Done"
+    printf '%s\t%s\t%s\t%s\n' "$NUM" "$HEAD" "$MERGE_SOURCE" "done" >> "$RESULTS_FILE"
+  else
+    # Merge failed — try auto-resolution
+    try_auto_resolve "$HEAD" "$MERGE_SOURCE" || true
+  fi
+done < <(echo "$PR_JSON" | jq -r '.[] | [.number, .headRefName, .baseRefName, .state] | @tsv')
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+printf "%-6s %-40s %-36s %s\n" "PR" "Head branch" "Merged from" "Status"
+echo "───────────────────────────────────────────────────────"
+while IFS=$'\t' read -r NUM HEAD BASE STATUS; do
+  printf "%-6s %-40s %-36s %s\n" "#$NUM" "$HEAD" "$BASE" "$STATUS"
+done < "$RESULTS_FILE"
+echo "═══════════════════════════════════════════════════════"
+
+git checkout "$ORIGINAL_BRANCH" -q
+echo ""
+echo "Restored branch: $ORIGINAL_BRANCH"

--- a/docs/database-consolidation-report.md
+++ b/docs/database-consolidation-report.md
@@ -1,0 +1,211 @@
+# Database Consolidation Report
+
+> Generated: 2026-04-24  
+> Scope: All EF Core entity configurations in `Anela.Heblo.Persistence`  
+> Database: PostgreSQL (Azure)
+
+---
+
+## Summary
+
+| Issue | Count | Severity |
+|-------|-------|----------|
+| Tables in `dbo` schema (SQL Server legacy) | 10 | HIGH |
+| Tables with no explicit schema | 11 | MEDIUM |
+| Tables using snake_case naming | 5 | HIGH |
+| Tables using singular form (inconsistent) | 5 | MEDIUM |
+| Entity-table name mismatch | 1 | LOW |
+| Duplicate table mappings (two config files for same table) | 2 | MEDIUM |
+| Legacy DbMapper pattern (should be IEntityTypeConfiguration) | 2 | LOW |
+
+**Total tables: 36**
+
+---
+
+## Full Table Inventory
+
+### Schema: `dbo` — 10 tables ⚠️
+
+> `dbo` is a SQL Server convention. On PostgreSQL it creates a non-standard schema. These tables should be migrated to `public`.
+
+| Table | EF Config File | Naming | Notes |
+|-------|---------------|--------|-------|
+| `BankStatements` | `Features/Bank/BankStatementImportConfiguration.cs` | PascalCase | |
+| `imported_marketing_transactions` | `Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` | **snake_case** | Also mapped via `IssuedInvoiceDbMapper.cs` — see duplicate issue |
+| `IssuedInvoice` | `Invoices/IssuedInvoiceConfiguration.cs` | PascalCase | **Singular** form; also in `Mapping/IssuedInvoiceDbMapper.cs` |
+| `IssuedInvoiceSyncData` | `Invoices/IssuedInvoiceSyncDataConfiguration.cs` | PascalCase | Also in `Mapping/IssuedInvoiceDbMapper.cs` |
+| `KnowledgeBaseChunks` | `KnowledgeBase/KnowledgeBaseChunkConfiguration.cs` | PascalCase | |
+| `KnowledgeBaseDocuments` | `KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs` | PascalCase | |
+| `KnowledgeBaseQuestionLogs` | `KnowledgeBase/KnowledgeBaseQuestionLogConfiguration.cs` | PascalCase | |
+| `StockTakingResults` | `Logistics/StockTaking/StockTakingConfiguration.cs` | PascalCase | Entity class is `StockTakingRecord` — name mismatch |
+| `Jobs` | `Mapping/RecurringJobsDbMapper.cs` | PascalCase | Legacy mapper; **singular** |
+| `ScheduledTask` | `Mapping/ScheduledTaskDbMapper.cs` | PascalCase | Legacy mapper; **singular** |
+
+---
+
+### Schema: `public` — 15 tables ✅
+
+| Table | EF Config File | Naming | Notes |
+|-------|---------------|--------|-------|
+| `JournalEntries` | `Catalog/Journal/JournalEntryConfiguration.cs` | PascalCase | |
+| `JournalEntryProducts` | `Catalog/Journal/JournalEntryProductConfiguration.cs` | PascalCase | |
+| `JournalEntryTagAssignments` | `Catalog/Journal/JournalEntryTagAssignmentConfiguration.cs` | PascalCase | |
+| `JournalEntryTags` | `Catalog/Journal/JournalEntryTagConfiguration.cs` | PascalCase | |
+| `StockUpOperations` | `Catalog/Stock/StockUpOperationConfiguration.cs` | PascalCase | |
+| `TransportBox` | `Logistics/TransportBoxes/TransportBoxConfiguration.cs` | PascalCase | **Singular** |
+| `TransportBoxItem` | `Logistics/TransportBoxes/TransportBoxItemConfiguration.cs` | PascalCase | **Singular** |
+| `TransportBoxStateLog` | `Logistics/TransportBoxes/TransportBoxStateLogConfiguration.cs` | PascalCase | **Singular** |
+| `ManufactureOrders` | `Manufacture/ManufactureOrderConfiguration.cs` | PascalCase | |
+| `ManufactureOrderNotes` | `Manufacture/ManufactureOrderNoteConfiguration.cs` | PascalCase | |
+| `ManufactureOrderProducts` | `Manufacture/ManufactureOrderProductConfiguration.cs` | PascalCase | |
+| `ManufactureOrderSemiProducts` | `Manufacture/ManufactureOrderSemiProductConfiguration.cs` | PascalCase | |
+| `PurchaseOrders` | `Purchase/PurchaseOrders/PurchaseOrderConfiguration.cs` | PascalCase | |
+| `PurchaseOrderHistory` | `Purchase/PurchaseOrders/PurchaseOrderHistoryConfiguration.cs` | PascalCase | |
+| `PurchaseOrderLines` | `Purchase/PurchaseOrders/PurchaseOrderLineConfiguration.cs` | PascalCase | |
+
+---
+
+### Schema: implicit (no `ToTable` schema arg) — 11 tables ⚠️
+
+> EF Core on PostgreSQL with no `HasDefaultSchema` set will use `public` by default, but this is implicit and fragile. Should be made explicit.
+
+#### PascalCase (6)
+
+| Table | EF Config File |
+|-------|---------------|
+| `ManufactureDifficultySettings` | `Catalog/ManufactureDifficulty/ManufactureDifficultySettingsConfiguration.cs` |
+| `UserDashboardSettings` | `Dashboard/UserDashboardSettingsConfiguration.cs` |
+| `UserDashboardTiles` | `Dashboard/UserDashboardTileConfiguration.cs` |
+| `GridLayouts` | `GridLayouts/GridLayoutConfiguration.cs` |
+| `ClassificationHistory` | `InvoiceClassification/ClassificationHistoryConfiguration.cs` |
+| `ClassificationRules` | `InvoiceClassification/ClassificationRuleConfiguration.cs` |
+
+#### snake_case (5)
+
+| Table | EF Config File |
+|-------|---------------|
+| `recurring_job_configurations` | `BackgroundJobs/RecurringJobConfigurationConfiguration.cs` |
+| `dqt_runs` | `DataQuality/DqtRunConfiguration.cs` |
+| `invoice_dqt_results` | `DataQuality/InvoiceDqtResultConfiguration.cs` |
+| `gift_package_manufacture_items` | `Logistics/GiftPackageManufacture/GiftPackageManufactureItemConfiguration.cs` |
+| `gift_package_manufacture_logs` | `Logistics/GiftPackageManufacture/GiftPackageManufactureLogConfiguration.cs` |
+
+---
+
+## Issues Detail
+
+### Issue 1 — `dbo` schema on PostgreSQL (HIGH)
+
+**10 tables** explicitly use `schema: "dbo"`. On SQL Server, `dbo` is the default schema. On PostgreSQL, this creates a real separate schema called `dbo` alongside `public`. This means:
+
+- Queries must always include the schema qualifier
+- No PostgreSQL tooling treats `dbo` as default
+- Inconsistent with the other 26 tables in `public`
+
+**Affected tables:** `BankStatements`, `imported_marketing_transactions`, `IssuedInvoice`, `IssuedInvoiceSyncData`, `KnowledgeBaseChunks`, `KnowledgeBaseDocuments`, `KnowledgeBaseQuestionLogs`, `StockTakingResults`, `Jobs`, `ScheduledTask`
+
+**Fix:** Migrate all `dbo` tables to `public` schema via EF migration (`ALTER TABLE dbo.X SET SCHEMA public`).
+
+---
+
+### Issue 2 — Inconsistent naming convention (HIGH)
+
+**31 tables** use `PascalCase`, **5 tables** use `snake_case`. The snake_case tables are all recent additions (DQT, GiftPackage, RecurringJobs). PostgreSQL convention strongly favors `snake_case`; the PascalCase tables work but require quoted identifiers in raw SQL.
+
+**Snake_case tables:** `recurring_job_configurations`, `dqt_runs`, `invoice_dqt_results`, `gift_package_manufacture_items`, `gift_package_manufacture_logs`
+
+**Decision needed:** Pick one convention and apply it. Options:
+- **Option A:** Keep PascalCase (existing majority) — rename the 5 snake_case tables.
+- **Option B:** Migrate to snake_case (PostgreSQL idiomatic) — rename 31 PascalCase tables. Higher effort, better long-term.
+
+---
+
+### Issue 3 — Tables with no explicit schema (MEDIUM)
+
+**11 tables** call `ToTable("Name")` without a schema argument. EF Core resolves this to the default schema, which is `public` on PostgreSQL if `HasDefaultSchema` is not set on the context. This works but is fragile — adding `HasDefaultSchema("dbo")` to the context would silently move all of them.
+
+**Fix:** Add `"public"` as the second argument to all 11 `ToTable()` calls. One-line change per file, no migration needed.
+
+---
+
+### Issue 4 — Plural vs singular table names (MEDIUM)
+
+Most tables use plural form (`ManufactureOrders`, `KnowledgeBaseChunks`) but 5 tables use singular:
+
+| Singular Table | Schema |
+|---------------|--------|
+| `IssuedInvoice` | dbo |
+| `TransportBox` | public |
+| `TransportBoxItem` | public |
+| `TransportBoxStateLog` | public |
+| `ScheduledTask` | dbo |
+| `Jobs` | dbo |
+
+**Fix:** Rename to plural form when migrating schemas (combine with Issue 1 migration).
+
+---
+
+### Issue 5 — Entity-table name mismatch (LOW)
+
+`StockTakingConfiguration.cs` maps the entity class `StockTakingRecord` to table `StockTakingResults`. The table name doesn't reflect the domain concept.
+
+**Config:** `Logistics/StockTaking/StockTakingConfiguration.cs`  
+**Entity:** `StockTakingRecord`  
+**Table:** `StockTakingResults` (in `dbo`)
+
+---
+
+### Issue 6 — Duplicate table mappings (MEDIUM)
+
+`IssuedInvoice` and `IssuedInvoiceSyncData` are configured in **two places**:
+- `Invoices/IssuedInvoiceConfiguration.cs` and `Invoices/IssuedInvoiceSyncDataConfiguration.cs` (standard `IEntityTypeConfiguration<T>`)
+- `Mapping/IssuedInvoiceDbMapper.cs` (old mapper pattern calling `modelBuilder.Entity<T>()` directly)
+
+This creates dual registration. EF Core will apply both, which is silently additive but confusing and error-prone.
+
+**Fix:** Delete `Mapping/IssuedInvoiceDbMapper.cs` entirely. Keep the `IEntityTypeConfiguration<T>` files.
+
+Similarly `imported_marketing_transactions` only has a configuration file — no duplicate — but is in the `Features/MarketingInvoices/` path while all other features use the domain-organized path. Minor inconsistency.
+
+---
+
+### Issue 7 — Legacy DbMapper pattern (LOW)
+
+`Mapping/RecurringJobsDbMapper.cs` and `Mapping/ScheduledTaskDbMapper.cs` use an old ad-hoc mapper pattern (direct `modelBuilder.Entity<>()` calls) instead of the standard `IEntityTypeConfiguration<T>` used by all other tables.
+
+**Fix:** Convert to `IEntityTypeConfiguration<T>` and move to the appropriate feature folder. Or accept as legacy if these tables are framework-managed (e.g., Hangfire).
+
+---
+
+## Recommended Consolidation Phases
+
+### Phase 1 — Schema: make implicit explicit (30 min, zero migration risk)
+Add `"public"` to the 11 `ToTable()` calls that omit the schema argument.  
+Files: 6 PascalCase + 5 snake_case configs listed in the implicit section above.  
+No DB migration needed — no change to actual schema.
+
+### Phase 2 — Remove duplicate mapping (15 min)
+Delete `Mapping/IssuedInvoiceDbMapper.cs`. The `IEntityTypeConfiguration<T>` files already handle the full mapping.  
+No DB migration needed.
+
+### Phase 3 — Migrate `dbo` tables to `public` (1–2 hours)
+Write a SQL migration or EF migration to `ALTER TABLE dbo.X SET SCHEMA public` for all 10 `dbo` tables.  
+Update the 10 configuration files: change `"dbo"` → `"public"`.  
+Update `Mapping/RecurringJobsDbMapper.cs` and `Mapping/ScheduledTaskDbMapper.cs` schemas.  
+Risk: medium — requires coordinated DB migration in all environments.
+
+### Phase 4 — Standardize table naming (2–8 hours depending on choice)
+Pick a convention (PascalCase or snake_case) and rename tables via migration.  
+Also fix singular → plural for the 5/6 singular tables.  
+Risk: medium — rename migrations required; raw SQL in any external tools must be updated.
+
+### Phase 5 — Fix entity-table mismatch (LOW)
+Rename `StockTakingResults` table to `StockTakingRecords` when doing Phase 4.
+
+---
+
+## Notes on `Jobs` and `ScheduledTask` tables
+
+These are mapped via `RecurringJobsDbMapper.cs` and `ScheduledTaskDbMapper.cs` in `dbo` schema. Verify whether these are:
+- **Hangfire tables** — if so, schema is controlled by Hangfire config, not EF, and the mappers are just read models. Do not rename.
+- **Application tables** — if so, treat like any other table and migrate.

--- a/docs/database-table-map.md
+++ b/docs/database-table-map.md
@@ -1,0 +1,384 @@
+# Database Table Map
+
+> **Purpose:** Complete pre-implementation reference for the DB consolidation project.  
+> Every table in the database is listed with its current state, every planned change, and which task in `docs/superpowers/plans/2026-04-24-db-consolidation.md` performs it.  
+> No change may be implemented without first being defined here.
+
+**Legend:**
+- ✅ No change needed
+- 🗑️ DROP — table is orphaned
+- 🔀 SCHEMA — schema change only
+- ✏️ RENAME — table/column rename (DB migration)
+- 📋 CONFIG — config file change only, no DB migration
+- 🔀✏️ SCHEMA + RENAME — both in same migration
+
+---
+
+## Summary Table
+
+| # | Current schema | Current table name | Target schema | Target table name | Changes | Task |
+|---|---------------|-------------------|--------------|------------------|---------|------|
+| 1 | `dbo` | `Jobs` | — | — | 🗑️ DROP (orphaned) | T0 |
+| 2 | `dbo` | `ScheduledTask` | — | — | 🗑️ DROP (orphaned) | T0 |
+| 3 | `dbo` | `BankStatements` | `public` | `BankStatements` | 🔀 SCHEMA | T3 |
+| 4 | `dbo` | `imported_marketing_transactions` | `public` | `ImportedMarketingTransactions` | 🔀✏️ SCHEMA + RENAME | T3+T4 |
+| 5 | `dbo` | `IssuedInvoice` | `public` | `IssuedInvoices` | 🔀✏️ SCHEMA + RENAME + index renames | T3+T5 |
+| 6 | `dbo` | `IssuedInvoiceSyncData` | `public` | `IssuedInvoiceSyncData` | 🔀 SCHEMA | T3 |
+| 7 | `dbo` | `KnowledgeBaseChunks` | `public` | `KnowledgeBaseChunks` | 🔀 SCHEMA | T3 |
+| 8 | `dbo` | `KnowledgeBaseDocuments` | `public` | `KnowledgeBaseDocuments` | 🔀 SCHEMA | T3 |
+| 9 | `dbo` | `KnowledgeBaseQuestionLogs` | `public` | `KnowledgeBaseQuestionLogs` | 🔀 SCHEMA | T3 |
+| 10 | `dbo` | `StockTakingResults` | `public` | `StockTakingRecords` | 🔀✏️ SCHEMA + RENAME (entity mismatch) | T3+T5 |
+| 11 | `dbo` | `PackingMaterial` | `public` | `PackingMaterials` | 🔀✏️ SCHEMA + RENAME + index rename | T3+T5 |
+| 12 | `dbo` | `PackingMaterialLog` | `public` | `PackingMaterialLogs` | 🔀✏️ SCHEMA + RENAME | T3+T5 |
+| 13 | implicit→`public` | `ManufactureDifficultySettings` | `public` | `ManufactureDifficultySettings` | 📋 CONFIG (explicit schema) | T2 |
+| 14 | implicit→`public` | `UserDashboardSettings` | `public` | `UserDashboardSettings` | 📋 CONFIG (explicit schema) | T2 |
+| 15 | implicit→`public` | `UserDashboardTiles` | `public` | `UserDashboardTiles` | 📋 CONFIG (explicit schema) | T2 |
+| 16 | implicit→`public` | `GridLayouts` | `public` | `GridLayouts` | 📋 CONFIG (explicit schema) | T2 |
+| 17 | implicit→`public` | `ClassificationHistory` | `public` | `ClassificationHistory` | 📋 CONFIG (explicit schema) | T2 |
+| 18 | implicit→`public` | `ClassificationRules` | `public` | `ClassificationRules` | 📋 CONFIG (explicit schema) | T2 |
+| 19 | implicit→`public` | `recurring_job_configurations` | `public` | `RecurringJobConfigurations` | ✏️ RENAME table + 8 column renames | T2+T4 |
+| 20 | implicit→`public` | `dqt_runs` | `public` | `DqtRuns` | ✏️ RENAME table + 10 column renames + 1 index rename | T2+T4 |
+| 21 | implicit→`public` | `invoice_dqt_results` | `public` | `InvoiceDqtResults` | ✏️ RENAME table + 7 column renames + 2 index renames | T2+T4 |
+| 22 | implicit→`public` | `gift_package_manufacture_items` | `public` | `GiftPackageManufactureItems` | ✏️ RENAME table + 4 column renames + 2 index renames + sequence rename | T2+T4 |
+| 23 | implicit→`public` | `gift_package_manufacture_logs` | `public` | `GiftPackageManufactureLogs` | ✏️ RENAME table + 7 column renames + 3 index renames + sequence rename | T2+T4 |
+| 24 | `public` | `JournalEntries` | `public` | `JournalEntries` | ✅ no change | — |
+| 25 | `public` | `JournalEntryProducts` | `public` | `JournalEntryProducts` | ✅ no change | — |
+| 26 | `public` | `JournalEntryTagAssignments` | `public` | `JournalEntryTagAssignments` | ✅ no change | — |
+| 27 | `public` | `JournalEntryTags` | `public` | `JournalEntryTags` | ✅ no change | — |
+| 28 | `public` | `StockUpOperations` | `public` | `StockUpOperations` | ✅ no change | — |
+| 29 | `public` | `TransportBox` | `public` | `TransportBoxes` | ✏️ RENAME (singular→plural) | T5 |
+| 30 | `public` | `TransportBoxItem` | `public` | `TransportBoxItems` | ✏️ RENAME (singular→plural) | T5 |
+| 31 | `public` | `TransportBoxStateLog` | `public` | `TransportBoxStateLogs` | ✏️ RENAME (singular→plural) | T5 |
+| 32 | `public` | `ManufactureOrders` | `public` | `ManufactureOrders` | ✅ no change | — |
+| 33 | `public` | `ManufactureOrderNotes` | `public` | `ManufactureOrderNotes` | ✅ no change | — |
+| 34 | `public` | `ManufactureOrderProducts` | `public` | `ManufactureOrderProducts` | ✅ no change | — |
+| 35 | `public` | `ManufactureOrderSemiProducts` | `public` | `ManufactureOrderSemiProducts` | ✅ no change | — |
+| 36 | `public` | `PurchaseOrders` | `public` | `PurchaseOrders` | ✅ no change | — |
+| 37 | `public` | `PurchaseOrderHistory` | `public` | `PurchaseOrderHistory` | ✅ no change | — |
+| 38 | `public` | `PurchaseOrderLines` | `public` | `PurchaseOrderLines` | ✅ no change | — |
+
+**Count:** 38 tables total — 2 drop, 9 schema-only, 16 rename (or schema+rename), 6 config-only, 15 no change.
+
+---
+
+## Tables 1–2: DROP (orphaned)
+
+### `dbo.Jobs` → DROP
+
+**Config file:** `Mapping/RecurringJobsDbMapper.cs` (delete entire file)  
+**Entity:** `RecurringJob` (domain class — delete after confirming no other use)  
+**Why orphaned:** `DbSet<RecurringJob>` and `ConfigureRecurringJobs()` are both commented out in `ApplicationDbContext`. The feature was replaced by Hangfire + `RecurringJobConfigurations`.
+
+**Pre-drop verification:**
+```sql
+SELECT COUNT(*) FROM dbo."Jobs";
+-- Expected: 0
+```
+
+**Drop SQL:**
+```sql
+DROP TABLE IF EXISTS dbo."Jobs";
+```
+
+---
+
+### `dbo.ScheduledTask` → DROP
+
+**Config file:** `Mapping/ScheduledTaskDbMapper.cs` (delete entire file)  
+**Entity:** `ScheduledTask`  
+**Why orphaned:** Same as above — commented out entirely in `ApplicationDbContext`.
+
+**Pre-drop verification:**
+```sql
+SELECT COUNT(*) FROM dbo."ScheduledTask";
+-- Expected: 0
+```
+
+**Drop SQL:**
+```sql
+DROP TABLE IF EXISTS dbo."ScheduledTask";
+```
+
+---
+
+## Tables 3–12: Schema change `dbo` → `public`
+
+All 10 of these share the same migration pattern. Handled in Task 3.
+
+### Simple schema changes (name stays the same)
+
+| # | Table | Config file |
+|---|-------|-------------|
+| 3 | `BankStatements` | `Features/Bank/BankStatementImportConfiguration.cs` |
+| 6 | `IssuedInvoiceSyncData` | `Invoices/IssuedInvoiceSyncDataConfiguration.cs` |
+| 7 | `KnowledgeBaseChunks` | `KnowledgeBase/KnowledgeBaseChunkConfiguration.cs` |
+| 8 | `KnowledgeBaseDocuments` | `KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs` |
+| 9 | `KnowledgeBaseQuestionLogs` | `KnowledgeBase/KnowledgeBaseQuestionLogConfiguration.cs` |
+
+Config change in each: `"dbo"` → `"public"`.  
+DB migration: `RenameTable(name: "X", schema: "dbo", newSchema: "public")`.  
+No column changes. No sequence risk (PostgreSQL moves owned sequences with `SET SCHEMA`).
+
+---
+
+### Schema change + additional rename (handled in two tasks)
+
+#### Table 4: `dbo.imported_marketing_transactions` → `public.ImportedMarketingTransactions`
+
+**Config file:** `Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`  
+**Auto-increment PK:** yes (`ValueGeneratedOnAdd`) — sequence moves automatically with schema change  
+**Column naming:** EF defaults (PascalCase) — no column renames needed  
+**Index names:** check config for any `HasDatabaseName` with snake_case — update to PascalCase  
+
+Task 3 migration step: `RenameTable(name: "imported_marketing_transactions", schema: "dbo", newSchema: "public")`  
+Task 4 migration step: `RenameTable(name: "imported_marketing_transactions", schema: "public", newName: "ImportedMarketingTransactions")`
+
+---
+
+#### Table 5: `dbo.IssuedInvoice` → `public.IssuedInvoices`
+
+**Config file:** `Invoices/IssuedInvoiceConfiguration.cs`  
+**Column naming:** explicit PascalCase `HasColumnName` — no column renames needed  
+**Indexes to rename** (all in Task 5 migration):
+
+| Current index name | Target index name |
+|-------------------|------------------|
+| `IX_IssuedInvoice_InvoiceDate` | `IX_IssuedInvoices_InvoiceDate` |
+| `IX_IssuedInvoice_LastSyncTime` | `IX_IssuedInvoices_LastSyncTime` |
+| `IX_IssuedInvoice_IsSynced` | `IX_IssuedInvoices_IsSynced` |
+| `IX_IssuedInvoice_ErrorType` | `IX_IssuedInvoices_ErrorType` |
+| `IX_IssuedInvoice_CustomerName` | `IX_IssuedInvoices_CustomerName` |
+
+Task 3: schema move. Task 5: rename table + rename 5 indexes.
+
+---
+
+#### Table 10: `dbo.StockTakingResults` → `public.StockTakingRecords`
+
+**Config file:** `Logistics/StockTaking/StockTakingConfiguration.cs`  
+**Entity class:** `StockTakingRecord`  
+**Issue:** table name `StockTakingResults` does not match entity name — should be `StockTakingRecords`  
+**Column naming:** check config for any index names to update  
+
+Task 3: schema move. Task 5: rename table to `StockTakingRecords`.
+
+---
+
+#### Table 11: `dbo.PackingMaterial` → `public.PackingMaterials`
+
+**Config file:** `PackingMaterials/PackingMaterialConfiguration.cs`  
+**Indexes to rename:**
+
+| Current | Target |
+|---------|--------|
+| `IX_PackingMaterial_Name` | `IX_PackingMaterials_Name` |
+
+Task 3: schema move. Task 5: rename table + rename 1 index.
+
+---
+
+#### Table 12: `dbo.PackingMaterialLog` → `public.PackingMaterialLogs`
+
+**Config file:** `PackingMaterials/PackingMaterialLogConfiguration.cs`  
+**Indexes:** check config — update any `HasDatabaseName` that embeds the old table name.
+
+Task 3: schema move. Task 5: rename table.
+
+---
+
+## Tables 13–18: Config-only (explicit schema)
+
+No DB migration. Only add `"public"` as second argument to `ToTable()`.
+
+| # | Table | Config file |
+|---|-------|-------------|
+| 13 | `ManufactureDifficultySettings` | `Catalog/ManufactureDifficulty/ManufactureDifficultySettingsConfiguration.cs` |
+| 14 | `UserDashboardSettings` | `Dashboard/UserDashboardSettingsConfiguration.cs` |
+| 15 | `UserDashboardTiles` | `Dashboard/UserDashboardTileConfiguration.cs` |
+| 16 | `GridLayouts` | `GridLayouts/GridLayoutConfiguration.cs` |
+| 17 | `ClassificationHistory` | `InvoiceClassification/ClassificationHistoryConfiguration.cs` |
+| 18 | `ClassificationRules` | `InvoiceClassification/ClassificationRuleConfiguration.cs` |
+
+---
+
+## Tables 19–23: snake_case → PascalCase (table + columns)
+
+These tables have both snake_case table names AND snake_case column names forced via `HasColumnName`. Both must be changed together in Task 4. Task 2 makes the schema explicit first (config-only, no DB change).
+
+---
+
+### Table 19: `recurring_job_configurations` → `RecurringJobConfigurations`
+
+**Config file:** `BackgroundJobs/RecurringJobConfigurationConfiguration.cs`  
+**Auto-increment PK:** no
+
+**Column renames (DB migration required):**
+
+| Current column | Target column |
+|---------------|--------------|
+| `id` | `Id` |
+| `job_name` | `JobName` |
+| `display_name` | `DisplayName` |
+| `description` | `Description` |
+| `cron_expression` | `CronExpression` |
+| `is_enabled` | `IsEnabled` |
+| `last_modified_at` | `LastModifiedAt` |
+| `last_modified_by` | `LastModifiedBy` |
+
+**Config changes:** remove all `HasColumnName(...)` calls — EF will map property names directly.
+
+---
+
+### Table 20: `dqt_runs` → `DqtRuns`
+
+**Config file:** `DataQuality/DqtRunConfiguration.cs`  
+**Auto-increment PK:** no (Guid)  
+**FK referenced by:** `invoice_dqt_results.dqt_run_id` → `InvoiceDqtResults.DqtRunId`
+
+**Column renames:**
+
+| Current column | Target column |
+|---------------|--------------|
+| `id` | `Id` |
+| `test_type` | `TestType` |
+| `date_from` | `DateFrom` |
+| `date_to` | `DateTo` |
+| `status` | `Status` |
+| `started_at` | `StartedAt` |
+| `completed_at` | `CompletedAt` |
+| `trigger_type` | `TriggerType` |
+| `total_checked` | `TotalChecked` |
+| `total_mismatches` | `TotalMismatches` |
+| `error_message` | `ErrorMessage` |
+
+**Index renames:**
+
+| Current | Target |
+|---------|--------|
+| `IX_dqt_runs_test_type_started_at` | `IX_DqtRuns_TestType_StartedAt` |
+
+---
+
+### Table 21: `invoice_dqt_results` → `InvoiceDqtResults`
+
+**Config file:** `DataQuality/InvoiceDqtResultConfiguration.cs`  
+**Auto-increment PK:** no (Guid)  
+**FK:** `dqt_run_id` references `dqt_runs.id` — both column and referenced table are being renamed, must rename FK constraint too
+
+**Column renames:**
+
+| Current column | Target column |
+|---------------|--------------|
+| `id` | `Id` |
+| `dqt_run_id` | `DqtRunId` |
+| `invoice_code` | `InvoiceCode` |
+| `mismatch_type` | `MismatchType` |
+| `shoptet_value` | `ShoptetValue` |
+| `flexi_value` | `FlexiValue` |
+| `details` | `Details` |
+
+**Index renames:**
+
+| Current | Target |
+|---------|--------|
+| `IX_invoice_dqt_results_dqt_run_id` | `IX_InvoiceDqtResults_DqtRunId` |
+| `IX_invoice_dqt_results_invoice_code` | `IX_InvoiceDqtResults_InvoiceCode` |
+
+---
+
+### Table 22: `gift_package_manufacture_items` → `GiftPackageManufactureItems`
+
+**Config file:** `Logistics/GiftPackageManufacture/GiftPackageManufactureItemConfiguration.cs`  
+**Auto-increment PK:** yes — sequence `gift_package_manufacture_items_id_seq` stays functional but name becomes stale after rename; optionally rename to `GiftPackageManufactureItems_Id_seq`  
+**FK:** `manufacture_log_id` references `gift_package_manufacture_logs.id`
+
+**Column renames:**
+
+| Current column | Target column |
+|---------------|--------------|
+| `id` | `Id` |
+| `manufacture_log_id` | `ManufactureLogId` |
+| `product_code` | `ProductCode` |
+| `quantity_consumed` | `QuantityConsumed` |
+
+**Index renames:**
+
+| Current | Target |
+|---------|--------|
+| `ix_gift_package_manufacture_items_manufacture_log_id` | `IX_GiftPackageManufactureItems_ManufactureLogId` |
+| `ix_gift_package_manufacture_items_product_code` | `IX_GiftPackageManufactureItems_ProductCode` |
+
+---
+
+### Table 23: `gift_package_manufacture_logs` → `GiftPackageManufactureLogs`
+
+**Config file:** `Logistics/GiftPackageManufacture/GiftPackageManufactureLogConfiguration.cs`  
+**Auto-increment PK:** yes — same sequence rename note as Table 22  
+**FK referenced by:** `gift_package_manufacture_items.manufacture_log_id`
+
+**Column renames:**
+
+| Current column | Target column |
+|---------------|--------------|
+| `id` | `Id` |
+| `gift_package_code` | `GiftPackageCode` |
+| `quantity_created` | `QuantityCreated` |
+| `stock_override_applied` | `StockOverrideApplied` |
+| `created_at` | `CreatedAt` |
+| `created_by` | `CreatedBy` |
+| `operation_type` | `OperationType` |
+
+**Index renames:**
+
+| Current | Target |
+|---------|--------|
+| `ix_gift_package_manufacture_logs_created_at` | `IX_GiftPackageManufactureLogs_CreatedAt` |
+| `ix_gift_package_manufacture_logs_gift_package_code` | `IX_GiftPackageManufactureLogs_GiftPackageCode` |
+| `ix_gift_package_manufacture_logs_operation_type` | `IX_GiftPackageManufactureLogs_OperationType` |
+
+---
+
+## Tables 29–31: Rename (singular → plural)
+
+These are already in the `public` schema with PascalCase names. Only issue is singular form.
+
+| # | Current | Target | Config file |
+|---|---------|--------|-------------|
+| 29 | `public.TransportBox` | `public.TransportBoxes` | `Logistics/TransportBoxes/TransportBoxConfiguration.cs` |
+| 30 | `public.TransportBoxItem` | `public.TransportBoxItems` | `Logistics/TransportBoxes/TransportBoxItemConfiguration.cs` |
+| 31 | `public.TransportBoxStateLog` | `public.TransportBoxStateLogs` | `Logistics/TransportBoxes/TransportBoxStateLogConfiguration.cs` |
+
+No column renames. Check each config for index names embedding the old table name and update them.
+
+---
+
+## Tables 24–28, 32–38: No changes
+
+| # | Table | Schema | Reason |
+|---|-------|--------|--------|
+| 24 | `JournalEntries` | public | ✅ |
+| 25 | `JournalEntryProducts` | public | ✅ |
+| 26 | `JournalEntryTagAssignments` | public | ✅ |
+| 27 | `JournalEntryTags` | public | ✅ |
+| 28 | `StockUpOperations` | public | ✅ |
+| 32 | `ManufactureOrders` | public | ✅ |
+| 33 | `ManufactureOrderNotes` | public | ✅ |
+| 34 | `ManufactureOrderProducts` | public | ✅ |
+| 35 | `ManufactureOrderSemiProducts` | public | ✅ |
+| 36 | `PurchaseOrders` | public | ✅ |
+| 37 | `PurchaseOrderHistory` | public | ✅ (`History` is uncountable — not renamed) |
+| 38 | `PurchaseOrderLines` | public | ✅ |
+
+---
+
+## Change count by task
+
+| Task | Tables affected | DB migration? | Change type |
+|------|----------------|--------------|-------------|
+| T0 | 2 (Jobs, ScheduledTask) | Yes | DROP |
+| T2 | 11 | No | Config: explicit schema |
+| T3 | 10 | Yes | SCHEMA dbo→public |
+| T4 | 6 | Yes | RENAME table + columns + indexes |
+| T5 | 7 | Yes | RENAME table + indexes |
+
+> Note: Tables 4, 5, 10, 11, 12 are touched in both T3 (schema) and T4/T5 (rename). The two migrations run sequentially — schema first, rename second.

--- a/docs/superpowers/plans/2026-04-24-db-consolidation.md
+++ b/docs/superpowers/plans/2026-04-24-db-consolidation.md
@@ -1,0 +1,814 @@
+# DB Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate the database model — remove dead code, unify all tables into the `public` schema, standardize naming conventions, and fix singular/plural inconsistencies.
+
+**Architecture:** All changes are EF Core configuration-only (Tasks 1–2) or EF Core migration + config updates (Tasks 3–6). Each task is independently deployable. Tasks 1 and 2 carry zero DB migration risk. Tasks 3–6 each require a manual `dotnet ef database update` in every environment (dev, stg, prod).
+
+**Tech Stack:** .NET 8, EF Core 8, PostgreSQL (Npgsql), `dotnet ef` CLI
+
+---
+
+## Context & Key Findings
+
+Before implementing, know these facts gathered from reading the source:
+
+**Dead code (mapper files already commented out in `ApplicationDbContext`):**
+- `Mapping/IssuedInvoiceDbMapper.cs` — commented out: `//modelBuilder.ConfigureIssuedInvoices();`
+- `Mapping/RecurringJobsDbMapper.cs` — commented out: `//modelBuilder.ConfigureRecurringJobs();`
+- `Mapping/ScheduledTaskDbMapper.cs` — commented out: `//modelBuilder.ConfigureScheduledTasks();`
+- The DbSets for `RecurringJob` and `ScheduledTask` are also commented out in `ApplicationDbContext.cs`
+
+**Live `dbo` tables (10):** `BankStatements`, `imported_marketing_transactions`, `IssuedInvoice`, `IssuedInvoiceSyncData`, `KnowledgeBaseChunks`, `KnowledgeBaseDocuments`, `KnowledgeBaseQuestionLogs`, `StockTakingResults`, `PackingMaterial`, `PackingMaterialLog`
+
+**Naming decision (required before Task 4):** See Task 4 preamble. Default recommendation: **keep PascalCase** (rename 5 snake_case tables, far less work than renaming 31).
+
+---
+
+## File Map
+
+### Files to delete (Task 1)
+- `backend/src/Anela.Heblo.Persistence/Mapping/IssuedInvoiceDbMapper.cs`
+- `backend/src/Anela.Heblo.Persistence/Mapping/RecurringJobsDbMapper.cs`
+- `backend/src/Anela.Heblo.Persistence/Mapping/ScheduledTaskDbMapper.cs`
+
+### Files to modify — schema only (Task 2, no DB migration)
+- `backend/src/Anela.Heblo.Persistence/Catalog/ManufactureDifficulty/ManufactureDifficultySettingsConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Dashboard/UserDashboardSettingsConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Dashboard/UserDashboardTileConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationHistoryConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/InvoiceClassification/ClassificationRuleConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/DataQuality/InvoiceDqtResultConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftPackageManufacture/GiftPackageManufactureItemConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftPackageManufacture/GiftPackageManufactureLogConfiguration.cs`
+
+### Files to modify — `dbo` → `public` schema (Task 3)
+- `backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceSyncDataConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseChunkConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseQuestionLogConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/StockTaking/StockTakingConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialLogConfiguration.cs`
+
+### Files to modify — snake_case → PascalCase rename (Task 4, if PascalCase chosen)
+- `backend/src/Anela.Heblo.Persistence/BackgroundJobs/RecurringJobConfigurationConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/DataQuality/DqtRunConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/DataQuality/InvoiceDqtResultConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftPackageManufacture/GiftPackageManufactureItemConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/GiftPackageManufacture/GiftPackageManufactureLogConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`
+
+### Files to modify — singular → plural + entity-table mismatch (Task 5)
+- `backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/TransportBoxes/TransportBoxConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/TransportBoxes/TransportBoxItemConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/TransportBoxes/TransportBoxStateLogConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Logistics/StockTaking/StockTakingConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialLogConfiguration.cs`
+
+---
+
+## Task 1: Delete dead mapper files
+
+**No DB migration needed. No application behavior changes.**
+
+The three mapper files in `Mapping/` are already fully inert — every call to them is commented out in `ApplicationDbContext.cs`. Deleting them removes confusion about which mapping is authoritative.
+
+**Files to delete:**
+- `backend/src/Anela.Heblo.Persistence/Mapping/IssuedInvoiceDbMapper.cs`
+- `backend/src/Anela.Heblo.Persistence/Mapping/RecurringJobsDbMapper.cs`
+- `backend/src/Anela.Heblo.Persistence/Mapping/ScheduledTaskDbMapper.cs`
+
+- [ ] **Step 1.1: Verify the mapper calls are commented out**
+
+```bash
+grep -n "ConfigureIssuedInvoices\|ConfigureRecurringJobs\|ConfigureScheduledTasks" \
+  backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+```
+
+Expected output (all commented):
+```
+94:        //modelBuilder.ConfigureScheduledTasks();
+95:        //modelBuilder.ConfigureIssuedInvoices();
+96:        //modelBuilder.ConfigureRecurringJobs();
+```
+
+If any line is NOT commented, comment it out before proceeding.
+
+- [ ] **Step 1.2: Delete the three files**
+
+```bash
+rm backend/src/Anela.Heblo.Persistence/Mapping/IssuedInvoiceDbMapper.cs
+rm backend/src/Anela.Heblo.Persistence/Mapping/RecurringJobsDbMapper.cs
+rm backend/src/Anela.Heblo.Persistence/Mapping/ScheduledTaskDbMapper.cs
+```
+
+- [ ] **Step 1.3: Check whether the `Mapping/` directory has any remaining files**
+
+```bash
+ls backend/src/Anela.Heblo.Persistence/Mapping/
+```
+
+If the directory is now empty, delete it:
+```bash
+rmdir backend/src/Anela.Heblo.Persistence/Mapping/
+```
+
+- [ ] **Step 1.4: Build to confirm no compile errors**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 1.5: Run backend tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add -A
+git commit -m "chore(db): delete dead mapper files (IssuedInvoice, RecurringJobs, ScheduledTask)"
+```
+
+---
+
+## Task 2: Explicit schema for implicit tables
+
+**No DB migration needed.** On PostgreSQL without `HasDefaultSchema`, EF resolves unqualified `ToTable("Name")` to the `public` schema. This task makes that explicit so future changes (e.g. adding `HasDefaultSchema`) can't silently break things.
+
+**11 configuration files.** Pattern: change `builder.ToTable("X")` → `builder.ToTable("X", "public")`.
+
+- [ ] **Step 2.1: Update the 6 PascalCase implicit configs**
+
+In each file below, find the `ToTable` call and add `"public"` as the second argument:
+
+**`Catalog/ManufactureDifficulty/ManufactureDifficultySettingsConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("ManufactureDifficultySettings");
+// After:
+builder.ToTable("ManufactureDifficultySettings", "public");
+```
+
+**`Dashboard/UserDashboardSettingsConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("UserDashboardSettings");
+// After:
+builder.ToTable("UserDashboardSettings", "public");
+```
+
+**`Dashboard/UserDashboardTileConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("UserDashboardTiles");
+// After:
+builder.ToTable("UserDashboardTiles", "public");
+```
+
+**`GridLayouts/GridLayoutConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("GridLayouts");
+// After:
+builder.ToTable("GridLayouts", "public");
+```
+
+**`InvoiceClassification/ClassificationHistoryConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("ClassificationHistory");
+// After:
+builder.ToTable("ClassificationHistory", "public");
+```
+
+**`InvoiceClassification/ClassificationRuleConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("ClassificationRules");
+// After:
+builder.ToTable("ClassificationRules", "public");
+```
+
+- [ ] **Step 2.2: Update the 5 snake_case implicit configs**
+
+**`BackgroundJobs/RecurringJobConfigurationConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("recurring_job_configurations");
+// After:
+builder.ToTable("recurring_job_configurations", "public");
+```
+
+**`DataQuality/DqtRunConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("dqt_runs");
+// After:
+builder.ToTable("dqt_runs", "public");
+```
+
+**`DataQuality/InvoiceDqtResultConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("invoice_dqt_results");
+// After:
+builder.ToTable("invoice_dqt_results", "public");
+```
+
+**`Logistics/GiftPackageManufacture/GiftPackageManufactureItemConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("gift_package_manufacture_items");
+// After:
+builder.ToTable("gift_package_manufacture_items", "public");
+```
+
+**`Logistics/GiftPackageManufacture/GiftPackageManufactureLogConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("gift_package_manufacture_logs");
+// After:
+builder.ToTable("gift_package_manufacture_logs", "public");
+```
+
+- [ ] **Step 2.3: Verify no ToTable call is missing a schema**
+
+```bash
+grep -rn "\.ToTable(" \
+  backend/src/Anela.Heblo.Persistence/ \
+  --include="*.cs" \
+  --exclude-dir=obj \
+  --exclude-dir=Migrations \
+  | grep -v '"dbo"' \
+  | grep -v '"public"' \
+  | grep -v "null"
+```
+
+Expected: **no output** (every ToTable now has an explicit schema).
+
+- [ ] **Step 2.4: Build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 2.5: Confirm EF model sees no schema drift (no pending migration)**
+
+```bash
+cd backend/src/Anela.Heblo.Persistence && \
+  dotnet ef migrations add Verify_ExplicitSchemas --no-build 2>&1 | head -5
+```
+
+Expected output contains: `No model changes were detected`  
+If a migration IS generated, inspect it — it should be empty. Delete it immediately:
+```bash
+# If empty migration was created, delete it:
+dotnet ef migrations remove
+```
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+cd ../../../..
+git add backend/src/Anela.Heblo.Persistence/
+git commit -m "chore(db): make schema explicit for 11 implicit ToTable calls (all => public)"
+```
+
+---
+
+## Task 3: Migrate `dbo` tables to `public` schema
+
+**Requires an EF Core migration + manual `dotnet ef database update` in every environment.**
+
+**Rollback SQL** (run in psql if migration must be reverted):
+```sql
+ALTER TABLE public."BankStatements"              SET SCHEMA dbo;
+ALTER TABLE public."imported_marketing_transactions" SET SCHEMA dbo;
+ALTER TABLE public."IssuedInvoice"               SET SCHEMA dbo;
+ALTER TABLE public."IssuedInvoiceSyncData"       SET SCHEMA dbo;
+ALTER TABLE public."KnowledgeBaseChunks"         SET SCHEMA dbo;
+ALTER TABLE public."KnowledgeBaseDocuments"      SET SCHEMA dbo;
+ALTER TABLE public."KnowledgeBaseQuestionLogs"   SET SCHEMA dbo;
+ALTER TABLE public."StockTakingResults"          SET SCHEMA dbo;
+ALTER TABLE public."PackingMaterial"             SET SCHEMA dbo;
+ALTER TABLE public."PackingMaterialLog"          SET SCHEMA dbo;
+```
+
+- [ ] **Step 3.1: Update all 10 `dbo` config files**
+
+Change `"dbo"` → `"public"` in the `ToTable` call in each file:
+
+```
+Features/Bank/BankStatementImportConfiguration.cs
+Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
+Invoices/IssuedInvoiceConfiguration.cs
+Invoices/IssuedInvoiceSyncDataConfiguration.cs
+KnowledgeBase/KnowledgeBaseChunkConfiguration.cs
+KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs
+KnowledgeBase/KnowledgeBaseQuestionLogConfiguration.cs
+Logistics/StockTaking/StockTakingConfiguration.cs
+PackingMaterials/PackingMaterialConfiguration.cs
+PackingMaterials/PackingMaterialLogConfiguration.cs
+```
+
+Example (same pattern for all 10):
+```csharp
+// Before:
+builder.ToTable("BankStatements", "dbo");
+// After:
+builder.ToTable("BankStatements", "public");
+```
+
+- [ ] **Step 3.2: Verify no `dbo` references remain in active config files**
+
+```bash
+grep -rn '"dbo"' \
+  backend/src/Anela.Heblo.Persistence/ \
+  --include="*.cs" \
+  --exclude-dir=obj \
+  --exclude-dir=Migrations
+```
+
+Expected: **no output**.
+
+- [ ] **Step 3.3: Build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 3.4: Generate EF migration**
+
+```bash
+cd backend/src/Anela.Heblo.Persistence && \
+  dotnet ef migrations add MoveTablesFromDboToPublicSchema
+```
+
+- [ ] **Step 3.5: Inspect the generated migration**
+
+```bash
+ls -t Migrations/ | head -2
+```
+
+Open the most recent `*_MoveTablesFromDboToPublicSchema.cs` file. The `Up()` method must contain exactly 10 `RenameTable` calls, one per table. Example of expected content:
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.RenameTable(name: "BankStatements",    schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "imported_marketing_transactions", schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "IssuedInvoice",     schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "IssuedInvoiceSyncData", schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "KnowledgeBaseChunks", schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "KnowledgeBaseDocuments", schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "KnowledgeBaseQuestionLogs", schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "StockTakingResults", schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "PackingMaterial",   schema: "dbo", newSchema: "public");
+    migrationBuilder.RenameTable(name: "PackingMaterialLog", schema: "dbo", newSchema: "public");
+}
+```
+
+If EF generated anything else (column changes, index changes) — stop and investigate before proceeding.
+
+- [ ] **Step 3.6: Apply migration to local dev database**
+
+```bash
+dotnet ef database update
+```
+
+Expected: `Done.` with no errors.
+
+- [ ] **Step 3.7: Run backend tests**
+
+```bash
+cd ../../.. && dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all pass.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/
+git commit -m "feat(db): migrate all dbo tables to public schema (10 tables)"
+```
+
+- [ ] **Step 3.9: Apply to staging**
+
+```bash
+# Connect to staging database connection string, then:
+dotnet ef database update --connection "<STAGING_CONNECTION_STRING>"
+```
+
+Or instruct ops to apply the migration manually.
+
+---
+
+## Task 4: Standardize table naming (snake_case vs PascalCase)
+
+> **DECISION GATE** — Choose before implementing:
+>
+> **Option A — Keep PascalCase (recommended, lower effort):**  
+> Rename 6 snake_case tables to PascalCase. Affects: `recurring_job_configurations` → `RecurringJobConfigurations`, `dqt_runs` → `DqtRuns`, `invoice_dqt_results` → `InvoiceDqtResults`, `gift_package_manufacture_items` → `GiftPackageManufactureItems`, `gift_package_manufacture_logs` → `GiftPackageManufactureLogs`, `imported_marketing_transactions` → `ImportedMarketingTransactions`.
+>
+> **Option B — Migrate all to snake_case (PostgreSQL idiomatic, higher effort):**  
+> Rename 31 PascalCase tables. Requires a large migration and updating all index names that include the table name. Estimate: 2–4 additional hours. Raw SQL queries and pgAdmin views must be updated.
+>
+> **This plan implements Option A.** If you choose Option B, adapt the steps accordingly.
+
+- [ ] **Step 4.1: Update the 6 snake_case config files to PascalCase table names**
+
+**`BackgroundJobs/RecurringJobConfigurationConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("recurring_job_configurations", "public");
+// After:
+builder.ToTable("RecurringJobConfigurations", "public");
+```
+
+Also update column name overrides in this file — change all `HasColumnName("snake_case")` to PascalCase:
+```csharp
+// Before:
+.HasColumnName("id")
+.HasColumnName("job_name")
+.HasColumnName("display_name")
+.HasColumnName("description")
+.HasColumnName("cron_expression")
+.HasColumnName("is_enabled")
+.HasColumnName("last_modified_at")
+.HasColumnName("last_modified_by")
+// After: remove all HasColumnName calls — EF will use property names directly (which are already PascalCase)
+```
+
+**`DataQuality/DqtRunConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("dqt_runs", "public");
+// After:
+builder.ToTable("DqtRuns", "public");
+```
+
+Also remove or update any `HasColumnName("snake_case")` overrides in this file to PascalCase.
+
+**`DataQuality/InvoiceDqtResultConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("invoice_dqt_results", "public");
+// After:
+builder.ToTable("InvoiceDqtResults", "public");
+```
+
+Also remove or update any `HasColumnName("snake_case")` overrides.
+
+**`Logistics/GiftPackageManufacture/GiftPackageManufactureItemConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("gift_package_manufacture_items", "public");
+// After:
+builder.ToTable("GiftPackageManufactureItems", "public");
+```
+
+**`Logistics/GiftPackageManufacture/GiftPackageManufactureLogConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("gift_package_manufacture_logs", "public");
+// After:
+builder.ToTable("GiftPackageManufactureLogs", "public");
+```
+
+**`Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("imported_marketing_transactions", "public");
+// After:
+builder.ToTable("ImportedMarketingTransactions", "public");
+```
+
+- [ ] **Step 4.2: Verify no snake_case table names remain**
+
+```bash
+grep -rn "ToTable" \
+  backend/src/Anela.Heblo.Persistence/ \
+  --include="*.cs" \
+  --exclude-dir=obj \
+  --exclude-dir=Migrations \
+  | grep -E '"[a-z][a-z_]+'
+```
+
+Expected: **no output**.
+
+- [ ] **Step 4.3: Build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 4.4: Generate EF migration**
+
+```bash
+cd backend/src/Anela.Heblo.Persistence && \
+  dotnet ef migrations add StandardizeTableNamingToPascalCase
+```
+
+- [ ] **Step 4.5: Inspect the generated migration**
+
+Open the generated migration file. The `Up()` method must contain exactly 6 `RenameTable` calls:
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.RenameTable(name: "recurring_job_configurations", schema: "public", newName: "RecurringJobConfigurations");
+    migrationBuilder.RenameTable(name: "dqt_runs",                     schema: "public", newName: "DqtRuns");
+    migrationBuilder.RenameTable(name: "invoice_dqt_results",          schema: "public", newName: "InvoiceDqtResults");
+    migrationBuilder.RenameTable(name: "gift_package_manufacture_items", schema: "public", newName: "GiftPackageManufactureItems");
+    migrationBuilder.RenameTable(name: "gift_package_manufacture_logs", schema: "public", newName: "GiftPackageManufactureLogs");
+    migrationBuilder.RenameTable(name: "imported_marketing_transactions", schema: "public", newName: "ImportedMarketingTransactions");
+}
+```
+
+Also expect column rename operations for the `RecurringJobConfigurations` table (from snake_case column names to PascalCase), and the DQT tables if they had snake_case column names. Verify each column rename corresponds to a real `HasColumnName` removal.
+
+> **Note:** EF Core may generate `RenameColumn` for each column in `RecurringJobConfigurations` since we removed `HasColumnName`. This is expected and correct — those columns need to be renamed in the DB to match the C# property names.
+
+- [ ] **Step 4.6: Apply migration to local dev database**
+
+```bash
+dotnet ef database update
+```
+
+Expected: `Done.`
+
+- [ ] **Step 4.7: Run backend tests**
+
+```bash
+cd ../../.. && dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all pass.
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/
+git commit -m "feat(db): standardize all table names to PascalCase (rename 6 snake_case tables)"
+```
+
+---
+
+## Task 5: Fix singular table names + entity-table mismatch
+
+**7 table renames.** All require `RenameTable` migrations.
+
+Tables being renamed:
+
+| Old name | New name | Config file |
+|----------|----------|-------------|
+| `IssuedInvoice` | `IssuedInvoices` | `Invoices/IssuedInvoiceConfiguration.cs` |
+| `TransportBox` | `TransportBoxes` | `Logistics/TransportBoxes/TransportBoxConfiguration.cs` |
+| `TransportBoxItem` | `TransportBoxItems` | `Logistics/TransportBoxes/TransportBoxItemConfiguration.cs` |
+| `TransportBoxStateLog` | `TransportBoxStateLogs` | `Logistics/TransportBoxes/TransportBoxStateLogConfiguration.cs` |
+| `StockTakingResults` | `StockTakingRecords` | `Logistics/StockTaking/StockTakingConfiguration.cs` |
+| `PackingMaterial` | `PackingMaterials` | `PackingMaterials/PackingMaterialConfiguration.cs` |
+| `PackingMaterialLog` | `PackingMaterialLogs` | `PackingMaterials/PackingMaterialLogConfiguration.cs` |
+
+**Rollback SQL:**
+```sql
+ALTER TABLE public."IssuedInvoices"       RENAME TO "IssuedInvoice";
+ALTER TABLE public."TransportBoxes"       RENAME TO "TransportBox";
+ALTER TABLE public."TransportBoxItems"    RENAME TO "TransportBoxItem";
+ALTER TABLE public."TransportBoxStateLogs" RENAME TO "TransportBoxStateLog";
+ALTER TABLE public."StockTakingRecords"   RENAME TO "StockTakingResults";
+ALTER TABLE public."PackingMaterials"     RENAME TO "PackingMaterial";
+ALTER TABLE public."PackingMaterialLogs"  RENAME TO "PackingMaterialLog";
+```
+
+- [ ] **Step 5.1: Update the 7 config files**
+
+**`Invoices/IssuedInvoiceConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("IssuedInvoice", "public");
+// After:
+builder.ToTable("IssuedInvoices", "public");
+```
+
+Also update index names that embed the old table name:
+```csharp
+// Before:
+.HasDatabaseName("IX_IssuedInvoice_InvoiceDate");
+// After:
+.HasDatabaseName("IX_IssuedInvoices_InvoiceDate");
+```
+Apply the same rename to all 5 indexes in this file (`IX_IssuedInvoice_LastSyncTime`, `IX_IssuedInvoice_IsSynced`, `IX_IssuedInvoice_ErrorType`, `IX_IssuedInvoice_CustomerName`).
+
+**`Logistics/TransportBoxes/TransportBoxConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("TransportBox", "public");
+// After:
+builder.ToTable("TransportBoxes", "public");
+```
+
+**`Logistics/TransportBoxes/TransportBoxItemConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("TransportBoxItem", "public");
+// After:
+builder.ToTable("TransportBoxItems", "public");
+```
+
+**`Logistics/TransportBoxes/TransportBoxStateLogConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("TransportBoxStateLog", "public");
+// After:
+builder.ToTable("TransportBoxStateLogs", "public");
+```
+
+**`Logistics/StockTaking/StockTakingConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("StockTakingResults", "public");
+// After:
+builder.ToTable("StockTakingRecords", "public");
+```
+
+**`PackingMaterials/PackingMaterialConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("PackingMaterial", "public");
+// After:
+builder.ToTable("PackingMaterials", "public");
+```
+
+Also update index name:
+```csharp
+// Before:
+.HasDatabaseName("IX_PackingMaterial_Name");
+// After:
+.HasDatabaseName("IX_PackingMaterials_Name");
+```
+
+**`PackingMaterials/PackingMaterialLogConfiguration.cs`**
+```csharp
+// Before:
+builder.ToTable("PackingMaterialLog", "public");
+// After:
+builder.ToTable("PackingMaterialLogs", "public");
+```
+
+- [ ] **Step 5.2: Build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded.`
+
+- [ ] **Step 5.3: Generate EF migration**
+
+```bash
+cd backend/src/Anela.Heblo.Persistence && \
+  dotnet ef migrations add NormalizeTableNamesPluralAndEntityMismatch
+```
+
+- [ ] **Step 5.4: Inspect the generated migration**
+
+The `Up()` method should contain exactly 7 `RenameTable` calls plus index renames for `IssuedInvoices` and `PackingMaterials`. Verify no unexpected column changes are included.
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.RenameTable(name: "IssuedInvoice",       schema: "public", newName: "IssuedInvoices");
+    migrationBuilder.RenameTable(name: "TransportBox",        schema: "public", newName: "TransportBoxes");
+    migrationBuilder.RenameTable(name: "TransportBoxItem",    schema: "public", newName: "TransportBoxItems");
+    migrationBuilder.RenameTable(name: "TransportBoxStateLog", schema: "public", newName: "TransportBoxStateLogs");
+    migrationBuilder.RenameTable(name: "StockTakingResults",  schema: "public", newName: "StockTakingRecords");
+    migrationBuilder.RenameTable(name: "PackingMaterial",     schema: "public", newName: "PackingMaterials");
+    migrationBuilder.RenameTable(name: "PackingMaterialLog",  schema: "public", newName: "PackingMaterialLogs");
+    // Plus RenameIndex calls for IX_IssuedInvoice_* and IX_PackingMaterial_Name
+}
+```
+
+- [ ] **Step 5.5: Apply migration to local dev database**
+
+```bash
+dotnet ef database update
+```
+
+Expected: `Done.`
+
+- [ ] **Step 5.6: Run backend tests**
+
+```bash
+cd ../../.. && dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all pass.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/
+git commit -m "feat(db): rename singular tables to plural and fix StockTakingResults -> StockTakingRecords"
+```
+
+---
+
+## Task 6: dotnet format pass + final verification
+
+- [ ] **Step 6.1: Run dotnet format**
+
+```bash
+dotnet format backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: exits 0, any formatting differences auto-applied.
+
+- [ ] **Step 6.2: Final check — no dbo, no snake_case, no implicit schemas**
+
+```bash
+grep -rn '"dbo"' backend/src/Anela.Heblo.Persistence/ --include="*.cs" --exclude-dir=obj --exclude-dir=Migrations
+```
+Expected: no output.
+
+```bash
+grep -rn '\.ToTable("' backend/src/Anela.Heblo.Persistence/ --include="*.cs" --exclude-dir=obj --exclude-dir=Migrations \
+  | grep -v '"public"' | grep -v '"dbo"'
+```
+Expected: no output.
+
+```bash
+grep -rn "ToTable" backend/src/Anela.Heblo.Persistence/ --include="*.cs" --exclude-dir=obj --exclude-dir=Migrations \
+  | grep -E '"[a-z][a-z_]+'
+```
+Expected: no output.
+
+- [ ] **Step 6.3: Full backend build + test**
+
+```bash
+dotnet build backend/ && dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build and all tests pass.
+
+- [ ] **Step 6.4: Commit formatting changes (if any)**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/
+git commit -m "chore: dotnet format after db consolidation"
+```
+
+- [ ] **Step 6.5: Apply pending migrations to staging**
+
+Apply all migrations from Tasks 3, 4, and 5 to staging environment in order:
+1. `MoveTablesFromDboToPublicSchema`
+2. `StandardizeTableNamingToPascalCase`
+3. `NormalizeTableNamesPluralAndEntityMismatch`
+
+```bash
+dotnet ef database update --connection "<STAGING_CONNECTION_STRING>"
+```
+
+---
+
+## Summary: Environment Deployment Order
+
+Each environment must have migrations applied in this order:
+1. Task 3: `MoveTablesFromDboToPublicSchema`
+2. Task 4: `StandardizeTableNamingToPascalCase`
+3. Task 5: `NormalizeTableNamesPluralAndEntityMismatch`
+
+Tasks 1 and 2 require only code deployment (no DB changes).
+
+| Task | DB migration? | Risk | Rollback |
+|------|-------------|------|---------|
+| Task 1 — delete dead mappers | No | None | git revert |
+| Task 2 — explicit schema | No | None | git revert |
+| Task 3 — dbo → public | Yes | Medium | SQL in Task 3 rollback section |
+| Task 4 — PascalCase names | Yes | Medium | `RenameTable` back |
+| Task 5 — plural + mismatch | Yes | Medium | SQL in Task 5 rollback section |
+| Task 6 — format + verify | No | None | — |

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -277,7 +277,12 @@ const Sidebar: React.FC<SidebarProps> = ({
           name: "Hangfire",
           href: "#",
           onClick: openHangfireDashboard,
-        }
+        },
+        {
+          id: 'data-quality',
+          name: 'Kvalita dat',
+          href: '/data-quality',
+        },
       ],
     },
     {
@@ -295,13 +300,6 @@ const Sidebar: React.FC<SidebarProps> = ({
           ? [{ id: 'kb-feedback', name: 'Feedback', href: '/knowledge-base/feedback' }]
           : []),
       ],
-    },
-    {
-      id: 'data-quality',
-      name: 'Kvalita dat',
-      href: '/data-quality',
-      icon: Database,
-      type: 'single' as const,
     },
   ];
 


### PR DESCRIPTION
## Summary

- Move **Kvalita dat** (DQT) sidebar item into the **Automatizace** group in `Sidebar.tsx`
- Add project-level `/backmerge-prs` skill bundled in `.claude/skills/` so all contributors get the command without a global install; includes Anela.Heblo-specific conflict resolution notes
- Add `docs/database-table-map.md` — maps all 38 tables to current state and target state for the DB consolidation plan

## Test plan

- [ ] Verify Kvalita dat appears under Automatizace in the sidebar (not top-level)
- [ ] Run `/backmerge-prs` in this repo to confirm the script executes from the project-level path
- [ ] Review `docs/database-table-map.md` for completeness against the consolidation report

🤖 Generated with [Claude Code](https://claude.ai/claude-code)