### PR TITLE
fix: return correct HTTP status codes for TransportBox state-change errors (#675)

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs
@@ -18,7 +18,7 @@ namespace Anela.Heblo.API.Controllers;
 [Authorize]
 [ApiController]
 [Route("api/transport-boxes")]
-public class TransportBoxController : ControllerBase
+public class TransportBoxController : BaseApiController
 {
     private readonly IMediator _mediator;
 
@@ -84,13 +84,7 @@ public class TransportBoxController : ControllerBase
     {
         request.BoxId = id; // Ensure consistency
         var response = await _mediator.Send(request, cancellationToken);
-
-        if (!response.Success)
-        {
-            return BadRequest(response);
-        }
-
-        return Ok(response);
+        return HandleResponse(response);
     }
 
     /// <summary>

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -131,7 +131,7 @@ public enum ErrorCodes
     // Transport module errors (14XX)
     [HttpStatusCode(HttpStatusCode.NotFound)]
     TransportBoxNotFound = 1401,
-    [HttpStatusCode(HttpStatusCode.BadRequest)]
+    [HttpStatusCode(HttpStatusCode.UnprocessableEntity)]
     TransportBoxStateChangeError = 1402,
     [HttpStatusCode(HttpStatusCode.BadRequest)]
     TransportBoxCreationError = 1403,

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs
@@ -1,0 +1,145 @@
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Logistics.Transport;
+
+public class TransportBoxControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly TransportBoxController _controller;
+
+    public TransportBoxControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _controller = new TransportBoxController(_mediatorMock.Object);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var serviceProvider = services.BuildServiceProvider();
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                RequestServices = serviceProvider
+            }
+        };
+    }
+
+    [Fact]
+    public async Task ChangeTransportBoxState_Success_Returns200()
+    {
+        // Arrange
+        var response = new ChangeTransportBoxStateResponse { Success = true };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<ChangeTransportBoxStateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var request = new ChangeTransportBoxStateRequest();
+
+        // Act
+        var result = await _controller.ChangeTransportBoxState(1, request, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task ChangeTransportBoxState_BoxNotFound_Returns404()
+    {
+        // Arrange
+        var response = new ChangeTransportBoxStateResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.TransportBoxNotFound
+        };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<ChangeTransportBoxStateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var request = new ChangeTransportBoxStateRequest();
+
+        // Act
+        var result = await _controller.ChangeTransportBoxState(999, request, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task ChangeTransportBoxState_InvalidStateTransition_Returns422()
+    {
+        // Arrange
+        var response = new ChangeTransportBoxStateResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.TransportBoxStateChangeError
+        };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<ChangeTransportBoxStateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var request = new ChangeTransportBoxStateRequest();
+
+        // Act
+        var result = await _controller.ChangeTransportBoxState(1, request, CancellationToken.None);
+
+        // Assert
+        var statusResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(422, statusResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeTransportBoxState_DuplicateActiveBox_Returns409()
+    {
+        // Arrange
+        var response = new ChangeTransportBoxStateResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.TransportBoxDuplicateActiveBoxFound
+        };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<ChangeTransportBoxStateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var request = new ChangeTransportBoxStateRequest();
+
+        // Act
+        var result = await _controller.ChangeTransportBoxState(1, request, CancellationToken.None);
+
+        // Assert
+        var statusResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(409, statusResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeTransportBoxState_RequiredFieldMissing_Returns400()
+    {
+        // Arrange
+        var response = new ChangeTransportBoxStateResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.RequiredFieldMissing
+        };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<ChangeTransportBoxStateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var request = new ChangeTransportBoxStateRequest();
+
+        // Act
+        var result = await _controller.ChangeTransportBoxState(1, request, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+}


### PR DESCRIPTION
## Summary

- `TransportBoxController` always returned HTTP 400 on any failure, masking domain-logic rejections in App Insights telemetry
- Fixed by making the controller extend `BaseApiController` and calling `HandleResponse()` which routes each `ErrorCode` to its annotated HTTP status
- Reclassified `TransportBoxStateChangeError` from `BadRequest` → `UnprocessableEntity` (422) since an invalid state transition is a domain rule violation, not a malformed request

## Status code mapping after this fix

| Error | Before | After |
|-------|--------|-------|
| `TransportBoxNotFound` | 400 | 404 |
| `TransportBoxStateChangeError` | 400 | 422 |
| `TransportBoxDuplicateActiveBoxFound` | 400 | 409 |
| `RequiredFieldMissing` | 400 | 400 |

## Test plan

- [x] New regression tests in `TransportBoxControllerTests` cover all four failure paths
- [x] All BE tests pass (`dotnet test` — 2296 pass, 7 pre-existing Docker integration failures)
- [x] Build succeeds (`dotnet build`)
- [x] `dotnet format --verify-no-changes` passes

Fixes #675