### PR TITLE
feat(photobank): API controllers — gallery endpoints and admin settings

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/MarketingCalendarController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/MarketingCalendarController.cs
@@ -1,0 +1,105 @@
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class MarketingCalendarController : BaseApiController
+    {
+        private readonly IMediator _mediator;
+
+        public MarketingCalendarController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        /// <summary>
+        /// Get marketing actions with optional filtering and pagination
+        /// </summary>
+        [HttpGet]
+        [ProducesResponseType(typeof(GetMarketingActionsResponse), StatusCodes.Status200OK)]
+        public async Task<ActionResult<GetMarketingActionsResponse>> GetMarketingActions(
+            [FromQuery] GetMarketingActionsRequest request)
+        {
+            var response = await _mediator.Send(request);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Get specific marketing action by ID
+        /// </summary>
+        [HttpGet("{id:int}")]
+        [ProducesResponseType(typeof(GetMarketingActionResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<GetMarketingActionResponse>> GetMarketingAction(int id)
+        {
+            var request = new GetMarketingActionRequest { Id = id };
+            var response = await _mediator.Send(request);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Get lightweight calendar view of marketing actions for a date range
+        /// </summary>
+        [HttpGet("calendar")]
+        [ProducesResponseType(typeof(GetMarketingCalendarResponse), StatusCodes.Status200OK)]
+        public async Task<ActionResult<GetMarketingCalendarResponse>> GetCalendar(
+            [FromQuery] GetMarketingCalendarRequest request)
+        {
+            var response = await _mediator.Send(request);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Create a new marketing action
+        /// </summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(CreateMarketingActionResponse), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<CreateMarketingActionResponse>> CreateMarketingAction(
+            [FromBody] CreateMarketingActionRequest request)
+        {
+            var response = await _mediator.Send(request);
+            if (response.Success)
+                return CreatedAtAction(nameof(GetMarketingAction), new { id = response.Id }, response);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Update an existing marketing action
+        /// </summary>
+        [HttpPut("{id:int}")]
+        [ProducesResponseType(typeof(UpdateMarketingActionResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<UpdateMarketingActionResponse>> UpdateMarketingAction(
+            int id,
+            [FromBody] UpdateMarketingActionRequest request)
+        {
+            request.Id = id;
+            var response = await _mediator.Send(request);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Delete a marketing action (soft delete)
+        /// </summary>
+        [HttpDelete("{id:int}")]
+        [ProducesResponseType(typeof(DeleteMarketingActionResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<DeleteMarketingActionResponse>> DeleteMarketingAction(int id)
+        {
+            var request = new DeleteMarketingActionRequest { Id = id };
+            var response = await _mediator.Send(request);
+            return HandleResponse(response);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers
+{
+    [ApiController]
+    [Route("api/photobank")]
+    [Authorize]
+    public class PhotobankController : BaseApiController
+    {
+        private readonly IMediator _mediator;
+
+        public PhotobankController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        /// <summary>
+        /// Get photos with optional tag AND filter, filename search, and pagination.
+        /// </summary>
+        [HttpGet("photos")]
+        [ProducesResponseType(typeof(GetPhotosResponse), StatusCodes.Status200OK)]
+        public async Task<ActionResult<GetPhotosResponse>> GetPhotos(
+            [FromQuery] List<string>? tags,
+            [FromQuery] string? search,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 48,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new GetPhotosRequest
+            {
+                Tags = tags,
+                Search = search,
+                Page = page,
+                PageSize = pageSize,
+            };
+            var response = await _mediator.Send(request, cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Get all tags with photo counts, sorted by count descending.
+        /// </summary>
+        [HttpGet("tags")]
+        [ProducesResponseType(typeof(GetTagsResponse), StatusCodes.Status200OK)]
+        public async Task<ActionResult<GetTagsResponse>> GetTags(CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(new GetTagsRequest(), cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Add a manual tag to a photo. Requires administrator role.
+        /// </summary>
+        [HttpPost("photos/{id:int}/tags")]
+        [Authorize(Roles = AuthorizationConstants.Roles.Administrator)]
+        [ProducesResponseType(typeof(AddPhotoTagResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<AddPhotoTagResponse>> AddPhotoTag(
+            int id,
+            [FromBody] AddPhotoTagBody body,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new AddPhotoTagRequest { PhotoId = id, TagName = body.TagName };
+            var response = await _mediator.Send(request, cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Remove a tag from a photo. Requires administrator role.
+        /// </summary>
+        [HttpDelete("photos/{id:int}/tags/{tagId:int}")]
+        [Authorize(Roles = AuthorizationConstants.Roles.Administrator)]
+        [ProducesResponseType(typeof(RemovePhotoTagResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<RemovePhotoTagResponse>> RemovePhotoTag(
+            int id,
+            int tagId,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new RemovePhotoTagRequest { PhotoId = id, TagId = tagId };
+            var response = await _mediator.Send(request, cancellationToken);
+            return HandleResponse(response);
+        }
+    }
+
+    public class AddPhotoTagBody
+    {
+        public string TagName { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankSettingsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankSettingsController.cs
@@ -1,0 +1,144 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Authorization;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers
+{
+    [ApiController]
+    [Route("api/photobank/settings")]
+    [Authorize(Roles = AuthorizationConstants.Roles.Administrator)]
+    public class PhotobankSettingsController : BaseApiController
+    {
+        private readonly IMediator _mediator;
+
+        public PhotobankSettingsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        // --- Index Roots ---
+
+        /// <summary>
+        /// Get configured SharePoint index roots.
+        /// </summary>
+        [HttpGet("roots")]
+        [ProducesResponseType(typeof(GetRootsResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<GetRootsResponse>> GetRoots(CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(new GetRootsRequest(), cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Add a new SharePoint index root.
+        /// </summary>
+        [HttpPost("roots")]
+        [ProducesResponseType(typeof(AddRootResponse), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<AddRootResponse>> AddRoot(
+            [FromBody] AddRootRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(request, cancellationToken);
+            if (response.Success)
+                return CreatedAtAction(nameof(GetRoots), response);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Delete a SharePoint index root.
+        /// </summary>
+        [HttpDelete("roots/{id:int}")]
+        [ProducesResponseType(typeof(DeleteRootResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<DeleteRootResponse>> DeleteRoot(
+            int id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(new DeleteRootRequest { Id = id }, cancellationToken);
+            return HandleResponse(response);
+        }
+
+        // --- Tag Rules ---
+
+        /// <summary>
+        /// Get all tag rules.
+        /// </summary>
+        [HttpGet("rules")]
+        [ProducesResponseType(typeof(GetRulesResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<GetRulesResponse>> GetRules(CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(new GetRulesRequest(), cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Add a new tag rule.
+        /// </summary>
+        [HttpPost("rules")]
+        [ProducesResponseType(typeof(AddRuleResponse), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<AddRuleResponse>> AddRule(
+            [FromBody] AddRuleRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(request, cancellationToken);
+            if (response.Success)
+                return CreatedAtAction(nameof(GetRules), response);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Update an existing tag rule.
+        /// </summary>
+        [HttpPut("rules/{id:int}")]
+        [ProducesResponseType(typeof(UpdateRuleResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<UpdateRuleResponse>> UpdateRule(
+            int id,
+            [FromBody] UpdateRuleRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            request.Id = id;
+            var response = await _mediator.Send(request, cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Delete a tag rule.
+        /// </summary>
+        [HttpDelete("rules/{id:int}")]
+        [ProducesResponseType(typeof(DeleteRuleResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<DeleteRuleResponse>> DeleteRule(
+            int id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(new DeleteRuleRequest { Id = id }, cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Re-apply all active tag rules. Deletes Rule-sourced tags and recomputes them.
+        /// Manual tags are never touched.
+        /// </summary>
+        [HttpPost("rules/reapply")]
+        [ProducesResponseType(typeof(ReapplyRulesResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<ReapplyRulesResponse>> ReapplyRules(CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(new ReapplyRulesRequest(), cancellationToken);
+            return HandleResponse(response);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -16,6 +16,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.Purchase;
 using Anela.Heblo.Application.Features.FinancialOverview;
 using Anela.Heblo.Application.Features.Journal;
+using Anela.Heblo.Application.Features.Marketing;
 using Anela.Heblo.Application.Features.Logistics;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture;
 using Anela.Heblo.Application.Features.Manufacture;
@@ -57,6 +58,7 @@ public static class ApplicationModule
         services.AddPurchaseModule();
         services.AddFinancialOverviewModule(configuration);
         services.AddJournalModule();
+        services.AddMarketingModule();
         services.AddManufactureModule(configuration);
         services.AddTransportModule();
         services.AddGiftPackageManufactureModule();

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -17,6 +17,7 @@ using Anela.Heblo.Application.Features.Purchase;
 using Anela.Heblo.Application.Features.FinancialOverview;
 using Anela.Heblo.Application.Features.Journal;
 using Anela.Heblo.Application.Features.Marketing;
+using Anela.Heblo.Application.Features.Photobank;
 using Anela.Heblo.Application.Features.Logistics;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture;
 using Anela.Heblo.Application.Features.Manufacture;
@@ -59,6 +60,7 @@ public static class ApplicationModule
         services.AddFinancialOverviewModule(configuration);
         services.AddJournalModule();
         services.AddMarketingModule();
+        services.AddPhotobankModule();
         services.AddManufactureModule(configuration);
         services.AddTransportModule();
         services.AddGiftPackageManufactureModule();

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/CreateMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/CreateMarketingActionRequest.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class CreateMarketingActionRequest : IRequest<CreateMarketingActionResponse>
+    {
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = null!;
+
+        [MaxLength(5000)]
+        public string? Description { get; set; }
+
+        [Required]
+        public MarketingActionType ActionType { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        public List<string>? AssociatedProducts { get; set; }
+        public List<CreateFolderLinkRequest>? FolderLinks { get; set; }
+
+        public class CreateFolderLinkRequest
+        {
+            [Required]
+            [MaxLength(100)]
+            public string FolderKey { get; set; } = null!;
+
+            [Required]
+            public MarketingFolderType FolderType { get; set; }
+        }
+    }
+
+    public class CreateMarketingActionResponse : BaseResponse
+    {
+        public int Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public string Message { get; set; } = "Marketing action created successfully";
+
+        public CreateMarketingActionResponse() : base() { }
+
+        public CreateMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/DeleteMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/DeleteMarketingActionRequest.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class DeleteMarketingActionRequest : IRequest<DeleteMarketingActionResponse>
+    {
+        public int Id { get; set; }
+    }
+
+    public class DeleteMarketingActionResponse : BaseResponse
+    {
+        public int Id { get; set; }
+        public string Message { get; set; } = "Marketing action deleted successfully";
+
+        public DeleteMarketingActionResponse() : base() { }
+
+        public DeleteMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionRequest.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class GetMarketingActionRequest : IRequest<GetMarketingActionResponse>
+    {
+        public int Id { get; set; }
+    }
+
+    public class GetMarketingActionResponse : BaseResponse
+    {
+        public MarketingActionDto? Action { get; set; }
+
+        public GetMarketingActionResponse() : base() { }
+
+        public GetMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingActionsRequest.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class GetMarketingActionsRequest : IRequest<GetMarketingActionsResponse>
+    {
+        public int PageNumber { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+        public string? SearchTerm { get; set; }
+        public string? ProductCodePrefix { get; set; }
+        public DateTime? StartDateFrom { get; set; }
+        public DateTime? StartDateTo { get; set; }
+        public DateTime? EndDateFrom { get; set; }
+        public DateTime? EndDateTo { get; set; }
+        public bool IncludeDeleted { get; set; } = false;
+    }
+
+    public class GetMarketingActionsResponse : BaseResponse
+    {
+        public List<MarketingActionDto> Actions { get; set; } = new();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages { get; set; }
+        public bool HasNextPage { get; set; }
+        public bool HasPreviousPage { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingCalendarRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/GetMarketingCalendarRequest.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class GetMarketingCalendarRequest : IRequest<GetMarketingCalendarResponse>
+    {
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+    }
+
+    public class GetMarketingCalendarResponse : BaseResponse
+    {
+        public List<MarketingActionCalendarDto> Actions { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionCalendarDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionCalendarDto.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class MarketingActionCalendarDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = null!;
+        public string ActionType { get; set; } = null!;
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public List<string> AssociatedProducts { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionDto.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class MarketingActionDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = null!;
+        public string? Description { get; set; }
+        public string ActionType { get; set; } = null!;
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<MarketingActionFolderLinkDto> FolderLinks { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionFolderLinkDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/MarketingActionFolderLinkDto.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class MarketingActionFolderLinkDto
+    {
+        public string FolderKey { get; set; } = null!;
+        public string FolderType { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/UpdateMarketingActionRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/Contracts/UpdateMarketingActionRequest.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.Contracts
+{
+    public class UpdateMarketingActionRequest : IRequest<UpdateMarketingActionResponse>
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = null!;
+
+        [MaxLength(5000)]
+        public string? Description { get; set; }
+
+        [Required]
+        public MarketingActionType ActionType { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        public List<string>? AssociatedProducts { get; set; }
+        public List<CreateMarketingActionRequest.CreateFolderLinkRequest>? FolderLinks { get; set; }
+    }
+
+    public class UpdateMarketingActionResponse : BaseResponse
+    {
+        public int Id { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string Message { get; set; } = "Marketing action updated successfully";
+
+        public UpdateMarketingActionResponse() : base() { }
+
+        public UpdateMarketingActionResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+            : base(errorCode, parameters) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
@@ -1,0 +1,16 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Marketing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Marketing
+{
+    public static class MarketingModule
+    {
+        public static IServiceCollection AddMarketingModule(this IServiceCollection services)
+        {
+            services.AddScoped<IMarketingActionRepository, MarketingActionRepository>();
+            // MediatR handlers are auto-registered by assembly scan
+            return services;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction
+{
+    public class CreateMarketingActionHandler : IRequestHandler<CreateMarketingActionRequest, CreateMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<CreateMarketingActionHandler> _logger;
+
+        public CreateMarketingActionHandler(
+            IMarketingActionRepository repository,
+            ICurrentUserService currentUserService,
+            ILogger<CreateMarketingActionHandler> logger)
+        {
+            _repository = repository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<CreateMarketingActionResponse> Handle(
+            CreateMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            if (!currentUser.IsAuthenticated || string.IsNullOrEmpty(currentUser.Id))
+            {
+                return new CreateMarketingActionResponse(ErrorCodes.UnauthorizedMarketingAccess, new Dictionary<string, string>
+                {
+                    { "resource", "marketing_action" },
+                });
+            }
+
+            var now = DateTime.UtcNow;
+
+            var action = new MarketingAction
+            {
+                Title = request.Title.Trim(),
+                Description = request.Description?.Trim(),
+                ActionType = request.ActionType,
+                StartDate = request.StartDate,
+                EndDate = request.EndDate,
+                CreatedAt = now,
+                ModifiedAt = now,
+                CreatedByUserId = currentUser.Id,
+                CreatedByUsername = currentUser.Name ?? "Unknown User",
+            };
+
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var product in request.AssociatedProducts.Distinct())
+                {
+                    action.AssociateWithProduct(product);
+                }
+            }
+
+            if (request.FolderLinks?.Any() == true)
+            {
+                foreach (var link in request.FolderLinks)
+                {
+                    action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);
+                }
+            }
+
+            var created = await _repository.AddAsync(action, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "MarketingAction {ActionId} created by user {UserId}",
+                created.Id,
+                currentUser.Id);
+
+            return new CreateMarketingActionResponse
+            {
+                Id = created.Id,
+                CreatedAt = created.CreatedAt,
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAction
+{
+    public class DeleteMarketingActionHandler : IRequestHandler<DeleteMarketingActionRequest, DeleteMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<DeleteMarketingActionHandler> _logger;
+
+        public DeleteMarketingActionHandler(
+            IMarketingActionRepository repository,
+            ICurrentUserService currentUserService,
+            ILogger<DeleteMarketingActionHandler> logger)
+        {
+            _repository = repository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<DeleteMarketingActionResponse> Handle(
+            DeleteMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            if (!currentUser.IsAuthenticated || string.IsNullOrEmpty(currentUser.Id))
+            {
+                return new DeleteMarketingActionResponse(ErrorCodes.UnauthorizedMarketingAccess, new Dictionary<string, string>
+                {
+                    { "resource", "marketing_action" },
+                });
+            }
+
+            var action = await _repository.GetByIdAsync(request.Id, cancellationToken);
+            if (action == null)
+            {
+                return new DeleteMarketingActionResponse(ErrorCodes.MarketingActionNotFound, new Dictionary<string, string>
+                {
+                    { "actionId", request.Id.ToString() },
+                });
+            }
+
+            await _repository.DeleteSoftAsync(request.Id, currentUser.Id, currentUser.Name ?? "Unknown User", cancellationToken);
+
+            _logger.LogInformation(
+                "MarketingAction {ActionId} deleted by user {UserId}",
+                request.Id,
+                currentUser.Id);
+
+            return new DeleteMarketingActionResponse { Id = request.Id };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingAction/GetMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingAction/GetMarketingActionHandler.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingActions;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingAction
+{
+    public class GetMarketingActionHandler : IRequestHandler<GetMarketingActionRequest, GetMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+
+        public GetMarketingActionHandler(IMarketingActionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetMarketingActionResponse> Handle(
+            GetMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var action = await _repository.GetByIdAsync(request.Id, cancellationToken);
+            if (action == null)
+            {
+                return new GetMarketingActionResponse(ErrorCodes.MarketingActionNotFound, new Dictionary<string, string>
+                {
+                    { "actionId", request.Id.ToString() },
+                });
+            }
+
+            return new GetMarketingActionResponse
+            {
+                Action = GetMarketingActionsHandler.MapToDto(action),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingActions/GetMarketingActionsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingActions/GetMarketingActionsHandler.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingActions
+{
+    public class GetMarketingActionsHandler : IRequestHandler<GetMarketingActionsRequest, GetMarketingActionsResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+
+        public GetMarketingActionsHandler(IMarketingActionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetMarketingActionsResponse> Handle(
+            GetMarketingActionsRequest request,
+            CancellationToken cancellationToken)
+        {
+            var criteria = new MarketingActionQueryCriteria
+            {
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize,
+                SearchTerm = request.SearchTerm,
+                ProductCodePrefix = request.ProductCodePrefix,
+                StartDateFrom = request.StartDateFrom,
+                StartDateTo = request.StartDateTo,
+                EndDateFrom = request.EndDateFrom,
+                EndDateTo = request.EndDateTo,
+                IncludeDeleted = request.IncludeDeleted,
+            };
+
+            var result = await _repository.GetPagedAsync(criteria, cancellationToken);
+
+            return new GetMarketingActionsResponse
+            {
+                Actions = result.Items.Select(MapToDto).ToList(),
+                TotalCount = result.TotalCount,
+                PageNumber = result.PageNumber,
+                PageSize = result.PageSize,
+                TotalPages = (int)Math.Ceiling((double)result.TotalCount / result.PageSize),
+                HasNextPage = result.PageNumber * result.PageSize < result.TotalCount,
+                HasPreviousPage = result.PageNumber > 1,
+            };
+        }
+
+        internal static MarketingActionDto MapToDto(MarketingAction action) =>
+            new()
+            {
+                Id = action.Id,
+                Title = action.Title,
+                Description = action.Description,
+                ActionType = action.ActionType.ToString(),
+                StartDate = action.StartDate,
+                EndDate = action.EndDate,
+                CreatedAt = action.CreatedAt,
+                ModifiedAt = action.ModifiedAt,
+                CreatedByUserId = action.CreatedByUserId,
+                CreatedByUsername = action.CreatedByUsername,
+                ModifiedByUserId = action.ModifiedByUserId,
+                ModifiedByUsername = action.ModifiedByUsername,
+                AssociatedProducts = action.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                FolderLinks = action.FolderLinks
+                    .Select(fl => new MarketingActionFolderLinkDto
+                    {
+                        FolderKey = fl.FolderKey,
+                        FolderType = fl.FolderType.ToString(),
+                    })
+                    .ToList(),
+            };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingCalendar/GetMarketingCalendarHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/GetMarketingCalendar/GetMarketingCalendarHandler.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Domain.Features.Marketing;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingCalendar
+{
+    public class GetMarketingCalendarHandler : IRequestHandler<GetMarketingCalendarRequest, GetMarketingCalendarResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+
+        public GetMarketingCalendarHandler(IMarketingActionRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetMarketingCalendarResponse> Handle(
+            GetMarketingCalendarRequest request,
+            CancellationToken cancellationToken)
+        {
+            var actions = await _repository.GetForCalendarAsync(
+                request.StartDate,
+                request.EndDate,
+                cancellationToken);
+
+            return new GetMarketingCalendarResponse
+            {
+                Actions = actions.Select(a => new MarketingActionCalendarDto
+                {
+                    Id = a.Id,
+                    Title = a.Title,
+                    ActionType = a.ActionType.ToString(),
+                    StartDate = a.StartDate,
+                    EndDate = a.EndDate,
+                    AssociatedProducts = a.ProductAssociations
+                        .Select(pa => pa.ProductCodePrefix)
+                        .Distinct()
+                        .ToList(),
+                }).ToList(),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAction
+{
+    public class UpdateMarketingActionHandler : IRequestHandler<UpdateMarketingActionRequest, UpdateMarketingActionResponse>
+    {
+        private readonly IMarketingActionRepository _repository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<UpdateMarketingActionHandler> _logger;
+
+        public UpdateMarketingActionHandler(
+            IMarketingActionRepository repository,
+            ICurrentUserService currentUserService,
+            ILogger<UpdateMarketingActionHandler> logger)
+        {
+            _repository = repository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<UpdateMarketingActionResponse> Handle(
+            UpdateMarketingActionRequest request,
+            CancellationToken cancellationToken)
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            if (!currentUser.IsAuthenticated || string.IsNullOrEmpty(currentUser.Id))
+            {
+                return new UpdateMarketingActionResponse(ErrorCodes.UnauthorizedMarketingAccess, new Dictionary<string, string>
+                {
+                    { "resource", "marketing_action" },
+                });
+            }
+
+            var action = await _repository.GetByIdAsync(request.Id, cancellationToken);
+            if (action == null)
+            {
+                return new UpdateMarketingActionResponse(ErrorCodes.MarketingActionNotFound, new Dictionary<string, string>
+                {
+                    { "actionId", request.Id.ToString() },
+                });
+            }
+
+            var now = DateTime.UtcNow;
+
+            action.Title = request.Title.Trim();
+            action.Description = request.Description?.Trim();
+            action.ActionType = request.ActionType;
+            action.StartDate = request.StartDate;
+            action.EndDate = request.EndDate;
+            action.ModifiedAt = now;
+            action.ModifiedByUserId = currentUser.Id;
+            action.ModifiedByUsername = currentUser.Name ?? "Unknown User";
+
+            // Replace product associations
+            action.ProductAssociations.Clear();
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var product in request.AssociatedProducts.Distinct())
+                {
+                    action.AssociateWithProduct(product);
+                }
+            }
+
+            // Replace folder links
+            action.FolderLinks.Clear();
+            if (request.FolderLinks?.Any() == true)
+            {
+                foreach (var link in request.FolderLinks)
+                {
+                    action.LinkToFolder(link.FolderKey.Trim(), link.FolderType);
+                }
+            }
+
+            await _repository.UpdateAsync(action, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "MarketingAction {ActionId} updated by user {UserId}",
+                action.Id,
+                currentUser.Id);
+
+            return new UpdateMarketingActionResponse
+            {
+                Id = action.Id,
+                ModifiedAt = action.ModifiedAt,
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagRequest.cs
@@ -1,0 +1,21 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddPhotoTagRequest : IRequest<AddPhotoTagResponse>
+    {
+        public int PhotoId { get; set; }
+        public string TagName { get; set; } = null!;
+    }
+
+    public class AddPhotoTagResponse : BaseResponse
+    {
+        public int TagId { get; set; }
+        public string TagName { get; set; } = null!;
+
+        public AddPhotoTagResponse() : base() { }
+
+        public AddPhotoTagResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRootRequest.cs
@@ -1,0 +1,16 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddRootRequest : IRequest<AddRootResponse>
+    {
+        public string SharePointPath { get; set; } = null!;
+        public string? DisplayName { get; set; }
+    }
+
+    public class AddRootResponse : BaseResponse
+    {
+        public int Id { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddRuleRequest.cs
@@ -1,0 +1,17 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddRuleRequest : IRequest<AddRuleResponse>
+    {
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public int SortOrder { get; set; }
+    }
+
+    public class AddRuleResponse : BaseResponse
+    {
+        public int Id { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/DeleteRootRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/DeleteRootRequest.cs
@@ -1,0 +1,17 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class DeleteRootRequest : IRequest<DeleteRootResponse>
+    {
+        public int Id { get; set; }
+    }
+
+    public class DeleteRootResponse : BaseResponse
+    {
+        public DeleteRootResponse() : base() { }
+
+        public DeleteRootResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/DeleteRuleRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/DeleteRuleRequest.cs
@@ -1,0 +1,17 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class DeleteRuleRequest : IRequest<DeleteRuleResponse>
+    {
+        public int Id { get; set; }
+    }
+
+    public class DeleteRuleResponse : BaseResponse
+    {
+        public DeleteRuleResponse() : base() { }
+
+        public DeleteRuleResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetPhotosRequest.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class GetPhotosRequest : IRequest<GetPhotosResponse>
+    {
+        public List<string>? Tags { get; set; }
+        public string? Search { get; set; }
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 48;
+    }
+
+    public class GetPhotosResponse : BaseResponse
+    {
+        public List<PhotoDto> Items { get; set; } = new();
+        public int Total { get; set; }
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetRootsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetRootsRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class GetRootsRequest : IRequest<GetRootsResponse>
+    {
+    }
+
+    public class GetRootsResponse : BaseResponse
+    {
+        public List<IndexRootDto> Roots { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetRulesRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetRulesRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class GetRulesRequest : IRequest<GetRulesResponse>
+    {
+    }
+
+    public class GetRulesResponse : BaseResponse
+    {
+        public List<TagRuleDto> Rules { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetTagsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetTagsRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class GetTagsRequest : IRequest<GetTagsResponse>
+    {
+    }
+
+    public class GetTagsResponse : BaseResponse
+    {
+        public List<TagWithCountDto> Tags { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/IndexRootDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/IndexRootDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class IndexRootDto
+    {
+        public int Id { get; set; }
+        public string SharePointPath { get; set; } = null!;
+        public string? DisplayName { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/PhotoDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/PhotoDto.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class PhotoDto
+    {
+        public int Id { get; set; }
+        public string SharePointFileId { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public string FolderPath { get; set; } = null!;
+        public string? SharePointWebUrl { get; set; }
+        public long? FileSizeBytes { get; set; }
+        public DateTime LastModifiedAt { get; set; }
+        public List<TagDto> Tags { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/ReapplyRulesRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/ReapplyRulesRequest.cs
@@ -1,0 +1,14 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class ReapplyRulesRequest : IRequest<ReapplyRulesResponse>
+    {
+    }
+
+    public class ReapplyRulesResponse : BaseResponse
+    {
+        public int PhotosUpdated { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RemovePhotoTagRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/RemovePhotoTagRequest.cs
@@ -1,0 +1,18 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class RemovePhotoTagRequest : IRequest<RemovePhotoTagResponse>
+    {
+        public int PhotoId { get; set; }
+        public int TagId { get; set; }
+    }
+
+    public class RemovePhotoTagResponse : BaseResponse
+    {
+        public RemovePhotoTagResponse() : base() { }
+
+        public RemovePhotoTagResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/TagDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/TagDto.cs
@@ -1,0 +1,16 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class TagDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public string? Source { get; set; }
+    }
+
+    public class TagWithCountDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public int Count { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/TagRuleDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/TagRuleDto.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class TagRuleDto
+    {
+        public int Id { get; set; }
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public bool IsActive { get; set; }
+        public int SortOrder { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/UpdateRuleRequest.cs
@@ -1,0 +1,21 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class UpdateRuleRequest : IRequest<UpdateRuleResponse>
+    {
+        public int Id { get; set; }
+        public string PathPattern { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+        public bool IsActive { get; set; }
+        public int SortOrder { get; set; }
+    }
+
+    public class UpdateRuleResponse : BaseResponse
+    {
+        public UpdateRuleResponse() : base() { }
+
+        public UpdateRuleResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -1,0 +1,16 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence.Photobank;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Photobank
+{
+    public static class PhotobankModule
+    {
+        public static IServiceCollection AddPhotobankModule(this IServiceCollection services)
+        {
+            services.AddScoped<IPhotobankRepository, PhotobankRepository>();
+            // MediatR handlers are auto-registered by assembly scan
+            return services;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/AddPhotoTag/AddPhotoTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/AddPhotoTag/AddPhotoTagHandler.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag
+{
+    public class AddPhotoTagHandler : IRequestHandler<AddPhotoTagRequest, AddPhotoTagResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public AddPhotoTagHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<AddPhotoTagResponse> Handle(AddPhotoTagRequest request, CancellationToken cancellationToken)
+        {
+            var photo = await _repository.GetPhotoByIdAsync(request.PhotoId, cancellationToken);
+            if (photo == null)
+                return new AddPhotoTagResponse(ErrorCodes.PhotoNotFound);
+
+            var normalizedName = request.TagName.Trim().ToLowerInvariant();
+            var tag = await _repository.GetOrCreateTagAsync(normalizedName, cancellationToken);
+
+            if (await _repository.PhotoTagExistsAsync(photo.Id, tag!.Id, cancellationToken))
+                return new AddPhotoTagResponse { TagId = tag.Id, TagName = tag.Name };
+
+            var photoTag = new PhotoTag
+            {
+                PhotoId = photo.Id,
+                TagId = tag.Id,
+                Source = PhotoTagSource.Manual,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            await _repository.AddPhotoTagAsync(photoTag, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            return new AddPhotoTagResponse { TagId = tag.Id, TagName = tag.Name };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/AddRoot/AddRootHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/AddRoot/AddRootHandler.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot
+{
+    public class AddRootHandler : IRequestHandler<AddRootRequest, AddRootResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public AddRootHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<AddRootResponse> Handle(AddRootRequest request, CancellationToken cancellationToken)
+        {
+            var root = new PhotobankIndexRoot
+            {
+                SharePointPath = request.SharePointPath.Trim(),
+                DisplayName = request.DisplayName?.Trim(),
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            var created = await _repository.AddRootAsync(root, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            return new AddRootResponse { Id = created.Id };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/AddRule/AddRuleHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/AddRule/AddRuleHandler.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.AddRule
+{
+    public class AddRuleHandler : IRequestHandler<AddRuleRequest, AddRuleResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public AddRuleHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<AddRuleResponse> Handle(AddRuleRequest request, CancellationToken cancellationToken)
+        {
+            var rule = new TagRule
+            {
+                PathPattern = request.PathPattern.Trim(),
+                TagName = request.TagName.Trim().ToLowerInvariant(),
+                IsActive = true,
+                SortOrder = request.SortOrder,
+            };
+
+            var created = await _repository.AddRuleAsync(rule, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            return new AddRuleResponse { Id = created.Id };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteRoot/DeleteRootHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteRoot/DeleteRootHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRoot
+{
+    public class DeleteRootHandler : IRequestHandler<DeleteRootRequest, DeleteRootResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public DeleteRootHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<DeleteRootResponse> Handle(DeleteRootRequest request, CancellationToken cancellationToken)
+        {
+            var deleted = await _repository.DeleteRootAsync(request.Id, cancellationToken);
+            if (!deleted)
+                return new DeleteRootResponse(ErrorCodes.PhotobankRootNotFound);
+
+            await _repository.SaveChangesAsync(cancellationToken);
+            return new DeleteRootResponse();
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteRule/DeleteRuleHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteRule/DeleteRuleHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRule
+{
+    public class DeleteRuleHandler : IRequestHandler<DeleteRuleRequest, DeleteRuleResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public DeleteRuleHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<DeleteRuleResponse> Handle(DeleteRuleRequest request, CancellationToken cancellationToken)
+        {
+            var deleted = await _repository.DeleteRuleAsync(request.Id, cancellationToken);
+            if (!deleted)
+                return new DeleteRuleResponse(ErrorCodes.PhotobankRuleNotFound);
+
+            await _repository.SaveChangesAsync(cancellationToken);
+            return new DeleteRuleResponse();
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
+{
+    public class GetPhotosHandler : IRequestHandler<GetPhotosRequest, GetPhotosResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public GetPhotosHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetPhotosResponse> Handle(GetPhotosRequest request, CancellationToken cancellationToken)
+        {
+            var (items, total) = await _repository.GetPhotosAsync(
+                request.Tags,
+                request.Search,
+                request.Page,
+                request.PageSize,
+                cancellationToken);
+
+            return new GetPhotosResponse
+            {
+                Items = items.Select(MapToDto).ToList(),
+                Total = total,
+                Page = request.Page,
+                PageSize = request.PageSize,
+            };
+        }
+
+        internal static PhotoDto MapToDto(Photo photo) => new()
+        {
+            Id = photo.Id,
+            SharePointFileId = photo.SharePointFileId,
+            Name = photo.FileName,
+            FolderPath = photo.FolderPath,
+            SharePointWebUrl = photo.SharePointWebUrl,
+            FileSizeBytes = photo.FileSizeBytes,
+            LastModifiedAt = photo.ModifiedAt,
+            Tags = photo.Tags.Select(pt => new TagDto
+            {
+                Id = pt.TagId,
+                Name = pt.Tag.Name,
+                Source = pt.Source.ToString(),
+            }).ToList(),
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetRoots/GetRootsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetRoots/GetRootsHandler.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetRoots
+{
+    public class GetRootsHandler : IRequestHandler<GetRootsRequest, GetRootsResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public GetRootsHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetRootsResponse> Handle(GetRootsRequest request, CancellationToken cancellationToken)
+        {
+            var roots = await _repository.GetRootsAsync(cancellationToken);
+
+            return new GetRootsResponse
+            {
+                Roots = roots.Select(r => new IndexRootDto
+                {
+                    Id = r.Id,
+                    SharePointPath = r.SharePointPath,
+                    DisplayName = r.DisplayName,
+                    IsActive = r.IsActive,
+                    CreatedAt = r.CreatedAt,
+                }).ToList(),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetRules/GetRulesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetRules/GetRulesHandler.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetRules
+{
+    public class GetRulesHandler : IRequestHandler<GetRulesRequest, GetRulesResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public GetRulesHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetRulesResponse> Handle(GetRulesRequest request, CancellationToken cancellationToken)
+        {
+            var rules = await _repository.GetRulesAsync(cancellationToken);
+
+            return new GetRulesResponse
+            {
+                Rules = rules.Select(r => new TagRuleDto
+                {
+                    Id = r.Id,
+                    PathPattern = r.PathPattern,
+                    TagName = r.TagName,
+                    IsActive = r.IsActive,
+                    SortOrder = r.SortOrder,
+                }).ToList(),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetTags/GetTagsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetTags/GetTagsHandler.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetTags
+{
+    public class GetTagsHandler : IRequestHandler<GetTagsRequest, GetTagsResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public GetTagsHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<GetTagsResponse> Handle(GetTagsRequest request, CancellationToken cancellationToken)
+        {
+            var tags = await _repository.GetTagsWithCountsAsync(cancellationToken);
+
+            return new GetTagsResponse
+            {
+                Tags = tags.Select(t => new TagWithCountDto
+                {
+                    Id = t.Tag.Id,
+                    Name = t.Tag.Name,
+                    Count = t.Count,
+                }).ToList(),
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/ReapplyRules/ReapplyRulesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/ReapplyRules/ReapplyRulesHandler.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.ReapplyRules
+{
+    public class ReapplyRulesHandler : IRequestHandler<ReapplyRulesRequest, ReapplyRulesResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public ReapplyRulesHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<ReapplyRulesResponse> Handle(ReapplyRulesRequest request, CancellationToken cancellationToken)
+        {
+            var activeRules = await _repository.GetRulesAsync(cancellationToken);
+            var photosUpdated = await _repository.ReapplyRulesAsync(activeRules, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            return new ReapplyRulesResponse { PhotosUpdated = photosUpdated };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RemovePhotoTag/RemovePhotoTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RemovePhotoTag/RemovePhotoTagHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.RemovePhotoTag
+{
+    public class RemovePhotoTagHandler : IRequestHandler<RemovePhotoTagRequest, RemovePhotoTagResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public RemovePhotoTagHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<RemovePhotoTagResponse> Handle(RemovePhotoTagRequest request, CancellationToken cancellationToken)
+        {
+            var photo = await _repository.GetPhotoByIdAsync(request.PhotoId, cancellationToken);
+            if (photo == null)
+                return new RemovePhotoTagResponse(ErrorCodes.PhotoNotFound);
+
+            await _repository.RemovePhotoTagAsync(request.PhotoId, request.TagId, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            return new RemovePhotoTagResponse();
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/UpdateRule/UpdateRuleHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/UpdateRule/UpdateRuleHandler.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule
+{
+    public class UpdateRuleHandler : IRequestHandler<UpdateRuleRequest, UpdateRuleResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public UpdateRuleHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<UpdateRuleResponse> Handle(UpdateRuleRequest request, CancellationToken cancellationToken)
+        {
+            var rule = await _repository.GetRuleByIdAsync(request.Id, cancellationToken);
+            if (rule == null)
+                return new UpdateRuleResponse(ErrorCodes.PhotobankRuleNotFound);
+
+            rule.PathPattern = request.PathPattern.Trim();
+            rule.TagName = request.TagName.Trim().ToLowerInvariant();
+            rule.IsActive = request.IsActive;
+            rule.SortOrder = request.SortOrder;
+
+            await _repository.UpdateRuleAsync(rule, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
+
+            return new UpdateRuleResponse();
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -232,6 +232,14 @@ public enum ErrorCodes
     [HttpStatusCode(HttpStatusCode.Forbidden)]
     UnauthorizedMarketingAccess = 2302,
 
+    // Photobank errors (24XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotoNotFound = 2401,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotobankRootNotFound = 2402,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotobankRuleNotFound = 2403,
+
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
     ExternalServiceError = 9001,

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -226,6 +226,12 @@ public enum ErrorCodes
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
     DqtExternalServiceError = 2203,
 
+    // Marketing Calendar errors (23XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    MarketingActionNotFound = 2301,
+    [HttpStatusCode(HttpStatusCode.Forbidden)]
+    UnauthorizedMarketingAccess = 2302,
+
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
     ExternalServiceError = 9001,

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/IMarketingActionRepository.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Domain.Features.Journal;
+using Anela.Heblo.Xcc.Persistance;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public interface IMarketingActionRepository : IRepository<MarketingAction, int>
+    {
+        Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default);
+
+        Task<PagedResult<MarketingAction>> GetPagedAsync(
+            MarketingActionQueryCriteria criteria,
+            CancellationToken cancellationToken = default);
+
+        Task<List<MarketingAction>> GetForCalendarAsync(
+            DateTime from,
+            DateTime to,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingAction : IEntity<int>
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Title { get; set; } = null!;
+
+        [MaxLength(5000)]
+        public string? Description { get; set; }
+
+        public MarketingActionType ActionType { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        public DateTime? EndDate { get; set; }
+
+        [Required]
+        public DateTime CreatedAt { get; set; }
+
+        [Required]
+        public DateTime ModifiedAt { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string CreatedByUserId { get; set; } = null!;
+
+        [MaxLength(100)]
+        public string? CreatedByUsername { get; set; }
+
+        [MaxLength(100)]
+        public string? ModifiedByUserId { get; set; }
+
+        [MaxLength(100)]
+        public string? ModifiedByUsername { get; set; }
+
+        public bool IsDeleted { get; set; }
+        public DateTime? DeletedAt { get; set; }
+
+        [MaxLength(100)]
+        public string? DeletedByUserId { get; set; }
+
+        [MaxLength(100)]
+        public string? DeletedByUsername { get; set; }
+
+        // Navigation properties
+        public virtual ICollection<MarketingActionProduct> ProductAssociations { get; set; } = new List<MarketingActionProduct>();
+        public virtual ICollection<MarketingActionFolderLink> FolderLinks { get; set; } = new List<MarketingActionFolderLink>();
+
+        // Domain methods
+        public void AssociateWithProduct(string productCode)
+        {
+            if (string.IsNullOrWhiteSpace(productCode))
+                throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))
+                return;
+
+            ProductAssociations.Add(new MarketingActionProduct
+            {
+                MarketingActionId = Id,
+                ProductCodePrefix = productCode.Trim().ToUpperInvariant(),
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        public void LinkToFolder(string folderKey, MarketingFolderType folderType)
+        {
+            if (string.IsNullOrWhiteSpace(folderKey))
+                throw new ArgumentException("Folder key cannot be empty", nameof(folderKey));
+
+            if (FolderLinks.Any(fl => fl.FolderKey == folderKey))
+                return;
+
+            FolderLinks.Add(new MarketingActionFolderLink
+            {
+                MarketingActionId = Id,
+                FolderKey = folderKey.Trim(),
+                FolderType = folderType,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        public void SoftDelete(string userId, string username)
+        {
+            IsDeleted = true;
+            DeletedAt = DateTime.UtcNow;
+            DeletedByUserId = userId;
+            DeletedByUsername = username;
+            ModifiedAt = DateTime.UtcNow;
+            ModifiedByUserId = userId;
+            ModifiedByUsername = username;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionFolderLink.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionFolderLink.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingActionFolderLink
+    {
+        public int MarketingActionId { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string FolderKey { get; set; } = null!;
+
+        public MarketingFolderType FolderType { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        // Navigation properties
+        public virtual MarketingAction MarketingAction { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionProduct.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionProduct.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingActionProduct
+    {
+        public int MarketingActionId { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string ProductCodePrefix { get; set; } = null!;
+
+        public DateTime CreatedAt { get; set; }
+
+        // Navigation properties
+        public virtual MarketingAction MarketingAction { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionQueryCriteria.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionQueryCriteria.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public class MarketingActionQueryCriteria
+    {
+        public int PageNumber { get; set; } = 1;
+        public int PageSize { get; set; } = 20;
+
+        public string? SearchTerm { get; set; }
+        public MarketingActionType? ActionType { get; set; }
+
+        public DateTime? StartDateFrom { get; set; }
+        public DateTime? StartDateTo { get; set; }
+
+        public DateTime? EndDateFrom { get; set; }
+        public DateTime? EndDateTo { get; set; }
+
+        public string? ProductCodePrefix { get; set; }
+
+        public bool IncludeDeleted { get; set; } = false;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingActionType.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public enum MarketingActionType
+    {
+        General = 0,
+        Promotion = 1,
+        Launch = 2,
+        Campaign = 3,
+        Event = 4,
+        Other = 99,
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingFolderType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingFolderType.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Domain.Features.Marketing
+{
+    public enum MarketingFolderType
+    {
+        General = 0,
+        Seasonal = 1,
+        ProductLine = 2,
+        Campaign = 3,
+        Other = 99,
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public interface IPhotobankRepository
+    {
+        // Photos
+        Task<(List<Photo> Items, int Total)> GetPhotosAsync(
+            List<string>? tags, string? search, int page, int pageSize,
+            CancellationToken cancellationToken);
+
+        Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken);
+
+        // Tags
+        Task<List<(Tag Tag, int Count)>> GetTagsWithCountsAsync(CancellationToken cancellationToken);
+        Task<Tag?> GetOrCreateTagAsync(string normalizedName, CancellationToken cancellationToken);
+        Task<Tag?> GetTagByIdAsync(int id, CancellationToken cancellationToken);
+
+        // Photo tags
+        Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken);
+        Task RemovePhotoTagAsync(int photoId, int tagId, CancellationToken cancellationToken);
+        Task<bool> PhotoTagExistsAsync(int photoId, int tagId, CancellationToken cancellationToken);
+
+        // Roots
+        Task<List<PhotobankIndexRoot>> GetRootsAsync(CancellationToken cancellationToken);
+        Task<PhotobankIndexRoot> AddRootAsync(PhotobankIndexRoot root, CancellationToken cancellationToken);
+        Task<bool> DeleteRootAsync(int id, CancellationToken cancellationToken);
+
+        // Rules
+        Task<List<TagRule>> GetRulesAsync(CancellationToken cancellationToken);
+        Task<TagRule> AddRuleAsync(TagRule rule, CancellationToken cancellationToken);
+        Task<TagRule?> GetRuleByIdAsync(int id, CancellationToken cancellationToken);
+        Task UpdateRuleAsync(TagRule rule, CancellationToken cancellationToken);
+        Task<bool> DeleteRuleAsync(int id, CancellationToken cancellationToken);
+
+        // Reapply rules
+        Task<int> ReapplyRulesAsync(List<TagRule> activeRules, CancellationToken cancellationToken);
+
+        Task SaveChangesAsync(CancellationToken cancellationToken);
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.MarketingInvoices;
 using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Features.GridLayouts;
@@ -90,6 +91,11 @@ public class ApplicationDbContext : DbContext
     // Data Quality module
     public DbSet<DqtRun> DqtRuns { get; set; } = null!;
     public DbSet<InvoiceDqtResult> InvoiceDqtResults { get; set; } = null!;
+
+    // Marketing Calendar module
+    public DbSet<MarketingAction> MarketingActions { get; set; } = null!;
+    public DbSet<MarketingActionProduct> MarketingActionProducts { get; set; } = null!;
+    public DbSet<MarketingActionFolderLink> MarketingActionFolderLinks { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionConfiguration.cs
@@ -1,0 +1,99 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionConfiguration : IEntityTypeConfiguration<MarketingAction>
+    {
+        public void Configure(EntityTypeBuilder<MarketingAction> builder)
+        {
+            builder.ToTable("MarketingActions", "public");
+
+            builder.HasKey(x => x.Id);
+
+            builder.Property(x => x.Title)
+                .HasMaxLength(200)
+                .IsRequired();
+
+            builder.Property(x => x.Description)
+                .HasMaxLength(5000)
+                .IsRequired(false);
+
+            builder.Property(x => x.ActionType)
+                .IsRequired();
+
+            builder.Property(x => x.StartDate)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.EndDate)
+                .IsRequired(false)
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.CreatedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.ModifiedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.CreatedByUserId)
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Property(x => x.CreatedByUsername)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.ModifiedByUserId)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.ModifiedByUsername)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.DeletedAt)
+                .IsRequired(false)
+                .AsUtcTimestamp();
+
+            builder.Property(x => x.DeletedByUserId)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            builder.Property(x => x.DeletedByUsername)
+                .HasMaxLength(100)
+                .IsRequired(false);
+
+            // Soft delete filter
+            builder.HasQueryFilter(x => !x.IsDeleted);
+
+            // Indexes for performance
+            builder.HasIndex(x => x.StartDate)
+                .HasDatabaseName("IX_MarketingActions_StartDate");
+
+            builder.HasIndex(x => x.EndDate)
+                .HasDatabaseName("IX_MarketingActions_EndDate");
+
+            builder.HasIndex(x => new { x.IsDeleted, x.StartDate, x.EndDate })
+                .HasDatabaseName("IX_MarketingActions_IsDeleted_StartDate_EndDate");
+
+            builder.HasIndex(x => x.ActionType)
+                .HasDatabaseName("IX_MarketingActions_ActionType");
+
+            // Navigation properties
+            builder.HasMany(x => x.ProductAssociations)
+                .WithOne(x => x.MarketingAction)
+                .HasForeignKey(x => x.MarketingActionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(x => x.FolderLinks)
+                .WithOne(x => x.MarketingAction)
+                .HasForeignKey(x => x.MarketingActionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionFolderLinkConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionFolderLinkConfiguration.cs
@@ -1,0 +1,33 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionFolderLinkConfiguration : IEntityTypeConfiguration<MarketingActionFolderLink>
+    {
+        public void Configure(EntityTypeBuilder<MarketingActionFolderLink> builder)
+        {
+            builder.ToTable("MarketingActionFolderLinks", "public");
+
+            // Composite primary key
+            builder.HasKey(x => new { x.MarketingActionId, x.FolderKey });
+
+            builder.Property(x => x.FolderKey)
+                .HasMaxLength(100)
+                .IsRequired();
+
+            builder.Property(x => x.FolderType)
+                .IsRequired();
+
+            builder.Property(x => x.CreatedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            // Index for marketing action lookups
+            builder.HasIndex(x => x.MarketingActionId)
+                .HasDatabaseName("IX_MarketingActionFolderLinks_MarketingActionId");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionProductConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionProductConfiguration.cs
@@ -1,0 +1,30 @@
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionProductConfiguration : IEntityTypeConfiguration<MarketingActionProduct>
+    {
+        public void Configure(EntityTypeBuilder<MarketingActionProduct> builder)
+        {
+            builder.ToTable("MarketingActionProducts", "public");
+
+            // Composite primary key
+            builder.HasKey(x => new { x.MarketingActionId, x.ProductCodePrefix });
+
+            builder.Property(x => x.ProductCodePrefix)
+                .HasMaxLength(50)
+                .IsRequired();
+
+            builder.Property(x => x.CreatedAt)
+                .IsRequired()
+                .AsUtcTimestamp();
+
+            // Index for product code prefix lookups
+            builder.HasIndex(x => x.ProductCodePrefix)
+                .HasDatabaseName("IX_MarketingActionProducts_ProductCodePrefix");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Marketing/MarketingActionRepository.cs
@@ -1,0 +1,131 @@
+using Anela.Heblo.Domain.Features.Journal;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Persistence.Marketing
+{
+    public class MarketingActionRepository : BaseRepository<MarketingAction, int>, IMarketingActionRepository
+    {
+        private readonly ILogger<MarketingActionRepository> _logger;
+
+        public MarketingActionRepository(ApplicationDbContext context, ILogger<MarketingActionRepository> logger)
+            : base(context)
+        {
+            _logger = logger;
+        }
+
+        public override async Task<MarketingAction?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        {
+            return await Context.Set<MarketingAction>()
+                .Include(x => x.ProductAssociations)
+                .Include(x => x.FolderLinks)
+                .FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted, cancellationToken);
+        }
+
+        public async Task DeleteSoftAsync(int id, string userId, string username, CancellationToken cancellationToken = default)
+        {
+            var entity = await GetByIdAsync(id, cancellationToken);
+            if (entity != null)
+            {
+                entity.SoftDelete(userId, username);
+                await UpdateAsync(entity, cancellationToken);
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        public async Task<PagedResult<MarketingAction>> GetPagedAsync(
+            MarketingActionQueryCriteria criteria,
+            CancellationToken cancellationToken = default)
+        {
+            var query = Context.Set<MarketingAction>()
+                .Include(x => x.ProductAssociations)
+                .Include(x => x.FolderLinks)
+                .AsQueryable();
+
+            if (!criteria.IncludeDeleted)
+            {
+                query = query.Where(x => !x.IsDeleted);
+            }
+
+            // Text search
+            if (!string.IsNullOrWhiteSpace(criteria.SearchTerm))
+            {
+                var searchTerm = criteria.SearchTerm.Trim().ToLower();
+                query = query.Where(x =>
+                    x.Title.ToLower().Contains(searchTerm) ||
+                    (x.Description != null && x.Description.ToLower().Contains(searchTerm)));
+            }
+
+            // Action type filter
+            if (criteria.ActionType.HasValue)
+            {
+                query = query.Where(x => x.ActionType == criteria.ActionType.Value);
+            }
+
+            // Date range filters
+            if (criteria.StartDateFrom.HasValue)
+            {
+                query = query.Where(x => x.StartDate >= criteria.StartDateFrom.Value);
+            }
+
+            if (criteria.StartDateTo.HasValue)
+            {
+                query = query.Where(x => x.StartDate <= criteria.StartDateTo.Value);
+            }
+
+            if (criteria.EndDateFrom.HasValue)
+            {
+                query = query.Where(x => x.EndDate.HasValue && x.EndDate >= criteria.EndDateFrom.Value);
+            }
+
+            if (criteria.EndDateTo.HasValue)
+            {
+                query = query.Where(x => x.EndDate.HasValue && x.EndDate <= criteria.EndDateTo.Value);
+            }
+
+            // Product code prefix filter
+            if (!string.IsNullOrWhiteSpace(criteria.ProductCodePrefix))
+            {
+                var prefix = criteria.ProductCodePrefix.Trim();
+                query = query.Where(x => x.ProductAssociations
+                    .Any(pa => prefix.StartsWith(pa.ProductCodePrefix)));
+            }
+
+            // Default sort: newest first by StartDate
+            query = query.OrderByDescending(x => x.StartDate)
+                .ThenByDescending(x => x.CreatedAt);
+
+            var totalCount = await query.CountAsync(cancellationToken);
+
+            var items = await query
+                .Skip((criteria.PageNumber - 1) * criteria.PageSize)
+                .Take(criteria.PageSize)
+                .ToListAsync(cancellationToken);
+
+            return new PagedResult<MarketingAction>
+            {
+                Items = items,
+                TotalCount = totalCount,
+                PageNumber = criteria.PageNumber,
+                PageSize = criteria.PageSize
+            };
+        }
+
+        public async Task<List<MarketingAction>> GetForCalendarAsync(
+            DateTime from,
+            DateTime to,
+            CancellationToken cancellationToken = default)
+        {
+            return await Context.Set<MarketingAction>()
+                .Include(x => x.ProductAssociations)
+                .Include(x => x.FolderLinks)
+                .Where(x => !x.IsDeleted &&
+                    x.StartDate <= to &&
+                    (!x.EndDate.HasValue || x.EndDate >= from))
+                .OrderBy(x => x.StartDate)
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424095051_AddMarketingCalendar")]
+    partial class AddMarketingCalendar
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -277,105 +280,6 @@ namespace Anela.Heblo.Persistence.Migrations
                         .HasDatabaseName("IX_StockUpOperations_State_CreatedAt");
 
                     b.ToTable("StockUpOperations", "public");
-                });
-
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.DataQuality.DqtRun", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("timestamp without time zone")
-                        .HasColumnName("completed_at");
-
-                    b.Property<DateOnly>("DateFrom")
-                        .HasColumnType("date")
-                        .HasColumnName("date_from");
-
-                    b.Property<DateOnly>("DateTo")
-                        .HasColumnType("date")
-                        .HasColumnName("date_to");
-
-                    b.Property<string>("ErrorMessage")
-                        .HasColumnType("text")
-                        .HasColumnName("error_message");
-
-                    b.Property<DateTime>("StartedAt")
-                        .HasColumnType("timestamp without time zone")
-                        .HasColumnName("started_at");
-
-                    b.Property<int>("Status")
-                        .HasColumnType("integer")
-                        .HasColumnName("status");
-
-                    b.Property<int>("TestType")
-                        .HasColumnType("integer")
-                        .HasColumnName("test_type");
-
-                    b.Property<int>("TotalChecked")
-                        .HasColumnType("integer")
-                        .HasColumnName("total_checked");
-
-                    b.Property<int>("TotalMismatches")
-                        .HasColumnType("integer")
-                        .HasColumnName("total_mismatches");
-
-                    b.Property<int>("TriggerType")
-                        .HasColumnType("integer")
-                        .HasColumnName("trigger_type");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("TestType", "StartedAt")
-                        .HasDatabaseName("IX_dqt_runs_test_type_started_at");
-
-                    b.ToTable("dqt_runs", (string)null);
-                });
-
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.DataQuality.InvoiceDqtResult", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<string>("Details")
-                        .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)")
-                        .HasColumnName("details");
-
-                    b.Property<Guid>("DqtRunId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("dqt_run_id");
-
-                    b.Property<string>("FlexiValue")
-                        .HasColumnType("text")
-                        .HasColumnName("flexi_value");
-
-                    b.Property<string>("InvoiceCode")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("invoice_code");
-
-                    b.Property<int>("MismatchType")
-                        .HasColumnType("integer")
-                        .HasColumnName("mismatch_type");
-
-                    b.Property<string>("ShoptetValue")
-                        .HasColumnType("text")
-                        .HasColumnName("shoptet_value");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DqtRunId")
-                        .HasDatabaseName("IX_invoice_dqt_results_dqt_run_id");
-
-                    b.HasIndex("InvoiceCode")
-                        .HasDatabaseName("IX_invoice_dqt_results_invoice_code");
-
-                    b.ToTable("invoice_dqt_results", (string)null);
                 });
 
             modelBuilder.Entity("Anela.Heblo.Domain.Features.GridLayouts.GridLayout", b =>
@@ -1950,15 +1854,6 @@ namespace Anela.Heblo.Persistence.Migrations
                     b.ToTable("UserDashboardTiles", (string)null);
                 });
 
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.DataQuality.InvoiceDqtResult", b =>
-                {
-                    b.HasOne("Anela.Heblo.Domain.Features.DataQuality.DqtRun", null)
-                        .WithMany("Results")
-                        .HasForeignKey("DqtRunId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("Anela.Heblo.Domain.Features.InvoiceClassification.ClassificationHistory", b =>
                 {
                     b.HasOne("Anela.Heblo.Domain.Features.InvoiceClassification.ClassificationRule", "ClassificationRule")
@@ -2170,11 +2065,6 @@ namespace Anela.Heblo.Persistence.Migrations
                         .IsRequired();
 
                     b.Navigation("DashboardSettings");
-                });
-
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.DataQuality.DqtRun", b =>
-                {
-                    b.Navigation("Results");
                 });
 
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Invoices.IssuedInvoice", b =>

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260424095051_AddMarketingCalendar.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMarketingCalendar : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MarketingActions",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(5000)", maxLength: 5000, nullable: true),
+                    ActionType = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp", nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    CreatedByUsername = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ModifiedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ModifiedByUsername = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp", nullable: true),
+                    DeletedByUserId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    DeletedByUsername = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingActions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MarketingActionFolderLinks",
+                schema: "public",
+                columns: table => new
+                {
+                    MarketingActionId = table.Column<int>(type: "integer", nullable: false),
+                    FolderKey = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    FolderType = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingActionFolderLinks", x => new { x.MarketingActionId, x.FolderKey });
+                    table.ForeignKey(
+                        name: "FK_MarketingActionFolderLinks_MarketingActions_MarketingAction~",
+                        column: x => x.MarketingActionId,
+                        principalSchema: "public",
+                        principalTable: "MarketingActions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MarketingActionProducts",
+                schema: "public",
+                columns: table => new
+                {
+                    MarketingActionId = table.Column<int>(type: "integer", nullable: false),
+                    ProductCodePrefix = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MarketingActionProducts", x => new { x.MarketingActionId, x.ProductCodePrefix });
+                    table.ForeignKey(
+                        name: "FK_MarketingActionProducts_MarketingActions_MarketingActionId",
+                        column: x => x.MarketingActionId,
+                        principalSchema: "public",
+                        principalTable: "MarketingActions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActionFolderLinks_MarketingActionId",
+                schema: "public",
+                table: "MarketingActionFolderLinks",
+                column: "MarketingActionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActionProducts_ProductCodePrefix",
+                schema: "public",
+                table: "MarketingActionProducts",
+                column: "ProductCodePrefix");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_ActionType",
+                schema: "public",
+                table: "MarketingActions",
+                column: "ActionType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_EndDate",
+                schema: "public",
+                table: "MarketingActions",
+                column: "EndDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_IsDeleted_StartDate_EndDate",
+                schema: "public",
+                table: "MarketingActions",
+                columns: new[] { "IsDeleted", "StartDate", "EndDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MarketingActions_StartDate",
+                schema: "public",
+                table: "MarketingActions",
+                column: "StartDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MarketingActionFolderLinks",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "MarketingActionProducts",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "MarketingActions",
+                schema: "public");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankRepository.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Domain.Features.Photobank;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.Photobank
+{
+    public class PhotobankRepository : IPhotobankRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public PhotobankRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // Photos
+
+        public async Task<(List<Photo> Items, int Total)> GetPhotosAsync(
+            List<string>? tags, string? search, int page, int pageSize,
+            CancellationToken cancellationToken)
+        {
+            var query = _context.Photos
+                .Include(p => p.Tags)
+                    .ThenInclude(pt => pt.Tag)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                var term = search.Trim().ToLowerInvariant();
+                query = query.Where(p => p.FileName.ToLower().Contains(term));
+            }
+
+            if (tags != null && tags.Count > 0)
+            {
+                var normalizedTags = tags
+                    .Where(t => !string.IsNullOrWhiteSpace(t))
+                    .Select(t => t.Trim().ToLowerInvariant())
+                    .ToList();
+
+                foreach (var tag in normalizedTags)
+                {
+                    var t = tag;
+                    query = query.Where(p => p.Tags.Any(pt => pt.Tag.Name == t));
+                }
+            }
+
+            var total = await query.CountAsync(cancellationToken);
+            var items = await query
+                .OrderByDescending(p => p.ModifiedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken);
+
+            return (items, total);
+        }
+
+        public async Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken)
+        {
+            return await _context.Photos
+                .Include(p => p.Tags)
+                    .ThenInclude(pt => pt.Tag)
+                .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+        }
+
+        // Tags
+
+        public async Task<List<(Tag Tag, int Count)>> GetTagsWithCountsAsync(CancellationToken cancellationToken)
+        {
+            var results = await _context.PhotobankTags
+                .Select(t => new
+                {
+                    Tag = t,
+                    Count = t.PhotoTags.Count,
+                })
+                .OrderByDescending(x => x.Count)
+                .ToListAsync(cancellationToken);
+
+            return results.Select(x => (x.Tag, x.Count)).ToList();
+        }
+
+        public async Task<Tag?> GetOrCreateTagAsync(string normalizedName, CancellationToken cancellationToken)
+        {
+            var existing = await _context.PhotobankTags
+                .FirstOrDefaultAsync(t => t.Name == normalizedName, cancellationToken);
+
+            if (existing != null)
+                return existing;
+
+            var tag = new Tag { Name = normalizedName };
+            _context.PhotobankTags.Add(tag);
+            await _context.SaveChangesAsync(cancellationToken);
+            return tag;
+        }
+
+        public async Task<Tag?> GetTagByIdAsync(int id, CancellationToken cancellationToken)
+        {
+            return await _context.PhotobankTags.FindAsync(new object[] { id }, cancellationToken);
+        }
+
+        // Photo tags
+
+        public async Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken)
+        {
+            _context.PhotoTags.Add(photoTag);
+            await Task.CompletedTask;
+        }
+
+        public async Task RemovePhotoTagAsync(int photoId, int tagId, CancellationToken cancellationToken)
+        {
+            var photoTag = await _context.PhotoTags
+                .FindAsync(new object[] { photoId, tagId }, cancellationToken);
+            if (photoTag != null)
+                _context.PhotoTags.Remove(photoTag);
+        }
+
+        public async Task<bool> PhotoTagExistsAsync(int photoId, int tagId, CancellationToken cancellationToken)
+        {
+            return await _context.PhotoTags
+                .AnyAsync(pt => pt.PhotoId == photoId && pt.TagId == tagId, cancellationToken);
+        }
+
+        // Roots
+
+        public async Task<List<PhotobankIndexRoot>> GetRootsAsync(CancellationToken cancellationToken)
+        {
+            return await _context.PhotobankIndexRoots
+                .OrderBy(r => r.CreatedAt)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<PhotobankIndexRoot> AddRootAsync(PhotobankIndexRoot root, CancellationToken cancellationToken)
+        {
+            _context.PhotobankIndexRoots.Add(root);
+            await Task.CompletedTask;
+            return root;
+        }
+
+        public async Task<bool> DeleteRootAsync(int id, CancellationToken cancellationToken)
+        {
+            var root = await _context.PhotobankIndexRoots.FindAsync(new object[] { id }, cancellationToken);
+            if (root == null)
+                return false;
+            _context.PhotobankIndexRoots.Remove(root);
+            return true;
+        }
+
+        // Rules
+
+        public async Task<List<TagRule>> GetRulesAsync(CancellationToken cancellationToken)
+        {
+            return await _context.PhotobankTagRules
+                .OrderBy(r => r.SortOrder)
+                .ThenBy(r => r.Id)
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<TagRule> AddRuleAsync(TagRule rule, CancellationToken cancellationToken)
+        {
+            _context.PhotobankTagRules.Add(rule);
+            await Task.CompletedTask;
+            return rule;
+        }
+
+        public async Task<TagRule?> GetRuleByIdAsync(int id, CancellationToken cancellationToken)
+        {
+            return await _context.PhotobankTagRules.FindAsync(new object[] { id }, cancellationToken);
+        }
+
+        public async Task UpdateRuleAsync(TagRule rule, CancellationToken cancellationToken)
+        {
+            _context.PhotobankTagRules.Update(rule);
+            await Task.CompletedTask;
+        }
+
+        public async Task<bool> DeleteRuleAsync(int id, CancellationToken cancellationToken)
+        {
+            var rule = await _context.PhotobankTagRules.FindAsync(new object[] { id }, cancellationToken);
+            if (rule == null)
+                return false;
+            _context.PhotobankTagRules.Remove(rule);
+            return true;
+        }
+
+        // Reapply rules
+
+        public async Task<int> ReapplyRulesAsync(List<TagRule> allRules, CancellationToken cancellationToken)
+        {
+            var activeRules = allRules.Where(r => r.IsActive).ToList();
+
+            // Remove all Rule-sourced PhotoTags
+            var ruleTags = await _context.PhotoTags
+                .Where(pt => pt.Source == PhotoTagSource.Rule)
+                .ToListAsync(cancellationToken);
+            _context.PhotoTags.RemoveRange(ruleTags);
+
+            // Load all photos to re-evaluate
+            var photos = await _context.Photos.ToListAsync(cancellationToken);
+
+            var photosUpdated = 0;
+            var now = DateTime.UtcNow;
+
+            foreach (var photo in photos)
+            {
+                var matchingTagNames = TagRuleMatcher.GetMatchingTags(photo.FolderPath, activeRules);
+                if (matchingTagNames.Count == 0)
+                    continue;
+
+                var tagsUpdated = false;
+                foreach (var tagName in matchingTagNames)
+                {
+                    var tag = await GetOrCreateTagAsync(tagName, cancellationToken);
+                    _context.PhotoTags.Add(new PhotoTag
+                    {
+                        PhotoId = photo.Id,
+                        TagId = tag!.Id,
+                        Source = PhotoTagSource.Rule,
+                        CreatedAt = now,
+                    });
+                    tagsUpdated = true;
+                }
+
+                if (tagsUpdated)
+                    photosUpdated++;
+            }
+
+            return photosUpdated;
+        }
+
+        public async Task SaveChangesAsync(CancellationToken cancellationToken)
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/ErrorHandlingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ErrorHandlingTests.cs
@@ -86,6 +86,7 @@ public class ErrorHandlingTests
         var shoptetOrdersErrors = errorCodes.Where(code => code >= 2100 && code < 2200).ToList(); // 21XX range
         var dataQualityErrors = errorCodes.Where(code => code >= 2200 && code < 2300).ToList(); // 22XX range
         var marketingErrors = errorCodes.Where(code => code >= 2300 && code < 2400).ToList(); // 23XX range
+        var photobankErrors = errorCodes.Where(code => code >= 2400 && code < 2500).ToList(); // 24XX range
         var externalServiceErrors = errorCodes.Where(code => code >= 9000 && code < 9100).ToList(); // 90XX range
 
         // Ensure we have some errors in the expected categories
@@ -102,6 +103,7 @@ public class ErrorHandlingTests
         Assert.True(shoptetOrdersErrors.Count > 0, "Should have Shoptet orders errors in 21XX range");
         Assert.True(dataQualityErrors.Count > 0, "Should have Data Quality errors in 22XX range");
         Assert.True(marketingErrors.Count > 0, "Should have Marketing Calendar errors in 23XX range");
+        Assert.True(photobankErrors.Count > 0, "Should have Photobank errors in 24XX range");
         Assert.True(externalServiceErrors.Count > 0, "Should have external service errors in 90XX range");
 
         // Ensure all error codes fall into defined module ranges
@@ -109,7 +111,8 @@ public class ErrorHandlingTests
                               manufactureErrors.Count + catalogErrors.Count + transportErrors.Count +
                               configErrors.Count + journalErrors.Count + analyticsErrors.Count +
                               fileStorageErrors.Count + backgroundJobsErrors.Count + knowledgeBaseErrors.Count +
-                              shoptetOrdersErrors.Count + dataQualityErrors.Count + marketingErrors.Count + externalServiceErrors.Count;
+                              shoptetOrdersErrors.Count + dataQualityErrors.Count + marketingErrors.Count +
+                              photobankErrors.Count + externalServiceErrors.Count;
 
         Assert.Equal(errorCodes.Count, categorizedCount);
     }

--- a/backend/test/Anela.Heblo.Tests/ErrorHandlingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ErrorHandlingTests.cs
@@ -85,6 +85,7 @@ public class ErrorHandlingTests
         var knowledgeBaseErrors = errorCodes.Where(code => code >= 2000 && code < 2100).ToList(); // 20XX range
         var shoptetOrdersErrors = errorCodes.Where(code => code >= 2100 && code < 2200).ToList(); // 21XX range
         var dataQualityErrors = errorCodes.Where(code => code >= 2200 && code < 2300).ToList(); // 22XX range
+        var marketingErrors = errorCodes.Where(code => code >= 2300 && code < 2400).ToList(); // 23XX range
         var externalServiceErrors = errorCodes.Where(code => code >= 9000 && code < 9100).ToList(); // 90XX range
 
         // Ensure we have some errors in the expected categories
@@ -99,6 +100,8 @@ public class ErrorHandlingTests
         Assert.True(backgroundJobsErrors.Count > 0, "Should have background jobs errors in 19XX range");
         Assert.True(knowledgeBaseErrors.Count > 0, "Should have knowledge base errors in 20XX range");
         Assert.True(shoptetOrdersErrors.Count > 0, "Should have Shoptet orders errors in 21XX range");
+        Assert.True(dataQualityErrors.Count > 0, "Should have Data Quality errors in 22XX range");
+        Assert.True(marketingErrors.Count > 0, "Should have Marketing Calendar errors in 23XX range");
         Assert.True(externalServiceErrors.Count > 0, "Should have external service errors in 90XX range");
 
         // Ensure all error codes fall into defined module ranges
@@ -106,7 +109,7 @@ public class ErrorHandlingTests
                               manufactureErrors.Count + catalogErrors.Count + transportErrors.Count +
                               configErrors.Count + journalErrors.Count + analyticsErrors.Count +
                               fileStorageErrors.Count + backgroundJobsErrors.Count + knowledgeBaseErrors.Count +
-                              shoptetOrdersErrors.Count + dataQualityErrors.Count + externalServiceErrors.Count;
+                              shoptetOrdersErrors.Count + dataQualityErrors.Count + marketingErrors.Count + externalServiceErrors.Count;
 
         Assert.Equal(errorCodes.Count, categorizedCount);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Marketing;
+
+public class CreateMarketingActionHandlerTests
+{
+    private readonly Mock<IMarketingActionRepository> _repositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ILogger<CreateMarketingActionHandler>> _loggerMock;
+    private readonly CreateMarketingActionHandler _handler;
+
+    public CreateMarketingActionHandlerTests()
+    {
+        _repositoryMock = new Mock<IMarketingActionRepository>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _loggerMock = new Mock<ILogger<CreateMarketingActionHandler>>();
+        _handler = new CreateMarketingActionHandler(
+            _repositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserNotAuthenticated_ShouldReturnUnauthorizedError()
+    {
+        // Arrange
+        var request = new CreateMarketingActionRequest
+        {
+            Title = "Summer Campaign",
+            ActionType = MarketingActionType.Campaign,
+            StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(Id: null, Name: null, Email: null, IsAuthenticated: false));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.UnauthorizedMarketingAccess);
+        result.Params.Should().ContainKey("resource");
+    }
+
+    [Fact]
+    public async Task Handle_WhenValidRequest_ShouldCreateActionSuccessfully()
+    {
+        // Arrange
+        var request = new CreateMarketingActionRequest
+        {
+            Title = "Summer Campaign",
+            ActionType = MarketingActionType.Event,
+            StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc),
+            AssociatedProducts = new List<string> { "TON001" },
+        };
+
+        var currentUser = new CurrentUser(
+            Id: "user123",
+            Name: "Test User",
+            Email: "test@example.com",
+            IsAuthenticated: true);
+
+        var createdAction = new MarketingAction
+        {
+            Id = 42,
+            Title = request.Title,
+            ActionType = request.ActionType,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            CreatedAt = DateTime.UtcNow,
+            CreatedByUserId = currentUser.Id!,
+        };
+
+        _currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(currentUser);
+        _repositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdAction);
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Id.Should().Be(42);
+        result.ErrorCode.Should().BeNull();
+
+        _repositoryMock.Verify(x => x.AddAsync(
+            It.Is<MarketingAction>(a =>
+                a.Title == "Summer Campaign" &&
+                a.ActionType == MarketingActionType.Event &&
+                a.CreatedByUserId == "user123"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _repositoryMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/GetMarketingCalendarHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/GetMarketingCalendarHandlerTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Application.Features.Marketing.Contracts;
+using Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingCalendar;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Marketing;
+
+public class GetMarketingCalendarHandlerTests
+{
+    private readonly Mock<IMarketingActionRepository> _repositoryMock;
+    private readonly GetMarketingCalendarHandler _handler;
+
+    public GetMarketingCalendarHandlerTests()
+    {
+        _repositoryMock = new Mock<IMarketingActionRepository>();
+        _handler = new GetMarketingCalendarHandler(_repositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenActionsExist_ShouldReturnMappedCalendarDtos()
+    {
+        // Arrange
+        var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        var actions = new List<MarketingAction>
+        {
+            new()
+            {
+                Id = 1,
+                Title = "June Launch",
+                ActionType = MarketingActionType.Event,
+                StartDate = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc),
+                ProductAssociations = new List<MarketingActionProduct>
+                {
+                    new() { ProductCodePrefix = "TON001" },
+                },
+            },
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetForCalendarAsync(start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(actions);
+
+        var request = new GetMarketingCalendarRequest { StartDate = start, EndDate = end };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Actions.Should().HaveCount(1);
+        result.Actions[0].Id.Should().Be(1);
+        result.Actions[0].Title.Should().Be("June Launch");
+        result.Actions[0].ActionType.Should().Be("Event");
+        result.Actions[0].AssociatedProducts.Should().ContainSingle("TON001");
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoActionsExist_ShouldReturnEmptyList()
+    {
+        // Arrange
+        var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        _repositoryMock
+            .Setup(x => x.GetForCalendarAsync(start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingAction>());
+
+        var request = new GetMarketingCalendarRequest { StartDate = start, EndDate = end };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Actions.Should().BeEmpty();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class GetPhotosHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly GetPhotosHandler _handler;
+
+    public GetPhotosHandlerTests()
+    {
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _handler = new GetPhotosHandler(_repositoryMock.Object);
+    }
+
+    private static Photo BuildPhoto(int id, string fileName, string folderPath, List<PhotoTag>? tags = null) =>
+        new()
+        {
+            Id = id,
+            SharePointFileId = $"sp-{id}",
+            FileName = fileName,
+            FolderPath = folderPath,
+            SharePointWebUrl = $"https://sp.example.com/file-{id}",
+            ModifiedAt = DateTime.UtcNow,
+            Tags = tags ?? new List<PhotoTag>(),
+        };
+
+    private static Tag BuildTag(int id, string name) => new() { Id = id, Name = name };
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_NoFilters_ReturnsAllPhotos()
+    {
+        // Arrange
+        var photos = new List<Photo>
+        {
+            BuildPhoto(1, "photo1.jpg", "Photos/2025"),
+            BuildPhoto(2, "photo2.jpg", "Photos/2026"),
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, null, 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((photos, 2));
+
+        var request = new GetPhotosRequest();
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Total.Should().Be(2);
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Id.Should().Be(1);
+        result.Items[1].Id.Should().Be(2);
+        result.Page.Should().Be(1);
+        result.PageSize.Should().Be(48);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_FilterByTag_PassesTagsToRepository()
+    {
+        // Arrange
+        var tag = BuildTag(1, "products");
+        var photoTag = new PhotoTag { PhotoId = 1, TagId = 1, Source = PhotoTagSource.Rule, Tag = tag };
+        var photos = new List<Photo>
+        {
+            BuildPhoto(1, "product.jpg", "Photos/Products", new List<PhotoTag> { photoTag }),
+        };
+        var tagFilter = new List<string> { "products" };
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(tagFilter, null, 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((photos, 1));
+
+        var request = new GetPhotosRequest { Tags = tagFilter };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Total.Should().Be(1);
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Tags.Should().ContainSingle(t => t.Name == "products");
+
+        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_FilterBySearch_PassesSearchToRepository()
+    {
+        // Arrange
+        var photos = new List<Photo>
+        {
+            BuildPhoto(1, "ruze-cervena.jpg", "Photos/Products"),
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, "ruze", 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((photos, 1));
+
+        var request = new GetPhotosRequest { Search = "ruze" };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Name.Should().Be("ruze-cervena.jpg");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_EmptyResult_ReturnsEmptyList()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new List<Photo>(), 0));
+
+        var request = new GetPhotosRequest { Tags = new List<string> { "nonexistent" } };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Total.Should().Be(0);
+        result.Items.Should().BeEmpty();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/ReapplyRulesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/ReapplyRulesHandlerTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Features.Photobank.UseCases.ReapplyRules;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class ReapplyRulesHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly ReapplyRulesHandler _handler;
+
+    public ReapplyRulesHandlerTests()
+    {
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _handler = new ReapplyRulesHandler(_repositoryMock.Object);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_ReturnsPhotosUpdatedCount()
+    {
+        // Arrange
+        var rules = new List<TagRule>
+        {
+            new() { Id = 1, PathPattern = "Photos/Products", TagName = "products", IsActive = true, SortOrder = 0 },
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetRulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rules);
+
+        _repositoryMock
+            .Setup(r => r.ReapplyRulesAsync(rules, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(5);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        // Act
+        var result = await _handler.Handle(new ReapplyRulesRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.PhotosUpdated.Should().Be(5);
+
+        _repositoryMock.Verify(r => r.ReapplyRulesAsync(rules, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_PreservesManualTags_DelegatedToRepository()
+    {
+        // Arrange — verify that ReapplyRulesAsync is called (repository handles preservation logic)
+        var rules = new List<TagRule>
+        {
+            new() { Id = 1, PathPattern = "Photos/Events", TagName = "events", IsActive = true, SortOrder = 0 },
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetRulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rules);
+
+        _repositoryMock
+            .Setup(r => r.ReapplyRulesAsync(rules, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        // Act
+        var result = await _handler.Handle(new ReapplyRulesRequest(), CancellationToken.None);
+
+        // Assert
+        result.PhotosUpdated.Should().Be(3);
+        // Repository is responsible for only removing Rule-source tags, not Manual ones
+        _repositoryMock.Verify(r => r.ReapplyRulesAsync(It.IsAny<List<TagRule>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_NoRules_ReturnsZeroPhotosUpdated()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetRulesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TagRule>());
+
+        _repositoryMock
+            .Setup(r => r.ReapplyRulesAsync(It.IsAny<List<TagRule>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        // Act
+        var result = await _handler.Handle(new ReapplyRulesRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.PhotosUpdated.Should().Be(0);
+    }
+}

--- a/docs/superpowers/specs/2026-04-24-photobank-design.md
+++ b/docs/superpowers/specs/2026-04-24-photobank-design.md
@@ -1,0 +1,253 @@
+# Photobank Feature Design
+
+**Date:** 2026-04-24
+**Status:** Approved
+**Supersedes:** `2026-04-14-photo-bank-design.md` (that spec jumped to AI tagging in MVP; this one starts simpler and adds AI later)
+**Branch target:** `feat/photobank`
+
+---
+
+## Overview
+
+A photo catalog that allows internal users to find photos stored on SharePoint by browsing and filtering via tags. Photos remain on SharePoint; the application maintains a metadata database of photos and their tags. An automated daily index job keeps the catalog in sync with SharePoint.
+
+**Scale:** 1,000–20,000 photos.
+**Access:** All authenticated users can browse. Admin role required to manage tags, rules, and index configuration.
+
+**Phasing:**
+- **MVP (this spec):** Folder-based tag rules + manual tags + daily sync + gallery UI
+- **Phase 2:** AI-generated tags (Azure AI Vision) — schema already prepared
+
+---
+
+## Architecture
+
+New vertical slice `Photobank` inside the existing Clean Architecture monorepo. No new infrastructure — reuses Postgres, Hangfire, and the existing Microsoft Graph integration pattern from `KnowledgeBase`.
+
+### Components
+
+| Component | Layer | Role |
+|---|---|---|
+| `PhotobankIndexJob` | Application | Hangfire daily job — Graph delta sync, tag rule application |
+| `PhotobankIndexRoot` | Domain / Persistence | Configured SharePoint root folders to index |
+| `TagRule` | Domain / Persistence | Path pattern → tag mappings, managed by admins |
+| `Photo` | Domain / Persistence | Photo metadata + SharePoint reference |
+| `Tag` | Domain / Persistence | Canonical tag list (lowercase-normalized) |
+| `PhotoTag` | Domain / Persistence | Many-to-many photo↔tag with source tracking |
+| API controllers | API | REST endpoints under `/api/photobank` |
+| React page | Frontend | Gallery + filter sidebar, listed under Marketing group |
+
+---
+
+## Data Model
+
+```
+PhotobankIndexRoot
+  Id                  uuid PK
+  FolderPath          text          -- SharePoint folder path (display/logging)
+  DriveId             text          -- Graph API drive ID
+  SiteId              text          -- Graph API site ID
+  RootItemId          text          -- Graph API item ID of the root folder
+  DeltaLink           text?         -- null = not yet indexed; stored after each run
+  LastIndexedAt       timestamp?
+  IsActive            bool
+
+Photo
+  Id                  uuid PK
+  SharePointFileId    text UNIQUE   -- Graph API item ID; stable across renames/moves
+  Name                text          -- filename
+  FolderPath          text          -- full folder path string
+  SharePointWebUrl    text          -- direct link to open in SharePoint
+  FileSizeBytes       bigint
+  LastModifiedAt      timestamp     -- from Graph API
+  IndexedAt           timestamp     -- when our job last processed this photo
+  IndexRootId         uuid FK → PhotobankIndexRoot
+
+Tag
+  Id                  uuid PK
+  Name                text UNIQUE   -- lowercase-normalized (e.g. "products", not "Products")
+
+PhotoTag
+  PhotoId             uuid FK → Photo
+  TagId               uuid FK → Tag
+  Source              enum(Rule, Manual, AI)   -- AI reserved for Phase 2
+  PRIMARY KEY (PhotoId, TagId)
+
+TagRule
+  Id                  uuid PK
+  PathPattern         text          -- e.g. "/Fotky/Produkty/*"
+  TagName             text          -- tag to apply (normalized at save time)
+  IsActive            bool
+  SortOrder           int
+```
+
+**Key decisions:**
+- `SharePointFileId` (Graph item ID) is the stable identity — used to upsert on rename/move
+- No `ThumbnailUrl` stored — thumbnails fetched by the frontend directly from Graph using the user's MSAL token, constructed from `DriveId` + `SharePointFileId`
+- Tags are lowercase-normalized at write time to prevent duplicates
+- `PhotoTag.Source` distinguishes rule-applied, manually added, and future AI tags — enables targeted re-apply without touching manual tags
+- A photo can have zero or any number of tags
+
+---
+
+## Indexing Job
+
+`PhotobankIndexJob` implements the existing `IRecurringJob` interface and runs daily via Hangfire.
+
+### Per configured root folder:
+
+1. Load `DeltaLink` from `PhotobankIndexRoot` (`null` = first run, full crawl)
+2. Call Graph: `GET /drives/{driveId}/items/{rootItemId}/delta?$token={deltaLink}`
+3. For each item in the delta response:
+   - **Image file** (jpg, jpeg, png, webp, gif, tiff) → upsert `Photo` by `SharePointFileId`
+   - **Deleted item** → delete `Photo` row and its `PhotoTag` rows
+   - **Non-image / folder** → skip
+4. For each upserted photo:
+   - Delete existing `PhotoTag` rows with `Source = Rule` for this photo
+   - Evaluate all active `TagRule`s against `FolderPath`
+   - Write new `PhotoTag` rows for all matching rules (`Source = Rule`)
+5. Save the new `deltaLink` back to `PhotobankIndexRoot.DeltaLink`
+6. Update `LastIndexedAt`
+
+### Tag rule pattern matching
+
+- Case-insensitive
+- `*` matches exactly one path segment (e.g. `/Fotky/*/Kampaně` matches `/Fotky/2024/Kampaně`)
+- All matching rules apply — not first-match-wins
+- Rules evaluated in `SortOrder` ascending order
+
+### Re-apply rules (admin action)
+
+Triggered via `POST /api/photobank/settings/rules/reapply`:
+
+1. Delete all `PhotoTag` rows where `Source = Rule` (all photos)
+2. Re-evaluate every active `TagRule` against every `Photo.FolderPath`
+3. Write new rule-based `PhotoTag` rows
+4. `Source = Manual` rows are never touched
+
+---
+
+## Tag System
+
+**Rule tags:** Applied by the index job based on `TagRule` path patterns. Re-created on each index run for changed photos, or on-demand via "Re-apply rules".
+
+**Manual tags:** Added/removed by admins per photo in the UI. Survive rule re-applies.
+
+**AI tags (Phase 2):** `Source = AI` already in enum. Requires adding `AiTaggedAt timestamp?` to `Photo` and integrating Azure AI Vision in the index job. No structural schema migration beyond that column.
+
+---
+
+## API Endpoints
+
+All under `/api/photobank`. Auth: existing Microsoft Entra ID. Admin endpoints require `AuthorizationConstants.Roles.Administrator` (`"administrator"`) role claim — same pattern as other admin-gated controllers.
+
+### Gallery (all authenticated users)
+
+```
+GET /api/photobank/photos
+    ?tags[]=products&tags[]=2024   -- AND filter: photos must have ALL specified tags
+    &search=ruz                    -- filename substring search (case-insensitive)
+    &page=1&pageSize=48
+    → { items: PhotoDto[], total: int, page: int, pageSize: int }
+
+GET /api/photobank/tags
+    → { tags: [{ id, name, count }] }   -- all tags with photo counts, sorted by count desc
+```
+
+### Photo tag management (admin)
+
+```
+POST   /api/photobank/photos/{id}/tags          body: { tagName: string }
+DELETE /api/photobank/photos/{id}/tags/{tagId}
+```
+
+### Settings (admin)
+
+```
+GET    /api/photobank/settings/roots
+POST   /api/photobank/settings/roots            body: { siteId, driveId, rootItemId, folderPath }
+    -- Note: siteId/driveId/rootItemId must be obtained via Graph Explorer or a future
+    -- path-resolver endpoint. v1 does not include a UI folder picker.
+DELETE /api/photobank/settings/roots/{id}
+
+GET    /api/photobank/settings/rules
+POST   /api/photobank/settings/rules            body: { pathPattern, tagName, sortOrder }
+PUT    /api/photobank/settings/rules/{id}
+DELETE /api/photobank/settings/rules/{id}
+
+POST   /api/photobank/settings/rules/reapply    → { photosUpdated: int }
+```
+
+---
+
+## Frontend
+
+**Route:** `/marketing/photobank` — listed under the **Marketing** group in the sidebar (alongside marketing calendar).
+
+### Gallery page
+
+**Left sidebar (fixed, ~220px):**
+- Filename search field
+- Tag list with counts — multi-select, AND semantics
+- "Clear filters" link when any filter is active
+
+**Main area:**
+- Responsive photo grid
+- Thumbnails fetched directly from Microsoft Graph:
+  `https://graph.microsoft.com/v1.0/drives/{driveId}/items/{fileId}/thumbnails/0/medium/content`
+  with user's MSAL `Authorization` header
+- Pagination (not infinite scroll) — consistent with other list pages in the app
+- Selected photo highlighted
+
+**Right drawer (opens on photo click):**
+- Larger thumbnail
+- Filename and folder path
+- Tag chips
+- "Open in SharePoint ↗" button
+- "Copy link" button
+- *(Admin only)* "+ Add tag" input and "✕" remove button per tag
+
+### Admin settings page
+
+**Route:** `/marketing/photobank/settings` — admin role required.
+
+- **Index roots tab:** configured root folders, add/remove, last indexed timestamp, active toggle
+- **Tag rules tab:** CRUD table (pattern, tag, sort order, active toggle)
+- **"Re-apply rules" button:** triggers reapply endpoint, shows `photosUpdated` count
+
+---
+
+## Microsoft Graph Integration
+
+Reuses the existing Graph client pattern from `GraphOneDriveService` (`KnowledgeBase` feature).
+
+**Application permissions required:**
+- `Sites.Read.All`
+- `Files.Read.All`
+
+**Delegated scope (frontend MSAL) required:**
+- `Files.Read` or `Files.Read.All` — for thumbnail fetching from Graph in the browser
+
+---
+
+## Future AI Upgrade Path (Phase 2)
+
+1. Add `AiTaggedAt timestamp?` column to `Photo`
+2. Index job calls Azure AI Vision per photo, writes `PhotoTag` rows with `Source = AI`
+3. Admin settings page gains "Re-run AI tagging" button using same re-apply pattern
+4. UI optionally shows tag source badge (rule / manual / AI)
+
+No structural schema changes beyond `AiTaggedAt`.
+
+---
+
+## Out of Scope (v1)
+
+- Photo download proxying (users open in SharePoint directly)
+- Per-folder access control (all authenticated users see all photos)
+- Real-time indexing via SharePoint webhooks
+- AI-generated tags (Phase 2)
+- Vector embeddings / semantic search
+- OCR text extraction
+- Duplicate photo detection
+- Bulk tag editing

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -114,6 +114,11 @@ export default defineConfig({
       testDir: './test/e2e/core',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'marketing',
+      testDir: './test/e2e/marketing',
+      use: { ...devices['Desktop Chrome'] },
+    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import RecurringJobsPage from "./pages/RecurringJobsPage";
 import KnowledgeBasePage from "./pages/KnowledgeBasePage";
 import KnowledgeBaseFeedbackPage from "./pages/KnowledgeBaseFeedbackPage";
 import ExpeditionListArchivePage from "./pages/ExpeditionListArchivePage";
+import MarketingCalendarPage from "./components/marketing/pages/MarketingCalendarPage";
 import AuthGuard from "./components/auth/AuthGuard";
 import { StatusBar } from "./components/StatusBar";
 import { loadConfig, Config } from "./config/runtimeConfig";
@@ -386,6 +387,10 @@ function App() {
                           element={<ProductMarginsList />}
                         />
                         <Route path="/journal" element={<JournalList />} />
+                        <Route
+                          path="/marketing/calendar"
+                          element={<MarketingCalendarPage />}
+                        />
                         <Route
                           path="/journal/new"
                           element={<JournalEntryNew />}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -385,6 +385,7 @@ export const QUERY_KEYS = {
   productMarginSummary: ["productMarginSummary"] as const,
   financialOverview: ["financialOverview"] as const,
   journal: ["journal"] as const,
+  marketingCalendar: ["marketing-calendar"] as const,
   transportBox: ["transport-boxes"] as const,
   transportBoxTransitions: ["transportBoxTransitions"] as const,
   manufactureOutput: ["manufacture-output"] as const,

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -1314,95 +1314,6 @@ export class ApiClient {
         return Promise.resolve<RecalculateProductWeightResponse>(null as any);
     }
 
-    catalog_EnqueueStockTaking(request: EnqueueStockTakingRequest): Promise<EnqueueStockTakingResponse> {
-        let url_ = this.baseUrl + "/api/Catalog/stock-taking/enqueue";
-        url_ = url_.replace(/[?&]$/, "");
-
-        const content_ = JSON.stringify(request);
-
-        let options_: RequestInit = {
-            body: content_,
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Accept": "application/json"
-            }
-        };
-
-        return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processCatalog_EnqueueStockTaking(_response);
-        });
-    }
-
-    protected processCatalog_EnqueueStockTaking(response: Response): Promise<EnqueueStockTakingResponse> {
-        const status = response.status;
-        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 202) {
-            return response.text().then((_responseText) => {
-            let result202: any = null;
-            let resultData202 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result202 = EnqueueStockTakingResponse.fromJS(resultData202);
-            return result202;
-            });
-        } else if (status === 400) {
-            return response.text().then((_responseText) => {
-            let result400: any = null;
-            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result400 = ProblemDetails.fromJS(resultData400);
-            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
-            });
-        } else if (status !== 200 && status !== 204) {
-            return response.text().then((_responseText) => {
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-            });
-        }
-        return Promise.resolve<EnqueueStockTakingResponse>(null as any);
-    }
-
-    catalog_GetStockTakingJobStatus(jobId: string): Promise<GetStockTakingJobStatusResponse> {
-        let url_ = this.baseUrl + "/api/Catalog/stock-taking/job-status/{jobId}";
-        if (jobId === undefined || jobId === null)
-            throw new Error("The parameter 'jobId' must be defined.");
-        url_ = url_.replace("{jobId}", encodeURIComponent("" + jobId));
-        url_ = url_.replace(/[?&]$/, "");
-
-        let options_: RequestInit = {
-            method: "GET",
-            headers: {
-                "Accept": "application/json"
-            }
-        };
-
-        return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processCatalog_GetStockTakingJobStatus(_response);
-        });
-    }
-
-    protected processCatalog_GetStockTakingJobStatus(response: Response): Promise<GetStockTakingJobStatusResponse> {
-        const status = response.status;
-        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 200) {
-            return response.text().then((_responseText) => {
-            let result200: any = null;
-            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = GetStockTakingJobStatusResponse.fromJS(resultData200);
-            return result200;
-            });
-        } else if (status === 404) {
-            return response.text().then((_responseText) => {
-            let result404: any = null;
-            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result404 = ProblemDetails.fromJS(resultData404);
-            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
-            });
-        } else if (status !== 200 && status !== 204) {
-            return response.text().then((_responseText) => {
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-            });
-        }
-        return Promise.resolve<GetStockTakingJobStatusResponse>(null as any);
-    }
-
     configuration_GetConfiguration(): Promise<GetConfigurationResponse> {
         let url_ = this.baseUrl + "/api/Configuration";
         url_ = url_.replace(/[?&]$/, "");
@@ -1677,6 +1588,135 @@ export class ApiClient {
             });
         }
         return Promise.resolve<FileResponse>(null as any);
+    }
+
+    dataQuality_GetRuns(testType: DqtTestType | null | undefined, status: DqtRunStatus | null | undefined, pageNumber: number | undefined, pageSize: number | undefined): Promise<GetDqtRunsResponse> {
+        let url_ = this.baseUrl + "/api/data-quality/runs?";
+        if (testType !== undefined && testType !== null)
+            url_ += "testType=" + encodeURIComponent("" + testType) + "&";
+        if (status !== undefined && status !== null)
+            url_ += "status=" + encodeURIComponent("" + status) + "&";
+        if (pageNumber === null)
+            throw new Error("The parameter 'pageNumber' cannot be null.");
+        else if (pageNumber !== undefined)
+            url_ += "pageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDataQuality_GetRuns(_response);
+        });
+    }
+
+    protected processDataQuality_GetRuns(response: Response): Promise<GetDqtRunsResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetDqtRunsResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetDqtRunsResponse>(null as any);
+    }
+
+    dataQuality_RunDqt(request: RunDqtRequest): Promise<RunDqtResponse> {
+        let url_ = this.baseUrl + "/api/data-quality/runs";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDataQuality_RunDqt(_response);
+        });
+    }
+
+    protected processDataQuality_RunDqt(response: Response): Promise<RunDqtResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RunDqtResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RunDqtResponse>(null as any);
+    }
+
+    dataQuality_GetRunDetail(id: string, resultPage: number | undefined, resultPageSize: number | undefined): Promise<GetDqtRunDetailResponse> {
+        let url_ = this.baseUrl + "/api/data-quality/runs/{id}?";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (resultPage === null)
+            throw new Error("The parameter 'resultPage' cannot be null.");
+        else if (resultPage !== undefined)
+            url_ += "resultPage=" + encodeURIComponent("" + resultPage) + "&";
+        if (resultPageSize === null)
+            throw new Error("The parameter 'resultPageSize' cannot be null.");
+        else if (resultPageSize !== undefined)
+            url_ += "resultPageSize=" + encodeURIComponent("" + resultPageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDataQuality_GetRunDetail(_response);
+        });
+    }
+
+    protected processDataQuality_GetRunDetail(response: Response): Promise<GetDqtRunDetailResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetDqtRunDetailResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetDqtRunDetailResponse>(null as any);
     }
 
     departments_GetDepartments(): Promise<Department[]> {
@@ -2254,7 +2294,7 @@ export class ApiClient {
         return Promise.resolve<DownloadFromUrlResponse>(null as any);
     }
 
-    financialOverview_GetFinancialOverview(months: number | null | undefined, includeStockData: boolean | undefined): Promise<GetFinancialOverviewResponse> {
+    financialOverview_GetFinancialOverview(months: number | null | undefined, includeStockData: boolean | undefined, excludedDepartments: string[] | null | undefined, includeCurrentMonth: boolean | undefined): Promise<GetFinancialOverviewResponse> {
         let url_ = this.baseUrl + "/api/FinancialOverview?";
         if (months !== undefined && months !== null)
             url_ += "months=" + encodeURIComponent("" + months) + "&";
@@ -2262,6 +2302,12 @@ export class ApiClient {
             throw new Error("The parameter 'includeStockData' cannot be null.");
         else if (includeStockData !== undefined)
             url_ += "includeStockData=" + encodeURIComponent("" + includeStockData) + "&";
+        if (excludedDepartments !== undefined && excludedDepartments !== null)
+            excludedDepartments && excludedDepartments.forEach(item => { url_ += "excludedDepartments=" + encodeURIComponent("" + item) + "&"; });
+        if (includeCurrentMonth === null)
+            throw new Error("The parameter 'includeCurrentMonth' cannot be null.");
+        else if (includeCurrentMonth !== undefined)
+            url_ += "includeCurrentMonth=" + encodeURIComponent("" + includeCurrentMonth) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {
@@ -5160,6 +5206,308 @@ export class ApiClient {
         return Promise.resolve<GetManufacturingStockAnalysisResponse>(null as any);
     }
 
+    marketingCalendar_GetMarketingActions(pageNumber: number | undefined, pageSize: number | undefined, searchTerm: string | null | undefined, productCodePrefix: string | null | undefined, startDateFrom: Date | null | undefined, startDateTo: Date | null | undefined, endDateFrom: Date | null | undefined, endDateTo: Date | null | undefined, includeDeleted: boolean | undefined): Promise<GetMarketingActionsResponse> {
+        let url_ = this.baseUrl + "/api/MarketingCalendar?";
+        if (pageNumber === null)
+            throw new Error("The parameter 'pageNumber' cannot be null.");
+        else if (pageNumber !== undefined)
+            url_ += "PageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "PageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (searchTerm !== undefined && searchTerm !== null)
+            url_ += "SearchTerm=" + encodeURIComponent("" + searchTerm) + "&";
+        if (productCodePrefix !== undefined && productCodePrefix !== null)
+            url_ += "ProductCodePrefix=" + encodeURIComponent("" + productCodePrefix) + "&";
+        if (startDateFrom !== undefined && startDateFrom !== null)
+            url_ += "StartDateFrom=" + encodeURIComponent(startDateFrom ? "" + startDateFrom.toISOString() : "") + "&";
+        if (startDateTo !== undefined && startDateTo !== null)
+            url_ += "StartDateTo=" + encodeURIComponent(startDateTo ? "" + startDateTo.toISOString() : "") + "&";
+        if (endDateFrom !== undefined && endDateFrom !== null)
+            url_ += "EndDateFrom=" + encodeURIComponent(endDateFrom ? "" + endDateFrom.toISOString() : "") + "&";
+        if (endDateTo !== undefined && endDateTo !== null)
+            url_ += "EndDateTo=" + encodeURIComponent(endDateTo ? "" + endDateTo.toISOString() : "") + "&";
+        if (includeDeleted === null)
+            throw new Error("The parameter 'includeDeleted' cannot be null.");
+        else if (includeDeleted !== undefined)
+            url_ += "IncludeDeleted=" + encodeURIComponent("" + includeDeleted) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarketingCalendar_GetMarketingActions(_response);
+        });
+    }
+
+    protected processMarketingCalendar_GetMarketingActions(response: Response): Promise<GetMarketingActionsResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetMarketingActionsResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetMarketingActionsResponse>(null as any);
+    }
+
+    marketingCalendar_CreateMarketingAction(request: CreateMarketingActionRequest): Promise<CreateMarketingActionResponse> {
+        let url_ = this.baseUrl + "/api/MarketingCalendar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarketingCalendar_CreateMarketingAction(_response);
+        });
+    }
+
+    protected processMarketingCalendar_CreateMarketingAction(response: Response): Promise<CreateMarketingActionResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 201) {
+            return response.text().then((_responseText) => {
+            let result201: any = null;
+            let resultData201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result201 = CreateMarketingActionResponse.fromJS(resultData201);
+            return result201;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<CreateMarketingActionResponse>(null as any);
+    }
+
+    marketingCalendar_GetMarketingAction(id: number): Promise<GetMarketingActionResponse> {
+        let url_ = this.baseUrl + "/api/MarketingCalendar/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarketingCalendar_GetMarketingAction(_response);
+        });
+    }
+
+    protected processMarketingCalendar_GetMarketingAction(response: Response): Promise<GetMarketingActionResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetMarketingActionResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetMarketingActionResponse>(null as any);
+    }
+
+    marketingCalendar_UpdateMarketingAction(id: number, request: UpdateMarketingActionRequest): Promise<UpdateMarketingActionResponse> {
+        let url_ = this.baseUrl + "/api/MarketingCalendar/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarketingCalendar_UpdateMarketingAction(_response);
+        });
+    }
+
+    protected processMarketingCalendar_UpdateMarketingAction(response: Response): Promise<UpdateMarketingActionResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = UpdateMarketingActionResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<UpdateMarketingActionResponse>(null as any);
+    }
+
+    marketingCalendar_DeleteMarketingAction(id: number): Promise<DeleteMarketingActionResponse> {
+        let url_ = this.baseUrl + "/api/MarketingCalendar/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarketingCalendar_DeleteMarketingAction(_response);
+        });
+    }
+
+    protected processMarketingCalendar_DeleteMarketingAction(response: Response): Promise<DeleteMarketingActionResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = DeleteMarketingActionResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result401);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<DeleteMarketingActionResponse>(null as any);
+    }
+
+    marketingCalendar_GetCalendar(startDate: Date | undefined, endDate: Date | undefined): Promise<GetMarketingCalendarResponse> {
+        let url_ = this.baseUrl + "/api/MarketingCalendar/calendar?";
+        if (startDate === null)
+            throw new Error("The parameter 'startDate' cannot be null.");
+        else if (startDate !== undefined)
+            url_ += "StartDate=" + encodeURIComponent(startDate ? "" + startDate.toISOString() : "") + "&";
+        if (endDate === null)
+            throw new Error("The parameter 'endDate' cannot be null.");
+        else if (endDate !== undefined)
+            url_ += "EndDate=" + encodeURIComponent(endDate ? "" + endDate.toISOString() : "") + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMarketingCalendar_GetCalendar(_response);
+        });
+    }
+
+    protected processMarketingCalendar_GetCalendar(response: Response): Promise<GetMarketingCalendarResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetMarketingCalendarResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetMarketingCalendarResponse>(null as any);
+    }
+
     orgChart_GetOrganizationStructure(): Promise<OrgChartResponse> {
         let url_ = this.baseUrl + "/api/OrgChart";
         url_ = url_.replace(/[?&]$/, "");
@@ -7342,6 +7690,11 @@ export enum ErrorCodes {
     KnowledgeBaseAiUnavailable = "KnowledgeBaseAiUnavailable",
     ShoptetOrderInvalidSourceState = "ShoptetOrderInvalidSourceState",
     ShoptetOrderNotFound = "ShoptetOrderNotFound",
+    DqtRunNotFound = "DqtRunNotFound",
+    DqtInvalidDateRange = "DqtInvalidDateRange",
+    DqtExternalServiceError = "DqtExternalServiceError",
+    MarketingActionNotFound = "MarketingActionNotFound",
+    UnauthorizedMarketingAccess = "UnauthorizedMarketingAccess",
     ExternalServiceError = "ExternalServiceError",
     FlexiApiError = "FlexiApiError",
     ShoptetApiError = "ShoptetApiError",
@@ -10241,208 +10594,6 @@ export interface IRecalculateProductWeightRequest {
     productCode?: string | undefined;
 }
 
-export class EnqueueStockTakingResponse extends BaseResponse implements IEnqueueStockTakingResponse {
-    jobId?: string;
-    message?: string;
-
-    constructor(data?: IEnqueueStockTakingResponse) {
-        super(data);
-    }
-
-    override init(_data?: any) {
-        super.init(_data);
-        if (_data) {
-            this.jobId = _data["jobId"];
-            this.message = _data["message"];
-        }
-    }
-
-    static override fromJS(data: any): EnqueueStockTakingResponse {
-        data = typeof data === 'object' ? data : {};
-        let result = new EnqueueStockTakingResponse();
-        result.init(data);
-        return result;
-    }
-
-    override toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["jobId"] = this.jobId;
-        data["message"] = this.message;
-        super.toJSON(data);
-        return data;
-    }
-}
-
-export interface IEnqueueStockTakingResponse extends IBaseResponse {
-    jobId?: string;
-    message?: string;
-}
-
-export class EnqueueStockTakingRequest implements IEnqueueStockTakingRequest {
-    productCode?: string;
-    targetAmount?: number;
-    softStockTaking?: boolean;
-
-    constructor(data?: IEnqueueStockTakingRequest) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property))
-                    (<any>this)[property] = (<any>data)[property];
-            }
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.productCode = _data["productCode"];
-            this.targetAmount = _data["targetAmount"];
-            this.softStockTaking = _data["softStockTaking"];
-        }
-    }
-
-    static fromJS(data: any): EnqueueStockTakingRequest {
-        data = typeof data === 'object' ? data : {};
-        let result = new EnqueueStockTakingRequest();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["productCode"] = this.productCode;
-        data["targetAmount"] = this.targetAmount;
-        data["softStockTaking"] = this.softStockTaking;
-        return data;
-    }
-}
-
-export interface IEnqueueStockTakingRequest {
-    productCode?: string;
-    targetAmount?: number;
-    softStockTaking?: boolean;
-}
-
-export class GetStockTakingJobStatusResponse extends BaseResponse implements IGetStockTakingJobStatusResponse {
-    jobId?: string;
-    status?: string;
-    isCompleted?: boolean;
-    isSucceeded?: boolean;
-    isFailed?: boolean;
-    errorMessage?: string | undefined;
-    result?: StockTakingResultDto | undefined;
-
-    constructor(data?: IGetStockTakingJobStatusResponse) {
-        super(data);
-    }
-
-    override init(_data?: any) {
-        super.init(_data);
-        if (_data) {
-            this.jobId = _data["jobId"];
-            this.status = _data["status"];
-            this.isCompleted = _data["isCompleted"];
-            this.isSucceeded = _data["isSucceeded"];
-            this.isFailed = _data["isFailed"];
-            this.errorMessage = _data["errorMessage"];
-            this.result = _data["result"] ? StockTakingResultDto.fromJS(_data["result"]) : <any>undefined;
-        }
-    }
-
-    static override fromJS(data: any): GetStockTakingJobStatusResponse {
-        data = typeof data === 'object' ? data : {};
-        let result = new GetStockTakingJobStatusResponse();
-        result.init(data);
-        return result;
-    }
-
-    override toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["jobId"] = this.jobId;
-        data["status"] = this.status;
-        data["isCompleted"] = this.isCompleted;
-        data["isSucceeded"] = this.isSucceeded;
-        data["isFailed"] = this.isFailed;
-        data["errorMessage"] = this.errorMessage;
-        data["result"] = this.result ? this.result.toJSON() : <any>undefined;
-        super.toJSON(data);
-        return data;
-    }
-}
-
-export interface IGetStockTakingJobStatusResponse extends IBaseResponse {
-    jobId?: string;
-    status?: string;
-    isCompleted?: boolean;
-    isSucceeded?: boolean;
-    isFailed?: boolean;
-    errorMessage?: string | undefined;
-    result?: StockTakingResultDto | undefined;
-}
-
-export class StockTakingResultDto implements IStockTakingResultDto {
-    id?: string;
-    type?: string;
-    code?: string;
-    amountNew?: number;
-    amountOld?: number;
-    date?: Date;
-    user?: string;
-    error?: string;
-
-    constructor(data?: IStockTakingResultDto) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property))
-                    (<any>this)[property] = (<any>data)[property];
-            }
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.id = _data["id"];
-            this.type = _data["type"];
-            this.code = _data["code"];
-            this.amountNew = _data["amountNew"];
-            this.amountOld = _data["amountOld"];
-            this.date = _data["date"] ? new Date(_data["date"].toString()) : <any>undefined;
-            this.user = _data["user"];
-            this.error = _data["error"];
-        }
-    }
-
-    static fromJS(data: any): StockTakingResultDto {
-        data = typeof data === 'object' ? data : {};
-        let result = new StockTakingResultDto();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["id"] = this.id;
-        data["type"] = this.type;
-        data["code"] = this.code;
-        data["amountNew"] = this.amountNew;
-        data["amountOld"] = this.amountOld;
-        data["date"] = this.date ? this.date.toISOString() : <any>undefined;
-        data["user"] = this.user;
-        data["error"] = this.error;
-        return data;
-    }
-}
-
-export interface IStockTakingResultDto {
-    id?: string;
-    type?: string;
-    code?: string;
-    amountNew?: number;
-    amountOld?: number;
-    date?: Date;
-    user?: string;
-    error?: string;
-}
-
 export class GetConfigurationResponse extends BaseResponse implements IGetConfigurationResponse {
     version?: string;
     environment?: string;
@@ -10702,6 +10853,339 @@ export class SaveUserSettingsRequest implements ISaveUserSettingsRequest {
 export interface ISaveUserSettingsRequest {
     userId?: string;
     tiles?: UserDashboardTileDto[];
+}
+
+export class GetDqtRunsResponse extends BaseResponse implements IGetDqtRunsResponse {
+    items?: DqtRunDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+
+    constructor(data?: IGetDqtRunsResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["items"])) {
+                this.items = [] as any;
+                for (let item of _data["items"])
+                    this.items!.push(DqtRunDto.fromJS(item));
+            }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+            this.totalPages = _data["totalPages"];
+        }
+    }
+
+    static override fromJS(data: any): GetDqtRunsResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetDqtRunsResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.items)) {
+            data["items"] = [];
+            for (let item of this.items)
+                data["items"].push(item.toJSON());
+        }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        data["totalPages"] = this.totalPages;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetDqtRunsResponse extends IBaseResponse {
+    items?: DqtRunDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+}
+
+export class DqtRunDto implements IDqtRunDto {
+    id?: string;
+    testType?: string;
+    dateFrom?: Date;
+    dateTo?: Date;
+    status?: string;
+    startedAt?: Date;
+    completedAt?: Date | undefined;
+    triggerType?: string;
+    totalChecked?: number;
+    totalMismatches?: number;
+    errorMessage?: string | undefined;
+
+    constructor(data?: IDqtRunDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.testType = _data["testType"];
+            this.dateFrom = _data["dateFrom"] ? new Date(_data["dateFrom"].toString()) : <any>undefined;
+            this.dateTo = _data["dateTo"] ? new Date(_data["dateTo"].toString()) : <any>undefined;
+            this.status = _data["status"];
+            this.startedAt = _data["startedAt"] ? new Date(_data["startedAt"].toString()) : <any>undefined;
+            this.completedAt = _data["completedAt"] ? new Date(_data["completedAt"].toString()) : <any>undefined;
+            this.triggerType = _data["triggerType"];
+            this.totalChecked = _data["totalChecked"];
+            this.totalMismatches = _data["totalMismatches"];
+            this.errorMessage = _data["errorMessage"];
+        }
+    }
+
+    static fromJS(data: any): DqtRunDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new DqtRunDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["testType"] = this.testType;
+        data["dateFrom"] = this.dateFrom ? formatDate(this.dateFrom) : <any>undefined;
+        data["dateTo"] = this.dateTo ? formatDate(this.dateTo) : <any>undefined;
+        data["status"] = this.status;
+        data["startedAt"] = this.startedAt ? this.startedAt.toISOString() : <any>undefined;
+        data["completedAt"] = this.completedAt ? this.completedAt.toISOString() : <any>undefined;
+        data["triggerType"] = this.triggerType;
+        data["totalChecked"] = this.totalChecked;
+        data["totalMismatches"] = this.totalMismatches;
+        data["errorMessage"] = this.errorMessage;
+        return data;
+    }
+}
+
+export interface IDqtRunDto {
+    id?: string;
+    testType?: string;
+    dateFrom?: Date;
+    dateTo?: Date;
+    status?: string;
+    startedAt?: Date;
+    completedAt?: Date | undefined;
+    triggerType?: string;
+    totalChecked?: number;
+    totalMismatches?: number;
+    errorMessage?: string | undefined;
+}
+
+export enum DqtTestType {
+    IssuedInvoiceComparison = "IssuedInvoiceComparison",
+}
+
+export enum DqtRunStatus {
+    Running = "Running",
+    Completed = "Completed",
+    Failed = "Failed",
+}
+
+export class GetDqtRunDetailResponse extends BaseResponse implements IGetDqtRunDetailResponse {
+    run?: DqtRunDto | undefined;
+    results?: InvoiceDqtResultDto[];
+
+    constructor(data?: IGetDqtRunDetailResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.run = _data["run"] ? DqtRunDto.fromJS(_data["run"]) : <any>undefined;
+            if (Array.isArray(_data["results"])) {
+                this.results = [] as any;
+                for (let item of _data["results"])
+                    this.results!.push(InvoiceDqtResultDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetDqtRunDetailResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetDqtRunDetailResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["run"] = this.run ? this.run.toJSON() : <any>undefined;
+        if (Array.isArray(this.results)) {
+            data["results"] = [];
+            for (let item of this.results)
+                data["results"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetDqtRunDetailResponse extends IBaseResponse {
+    run?: DqtRunDto | undefined;
+    results?: InvoiceDqtResultDto[];
+}
+
+export class InvoiceDqtResultDto implements IInvoiceDqtResultDto {
+    id?: string;
+    invoiceCode?: string;
+    mismatchType?: number;
+    mismatchFlags?: string[];
+    shoptetValue?: string | undefined;
+    flexiValue?: string | undefined;
+    details?: string | undefined;
+
+    constructor(data?: IInvoiceDqtResultDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.invoiceCode = _data["invoiceCode"];
+            this.mismatchType = _data["mismatchType"];
+            if (Array.isArray(_data["mismatchFlags"])) {
+                this.mismatchFlags = [] as any;
+                for (let item of _data["mismatchFlags"])
+                    this.mismatchFlags!.push(item);
+            }
+            this.shoptetValue = _data["shoptetValue"];
+            this.flexiValue = _data["flexiValue"];
+            this.details = _data["details"];
+        }
+    }
+
+    static fromJS(data: any): InvoiceDqtResultDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new InvoiceDqtResultDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["invoiceCode"] = this.invoiceCode;
+        data["mismatchType"] = this.mismatchType;
+        if (Array.isArray(this.mismatchFlags)) {
+            data["mismatchFlags"] = [];
+            for (let item of this.mismatchFlags)
+                data["mismatchFlags"].push(item);
+        }
+        data["shoptetValue"] = this.shoptetValue;
+        data["flexiValue"] = this.flexiValue;
+        data["details"] = this.details;
+        return data;
+    }
+}
+
+export interface IInvoiceDqtResultDto {
+    id?: string;
+    invoiceCode?: string;
+    mismatchType?: number;
+    mismatchFlags?: string[];
+    shoptetValue?: string | undefined;
+    flexiValue?: string | undefined;
+    details?: string | undefined;
+}
+
+export class RunDqtResponse extends BaseResponse implements IRunDqtResponse {
+    dqtRunId?: string | undefined;
+
+    constructor(data?: IRunDqtResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.dqtRunId = _data["dqtRunId"];
+        }
+    }
+
+    static override fromJS(data: any): RunDqtResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new RunDqtResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["dqtRunId"] = this.dqtRunId;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IRunDqtResponse extends IBaseResponse {
+    dqtRunId?: string | undefined;
+}
+
+export class RunDqtRequest implements IRunDqtRequest {
+    testType?: DqtTestType;
+    dateFrom?: Date;
+    dateTo?: Date;
+
+    constructor(data?: IRunDqtRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.testType = _data["testType"];
+            this.dateFrom = _data["dateFrom"] ? new Date(_data["dateFrom"].toString()) : <any>undefined;
+            this.dateTo = _data["dateTo"] ? new Date(_data["dateTo"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): RunDqtRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new RunDqtRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["testType"] = this.testType;
+        data["dateFrom"] = this.dateFrom ? formatDate(this.dateFrom) : <any>undefined;
+        data["dateTo"] = this.dateTo ? formatDate(this.dateTo) : <any>undefined;
+        return data;
+    }
+}
+
+export interface IRunDqtRequest {
+    testType?: DqtTestType;
+    dateFrom?: Date;
+    dateTo?: Date;
 }
 
 export class Department implements IDepartment {
@@ -15616,6 +16100,7 @@ export class CalculateBatchPlanResponse extends BaseResponse implements ICalcula
     totalVolumeUsed?: number;
     totalVolumeAvailable?: number;
     manufactureType?: ManufactureType;
+    directSemiproductAmount?: number;
 
     constructor(data?: ICalculateBatchPlanResponse) {
         super(data);
@@ -15635,6 +16120,7 @@ export class CalculateBatchPlanResponse extends BaseResponse implements ICalcula
             this.totalVolumeUsed = _data["totalVolumeUsed"];
             this.totalVolumeAvailable = _data["totalVolumeAvailable"];
             this.manufactureType = _data["manufactureType"];
+            this.directSemiproductAmount = _data["directSemiproductAmount"];
         }
     }
 
@@ -15658,6 +16144,7 @@ export class CalculateBatchPlanResponse extends BaseResponse implements ICalcula
         data["totalVolumeUsed"] = this.totalVolumeUsed;
         data["totalVolumeAvailable"] = this.totalVolumeAvailable;
         data["manufactureType"] = this.manufactureType;
+        data["directSemiproductAmount"] = this.directSemiproductAmount;
         super.toJSON(data);
         return data;
     }
@@ -15671,6 +16158,7 @@ export interface ICalculateBatchPlanResponse extends IBaseResponse {
     totalVolumeUsed?: number;
     totalVolumeAvailable?: number;
     manufactureType?: ManufactureType;
+    directSemiproductAmount?: number;
 }
 
 export class SemiproductInfoDto implements ISemiproductInfoDto {
@@ -15905,8 +16393,8 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
     totalWeightToUse?: number | undefined;
     targetDaysCoverage?: number | undefined;
     productConstraints?: ProductSizeConstraint[];
-    manufactureType?: ManufactureType | undefined;
     directSemiproductAmount?: number | undefined;
+    manufactureType?: ManufactureType | undefined;
 
     constructor(data?: ICalculateBatchPlanRequest) {
         if (data) {
@@ -15932,8 +16420,8 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
                 for (let item of _data["productConstraints"])
                     this.productConstraints!.push(ProductSizeConstraint.fromJS(item));
             }
-            this.manufactureType = _data["manufactureType"];
             this.directSemiproductAmount = _data["directSemiproductAmount"];
+            this.manufactureType = _data["manufactureType"];
         }
     }
 
@@ -15959,8 +16447,8 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
             for (let item of this.productConstraints)
                 data["productConstraints"].push(item.toJSON());
         }
-        data["manufactureType"] = this.manufactureType;
         data["directSemiproductAmount"] = this.directSemiproductAmount;
+        data["manufactureType"] = this.manufactureType;
         return data;
     }
 }
@@ -15975,8 +16463,8 @@ export interface ICalculateBatchPlanRequest {
     totalWeightToUse?: number | undefined;
     targetDaysCoverage?: number | undefined;
     productConstraints?: ProductSizeConstraint[];
-    manufactureType?: ManufactureType | undefined;
     directSemiproductAmount?: number | undefined;
+    manufactureType?: ManufactureType | undefined;
 }
 
 export class ProductSizeConstraint implements IProductSizeConstraint {
@@ -18908,6 +19396,685 @@ export enum ManufacturingStockSortBy {
     MinimumStock = "MinimumStock",
     OverstockPercentage = "OverstockPercentage",
     BatchSize = "BatchSize",
+}
+
+export class GetMarketingActionsResponse extends BaseResponse implements IGetMarketingActionsResponse {
+    actions?: MarketingActionDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+
+    constructor(data?: IGetMarketingActionsResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["actions"])) {
+                this.actions = [] as any;
+                for (let item of _data["actions"])
+                    this.actions!.push(MarketingActionDto.fromJS(item));
+            }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+            this.totalPages = _data["totalPages"];
+            this.hasNextPage = _data["hasNextPage"];
+            this.hasPreviousPage = _data["hasPreviousPage"];
+        }
+    }
+
+    static override fromJS(data: any): GetMarketingActionsResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetMarketingActionsResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.actions)) {
+            data["actions"] = [];
+            for (let item of this.actions)
+                data["actions"].push(item.toJSON());
+        }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        data["totalPages"] = this.totalPages;
+        data["hasNextPage"] = this.hasNextPage;
+        data["hasPreviousPage"] = this.hasPreviousPage;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetMarketingActionsResponse extends IBaseResponse {
+    actions?: MarketingActionDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
+}
+
+export class MarketingActionDto implements IMarketingActionDto {
+    id?: number;
+    title?: string;
+    description?: string | undefined;
+    actionType?: string;
+    startDate?: Date;
+    endDate?: Date | undefined;
+    createdAt?: Date;
+    modifiedAt?: Date;
+    createdByUserId?: string;
+    createdByUsername?: string | undefined;
+    modifiedByUserId?: string | undefined;
+    modifiedByUsername?: string | undefined;
+    associatedProducts?: string[];
+    folderLinks?: MarketingActionFolderLinkDto[];
+
+    constructor(data?: IMarketingActionDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.title = _data["title"];
+            this.description = _data["description"];
+            this.actionType = _data["actionType"];
+            this.startDate = _data["startDate"] ? new Date(_data["startDate"].toString()) : <any>undefined;
+            this.endDate = _data["endDate"] ? new Date(_data["endDate"].toString()) : <any>undefined;
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.modifiedAt = _data["modifiedAt"] ? new Date(_data["modifiedAt"].toString()) : <any>undefined;
+            this.createdByUserId = _data["createdByUserId"];
+            this.createdByUsername = _data["createdByUsername"];
+            this.modifiedByUserId = _data["modifiedByUserId"];
+            this.modifiedByUsername = _data["modifiedByUsername"];
+            if (Array.isArray(_data["associatedProducts"])) {
+                this.associatedProducts = [] as any;
+                for (let item of _data["associatedProducts"])
+                    this.associatedProducts!.push(item);
+            }
+            if (Array.isArray(_data["folderLinks"])) {
+                this.folderLinks = [] as any;
+                for (let item of _data["folderLinks"])
+                    this.folderLinks!.push(MarketingActionFolderLinkDto.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): MarketingActionDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new MarketingActionDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["title"] = this.title;
+        data["description"] = this.description;
+        data["actionType"] = this.actionType;
+        data["startDate"] = this.startDate ? this.startDate.toISOString() : <any>undefined;
+        data["endDate"] = this.endDate ? this.endDate.toISOString() : <any>undefined;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["modifiedAt"] = this.modifiedAt ? this.modifiedAt.toISOString() : <any>undefined;
+        data["createdByUserId"] = this.createdByUserId;
+        data["createdByUsername"] = this.createdByUsername;
+        data["modifiedByUserId"] = this.modifiedByUserId;
+        data["modifiedByUsername"] = this.modifiedByUsername;
+        if (Array.isArray(this.associatedProducts)) {
+            data["associatedProducts"] = [];
+            for (let item of this.associatedProducts)
+                data["associatedProducts"].push(item);
+        }
+        if (Array.isArray(this.folderLinks)) {
+            data["folderLinks"] = [];
+            for (let item of this.folderLinks)
+                data["folderLinks"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface IMarketingActionDto {
+    id?: number;
+    title?: string;
+    description?: string | undefined;
+    actionType?: string;
+    startDate?: Date;
+    endDate?: Date | undefined;
+    createdAt?: Date;
+    modifiedAt?: Date;
+    createdByUserId?: string;
+    createdByUsername?: string | undefined;
+    modifiedByUserId?: string | undefined;
+    modifiedByUsername?: string | undefined;
+    associatedProducts?: string[];
+    folderLinks?: MarketingActionFolderLinkDto[];
+}
+
+export class MarketingActionFolderLinkDto implements IMarketingActionFolderLinkDto {
+    folderKey?: string;
+    folderType?: string;
+
+    constructor(data?: IMarketingActionFolderLinkDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.folderKey = _data["folderKey"];
+            this.folderType = _data["folderType"];
+        }
+    }
+
+    static fromJS(data: any): MarketingActionFolderLinkDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new MarketingActionFolderLinkDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["folderKey"] = this.folderKey;
+        data["folderType"] = this.folderType;
+        return data;
+    }
+}
+
+export interface IMarketingActionFolderLinkDto {
+    folderKey?: string;
+    folderType?: string;
+}
+
+export class GetMarketingActionResponse extends BaseResponse implements IGetMarketingActionResponse {
+    action?: MarketingActionDto | undefined;
+
+    constructor(data?: IGetMarketingActionResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.action = _data["action"] ? MarketingActionDto.fromJS(_data["action"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): GetMarketingActionResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetMarketingActionResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["action"] = this.action ? this.action.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetMarketingActionResponse extends IBaseResponse {
+    action?: MarketingActionDto | undefined;
+}
+
+export class GetMarketingCalendarResponse extends BaseResponse implements IGetMarketingCalendarResponse {
+    actions?: MarketingActionCalendarDto[];
+
+    constructor(data?: IGetMarketingCalendarResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["actions"])) {
+                this.actions = [] as any;
+                for (let item of _data["actions"])
+                    this.actions!.push(MarketingActionCalendarDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetMarketingCalendarResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetMarketingCalendarResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.actions)) {
+            data["actions"] = [];
+            for (let item of this.actions)
+                data["actions"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetMarketingCalendarResponse extends IBaseResponse {
+    actions?: MarketingActionCalendarDto[];
+}
+
+export class MarketingActionCalendarDto implements IMarketingActionCalendarDto {
+    id?: number;
+    title?: string;
+    actionType?: string;
+    startDate?: Date;
+    endDate?: Date | undefined;
+    associatedProducts?: string[];
+
+    constructor(data?: IMarketingActionCalendarDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.title = _data["title"];
+            this.actionType = _data["actionType"];
+            this.startDate = _data["startDate"] ? new Date(_data["startDate"].toString()) : <any>undefined;
+            this.endDate = _data["endDate"] ? new Date(_data["endDate"].toString()) : <any>undefined;
+            if (Array.isArray(_data["associatedProducts"])) {
+                this.associatedProducts = [] as any;
+                for (let item of _data["associatedProducts"])
+                    this.associatedProducts!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): MarketingActionCalendarDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new MarketingActionCalendarDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["title"] = this.title;
+        data["actionType"] = this.actionType;
+        data["startDate"] = this.startDate ? this.startDate.toISOString() : <any>undefined;
+        data["endDate"] = this.endDate ? this.endDate.toISOString() : <any>undefined;
+        if (Array.isArray(this.associatedProducts)) {
+            data["associatedProducts"] = [];
+            for (let item of this.associatedProducts)
+                data["associatedProducts"].push(item);
+        }
+        return data;
+    }
+}
+
+export interface IMarketingActionCalendarDto {
+    id?: number;
+    title?: string;
+    actionType?: string;
+    startDate?: Date;
+    endDate?: Date | undefined;
+    associatedProducts?: string[];
+}
+
+export class CreateMarketingActionResponse extends BaseResponse implements ICreateMarketingActionResponse {
+    id?: number;
+    createdAt?: Date;
+    message?: string;
+
+    constructor(data?: ICreateMarketingActionResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.id = _data["id"];
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.message = _data["message"];
+        }
+    }
+
+    static override fromJS(data: any): CreateMarketingActionResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateMarketingActionResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["message"] = this.message;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface ICreateMarketingActionResponse extends IBaseResponse {
+    id?: number;
+    createdAt?: Date;
+    message?: string;
+}
+
+export class CreateMarketingActionRequest implements ICreateMarketingActionRequest {
+    title!: string;
+    description?: string | undefined;
+    actionType!: MarketingActionType;
+    startDate!: Date;
+    endDate?: Date | undefined;
+    associatedProducts?: string[] | undefined;
+    folderLinks?: CreateFolderLinkRequest[] | undefined;
+
+    constructor(data?: ICreateMarketingActionRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.title = _data["title"];
+            this.description = _data["description"];
+            this.actionType = _data["actionType"];
+            this.startDate = _data["startDate"] ? new Date(_data["startDate"].toString()) : <any>undefined;
+            this.endDate = _data["endDate"] ? new Date(_data["endDate"].toString()) : <any>undefined;
+            if (Array.isArray(_data["associatedProducts"])) {
+                this.associatedProducts = [] as any;
+                for (let item of _data["associatedProducts"])
+                    this.associatedProducts!.push(item);
+            }
+            if (Array.isArray(_data["folderLinks"])) {
+                this.folderLinks = [] as any;
+                for (let item of _data["folderLinks"])
+                    this.folderLinks!.push(CreateFolderLinkRequest.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): CreateMarketingActionRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateMarketingActionRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["title"] = this.title;
+        data["description"] = this.description;
+        data["actionType"] = this.actionType;
+        data["startDate"] = this.startDate ? this.startDate.toISOString() : <any>undefined;
+        data["endDate"] = this.endDate ? this.endDate.toISOString() : <any>undefined;
+        if (Array.isArray(this.associatedProducts)) {
+            data["associatedProducts"] = [];
+            for (let item of this.associatedProducts)
+                data["associatedProducts"].push(item);
+        }
+        if (Array.isArray(this.folderLinks)) {
+            data["folderLinks"] = [];
+            for (let item of this.folderLinks)
+                data["folderLinks"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface ICreateMarketingActionRequest {
+    title: string;
+    description?: string | undefined;
+    actionType: MarketingActionType;
+    startDate: Date;
+    endDate?: Date | undefined;
+    associatedProducts?: string[] | undefined;
+    folderLinks?: CreateFolderLinkRequest[] | undefined;
+}
+
+export enum MarketingActionType {
+    General = "General",
+    Promotion = "Promotion",
+    Launch = "Launch",
+    Campaign = "Campaign",
+    Event = "Event",
+    Other = "Other",
+}
+
+export class CreateFolderLinkRequest implements ICreateFolderLinkRequest {
+    folderKey!: string;
+    folderType!: MarketingFolderType;
+
+    constructor(data?: ICreateFolderLinkRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.folderKey = _data["folderKey"];
+            this.folderType = _data["folderType"];
+        }
+    }
+
+    static fromJS(data: any): CreateFolderLinkRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateFolderLinkRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["folderKey"] = this.folderKey;
+        data["folderType"] = this.folderType;
+        return data;
+    }
+}
+
+export interface ICreateFolderLinkRequest {
+    folderKey: string;
+    folderType: MarketingFolderType;
+}
+
+export enum MarketingFolderType {
+    General = "General",
+    Seasonal = "Seasonal",
+    ProductLine = "ProductLine",
+    Campaign = "Campaign",
+    Other = "Other",
+}
+
+export class UpdateMarketingActionResponse extends BaseResponse implements IUpdateMarketingActionResponse {
+    id?: number;
+    modifiedAt?: Date;
+    message?: string;
+
+    constructor(data?: IUpdateMarketingActionResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.id = _data["id"];
+            this.modifiedAt = _data["modifiedAt"] ? new Date(_data["modifiedAt"].toString()) : <any>undefined;
+            this.message = _data["message"];
+        }
+    }
+
+    static override fromJS(data: any): UpdateMarketingActionResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateMarketingActionResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["modifiedAt"] = this.modifiedAt ? this.modifiedAt.toISOString() : <any>undefined;
+        data["message"] = this.message;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUpdateMarketingActionResponse extends IBaseResponse {
+    id?: number;
+    modifiedAt?: Date;
+    message?: string;
+}
+
+export class UpdateMarketingActionRequest implements IUpdateMarketingActionRequest {
+    id?: number;
+    title!: string;
+    description?: string | undefined;
+    actionType!: MarketingActionType;
+    startDate!: Date;
+    endDate?: Date | undefined;
+    associatedProducts?: string[] | undefined;
+    folderLinks?: CreateFolderLinkRequest[] | undefined;
+
+    constructor(data?: IUpdateMarketingActionRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.title = _data["title"];
+            this.description = _data["description"];
+            this.actionType = _data["actionType"];
+            this.startDate = _data["startDate"] ? new Date(_data["startDate"].toString()) : <any>undefined;
+            this.endDate = _data["endDate"] ? new Date(_data["endDate"].toString()) : <any>undefined;
+            if (Array.isArray(_data["associatedProducts"])) {
+                this.associatedProducts = [] as any;
+                for (let item of _data["associatedProducts"])
+                    this.associatedProducts!.push(item);
+            }
+            if (Array.isArray(_data["folderLinks"])) {
+                this.folderLinks = [] as any;
+                for (let item of _data["folderLinks"])
+                    this.folderLinks!.push(CreateFolderLinkRequest.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): UpdateMarketingActionRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateMarketingActionRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["title"] = this.title;
+        data["description"] = this.description;
+        data["actionType"] = this.actionType;
+        data["startDate"] = this.startDate ? this.startDate.toISOString() : <any>undefined;
+        data["endDate"] = this.endDate ? this.endDate.toISOString() : <any>undefined;
+        if (Array.isArray(this.associatedProducts)) {
+            data["associatedProducts"] = [];
+            for (let item of this.associatedProducts)
+                data["associatedProducts"].push(item);
+        }
+        if (Array.isArray(this.folderLinks)) {
+            data["folderLinks"] = [];
+            for (let item of this.folderLinks)
+                data["folderLinks"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface IUpdateMarketingActionRequest {
+    id?: number;
+    title: string;
+    description?: string | undefined;
+    actionType: MarketingActionType;
+    startDate: Date;
+    endDate?: Date | undefined;
+    associatedProducts?: string[] | undefined;
+    folderLinks?: CreateFolderLinkRequest[] | undefined;
+}
+
+export class DeleteMarketingActionResponse extends BaseResponse implements IDeleteMarketingActionResponse {
+    id?: number;
+    message?: string;
+
+    constructor(data?: IDeleteMarketingActionResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.id = _data["id"];
+            this.message = _data["message"];
+        }
+    }
+
+    static override fromJS(data: any): DeleteMarketingActionResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new DeleteMarketingActionResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["message"] = this.message;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IDeleteMarketingActionResponse extends IBaseResponse {
+    id?: number;
+    message?: string;
 }
 
 export class OrgChartResponse extends BaseResponse implements IOrgChartResponse {

--- a/frontend/src/api/hooks/useMarketingCalendar.ts
+++ b/frontend/src/api/hooks/useMarketingCalendar.ts
@@ -1,0 +1,163 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+
+interface GetMarketingActionsParams {
+  pageNumber?: number;
+  pageSize?: number;
+  searchTerm?: string;
+  productCodePrefix?: string;
+  startDateFrom?: Date;
+  startDateTo?: Date;
+  endDateFrom?: Date;
+  endDateTo?: Date;
+  includeDeleted?: boolean;
+}
+
+interface GetMarketingCalendarParams {
+  startDate: Date;
+  endDate: Date;
+}
+
+interface CreateMarketingActionPayload {
+  title: string;
+  description?: string;
+  actionType: number;
+  startDate: Date;
+  endDate?: Date;
+  associatedProducts?: string[];
+  folderLinks?: Array<{ folderKey: string; folderType: number }>;
+}
+
+interface UpdateMarketingActionPayload {
+  id: number;
+  title: string;
+  description?: string;
+  actionType: number;
+  startDate: Date;
+  endDate?: Date;
+  associatedProducts?: string[];
+  folderLinks?: Array<{ folderKey: string; folderType: number }>;
+}
+
+export const useMarketingActions = (
+  params: GetMarketingActionsParams = {},
+) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.marketingCalendar, "actions", params],
+    queryFn: async () => {
+      const client = await getAuthenticatedApiClient();
+      return await (client as any).marketingCalendar_GetMarketingActions(
+        params.pageNumber,
+        params.pageSize,
+        params.searchTerm,
+        params.productCodePrefix,
+        params.startDateFrom,
+        params.startDateTo,
+        params.endDateFrom,
+        params.endDateTo,
+        params.includeDeleted,
+      );
+    },
+  });
+};
+
+export const useMarketingAction = (id: number) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.marketingCalendar, "action", id],
+    queryFn: async () => {
+      const client = await getAuthenticatedApiClient();
+      return await (client as any).marketingCalendar_GetMarketingAction(id);
+    },
+    enabled: id > 0,
+  });
+};
+
+export const useMarketingCalendar = (params: GetMarketingCalendarParams) => {
+  return useQuery({
+    queryKey: [
+      ...QUERY_KEYS.marketingCalendar,
+      "calendar",
+      params.startDate,
+      params.endDate,
+    ],
+    queryFn: async () => {
+      const client = await getAuthenticatedApiClient();
+      return await (client as any).marketingCalendar_GetCalendar(
+        params.startDate,
+        params.endDate,
+      );
+    },
+    enabled: !!params.startDate && !!params.endDate,
+  });
+};
+
+export const useCreateMarketingAction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (request: CreateMarketingActionPayload) => {
+      const client = await getAuthenticatedApiClient();
+      return await (client as any).marketingCalendar_CreateMarketingAction(
+        request,
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "actions"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "calendar"],
+      });
+    },
+  });
+};
+
+export const useUpdateMarketingAction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      request,
+    }: {
+      id: number;
+      request: Omit<UpdateMarketingActionPayload, "id">;
+    }) => {
+      const client = await getAuthenticatedApiClient();
+      return await (client as any).marketingCalendar_UpdateMarketingAction(id, {
+        ...request,
+        id,
+      });
+    },
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "actions"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "calendar"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "action", id],
+      });
+    },
+  });
+};
+
+export const useDeleteMarketingAction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const client = await getAuthenticatedApiClient();
+      return await (client as any).marketingCalendar_DeleteMarketingAction(id);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "actions"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.marketingCalendar, "calendar"],
+      });
+    },
+  });
+};

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   ExternalLink,
   FileText,
   Database,
+  Megaphone,
 } from "lucide-react";
 import UserProfile from "../auth/UserProfile";
 import { useAuth } from "../../auth/useAuth";
@@ -134,6 +135,15 @@ const Sidebar: React.FC<SidebarProps> = ({
         { id: "catalog", name: "Katalog", href: "/catalog" },
         { id: "marze-produktu", name: "Marže", href: "/products/margins" },
         { id: "journal", name: "Deník", href: "/journal" },
+      ],
+    },
+    {
+      id: "marketing",
+      name: "Marketing",
+      icon: Megaphone,
+      type: "section" as const,
+      items: [
+        { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
       ],
     },
     {

--- a/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import type { CalendarEvent } from "./useCalendarLayout";
+
+const ACTION_TYPE_COLORS: Record<string, string> = {
+  SocialMedia: "bg-blue-500 text-white",
+  Event: "bg-purple-500 text-white",
+  Email: "bg-green-500 text-white",
+  PR: "bg-yellow-500 text-gray-900",
+  Photoshoot: "bg-pink-500 text-white",
+  Other: "bg-gray-500 text-white",
+};
+
+const BAR_HEIGHT_PX = 22;
+const BAR_GAP_PX = 2;
+const TOP_OFFSET_PX = 28; // space below date number in day cell
+
+interface MarketingEventBarProps {
+  event: CalendarEvent;
+  startCol: number; // 1–7
+  endCol: number; // 1–7, inclusive
+  lane: number;
+  onClick: (id: number) => void;
+}
+
+const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
+  event,
+  startCol,
+  endCol,
+  lane,
+  onClick,
+}) => {
+  const colorClass =
+    ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
+  const top = TOP_OFFSET_PX + lane * (BAR_HEIGHT_PX + BAR_GAP_PX);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onClick(event.id)}
+      onKeyDown={(e) => e.key === "Enter" && onClick(event.id)}
+      title={event.title}
+      style={{
+        gridColumnStart: startCol,
+        gridColumnEnd: endCol + 1,
+        gridRow: 1,
+        top,
+        height: BAR_HEIGHT_PX,
+        position: "absolute",
+        left: 2,
+        right: 2,
+        zIndex: 10,
+        pointerEvents: "auto",
+      }}
+      className={`
+        ${colorClass}
+        rounded px-1 text-xs font-medium truncate cursor-pointer
+        hover:opacity-80 transition-opacity select-none
+      `}
+    >
+      {event.title}
+    </div>
+  );
+};
+
+export const BAR_HEIGHT_PX_EXPORT = BAR_HEIGHT_PX;
+export const BAR_GAP_PX_EXPORT = BAR_GAP_PX;
+export const TOP_OFFSET_PX_EXPORT = TOP_OFFSET_PX;
+
+export default MarketingEventBar;

--- a/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
@@ -1,0 +1,189 @@
+import React, { useMemo } from "react";
+import type { CalendarEvent, EventSegment } from "./useCalendarLayout";
+import { useCalendarLayout } from "./useCalendarLayout";
+import MarketingEventBar, {
+  BAR_HEIGHT_PX_EXPORT as BAR_H,
+  BAR_GAP_PX_EXPORT as BAR_G,
+  TOP_OFFSET_PX_EXPORT as TOP_OFF,
+} from "./MarketingEventBar";
+
+const WEEK_DAYS = ["Po", "Út", "St", "Čt", "Pá", "So", "Ne"];
+
+// Minimum row height when no events; grows per lane
+const BASE_ROW_HEIGHT_PX = 64;
+
+interface MarketingMonthCalendarProps {
+  year: number;
+  month: number; // 0-based
+  events: CalendarEvent[];
+  onEventClick: (id: number) => void;
+  className?: string;
+}
+
+interface DayCell {
+  date: Date;
+  isCurrentMonth: boolean;
+  weekRow: number;
+  col: number; // 1–7
+}
+
+const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
+  year,
+  month,
+  events,
+  onEventClick,
+  className,
+}) => {
+  const today = new Date();
+  const segments = useCalendarLayout(events, year, month);
+
+  // Build day cells — same Monday-anchor logic as useCalendarLayout
+  const { dayCells, weekCount } = useMemo(() => {
+    const firstOfMonth = new Date(year, month, 1);
+    const firstMonday = new Date(firstOfMonth);
+    const dow = firstOfMonth.getDay();
+    firstMonday.setDate(firstOfMonth.getDate() + (dow === 0 ? -6 : 1 - dow));
+
+    const cells: DayCell[] = [];
+    let weekRow = 0;
+    let col = 1;
+
+    // 6 weeks × 7 days
+    for (let i = 0; i < 42; i++) {
+      const date = new Date(firstMonday);
+      date.setDate(firstMonday.getDate() + i);
+      cells.push({
+        date,
+        isCurrentMonth: date.getMonth() === month,
+        weekRow,
+        col,
+      });
+      col++;
+      if (col > 7) {
+        col = 1;
+        weekRow++;
+      }
+    }
+
+    // Trim trailing empty weeks (all outside current month)
+    const isWeekAllOutsideMonth = (w: number) =>
+      cells.filter((c) => c.weekRow === w).every((c) => !c.isCurrentMonth);
+
+    let lastWeek = 5;
+    while (lastWeek > 0 && isWeekAllOutsideMonth(lastWeek)) {
+      lastWeek--;
+    }
+
+    return {
+      dayCells: cells.filter((c) => c.weekRow <= lastWeek),
+      weekCount: lastWeek + 1,
+    };
+  }, [year, month]);
+
+  // Calculate min-height per week row based on max lane used
+  const rowMinHeights = useMemo(() => {
+    const heights: number[] = Array(weekCount).fill(BASE_ROW_HEIGHT_PX);
+    for (const seg of segments) {
+      if (seg.weekRow < weekCount) {
+        const needed = TOP_OFF + (seg.lane + 1) * (BAR_H + BAR_G) + 4;
+        if (needed > heights[seg.weekRow]) {
+          heights[seg.weekRow] = needed;
+        }
+      }
+    }
+    return heights;
+  }, [segments, weekCount]);
+
+  const isToday = (date: Date) =>
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+
+  // Group segments by weekRow for rendering
+  const segmentsByRow = useMemo(() => {
+    const map = new Map<number, EventSegment[]>();
+    for (const seg of segments) {
+      const list = map.get(seg.weekRow) ?? [];
+      list.push(seg);
+      map.set(seg.weekRow, list);
+    }
+    return map;
+  }, [segments]);
+
+  return (
+    <div className={`flex flex-col border border-gray-200 rounded-lg overflow-hidden bg-white${className ? ` ${className}` : ""}`}>
+      {/* Header row */}
+      <div className="grid grid-cols-7 border-b border-gray-200 flex-shrink-0">
+        {WEEK_DAYS.map((day) => (
+          <div
+            key={day}
+            className="py-2 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Week rows */}
+      <div className="flex flex-col flex-1">
+      {Array.from({ length: weekCount }, (_, w) => {
+        const rowCells = dayCells.filter((c) => c.weekRow === w);
+        const rowSegs = segmentsByRow.get(w) ?? [];
+
+        return (
+          <div
+            key={w}
+            className="relative flex-1 grid grid-cols-7 border-b border-gray-200 last:border-b-0"
+            style={{ minHeight: rowMinHeights[w] }}
+          >
+            {/* Background: day cells */}
+            {rowCells.map((cell) => (
+              <div
+                key={cell.date.toISOString()}
+                className={`
+                  border-r border-gray-100 last:border-r-0 p-1
+                  ${!cell.isCurrentMonth ? "bg-gray-50" : ""}
+                `}
+              >
+                <span
+                  className={`
+                    inline-flex items-center justify-center w-6 h-6 text-sm rounded-full
+                    ${
+                      isToday(cell.date)
+                        ? "bg-indigo-600 text-white font-bold"
+                        : cell.isCurrentMonth
+                          ? "text-gray-900"
+                          : "text-gray-400"
+                    }
+                  `}
+                >
+                  {cell.date.getDate()}
+                </span>
+              </div>
+            ))}
+
+            {/* Overlay: event bars — direct absolutely positioned grid children */}
+            <div
+              className="absolute inset-0 grid grid-cols-7"
+              style={{ pointerEvents: "none" }}
+            >
+              {rowSegs.map((seg) => (
+                <MarketingEventBar
+                  key={`${seg.event.id}-${seg.weekRow}`}
+                  event={seg.event}
+                  startCol={seg.startCol}
+                  endCol={seg.endCol}
+                  lane={seg.lane}
+                  onClick={onEventClick}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+      </div>
+    </div>
+  );
+};
+
+export default MarketingMonthCalendar;

--- a/frontend/src/components/marketing/calendar/useCalendarLayout.ts
+++ b/frontend/src/components/marketing/calendar/useCalendarLayout.ts
@@ -1,0 +1,106 @@
+import { useMemo } from "react";
+
+export interface CalendarEvent {
+  id: number;
+  title: string;
+  actionType: string;
+  dateFrom: string; // "YYYY-MM-DD"
+  dateTo: string; // "YYYY-MM-DD"
+  associatedProducts: string[];
+}
+
+export interface EventSegment {
+  event: CalendarEvent;
+  startCol: number; // 1–7 (Mon=1 … Sun=7)
+  endCol: number; // 1–7, inclusive
+  weekRow: number; // 0-based week index within the month grid
+  lane: number; // 0-based vertical stack position
+}
+
+// Returns the Mon-based column (1=Mon, 7=Sun) for a given Date
+function toCol(date: Date): number {
+  const day = date.getDay(); // 0=Sun
+  return day === 0 ? 7 : day;
+}
+
+export function useCalendarLayout(
+  events: CalendarEvent[],
+  year: number,
+  month: number, // 0-based (0=Jan)
+): EventSegment[] {
+  return useMemo(() => {
+    if (!events.length) return [];
+
+    // Build week-row boundaries: each row covers Mon–Sun
+    const firstOfMonth = new Date(year, month, 1);
+    // Monday of the first week shown on the calendar
+    const firstMonday = new Date(firstOfMonth);
+    const dow = firstOfMonth.getDay(); // 0=Sun
+    const offsetToMonday = dow === 0 ? -6 : 1 - dow;
+    firstMonday.setDate(firstOfMonth.getDate() + offsetToMonday);
+
+    // Build array of week-row start dates (Mondays)
+    const weekStarts: Date[] = [];
+    for (let w = 0; w < 6; w++) {
+      const monday = new Date(firstMonday);
+      monday.setDate(firstMonday.getDate() + w * 7);
+      weekStarts.push(monday);
+    }
+
+    // Split each event into one segment per week row it touches
+    const rawSegments: Omit<EventSegment, "lane">[] = [];
+
+    for (const event of events) {
+      const evFrom = new Date(event.dateFrom);
+      const evTo = new Date(event.dateTo);
+
+      for (let w = 0; w < weekStarts.length; w++) {
+        const weekStart = weekStarts[w]; // Monday
+        const weekEnd = new Date(weekStart);
+        weekEnd.setDate(weekStart.getDate() + 6); // Sunday
+
+        // Skip weeks that don't overlap this event
+        if (evTo < weekStart || evFrom > weekEnd) continue;
+
+        // Clamp to week boundaries
+        const segFrom = evFrom < weekStart ? weekStart : evFrom;
+        const segTo = evTo > weekEnd ? weekEnd : evTo;
+
+        rawSegments.push({
+          event,
+          startCol: toCol(segFrom),
+          endCol: toCol(segTo),
+          weekRow: w,
+        });
+      }
+    }
+
+    // Assign lanes per week row using greedy interval algorithm
+    // Sort by startCol within each row, then assign lowest free lane
+    const byRow = new Map<number, Omit<EventSegment, "lane">[]>();
+    for (const seg of rawSegments) {
+      const list = byRow.get(seg.weekRow) ?? [];
+      list.push(seg);
+      byRow.set(seg.weekRow, list);
+    }
+
+    const segments: EventSegment[] = [];
+
+    for (const [, rowSegs] of Array.from(byRow)) {
+      const sorted = [...rowSegs].sort((a, b) => a.startCol - b.startCol);
+      // laneEnd[i] = endCol of the last segment placed in lane i
+      const laneEnd: number[] = [];
+
+      for (const seg of sorted) {
+        let lane = laneEnd.findIndex((end) => end < seg.startCol);
+        if (lane === -1) {
+          lane = laneEnd.length;
+        }
+        laneEnd[lane] = seg.endCol;
+        segments.push({ ...seg, lane });
+      }
+    }
+
+    return segments;
+  }, [events, year, month]);
+}

--- a/frontend/src/components/marketing/detail/MarketingActionModal.tsx
+++ b/frontend/src/components/marketing/detail/MarketingActionModal.tsx
@@ -1,0 +1,444 @@
+import React, { useState, useEffect } from "react";
+import { X, Plus, Trash2 } from "lucide-react";
+import type { MarketingActionDto } from "../list/MarketingActionGrid";
+import {
+  useCreateMarketingAction,
+  useUpdateMarketingAction,
+  useDeleteMarketingAction,
+} from "../../../api/hooks/useMarketingCalendar";
+
+const ACTION_TYPE_OPTIONS = [
+  { value: 0, label: "Sociální sítě", backendName: "General" },
+  { value: 1, label: "Událost", backendName: "Promotion" },
+  { value: 2, label: "Email", backendName: "Launch" },
+  { value: 3, label: "PR", backendName: "Campaign" },
+  { value: 4, label: "Fotografie", backendName: "Event" },
+  { value: 99, label: "Ostatní", backendName: "Other" },
+];
+
+const FOLDER_TYPE_OPTIONS = [
+  { value: 0, label: "Obrázky", backendName: "General" },
+  { value: 1, label: "Texty", backendName: "Seasonal" },
+  { value: 2, label: "Videa", backendName: "ProductLine" },
+  { value: 3, label: "Grafika", backendName: "Campaign" },
+  { value: 99, label: "Ostatní", backendName: "Other" },
+];
+
+const resolveOptionValue = (
+  options: Array<{ value: number; backendName: string }>,
+  raw: string | number | undefined,
+): number => {
+  if (raw == null) return options[0]?.value ?? 0;
+  const numeric = Number(raw);
+  const byValue = options.find((o) => !isNaN(numeric) && o.value === numeric);
+  if (byValue) return byValue.value;
+  const byName = options.find((o) => o.backendName === String(raw));
+  return byName?.value ?? options[0]?.value ?? 0;
+};
+
+interface FolderLinkInput {
+  path: string;
+  label: string;
+  folderType: number;
+}
+
+interface FormState {
+  title: string;
+  detail: string;
+  actionType: number;
+  dateFrom: string;
+  dateTo: string;
+  associatedProducts: string[];
+  folderLinks: FolderLinkInput[];
+  productInput: string;
+}
+
+const EMPTY_FORM: FormState = {
+  title: "",
+  detail: "",
+  actionType: 0,
+  dateFrom: "",
+  dateTo: "",
+  associatedProducts: [],
+  folderLinks: [],
+  productInput: "",
+};
+
+interface MarketingActionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  existingAction?: MarketingActionDto | null;
+}
+
+const toDateInputValue = (d: string | Date | undefined): string => {
+  if (!d) return "";
+  if (d instanceof Date) {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+  return String(d).substring(0, 10);
+};
+
+const FORM_ID = "marketing-action-form";
+
+const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
+  isOpen,
+  onClose,
+  existingAction,
+}) => {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  const createMutation = useCreateMarketingAction();
+  const updateMutation = useUpdateMarketingAction();
+  const deleteMutation = useDeleteMarketingAction();
+
+  const isEdit = !!existingAction;
+
+  useEffect(() => {
+    if (existingAction) {
+      setForm({
+        title: existingAction.title ?? "",
+        detail: existingAction.detail ?? "",
+        actionType: resolveOptionValue(ACTION_TYPE_OPTIONS, existingAction.actionType),
+        dateFrom: toDateInputValue(existingAction.dateFrom),
+        dateTo: toDateInputValue(existingAction.dateTo),
+        associatedProducts: existingAction.associatedProducts ?? [],
+        folderLinks: (existingAction.folderLinks ?? []).map((fl) => ({
+          path: fl.path ?? "",
+          label: fl.label ?? "",
+          folderType: resolveOptionValue(FOLDER_TYPE_OPTIONS, fl.folderType),
+        })),
+        productInput: "",
+      });
+    } else {
+      setForm(EMPTY_FORM);
+    }
+    setError(null);
+  }, [existingAction, isOpen]);
+
+  if (!isOpen) return null;
+
+  const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const addProduct = () => {
+    const code = form.productInput.trim().toUpperCase();
+    if (code && !form.associatedProducts.includes(code)) {
+      set("associatedProducts", [...form.associatedProducts, code]);
+      set("productInput", "");
+    }
+  };
+
+  const removeProduct = (code: string) =>
+    set(
+      "associatedProducts",
+      form.associatedProducts.filter((p) => p !== code),
+    );
+
+  const addFolderLink = () =>
+    set("folderLinks", [
+      ...form.folderLinks,
+      { path: "", label: "", folderType: 0 },
+    ]);
+
+  const updateFolderLink = (
+    i: number,
+    field: keyof FolderLinkInput,
+    value: string | number,
+  ) =>
+    set(
+      "folderLinks",
+      form.folderLinks.map((fl, idx) =>
+        idx === i ? { ...fl, [field]: value } : fl,
+      ),
+    );
+
+  const removeFolderLink = (i: number) =>
+    set(
+      "folderLinks",
+      form.folderLinks.filter((_, idx) => idx !== i),
+    );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const payload = {
+      title: form.title.trim(),
+      description: form.detail.trim() || undefined,
+      actionType: form.actionType,
+      startDate: new Date(form.dateFrom),
+      endDate: form.dateTo ? new Date(form.dateTo) : undefined,
+      associatedProducts: form.associatedProducts,
+      folderLinks: form.folderLinks
+        .filter((fl) => fl.path.trim())
+        .map((fl) => ({
+          folderKey: fl.path.trim(),
+          folderType: fl.folderType,
+        })),
+    };
+
+    try {
+      if (isEdit && existingAction?.id != null) {
+        await updateMutation.mutateAsync({ id: existingAction.id, request: payload });
+      } else {
+        await createMutation.mutateAsync(payload);
+      }
+      onClose();
+    } catch {
+      setError("Nepodařilo se uložit akci. Zkuste to znovu.");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!existingAction?.id) return;
+    if (!window.confirm(`Opravdu smazat akci "${existingAction.title}"?`))
+      return;
+    try {
+      await deleteMutation.mutateAsync(existingAction.id);
+      onClose();
+    } catch {
+      setError("Nepodařilo se smazat akci.");
+    }
+  };
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+  const isDeleting = deleteMutation.isPending;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {isEdit ? "Upravit akci" : "Nová marketingová akce"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <X className="h-5 w-5 text-gray-500" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <form
+          id={FORM_ID}
+          onSubmit={handleSubmit}
+          className="flex-1 overflow-y-auto px-6 py-4 space-y-4"
+        >
+          {error && (
+            <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-md px-3 py-2">
+              {error}
+            </div>
+          )}
+
+          {/* Title */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Název *
+            </label>
+            <input
+              required
+              value={form.title}
+              onChange={(e) => set("title", e.target.value)}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+
+          {/* ActionType + dates row */}
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Typ *
+              </label>
+              <select
+                value={form.actionType}
+                onChange={(e) => set("actionType", Number(e.target.value))}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                {ACTION_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Od *
+              </label>
+              <input
+                required
+                type="date"
+                value={form.dateFrom}
+                onChange={(e) => set("dateFrom", e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Do *
+              </label>
+              <input
+                required
+                type="date"
+                value={form.dateTo}
+                min={form.dateFrom}
+                onChange={(e) => set("dateTo", e.target.value)}
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+          </div>
+
+          {/* Detail */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Popis
+            </label>
+            <textarea
+              value={form.detail}
+              onChange={(e) => set("detail", e.target.value)}
+              rows={3}
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+            />
+          </div>
+
+          {/* Products */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Produkty
+            </label>
+            <div className="flex gap-2">
+              <input
+                value={form.productInput}
+                onChange={(e) => set("productInput", e.target.value)}
+                onKeyDown={(e) =>
+                  e.key === "Enter" && (e.preventDefault(), addProduct())
+                }
+                placeholder="Kód produktu (Enter)"
+                className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+              <button
+                type="button"
+                onClick={addProduct}
+                className="px-3 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 transition-colors"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </div>
+            {form.associatedProducts.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-2">
+                {form.associatedProducts.map((code) => (
+                  <span
+                    key={code}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-100 text-indigo-800 rounded text-xs"
+                  >
+                    {code}
+                    <button type="button" onClick={() => removeProduct(code)}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Folder links */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="block text-sm font-medium text-gray-700">
+                Složky
+              </label>
+              <button
+                type="button"
+                onClick={addFolderLink}
+                className="text-xs text-indigo-600 hover:text-indigo-800 flex items-center gap-1"
+              >
+                <Plus className="h-3 w-3" /> Přidat složku
+              </button>
+            </div>
+            <div className="space-y-2">
+              {form.folderLinks.map((fl, i) => (
+                <div key={i} className="flex gap-2 items-start">
+                  <input
+                    value={fl.path}
+                    onChange={(e) => updateFolderLink(i, "path", e.target.value)}
+                    placeholder="Cesta ke složce"
+                    className="flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <input
+                    value={fl.label}
+                    onChange={(e) =>
+                      updateFolderLink(i, "label", e.target.value)
+                    }
+                    placeholder="Popis (volitelný)"
+                    className="w-32 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                  <select
+                    value={fl.folderType}
+                    onChange={(e) =>
+                      updateFolderLink(i, "folderType", Number(e.target.value))
+                    }
+                    className="w-28 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    {FOLDER_TYPE_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => removeFolderLink(i)}
+                    className="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </form>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t border-gray-200">
+          <div>
+            {isEdit && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-md transition-colors disabled:opacity-50"
+              >
+                {isDeleting ? "Mazání..." : "Smazat"}
+              </button>
+            )}
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+            >
+              Zrušit
+            </button>
+            <button
+              type="submit"
+              form={FORM_ID}
+              disabled={isSaving}
+              className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md transition-colors disabled:opacity-50"
+            >
+              {isSaving ? "Ukládání..." : isEdit ? "Uložit" : "Vytvořit"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MarketingActionModal;

--- a/frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx
+++ b/frontend/src/components/marketing/detail/__tests__/MarketingActionModal.test.tsx
@@ -1,0 +1,271 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MarketingActionModal from "../MarketingActionModal";
+import type { MarketingActionDto } from "../../list/MarketingActionGrid";
+
+const mockCreateMutateAsync = jest.fn();
+const mockUpdateMutateAsync = jest.fn();
+const mockDeleteMutateAsync = jest.fn();
+
+jest.mock("../../../../api/hooks/useMarketingCalendar", () => ({
+  useCreateMarketingAction: () => ({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+  }),
+  useUpdateMarketingAction: () => ({
+    mutateAsync: mockUpdateMutateAsync,
+    isPending: false,
+  }),
+  useDeleteMarketingAction: () => ({
+    mutateAsync: mockDeleteMutateAsync,
+    isPending: false,
+  }),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  existingAction: null,
+};
+
+function fillRequiredFields() {
+  const titleInput = screen.getAllByRole("textbox")[0];
+  fireEvent.change(titleInput, { target: { value: "Test akce" } });
+
+  const dateInputs = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+  fireEvent.change(dateInputs[0], { target: { value: "2026-05-01" } });
+  fireEvent.change(dateInputs[1], { target: { value: "2026-05-31" } });
+}
+
+function submitForm() {
+  fireEvent.submit(document.getElementById("marketing-action-form")!);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreateMutateAsync.mockResolvedValue({});
+  mockUpdateMutateAsync.mockResolvedValue({});
+  mockDeleteMutateAsync.mockResolvedValue({});
+});
+
+// ─── CREATE ────────────────────────────────────────────────────────────────────
+
+describe("MarketingActionModal — create", () => {
+  it("submits actionType as a number, not a label string", async () => {
+    render(<MarketingActionModal {...defaultProps} />);
+    fillRequiredFields();
+    submitForm();
+
+    await waitFor(() =>
+      expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ actionType: 0 }),
+      ),
+    );
+    expect(typeof mockCreateMutateAsync.mock.calls[0][0].actionType).toBe("number");
+  });
+
+  it('submits "Ostatní" actionType as 99, not 5', async () => {
+    render(<MarketingActionModal {...defaultProps} />);
+    fillRequiredFields();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "99" } });
+    submitForm();
+
+    await waitFor(() =>
+      expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ actionType: 99 }),
+      ),
+    );
+  });
+
+  it("submits startDate and endDate as Date objects", async () => {
+    render(<MarketingActionModal {...defaultProps} />);
+    fillRequiredFields();
+    submitForm();
+
+    await waitFor(() => {
+      const payload = mockCreateMutateAsync.mock.calls[0][0];
+      expect(payload.startDate).toBeInstanceOf(Date);
+      expect(payload.endDate).toBeInstanceOf(Date);
+    });
+  });
+
+  it("calls onClose after successful submit", async () => {
+    const onClose = jest.fn();
+    render(<MarketingActionModal {...defaultProps} onClose={onClose} />);
+    fillRequiredFields();
+    submitForm();
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("shows error message when create fails", async () => {
+    mockCreateMutateAsync.mockRejectedValue(new Error("API error"));
+    render(<MarketingActionModal {...defaultProps} />);
+    fillRequiredFields();
+    submitForm();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Nepodařilo se uložit akci. Zkuste to znovu."),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+// ─── EDIT — field population ───────────────────────────────────────────────────
+
+describe("MarketingActionModal — edit field population", () => {
+  const existingAction: MarketingActionDto = {
+    id: 1,
+    title: "Existující akce",
+    detail: "Popis akce",
+    actionType: "Other",
+    dateFrom: "2026-04-01T10:00:00",
+    dateTo: "2026-04-30T23:59:00",
+    associatedProducts: ["AKL001", "AKL002"],
+    folderLinks: [{ path: "folder/key", label: "Složka", folderType: "Campaign" }],
+  };
+
+  it("populates title", () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue("Existující akce");
+  });
+
+  it("populates dateFrom as YYYY-MM-DD from ISO string", () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    const dates = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    expect(dates[0]).toHaveValue("2026-04-01");
+  });
+
+  it("populates dateTo as YYYY-MM-DD from ISO string", () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    const dates = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    expect(dates[1]).toHaveValue("2026-04-30");
+  });
+
+  it("populates dateFrom as YYYY-MM-DD from Date object", () => {
+    render(
+      <MarketingActionModal
+        {...defaultProps}
+        existingAction={{ ...existingAction, dateFrom: new Date("2026-04-15T00:00:00") }}
+      />,
+    );
+    const dates = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    expect(dates[0]).toHaveValue("2026-04-15");
+  });
+
+  it('restores actionType "Other" (backend name) to select value 99', () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    const actionTypeSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    expect(actionTypeSelect.value).toBe("99");
+  });
+
+  it("restores actionType by backend enum name (Launch → 2)", () => {
+    render(
+      <MarketingActionModal
+        {...defaultProps}
+        existingAction={{ ...existingAction, actionType: "Launch" }}
+      />,
+    );
+    const actionTypeSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    expect(actionTypeSelect.value).toBe("2");
+  });
+
+  it("restores actionType by numeric string (e.g. '2')", () => {
+    render(
+      <MarketingActionModal
+        {...defaultProps}
+        existingAction={{ ...existingAction, actionType: "2" }}
+      />,
+    );
+    const actionTypeSelect = screen.getAllByRole("combobox")[0] as HTMLSelectElement;
+    expect(actionTypeSelect.value).toBe("2");
+  });
+
+  it("populates associatedProducts chips", () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    expect(screen.getByText("AKL001")).toBeInTheDocument();
+    expect(screen.getByText("AKL002")).toBeInTheDocument();
+  });
+});
+
+// ─── EDIT — submit payload ─────────────────────────────────────────────────────
+
+describe("MarketingActionModal — edit submit", () => {
+  const existingAction: MarketingActionDto = {
+    id: 1,
+    title: "Existující akce",
+    detail: "Popis",
+    actionType: "Other",
+    dateFrom: "2026-04-01T00:00:00",
+    dateTo: "2026-04-30T00:00:00",
+    associatedProducts: [],
+    folderLinks: [{ path: "folder/key", label: "Složka", folderType: "Campaign" }],
+  };
+
+  it("submits actionType as number 99 when editing Other", async () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    submitForm();
+
+    await waitFor(() =>
+      expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 1,
+          request: expect.objectContaining({ actionType: 99 }),
+        }),
+      ),
+    );
+  });
+
+  it("submits folderType as number (Campaign → 3)", async () => {
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+    submitForm();
+
+    await waitFor(() => {
+      const { request } = mockUpdateMutateAsync.mock.calls[0][0];
+      expect(request.folderLinks[0].folderType).toBe(3);
+    });
+  });
+});
+
+// ─── DELETE ────────────────────────────────────────────────────────────────────
+
+describe("MarketingActionModal — delete", () => {
+  const existingAction: MarketingActionDto = {
+    id: 42,
+    title: "Ke smazání",
+    actionType: "General",
+    dateFrom: "2026-04-01",
+    dateTo: "2026-04-30",
+  };
+
+  it("calls delete mutation with action id after confirmation", async () => {
+    window.confirm = jest.fn(() => true);
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /smazat/i }));
+
+    await waitFor(() => expect(mockDeleteMutateAsync).toHaveBeenCalledWith(42));
+  });
+
+  it("does not delete when confirmation is cancelled", async () => {
+    window.confirm = jest.fn(() => false);
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /smazat/i }));
+
+    await waitFor(() => expect(mockDeleteMutateAsync).not.toHaveBeenCalled());
+  });
+
+  it("shows error when delete fails", async () => {
+    window.confirm = jest.fn(() => true);
+    mockDeleteMutateAsync.mockRejectedValue(new Error("Delete failed"));
+    render(<MarketingActionModal {...defaultProps} existingAction={existingAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /smazat/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Nepodařilo se smazat akci.")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/marketing/list/MarketingActionFilters.tsx
+++ b/frontend/src/components/marketing/list/MarketingActionFilters.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { X } from "lucide-react";
+
+interface Filters {
+  searchText: string;
+  dateFrom: string;
+  dateTo: string;
+}
+
+interface MarketingActionFiltersProps {
+  filters: Filters;
+  onChange: (filters: Filters) => void;
+  onClear: () => void;
+}
+
+const EMPTY_FILTERS: Filters = { searchText: "", dateFrom: "", dateTo: "" };
+
+const hasActiveFilters = (f: Filters) =>
+  f.searchText !== "" || f.dateFrom !== "" || f.dateTo !== "";
+
+const MarketingActionFilters: React.FC<MarketingActionFiltersProps> = ({
+  filters,
+  onChange,
+  onClear,
+}) => {
+  const set =
+    (key: keyof Filters) => (e: React.ChangeEvent<HTMLInputElement>) =>
+      onChange({ ...filters, [key]: e.target.value });
+
+  return (
+    <div className="flex flex-wrap gap-3 items-center p-4 bg-white border border-gray-200 rounded-lg">
+      <input
+        type="text"
+        placeholder="Hledat název..."
+        value={filters.searchText}
+        onChange={set("searchText")}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 min-w-[200px]"
+      />
+      <input
+        type="date"
+        value={filters.dateFrom}
+        onChange={set("dateFrom")}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        title="Od"
+      />
+      <span className="text-gray-400 text-sm">–</span>
+      <input
+        type="date"
+        value={filters.dateTo}
+        onChange={set("dateTo")}
+        className="border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        title="Do"
+      />
+      {hasActiveFilters(filters) && (
+        <button
+          onClick={onClear}
+          className="flex items-center gap-1 px-3 py-2 text-sm text-gray-600 hover:text-gray-900 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+        >
+          <X className="h-3 w-3" />
+          Zrušit filtry
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default MarketingActionFilters;
+export { EMPTY_FILTERS };
+export type { Filters as MarketingFilters };

--- a/frontend/src/components/marketing/list/MarketingActionGrid.tsx
+++ b/frontend/src/components/marketing/list/MarketingActionGrid.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export interface MarketingActionDto {
+  id?: number;
+  title?: string;
+  detail?: string;
+  actionType?: string;
+  dateFrom?: string | Date;
+  dateTo?: string | Date;
+  associatedProducts?: string[];
+  folderLinks?: Array<{
+    path?: string;
+    label?: string;
+    folderType?: string;
+  }>;
+}
+
+const ACTION_TYPE_BADGE: Record<string, string> = {
+  SocialMedia: "bg-blue-100 text-blue-800",
+  Event: "bg-purple-100 text-purple-800",
+  Email: "bg-green-100 text-green-800",
+  PR: "bg-yellow-100 text-yellow-800",
+  Photoshoot: "bg-pink-100 text-pink-800",
+  Other: "bg-gray-100 text-gray-800",
+};
+
+const ACTION_TYPE_LABELS: Record<string, string> = {
+  SocialMedia: "Sociální sítě",
+  Event: "Událost",
+  Email: "Email",
+  PR: "PR",
+  Photoshoot: "Fotografie",
+  Other: "Ostatní",
+};
+
+const formatDate = (d: string | Date | null | undefined) => {
+  if (!d) return "—";
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleDateString("cs-CZ");
+};
+
+interface MarketingActionGridProps {
+  actions: MarketingActionDto[];
+  totalPages: number;
+  pageNumber: number;
+  onPageChange: (page: number) => void;
+  onActionClick: (id: number) => void;
+  isLoading?: boolean;
+}
+
+const MarketingActionGrid: React.FC<MarketingActionGridProps> = ({
+  actions,
+  totalPages,
+  pageNumber,
+  onPageChange,
+  onActionClick,
+  isLoading,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="p-8 text-center text-gray-500 text-sm">Načítání...</div>
+    );
+  }
+
+  if (actions.length === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500 text-sm">
+        Žádné marketingové akce nebyly nalezeny.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {["Název", "Typ", "Od", "Do", "Produkty"].map((h) => (
+                <th
+                  key={h}
+                  className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {actions.map((action) => (
+              <tr
+                key={action.id}
+                onClick={() => onActionClick(action.id!)}
+                className="hover:bg-gray-50 cursor-pointer transition-colors"
+              >
+                <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                  {action.title}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                      ACTION_TYPE_BADGE[action.actionType ?? ""] ??
+                      ACTION_TYPE_BADGE.Other
+                    }`}
+                  >
+                    {ACTION_TYPE_LABELS[action.actionType ?? ""] ??
+                      action.actionType}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {formatDate(action.dateFrom as string)}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {formatDate(action.dateTo as string)}
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-600">
+                  {action.associatedProducts?.join(", ") || "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 px-4 py-3 border-t border-gray-200">
+          <button
+            onClick={() => onPageChange(pageNumber - 1)}
+            disabled={pageNumber <= 1}
+            className="p-1 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4 text-gray-600" />
+          </button>
+          <span className="text-sm text-gray-600">
+            {pageNumber} / {totalPages}
+          </span>
+          <button
+            onClick={() => onPageChange(pageNumber + 1)}
+            disabled={pageNumber >= totalPages}
+            className="p-1 rounded hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronRight className="h-4 w-4 text-gray-600" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MarketingActionGrid;

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -1,0 +1,256 @@
+import React, { useState, useMemo } from "react";
+import { Plus, Calendar, List } from "lucide-react";
+import CalendarNavigation from "../../manufacture/calendar/CalendarNavigation";
+import MarketingMonthCalendar from "../calendar/MarketingMonthCalendar";
+import MarketingActionGrid from "../list/MarketingActionGrid";
+import type { MarketingActionDto } from "../list/MarketingActionGrid";
+import MarketingActionFilters, {
+  EMPTY_FILTERS,
+  type MarketingFilters,
+} from "../list/MarketingActionFilters";
+import MarketingActionModal from "../detail/MarketingActionModal";
+import {
+  useMarketingCalendar,
+  useMarketingActions,
+  useMarketingAction,
+} from "../../../api/hooks/useMarketingCalendar";
+import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
+
+const CZECH_MONTHS = [
+  "Leden",
+  "Únor",
+  "Březen",
+  "Duben",
+  "Květen",
+  "Červen",
+  "Červenec",
+  "Srpen",
+  "Září",
+  "Říjen",
+  "Listopad",
+  "Prosinec",
+];
+
+type ViewMode = "calendar" | "list";
+
+const MarketingCalendarPage: React.FC = () => {
+  const [viewMode, setViewMode] = useState<ViewMode>("calendar");
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [filters, setFilters] = useState<MarketingFilters>(EMPTY_FILTERS);
+  const [pageNumber, setPageNumber] = useState(1);
+  const [selectedActionId, setSelectedActionId] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingAction, setEditingAction] = useState<MarketingActionDto | null>(
+    null,
+  );
+
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+
+  // Calendar query — first and last day of the displayed month grid
+  const { startDate, endDate } = useMemo(() => {
+    const first = new Date(year, month, 1);
+    const firstMonday = new Date(first);
+    const dow = first.getDay();
+    firstMonday.setDate(first.getDate() + (dow === 0 ? -6 : 1 - dow));
+    const lastSunday = new Date(firstMonday);
+    lastSunday.setDate(firstMonday.getDate() + 41);
+    return {
+      startDate: firstMonday,
+      endDate: lastSunday,
+    };
+  }, [year, month]);
+
+  const calendarQuery = useMarketingCalendar({ startDate, endDate });
+  const listQuery = useMarketingActions({
+    pageNumber,
+    searchTerm: filters.searchText || undefined,
+    startDateFrom: filters.dateFrom ? new Date(filters.dateFrom) : undefined,
+    startDateTo: filters.dateTo ? new Date(filters.dateTo) : undefined,
+  });
+  const detailQuery = useMarketingAction(selectedActionId ?? 0);
+
+  const calendarEvents = useMemo(
+    () =>
+      ((calendarQuery.data as any)?.actions ?? []).map((a: any) => ({
+        id: a.id!,
+        title: a.title ?? "",
+        actionType: a.actionType ?? "Other",
+        dateFrom: String(a.dateFrom ?? a.startDate ?? ""),
+        dateTo: String(a.dateTo ?? a.endDate ?? ""),
+        associatedProducts: a.associatedProducts ?? [],
+      })),
+    [calendarQuery.data],
+  );
+
+  const listActions: MarketingActionDto[] = useMemo(
+    () =>
+      ((listQuery.data as any)?.actions ?? []).map((a: any) => ({
+        id: a.id,
+        title: a.title,
+        detail: a.description,
+        actionType: a.actionType,
+        dateFrom: a.startDate ?? a.dateFrom,
+        dateTo: a.endDate ?? a.dateTo,
+        associatedProducts: a.associatedProducts,
+        folderLinks: a.folderLinks,
+      })),
+    [listQuery.data],
+  );
+
+  const totalPages: number = (listQuery.data as any)?.totalPages ?? 1;
+
+  const periodLabel = `${CZECH_MONTHS[month]} ${year}`;
+
+  const goToPrev = () =>
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() - 1, 1));
+  const goToNext = () =>
+    setCurrentDate((d) => new Date(d.getFullYear(), d.getMonth() + 1, 1));
+  const goToToday = () => setCurrentDate(new Date());
+
+  const openCreate = () => {
+    setEditingAction(null);
+    setIsModalOpen(true);
+  };
+
+  const openEdit = (id: number) => {
+    setSelectedActionId(id);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setEditingAction(null);
+    setSelectedActionId(null);
+  };
+
+  // Sync detail data into editingAction when it arrives
+  React.useEffect(() => {
+    if ((detailQuery.data as any)?.action) {
+      const a = (detailQuery.data as any).action;
+      setEditingAction({
+        id: a.id,
+        title: a.title,
+        detail: a.description ?? a.detail,
+        actionType: a.actionType,
+        dateFrom: a.startDate ?? a.dateFrom,
+        dateTo: a.endDate ?? a.dateTo,
+        associatedProducts: a.associatedProducts,
+        folderLinks: a.folderLinks,
+      });
+    }
+  }, [detailQuery.data]);
+
+  return (
+    <div className="flex flex-col" style={{ height: PAGE_CONTAINER_HEIGHT }}>
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-6 py-4 bg-white border-b border-gray-200 flex-shrink-0">
+        <h1 className="text-xl font-semibold text-gray-900">
+          Marketingový kalendář
+        </h1>
+        <div className="flex items-center gap-3">
+          {/* View toggle */}
+          <div className="flex border border-gray-200 rounded-lg overflow-hidden">
+            <button
+              onClick={() => setViewMode("calendar")}
+              className={`px-3 py-2 text-sm flex items-center gap-1.5 transition-colors ${
+                viewMode === "calendar"
+                  ? "bg-indigo-600 text-white"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              <Calendar className="h-4 w-4" />
+              Kalendář
+            </button>
+            <button
+              onClick={() => setViewMode("list")}
+              className={`px-3 py-2 text-sm flex items-center gap-1.5 transition-colors ${
+                viewMode === "list"
+                  ? "bg-indigo-600 text-white"
+                  : "text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              <List className="h-4 w-4" />
+              Seznam
+            </button>
+          </div>
+          <button
+            onClick={openCreate}
+            className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            Nová akce
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        {viewMode === "calendar" ? (
+          <div className="flex flex-col h-full gap-4">
+            <div className="flex-shrink-0">
+              <CalendarNavigation
+                onPrevious={goToPrev}
+                onNext={goToNext}
+                onToday={goToToday}
+                currentPeriodLabel={periodLabel}
+              />
+            </div>
+            {calendarQuery.isLoading ? (
+              <div className="text-center py-12 text-gray-500 text-sm">
+                Načítání...
+              </div>
+            ) : calendarQuery.error ? (
+              <div className="text-center py-12 text-red-500 text-sm">
+                Chyba při načítání kalendáře.
+              </div>
+            ) : (
+              <div className="flex-1 min-h-0">
+                <MarketingMonthCalendar
+                  year={year}
+                  month={month}
+                  events={calendarEvents}
+                  onEventClick={openEdit}
+                  className="h-full"
+                />
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <MarketingActionFilters
+              filters={filters}
+              onChange={(f) => {
+                setFilters(f);
+                setPageNumber(1);
+              }}
+              onClear={() => {
+                setFilters(EMPTY_FILTERS);
+                setPageNumber(1);
+              }}
+            />
+            <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+              <MarketingActionGrid
+                actions={listActions}
+                totalPages={totalPages}
+                pageNumber={pageNumber}
+                onPageChange={setPageNumber}
+                onActionClick={openEdit}
+                isLoading={listQuery.isLoading}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Modal */}
+      <MarketingActionModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        existingAction={editingAction}
+      />
+    </div>
+  );
+};
+
+export default MarketingCalendarPage;

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -202,6 +202,11 @@ const resources = {
         MarketingActionNotFound: "Marketingová akce nebyla nalezena",
         UnauthorizedMarketingAccess: "Nemáte oprávnění k této marketingové akci",
 
+        // Photobank module errors
+        PhotoNotFound: "Fotka nebyla nalezena",
+        PhotobankRootNotFound: "Kořenový adresář fotobanka nebyl nalezen",
+        PhotobankRuleNotFound: "Pravidlo tagu nebylo nalezeno",
+
         // External Service errors
         ExternalServiceError: "Chyba externí služby",
         FlexiApiError: "Chyba ABRA Flexi API",

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -198,6 +198,10 @@ const resources = {
         ShoptetOrderInvalidSourceState: "Objednávku nelze zablokovat – není ve povoleném stavu",
         ShoptetOrderNotFound: "Objednávka nebyla nalezena",
 
+        // Marketing Calendar module errors
+        MarketingActionNotFound: "Marketingová akce nebyla nalezena",
+        UnauthorizedMarketingAccess: "Nemáte oprávnění k této marketingové akci",
+
         // External Service errors
         ExternalServiceError: "Chyba externí služby",
         FlexiApiError: "Chyba ABRA Flexi API",

--- a/frontend/test/e2e/helpers/e2e-auth-helper.ts
+++ b/frontend/test/e2e/helpers/e2e-auth-helper.ts
@@ -130,16 +130,18 @@ export async function navigateToApp(page: any): Promise<void> {
 async function navigateToAppWithServicePrincipal(page: any): Promise<void> {
   // First, establish E2E session with backend
   const apiBaseUrl = process.env.PLAYWRIGHT_BASE_URL;
+  // When frontend runs on a separate port (local dev), PLAYWRIGHT_FRONTEND_URL overrides the
+  // navigation target. Falls back to apiBaseUrl for single-origin envs (staging/production).
+  const frontendBaseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || apiBaseUrl;
   const e2eAppUrl = `${apiBaseUrl}/api/e2etest/app`;
-  
+
   await page.goto(e2eAppUrl);
   await page.waitForLoadState('domcontentloaded');
-  
+
   // Extract E2E session cookie and set it for frontend domain
   const cookies = await page.context().cookies();
   const e2eCookie = cookies.find(c => c.name === 'E2ETestSession');
   if (e2eCookie) {
-    // Use the staging domain for the cookie, not localhost
     const stagingDomain = new URL(apiBaseUrl).hostname;
     await page.context().addCookies([{
       name: e2eCookie.name,
@@ -150,9 +152,9 @@ async function navigateToAppWithServicePrincipal(page: any): Promise<void> {
       sameSite: 'Lax'
     }]);
   }
-  
-  // Navigate to root first with E2E flag
-  const frontendWithE2E = `${apiBaseUrl}?e2e=true`;
+
+  // Navigate to the React frontend with E2E flag
+  const frontendWithE2E = `${frontendBaseUrl}?e2e=true`;
   
   // Get token for sessionStorage
   const token = await getServicePrincipalToken();
@@ -215,7 +217,7 @@ export async function navigateToTransportBoxes(page: any): Promise<void> {
   
   // If UI navigation fails, go directly to the path and handle the page differently
   console.log('🔄 Trying direct navigation...');
-  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
   await page.goto(`${baseUrl}/logistics/transport-boxes`);
   await page.waitForLoadState('domcontentloaded');
   await waitForPageLoad(page);
@@ -250,7 +252,7 @@ export async function navigateToCatalog(page: any): Promise<void> {
     }
   } catch (e) {
     // If UI navigation fails, go directly to the path
-    const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+    const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
     await page.goto(`${baseUrl}/catalog`);
     await page.waitForLoadState('domcontentloaded');
     await waitForLoadingComplete(page);
@@ -264,7 +266,7 @@ export async function navigateToStockOperations(page: any): Promise<void> {
   await waitForLoadingComplete(page);
 
   // Direct navigation to stock operations
-  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
   await page.goto(`${baseUrl}/stock-operations`);
   await page.waitForLoadState('domcontentloaded');
   await waitForLoadingComplete(page);
@@ -308,7 +310,7 @@ export async function navigateToTransportBoxReceive(page: any): Promise<void> {
 
   // If UI navigation fails, go directly to the path
   console.log('🔄 Trying direct navigation to transport box receive...');
-  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
   await page.goto(`${baseUrl}/warehouse/transport-box-receive`);
   await page.waitForLoadState('domcontentloaded');
   await waitForPageLoad(page);
@@ -352,7 +354,7 @@ export async function navigateToInvoiceClassification(page: any): Promise<void> 
 
   // If UI navigation fails, go directly to the path
   console.log('🔄 Trying direct navigation to invoice classification...');
-  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
   await page.goto(`${baseUrl}/purchase/invoice-classification`);
   await page.waitForLoadState('domcontentloaded');
   await waitForPageLoad(page);
@@ -396,10 +398,47 @@ export async function navigateToIssuedInvoices(page: any): Promise<void> {
 
   // If UI navigation fails, go directly to the path
   console.log('🔄 Trying direct navigation to issued invoices...');
-  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
   await page.goto(`${baseUrl}/customer/issued-invoices`);
   await page.waitForLoadState('domcontentloaded');
   await waitForLoadingComplete(page);
 
   console.log('✅ Direct navigation to issued invoices completed');
+}
+
+export async function navigateToMarketingCalendar(page: any): Promise<void> {
+  await navigateToApp(page);
+
+  await waitForLoadingComplete(page);
+
+  const baseUrl = process.env.PLAYWRIGHT_FRONTEND_URL || process.env.PLAYWRIGHT_BASE_URL || 'https://heblo.stg.anela.cz';
+
+  // Try sidebar navigation first
+  try {
+    console.log('🧭 Attempting UI navigation to marketing calendar via sidebar...');
+    const marketingSection = page.locator('button').filter({ hasText: 'Marketing' }).first();
+    if (await marketingSection.isVisible({ timeout: 5000 })) {
+      await marketingSection.click();
+      await waitForLoadingComplete(page);
+
+      const calendarLink = page.locator('text="Kalendář"').first();
+      if (await calendarLink.isVisible({ timeout: 5000 })) {
+        await calendarLink.click();
+        await page.waitForLoadState('domcontentloaded');
+        await waitForLoadingComplete(page);
+        console.log('✅ UI navigation to marketing calendar successful');
+        return;
+      }
+    }
+  } catch (e) {
+    console.log('❌ UI navigation failed:', (e as Error).message);
+  }
+
+  // Fall back to direct navigation
+  console.log('🔄 Trying direct navigation to marketing calendar...');
+  await page.goto(`${baseUrl}/marketing/calendar`);
+  await page.waitForLoadState('domcontentloaded');
+  await waitForLoadingComplete(page);
+
+  console.log('✅ Direct navigation to marketing calendar completed');
 }

--- a/frontend/test/e2e/marketing/calendar-view.spec.ts
+++ b/frontend/test/e2e/marketing/calendar-view.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import { navigateToMarketingCalendar } from '../helpers/e2e-auth-helper';
+
+test.describe('Marketing Calendar — Calendar View', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+
+    // Ensure calendar view is active (it is the default, but be explicit)
+    const calendarToggle = page.locator('button').filter({ hasText: 'Kalendář' }).first();
+    await calendarToggle.click();
+    await expect(calendarToggle).toHaveClass(/bg-indigo-600/);
+  });
+
+  test('should render day-of-week header row', async ({ page }) => {
+    // Calendar grid must show Czech weekday abbreviations Mon–Sun
+    const expectedHeaders = ['Po', 'Út', 'St', 'Čt', 'Pá', 'So', 'Ne'];
+    for (const day of expectedHeaders) {
+      await expect(page.locator(`text="${day}"`).first()).toBeVisible({ timeout: 10000 });
+    }
+  });
+
+  test('should render at least one calendar day cell', async ({ page }) => {
+    // Wait for loading to finish
+    await expect(page.locator('text=Načítání...').first()).not.toBeVisible({ timeout: 15000 });
+
+    // Day numbers 1–31 appear in the calendar grid
+    const dayOne = page.locator('text="1"').first();
+    await expect(dayOne).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should navigate to previous month', async ({ page }) => {
+    const czechMonths = [
+      'Leden', 'Únor', 'Březen', 'Duben', 'Květen', 'Červen',
+      'Červenec', 'Srpen', 'Září', 'Říjen', 'Listopad', 'Prosinec',
+    ];
+
+    const now = new Date();
+    const prevMonthIndex = now.getMonth() === 0 ? 11 : now.getMonth() - 1;
+    const prevMonthName = czechMonths[prevMonthIndex];
+    const prevYear = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear();
+
+    // CalendarNavigation renders prev/next as icon buttons; locate by position in nav row
+    // The period label sits between the navigation buttons — click the first button before it
+    const periodLabel = page.locator(`text=/${czechMonths[now.getMonth()]}/`).first();
+    await expect(periodLabel).toBeVisible({ timeout: 10000 });
+
+    // Prev button is the first sibling button before the period label
+    const navButtons = page.locator('button').filter({ hasText: /^$/ }); // icon-only buttons
+    await navButtons.first().click();
+
+    await expect(page.locator(`text=/${prevMonthName}/`).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(`text=/${prevYear}/`).first()).toBeVisible();
+  });
+
+  test('should navigate to next month', async ({ page }) => {
+    const czechMonths = [
+      'Leden', 'Únor', 'Březen', 'Duben', 'Květen', 'Červen',
+      'Červenec', 'Srpen', 'Září', 'Říjen', 'Listopad', 'Prosinec',
+    ];
+
+    const now = new Date();
+    const nextMonthIndex = (now.getMonth() + 1) % 12;
+    const nextMonthName = czechMonths[nextMonthIndex];
+    const nextYear = now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear();
+
+    // Next button follows the period label — it's the last icon-only button in the nav row
+    const navButtons = page.locator('button').filter({ hasText: /^$/ });
+    await navButtons.last().click();
+
+    await expect(page.locator(`text=/${nextMonthName}/`).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(`text=/${nextYear}/`).first()).toBeVisible();
+  });
+
+  test('should return to current month when clicking Dnes', async ({ page }) => {
+    const czechMonths = [
+      'Leden', 'Únor', 'Březen', 'Duben', 'Květen', 'Červen',
+      'Červenec', 'Srpen', 'Září', 'Říjen', 'Listopad', 'Prosinec',
+    ];
+    const currentMonthName = czechMonths[new Date().getMonth()];
+
+    // Navigate away to next month first
+    const navButtons = page.locator('button').filter({ hasText: /^$/ });
+    await navButtons.last().click();
+
+    // Return via Dnes button
+    const todayButton = page.locator('button').filter({ hasText: 'Dnes' }).first();
+    await expect(todayButton).toBeVisible({ timeout: 5000 });
+    await todayButton.click();
+
+    await expect(page.locator(`text=/${currentMonthName}/`).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('should open edit modal when clicking an event bar', async ({ page }) => {
+    // Event bars are only present when there are marketing actions in the current month.
+    // Locate by background-color style (MarketingEventBar sets inline bg colour by action type).
+    await expect(page.locator('text=Načítání...').first()).not.toBeVisible({ timeout: 15000 });
+
+    const eventBars = page.locator('[style*="background-color"]').filter({ hasText: /.+/ });
+    const count = await eventBars.count();
+
+    if (count === 0) {
+      console.log('No event bars found in current month — skipping click test');
+      return;
+    }
+
+    await eventBars.first().click();
+
+    // Edit modal opens — Uložit and Zrušit buttons appear
+    await expect(page.locator('button').filter({ hasText: 'Uložit' }).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button').filter({ hasText: 'Zrušit' }).first()).toBeVisible();
+  });
+
+  test('should close edit modal via Zrušit', async ({ page }) => {
+    await expect(page.locator('text=Načítání...').first()).not.toBeVisible({ timeout: 15000 });
+
+    const eventBars = page.locator('[style*="background-color"]').filter({ hasText: /.+/ });
+    const count = await eventBars.count();
+
+    if (count === 0) {
+      console.log('No event bars found — skipping close-modal test');
+      return;
+    }
+
+    await eventBars.first().click();
+
+    const cancelButton = page.locator('button').filter({ hasText: 'Zrušit' }).first();
+    await expect(cancelButton).toBeVisible({ timeout: 5000 });
+    await cancelButton.click();
+
+    // Modal dismissed — Zrušit button no longer visible
+    await expect(page.locator('button').filter({ hasText: 'Zrušit' }).first()).not.toBeVisible({ timeout: 3000 });
+  });
+});

--- a/frontend/test/e2e/marketing/create-record.spec.ts
+++ b/frontend/test/e2e/marketing/create-record.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '@playwright/test';
+import { navigateToMarketingCalendar } from '../helpers/e2e-auth-helper';
+
+// Action type labels as rendered in MarketingActionModal dropdown (Czech)
+const ACTION_TYPE_OPTIONS = ['Sociální sítě', 'Událost', 'Email', 'PR', 'Fotografie', 'Ostatní'];
+
+test.describe('Marketing Calendar — Create New Record', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+  });
+
+  test('should open create modal when clicking Nová akce', async ({ page }) => {
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+
+    // Create mode shows Vytvořit (not Uložit)
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button').filter({ hasText: 'Zrušit' }).first()).toBeVisible();
+
+    // Delete button must NOT appear in create mode
+    await expect(page.locator('button').filter({ hasText: 'Smazat' }).first()).not.toBeVisible();
+  });
+
+  test('should display all required form fields', async ({ page }) => {
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+
+    // Title input
+    const titleInput = page.locator('input').filter({ hasNot: page.locator('[type="date"]') }).first();
+    await expect(titleInput).toBeVisible();
+
+    // Type dropdown
+    await expect(page.locator('select').first()).toBeVisible();
+
+    // Od / Do date inputs
+    const dateInputs = page.locator('input[type="date"]');
+    await expect(dateInputs.first()).toBeVisible();
+    await expect(dateInputs.nth(1)).toBeVisible();
+
+    // Description textarea
+    await expect(page.locator('textarea').first()).toBeVisible();
+  });
+
+  test('should list all action type options in the dropdown', async ({ page }) => {
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+
+    const typeSelect = page.locator('select').first();
+
+    for (const label of ACTION_TYPE_OPTIONS) {
+      await expect(typeSelect.locator(`option:has-text("${label}")`)).toHaveCount(1);
+    }
+  });
+
+  test('should dismiss modal via Zrušit without saving', async ({ page }) => {
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+
+    await page.locator('button').filter({ hasText: 'Zrušit' }).first().click();
+
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('should keep modal open when submitting without a title', async ({ page }) => {
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+
+    // Fill dates but leave title empty
+    const dateInputs = page.locator('input[type="date"]');
+    await dateInputs.first().fill('2099-06-01');
+    await dateInputs.nth(1).fill('2099-06-30');
+
+    await page.locator('button').filter({ hasText: 'Vytvořit' }).first().click();
+
+    // Modal must remain open — title is required
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 3000 });
+  });
+
+  test('should create a new marketing action and verify it appears in grid view', async ({ page }) => {
+    const uniqueTitle = `E2E Test Akce ${Date.now()}`;
+
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+
+    // Fill title — first text input in the modal
+    const titleInput = page.locator('input[type="text"]').first();
+    await titleInput.fill(uniqueTitle);
+
+    // Select action type
+    await page.locator('select').first().selectOption({ label: 'Událost' });
+
+    // Set date range (far future to avoid polluting visible calendar months)
+    const dateInputs = page.locator('input[type="date"]');
+    await dateInputs.first().fill('2099-06-01');
+    await dateInputs.nth(1).fill('2099-06-30');
+
+    // Submit
+    await page.locator('button').filter({ hasText: 'Vytvořit' }).first().click();
+
+    // Modal closes after successful creation
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).not.toBeVisible({ timeout: 10000 });
+
+    // Switch to grid view to verify the record was persisted
+    const listToggle = page.locator('button').filter({ hasText: 'Seznam' }).first();
+    await listToggle.click();
+    await expect(listToggle).toHaveClass(/bg-indigo-600/);
+
+    // Search for the newly created action by title
+    const searchInput = page.locator('input[type="text"]').first();
+    await searchInput.fill(uniqueTitle);
+    await page.waitForTimeout(1500);
+
+    const matchingRow = page.locator('tbody tr').filter({ hasText: uniqueTitle });
+
+    if (await matchingRow.count() === 0) {
+      throw new Error(
+        `Newly created action "${uniqueTitle}" not found in grid after creation. ` +
+        'Either the API call failed or the grid is not refreshing after create.'
+      );
+    }
+
+    await expect(matchingRow.first()).toBeVisible();
+  });
+
+  test('should create an action with all optional fields filled', async ({ page }) => {
+    const uniqueTitle = `E2E Plný formulář ${Date.now()}`;
+
+    await page.locator('button').filter({ hasText: 'Nová akce' }).click();
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).toBeVisible({ timeout: 5000 });
+
+    // Title
+    await page.locator('input[type="text"]').first().fill(uniqueTitle);
+
+    // Type
+    await page.locator('select').first().selectOption({ label: 'Email' });
+
+    // Dates
+    const dateInputs = page.locator('input[type="date"]');
+    await dateInputs.first().fill('2099-07-01');
+    await dateInputs.nth(1).fill('2099-07-15');
+
+    // Description
+    await page.locator('textarea').first().fill('E2E test description — generated by automated test');
+
+    // Add a product code if the product input is present
+    const productInput = page.locator('input[placeholder*="kód"], input[placeholder*="Kód"]').first();
+    const hasProductInput = await productInput.isVisible({ timeout: 2000 }).catch(() => false);
+    if (hasProductInput) {
+      await productInput.fill('AKL001');
+      const addButton = page.locator('button').filter({ hasText: 'Přidat' }).first();
+      await addButton.click();
+      // Badge for the added product should appear
+      await expect(page.locator('text=AKL001').first()).toBeVisible({ timeout: 3000 });
+    }
+
+    // Submit
+    await page.locator('button').filter({ hasText: 'Vytvořit' }).first().click();
+
+    // Modal closes on success
+    await expect(page.locator('button').filter({ hasText: 'Vytvořit' }).first()).not.toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/test/e2e/marketing/grid-view.spec.ts
+++ b/frontend/test/e2e/marketing/grid-view.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/test';
+import { navigateToMarketingCalendar } from '../helpers/e2e-auth-helper';
+
+test.describe('Marketing Calendar — Grid (List) View', () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+
+    // Switch to list/grid view
+    const listToggle = page.locator('button').filter({ hasText: 'Seznam' }).first();
+    await listToggle.click();
+    await expect(listToggle).toHaveClass(/bg-indigo-600/);
+  });
+
+  test('should deactivate calendar toggle when switching to grid view', async ({ page }) => {
+    const calendarToggle = page.locator('button').filter({ hasText: 'Kalendář' }).first();
+    await expect(calendarToggle).not.toHaveClass(/bg-indigo-600/);
+  });
+
+  test('should display filter controls', async ({ page }) => {
+    // MarketingActionFilters renders a text search input
+    const searchInput = page.locator('input[type="text"], input[placeholder]').first();
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+
+    // And two date inputs (Od / Do)
+    const dateInputs = page.locator('input[type="date"]');
+    await expect(dateInputs.first()).toBeVisible();
+  });
+
+  test('should display table column headers', async ({ page }) => {
+    // MarketingActionGrid columns: Název, Typ, Od, Do
+    await expect(page.locator('text=Název').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Typ').first()).toBeVisible();
+    await expect(page.locator('text=Od').first()).toBeVisible();
+    await expect(page.locator('text=Do').first()).toBeVisible();
+  });
+
+  test('should filter rows by search text returning no results', async ({ page }) => {
+    const searchInput = page.locator('input[type="text"], input[placeholder]').first();
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+
+    // Use a string that will never match a real marketing action title
+    await searchInput.fill('zzznomatch_xyzxyz_e2e');
+
+    // Wait for debounce and API response
+    await page.waitForTimeout(1500);
+
+    const rows = page.locator('tbody tr');
+    const rowCount = await rows.count();
+    expect(rowCount).toBe(0);
+  });
+
+  test('should clear search filter and restore rows', async ({ page }) => {
+    const searchInput = page.locator('input[type="text"], input[placeholder]').first();
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+
+    await searchInput.fill('zzznomatch_xyzxyz_e2e');
+    await page.waitForTimeout(1500);
+
+    // Clear the filter
+    await searchInput.clear();
+    await page.waitForTimeout(1500);
+
+    await expect(searchInput).toHaveValue('');
+  });
+
+  test('should filter rows by date range that returns no results', async ({ page }) => {
+    const dateInputs = page.locator('input[type="date"]');
+    const inputCount = await dateInputs.count();
+
+    if (inputCount < 2) {
+      throw new Error(
+        `Expected at least 2 date inputs in filter controls, found ${inputCount}. ` +
+        'MarketingActionFilters component may have changed.'
+      );
+    }
+
+    // Set a far-future range with no data
+    await dateInputs.first().fill('2099-01-01');
+    await dateInputs.nth(1).fill('2099-01-31');
+    await page.waitForTimeout(1500);
+
+    const rows = page.locator('tbody tr');
+    expect(await rows.count()).toBe(0);
+  });
+
+  test('should open edit modal when clicking a grid row', async ({ page }) => {
+    await page.waitForTimeout(2000);
+
+    const rows = page.locator('tbody tr');
+    const rowCount = await rows.count();
+
+    if (rowCount === 0) {
+      console.log('No rows in grid — skipping row-click test');
+      return;
+    }
+
+    await rows.first().click();
+
+    // Edit modal: footer has Uložit (save) and Zrušit (cancel)
+    await expect(page.locator('button').filter({ hasText: 'Uložit' }).first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button').filter({ hasText: 'Zrušit' }).first()).toBeVisible();
+  });
+
+  test('should close edit modal via Zrušit', async ({ page }) => {
+    await page.waitForTimeout(2000);
+
+    const rows = page.locator('tbody tr');
+    if (await rows.count() === 0) {
+      console.log('No rows in grid — skipping modal-close test');
+      return;
+    }
+
+    await rows.first().click();
+
+    const cancelButton = page.locator('button').filter({ hasText: 'Zrušit' }).first();
+    await expect(cancelButton).toBeVisible({ timeout: 5000 });
+    await cancelButton.click();
+
+    await expect(page.locator('button').filter({ hasText: 'Zrušit' }).first()).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test('should show next page button when more than one page exists', async ({ page }) => {
+    await page.waitForTimeout(2000);
+
+    const rows = page.locator('tbody tr');
+    if (await rows.count() === 0) {
+      console.log('No rows — skipping pagination test');
+      return;
+    }
+
+    // Pagination controls rendered by MarketingActionGrid
+    const nextButton = page.locator('button').filter({ hasText: /Další/ }).first();
+    const prevButton = page.locator('button').filter({ hasText: /Předchozí/ }).first();
+
+    // At least one pagination button should be present
+    const hasNext = await nextButton.isVisible().catch(() => false);
+    const hasPrev = await prevButton.isVisible().catch(() => false);
+
+    expect(hasNext || hasPrev).toBe(true);
+  });
+});

--- a/frontend/test/e2e/marketing/loading.spec.ts
+++ b/frontend/test/e2e/marketing/loading.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { navigateToApp, navigateToMarketingCalendar } from '../helpers/e2e-auth-helper';
+
+test.describe('Marketing Calendar — Page Loading', () => {
+  test('should navigate to marketing calendar via sidebar', async ({ page }) => {
+    await navigateToApp(page);
+
+    // Expand Marketing section in sidebar
+    const marketingSection = page.locator('button').filter({ hasText: 'Marketing' }).first();
+    await expect(marketingSection).toBeVisible({ timeout: 10000 });
+    await marketingSection.click();
+
+    // Click the Kalendář sub-item
+    const calendarLink = page.locator('a[href="/marketing/calendar"], text="Kalendář"').first();
+    await expect(calendarLink).toBeVisible({ timeout: 5000 });
+    await calendarLink.click();
+
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(page.locator('h1').filter({ hasText: 'Marketingový kalendář' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should display page heading and toolbar controls', async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+
+    await expect(page.locator('h1').filter({ hasText: 'Marketingový kalendář' })).toBeVisible();
+
+    // View toggle buttons
+    await expect(page.locator('button').filter({ hasText: 'Kalendář' }).first()).toBeVisible();
+    await expect(page.locator('button').filter({ hasText: 'Seznam' }).first()).toBeVisible();
+
+    // New action button
+    await expect(page.locator('button').filter({ hasText: 'Nová akce' })).toBeVisible();
+  });
+
+  test('should load calendar view by default', async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+
+    // Calendar toggle should have active (indigo) styling
+    const calendarToggle = page.locator('button').filter({ hasText: 'Kalendář' }).first();
+    await expect(calendarToggle).toHaveClass(/bg-indigo-600/);
+
+    // List toggle should not be active
+    const listToggle = page.locator('button').filter({ hasText: 'Seznam' }).first();
+    await expect(listToggle).not.toHaveClass(/bg-indigo-600/);
+  });
+
+  test('should display current month and year in calendar header', async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+
+    const czechMonths = [
+      'Leden', 'Únor', 'Březen', 'Duben', 'Květen', 'Červen',
+      'Červenec', 'Srpen', 'Září', 'Říjen', 'Listopad', 'Prosinec',
+    ];
+    const currentMonthName = czechMonths[new Date().getMonth()];
+    const currentYear = new Date().getFullYear().toString();
+
+    // Period label must contain current month name
+    await expect(page.locator(`text=/${currentMonthName}/`).first()).toBeVisible({ timeout: 10000 });
+
+    // Period label must contain current year
+    await expect(page.locator(`text=/${currentYear}/`).first()).toBeVisible();
+  });
+
+  test('should finish loading without error state', async ({ page }) => {
+    await navigateToMarketingCalendar(page);
+
+    // Wait up to 15s for loading text to disappear
+    await expect(page.locator('text=Načítání...').first()).not.toBeVisible({ timeout: 15000 });
+
+    // Error state should not be shown
+    await expect(page.locator('text=Chyba při načítání kalendáře.').first()).not.toBeVisible();
+  });
+});

--- a/scripts/run-playwright-tests.sh
+++ b/scripts/run-playwright-tests.sh
@@ -78,7 +78,7 @@ export PLAYWRIGHT_BASE_URL="$STAGING_URL"
 export CI=false  # Disable CI mode for better debugging
 
 # Define available modules
-MODULES=("catalog" "issued-invoices" "stock-operations" "transport" "manufacturing" "core")
+MODULES=("catalog" "issued-invoices" "stock-operations" "transport" "manufacturing" "core" "marketing")
 
 # Build test command
 PLAYWRIGHT_CMD="npx playwright test"


### PR DESCRIPTION
## Summary

- Implements all REST endpoints for the Photobank feature (issue #758)
- `PhotobankController`: `GET /api/photobank/photos` (tag AND filter, filename search, pagination), `GET /api/photobank/tags`, `POST/DELETE /api/photobank/photos/{id}/tags` (admin)
- `PhotobankSettingsController`: full CRUD for index roots and tag rules, `POST /api/photobank/settings/rules/reapply` (admin)
- 12 MediatR handlers following existing Vertical Slice / Clean Architecture patterns
- `IPhotobankRepository` domain interface + EF Core implementation with correct tag AND filter query
- `ReapplyRules` removes only `Rule`-source `PhotoTag` rows, preserving `Manual` tags
- Error codes 24XX range, Czech i18n translations, 7 new unit tests

## Test plan

- [x] `dotnet build` — 0 errors
- [x] All 14 Photobank tests pass (`dotnet test --filter Photobank`)
- [x] Full test suite: 2331 passed, 7 pre-existing KnowledgeBase integration failures (need live DB), 0 new regressions
- [x] Localization coverage test passes (new error codes have translations)
- [x] Frontend Jest: 754 passed, 2 pre-existing `exceljs` module failures

Closes #758