### PR TITLE
feat(photobank): Task 1 — domain entities, EF config, migration, TagRuleMatcher

### DIFF
--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/Photo.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/Photo.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public class Photo
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(500)]
+        public string SharePointFileId { get; set; } = null!; // unique
+
+        [Required]
+        [MaxLength(2000)]
+        public string FolderPath { get; set; } = null!;
+
+        [Required]
+        [MaxLength(200)]
+        public string FileName { get; set; } = null!;
+
+        [MaxLength(2000)]
+        public string? SharePointWebUrl { get; set; }
+
+        [MaxLength(50)]
+        public string? MimeType { get; set; }
+
+        public long? FileSizeBytes { get; set; }
+
+        public DateTime? TakenAt { get; set; }
+
+        public DateTime IndexedAt { get; set; }
+
+        public DateTime ModifiedAt { get; set; }
+
+        public virtual ICollection<PhotoTag> Tags { get; set; } = new List<PhotoTag>();
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotoTag.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotoTag.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public class PhotoTag
+    {
+        public int PhotoId { get; set; }
+        public int TagId { get; set; }
+
+        public PhotoTagSource Source { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public virtual Photo Photo { get; set; } = null!;
+        public virtual Tag Tag { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotoTagSource.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotoTagSource.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public enum PhotoTagSource
+    {
+        Rule = 0,
+        Manual = 1,
+        AI = 2,
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotobankIndexRoot.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotobankIndexRoot.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public class PhotobankIndexRoot
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(1000)]
+        public string SharePointPath { get; set; } = null!;
+
+        [MaxLength(200)]
+        public string? DisplayName { get; set; }
+
+        public bool IsActive { get; set; } = true;
+
+        public DateTime CreatedAt { get; set; }
+
+        [MaxLength(100)]
+        public string? CreatedByUserId { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/Tag.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/Tag.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public class Tag
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; } = null!; // always lowercase-normalized
+
+        public virtual ICollection<PhotoTag> PhotoTags { get; set; } = new List<PhotoTag>();
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRule.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRule.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public class TagRule
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(1000)]
+        public string PathPattern { get; set; } = null!;
+
+        [Required]
+        [MaxLength(100)]
+        public string TagName { get; set; } = null!;
+
+        public bool IsActive { get; set; } = true;
+
+        public int SortOrder { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRuleMatcher.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRuleMatcher.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public static class TagRuleMatcher
+    {
+        /// <summary>
+        /// Returns all tag names whose PathPattern matches the given folderPath.
+        /// Only active rules are considered.
+        /// Pattern matching: case-insensitive prefix, '*' matches exactly one segment.
+        /// All matching rules apply (not first-match-wins).
+        /// </summary>
+        public static IReadOnlyList<string> GetMatchingTags(
+            string folderPath,
+            IEnumerable<TagRule> rules)
+        {
+            if (string.IsNullOrEmpty(folderPath)) return Array.Empty<string>();
+
+            var pathSegments = folderPath
+                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            return rules
+                .Where(r => r.IsActive)
+                .OrderBy(r => r.SortOrder)
+                .Where(r => Matches(pathSegments, r.PathPattern))
+                .Select(r => r.TagName.ToLowerInvariant())
+                .Distinct()
+                .ToList();
+        }
+
+        private static bool Matches(string[] pathSegments, string pattern)
+        {
+            var patternSegments = pattern
+                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            if (patternSegments.Length > pathSegments.Length)
+                return false;
+
+            for (var i = 0; i < patternSegments.Length; i++)
+            {
+                var p = patternSegments[i];
+                if (p == "*")
+                {
+                    // '*' matches exactly one segment — already consuming one via loop
+                    continue;
+                }
+
+                if (!string.Equals(p, pathSegments[i], StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Photobank;
 using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Anela.Heblo.Domain.Features.Bank;
@@ -90,6 +91,13 @@ public class ApplicationDbContext : DbContext
     // Data Quality module
     public DbSet<DqtRun> DqtRuns { get; set; } = null!;
     public DbSet<InvoiceDqtResult> InvoiceDqtResults { get; set; } = null!;
+
+    // Photobank
+    public DbSet<PhotobankIndexRoot> PhotobankIndexRoots { get; set; } = null!;
+    public DbSet<Photo> Photos { get; set; } = null!;
+    public DbSet<Tag> PhotobankTags { get; set; } = null!;
+    public DbSet<PhotoTag> PhotoTags { get; set; } = null!;
+    public DbSet<TagRule> PhotobankTagRules { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260424122851_AddPhotobankTables.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260424122851_AddPhotobankTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424122851_AddPhotobankTables")]
+    partial class AddPhotobankTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260424122851_AddPhotobankTables.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260424122851_AddPhotobankTables.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhotobankTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PhotobankIndexRoots",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SharePointPath = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhotobankIndexRoots", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PhotobankTagRules",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PathPattern = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    TagName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhotobankTagRules", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PhotobankTags",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhotobankTags", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Photos",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SharePointFileId = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    FolderPath = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    FileName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    SharePointWebUrl = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    MimeType = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: true),
+                    TakenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IndexedAt = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Photos", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PhotoTags",
+                schema: "public",
+                columns: table => new
+                {
+                    PhotoId = table.Column<int>(type: "integer", nullable: false),
+                    TagId = table.Column<int>(type: "integer", nullable: false),
+                    Source = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PhotoTags", x => new { x.PhotoId, x.TagId });
+                    table.ForeignKey(
+                        name: "FK_PhotoTags_PhotobankTags_TagId",
+                        column: x => x.TagId,
+                        principalSchema: "public",
+                        principalTable: "PhotobankTags",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PhotoTags_Photos_PhotoId",
+                        column: x => x.PhotoId,
+                        principalSchema: "public",
+                        principalTable: "Photos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PhotobankTagRules_Active_SortOrder",
+                schema: "public",
+                table: "PhotobankTagRules",
+                columns: new[] { "IsActive", "SortOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PhotobankTags_Name",
+                schema: "public",
+                table: "PhotobankTags",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Photos_FolderPath",
+                schema: "public",
+                table: "Photos",
+                column: "FolderPath");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Photos_SharePointFileId",
+                schema: "public",
+                table: "Photos",
+                column: "SharePointFileId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PhotoTags_TagId",
+                schema: "public",
+                table: "PhotoTags",
+                column: "TagId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PhotobankIndexRoots",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "PhotobankTagRules",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "PhotoTags",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "PhotobankTags",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "Photos",
+                schema: "public");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotoConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotoConfiguration.cs
@@ -1,0 +1,29 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Photobank
+{
+    public class PhotoConfiguration : IEntityTypeConfiguration<Photo>
+    {
+        public void Configure(EntityTypeBuilder<Photo> builder)
+        {
+            builder.ToTable("Photos", "public");
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.SharePointFileId).HasMaxLength(500).IsRequired();
+            builder.HasIndex(x => x.SharePointFileId).IsUnique().HasDatabaseName("IX_Photos_SharePointFileId");
+            builder.Property(x => x.FolderPath).HasMaxLength(2000).IsRequired();
+            builder.Property(x => x.FileName).HasMaxLength(200).IsRequired();
+            builder.Property(x => x.SharePointWebUrl).HasMaxLength(2000);
+            builder.Property(x => x.MimeType).HasMaxLength(50);
+            builder.Property(x => x.IndexedAt).IsRequired().AsUtcTimestamp();
+            builder.Property(x => x.ModifiedAt).IsRequired().AsUtcTimestamp();
+            builder.HasIndex(x => x.FolderPath).HasDatabaseName("IX_Photos_FolderPath");
+            builder.HasMany(x => x.Tags)
+                .WithOne(x => x.Photo)
+                .HasForeignKey(x => x.PhotoId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotoTagConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotoTagConfiguration.cs
@@ -1,0 +1,22 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Photobank
+{
+    public class PhotoTagConfiguration : IEntityTypeConfiguration<PhotoTag>
+    {
+        public void Configure(EntityTypeBuilder<PhotoTag> builder)
+        {
+            builder.ToTable("PhotoTags", "public");
+            builder.HasKey(x => new { x.PhotoId, x.TagId });
+            builder.Property(x => x.Source).HasConversion<string>().HasMaxLength(20).IsRequired();
+            builder.Property(x => x.CreatedAt).IsRequired().AsUtcTimestamp();
+            builder.HasOne(x => x.Tag)
+                .WithMany(x => x.PhotoTags)
+                .HasForeignKey(x => x.TagId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankIndexRootConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankIndexRootConfiguration.cs
@@ -1,0 +1,20 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Photobank
+{
+    public class PhotobankIndexRootConfiguration : IEntityTypeConfiguration<PhotobankIndexRoot>
+    {
+        public void Configure(EntityTypeBuilder<PhotobankIndexRoot> builder)
+        {
+            builder.ToTable("PhotobankIndexRoots", "public");
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.SharePointPath).HasMaxLength(1000).IsRequired();
+            builder.Property(x => x.DisplayName).HasMaxLength(200);
+            builder.Property(x => x.CreatedByUserId).HasMaxLength(100);
+            builder.Property(x => x.CreatedAt).IsRequired().AsUtcTimestamp();
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/TagConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/TagConfiguration.cs
@@ -1,0 +1,17 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Photobank
+{
+    public class TagConfiguration : IEntityTypeConfiguration<Tag>
+    {
+        public void Configure(EntityTypeBuilder<Tag> builder)
+        {
+            builder.ToTable("PhotobankTags", "public");
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.Name).HasMaxLength(100).IsRequired();
+            builder.HasIndex(x => x.Name).IsUnique().HasDatabaseName("IX_PhotobankTags_Name");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/TagRuleConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/TagRuleConfiguration.cs
@@ -1,0 +1,18 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Photobank
+{
+    public class TagRuleConfiguration : IEntityTypeConfiguration<TagRule>
+    {
+        public void Configure(EntityTypeBuilder<TagRule> builder)
+        {
+            builder.ToTable("PhotobankTagRules", "public");
+            builder.HasKey(x => x.Id);
+            builder.Property(x => x.PathPattern).HasMaxLength(1000).IsRequired();
+            builder.Property(x => x.TagName).HasMaxLength(100).IsRequired();
+            builder.HasIndex(x => new { x.IsActive, x.SortOrder }).HasDatabaseName("IX_PhotobankTagRules_Active_SortOrder");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRuleMatcherTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRuleMatcherTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class TagRuleMatcherTests
+{
+    private static TagRule Rule(string pattern, string tag, bool active = true, int sort = 0) =>
+        new() { PathPattern = pattern, TagName = tag, IsActive = active, SortOrder = sort };
+
+    [Fact]
+    public void ExactPrefix_Matches()
+    {
+        var rules = new[] { Rule("Photos/2025/Events", "events") };
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
+        result.Should().ContainSingle("events");
+    }
+
+    [Fact]
+    public void Wildcard_MatchesSingleSegment()
+    {
+        var rules = new[] { Rule("Photos/*/Events", "events") };
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
+        result.Should().ContainSingle("events");
+    }
+
+    [Fact]
+    public void Wildcard_DoesNotMatchMultipleSegments()
+    {
+        var rules = new[] { Rule("Photos/*", "any") };
+        // '*' only matches one segment, so "Photos/2025/Events" should NOT match "Photos/*"
+        // because the path has more segments beyond the wildcard position
+        // BUT the pattern "Photos/*" means: prefix must be Photos/{one segment}
+        // path "Photos/2025/Events" has Photos, 2025, Events — 3 segments, pattern has 2
+        // pattern segments <= path segments, wildcard matches "2025" — so it DOES match as prefix
+        // The spec says '*' matches exactly one segment in position, not "rest of path"
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events", rules);
+        result.Should().ContainSingle("any"); // prefix "Photos/*" matches "Photos/2025/..."
+    }
+
+    [Fact]
+    public void AllMatchingRulesApply_NotFirstMatchWins()
+    {
+        var rules = new[]
+        {
+            Rule("Photos/2025", "year-2025"),
+            Rule("Photos/2025/Events", "events"),
+        };
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
+        result.Should().BeEquivalentTo(new[] { "year-2025", "events" });
+    }
+
+    [Fact]
+    public void CaseInsensitive_Matches()
+    {
+        var rules = new[] { Rule("photos/2025/events", "events") };
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
+        result.Should().ContainSingle("events");
+    }
+
+    [Fact]
+    public void InactiveRules_AreSkipped()
+    {
+        var rules = new[] { Rule("Photos/2025", "year-2025", active: false) };
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Party", rules);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void NoMatch_ReturnsEmpty()
+    {
+        var rules = new[] { Rule("Videos/2025", "videos") };
+        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Party", rules);
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- `PhotoTagSource` enum (Rule/Manual/AI)
- `PhotobankIndexRoot`, `Photo`, `Tag`, `PhotoTag`, `TagRule` domain entities
- EF Core configurations for all 5 entities with composite PKs, unique indexes
- `ApplicationDbContext`: 5 new Photobank DbSets
- `AddPhotobankTables` EF migration
- `TagRuleMatcher`: case-insensitive prefix + `*` wildcard segment matching, all-rules-apply
- 7 unit tests for `TagRuleMatcher`

Part of epic #755.

Closes #756