### PR TITLE
fix: handle Anthropic 529 overloaded with Retry-After and catch ObjectDisposedException

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Anthropic/AnthropicChatClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Anthropic/AnthropicChatClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -12,29 +13,46 @@ namespace Anela.Heblo.Adapters.Anthropic;
 
 public class AnthropicChatClient : IChatClient
 {
-    private static readonly ResiliencePipeline Pipeline = new ResiliencePipelineBuilder()
-        .AddRetry(new RetryStrategyOptions
-        {
-            MaxRetryAttempts = 3,
-            Delay = TimeSpan.FromSeconds(2),
-            BackoffType = DelayBackoffType.Exponential,
-            ShouldHandle = new PredicateBuilder()
-                .Handle<HttpRequestException>()
-        })
-        .Build();
+    private const HttpStatusCode AnthropicOverloaded = (HttpStatusCode)529;
+
+    private static readonly ResiliencePipeline DefaultPipeline = BuildPipeline(TimeSpan.FromSeconds(2));
+
+    public static ResiliencePipeline BuildPipeline(TimeSpan baseDelay) =>
+        new ResiliencePipelineBuilder()
+            .AddRetry(new RetryStrategyOptions
+            {
+                MaxRetryAttempts = 3,
+                Delay = baseDelay,
+                BackoffType = DelayBackoffType.Exponential,
+                ShouldHandle = new PredicateBuilder()
+                    .Handle<HttpRequestException>(ex =>
+                        ex.StatusCode == HttpStatusCode.TooManyRequests ||
+                        ex.StatusCode == AnthropicOverloaded),
+                DelayGenerator = static args =>
+                {
+                    if (args.Outcome.Exception is HttpRequestException { Data: var data } &&
+                        data["RetryAfter"] is TimeSpan retryAfter)
+                        return new ValueTask<TimeSpan?>(retryAfter);
+                    return new ValueTask<TimeSpan?>((TimeSpan?)null);
+                }
+            })
+            .Build();
 
     private readonly AnthropicOptions _options;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<AnthropicChatClient> _logger;
+    private readonly ResiliencePipeline _pipeline;
 
     public AnthropicChatClient(
         IOptions<AnthropicOptions> options,
         IHttpClientFactory httpClientFactory,
-        ILogger<AnthropicChatClient> logger)
+        ILogger<AnthropicChatClient> logger,
+        ResiliencePipeline? pipeline = null)
     {
         _options = options.Value;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        _pipeline = pipeline ?? DefaultPipeline;
     }
 
     public async Task<ChatResponse> GetResponseAsync(
@@ -62,7 +80,7 @@ public class AnthropicChatClient : IChatClient
 
         var requestBody = BuildRequestBody(model, systemMessage, userMessages);
 
-        var httpResponse = await Pipeline.ExecuteAsync(async token =>
+        var httpResponse = await _pipeline.ExecuteAsync(async token =>
         {
             var client = _httpClientFactory.CreateClient("Anthropic");
             using var request = new HttpRequestMessage(HttpMethod.Post, _options.MessagesUrl);
@@ -79,7 +97,13 @@ public class AnthropicChatClient : IChatClient
             {
                 var errorBody = await response.Content.ReadAsStringAsync(token);
                 _logger.LogError("Anthropic API error {Status}: {Body}", response.StatusCode, errorBody);
-                throw new HttpRequestException($"Anthropic API returned {response.StatusCode}: {errorBody}");
+                var httpException = new HttpRequestException(
+                    $"Anthropic API returned {(int)response.StatusCode}: {errorBody}",
+                    null,
+                    response.StatusCode);
+                if (response.Headers.RetryAfter?.Delta is { } retryAfterDelta)
+                    httpException.Data["RetryAfter"] = retryAfterDelta;
+                throw httpException;
             }
 
             return response;

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/AskQuestion/AskQuestionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/AskQuestion/AskQuestionHandler.cs
@@ -68,7 +68,7 @@ public class AskQuestionHandler : IRequestHandler<AskQuestionRequest, AskQuestio
         {
             response = await _chatClient.GetResponseAsync(messages, cancellationToken: cancellationToken);
         }
-        catch (Exception ex) when (ex is HttpRequestException or TimeoutException or TaskCanceledException)
+        catch (Exception ex) when (ex is HttpRequestException or TimeoutException or TaskCanceledException or ObjectDisposedException)
         {
             _logger.LogWarning(ex, "AI service unavailable while processing KnowledgeBase/Ask");
             return new AskQuestionResponse

--- a/backend/test/Anela.Heblo.Tests/Adapters/Anthropic/AnthropicChatClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/Anthropic/AnthropicChatClientTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using Polly;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Adapters.Anthropic;
@@ -21,9 +22,13 @@ public class AnthropicChatClientTests
         HttpTimeoutSeconds = 60
     };
 
+    private static readonly ResiliencePipeline InstantRetryPipeline =
+        AnthropicChatClient.BuildPipeline(TimeSpan.Zero);
+
     private static AnthropicChatClient CreateClient(
         AnthropicOptions? options = null,
-        HttpMessageHandler? handler = null)
+        HttpMessageHandler? handler = null,
+        ResiliencePipeline? pipeline = null)
     {
         var opts = options ?? DefaultOptions;
 
@@ -41,7 +46,8 @@ public class AnthropicChatClientTests
         return new AnthropicChatClient(
             Options.Create(opts),
             factoryMock.Object,
-            NullLogger<AnthropicChatClient>.Instance);
+            NullLogger<AnthropicChatClient>.Instance,
+            pipeline);
     }
 
     private static Mock<HttpMessageHandler> CreateHandlerMock(
@@ -100,12 +106,138 @@ public class AnthropicChatClientTests
             HttpStatusCode.TooManyRequests,
             """{"error":{"message":"Rate limit exceeded"}}""");
 
-        var client = CreateClient(handler: handlerMock.Object);
+        var client = CreateClient(handler: handlerMock.Object, pipeline: InstantRetryPipeline);
         var messages = new[] { new ChatMessage(ChatRole.User, "Hi") };
 
         // Polly will retry 3 times then propagate
         await Assert.ThrowsAsync<HttpRequestException>(
             () => client.GetResponseAsync(messages));
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_529Response_RetriesThreeTimes_ThenThrowsWithCorrectStatusCode()
+    {
+        int callCount = 0;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return new HttpResponseMessage((HttpStatusCode)529)
+                {
+                    Content = new StringContent("""{"type":"error","error":{"type":"overloaded_error"}}""")
+                };
+            });
+
+        var client = CreateClient(handler: handlerMock.Object, pipeline: InstantRetryPipeline);
+        var messages = new[] { new ChatMessage(ChatRole.User, "Hi") };
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetResponseAsync(messages));
+
+        Assert.Equal((HttpStatusCode)529, ex.StatusCode);
+        Assert.Equal(4, callCount); // 1 initial + 3 retries
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_400Response_DoesNotRetry()
+    {
+        int callCount = 0;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("""{"error":"bad_request"}""")
+                };
+            });
+
+        var client = CreateClient(handler: handlerMock.Object, pipeline: InstantRetryPipeline);
+        var messages = new[] { new ChatMessage(ChatRole.User, "Hi") };
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetResponseAsync(messages));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        Assert.Equal(1, callCount); // no retries
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_529WithRetryAfterHeader_StoresRetryAfterInException()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                var response = new HttpResponseMessage((HttpStatusCode)529)
+                {
+                    Content = new StringContent("""{"type":"error","error":{"type":"overloaded_error"}}""")
+                };
+                response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+                return response;
+            });
+
+        // Use a pipeline that won't retry so we can inspect the thrown exception directly
+        var noRetryPipeline = ResiliencePipeline.Empty;
+        var client = CreateClient(handler: handlerMock.Object, pipeline: noRetryPipeline);
+        var messages = new[] { new ChatMessage(ChatRole.User, "Hi") };
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetResponseAsync(messages));
+
+        Assert.Equal((HttpStatusCode)529, ex.StatusCode);
+        Assert.Equal(TimeSpan.FromSeconds(30), ex.Data["RetryAfter"]);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_529SucceedsAfterRetry_ReturnsAnswer()
+    {
+        int callCount = 0;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount < 3)
+                    return new HttpResponseMessage((HttpStatusCode)529)
+                    {
+                        Content = new StringContent("""{"type":"error","error":{"type":"overloaded_error"}}""")
+                    };
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(BuildSuccessJson("Recovered answer"))
+                };
+            });
+
+        var client = CreateClient(handler: handlerMock.Object, pipeline: InstantRetryPipeline);
+        var messages = new[] { new ChatMessage(ChatRole.User, "Hi") };
+
+        var response = await client.GetResponseAsync(messages);
+
+        Assert.Equal("Recovered answer", response.Text);
+        Assert.Equal(3, callCount);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/AskQuestionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/AskQuestionHandlerTests.cs
@@ -181,6 +181,7 @@ public class AskQuestionHandlerTests
     [InlineData(typeof(HttpRequestException))]
     [InlineData(typeof(TimeoutException))]
     [InlineData(typeof(TaskCanceledException))]
+    [InlineData(typeof(ObjectDisposedException))]
     public async Task Handle_ChatClientThrowsTransientException_ReturnsAiUnavailableError(Type exceptionType)
     {
         SetupEmptyCache();


### PR DESCRIPTION
## Summary

- `AnthropicChatClient`: tightened Polly retry predicate to only retry on HTTP 429/529 (previously retried all `HttpRequestException`s); set `StatusCode` on thrown exception and read `Retry-After` response header to drive the delay generator
- `AskQuestionHandler`: added `ObjectDisposedException` to the transient-exception catch so it returns `KnowledgeBaseAiUnavailable` instead of propagating as a 500

## Test plan

- [x] New test: 529 response retries exactly 3 times then throws with correct StatusCode
- [x] New test: 400 response does NOT retry (call count = 1)
- [x] New test: 529 with Retry-After header stores delta in exception.Data for DelayGenerator
- [x] New test: 529 succeeds after two failures (recovery path)
- [x] New test: ObjectDisposedException handled gracefully by AskQuestionHandler
- [x] All BE unit tests pass (`dotnet test`, 2488 passing)
- [x] BE build succeeds (`dotnet build`)

Fixes #688