### PR TITLE
fix: distinguish FlexiBee timeout vs caller cancellation in LedgerService and FlexiProductPriceErpClient

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Accounting/Ledger/LedgerService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Accounting/Ledger/LedgerService.cs
@@ -1,7 +1,9 @@
 using Anela.Heblo.Domain.Accounting.Ledger;
 using AutoMapper;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
+using Rem.FlexiBeeSDK.Model.Accounting.Ledger;
 
 namespace Anela.Heblo.Adapters.Flexi.Accounting.Ledger;
 
@@ -10,12 +12,14 @@ public class LedgerService : ILedgerService
     private readonly ILedgerClient _ledgerClient;
     private readonly IMemoryCache _cache;
     private readonly IMapper _mapper;
+    private readonly ILogger<LedgerService> _logger;
 
-    public LedgerService(ILedgerClient ledgerClient, IMemoryCache cache, IMapper mapper)
+    public LedgerService(ILedgerClient ledgerClient, IMemoryCache cache, IMapper mapper, ILogger<LedgerService> logger)
     {
         _ledgerClient = ledgerClient ?? throw new ArgumentNullException(nameof(ledgerClient));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<IList<LedgerItem>> GetLedgerItems(DateTime dateFrom, DateTime dateTo, IEnumerable<string>? debitAccountPrefix = null, IEnumerable<string>? creditAccountPrefix = null, string? department = null, CancellationToken cancellationToken = default)
@@ -30,14 +34,34 @@ public class LedgerService : ILedgerService
             return cachedResult!;
         }
 
-        // Získání dat z FlexiBee pomocí ILedgerClient s filtry
-        var flexiData = await _ledgerClient.GetAsync(
-            dateFrom,
-            dateTo,
-            debitPrefixes,
-            creditPrefixes,
-            department,
-            cancellationToken: cancellationToken);
+        IReadOnlyList<LedgerItemFlexiDto> flexiData;
+        try
+        {
+            // Získání dat z FlexiBee pomocí ILedgerClient s filtry
+            flexiData = await _ledgerClient.GetAsync(
+                dateFrom,
+                dateTo,
+                debitPrefixes,
+                creditPrefixes,
+                department,
+                cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex,
+                "FlexiBee ucetni-denik/query request timed out (internal HttpClient timeout). " +
+                "DateFrom: {DateFrom}, DateTo: {DateTo}",
+                dateFrom, dateTo);
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation(
+                "FlexiBee ucetni-denik/query request was canceled by the caller (client abort). " +
+                "DateFrom: {DateFrom}, DateTo: {DateTo}",
+                dateFrom, dateTo);
+            throw;
+        }
 
         var result = _mapper.Map<List<LedgerItem>>(flexiData);
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Price/FlexiProductPriceErpClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Price/FlexiProductPriceErpClient.cs
@@ -13,6 +13,7 @@ public class FlexiProductPriceErpClient : UserQueryClient<ProductPriceFlexiDto>,
 {
     private readonly IMemoryCache _cache;
     private readonly IBoMClient _bomClient;
+    private readonly ILogger<FlexiProductPriceErpClient> _clientLogger;
     private const string CacheKey = "FlexiProductPrices";
 
     public FlexiProductPriceErpClient(
@@ -21,12 +22,14 @@ public class FlexiProductPriceErpClient : UserQueryClient<ProductPriceFlexiDto>,
         IResultHandler resultHandler,
         IMemoryCache cache,
         ILogger<ReceivedInvoiceClient> logger,
-        IBoMClient bomClient
+        IBoMClient bomClient,
+        ILogger<FlexiProductPriceErpClient> clientLogger
     )
         : base(connection, httpClientFactory, resultHandler, logger)
     {
         _cache = cache;
         _bomClient = bomClient;
+        _clientLogger = clientLogger;
     }
 
     protected override int QueryId => 41;
@@ -64,7 +67,22 @@ public class FlexiProductPriceErpClient : UserQueryClient<ProductPriceFlexiDto>,
 
         if (data == null)
         {
-            data = await GetAsync(0, cancellationToken);
+            try
+            {
+                data = await GetAsync(0, cancellationToken);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                _clientLogger.LogWarning(ex,
+                    "FlexiBee uzivatelsky-dotaz/41 request timed out (internal HttpClient timeout).");
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                _clientLogger.LogInformation(
+                    "FlexiBee uzivatelsky-dotaz/41 request was canceled by the caller (client abort).");
+                throw;
+            }
 
             // Safe cache set with disposed object protection
             try

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Accounting/LedgerServiceTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Accounting/LedgerServiceTests.cs
@@ -1,0 +1,106 @@
+using Anela.Heblo.Adapters.Flexi.Accounting.Ledger;
+using Anela.Heblo.Domain.Accounting.Ledger;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Accounting.Ledger;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Accounting;
+
+public class LedgerServiceTests
+{
+    private readonly Mock<ILedgerClient> _mockLedgerClient;
+    private readonly Mock<ILogger<LedgerService>> _mockLogger;
+    private readonly LedgerService _service;
+
+    public LedgerServiceTests()
+    {
+        _mockLedgerClient = new Mock<ILedgerClient>();
+        _mockLogger = new Mock<ILogger<LedgerService>>();
+        var mockCache = new Mock<IMemoryCache>();
+        var mockMapper = new Mock<IMapper>();
+
+        // Cache always misses so we reach the HTTP call
+        object? cacheOut = null;
+        mockCache.Setup(x => x.TryGetValue(It.IsAny<object>(), out cacheOut)).Returns(false);
+        mockCache.Setup(x => x.CreateEntry(It.IsAny<object>())).Returns(Mock.Of<ICacheEntry>());
+
+        // Mapper returns empty list
+        mockMapper
+            .Setup(x => x.Map<List<LedgerItem>>(It.IsAny<object>()))
+            .Returns(new List<LedgerItem>());
+
+        _service = new LedgerService(
+            _mockLedgerClient.Object,
+            mockCache.Object,
+            mockMapper.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetLedgerItems_WhenInternalTimeoutCancels_LogsWarningAndRethrows()
+    {
+        // Arrange — HttpClient internal timeout: its own CTS fires, not the caller's
+        var timeoutCts = new CancellationTokenSource();
+        var timeoutException = new TaskCanceledException("HttpClient timeout", null, timeoutCts.Token);
+        await timeoutCts.CancelAsync();
+
+        _mockLedgerClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(),
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(timeoutException);
+
+        // Act — caller's token is NOT canceled
+        var act = async () => await _service.GetLedgerItems(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("timed out")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetLedgerItems_WhenCallerCancels_LogsInformationAndRethrows()
+    {
+        // Arrange — caller cancels via their own token
+        using var callerCts = new CancellationTokenSource();
+        var canceledException = new TaskCanceledException("Caller canceled", null, callerCts.Token);
+        await callerCts.CancelAsync();
+
+        _mockLedgerClient
+            .Setup(x => x.GetAsync(
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(),
+                It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(canceledException);
+
+        // Act — same token is canceled
+        var act = async () => await _service.GetLedgerItems(
+            DateTime.UtcNow.AddDays(-7), DateTime.UtcNow,
+            cancellationToken: callerCts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("canceled by the caller")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Adapters/Flexi/FlexiProductPriceErpClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/Flexi/FlexiProductPriceErpClientTests.cs
@@ -17,6 +17,7 @@ public class FlexiProductPriceErpClientTests
     private readonly Mock<IResultHandler> _resultHandlerMock;
     private readonly Mock<IMemoryCache> _memoryCacheMock;
     private readonly Mock<ILogger<ReceivedInvoiceClient>> _loggerMock;
+    private readonly Mock<ILogger<FlexiProductPriceErpClient>> _clientLoggerMock;
     private readonly Mock<IBoMClient> _bomClientMock;
     private readonly FlexiBeeSettings _flexiBeeSettings;
     private readonly FlexiProductPriceErpClient _client;
@@ -27,6 +28,7 @@ public class FlexiProductPriceErpClientTests
         _resultHandlerMock = new Mock<IResultHandler>();
         _memoryCacheMock = new Mock<IMemoryCache>();
         _loggerMock = new Mock<ILogger<ReceivedInvoiceClient>>();
+        _clientLoggerMock = new Mock<ILogger<FlexiProductPriceErpClient>>();
         _bomClientMock = new Mock<IBoMClient>();
 
         _flexiBeeSettings = new FlexiBeeSettings
@@ -43,7 +45,8 @@ public class FlexiProductPriceErpClientTests
             _resultHandlerMock.Object,
             _memoryCacheMock.Object,
             _loggerMock.Object,
-            _bomClientMock.Object);
+            _bomClientMock.Object,
+            _clientLoggerMock.Object);
     }
 
     [Fact]
@@ -144,5 +147,77 @@ public class FlexiProductPriceErpClientTests
 
         // Assert
         _bomClientMock.Verify(x => x.RecalculatePurchasePrice(bomId, cancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenInternalTimeoutCancels_LogsWarningAndRethrows()
+    {
+        // Arrange — HttpClient internal timeout: its own CTS fires, not the caller's
+        var timeoutCts = new CancellationTokenSource();
+        var timeoutException = new TaskCanceledException("HttpClient timeout", null, timeoutCts.Token);
+        await timeoutCts.CancelAsync();
+
+        // Cache miss
+        object? cacheOut = null;
+        _memoryCacheMock.Setup(x => x.TryGetValue(It.IsAny<object>(), out cacheOut)).Returns(false);
+
+        // HTTP client throws timeout exception
+        var handler = new ThrowingHttpMessageHandler(timeoutException);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test.flexibee.com/") };
+        _httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        // Act — caller's token is NOT canceled
+        var act = async () => await _client.GetAllAsync(false, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _clientLoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("timed out")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenCallerCancels_LogsInformationAndRethrows()
+    {
+        // Arrange — caller cancels via their own token
+        using var callerCts = new CancellationTokenSource();
+        var canceledException = new TaskCanceledException("Caller canceled", null, callerCts.Token);
+        await callerCts.CancelAsync();
+
+        // Cache miss
+        object? cacheOut = null;
+        _memoryCacheMock.Setup(x => x.TryGetValue(It.IsAny<object>(), out cacheOut)).Returns(false);
+
+        // HTTP client throws caller cancellation exception
+        var handler = new ThrowingHttpMessageHandler(canceledException);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://test.flexibee.com/") };
+        _httpClientFactoryMock.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        // Act — same token is canceled
+        var act = async () => await _client.GetAllAsync(false, callerCts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _clientLoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("canceled by the caller")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+        public ThrowingHttpMessageHandler(Exception exception) => _exception = exception;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw _exception;
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: Same pattern as #676 — FlexiBee endpoints `ucetni-denik/query` and `uzivatelsky-dotaz/41` could time out without distinguishing between internal HttpClient timeout and caller-initiated cancellation.
- **Fix for `LedgerService.GetLedgerItems`**: Added `OperationCanceledException` handling around the `_ledgerClient.GetAsync()` call (ucetni-denik/query). Internal timeout → Warning log; caller abort → Information log. Also injected `ILogger<LedgerService>`.
- **Fix for `FlexiProductPriceErpClient.GetAllAsync`**: Added same cancellation handling around `GetAsync(0, ct)` (uzivatelsky-dotaz/41). Injected dedicated `ILogger<FlexiProductPriceErpClient>` to avoid reusing the base-class logger.

## Test plan

- [x] Bug is no longer reproducible via the steps in #689
- [x] New regression tests: `LedgerServiceTests` (2 tests) + `FlexiProductPriceErpClientTests` cancellation tests (2 tests)
- [x] All BE tests pass (`dotnet test`) — 2297 passed, 7 pre-existing integration failures (DB required)
- [x] All FE tests pass (`npm test`) — 787 passed, 5 skipped
- [x] Both builds succeed (`dotnet build` + `npm run build`)
- [x] `dotnet format --verify-no-changes` passes

Fixes #689