### PR TITLE
chore(workonepic): work directly on epic branch via worktree

### DIFF
--- a/.claude/skills/workonepic/SKILL.md
+++ b/.claude/skills/workonepic/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workonepic
-description: Use when the user says "work on epic", "pick up epic task", "workonepic", or provides an epic issue number to work on. Finds the oldest open subtask of the epic tagged "agent", creates a branch from the epic's branch, backmerges main, implements the task, validates against spec, runs all tests, commits with @claude marker, pushes, creates a PR to the epic branch, and marks the subtask as solved.
+description: Use when the user says "work on epic", "pick up epic task", "workonepic", or provides an epic issue number to work on. Finds the oldest open subtask of the epic tagged "agent", checks out the epic branch, backmerges main, implements the task directly on the epic branch, validates against spec, runs all tests, commits with @claude marker, pushes, and marks the subtask as solved.
 ---
 
 # Work on Epic — Pick Up and Implement Next Agent Subtask
 
-End-to-end workflow for picking up the oldest open "agent"-tagged subtask of a given epic, implementing it, and delivering a PR back to the epic branch.
+End-to-end workflow for picking up the oldest open "agent"-tagged subtask of a given epic, implementing it directly on the epic branch inside a worktree, and pushing the result.
 
 ## Usage
 
@@ -64,17 +64,20 @@ Pick the **oldest** (earliest `createdAt` / lowest number) open subtask that:
 gh issue edit <subtask-number> --remove-label "agent" --add-label "agent-wip"
 ```
 
-### 4. Create a feature branch from the epic branch
+### 4. Set up a git worktree for the epic branch
+
+Invoke `superpowers:using-git-worktrees` to create an isolated worktree checked out to the epic branch. This keeps the working directory clean and avoids disturbing the main checkout.
 
 ```bash
-git checkout <epic-branch>
+git fetch origin
+git worktree add ../worktrees/<epic-branch-slug> <epic-branch>
+cd ../worktrees/<epic-branch-slug>
 git pull origin <epic-branch>
-git checkout -b feat/<subtask-number>-<kebab-slug-from-title>
 ```
 
-Branch naming: always prefix with `feat/` and include the subtask issue number.
+All work for this subtask happens directly on the epic branch inside this worktree — do **not** create a separate feature branch.
 
-### 5. Backmerge main into the new branch
+### 5. Backmerge main into the epic branch
 
 ```bash
 git fetch origin main
@@ -132,23 +135,22 @@ cd frontend && npm run lint
 
 **STOP if any test or lint check fails.** Fix failures first, then re-run. E2E tests are **not** required here.
 
-### 12. Commit, push, and open a PR
+### 12. Commit and push to the epic branch
 
 Stage all changes and create a conventional commit with `@claude` in the body:
 
 ```
 feat: <description of what was implemented>
 
+Implements #<subtask-number>
+
 @claude
 ```
 
-Push and create a PR — **target the epic branch**, not `main`:
+Push directly to the epic branch — no separate PR is needed per subtask:
 
 ```bash
-git push -u origin <feature-branch>
-gh pr create --base <epic-branch> \
-  --title "feat: <description>" \
-  --body "<summary of changes>\n\nCloses #<subtask-number>"
+git push origin <epic-branch>
 ```
 
 ### 13. Mark subtask as solved — swap label "agent-wip" → "agent-solved"
@@ -159,11 +161,13 @@ gh issue edit <subtask-number> --remove-label "agent-wip" --add-label "agent-sol
 
 ## Hard Gates
 
-- **ALWAYS** create a new branch from the epic branch — never work directly on the epic branch or on `main`
-- **ALWAYS** backmerge `main` before starting implementation
+- **ALWAYS** use a git worktree — invoke `superpowers:using-git-worktrees` to set up a worktree for the epic branch before doing any implementation work
+- **ALWAYS** work directly on the epic branch — never create a per-subtask feature branch
+- **NEVER** work on `main` directly
+- **ALWAYS** backmerge `main` into the epic branch before starting implementation
 - **ALWAYS** validate the implementation against the full subtask spec before running tests
 - **ALWAYS** use subagent-driven development for implementation
 - All BE and FE tests (excluding E2E) **MUST** pass before pushing
 - The commit message **MUST** contain `@claude`
-- The PR **MUST** target the epic branch, not `main`
+- Changes are pushed directly to the epic branch — **no per-subtask PR** is created
 - The subtask label **MUST** be updated at both the start (`agent` → `agent-wip`) and end (`agent-wip` → `agent-solved`)


### PR DESCRIPTION
## Summary

- Removes per-subtask feature branch creation — all work now happens directly on the epic branch
- Adds a mandatory git worktree setup step (invokes `superpowers:using-git-worktrees`) before implementation starts
- Removes the per-subtask PR creation step — commits push straight to the epic branch
- Updates Hard Gates and frontmatter description to match the new flow

## Test plan

- [ ] Verify the skill is loadable and the step numbering is sequential
- [ ] Manually invoke `/workonepic` on an epic and confirm it sets up a worktree and commits to the epic branch without creating a feature branch