### PR TITLE
fix: use hybrid cache+realtime for IncludeCurrentMonth=true in FinancialOverview

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/FinancialOverview/Services/FinancialAnalysisService.cs
@@ -45,18 +45,34 @@ public class FinancialAnalysisService : IFinancialAnalysisService
         _logger.LogInformation("Fetching financial overview for {Months} months, IncludeStock={IncludeStock}, ExcludedDepartments={ExcludedDepartments}, IncludeCurrentMonth={IncludeCurrentMonth}",
             months, includeStockData, excludedDepartments?.Count ?? 0, includeCurrentMonth);
 
-        // When departments are excluded or current month is requested, use real-time calculation.
-        // The cache stores pre-aggregated totals per completed month and cannot handle these cases.
-        if (excludedDepartments is { Count: > 0 } || includeCurrentMonth)
+        // Department filter always requires real-time (cache stores undivided totals per month)
+        if (excludedDepartments is { Count: > 0 })
         {
-            if (excludedDepartments is { Count: > 0 })
-                _logger.LogInformation("Department filter active ({Count} excluded), bypassing cache for real-time calculation",
-                    excludedDepartments.Count);
-
-            if (includeCurrentMonth)
-                _logger.LogInformation("Current month requested, bypassing cache for real-time calculation");
-
+            _logger.LogInformation("Department filter active ({Count} excluded), bypassing cache for real-time calculation",
+                excludedDepartments.Count);
             return await GetFinancialOverviewRealTimeAsync(months, includeStockData, excludedDepartments, includeCurrentMonth, cancellationToken);
+        }
+
+        // Current month requested without department filter: use hybrid path
+        // (cache for completed months + real-time for current partial month only)
+        if (includeCurrentMonth)
+        {
+            _logger.LogInformation("Current month requested, using hybrid calculation (cache + real-time current month only)");
+            try
+            {
+                var hybridCacheStatus = GetCacheStatus();
+                if (hybridCacheStatus.CachedMonthsCount == 0)
+                {
+                    _logger.LogInformation("Cache is empty, falling back to full real-time calculation for current month request");
+                    return await GetFinancialOverviewRealTimeAsync(months, includeStockData, null, true, cancellationToken);
+                }
+                return await GetHybridWithCurrentMonthAsync(months, includeStockData, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Hybrid current-month calculation failed, falling back to full real-time");
+                return await GetFinancialOverviewRealTimeAsync(months, includeStockData, null, true, cancellationToken);
+            }
         }
 
         try
@@ -245,6 +261,102 @@ public class FinancialAnalysisService : IFinancialAnalysisService
             _logger.LogError(ex, "Failed to refresh monthly data for {Year}-{Month:D2}",
                 monthStart.Year, monthStart.Month);
         }
+    }
+
+    private async Task<GetFinancialOverviewResponse> GetHybridWithCurrentMonthAsync(
+        int months,
+        bool includeStockData,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var currentMonthStart = new DateTime(now.Year, now.Month, 1);
+        var currentMonthEnd = now.Date;
+
+        _logger.LogInformation(
+            "Fetching current month ({Year}-{Month:D2}) data in real-time, serving {CompletedMonths} completed month(s) from cache",
+            now.Year, now.Month, months - 1);
+
+        // Fetch only the current (partial) month in parallel — narrow query instead of full date range
+        var debitItemsTask = _ledgerService.GetLedgerItems(
+            currentMonthStart,
+            currentMonthEnd,
+            debitAccountPrefix: new[] { "5", "6" },
+            cancellationToken: cancellationToken);
+
+        var creditItemsTask = _ledgerService.GetLedgerItems(
+            currentMonthStart,
+            currentMonthEnd,
+            creditAccountPrefix: new[] { "5", "6" },
+            cancellationToken: cancellationToken);
+
+        var stockChangesTask = includeStockData
+            ? _stockValueService.GetStockValueChangesAsync(currentMonthStart, currentMonthEnd, cancellationToken)
+            : Task.FromResult<IReadOnlyList<MonthlyStockChange>>(new List<MonthlyStockChange>());
+
+        await Task.WhenAll(debitItemsTask, creditItemsTask, stockChangesTask);
+
+        var debitItems = await debitItemsTask;
+        var creditItems = await creditItemsTask;
+        var stockChanges = await stockChangesTask;
+
+        // Compute income/expenses for current month
+        var debit5 = debitItems.Where(i => i.DebitAccountNumber?.StartsWith("5") == true).Sum(i => i.Amount);
+        var credit5 = creditItems.Where(i => i.CreditAccountNumber?.StartsWith("5") == true).Sum(i => i.Amount);
+        var expenses = debit5 - credit5;
+
+        var credit6 = creditItems.Where(i => i.CreditAccountNumber?.StartsWith("6") == true).Sum(i => i.Amount);
+        var debit6 = debitItems.Where(i => i.DebitAccountNumber?.StartsWith("6") == true).Sum(i => i.Amount);
+        var income = credit6 - debit6;
+        var financialBalance = income - expenses;
+
+        var stockChange = stockChanges.FirstOrDefault();
+        var currentMonthDto = new MonthlyFinancialDataDto
+        {
+            Year = now.Year,
+            Month = now.Month,
+            MonthYearDisplay = $"{now.Month:D2}/{now.Year}",
+            Income = income,
+            Expenses = expenses,
+            FinancialBalance = financialBalance,
+            StockChanges = includeStockData && stockChange != null ? new StockChangeDto
+            {
+                Materials = stockChange.StockChanges.Materials,
+                SemiProducts = stockChange.StockChanges.SemiProducts,
+                Products = stockChange.StockChanges.Products
+            } : null,
+            TotalStockValueChange = includeStockData ? (stockChange?.TotalStockValueChange ?? 0) : null,
+            TotalBalance = includeStockData
+                ? financialBalance + (stockChange?.TotalStockValueChange ?? 0)
+                : null
+        };
+
+        // Get cached data for completed months (months-1 most recent completed months)
+        var completedData = months > 1
+            ? GetCachedFinancialOverview(months - 1, includeStockData).Data
+            : new List<MonthlyFinancialDataDto>();
+
+        // Merge: current month first (most recent), then completed months in descending order
+        var allData = new List<MonthlyFinancialDataDto> { currentMonthDto };
+        allData.AddRange(completedData);
+
+        _logger.LogInformation(
+            "Hybrid financial overview ready: 1 real-time month + {CompletedCount} cached month(s)",
+            completedData.Count);
+
+        return new GetFinancialOverviewResponse
+        {
+            Data = allData,
+            Summary = new FinancialSummaryDto
+            {
+                TotalIncome = allData.Sum(d => d.Income),
+                TotalExpenses = allData.Sum(d => d.Expenses),
+                TotalBalance = allData.Sum(d => d.FinancialBalance),
+                AverageMonthlyIncome = allData.Any() ? allData.Average(d => d.Income) : 0,
+                AverageMonthlyExpenses = allData.Any() ? allData.Average(d => d.Expenses) : 0,
+                AverageMonthlyBalance = allData.Any() ? allData.Average(d => d.FinancialBalance) : 0,
+                StockSummary = includeStockData ? CreateStockSummary(allData) : null
+            }
+        };
     }
 
     private GetFinancialOverviewResponse GetCachedFinancialOverview(int months, bool includeStockData)

--- a/backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/FinancialOverview/FinancialAnalysisServiceTests.cs
@@ -1,0 +1,185 @@
+using Anela.Heblo.Application.Features.FinancialOverview;
+using Anela.Heblo.Application.Features.FinancialOverview.Services;
+using Anela.Heblo.Domain.Accounting.Ledger;
+using Anela.Heblo.Domain.Features.FinancialOverview;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Anela.Heblo.Tests.Application.FinancialOverview;
+
+public class FinancialAnalysisServiceTests
+{
+    private readonly Mock<ILedgerService> _ledgerServiceMock;
+    private readonly Mock<IStockValueService> _stockValueServiceMock;
+    private readonly IMemoryCache _memoryCache;
+    private readonly FinancialAnalysisService _service;
+
+    public FinancialAnalysisServiceTests()
+    {
+        _ledgerServiceMock = new Mock<ILedgerService>();
+        _stockValueServiceMock = new Mock<IStockValueService>();
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        var options = Options.Create(new FinancialAnalysisOptions { MonthsToCache = 24 });
+
+        _service = new FinancialAnalysisService(
+            _ledgerServiceMock.Object,
+            _stockValueServiceMock.Object,
+            NullLogger<FinancialAnalysisService>.Instance,
+            options,
+            _memoryCache);
+
+        // Default: ledger returns empty list
+        _ledgerServiceMock
+            .Setup(x => x.GetLedgerItems(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LedgerItem>());
+
+        // Default: stock service returns empty list
+        _stockValueServiceMock
+            .Setup(x => x.GetStockValueChangesAsync(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MonthlyStockChange>());
+    }
+
+    [Fact]
+    public async Task GetFinancialOverviewAsync_WhenIncludeCurrentMonthTrue_AndCachePopulated_OnlyFetchesCurrentMonthFromLedger()
+    {
+        // Arrange: seed the cache with some completed months so cache is not empty
+        var now = DateTime.UtcNow;
+        var prevMonth = now.AddMonths(-1);
+        SeedCacheForMonth(prevMonth.Year, prevMonth.Month);
+
+        // Act
+        await _service.GetFinancialOverviewAsync(
+            months: 3,
+            includeStockData: false,
+            includeCurrentMonth: true);
+
+        // Assert: ledger should only be called with the current month date range
+        var currentMonthStart = new DateTime(now.Year, now.Month, 1);
+        var currentMonthEnd = now.Date;
+
+        _ledgerServiceMock.Verify(
+            x => x.GetLedgerItems(
+                It.Is<DateTime>(d => d == currentMonthStart),
+                It.Is<DateTime>(d => d == currentMonthEnd),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeast(1),
+            "Ledger should be called with current month range only");
+
+        // Assert: ledger should NOT be called with a start date more than 1 month ago
+        var twoMonthsAgo = currentMonthStart.AddMonths(-1);
+        _ledgerServiceMock.Verify(
+            x => x.GetLedgerItems(
+                It.Is<DateTime>(d => d < twoMonthsAgo),
+                It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Ledger should NOT be called with historical date range when cache is populated");
+    }
+
+    [Fact]
+    public async Task GetFinancialOverviewAsync_WhenIncludeCurrentMonthTrue_AndCacheEmpty_FallsBackToFullRealTime()
+    {
+        // Arrange: cache is empty (not seeded)
+
+        var now = DateTime.UtcNow;
+
+        // Act
+        await _service.GetFinancialOverviewAsync(
+            months: 3,
+            includeStockData: false,
+            includeCurrentMonth: true);
+
+        // Assert: ledger is called with a start date that is months ago (full real-time range)
+        var threeMonthsAgo = new DateTime(now.Year, now.Month, 1).AddMonths(-3 + 1);
+        // With includeCurrentMonth=true, endDate=today, startDate=endDate-months+1 months
+        _ledgerServiceMock.Verify(
+            x => x.GetLedgerItems(
+                It.Is<DateTime>(d => d <= threeMonthsAgo.AddDays(1)),
+                It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeast(1),
+            "With empty cache, full real-time range should be used");
+    }
+
+    [Fact]
+    public async Task GetFinancialOverviewAsync_WhenIncludeCurrentMonthTrue_AndCachePopulated_ReturnsCorrectMonthCount()
+    {
+        // Arrange: seed cache for 2 completed months
+        var now = DateTime.UtcNow;
+        SeedCacheForMonth(now.AddMonths(-1).Year, now.AddMonths(-1).Month);
+        SeedCacheForMonth(now.AddMonths(-2).Year, now.AddMonths(-2).Month);
+
+        // Act: request 3 months including current
+        var result = await _service.GetFinancialOverviewAsync(
+            months: 3,
+            includeStockData: false,
+            includeCurrentMonth: true);
+
+        // Assert: result contains current month + 2 completed = 3 months
+        result.Data.Should().HaveCount(3);
+        result.Data[0].Year.Should().Be(now.Year);
+        result.Data[0].Month.Should().Be(now.Month, "current month should be first (most recent)");
+    }
+
+    [Fact]
+    public async Task GetFinancialOverviewAsync_WhenDepartmentsExcludedAndCurrentMonthRequested_UsesFullRealTime()
+    {
+        // Arrange: seed cache so it's not empty
+        var now = DateTime.UtcNow;
+        SeedCacheForMonth(now.AddMonths(-1).Year, now.AddMonths(-1).Month);
+
+        var excludedDepartments = new List<string> { "Marketing" };
+
+        // Act
+        await _service.GetFinancialOverviewAsync(
+            months: 3,
+            includeStockData: false,
+            excludedDepartments: excludedDepartments,
+            includeCurrentMonth: true);
+
+        // Assert: with department filter, real-time is used — ledger is called with wide date range
+        _ledgerServiceMock.Verify(
+            x => x.GetLedgerItems(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<IEnumerable<string>?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeast(1));
+    }
+
+    private void SeedCacheForMonth(int year, int month)
+    {
+        var key = $"financial_monthly_data_{year}_{month}";
+        _memoryCache.Set(key, new Anela.Heblo.Domain.Features.FinancialOverview.MonthlyFinancialData
+        {
+            Year = year,
+            Month = month,
+            Income = 10000m,
+            Expenses = 8000m
+        }, TimeSpan.FromHours(1));
+    }
+}


### PR DESCRIPTION
## Summary

- When `IncludeCurrentMonth=true`, the service bypassed the in-memory cache entirely and ran a wide ledger query spanning the full requested date range (e.g. 6 months), causing ~15 s responses with no caching benefit
- Fix introduces a **hybrid path**: completed months are served from cache; only the current (partial) month is fetched from the ledger in real-time
- This narrows the real-time query from N months to 1 month, eliminating the 7× performance regression reported in App Insights telemetry

## Test plan

- [ ] Bug is no longer reproducible via the steps in #665
- [ ] New regression tests added (`FinancialAnalysisServiceTests` — 4 tests covering hybrid path, cache-empty fallback, correct month count, and dept-filter override)
- [ ] All BE tests pass (`dotnet test` — 23/23 FinancialOverview tests pass; 7 Docker-integration failures are pre-existing)
- [ ] FE build passes (`npm run build` — success)
- [ ] BE build passes (`dotnet build` — 0 errors)

Fixes #665