### PR TITLE
fix: return 503 instead of 500 when SPA index.html is missing in production

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -200,6 +200,39 @@ public static class ApplicationBuilderExtensions
                 await next();
             });
 
+            // Guard: if index.html is absent (e.g. frontend build not deployed), respond with
+            // 503 Service Unavailable instead of letting UseSpa throw InvalidOperationException.
+            // This prevents the unhandled exception spike seen in App Insights (issue #667).
+            var indexHtmlPath = Path.Combine(app.Environment.ContentRootPath, "wwwroot", "index.html");
+            if (!File.Exists(indexHtmlPath))
+            {
+                var logger = app.Services.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("Anela.Heblo.API.SpaFallback");
+                logger.LogError(
+                    "SPA frontend build not found at {IndexHtmlPath}. Skipping UseSpa — " +
+                    "all unmatched GET requests will return 503 until the frontend is deployed.",
+                    indexHtmlPath);
+
+                // Only intercept GET/HEAD requests with no matched endpoint (SPA fallback paths).
+                // API and health endpoints have a matched endpoint at this point, so they
+                // pass through via next() — mirroring how the real UseSpa middleware works.
+                app.Use(async (context, next) =>
+                {
+                    if (context.GetEndpoint() is null &&
+                        (HttpMethods.IsGet(context.Request.Method) || HttpMethods.IsHead(context.Request.Method)))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                        context.Response.ContentType = "text/plain; charset=utf-8";
+                        await context.Response.WriteAsync(
+                            "Service temporarily unavailable: frontend build not deployed.");
+                        return;
+                    }
+                    await next();
+                });
+
+                return app;
+            }
+
             app.UseSpa(spa =>
             {
                 spa.Options.SourcePath = "wwwroot";

--- a/backend/test/Anela.Heblo.Tests/SpaFallbackTests.cs
+++ b/backend/test/Anela.Heblo.Tests/SpaFallbackTests.cs
@@ -48,4 +48,25 @@ public class SpaFallbackTests : IClassFixture<HebloWebApplicationFactory>
         response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed,
             because: $"the SPA fallback must reject {method} requests to any unmatched path");
     }
+
+    [Fact]
+    public async Task Get_Request_To_SpaPath_Returns_503_When_IndexHtml_Missing()
+    {
+        // In the test environment, wwwroot/index.html does not exist (no frontend build).
+        // The guard added in ConfigureSpaFallback (issue #667) must return 503 instead of
+        // letting UseSpa throw InvalidOperationException (which would surface as a 500).
+        var response = await _client.GetAsync("/");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable,
+            because: "when index.html is absent the SPA fallback must return 503, not 500");
+    }
+
+    [Fact]
+    public async Task Get_Request_To_Nested_SpaRoute_Returns_503_When_IndexHtml_Missing()
+    {
+        var response = await _client.GetAsync("/some/nested/route");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable,
+            because: "all unmatched GET routes must return 503 when the frontend build is not deployed");
+    }
 }


### PR DESCRIPTION
## Summary

- When `wwwroot/index.html` is absent (e.g. incomplete deployment), `UseSpa` was throwing `InvalidOperationException` which surfaced as unhandled HTTP 500
- Added a guard in `ConfigureSpaFallback` that checks for `index.html` at pipeline build time; if missing, unmatched GET/HEAD requests receive a graceful 503 with a human-readable message instead of crashing
- API and health endpoints are unaffected — the middleware checks `GetEndpoint()` before intercepting, matching the same logic as the real `UseSpa` middleware

## Test plan

- [x] New tests `Get_Request_To_SpaPath_Returns_503_When_IndexHtml_Missing` and `Get_Request_To_Nested_SpaRoute_Returns_503_When_IndexHtml_Missing` added to `SpaFallbackTests.cs`
- [x] All 9 SpaFallback tests pass
- [x] All BE tests pass (`dotnet test` — 7 pre-existing Testcontainer failures unrelated to this change)
- [x] Build succeeds (`dotnet build`)
- [x] Format check passes (`dotnet format --verify-no-changes`)

Fixes #667