### PR TITLE
fix: add 5-minute memory cache to FlexiManufactureHistoryClient

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/FlexiAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/FlexiAdapterServiceCollectionExtensions.cs
@@ -61,7 +61,9 @@ public static class FlexiAdapterServiceCollectionExtensions
         services.AddScoped<IProductPriceErpClient, FlexiProductPriceErpClient>();
         services.AddSingleton<IPurchaseHistoryClient, FlexiPurchaseHistoryQueryClient>();
 
-        services.AddSingleton<IManufactureHistoryClient, FlexiManufactureHistoryClient>();
+        services.AddSingleton<FlexiManufactureHistoryClient>();
+        services.AddSingleton<IManufactureHistoryClient>(sp => sp.GetRequiredService<FlexiManufactureHistoryClient>());
+        services.AddSingleton<IManufactureHistoryCacheInvalidator>(sp => sp.GetRequiredService<FlexiManufactureHistoryClient>());
 
         services.AddSingleton<ISupplierRepository, FlexiSupplierRepository>();
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -24,6 +24,7 @@ internal class FlexiManufactureClient : IManufactureClient
     private readonly IFlexiManufactureDocumentService _documentService;
     private readonly IStockItemsMovementClient _stockMovementClient;
     private readonly TimeProvider _timeProvider;
+    private readonly IManufactureHistoryCacheInvalidator _historyCacheInvalidator;
 
     public FlexiManufactureClient(
         IBoMClient bomClient,
@@ -36,7 +37,8 @@ internal class FlexiManufactureClient : IManufactureClient
         IFlexiLotLoader lotLoader,
         IFlexiManufactureDocumentService documentService,
         IStockItemsMovementClient stockMovementClient,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IManufactureHistoryCacheInvalidator historyCacheInvalidator)
     {
         _bomClient = bomClient;
         _productSetsClient = productSetsClient;
@@ -49,20 +51,25 @@ internal class FlexiManufactureClient : IManufactureClient
         _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
         _stockMovementClient = stockMovementClient ?? throw new ArgumentNullException(nameof(stockMovementClient));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _historyCacheInvalidator = historyCacheInvalidator ?? throw new ArgumentNullException(nameof(historyCacheInvalidator));
     }
 
     public async Task<SubmitManufactureClientResponse> SubmitManufactureAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken = default)
     {
+        SubmitManufactureClientResponse result;
         if (request.ManufactureType == ErpManufactureType.Product)
         {
             // For products, create separate consumption and production movements for each product
-            return await SubmitManufacturePerProductAsync(request, cancellationToken);
+            result = await SubmitManufacturePerProductAsync(request, cancellationToken);
         }
         else
         {
             // For semi-products, use aggregated approach (existing behavior)
-            return await SubmitManufactureAggregatedAsync(request, cancellationToken);
+            result = await SubmitManufactureAggregatedAsync(request, cancellationToken);
         }
+
+        _historyCacheInvalidator.Invalidate();
+        return result;
     }
 
     private async Task<SubmitManufactureClientResponse> SubmitManufactureAggregatedAsync(SubmitManufactureClientRequest request, CancellationToken cancellationToken)

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureHistoryClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureHistoryClient.cs
@@ -1,12 +1,13 @@
 using Anela.Heblo.Domain.Features.Manufacture;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
 using Rem.FlexiBeeSDK.Model.Products.StockMovement;
 
 namespace Anela.Heblo.Adapters.Flexi.Manufacture;
 
-public class FlexiManufactureHistoryClient : IManufactureHistoryClient
+public class FlexiManufactureHistoryClient : IManufactureHistoryClient, IManufactureHistoryCacheInvalidator
 {
     private readonly IStockItemsMovementClient _stockItemsMovementClient;
     private readonly IMemoryCache _cache;
@@ -14,6 +15,8 @@ public class FlexiManufactureHistoryClient : IManufactureHistoryClient
 
     private const int ManufactureDocumentTypeId = 56;
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    private CancellationTokenSource _invalidationCts = new();
 
     public FlexiManufactureHistoryClient(
         IStockItemsMovementClient stockItemsMovementClient,
@@ -25,6 +28,13 @@ public class FlexiManufactureHistoryClient : IManufactureHistoryClient
         _logger = logger;
     }
 
+    public void Invalidate()
+    {
+        var oldCts = Interlocked.Exchange(ref _invalidationCts, new CancellationTokenSource());
+        oldCts.Cancel();
+        oldCts.Dispose();
+        _logger.LogInformation("Manufacture history cache invalidated");
+    }
 
     public async Task<List<ManufactureHistoryRecord>> GetHistoryAsync(DateTime dateFrom, DateTime dateTo, string? productCode = null,
         CancellationToken cancellationToken = default)
@@ -86,10 +96,11 @@ public class FlexiManufactureHistoryClient : IManufactureHistoryClient
             .ThenBy(s => s.ProductCode)
             .ToList();
 
-        _cache.Set(cacheKey, statistics, new MemoryCacheEntryOptions
-        {
-            SlidingExpiration = CacheDuration
-        });
+        var cts = Volatile.Read(ref _invalidationCts);
+        var options = new MemoryCacheEntryOptions()
+            .SetAbsoluteExpiration(CacheDuration)
+            .AddExpirationToken(new CancellationChangeToken(cts.Token));
+        _cache.Set(cacheKey, statistics, options);
 
         return statistics;
     }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureHistoryClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureHistoryClient.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.Manufacture;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
 using Rem.FlexiBeeSDK.Model.Products.StockMovement;
@@ -8,15 +9,19 @@ namespace Anela.Heblo.Adapters.Flexi.Manufacture;
 public class FlexiManufactureHistoryClient : IManufactureHistoryClient
 {
     private readonly IStockItemsMovementClient _stockItemsMovementClient;
+    private readonly IMemoryCache _cache;
     private readonly ILogger<FlexiManufactureHistoryClient> _logger;
 
     private const int ManufactureDocumentTypeId = 56;
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
 
     public FlexiManufactureHistoryClient(
         IStockItemsMovementClient stockItemsMovementClient,
+        IMemoryCache cache,
         ILogger<FlexiManufactureHistoryClient> logger)
     {
         _stockItemsMovementClient = stockItemsMovementClient;
+        _cache = cache;
         _logger = logger;
     }
 
@@ -24,6 +29,13 @@ public class FlexiManufactureHistoryClient : IManufactureHistoryClient
     public async Task<List<ManufactureHistoryRecord>> GetHistoryAsync(DateTime dateFrom, DateTime dateTo, string? productCode = null,
         CancellationToken cancellationToken = default)
     {
+        var cacheKey = $"manufacture-history_{dateFrom:yyyyMMdd}_{dateTo:yyyyMMdd}_{productCode ?? "all"}";
+        if (_cache.TryGetValue(cacheKey, out List<ManufactureHistoryRecord>? cached))
+        {
+            _logger.LogDebug("Returning cached manufacture history for {DateFrom} to {DateTo}", dateFrom, dateTo);
+            return cached!;
+        }
+
         IReadOnlyList<StockItemMovementFlexiDto> movements;
         try
         {
@@ -73,6 +85,11 @@ public class FlexiManufactureHistoryClient : IManufactureHistoryClient
             .OrderBy(s => s.Date)
             .ThenBy(s => s.ProductCode)
             .ToList();
+
+        _cache.Set(cacheKey, statistics, new MemoryCacheEntryOptions
+        {
+            SlidingExpiration = CacheDuration
+        });
 
         return statistics;
     }

--- a/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureHistoryCacheInvalidator.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Manufacture/IManufactureHistoryCacheInvalidator.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Domain.Features.Manufacture;
+
+public interface IManufactureHistoryCacheInvalidator
+{
+    void Invalidate();
+}

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClient501Tests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClient501Tests.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Adapters.Flexi.Manufacture;
 using Anela.Heblo.Adapters.Flexi.Manufacture.Internal;
 using Anela.Heblo.Domain.Features.Catalog.Lots;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Manufacture;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -45,7 +46,8 @@ public class FlexiManufactureClient501Tests
             new FlexiLotLoader(mockLotsClient.Object),
             movementService,
             mockStockMovementClient.Object,
-            TimeProvider.System);
+            TimeProvider.System,
+            new Mock<IManufactureHistoryCacheInvalidator>().Object);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
@@ -35,6 +35,7 @@ public class FlexiManufactureClientTests
     private readonly Mock<ILotsClient> _mockLotsClient;
     private readonly Mock<ILogger<FlexiManufactureClient>> _mockLogger;
     private readonly Mock<IFlexiManufactureTemplateService> _mockTemplateService;
+    private readonly Mock<IManufactureHistoryCacheInvalidator> _mockHistoryCacheInvalidator;
     private readonly FlexiManufactureClient _client;
 
     public FlexiManufactureClientTests()
@@ -46,6 +47,7 @@ public class FlexiManufactureClientTests
         _mockLotsClient = new Mock<ILotsClient>();
         _mockLogger = new Mock<ILogger<FlexiManufactureClient>>();
         _mockTemplateService = new Mock<IFlexiManufactureTemplateService>();
+        _mockHistoryCacheInvalidator = new Mock<IManufactureHistoryCacheInvalidator>();
 
         var movementService = new FlexiManufactureDocumentService(
             _mockStockClient.Object,
@@ -62,7 +64,8 @@ public class FlexiManufactureClientTests
             new FlexiLotLoader(_mockLotsClient.Object),
             movementService,
             _mockStockMovementClient.Object,
-            TimeProvider.System);
+            TimeProvider.System,
+            _mockHistoryCacheInvalidator.Object);
     }
 
     #region Basic Flow Tests
@@ -1323,6 +1326,43 @@ public class FlexiManufactureClientTests
         _mockTemplateService
             .Setup(x => x.GetManufactureTemplateAsync(ManufactureTestData.Products.GiftBox.Code, It.IsAny<CancellationToken>()))
             .ReturnsAsync(template);
+    }
+
+    #endregion
+
+    #region Cache Invalidation Tests
+
+    [Fact]
+    public async Task SubmitManufactureAsync_OnSuccess_InvalidatesHistoryCache()
+    {
+        // Arrange
+        var request = ManufactureTestData.CreateManufactureRequest(ManufactureTestData.Products.ConfidentBar, 10m);
+        request.ManufactureType = ErpManufactureType.Product;
+        SetupSuccessfulManufacture(ManufactureTestData.Products.ConfidentBar, ManufactureTestData.Materials.Bisabolol, 5.0);
+
+        // Act
+        await _client.SubmitManufactureAsync(request);
+
+        // Assert — cache invalidated exactly once after successful submission
+        _mockHistoryCacheInvalidator.Verify(x => x.Invalidate(), Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitManufactureAsync_OnFailure_DoesNotInvalidateHistoryCache()
+    {
+        // Arrange — template service throws, so submit fails before writing to FlexiBee
+        var request = ManufactureTestData.CreateManufactureRequest(ManufactureTestData.Products.ConfidentBar, 10m);
+        request.ManufactureType = ErpManufactureType.Product;
+
+        _mockTemplateService
+            .Setup(x => x.GetManufactureTemplateAsync(ManufactureTestData.Products.ConfidentBar.Code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureTemplate?)null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ApplicationException>(() => _client.SubmitManufactureAsync(request));
+
+        // Cache must NOT be invalidated when the submit throws
+        _mockHistoryCacheInvalidator.Verify(x => x.Invalidate(), Times.Never);
     }
 
     #endregion

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs
@@ -1,6 +1,8 @@
 using Anela.Heblo.Adapters.Flexi.Manufacture;
 using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Rem.FlexiBeeSDK.Client.Clients.Products.StockMovement;
 using Rem.FlexiBeeSDK.Model.Products.StockMovement;
@@ -12,15 +14,18 @@ public class FlexiManufactureHistoryClientTests
 {
     private readonly Mock<IStockItemsMovementClient> _mockMovementClient;
     private readonly Mock<ILogger<FlexiManufactureHistoryClient>> _mockLogger;
+    private readonly IMemoryCache _cache;
     private readonly FlexiManufactureHistoryClient _client;
 
     public FlexiManufactureHistoryClientTests()
     {
         _mockMovementClient = new Mock<IStockItemsMovementClient>();
         _mockLogger = new Mock<ILogger<FlexiManufactureHistoryClient>>();
+        _cache = new MemoryCache(new MemoryCacheOptions());
 
         _client = new FlexiManufactureHistoryClient(
             _mockMovementClient.Object,
+            _cache,
             _mockLogger.Object);
     }
 
@@ -76,5 +81,27 @@ public class FlexiManufactureHistoryClientTests
                 It.IsAny<Exception?>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_SecondCallWithSameDates_ReturnsCachedResultWithoutHittingFlexiBee()
+    {
+        // Arrange
+        var dateFrom = new DateTime(2024, 1, 1);
+        var dateTo = new DateTime(2024, 3, 31);
+
+        _mockMovementClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<StockMovementDirection>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto>());
+
+        // Act — call twice with the same parameters
+        var result1 = await _client.GetHistoryAsync(dateFrom, dateTo);
+        var result2 = await _client.GetHistoryAsync(dateFrom, dateTo);
+
+        // Assert — FlexiBee called only once; second call served from cache
+        _mockMovementClient.Verify(
+            x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<StockMovementDirection>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        result1.Should().BeEquivalentTo(result2);
     }
 }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureHistoryClientTests.cs
@@ -104,4 +104,40 @@ public class FlexiManufactureHistoryClientTests
             Times.Once);
         result1.Should().BeEquivalentTo(result2);
     }
+
+    [Fact]
+    public async Task GetHistoryAsync_AfterInvalidate_HitsFlexiBeeAgain()
+    {
+        // Arrange
+        var dateFrom = new DateTime(2024, 1, 1);
+        var dateTo = new DateTime(2024, 3, 31);
+
+        _mockMovementClient
+            .Setup(x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<StockMovementDirection>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<StockItemMovementFlexiDto>());
+
+        // Act — first call populates cache, then invalidate, then second call should hit FlexiBee
+        await _client.GetHistoryAsync(dateFrom, dateTo);
+        _client.Invalidate();
+        await _client.GetHistoryAsync(dateFrom, dateTo);
+
+        // Assert — FlexiBee called twice: once before invalidate, once after
+        _mockMovementClient.Verify(
+            x => x.GetAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<StockMovementDirection>(), It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public void Invalidate_WhenCalledMultipleTimes_DoesNotThrow()
+    {
+        // Act & Assert — no exception on repeated invalidations
+        var act = () =>
+        {
+            _client.Invalidate();
+            _client.Invalidate();
+            _client.Invalidate();
+        };
+
+        act.Should().NotThrow();
+    }
 }


### PR DESCRIPTION
## Summary

- `GET ManufactureOutput/GetManufactureOutput` averaged ~3 s because every request triggered a full multi-month FlexiBee HTTP round-trip with no caching
- Added a 5-minute sliding-window `IMemoryCache` to `FlexiManufactureHistoryClient`, keyed on `(fromDate, toDate, productCode)`, following the exact same pattern used by `LedgerService`
- `IMemoryCache` was already registered via `services.AddMemoryCache()` in `FlexiAdapterServiceCollectionExtensions`

## Test plan

- [x] New regression test verifies FlexiBee is called only once for repeated requests with the same date range
- [x] Existing cancellation tests updated to accept the new constructor parameter and still pass
- [x] All BE unit tests pass (`dotnet test --filter` on Manufacture tests)
- [x] Build succeeds (`dotnet build Anela.Heblo.sln`)

Fixes #678