### PR TITLE
feat(marketing): Task 5 — Frontend calendar and grid components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import RecurringJobsPage from "./pages/RecurringJobsPage";
 import KnowledgeBasePage from "./pages/KnowledgeBasePage";
 import KnowledgeBaseFeedbackPage from "./pages/KnowledgeBaseFeedbackPage";
 import ExpeditionListArchivePage from "./pages/ExpeditionListArchivePage";
+import MarketingCalendarPage from "./components/marketing/pages/MarketingCalendarPage";
 import AuthGuard from "./components/auth/AuthGuard";
 import { StatusBar } from "./components/StatusBar";
 import { loadConfig, Config } from "./config/runtimeConfig";
@@ -386,6 +387,10 @@ function App() {
                           element={<ProductMarginsList />}
                         />
                         <Route path="/journal" element={<JournalList />} />
+                        <Route
+                          path="/marketing/calendar"
+                          element={<MarketingCalendarPage />}
+                        />
                         <Route
                           path="/journal/new"
                           element={<JournalEntryNew />}

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   ExternalLink,
   FileText,
   Database,
+  Megaphone,
 } from "lucide-react";
 import UserProfile from "../auth/UserProfile";
 import { useAuth } from "../../auth/useAuth";
@@ -134,6 +135,15 @@ const Sidebar: React.FC<SidebarProps> = ({
         { id: "catalog", name: "Katalog", href: "/catalog" },
         { id: "marze-produktu", name: "Marže", href: "/products/margins" },
         { id: "journal", name: "Deník", href: "/journal" },
+      ],
+    },
+    {
+      id: "marketing",
+      name: "Marketing",
+      icon: Megaphone,
+      type: "section" as const,
+      items: [
+        { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
       ],
     },
     {

--- a/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import type { CalendarEvent } from "./useCalendarLayout";
+
+const ACTION_TYPE_COLORS: Record<string, string> = {
+  SocialMedia: "bg-blue-500 text-white",
+  Event: "bg-purple-500 text-white",
+  Email: "bg-green-500 text-white",
+  PR: "bg-yellow-500 text-gray-900",
+  Photoshoot: "bg-pink-500 text-white",
+  Other: "bg-gray-500 text-white",
+};
+
+const BAR_HEIGHT_PX = 22;
+const BAR_GAP_PX = 2;
+const TOP_OFFSET_PX = 28; // space below date number in day cell
+
+interface MarketingEventBarProps {
+  event: CalendarEvent;
+  startCol: number; // 1–7
+  endCol: number; // 1–7, inclusive
+  lane: number;
+  onClick: (id: number) => void;
+}
+
+const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
+  event,
+  startCol,
+  endCol,
+  lane,
+  onClick,
+}) => {
+  const colorClass =
+    ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
+  const top = TOP_OFFSET_PX + lane * (BAR_HEIGHT_PX + BAR_GAP_PX);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onClick(event.id)}
+      onKeyDown={(e) => e.key === "Enter" && onClick(event.id)}
+      title={event.title}
+      style={{
+        gridColumnStart: startCol,
+        gridColumnEnd: endCol + 1,
+        top,
+        height: BAR_HEIGHT_PX,
+        position: "absolute",
+        left: 2,
+        right: 2,
+        zIndex: 10,
+      }}
+      className={`
+        ${colorClass}
+        rounded px-1 text-xs font-medium truncate cursor-pointer
+        hover:opacity-80 transition-opacity select-none
+      `}
+    >
+      {event.title}
+    </div>
+  );
+};
+
+export const BAR_HEIGHT_PX_EXPORT = BAR_HEIGHT_PX;
+export const BAR_GAP_PX_EXPORT = BAR_GAP_PX;
+export const TOP_OFFSET_PX_EXPORT = TOP_OFFSET_PX;
+
+export default MarketingEventBar;

--- a/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
@@ -1,0 +1,194 @@
+import React, { useMemo } from "react";
+import type { CalendarEvent, EventSegment } from "./useCalendarLayout";
+import { useCalendarLayout } from "./useCalendarLayout";
+import MarketingEventBar, {
+  BAR_HEIGHT_PX_EXPORT as BAR_H,
+  BAR_GAP_PX_EXPORT as BAR_G,
+  TOP_OFFSET_PX_EXPORT as TOP_OFF,
+} from "./MarketingEventBar";
+
+const WEEK_DAYS = ["Po", "Út", "St", "Čt", "Pá", "So", "Ne"];
+
+// Minimum row height when no events; grows per lane
+const BASE_ROW_HEIGHT_PX = 64;
+
+interface MarketingMonthCalendarProps {
+  year: number;
+  month: number; // 0-based
+  events: CalendarEvent[];
+  onEventClick: (id: number) => void;
+}
+
+interface DayCell {
+  date: Date;
+  isCurrentMonth: boolean;
+  weekRow: number;
+  col: number; // 1–7
+}
+
+const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
+  year,
+  month,
+  events,
+  onEventClick,
+}) => {
+  const today = new Date();
+  const segments = useCalendarLayout(events, year, month);
+
+  // Build day cells — same Monday-anchor logic as useCalendarLayout
+  const { dayCells, weekCount } = useMemo(() => {
+    const firstOfMonth = new Date(year, month, 1);
+    const firstMonday = new Date(firstOfMonth);
+    const dow = firstOfMonth.getDay();
+    firstMonday.setDate(firstOfMonth.getDate() + (dow === 0 ? -6 : 1 - dow));
+
+    const cells: DayCell[] = [];
+    let weekRow = 0;
+    let col = 1;
+
+    // 6 weeks × 7 days
+    for (let i = 0; i < 42; i++) {
+      const date = new Date(firstMonday);
+      date.setDate(firstMonday.getDate() + i);
+      cells.push({
+        date,
+        isCurrentMonth: date.getMonth() === month,
+        weekRow,
+        col,
+      });
+      col++;
+      if (col > 7) {
+        col = 1;
+        weekRow++;
+      }
+    }
+
+    // Trim trailing empty weeks (all outside current month)
+    const isWeekAllOutsideMonth = (w: number) =>
+      cells.filter((c) => c.weekRow === w).every((c) => !c.isCurrentMonth);
+
+    let lastWeek = 5;
+    while (lastWeek > 0 && isWeekAllOutsideMonth(lastWeek)) {
+      lastWeek--;
+    }
+
+    return {
+      dayCells: cells.filter((c) => c.weekRow <= lastWeek),
+      weekCount: lastWeek + 1,
+    };
+  }, [year, month]);
+
+  // Calculate min-height per week row based on max lane used
+  const rowMinHeights = useMemo(() => {
+    const heights: number[] = Array(weekCount).fill(BASE_ROW_HEIGHT_PX);
+    for (const seg of segments) {
+      if (seg.weekRow < weekCount) {
+        const needed = TOP_OFF + (seg.lane + 1) * (BAR_H + BAR_G) + 4;
+        if (needed > heights[seg.weekRow]) {
+          heights[seg.weekRow] = needed;
+        }
+      }
+    }
+    return heights;
+  }, [segments, weekCount]);
+
+  const isToday = (date: Date) =>
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+
+  // Group segments by weekRow for rendering
+  const segmentsByRow = useMemo(() => {
+    const map = new Map<number, EventSegment[]>();
+    for (const seg of segments) {
+      const list = map.get(seg.weekRow) ?? [];
+      list.push(seg);
+      map.set(seg.weekRow, list);
+    }
+    return map;
+  }, [segments]);
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden bg-white">
+      {/* Header row */}
+      <div className="grid grid-cols-7 border-b border-gray-200">
+        {WEEK_DAYS.map((day) => (
+          <div
+            key={day}
+            className="py-2 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Week rows */}
+      {Array.from({ length: weekCount }, (_, w) => {
+        const rowCells = dayCells.filter((c) => c.weekRow === w);
+        const rowSegs = segmentsByRow.get(w) ?? [];
+
+        return (
+          <div
+            key={w}
+            className="relative grid grid-cols-7 border-b border-gray-200 last:border-b-0"
+            style={{ minHeight: rowMinHeights[w] }}
+          >
+            {/* Background: day cells */}
+            {rowCells.map((cell) => (
+              <div
+                key={cell.date.toISOString()}
+                className={`
+                  border-r border-gray-100 last:border-r-0 p-1
+                  ${!cell.isCurrentMonth ? "bg-gray-50" : ""}
+                `}
+              >
+                <span
+                  className={`
+                    inline-flex items-center justify-center w-6 h-6 text-sm rounded-full
+                    ${
+                      isToday(cell.date)
+                        ? "bg-indigo-600 text-white font-bold"
+                        : cell.isCurrentMonth
+                          ? "text-gray-900"
+                          : "text-gray-400"
+                    }
+                  `}
+                >
+                  {cell.date.getDate()}
+                </span>
+              </div>
+            ))}
+
+            {/* Overlay: event bars — absolutely positioned over the grid */}
+            <div
+              className="absolute inset-0 grid grid-cols-7"
+              style={{ pointerEvents: "none" }}
+            >
+              {rowSegs.map((seg) => (
+                <div
+                  key={`${seg.event.id}-${seg.weekRow}`}
+                  style={{
+                    gridColumn: "1 / -1",
+                    position: "relative",
+                    gridRow: 1,
+                    pointerEvents: "auto",
+                  }}
+                >
+                  <MarketingEventBar
+                    event={seg.event}
+                    startCol={seg.startCol}
+                    endCol={seg.endCol}
+                    lane={seg.lane}
+                    onClick={onEventClick}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MarketingMonthCalendar;

--- a/frontend/src/components/marketing/calendar/useCalendarLayout.ts
+++ b/frontend/src/components/marketing/calendar/useCalendarLayout.ts
@@ -1,0 +1,106 @@
+import { useMemo } from "react";
+
+export interface CalendarEvent {
+  id: number;
+  title: string;
+  actionType: string;
+  dateFrom: string; // "YYYY-MM-DD"
+  dateTo: string; // "YYYY-MM-DD"
+  associatedProducts: string[];
+}
+
+export interface EventSegment {
+  event: CalendarEvent;
+  startCol: number; // 1–7 (Mon=1 … Sun=7)
+  endCol: number; // 1–7, inclusive
+  weekRow: number; // 0-based week index within the month grid
+  lane: number; // 0-based vertical stack position
+}
+
+// Returns the Mon-based column (1=Mon, 7=Sun) for a given Date
+function toCol(date: Date): number {
+  const day = date.getDay(); // 0=Sun
+  return day === 0 ? 7 : day;
+}
+
+export function useCalendarLayout(
+  events: CalendarEvent[],
+  year: number,
+  month: number, // 0-based (0=Jan)
+): EventSegment[] {
+  return useMemo(() => {
+    if (!events.length) return [];
+
+    // Build week-row boundaries: each row covers Mon–Sun
+    const firstOfMonth = new Date(year, month, 1);
+    // Monday of the first week shown on the calendar
+    const firstMonday = new Date(firstOfMonth);
+    const dow = firstOfMonth.getDay(); // 0=Sun
+    const offsetToMonday = dow === 0 ? -6 : 1 - dow;
+    firstMonday.setDate(firstOfMonth.getDate() + offsetToMonday);
+
+    // Build array of week-row start dates (Mondays)
+    const weekStarts: Date[] = [];
+    for (let w = 0; w < 6; w++) {
+      const monday = new Date(firstMonday);
+      monday.setDate(firstMonday.getDate() + w * 7);
+      weekStarts.push(monday);
+    }
+
+    // Split each event into one segment per week row it touches
+    const rawSegments: Omit<EventSegment, "lane">[] = [];
+
+    for (const event of events) {
+      const evFrom = new Date(event.dateFrom);
+      const evTo = new Date(event.dateTo);
+
+      for (let w = 0; w < weekStarts.length; w++) {
+        const weekStart = weekStarts[w]; // Monday
+        const weekEnd = new Date(weekStart);
+        weekEnd.setDate(weekStart.getDate() + 6); // Sunday
+
+        // Skip weeks that don't overlap this event
+        if (evTo < weekStart || evFrom > weekEnd) continue;
+
+        // Clamp to week boundaries
+        const segFrom = evFrom < weekStart ? weekStart : evFrom;
+        const segTo = evTo > weekEnd ? weekEnd : evTo;
+
+        rawSegments.push({
+          event,
+          startCol: toCol(segFrom),
+          endCol: toCol(segTo),
+          weekRow: w,
+        });
+      }
+    }
+
+    // Assign lanes per week row using greedy interval algorithm
+    // Sort by startCol within each row, then assign lowest free lane
+    const byRow = new Map<number, Omit<EventSegment, "lane">[]>();
+    for (const seg of rawSegments) {
+      const list = byRow.get(seg.weekRow) ?? [];
+      list.push(seg);
+      byRow.set(seg.weekRow, list);
+    }
+
+    const segments: EventSegment[] = [];
+
+    for (const [, rowSegs] of byRow) {
+      const sorted = [...rowSegs].sort((a, b) => a.startCol - b.startCol);
+      // laneEnd[i] = endCol of the last segment placed in lane i
+      const laneEnd: number[] = [];
+
+      for (const seg of sorted) {
+        let lane = laneEnd.findIndex((end) => end < seg.startCol);
+        if (lane === -1) {
+          lane = laneEnd.length;
+        }
+        laneEnd[lane] = seg.endCol;
+        segments.push({ ...seg, lane });
+      }
+    }
+
+    return segments;
+  }, [events, year, month]);
+}

--- a/frontend/src/components/marketing/detail/MarketingActionModal.tsx
+++ b/frontend/src/components/marketing/detail/MarketingActionModal.tsx
@@ -1,0 +1,431 @@
+import React, { useState, useEffect } from "react";
+import { X, Plus, Trash2 } from "lucide-react";
+import type { MarketingActionDto } from "../list/MarketingActionGrid";
+import {
+  useCreateMarketingAction,
+  useUpdateMarketingAction,
+  useDeleteMarketingAction,
+} from "../../../api/hooks/useMarketingCalendar";
+
+const ACTION_TYPE_OPTIONS = [
+  { value: 0, label: "Sociální sítě" },
+  { value: 1, label: "Událost" },
+  { value: 2, label: "Email" },
+  { value: 3, label: "PR" },
+  { value: 4, label: "Fotografie" },
+  { value: 5, label: "Ostatní" },
+];
+
+const FOLDER_TYPE_OPTIONS = [
+  { value: 0, label: "Obrázky" },
+  { value: 1, label: "Texty" },
+  { value: 2, label: "Videa" },
+  { value: 3, label: "Grafika" },
+  { value: 4, label: "Ostatní" },
+];
+
+interface FolderLinkInput {
+  path: string;
+  label: string;
+  folderType: number;
+}
+
+interface FormState {
+  title: string;
+  detail: string;
+  actionType: number;
+  dateFrom: string;
+  dateTo: string;
+  associatedProducts: string[];
+  folderLinks: FolderLinkInput[];
+  productInput: string;
+}
+
+const EMPTY_FORM: FormState = {
+  title: "",
+  detail: "",
+  actionType: 0,
+  dateFrom: "",
+  dateTo: "",
+  associatedProducts: [],
+  folderLinks: [],
+  productInput: "",
+};
+
+interface MarketingActionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  existingAction?: MarketingActionDto | null;
+}
+
+const FORM_ID = "marketing-action-form";
+
+const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
+  isOpen,
+  onClose,
+  existingAction,
+}) => {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  const createMutation = useCreateMarketingAction();
+  const updateMutation = useUpdateMarketingAction();
+  const deleteMutation = useDeleteMarketingAction();
+
+  const isEdit = !!existingAction;
+
+  useEffect(() => {
+    if (existingAction) {
+      setForm({
+        title: existingAction.title ?? "",
+        detail: existingAction.detail ?? "",
+        actionType:
+          ACTION_TYPE_OPTIONS.findIndex(
+            (o) =>
+              o.label === existingAction.actionType ||
+              o.value.toString() === existingAction.actionType,
+          ) ?? 0,
+        dateFrom: existingAction.dateFrom
+          ? String(existingAction.dateFrom)
+          : "",
+        dateTo: existingAction.dateTo ? String(existingAction.dateTo) : "",
+        associatedProducts: existingAction.associatedProducts ?? [],
+        folderLinks: (existingAction.folderLinks ?? []).map((fl) => ({
+          path: fl.path ?? "",
+          label: fl.label ?? "",
+          folderType:
+            FOLDER_TYPE_OPTIONS.findIndex((o) => o.label === fl.folderType) ??
+            0,
+        })),
+        productInput: "",
+      });
+    } else {
+      setForm(EMPTY_FORM);
+    }
+    setError(null);
+  }, [existingAction, isOpen]);
+
+  if (!isOpen) return null;
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const addProduct = () => {
+    const code = form.productInput.trim().toUpperCase();
+    if (code && !form.associatedProducts.includes(code)) {
+      set("associatedProducts", [...form.associatedProducts, code]);
+      set("productInput", "");
+    }
+  };
+
+  const removeProduct = (code: string) =>
+    set(
+      "associatedProducts",
+      form.associatedProducts.filter((p) => p !== code),
+    );
+
+  const addFolderLink = () =>
+    set("folderLinks", [
+      ...form.folderLinks,
+      { path: "", label: "", folderType: 0 },
+    ]);
+
+  const updateFolderLink = (
+    i: number,
+    field: keyof FolderLinkInput,
+    value: string | number,
+  ) =>
+    set(
+      "folderLinks",
+      form.folderLinks.map((fl, idx) =>
+        idx === i ? { ...fl, [field]: value } : fl,
+      ),
+    );
+
+  const removeFolderLink = (i: number) =>
+    set(
+      "folderLinks",
+      form.folderLinks.filter((_, idx) => idx !== i),
+    );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const payload = {
+      title: form.title.trim(),
+      description: form.detail.trim() || undefined,
+      actionType: ACTION_TYPE_OPTIONS[form.actionType]?.label ?? "Other",
+      startDate: new Date(form.dateFrom),
+      endDate: form.dateTo ? new Date(form.dateTo) : undefined,
+      associatedProducts: form.associatedProducts,
+      folderLinks: form.folderLinks
+        .filter((fl) => fl.path.trim())
+        .map((fl) => ({
+          folderKey: fl.path.trim(),
+          folderType:
+            FOLDER_TYPE_OPTIONS[fl.folderType]?.label ?? "Ostatní",
+        })),
+    };
+
+    try {
+      if (isEdit && existingAction?.id != null) {
+        await updateMutation.mutateAsync({ id: existingAction.id, request: payload });
+      } else {
+        await createMutation.mutateAsync(payload);
+      }
+      onClose();
+    } catch {
+      setError("Nepodařilo se uložit akci. Zkuste to znovu.");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!existingAction?.id) return;
+    if (!window.confirm(`Opravdu smazat akci "${existingAction.title}"?`))
+      return;
+    try {
+      await deleteMutation.mutateAsync(existingAction.id);
+      onClose();
+    } catch {
+      setError("Nepodařilo se smazat akci.");
+    }
+  };
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+  const isDeleting = deleteMutation.isPending;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {isEdit ? "Upravit akci" : "Nová marketingová akce"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <X className="h-5 w-5 text-gray-500" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form
+          id={FORM_ID}
+          onSubmit={handleSubmit}
+          className="flex-1 overflow-y-auto px-6 py-4 space-y-4"
+        >
+          {error && (
+            <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md px-3 py-2">
+              {error}
+            </div>
+          )}
+
+          {/* Title */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Název *
+            </label>
+            <input
+              required
+              value={form.title}
+              onChange={(e) => set("title", e.target.value)}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          {/* ActionType + dates row */}
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Typ *
+              </label>
+              <select
+                value={form.actionType}
+                onChange={(e) => set("actionType", Number(e.target.value))}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                {ACTION_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Od *
+              </label>
+              <input
+                required
+                type="date"
+                value={form.dateFrom}
+                onChange={(e) => set("dateFrom", e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Do *
+              </label>
+              <input
+                required
+                type="date"
+                value={form.dateTo}
+                min={form.dateFrom}
+                onChange={(e) => set("dateTo", e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+          </div>
+
+          {/* Detail */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Popis
+            </label>
+            <textarea
+              value={form.detail}
+              onChange={(e) => set("detail", e.target.value)}
+              rows={3}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+            />
+          </div>
+
+          {/* Products */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Produkty
+            </label>
+            <div className="flex gap-2">
+              <input
+                value={form.productInput}
+                onChange={(e) => set("productInput", e.target.value)}
+                onKeyDown={(e) =>
+                  e.key === "Enter" && (e.preventDefault(), addProduct())
+                }
+                placeholder="Kód produktu (Enter)"
+                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              <button
+                type="button"
+                onClick={addProduct}
+                className="px-3 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 transition-colors"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </div>
+            {form.associatedProducts.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-2">
+                {form.associatedProducts.map((code) => (
+                  <span
+                    key={code}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-100 text-indigo-800 rounded text-xs"
+                  >
+                    {code}
+                    <button type="button" onClick={() => removeProduct(code)}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Folder links */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Složky
+              </label>
+              <button
+                type="button"
+                onClick={addFolderLink}
+                className="text-xs text-indigo-600 hover:text-indigo-800 flex items-center gap-1"
+              >
+                <Plus className="h-3 w-3" /> Přidat složku
+              </button>
+            </div>
+            <div className="space-y-2">
+              {form.folderLinks.map((fl, i) => (
+                <div key={i} className="flex gap-2 items-start">
+                  <input
+                    value={fl.path}
+                    onChange={(e) => updateFolderLink(i, "path", e.target.value)}
+                    placeholder="Cesta ke složce"
+                    className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <input
+                    value={fl.label}
+                    onChange={(e) =>
+                      updateFolderLink(i, "label", e.target.value)
+                    }
+                    placeholder="Popis (volitelný)"
+                    className="w-32 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <select
+                    value={fl.folderType}
+                    onChange={(e) =>
+                      updateFolderLink(i, "folderType", Number(e.target.value))
+                    }
+                    className="w-28 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    {FOLDER_TYPE_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => removeFolderLink(i)}
+                    className="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </form>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200">
+          <div>
+            {isEdit && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-md transition-colors disabled:opacity-50"
+              >
+                {isDeleting ? "Mazání..." : "Smazat"}
+              </button>
+            )}
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+            >
+              Zrušit
+            </button>
+            <button
+              type="submit"
+              form={FORM_ID}
+              disabled={isSaving}
+              className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md transition-colors disabled:opacity-50"
+            >
+              {isSaving ? "Ukládání..." : isEdit ? "Uložit" : "Vytvořit"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MarketingActionModal;

--- a/frontend/src/components/marketing/list/MarketingActionFilters.tsx
+++ b/frontend/src/components/marketing/list/MarketingActionFilters.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { X } from "lucide-react";
+
+interface Filters {
+  searchText: string;
+  dateFrom: string;
+  dateTo: string;
+}
+
+interface MarketingActionFiltersProps {
+  filters: Filters;
+  onChange: (filters: Filters) => void;
+  onClear: () => void;
+}
+
+const EMPTY_FILTERS: Filters = { searchText: "", dateFrom: "", dateTo: "" };
+
+const hasActiveFilters = (f: Filters) =>
+  f.searchText !== "" || f.dateFrom !== "" || f.dateTo !== "";
+
+const MarketingActionFilters: React.FC<MarketingActionFiltersProps> = ({
+  filters,
+  onChange,
+  onClear,
+}) => {
+  const set =
+    (key: keyof Filters) => (e: React.ChangeEvent<HTMLInputElement>) =>
+      onChange({ ...filters, [key]: e.target.value });
+
+  return (
+    <div className="flex flex-wrap gap-3 items-center p-4 bg-white border border-gray-200 rounded-lg">
+      <input
+        type="text"
+        placeholder="Hledat název..."
+        value={filters.searchText}
+        onChange={set("searchText")}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 min-w-[200px]"
+      />
+      <input
+        type="date"
+        value={filters.dateFrom}
+        onChange={set("dateFrom")}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        title="Od"
+      />
+      <span className="text-gray-400 text-sm">–</span>
+      <input
+        type="date"
+        value={filters.dateTo}
+        onChange={set("dateTo")}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        title="Do"
+      />
+      {hasActiveFilters(filters) && (
+        <button
+          onClick={onClear}
+          className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+        >
+          <X className="h-3 w-3" />
+          Zrušit filtry
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default MarketingActionFilters;
+export { EMPTY_FILTERS };
+export type { Filters as MarketingFilters };

--- a/frontend/src/components/marketing/list/MarketingActionGrid.tsx
+++ b/frontend/src/components/marketing/list/MarketingActionGrid.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export interface MarketingActionDto {
+  id?: number;
+  title?: string;
+  detail?: string;
+  actionType?: string;
+  dateFrom?: string | Date;
+  dateTo?: string | Date;
+  associatedProducts?: string[];
+  folderLinks?: Array<{
+    path?: string;
+    label?: string;
+    folderType?: string;
+  }>;
+}
+
+const ACTION_TYPE_BADGE: Record<string, string> = {
+  SocialMedia: "bg-blue-100 text-blue-800",
+  Event: "bg-purple-100 text-purple-800",
+  Email: "bg-green-100 text-green-800",
+  PR: "bg-yellow-100 text-yellow-800",
+  Photoshoot: "bg-pink-100 text-pink-800",
+  Other: "bg-gray-100 text-gray-800",
+};
+
+const ACTION_TYPE_LABELS: Record<string, string> = {
+  SocialMedia: "Sociální sítě",
+  Event: "Událost",
+  Email: "Email",
+  PR: "PR",
+  Photoshoot: "Fotografie",
+  Other: "Ostatní",
+};
+
+const formatDate = (d: string | Date | null | undefined) => {
+  if (!d) return "—";
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleDateString("cs-CZ");
+};
+
+interface MarketingActionGridProps {
+  actions: MarketingActionDto[];
+  totalPages: number;
+  pageNumber: number;
+  onPageChange: (page: number) => void;
+  onActionClick: (id: number) => void;
+  isLoading?: boolean;
+}
+
+const MarketingActionGrid: React.FC<MarketingActionGridProps> = ({
+  actions,
+  totalPages,
+  pageNumber,
+  onPageChange,
+  onActionClick,
+  isLoading,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="p-8 text-center text-gray-500 text-sm">Načítání...</div>
+    );
+  }
+
+  if (actions.length === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500 text-sm">
+        Žádné marketingové akce nebyly nalezeny.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {["Název", "Typ", "Od", "Do", "Produkty"].map((h) => (
+                <th
+                  key={h}
+                  className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {actions.map((action) => (
+              <tr
+                key={action.id}
+                onClick={() => onActionClick(action.id!)}
+                className="hover:bg-gray-50 cursor-pointer transition-colors"
+              >
+                <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                  {action.title}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                      ACTION_TYPE_BADGE[action.actionType ?? ""] ??
+                      ACTION_TYPE_BADGE.Other
+                    }`}
+                  >
+                    {ACTION_TYPE_LABELS[action.actionType ?? ""] ??
+                      action.actionType}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {formatDate(action.dateFrom as string)}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {formatDate(action.dateTo as string)}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {action.associatedProducts?.join(", ") || "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 px-4 py-3 border-t border-gray-200">
+          <button
+            onClick={() => onPageChange(pageNumber - 1)}
+            disabled={pageNumber <= 1}
+            className="p-1 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4 text-gray-600" />
+          </button>
+          <span className="text-sm text-gray-600">
+            {pageNumber} / {totalPages}
+          </span>
+          <button
+            onClick={() => onPageChange(pageNumber + 1)}
+            disabled={pageNumber >= totalPages}
+            className="p-1 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronRight className="h-4 w-4 text-gray-600" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MarketingActionGrid;

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -1,0 +1,251 @@
+import React, { useState, useMemo } from "react";
+import { Plus, Calendar, List } from "lucide-react";
+import CalendarNavigation from "../../manufacture/calendar/CalendarNavigation";
+import MarketingMonthCalendar from "../calendar/MarketingMonthCalendar";
+import MarketingActionGrid from "../list/MarketingActionGrid";
+import type { MarketingActionDto } from "../list/MarketingActionGrid";
+import MarketingActionFilters, {
+  EMPTY_FILTERS,
+  type MarketingFilters,
+} from "../list/MarketingActionFilters";
+import MarketingActionModal from "../detail/MarketingActionModal";
+import {
+  useMarketingCalendar,
+  useMarketingActions,
+  useMarketingAction,
+} from "../../../api/hooks/useMarketingCalendar";
+import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
+
+const CZECH_MONTHS = [
+  "Leden",
+  "Únor",
+  "Březen",
+  "Duben",
+  "Květen",
+  "Červen",
+  "Červenec",
+  "Srpen",
+  "Září",
+  "Říjen",
+  "Listopad",
+  "Prosinec",
+];
+
+type ViewMode = "calendar" | "list";
+
+const MarketingCalendarPage: React.FC = () => {
+  const [viewMode, setViewMode] = useState<ViewMode>("calendar");
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [filters, setFilters] = useState<MarketingFilters>(EMPTY_FILTERS);
+  const [pageNumber, setPageNumber] = useState(1);
+  const [selectedActionId, setSelectedActionId] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingAction, setEditingAction] = useState<MarketingActionDto | null>(
+    null,
+  );
+
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  // Calendar query — first and last day of the displayed month grid
+  const { startDate, endDate } = useMemo(() => {
+    const first = new Date(year, month, 1);
+    const firstMonday = new Date(first);
+    const dow = first.getDay();
+    firstMonday.setDate(first.getDate() + (dow === 0 ? -6 : 1 - dow));
+    const lastSunday = new Date(firstMonday);
+    lastSunday.setDate(firstMonday.getDate() + 41);
+    return {
+      startDate: firstMonday,
+      endDate: lastSunday,
+    };
+  }, [year, month]);
+
+  const calendarQuery = useMarketingCalendar({ startDate, endDate });
+  const listQuery = useMarketingActions({
+    pageNumber,
+    searchTerm: filters.searchText || undefined,
+    startDateFrom: filters.dateFrom ? new Date(filters.dateFrom) : undefined,
+    startDateTo: filters.dateTo ? new Date(filters.dateTo) : undefined,
+  });
+  const detailQuery = useMarketingAction(selectedActionId ?? 0);
+
+  const calendarEvents = useMemo(
+    () =>
+      ((calendarQuery.data as any)?.actions ?? []).map((a: any) => ({
+        id: a.id!,
+        title: a.title ?? "",
+        actionType: a.actionType ?? "Other",
+        dateFrom: String(a.dateFrom ?? a.startDate ?? ""),
+        dateTo: String(a.dateTo ?? a.endDate ?? ""),
+        associatedProducts: a.associatedProducts ?? [],
+      })),
+    [calendarQuery.data],
+  );
+
+  const listActions: MarketingActionDto[] = useMemo(
+    () =>
+      ((listQuery.data as any)?.actions ?? []).map((a: any) => ({
+        id: a.id,
+        title: a.title,
+        detail: a.description,
+        actionType: a.actionType,
+        dateFrom: a.startDate ?? a.dateFrom,
+        dateTo: a.endDate ?? a.dateTo,
+        associatedProducts: a.associatedProducts,
+        folderLinks: a.folderLinks,
+      })),
+    [listQuery.data],
+  );
+
+  const totalPages: number = (listQuery.data as any)?.totalPages ?? 1;
+
+  const periodLabel = `${CZECH_MONTHS[month]} ${year}`;
+
+  const goToPrev = () =>
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+  const goToNext = () =>
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+  const goToToday = () => setCurrentDate(new Date());
+
+  const openCreate = () => {
+    setEditingAction(null);
+    setIsModalOpen(true);
+  };
+
+  const openEdit = (id: number) => {
+    setSelectedActionId(id);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setEditingAction(null);
+    setSelectedActionId(null);
+  };
+
+  // Sync detail data into editingAction when it arrives
+  React.useEffect(() => {
+    if ((detailQuery.data as any)?.action) {
+      const a = (detailQuery.data as any).action;
+      setEditingAction({
+        id: a.id,
+        title: a.title,
+        detail: a.description ?? a.detail,
+        actionType: a.actionType,
+        dateFrom: a.startDate ?? a.dateFrom,
+        dateTo: a.endDate ?? a.dateTo,
+        associatedProducts: a.associatedProducts,
+        folderLinks: a.folderLinks,
+      });
+    }
+  }, [detailQuery.data]);
+
+  return (
+    <div className="flex flex-col" style={{ height: PAGE_CONTAINER_HEIGHT }}>
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-6 py-4 bg-white border-b border-gray-200 flex-shrink-0">
+        <h1 className="text-xl font-semibold text-gray-900">
+          Marketingový kalendář
+        </h1>
+        <div className="flex items-center gap-3">
+          {/* View toggle */}
+          <div className="flex border border-gray-200 rounded-lg overflow-hidden">
+            <button
+              onClick={() => setViewMode("calendar")}
+              className={`px-3 py-2 text-sm flex items-center gap-1.5 transition-colors ${
+                viewMode === "calendar"
+                  ? "bg-indigo-600 text-white"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              <Calendar className="h-4 w-4" />
+              Kalendář
+            </button>
+            <button
+              onClick={() => setViewMode("list")}
+              className={`px-3 py-2 text-sm flex items-center gap-1.5 transition-colors ${
+                viewMode === "list"
+                  ? "bg-indigo-600 text-white"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              <List className="h-4 w-4" />
+              Seznam
+            </button>
+          </div>
+          <button
+            onClick={openCreate}
+            className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            Nová akce
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        {viewMode === "calendar" ? (
+          <div className="space-y-4">
+            <CalendarNavigation
+              onPrevious={goToPrev}
+              onNext={goToNext}
+              onToday={goToToday}
+              currentPeriodLabel={periodLabel}
+            />
+            {calendarQuery.isLoading ? (
+              <div className="text-center py-12 text-gray-500 text-sm">
+                Načítání...
+              </div>
+            ) : calendarQuery.error ? (
+              <div className="text-center py-12 text-red-500 text-sm">
+                Chyba při načítání kalendáře.
+              </div>
+            ) : (
+              <MarketingMonthCalendar
+                year={year}
+                month={month}
+                events={calendarEvents}
+                onEventClick={openEdit}
+              />
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <MarketingActionFilters
+              filters={filters}
+              onChange={(f) => {
+                setFilters(f);
+                setPageNumber(1);
+              }}
+              onClear={() => {
+                setFilters(EMPTY_FILTERS);
+                setPageNumber(1);
+              }}
+            />
+            <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+              <MarketingActionGrid
+                actions={listActions}
+                totalPages={totalPages}
+                pageNumber={pageNumber}
+                onPageChange={setPageNumber}
+                onActionClick={openEdit}
+                isLoading={listQuery.isLoading}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Modal */}
+      <MarketingActionModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        existingAction={editingAction}
+      />
+    </div>
+  );
+};
+
+export default MarketingCalendarPage;


### PR DESCRIPTION
## Summary

Completes the Marketing Calendar UI:

- `useCalendarLayout` — pure layout hook, places spanning event bars in week rows with lane stacking
- `MarketingEventBar` — colored spanning bar with truncated title and tooltip
- `MarketingMonthCalendar` — 7-column Mon–Sun monthly grid with absolute-positioned event overlay
- `MarketingActionFilters` — search text + date range filter controls
- `MarketingActionGrid` — paginated table with action type badges and row actions
- `MarketingActionModal` — create/edit/delete modal with all fields, product picker, folder links
- `MarketingCalendarPage` — top-level page with month/list view tabs
- Route `/marketing/calendar` registered
- Sidebar `Marketing > Kalendář` entry added

Depends on #731–#734. Part of epic #730.

Closes #735