### PR TITLE
feat(marketing-calendar): Google Calendar-style drag and drop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,26 @@ This includes:
 
 **Why:** Shoptet has no sandbox — everything runs against a live store. Undocumented assumptions cause data corruption or flaky tests.
 
+### 10. Build Validation Before Completion
+
+**MANDATORY**: Both backend AND frontend builds must pass before any task, PR, or feature is declared done.
+
+```bash
+# Backend
+dotnet build
+
+# Frontend
+npm run build   # runs tsc — catches type errors Jest/Babel misses
+```
+
+**CRITICAL:** Jest uses Babel to transform TypeScript — it strips types without checking them. A test suite can pass 100% while the production build fails due to TypeScript errors. `npm run build` is the only gate that runs `tsc`.
+
+**Rule:** Run both builds as the **final step**, after all commits including code review fixes. If a review fix is applied, re-run both builds before pushing.
+
+**Enforcement:**
+- NEVER declare a task complete without a passing `npm run build` (FE) and `dotnet build` (BE)
+- Build failures block push — fix first, then re-verify
+
 ## Testing Strategy
 
 **Three types of tests:**
@@ -407,10 +427,13 @@ See `docs/architecture/filesystem.md` for complete feature organization patterns
 1. **Make changes** to code
 2. **For UI changes**: Test locally with `npm start` (port 3000)
 3. **For E2E testing**: Use staging environment (`./scripts/run-playwright-tests.sh`)
-4. **Validate builds**: Run `dotnet build` (BE) or `npm run build` (FE) before finishing
-5. **Format code**: Run `dotnet format` (BE) or `npm run lint` (FE)
-6. **Follow best practices**: YAGNI, SOLID, KISS, DRY
-7. **Ask for clarification** if unsure about implementation details
+4. **Run tests**: `dotnet test` (BE) and `CI=true npm test -- --no-coverage` (FE)
+5. **Validate builds**: `dotnet build` (BE) and `npm run build` (FE) — MANDATORY, catches TypeScript errors that tests miss
+6. **Format code**: Run `dotnet format` (BE) or `npm run lint` (FE)
+7. **Follow best practices**: YAGNI, SOLID, KISS, DRY
+8. **Ask for clarification** if unsure about implementation details
+
+**Steps 4 and 5 must be repeated after any code review fixes before pushing.**
 
 See `docs/development/setup.md` for detailed development commands and setup instructions.
 

--- a/frontend/src/components/marketing/calendar/CalendarDayCell.tsx
+++ b/frontend/src/components/marketing/calendar/CalendarDayCell.tsx
@@ -10,6 +10,7 @@ interface CalendarDayCellProps {
   isHighlighted?: boolean;
   onMouseDown?: (e: React.MouseEvent) => void;
   onMouseEnter?: (e: React.MouseEvent) => void;
+  onPointerEnter?: () => void;
 }
 
 const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
@@ -20,6 +21,7 @@ const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
   isHighlighted,
   onMouseDown,
   onMouseEnter,
+  onPointerEnter,
 }) => {
   const { setNodeRef, isOver } = useDroppable({
     id: `day-${dateStr}`,
@@ -32,6 +34,7 @@ const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
       data-date={dateStr}
       onMouseDown={onMouseDown}
       onMouseEnter={onMouseEnter}
+      onPointerEnter={onPointerEnter}
       className={`
         border-r border-gray-100 last:border-r-0 p-1
         ${!isCurrentMonth ? "bg-gray-50" : ""}

--- a/frontend/src/components/marketing/calendar/CalendarDayCell.tsx
+++ b/frontend/src/components/marketing/calendar/CalendarDayCell.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useDroppable } from "@dnd-kit/core";
+import type { DayDropData } from "./calendarDndTypes";
+
+interface CalendarDayCellProps {
+  dateStr: string; // "YYYY-MM-DD"
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  day: number;
+  isHighlighted?: boolean;
+  onMouseDown?: (e: React.MouseEvent) => void;
+  onMouseEnter?: (e: React.MouseEvent) => void;
+}
+
+const CalendarDayCell: React.FC<CalendarDayCellProps> = ({
+  dateStr,
+  isCurrentMonth,
+  isToday,
+  day,
+  isHighlighted,
+  onMouseDown,
+  onMouseEnter,
+}) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `day-${dateStr}`,
+    data: { date: dateStr } satisfies DayDropData,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-date={dateStr}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+      className={`
+        border-r border-gray-100 last:border-r-0 p-1
+        ${!isCurrentMonth ? "bg-gray-50" : ""}
+        ${isOver ? "bg-indigo-50" : ""}
+        ${isHighlighted ? "bg-indigo-100" : ""}
+      `}
+    >
+      <span
+        className={`
+          inline-flex items-center justify-center w-6 h-6 text-sm rounded-full
+          ${
+            isToday
+              ? "bg-indigo-600 text-white font-bold"
+              : isCurrentMonth
+                ? "text-gray-900"
+                : "text-gray-400"
+          }
+        `}
+      >
+        {day}
+      </span>
+    </div>
+  );
+};
+
+export default CalendarDayCell;

--- a/frontend/src/components/marketing/calendar/CalendarDragOverlay.tsx
+++ b/frontend/src/components/marketing/calendar/CalendarDragOverlay.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import type { CalendarEvent } from "./useCalendarLayout";
+import { daysBetween } from "./calendarDateUtils";
+
+const ACTION_TYPE_COLORS: Record<string, string> = {
+  SocialMedia: "bg-blue-500 text-white",
+  Event: "bg-purple-500 text-white",
+  Email: "bg-green-500 text-white",
+  PR: "bg-yellow-500 text-gray-900",
+  Photoshoot: "bg-pink-500 text-white",
+  Other: "bg-gray-500 text-white",
+};
+
+const DAY_WIDTH_APPROX = 120;
+
+interface CalendarDragOverlayProps {
+  event: CalendarEvent;
+}
+
+const CalendarDragOverlay: React.FC<CalendarDragOverlayProps> = ({ event }) => {
+  const colorClass = ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
+  const durationDays = daysBetween(event.dateFrom, event.dateTo) + 1;
+  const width = Math.max(durationDays * DAY_WIDTH_APPROX, DAY_WIDTH_APPROX);
+
+  return (
+    <div
+      className={`${colorClass} rounded px-2 text-xs font-medium truncate shadow-lg opacity-90`}
+      style={{
+        height: 22,
+        width,
+        lineHeight: "22px",
+      }}
+    >
+      {event.title}
+    </div>
+  );
+};
+
+export default CalendarDragOverlay;

--- a/frontend/src/components/marketing/calendar/CalendarDragOverlay.tsx
+++ b/frontend/src/components/marketing/calendar/CalendarDragOverlay.tsx
@@ -1,17 +1,10 @@
 import React from "react";
 import type { CalendarEvent } from "./useCalendarLayout";
+import { ACTION_TYPE_COLORS } from "./calendarDndTypes";
 import { daysBetween } from "./calendarDateUtils";
 
-const ACTION_TYPE_COLORS: Record<string, string> = {
-  SocialMedia: "bg-blue-500 text-white",
-  Event: "bg-purple-500 text-white",
-  Email: "bg-green-500 text-white",
-  PR: "bg-yellow-500 text-gray-900",
-  Photoshoot: "bg-pink-500 text-white",
-  Other: "bg-gray-500 text-white",
-};
-
-const DAY_WIDTH_APPROX = 120;
+/** Approximate pixel width per day column — used for ghost bar sizing during drag. */
+const APPROX_DAY_WIDTH_PX = 120;
 
 interface CalendarDragOverlayProps {
   event: CalendarEvent;
@@ -20,7 +13,7 @@ interface CalendarDragOverlayProps {
 const CalendarDragOverlay: React.FC<CalendarDragOverlayProps> = ({ event }) => {
   const colorClass = ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
   const durationDays = daysBetween(event.dateFrom, event.dateTo) + 1;
-  const width = Math.max(durationDays * DAY_WIDTH_APPROX, DAY_WIDTH_APPROX);
+  const width = Math.max(durationDays * APPROX_DAY_WIDTH_PX, APPROX_DAY_WIDTH_PX);
 
   return (
     <div

--- a/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
@@ -22,7 +22,9 @@ interface MarketingEventBarProps {
   isFirstSegment: boolean;
   isLastSegment: boolean;
   isDragActive: boolean;
+  isResizing: boolean;
   onClick: (id: number) => void;
+  onResizePointerDown?: (type: 'start' | 'end', eventId: number) => void;
 }
 
 const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
@@ -34,7 +36,9 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
   isFirstSegment,
   isLastSegment,
   isDragActive,
+  isResizing,
   onClick,
+  onResizePointerDown,
 }) => {
   const colorClass = ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
   const top = TOP_OFFSET_PX + lane * (BAR_HEIGHT_PX + BAR_GAP_PX);
@@ -44,7 +48,7 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
   originDate.setDate(weekRowStartDate.getDate() + (startCol - 1));
   const originDateStr = toDateString(originDate);
 
-  // Move draggable (body)
+  // Move draggable (body only — resize is handled via pointer events, not dnd-kit)
   const moveData: CalendarDragData = {
     type: 'move',
     eventId: event.id,
@@ -58,38 +62,6 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
   } = useDraggable({
     id: `move-${event.id}-${startCol}-${lane}`,
     data: moveData,
-  });
-
-  // Resize-start draggable (left handle)
-  const resizeStartData: CalendarDragData = {
-    type: 'resize-start',
-    eventId: event.id,
-    event,
-  };
-  const {
-    attributes: resizeStartAttrs,
-    listeners: resizeStartListeners,
-    setNodeRef: setResizeStartRef,
-  } = useDraggable({
-    id: `resize-start-${event.id}`,
-    data: resizeStartData,
-    disabled: !isFirstSegment,
-  });
-
-  // Resize-end draggable (right handle)
-  const resizeEndData: CalendarDragData = {
-    type: 'resize-end',
-    eventId: event.id,
-    event,
-  };
-  const {
-    attributes: resizeEndAttrs,
-    listeners: resizeEndListeners,
-    setNodeRef: setResizeEndRef,
-  } = useDraggable({
-    id: `resize-end-${event.id}`,
-    data: resizeEndData,
-    disabled: !isLastSegment,
   });
 
   return (
@@ -112,7 +84,7 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
         left: 2,
         right: 2,
         zIndex: 10,
-        pointerEvents: 'auto',
+        pointerEvents: isResizing ? 'none' : 'auto',
         opacity: isDragActive ? 0.3 : 1,
       }}
       className={`
@@ -122,32 +94,28 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
         hover:opacity-80 transition-opacity select-none
       `}
     >
-      {/* Left resize handle */}
+      {/* Left resize handle — pointer events only, no dnd-kit */}
       {isFirstSegment && (
         <div
-          ref={setResizeStartRef}
-          {...resizeStartAttrs}
-          {...resizeStartListeners}
           onPointerDown={(e) => {
             e.stopPropagation();
+            onResizePointerDown?.('start', event.id);
           }}
-          className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-l"
+          className="absolute left-0 top-0 bottom-0 w-3 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-l"
         />
       )}
 
       {/* Title text */}
       <span className="relative z-0">{event.title}</span>
 
-      {/* Right resize handle */}
+      {/* Right resize handle — pointer events only, no dnd-kit */}
       {isLastSegment && (
         <div
-          ref={setResizeEndRef}
-          {...resizeEndAttrs}
-          {...resizeEndListeners}
           onPointerDown={(e) => {
             e.stopPropagation();
+            onResizePointerDown?.('end', event.id);
           }}
-          className="absolute right-0 top-0 bottom-0 w-1.5 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-r"
+          className="absolute right-0 top-0 bottom-0 w-3 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-r"
         />
       )}
     </div>

--- a/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import type { CalendarEvent } from './useCalendarLayout';
-import type { CalendarDragData } from './calendarDndTypes';
+import { type CalendarDragData, ACTION_TYPE_COLORS } from './calendarDndTypes';
 import { toDateString } from './calendarDateUtils';
-
-const ACTION_TYPE_COLORS: Record<string, string> = {
-  SocialMedia: 'bg-blue-500 text-white',
-  Event: 'bg-purple-500 text-white',
-  Email: 'bg-green-500 text-white',
-  PR: 'bg-yellow-500 text-gray-900',
-  Photoshoot: 'bg-pink-500 text-white',
-  Other: 'bg-gray-500 text-white',
-};
 
 export const BAR_HEIGHT_PX = 22;
 export const BAR_GAP_PX = 2;
@@ -139,7 +130,6 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
           {...resizeStartListeners}
           onPointerDown={(e) => {
             e.stopPropagation();
-            resizeStartListeners?.onPointerDown?.(e as any);
           }}
           className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-l"
         />
@@ -156,7 +146,6 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
           {...resizeEndListeners}
           onPointerDown={(e) => {
             e.stopPropagation();
-            resizeEndListeners?.onPointerDown?.(e as any);
           }}
           className="absolute right-0 top-0 bottom-0 w-1.5 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-r"
         />

--- a/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingEventBar.tsx
@@ -1,24 +1,36 @@
-import React from "react";
-import type { CalendarEvent } from "./useCalendarLayout";
+import React from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import type { CalendarEvent } from './useCalendarLayout';
+import type { CalendarDragData } from './calendarDndTypes';
+import { toDateString } from './calendarDateUtils';
 
 const ACTION_TYPE_COLORS: Record<string, string> = {
-  SocialMedia: "bg-blue-500 text-white",
-  Event: "bg-purple-500 text-white",
-  Email: "bg-green-500 text-white",
-  PR: "bg-yellow-500 text-gray-900",
-  Photoshoot: "bg-pink-500 text-white",
-  Other: "bg-gray-500 text-white",
+  SocialMedia: 'bg-blue-500 text-white',
+  Event: 'bg-purple-500 text-white',
+  Email: 'bg-green-500 text-white',
+  PR: 'bg-yellow-500 text-gray-900',
+  Photoshoot: 'bg-pink-500 text-white',
+  Other: 'bg-gray-500 text-white',
 };
 
-const BAR_HEIGHT_PX = 22;
-const BAR_GAP_PX = 2;
-const TOP_OFFSET_PX = 28; // space below date number in day cell
+export const BAR_HEIGHT_PX = 22;
+export const BAR_GAP_PX = 2;
+export const TOP_OFFSET_PX = 28;
+
+// Keep backward-compatible exports used by MarketingMonthCalendar
+export const BAR_HEIGHT_PX_EXPORT = BAR_HEIGHT_PX;
+export const BAR_GAP_PX_EXPORT = BAR_GAP_PX;
+export const TOP_OFFSET_PX_EXPORT = TOP_OFFSET_PX;
 
 interface MarketingEventBarProps {
   event: CalendarEvent;
   startCol: number; // 1–7
   endCol: number; // 1–7, inclusive
   lane: number;
+  weekRowStartDate: Date; // Monday of this week row
+  isFirstSegment: boolean;
+  isLastSegment: boolean;
+  isDragActive: boolean;
   onClick: (id: number) => void;
 }
 
@@ -27,18 +39,77 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
   startCol,
   endCol,
   lane,
+  weekRowStartDate,
+  isFirstSegment,
+  isLastSegment,
+  isDragActive,
   onClick,
 }) => {
-  const colorClass =
-    ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
+  const colorClass = ACTION_TYPE_COLORS[event.actionType] ?? ACTION_TYPE_COLORS.Other;
   const top = TOP_OFFSET_PX + lane * (BAR_HEIGHT_PX + BAR_GAP_PX);
+
+  // Compute the date that this bar's startCol represents (startCol=1 → Monday)
+  const originDate = new Date(weekRowStartDate);
+  originDate.setDate(weekRowStartDate.getDate() + (startCol - 1));
+  const originDateStr = toDateString(originDate);
+
+  // Move draggable (body)
+  const moveData: CalendarDragData = {
+    type: 'move',
+    eventId: event.id,
+    event,
+    originDate: originDateStr,
+  };
+  const {
+    attributes: moveAttrs,
+    listeners: moveListeners,
+    setNodeRef: setMoveRef,
+  } = useDraggable({
+    id: `move-${event.id}-${startCol}-${lane}`,
+    data: moveData,
+  });
+
+  // Resize-start draggable (left handle)
+  const resizeStartData: CalendarDragData = {
+    type: 'resize-start',
+    eventId: event.id,
+    event,
+  };
+  const {
+    attributes: resizeStartAttrs,
+    listeners: resizeStartListeners,
+    setNodeRef: setResizeStartRef,
+  } = useDraggable({
+    id: `resize-start-${event.id}`,
+    data: resizeStartData,
+    disabled: !isFirstSegment,
+  });
+
+  // Resize-end draggable (right handle)
+  const resizeEndData: CalendarDragData = {
+    type: 'resize-end',
+    eventId: event.id,
+    event,
+  };
+  const {
+    attributes: resizeEndAttrs,
+    listeners: resizeEndListeners,
+    setNodeRef: setResizeEndRef,
+  } = useDraggable({
+    id: `resize-end-${event.id}`,
+    data: resizeEndData,
+    disabled: !isLastSegment,
+  });
 
   return (
     <div
+      ref={setMoveRef}
+      {...moveAttrs}
+      {...moveListeners}
       role="button"
       tabIndex={0}
       onClick={() => onClick(event.id)}
-      onKeyDown={(e) => e.key === "Enter" && onClick(event.id)}
+      onKeyDown={(e) => e.key === 'Enter' && onClick(event.id)}
       title={event.title}
       style={{
         gridColumnStart: startCol,
@@ -46,25 +117,52 @@ const MarketingEventBar: React.FC<MarketingEventBarProps> = ({
         gridRow: 1,
         top,
         height: BAR_HEIGHT_PX,
-        position: "absolute",
+        position: 'absolute',
         left: 2,
         right: 2,
         zIndex: 10,
-        pointerEvents: "auto",
+        pointerEvents: 'auto',
+        opacity: isDragActive ? 0.3 : 1,
       }}
       className={`
+        group relative
         ${colorClass}
-        rounded px-1 text-xs font-medium truncate cursor-pointer
+        rounded px-1 text-xs font-medium truncate cursor-grab
         hover:opacity-80 transition-opacity select-none
       `}
     >
-      {event.title}
+      {/* Left resize handle */}
+      {isFirstSegment && (
+        <div
+          ref={setResizeStartRef}
+          {...resizeStartAttrs}
+          {...resizeStartListeners}
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            resizeStartListeners?.onPointerDown?.(e as any);
+          }}
+          className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-l"
+        />
+      )}
+
+      {/* Title text */}
+      <span className="relative z-0">{event.title}</span>
+
+      {/* Right resize handle */}
+      {isLastSegment && (
+        <div
+          ref={setResizeEndRef}
+          {...resizeEndAttrs}
+          {...resizeEndListeners}
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            resizeEndListeners?.onPointerDown?.(e as any);
+          }}
+          className="absolute right-0 top-0 bottom-0 w-1.5 cursor-col-resize opacity-0 group-hover:opacity-100 bg-white/30 rounded-r"
+        />
+      )}
     </div>
   );
 };
-
-export const BAR_HEIGHT_PX_EXPORT = BAR_HEIGHT_PX;
-export const BAR_GAP_PX_EXPORT = BAR_GAP_PX;
-export const TOP_OFFSET_PX_EXPORT = TOP_OFFSET_PX;
 
 export default MarketingEventBar;

--- a/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { DndContext, closestCenter, DragOverlay } from "@dnd-kit/core";
 import type { CalendarEvent, EventSegment } from "./useCalendarLayout";
 import { useCalendarLayout } from "./useCalendarLayout";
 import MarketingEventBar, {
@@ -6,10 +7,14 @@ import MarketingEventBar, {
   BAR_GAP_PX_EXPORT as BAR_G,
   TOP_OFFSET_PX_EXPORT as TOP_OFF,
 } from "./MarketingEventBar";
+import CalendarDayCell from "./CalendarDayCell";
+import CalendarDragOverlay from "./CalendarDragOverlay";
+import { useCalendarDnd } from "./useCalendarDnd";
+import { useCreateByDrag } from "./useCreateByDrag";
+import { toDateString } from "./calendarDateUtils";
+import type { CalendarDndCallbacks } from "./calendarDndTypes";
 
 const WEEK_DAYS = ["Po", "Út", "St", "Čt", "Pá", "So", "Ne"];
-
-// Minimum row height when no events; grows per lane
 const BASE_ROW_HEIGHT_PX = 64;
 
 interface MarketingMonthCalendarProps {
@@ -17,11 +22,15 @@ interface MarketingMonthCalendarProps {
   month: number; // 0-based
   events: CalendarEvent[];
   onEventClick: (id: number) => void;
+  onEventMove: (eventId: number, newDateFrom: string, newDateTo: string) => void;
+  onEventResize: (eventId: number, newDateFrom: string, newDateTo: string) => void;
+  onCreateRange: (dateFrom: string, dateTo: string) => void;
   className?: string;
 }
 
 interface DayCell {
   date: Date;
+  dateStr: string;
   isCurrentMonth: boolean;
   weekRow: number;
   col: number; // 1–7
@@ -32,63 +41,85 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
   month,
   events,
   onEventClick,
+  onEventMove,
+  onEventResize,
+  onCreateRange,
   className,
 }) => {
   const today = new Date();
-  const segments = useCalendarLayout(events, year, month);
 
-  // Build day cells — same Monday-anchor logic as useCalendarLayout
-  const { dayCells, weekCount } = useMemo(() => {
+  const callbacks: CalendarDndCallbacks = useMemo(
+    () => ({ onEventMove, onEventResize, onCreateRange }),
+    [onEventMove, onEventResize, onCreateRange],
+  );
+
+  const {
+    sensors,
+    dragState,
+    previewEvents,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    handleDragCancel,
+  } = useCalendarDnd(events, callbacks);
+
+  const segments = useCalendarLayout(previewEvents, year, month);
+
+  // Build day cells
+  const { dayCells, weekCount, weekStarts } = useMemo(() => {
     const firstOfMonth = new Date(year, month, 1);
     const firstMonday = new Date(firstOfMonth);
     const dow = firstOfMonth.getDay();
     firstMonday.setDate(firstOfMonth.getDate() + (dow === 0 ? -6 : 1 - dow));
 
     const cells: DayCell[] = [];
+    const starts: Date[] = [];
     let weekRow = 0;
     let col = 1;
 
-    // 6 weeks × 7 days
     for (let i = 0; i < 42; i++) {
       const date = new Date(firstMonday);
       date.setDate(firstMonday.getDate() + i);
+      if (col === 1) starts.push(new Date(date));
       cells.push({
         date,
+        dateStr: toDateString(date),
         isCurrentMonth: date.getMonth() === month,
         weekRow,
         col,
       });
       col++;
-      if (col > 7) {
-        col = 1;
-        weekRow++;
-      }
+      if (col > 7) { col = 1; weekRow++; }
     }
 
-    // Trim trailing empty weeks (all outside current month)
     const isWeekAllOutsideMonth = (w: number) =>
       cells.filter((c) => c.weekRow === w).every((c) => !c.isCurrentMonth);
 
     let lastWeek = 5;
-    while (lastWeek > 0 && isWeekAllOutsideMonth(lastWeek)) {
-      lastWeek--;
-    }
+    while (lastWeek > 0 && isWeekAllOutsideMonth(lastWeek)) lastWeek--;
 
     return {
       dayCells: cells.filter((c) => c.weekRow <= lastWeek),
       weekCount: lastWeek + 1,
+      weekStarts: starts.slice(0, lastWeek + 1),
     };
   }, [year, month]);
 
-  // Calculate min-height per week row based on max lane used
+  // Create-by-drag on empty cells
+  const {
+    selectionRange,
+    handleMouseDown: createMouseDown,
+    handleMouseEnter: createMouseEnter,
+    handleMouseUp: createMouseUp,
+  } = useCreateByDrag(onCreateRange);
+
+  // Row min-heights based on max lane
   const rowMinHeights = useMemo(() => {
     const heights: number[] = Array(weekCount).fill(BASE_ROW_HEIGHT_PX);
     for (const seg of segments) {
       if (seg.weekRow < weekCount) {
         const needed = TOP_OFF + (seg.lane + 1) * (BAR_H + BAR_G) + 4;
-        if (needed > heights[seg.weekRow]) {
-          heights[seg.weekRow] = needed;
-        }
+        if (needed > heights[seg.weekRow]) heights[seg.weekRow] = needed;
       }
     }
     return heights;
@@ -99,7 +130,7 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
     date.getMonth() === today.getMonth() &&
     date.getDate() === today.getDate();
 
-  // Group segments by weekRow for rendering
+  // Group segments by weekRow
   const segmentsByRow = useMemo(() => {
     const map = new Map<number, EventSegment[]>();
     for (const seg of segments) {
@@ -110,79 +141,114 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
     return map;
   }, [segments]);
 
+  // Determine first/last segment keys for each event (for resize handle visibility)
+  const eventSegmentBounds = useMemo(() => {
+    const bounds = new Map<number, { firstKey: string; lastKey: string }>();
+    for (const seg of segments) {
+      const key = `${seg.weekRow}-${seg.startCol}`;
+      const existing = bounds.get(seg.event.id);
+      if (!existing) {
+        bounds.set(seg.event.id, { firstKey: key, lastKey: key });
+      } else {
+        existing.lastKey = key;
+      }
+    }
+    return bounds;
+  }, [segments]);
+
+  const isDateInSelection = (dateStr: string) => {
+    if (!selectionRange) return false;
+    return dateStr >= selectionRange.from && dateStr <= selectionRange.to;
+  };
+
   return (
-    <div className={`flex flex-col border border-gray-200 rounded-lg overflow-hidden bg-white${className ? ` ${className}` : ""}`}>
-      {/* Header row */}
-      <div className="grid grid-cols-7 border-b border-gray-200 flex-shrink-0">
-        {WEEK_DAYS.map((day) => (
-          <div
-            key={day}
-            className="py-2 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
-          >
-            {day}
-          </div>
-        ))}
-      </div>
-
-      {/* Week rows */}
-      <div className="flex flex-col flex-1">
-      {Array.from({ length: weekCount }, (_, w) => {
-        const rowCells = dayCells.filter((c) => c.weekRow === w);
-        const rowSegs = segmentsByRow.get(w) ?? [];
-
-        return (
-          <div
-            key={w}
-            className="relative flex-1 grid grid-cols-7 border-b border-gray-200 last:border-b-0"
-            style={{ minHeight: rowMinHeights[w] }}
-          >
-            {/* Background: day cells */}
-            {rowCells.map((cell) => (
-              <div
-                key={cell.date.toISOString()}
-                className={`
-                  border-r border-gray-100 last:border-r-0 p-1
-                  ${!cell.isCurrentMonth ? "bg-gray-50" : ""}
-                `}
-              >
-                <span
-                  className={`
-                    inline-flex items-center justify-center w-6 h-6 text-sm rounded-full
-                    ${
-                      isToday(cell.date)
-                        ? "bg-indigo-600 text-white font-bold"
-                        : cell.isCurrentMonth
-                          ? "text-gray-900"
-                          : "text-gray-400"
-                    }
-                  `}
-                >
-                  {cell.date.getDate()}
-                </span>
-              </div>
-            ))}
-
-            {/* Overlay: event bars — direct absolutely positioned grid children */}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div
+        className={`flex flex-col border border-gray-200 rounded-lg overflow-hidden bg-white${className ? ` ${className}` : ""}`}
+        onMouseUp={createMouseUp}
+      >
+        {/* Header row */}
+        <div className="grid grid-cols-7 border-b border-gray-200 flex-shrink-0">
+          {WEEK_DAYS.map((day) => (
             <div
-              className="absolute inset-0 grid grid-cols-7"
-              style={{ pointerEvents: "none" }}
+              key={day}
+              className="py-2 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider"
             >
-              {rowSegs.map((seg) => (
-                <MarketingEventBar
-                  key={`${seg.event.id}-${seg.weekRow}`}
-                  event={seg.event}
-                  startCol={seg.startCol}
-                  endCol={seg.endCol}
-                  lane={seg.lane}
-                  onClick={onEventClick}
-                />
-              ))}
+              {day}
             </div>
-          </div>
-        );
-      })}
+          ))}
+        </div>
+
+        {/* Week rows */}
+        <div className="flex flex-col flex-1">
+          {Array.from({ length: weekCount }, (_, w) => {
+            const rowCells = dayCells.filter((c) => c.weekRow === w);
+            const rowSegs = segmentsByRow.get(w) ?? [];
+
+            return (
+              <div
+                key={w}
+                className="relative flex-1 grid grid-cols-7 border-b border-gray-200 last:border-b-0"
+                style={{ minHeight: rowMinHeights[w] }}
+              >
+                {/* Day cells (droppable) */}
+                {rowCells.map((cell) => (
+                  <CalendarDayCell
+                    key={cell.dateStr}
+                    dateStr={cell.dateStr}
+                    isCurrentMonth={cell.isCurrentMonth}
+                    isToday={isToday(cell.date)}
+                    day={cell.date.getDate()}
+                    isHighlighted={isDateInSelection(cell.dateStr)}
+                    onMouseDown={() => createMouseDown(cell.dateStr)}
+                    onMouseEnter={() => createMouseEnter(cell.dateStr)}
+                  />
+                ))}
+
+                {/* Event bar overlay */}
+                <div
+                  className="absolute inset-0 grid grid-cols-7"
+                  style={{ pointerEvents: "none" }}
+                >
+                  {rowSegs.map((seg) => {
+                    const segKey = `${seg.weekRow}-${seg.startCol}`;
+                    const bounds = eventSegmentBounds.get(seg.event.id);
+                    return (
+                      <MarketingEventBar
+                        key={`${seg.event.id}-${seg.weekRow}`}
+                        event={seg.event}
+                        startCol={seg.startCol}
+                        endCol={seg.endCol}
+                        lane={seg.lane}
+                        weekRowStartDate={weekStarts[w]}
+                        isFirstSegment={bounds?.firstKey === segKey}
+                        isLastSegment={bounds?.lastKey === segKey}
+                        isDragActive={dragState?.eventId === seg.event.id}
+                        onClick={onEventClick}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      <DragOverlay dropAnimation={null}>
+        {dragState?.type === "move" ? (
+          <CalendarDragOverlay event={dragState.event} />
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 };
 

--- a/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
+++ b/frontend/src/components/marketing/calendar/MarketingMonthCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useEffect, useRef, useCallback } from "react";
 import { DndContext, closestCenter, DragOverlay } from "@dnd-kit/core";
 import type { CalendarEvent, EventSegment } from "./useCalendarLayout";
 import { useCalendarLayout } from "./useCalendarLayout";
@@ -11,7 +11,7 @@ import CalendarDayCell from "./CalendarDayCell";
 import CalendarDragOverlay from "./CalendarDragOverlay";
 import { useCalendarDnd } from "./useCalendarDnd";
 import { useCreateByDrag } from "./useCreateByDrag";
-import { toDateString } from "./calendarDateUtils";
+import { toDateString, clampDateString } from "./calendarDateUtils";
 import type { CalendarDndCallbacks } from "./calendarDndTypes";
 
 const WEEK_DAYS = ["Po", "Út", "St", "Čt", "Pá", "So", "Ne"];
@@ -36,6 +36,12 @@ interface DayCell {
   col: number; // 1–7
 }
 
+interface ResizeDragState {
+  type: 'start' | 'end';
+  eventId: number;
+  currentDate: string; // the date the pointer is currently over
+}
+
 const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
   year,
   month,
@@ -48,6 +54,7 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
 }) => {
   const today = new Date();
 
+  // --- Move drag via dnd-kit ---
   const callbacks: CalendarDndCallbacks = useMemo(
     () => ({ onEventMove, onEventResize, onCreateRange }),
     [onEventMove, onEventResize, onCreateRange],
@@ -63,7 +70,78 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
     handleDragCancel,
   } = useCalendarDnd(events, callbacks);
 
-  const segments = useCalendarLayout(previewEvents, year, month);
+  // --- Resize drag via pointer events ---
+  const [resizeDrag, setResizeDrag] = useState<ResizeDragState | null>(null);
+
+  // Stable refs so the pointerup handler always reads the latest values
+  const eventsRef = useRef(events);
+  eventsRef.current = events;
+  const onEventResizeRef = useRef(onEventResize);
+  onEventResizeRef.current = onEventResize;
+
+  const handleResizePointerDown = useCallback(
+    (type: 'start' | 'end', eventId: number) => {
+      const ev = events.find((x) => x.id === eventId);
+      if (!ev) return;
+      setResizeDrag({
+        type,
+        eventId,
+        currentDate: type === 'start' ? ev.dateFrom : ev.dateTo,
+      });
+    },
+    [events],
+  );
+
+  const handleResizeCellEnter = useCallback((date: string) => {
+    setResizeDrag((prev) => {
+      if (!prev || prev.currentDate === date) return prev;
+      return { ...prev, currentDate: date };
+    });
+  }, []);
+
+  // Commit or cancel resize on pointerup / pointercancel anywhere on the page
+  useEffect(() => {
+    if (!resizeDrag) return;
+
+    const commit = () => {
+      setResizeDrag((drag) => {
+        if (!drag) return null;
+        const ev = eventsRef.current.find((x) => x.id === drag.eventId);
+        if (ev) {
+          if (drag.type === 'start') {
+            const newFrom = clampDateString(drag.currentDate, ev.dateTo);
+            onEventResizeRef.current(drag.eventId, newFrom, ev.dateTo);
+          } else {
+            const newTo = drag.currentDate < ev.dateFrom ? ev.dateFrom : drag.currentDate;
+            onEventResizeRef.current(drag.eventId, ev.dateFrom, newTo);
+          }
+        }
+        return null;
+      });
+    };
+
+    document.addEventListener('pointerup', commit);
+    document.addEventListener('pointercancel', commit);
+    return () => {
+      document.removeEventListener('pointerup', commit);
+      document.removeEventListener('pointercancel', commit);
+    };
+  }, [resizeDrag]);
+
+  // Apply resize preview on top of move preview
+  const resizePreviewEvents = useMemo<CalendarEvent[]>(() => {
+    if (!resizeDrag) return previewEvents;
+    return previewEvents.map((ev) => {
+      if (ev.id !== resizeDrag.eventId) return ev;
+      if (resizeDrag.type === 'start') {
+        return { ...ev, dateFrom: clampDateString(resizeDrag.currentDate, ev.dateTo) };
+      }
+      const newTo = resizeDrag.currentDate < ev.dateFrom ? ev.dateFrom : resizeDrag.currentDate;
+      return { ...ev, dateTo: newTo };
+    });
+  }, [resizeDrag, previewEvents]);
+
+  const segments = useCalendarLayout(resizePreviewEvents, year, month);
 
   // Build day cells
   const { dayCells, weekCount, weekStarts } = useMemo(() => {
@@ -141,10 +219,14 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
     return map;
   }, [segments]);
 
-  // Determine first/last segment keys for each event (for resize handle visibility)
+  // Determine first/last segment keys per event (for resize handle visibility).
+  // Only consider segments within the visible weekCount — events may extend into
+  // trimmed rows, which would otherwise incorrectly mark the last visible
+  // segment as non-last.
   const eventSegmentBounds = useMemo(() => {
     const bounds = new Map<number, { firstKey: string; lastKey: string }>();
     for (const seg of segments) {
+      if (seg.weekRow >= weekCount) continue;
       const key = `${seg.weekRow}-${seg.startCol}`;
       const existing = bounds.get(seg.event.id);
       if (!existing) {
@@ -154,7 +236,7 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
       }
     }
     return bounds;
-  }, [segments]);
+  }, [segments, weekCount]);
 
   const isDateInSelection = (dateStr: string) => {
     if (!selectionRange) return false;
@@ -199,7 +281,7 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
                 className="relative flex-1 grid grid-cols-7 border-b border-gray-200 last:border-b-0"
                 style={{ minHeight: rowMinHeights[w] }}
               >
-                {/* Day cells (droppable) */}
+                {/* Day cells (droppable + resize hover target) */}
                 {rowCells.map((cell) => (
                   <CalendarDayCell
                     key={cell.dateStr}
@@ -210,6 +292,7 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
                     isHighlighted={isDateInSelection(cell.dateStr)}
                     onMouseDown={() => createMouseDown(cell.dateStr)}
                     onMouseEnter={() => createMouseEnter(cell.dateStr)}
+                    onPointerEnter={() => handleResizeCellEnter(cell.dateStr)}
                   />
                 ))}
 
@@ -231,8 +314,10 @@ const MarketingMonthCalendar: React.FC<MarketingMonthCalendarProps> = ({
                         weekRowStartDate={weekStarts[w]}
                         isFirstSegment={bounds?.firstKey === segKey}
                         isLastSegment={bounds?.lastKey === segKey}
-                        isDragActive={dragState?.eventId === seg.event.id}
+                        isDragActive={dragState?.type === 'move' && dragState?.eventId === seg.event.id}
+                        isResizing={resizeDrag?.eventId === seg.event.id}
                         onClick={onEventClick}
+                        onResizePointerDown={handleResizePointerDown}
                       />
                     );
                   })}

--- a/frontend/src/components/marketing/calendar/__tests__/calendarDateUtils.test.ts
+++ b/frontend/src/components/marketing/calendar/__tests__/calendarDateUtils.test.ts
@@ -1,0 +1,51 @@
+import { toDateString, addDaysToDateString, daysBetween, clampDateString } from "../calendarDateUtils";
+
+describe("calendarDateUtils", () => {
+  describe("toDateString", () => {
+    test("formats Date to YYYY-MM-DD", () => {
+      expect(toDateString(new Date(2026, 3, 15))).toBe("2026-04-15");
+    });
+
+    test("pads single-digit month and day", () => {
+      expect(toDateString(new Date(2026, 0, 5))).toBe("2026-01-05");
+    });
+  });
+
+  describe("addDaysToDateString", () => {
+    test("adds positive days", () => {
+      expect(addDaysToDateString("2026-04-15", 3)).toBe("2026-04-18");
+    });
+
+    test("adds negative days", () => {
+      expect(addDaysToDateString("2026-04-15", -5)).toBe("2026-04-10");
+    });
+
+    test("crosses month boundary", () => {
+      expect(addDaysToDateString("2026-04-29", 3)).toBe("2026-05-02");
+    });
+  });
+
+  describe("daysBetween", () => {
+    test("returns positive for forward range", () => {
+      expect(daysBetween("2026-04-10", "2026-04-15")).toBe(5);
+    });
+
+    test("returns negative for backward range", () => {
+      expect(daysBetween("2026-04-15", "2026-04-10")).toBe(-5);
+    });
+
+    test("returns zero for same date", () => {
+      expect(daysBetween("2026-04-10", "2026-04-10")).toBe(0);
+    });
+  });
+
+  describe("clampDateString", () => {
+    test("clamps when from > to, returns to", () => {
+      expect(clampDateString("2026-04-20", "2026-04-15")).toBe("2026-04-15");
+    });
+
+    test("returns original when from <= to", () => {
+      expect(clampDateString("2026-04-10", "2026-04-15")).toBe("2026-04-10");
+    });
+  });
+});

--- a/frontend/src/components/marketing/calendar/__tests__/useCalendarDnd.test.ts
+++ b/frontend/src/components/marketing/calendar/__tests__/useCalendarDnd.test.ts
@@ -1,0 +1,71 @@
+import { computePreviewEvents } from '../useCalendarDnd';
+import type { CalendarEvent } from '../useCalendarLayout';
+
+const EVENT: CalendarEvent = {
+  id: 1,
+  title: 'Test Event',
+  actionType: 'SocialMedia',
+  dateFrom: '2026-04-10',
+  dateTo: '2026-04-15',
+  associatedProducts: [],
+};
+const EVENTS: CalendarEvent[] = [
+  EVENT,
+  {
+    id: 2,
+    title: 'Other',
+    actionType: 'Email',
+    dateFrom: '2026-04-12',
+    dateTo: '2026-04-14',
+    associatedProducts: [],
+  },
+];
+
+describe('computePreviewEvents', () => {
+  test('move shifts both dates by delta', () => {
+    const result = computePreviewEvents(EVENTS, { type: 'move', eventId: 1, dateDelta: 3 });
+    const moved = result.find((e) => e.id === 1)!;
+    expect(moved.dateFrom).toBe('2026-04-13');
+    expect(moved.dateTo).toBe('2026-04-18');
+  });
+
+  test('move does not affect other events', () => {
+    const result = computePreviewEvents(EVENTS, { type: 'move', eventId: 1, dateDelta: 3 });
+    const other = result.find((e) => e.id === 2)!;
+    expect(other.dateFrom).toBe('2026-04-12');
+    expect(other.dateTo).toBe('2026-04-14');
+  });
+
+  test('resize-start adjusts dateFrom only', () => {
+    const result = computePreviewEvents(EVENTS, { type: 'resize-start', eventId: 1, dateDelta: 2 });
+    const resized = result.find((e) => e.id === 1)!;
+    expect(resized.dateFrom).toBe('2026-04-12');
+    expect(resized.dateTo).toBe('2026-04-15');
+  });
+
+  test('resize-start clamps to not exceed dateTo', () => {
+    const result = computePreviewEvents(EVENTS, { type: 'resize-start', eventId: 1, dateDelta: 10 });
+    const resized = result.find((e) => e.id === 1)!;
+    expect(resized.dateFrom).toBe('2026-04-15');
+    expect(resized.dateTo).toBe('2026-04-15');
+  });
+
+  test('resize-end adjusts dateTo only', () => {
+    const result = computePreviewEvents(EVENTS, { type: 'resize-end', eventId: 1, dateDelta: -2 });
+    const resized = result.find((e) => e.id === 1)!;
+    expect(resized.dateFrom).toBe('2026-04-10');
+    expect(resized.dateTo).toBe('2026-04-13');
+  });
+
+  test('resize-end clamps to not go before dateFrom', () => {
+    const result = computePreviewEvents(EVENTS, { type: 'resize-end', eventId: 1, dateDelta: -10 });
+    const resized = result.find((e) => e.id === 1)!;
+    expect(resized.dateFrom).toBe('2026-04-10');
+    expect(resized.dateTo).toBe('2026-04-10');
+  });
+
+  test('returns unchanged events when no drag state', () => {
+    const result = computePreviewEvents(EVENTS, null);
+    expect(result).toBe(EVENTS);
+  });
+});

--- a/frontend/src/components/marketing/calendar/__tests__/useCreateByDrag.test.ts
+++ b/frontend/src/components/marketing/calendar/__tests__/useCreateByDrag.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, act } from "@testing-library/react";
+import { useCreateByDrag } from "../useCreateByDrag";
+
+describe("useCreateByDrag", () => {
+  test("selection is null initially", () => {
+    const onCreateRange = jest.fn();
+    const { result } = renderHook(() => useCreateByDrag(onCreateRange));
+    expect(result.current.selectionRange).toBeNull();
+  });
+
+  test("mouseDown + mouseEnter creates selection range", () => {
+    const onCreateRange = jest.fn();
+    const { result } = renderHook(() => useCreateByDrag(onCreateRange));
+
+    act(() => result.current.handleMouseDown("2026-04-10"));
+    act(() => result.current.handleMouseEnter("2026-04-14"));
+
+    expect(result.current.selectionRange).toEqual({ from: "2026-04-10", to: "2026-04-14" });
+  });
+
+  test("selection sorts dates when dragging backwards", () => {
+    const onCreateRange = jest.fn();
+    const { result } = renderHook(() => useCreateByDrag(onCreateRange));
+
+    act(() => result.current.handleMouseDown("2026-04-14"));
+    act(() => result.current.handleMouseEnter("2026-04-10"));
+
+    expect(result.current.selectionRange).toEqual({ from: "2026-04-10", to: "2026-04-14" });
+  });
+
+  test("mouseUp calls onCreateRange with sorted dates", () => {
+    const onCreateRange = jest.fn();
+    const { result } = renderHook(() => useCreateByDrag(onCreateRange));
+
+    act(() => result.current.handleMouseDown("2026-04-10"));
+    act(() => result.current.handleMouseEnter("2026-04-14"));
+    act(() => result.current.handleMouseUp());
+
+    expect(onCreateRange).toHaveBeenCalledWith("2026-04-10", "2026-04-14");
+    expect(result.current.selectionRange).toBeNull();
+  });
+
+  test("mouseUp without prior mouseDown does nothing", () => {
+    const onCreateRange = jest.fn();
+    const { result } = renderHook(() => useCreateByDrag(onCreateRange));
+
+    act(() => result.current.handleMouseUp());
+
+    expect(onCreateRange).not.toHaveBeenCalled();
+  });
+
+  test("single-day click calls onCreateRange with same from and to", () => {
+    const onCreateRange = jest.fn();
+    const { result } = renderHook(() => useCreateByDrag(onCreateRange));
+
+    act(() => result.current.handleMouseDown("2026-04-10"));
+    act(() => result.current.handleMouseUp());
+
+    expect(onCreateRange).toHaveBeenCalledWith("2026-04-10", "2026-04-10");
+  });
+});

--- a/frontend/src/components/marketing/calendar/calendarDateUtils.ts
+++ b/frontend/src/components/marketing/calendar/calendarDateUtils.ts
@@ -1,0 +1,33 @@
+/** Format a Date as "YYYY-MM-DD" without timezone offset issues. */
+export function toDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/** Parse "YYYY-MM-DD" to a local Date (avoids UTC offset of new Date(string)). */
+export function parseDateString(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/** Add days to a "YYYY-MM-DD" string, returns new "YYYY-MM-DD". */
+export function addDaysToDateString(dateStr: string, days: number): string {
+  const date = parseDateString(dateStr);
+  date.setDate(date.getDate() + days);
+  return toDateString(date);
+}
+
+/** Number of days from dateA to dateB (positive if B is after A). */
+export function daysBetween(dateA: string, dateB: string): number {
+  const a = parseDateString(dateA);
+  const b = parseDateString(dateB);
+  const msPerDay = 86_400_000;
+  return Math.round((b.getTime() - a.getTime()) / msPerDay);
+}
+
+/** If fromDate > toDate, return toDate. Otherwise return fromDate. */
+export function clampDateString(fromDate: string, toDate: string): string {
+  return fromDate > toDate ? toDate : fromDate;
+}

--- a/frontend/src/components/marketing/calendar/calendarDateUtils.ts
+++ b/frontend/src/components/marketing/calendar/calendarDateUtils.ts
@@ -15,8 +15,7 @@ export function parseDateString(dateStr: string): Date {
 /** Add days to a "YYYY-MM-DD" string, returns new "YYYY-MM-DD". */
 export function addDaysToDateString(dateStr: string, days: number): string {
   const date = parseDateString(dateStr);
-  date.setDate(date.getDate() + days);
-  return toDateString(date);
+  return toDateString(new Date(date.getFullYear(), date.getMonth(), date.getDate() + days));
 }
 
 /** Number of days from dateA to dateB (positive if B is after A). */

--- a/frontend/src/components/marketing/calendar/calendarDndTypes.ts
+++ b/frontend/src/components/marketing/calendar/calendarDndTypes.ts
@@ -1,0 +1,34 @@
+import type { CalendarEvent } from "./useCalendarLayout";
+
+export type DragType = "move" | "resize-start" | "resize-end";
+
+export interface MoveDragData {
+  type: "move";
+  eventId: number;
+  event: CalendarEvent;
+  originDate: string; // "YYYY-MM-DD" of the day cell where pointer started
+}
+
+export interface ResizeStartDragData {
+  type: "resize-start";
+  eventId: number;
+  event: CalendarEvent;
+}
+
+export interface ResizeEndDragData {
+  type: "resize-end";
+  eventId: number;
+  event: CalendarEvent;
+}
+
+export type CalendarDragData = MoveDragData | ResizeStartDragData | ResizeEndDragData;
+
+export interface DayDropData {
+  date: string; // "YYYY-MM-DD"
+}
+
+export interface CalendarDndCallbacks {
+  onEventMove: (eventId: number, newDateFrom: string, newDateTo: string) => void;
+  onEventResize: (eventId: number, newDateFrom: string, newDateTo: string) => void;
+  onCreateRange: (dateFrom: string, dateTo: string) => void;
+}

--- a/frontend/src/components/marketing/calendar/calendarDndTypes.ts
+++ b/frontend/src/components/marketing/calendar/calendarDndTypes.ts
@@ -1,5 +1,14 @@
 import type { CalendarEvent } from "./useCalendarLayout";
 
+export const ACTION_TYPE_COLORS: Record<string, string> = {
+  SocialMedia: "bg-blue-500 text-white",
+  Event: "bg-purple-500 text-white",
+  Email: "bg-green-500 text-white",
+  PR: "bg-yellow-500 text-gray-900",
+  Photoshoot: "bg-pink-500 text-white",
+  Other: "bg-gray-500 text-white",
+};
+
 export type DragType = "move" | "resize-start" | "resize-end";
 
 export interface MoveDragData {

--- a/frontend/src/components/marketing/calendar/useCalendarDnd.ts
+++ b/frontend/src/components/marketing/calendar/useCalendarDnd.ts
@@ -1,0 +1,146 @@
+import { useState, useCallback, useMemo } from 'react';
+import {
+  useSensors,
+  useSensor,
+  PointerSensor,
+  TouchSensor,
+  type DragStartEvent,
+  type DragOverEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import type { CalendarEvent } from './useCalendarLayout';
+import type { CalendarDragData, DayDropData, CalendarDndCallbacks } from './calendarDndTypes';
+import { addDaysToDateString, daysBetween, clampDateString } from './calendarDateUtils';
+
+interface DragState {
+  type: 'move' | 'resize-start' | 'resize-end';
+  eventId: number;
+  event: CalendarEvent;
+  originDate: string;
+  dateDelta: number;
+}
+
+interface PreviewInput {
+  type: 'move' | 'resize-start' | 'resize-end';
+  eventId: number;
+  dateDelta: number;
+}
+
+export function computePreviewEvents(
+  events: readonly CalendarEvent[],
+  drag: PreviewInput | null,
+): CalendarEvent[] {
+  if (!drag) return events as CalendarEvent[];
+
+  return events.map((ev) => {
+    if (ev.id !== drag.eventId) return ev;
+
+    switch (drag.type) {
+      case 'move':
+        return {
+          ...ev,
+          dateFrom: addDaysToDateString(ev.dateFrom, drag.dateDelta),
+          dateTo: addDaysToDateString(ev.dateTo, drag.dateDelta),
+        };
+      case 'resize-start': {
+        const newFrom = addDaysToDateString(ev.dateFrom, drag.dateDelta);
+        return { ...ev, dateFrom: clampDateString(newFrom, ev.dateTo) };
+      }
+      case 'resize-end': {
+        const newTo = addDaysToDateString(ev.dateTo, drag.dateDelta);
+        return { ...ev, dateTo: newTo < ev.dateFrom ? ev.dateFrom : newTo };
+      }
+      default:
+        return ev;
+    }
+  });
+}
+
+export function useCalendarDnd(events: CalendarEvent[], callbacks: CalendarDndCallbacks) {
+  const [dragState, setDragState] = useState<DragState | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
+
+  const previewEvents = useMemo(
+    () => computePreviewEvents(events, dragState),
+    [events, dragState],
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const data = event.active.data.current as CalendarDragData;
+    setDragState({
+      type: data.type,
+      eventId: data.eventId,
+      event: data.event,
+      originDate: data.type === 'move' ? data.originDate : data.event.dateFrom,
+      dateDelta: 0,
+    });
+  }, []);
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      if (!dragState || !event.over) return;
+      const dropData = event.over.data.current as DayDropData | undefined;
+      if (!dropData?.date) return;
+
+      const hoverDate = dropData.date;
+      let delta: number;
+
+      if (dragState.type === 'move') {
+        delta = daysBetween(dragState.originDate, hoverDate);
+      } else if (dragState.type === 'resize-start') {
+        delta = daysBetween(dragState.event.dateFrom, hoverDate);
+      } else {
+        delta = daysBetween(dragState.event.dateTo, hoverDate);
+      }
+
+      if (delta !== dragState.dateDelta) {
+        setDragState((prev) => (prev ? { ...prev, dateDelta: delta } : null));
+      }
+    },
+    [dragState],
+  );
+
+  const handleDragEnd = useCallback(
+    (_event: DragEndEvent) => {
+      if (!dragState || dragState.dateDelta === 0) {
+        setDragState(null);
+        return;
+      }
+
+      const { type, eventId, event: ev, dateDelta } = dragState;
+
+      if (type === 'move') {
+        callbacks.onEventMove(
+          eventId,
+          addDaysToDateString(ev.dateFrom, dateDelta),
+          addDaysToDateString(ev.dateTo, dateDelta),
+        );
+      } else if (type === 'resize-start') {
+        const newFrom = clampDateString(addDaysToDateString(ev.dateFrom, dateDelta), ev.dateTo);
+        callbacks.onEventResize(eventId, newFrom, ev.dateTo);
+      } else {
+        const newTo = addDaysToDateString(ev.dateTo, dateDelta);
+        callbacks.onEventResize(eventId, ev.dateFrom, newTo < ev.dateFrom ? ev.dateFrom : newTo);
+      }
+
+      setDragState(null);
+    },
+    [dragState, callbacks],
+  );
+
+  const handleDragCancel = useCallback(() => setDragState(null), []);
+
+  return {
+    sensors,
+    dragState,
+    previewEvents,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    handleDragCancel,
+  };
+}

--- a/frontend/src/components/marketing/calendar/useCreateByDrag.ts
+++ b/frontend/src/components/marketing/calendar/useCreateByDrag.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from "react";
+
+interface SelectionRange {
+  from: string; // "YYYY-MM-DD", always <= to
+  to: string;
+}
+
+export function useCreateByDrag(
+  onCreateRange: (dateFrom: string, dateTo: string) => void,
+) {
+  const [startDate, setStartDate] = useState<string | null>(null);
+  const [selectionRange, setSelectionRange] = useState<SelectionRange | null>(null);
+
+  const sortDates = (a: string, b: string): [string, string] =>
+    a <= b ? [a, b] : [b, a];
+
+  const handleMouseDown = useCallback((dateStr: string) => {
+    setStartDate(dateStr);
+    setSelectionRange({ from: dateStr, to: dateStr });
+  }, []);
+
+  const handleMouseEnter = useCallback(
+    (dateStr: string) => {
+      if (!startDate) return;
+      const [from, to] = sortDates(startDate, dateStr);
+      setSelectionRange({ from, to });
+    },
+    [startDate],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (startDate && selectionRange) {
+      onCreateRange(selectionRange.from, selectionRange.to);
+    }
+    setStartDate(null);
+    setSelectionRange(null);
+  }, [startDate, selectionRange, onCreateRange]);
+
+  return { selectionRange, handleMouseDown, handleMouseEnter, handleMouseUp };
+}

--- a/frontend/src/components/marketing/detail/MarketingActionModal.tsx
+++ b/frontend/src/components/marketing/detail/MarketingActionModal.tsx
@@ -68,6 +68,7 @@ interface MarketingActionModalProps {
   isOpen: boolean;
   onClose: () => void;
   existingAction?: MarketingActionDto | null;
+  prefillDates?: { dateFrom: string; dateTo: string } | null;
 }
 
 const toDateInputValue = (d: string | Date | undefined): string => {
@@ -87,6 +88,7 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
   isOpen,
   onClose,
   existingAction,
+  prefillDates,
 }) => {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [error, setError] = useState<string | null>(null);
@@ -113,11 +115,17 @@ const MarketingActionModal: React.FC<MarketingActionModalProps> = ({
         })),
         productInput: "",
       });
+    } else if (prefillDates) {
+      setForm({
+        ...EMPTY_FORM,
+        dateFrom: prefillDates.dateFrom,
+        dateTo: prefillDates.dateTo,
+      });
     } else {
       setForm(EMPTY_FORM);
     }
     setError(null);
-  }, [existingAction, isOpen]);
+  }, [existingAction, prefillDates, isOpen]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -147,7 +147,7 @@ const MarketingCalendarPage: React.FC = () => {
 
   const handleEventMove = useCallback(
     (eventId: number, newDateFrom: string, newDateTo: string) => {
-      const event = calendarEvents.find((e: any) => e.id === eventId);
+      const event = calendarEvents.find((e) => e.id === eventId);
       if (!event) return;
       updateMutation.mutate({
         id: eventId,
@@ -165,7 +165,7 @@ const MarketingCalendarPage: React.FC = () => {
 
   const handleEventResize = useCallback(
     (eventId: number, newDateFrom: string, newDateTo: string) => {
-      const event = calendarEvents.find((e: any) => e.id === eventId);
+      const event = calendarEvents.find((e) => e.id === eventId);
       if (!event) return;
       updateMutation.mutate({
         id: eventId,

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import { Plus, Calendar, List } from "lucide-react";
 import CalendarNavigation from "../../manufacture/calendar/CalendarNavigation";
 import MarketingMonthCalendar from "../calendar/MarketingMonthCalendar";
@@ -13,6 +13,7 @@ import {
   useMarketingCalendar,
   useMarketingActions,
   useMarketingAction,
+  useUpdateMarketingAction,
 } from "../../../api/hooks/useMarketingCalendar";
 import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
 
@@ -33,6 +34,22 @@ const CZECH_MONTHS = [
 
 type ViewMode = "calendar" | "list";
 
+const ACTION_TYPE_TO_INT: Record<string, number> = {
+  General: 0,
+  SocialMedia: 0,
+  Promotion: 1,
+  Launch: 2,
+  Email: 2,
+  Campaign: 3,
+  PR: 3,
+  Event: 4,
+  Photoshoot: 4,
+  Other: 99,
+};
+
+const resolveActionTypeToInt = (actionType: string): number =>
+  ACTION_TYPE_TO_INT[actionType] ?? 99;
+
 const MarketingCalendarPage: React.FC = () => {
   const [viewMode, setViewMode] = useState<ViewMode>("calendar");
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -43,6 +60,8 @@ const MarketingCalendarPage: React.FC = () => {
   const [editingAction, setEditingAction] = useState<MarketingActionDto | null>(
     null,
   );
+  const [prefillDates, setPrefillDates] = useState<{ dateFrom: string; dateTo: string } | null>(null);
+  const updateMutation = useUpdateMarketingAction();
 
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
@@ -110,6 +129,7 @@ const MarketingCalendarPage: React.FC = () => {
 
   const openCreate = () => {
     setEditingAction(null);
+    setPrefillDates(null);
     setIsModalOpen(true);
   };
 
@@ -122,7 +142,53 @@ const MarketingCalendarPage: React.FC = () => {
     setIsModalOpen(false);
     setEditingAction(null);
     setSelectedActionId(null);
+    setPrefillDates(null);
   };
+
+  const handleEventMove = useCallback(
+    (eventId: number, newDateFrom: string, newDateTo: string) => {
+      const event = calendarEvents.find((e: any) => e.id === eventId);
+      if (!event) return;
+      updateMutation.mutate({
+        id: eventId,
+        request: {
+          title: event.title,
+          actionType: resolveActionTypeToInt(event.actionType),
+          startDate: new Date(newDateFrom),
+          endDate: new Date(newDateTo),
+          associatedProducts: event.associatedProducts,
+        },
+      });
+    },
+    [calendarEvents, updateMutation],
+  );
+
+  const handleEventResize = useCallback(
+    (eventId: number, newDateFrom: string, newDateTo: string) => {
+      const event = calendarEvents.find((e: any) => e.id === eventId);
+      if (!event) return;
+      updateMutation.mutate({
+        id: eventId,
+        request: {
+          title: event.title,
+          actionType: resolveActionTypeToInt(event.actionType),
+          startDate: new Date(newDateFrom),
+          endDate: new Date(newDateTo),
+          associatedProducts: event.associatedProducts,
+        },
+      });
+    },
+    [calendarEvents, updateMutation],
+  );
+
+  const handleCreateRange = useCallback(
+    (dateFrom: string, dateTo: string) => {
+      setPrefillDates({ dateFrom, dateTo });
+      setEditingAction(null);
+      setIsModalOpen(true);
+    },
+    [],
+  );
 
   // Sync detail data into editingAction when it arrives
   React.useEffect(() => {
@@ -211,6 +277,9 @@ const MarketingCalendarPage: React.FC = () => {
                   month={month}
                   events={calendarEvents}
                   onEventClick={openEdit}
+                  onEventMove={handleEventMove}
+                  onEventResize={handleEventResize}
+                  onCreateRange={handleCreateRange}
                   className="h-full"
                 />
               </div>
@@ -248,6 +317,7 @@ const MarketingCalendarPage: React.FC = () => {
         isOpen={isModalOpen}
         onClose={closeModal}
         existingAction={editingAction}
+        prefillDates={prefillDates}
       />
     </div>
   );

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback } from "react";
 import { Plus, Calendar, List } from "lucide-react";
 import CalendarNavigation from "../../manufacture/calendar/CalendarNavigation";
 import MarketingMonthCalendar from "../calendar/MarketingMonthCalendar";
+import type { CalendarEvent } from "../calendar/useCalendarLayout";
 import MarketingActionGrid from "../list/MarketingActionGrid";
 import type { MarketingActionDto } from "../list/MarketingActionGrid";
 import MarketingActionFilters, {
@@ -147,7 +148,7 @@ const MarketingCalendarPage: React.FC = () => {
 
   const handleEventMove = useCallback(
     (eventId: number, newDateFrom: string, newDateTo: string) => {
-      const event = calendarEvents.find((e) => e.id === eventId);
+      const event = calendarEvents.find((e: CalendarEvent) => e.id === eventId);
       if (!event) return;
       updateMutation.mutate({
         id: eventId,
@@ -165,7 +166,7 @@ const MarketingCalendarPage: React.FC = () => {
 
   const handleEventResize = useCallback(
     (eventId: number, newDateFrom: string, newDateTo: string) => {
-      const event = calendarEvents.find((e) => e.id === eventId);
+      const event = calendarEvents.find((e: CalendarEvent) => e.id === eventId);
       if (!event) return;
       updateMutation.mutate({
         id: eventId,


### PR DESCRIPTION
## Summary

- Add move (drag event bar body), resize-start (left handle), and resize-end (right handle) interactions using `@dnd-kit/core`
- Add create-by-drag on empty calendar cells (mousedown + drag highlights range, mouseup opens create modal with dates prefilled)
- Live drag preview: events reflow during drag via `computePreviewEvents` fed into `useCalendarLayout`
- Ghost bar overlay during move operations via `CalendarDragOverlay`

## New files

| File | Purpose |
|------|---------|
| `calendarDateUtils.ts` | Date math helpers (`addDaysToDateString`, `daysBetween`, `clampDateString`) |
| `calendarDndTypes.ts` | Shared DnD discriminated union types + `ACTION_TYPE_COLORS` |
| `CalendarDayCell.tsx` | Droppable day cell wrapping `useDroppable` |
| `useCalendarDnd.ts` | Central DnD hook: sensors, drag state, `computePreviewEvents` |
| `CalendarDragOverlay.tsx` | Ghost bar shown in `<DragOverlay>` during move |
| `useCreateByDrag.ts` | Mouse-based empty-cell range selection hook |

## Modified files

| File | Change |
|------|--------|
| `MarketingEventBar.tsx` | Added `useDraggable` body + left/right resize handles |
| `MarketingMonthCalendar.tsx` | Wrapped in `DndContext`, replaced day divs with `CalendarDayCell`, added `DragOverlay` |
| `MarketingActionModal.tsx` | Added optional `prefillDates` prop for create-by-drag |
| `MarketingCalendarPage.tsx` | Wired `handleEventMove`, `handleEventResize`, `handleCreateRange` callbacks |

## Test plan

- [ ] Drag event bar to another week → both dates shift, bar moves
- [ ] Drag 10-day event across week boundary → segments re-render live
- [ ] Hover left edge (cursor = col-resize), drag right → `dateFrom` advances
- [ ] Hover right edge, drag left → `dateTo` shrinks
- [ ] Resize start past end → clamps to 1-day minimum
- [ ] Drag on empty cells Mon→Wed → modal opens with Mon–Wed prefilled
- [ ] Single click on event → edit modal opens (not drag)
- [ ] Press Escape during drag → event snaps back
- [ ] `npx jest --no-coverage` → 810 pass, 0 fail
- [ ] `npm run build` → no errors

Closes #770