### PR TITLE
fix(manufacture): show material name when Flexi rejects lot due to insufficient stock

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureException.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureException.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
+
 namespace Anela.Heblo.Adapters.Flexi.Manufacture;
 
 public enum FlexiManufactureOperationKind
@@ -11,11 +13,12 @@ public enum FlexiManufactureOperationKind
     Allocation
 }
 
-public class FlexiManufactureException : Exception
+public class FlexiManufactureException : Exception, IHasFailedConsumptionItems
 {
     public FlexiManufactureOperationKind OperationKind { get; }
     public int? WarehouseId { get; }
     public string? RawFlexiError { get; }
+    public IReadOnlyList<FailedConsumptionItem> FailedItems { get; }
 
     public override string Message =>
         string.IsNullOrEmpty(RawFlexiError)
@@ -27,11 +30,13 @@ public class FlexiManufactureException : Exception
         string message,
         int? warehouseId = null,
         string? rawFlexiError = null,
+        IReadOnlyList<FailedConsumptionItem>? failedItems = null,
         Exception? innerException = null)
         : base(message, innerException)
     {
         OperationKind = operationKind;
         WarehouseId = warehouseId;
         RawFlexiError = rawFlexiError;
+        FailedItems = failedItems ?? [];
     }
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureDocumentService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureDocumentService.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Adapters.Flexi.Stock;
+using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -97,11 +98,16 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
 
             if (consumptionResult != null && !consumptionResult.IsSuccess)
             {
+                var failedItems = warehouseGroup
+                    .Select(i => new FailedConsumptionItem(i.ProductCode, i.ProductName, i.LotNumber, i.Expiration, i.Amount))
+                    .ToList();
+
                 throw new FlexiManufactureException(
                     FlexiManufactureOperationKind.ConsumptionMovement,
                     $"Failed to create consumption stock movement for warehouse {warehouseId}",
                     warehouseId: warehouseId,
-                    rawFlexiError: consumptionResult.GetErrorMessage());
+                    rawFlexiError: consumptionResult.GetErrorMessage(),
+                    failedItems: failedItems);
             }
 
             var docCode = consumptionResult?.Result?.Results?.FirstOrDefault()?.Code;
@@ -242,11 +248,16 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
 
             if (consumptionResult != null && !consumptionResult.IsSuccess)
             {
+                var failedItems = warehouseGroup
+                    .Select(i => new FailedConsumptionItem(i.ProductCode, i.ProductName, i.LotNumber, i.Expiration, i.Amount))
+                    .ToList();
+
                 throw new FlexiManufactureException(
                     FlexiManufactureOperationKind.ConsumptionMovement,
                     $"Failed to create consumption stock movement for warehouse {warehouseId}",
                     warehouseId: warehouseId,
-                    rawFlexiError: consumptionResult.GetErrorMessage());
+                    rawFlexiError: consumptionResult.GetErrorMessage(),
+                    failedItems: failedItems);
             }
 
             capturedDocCode = consumptionResult?.Result?.Results?.FirstOrDefault()?.Code;
@@ -346,11 +357,22 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
 
         if (result != null && !result.IsSuccess)
         {
+            List<FailedConsumptionItem> failedItems =
+            [
+                new(
+                    request.DirectSemiProductOutputCode!,
+                    request.DirectSemiProductOutputName ?? request.DirectSemiProductOutputCode!,
+                    request.LotNumber,
+                    request.ExpirationDate,
+                    (double)request.DirectSemiProductOutputAmount)
+            ];
+
             throw new FlexiManufactureException(
                 FlexiManufactureOperationKind.ConsumptionMovement,
                 "Failed to create discard stock movement for direct semiproduct output",
                 warehouseId: warehouseId,
-                rawFlexiError: result.GetErrorMessage());
+                rawFlexiError: result.GetErrorMessage(),
+                failedItems: failedItems);
         }
 
         return result?.Result?.Results?.FirstOrDefault()?.Code;

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/FailedConsumptionItem.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/FailedConsumptionItem.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
+
+public sealed record FailedConsumptionItem(
+    string ProductCode,
+    string ProductName,
+    string? LotNumber,
+    DateOnly? Expiration,
+    double Amount);
+
+public interface IHasFailedConsumptionItems
+{
+    IReadOnlyList<FailedConsumptionItem> FailedItems { get; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/CannotAllocateFullAmountFilter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/CannotAllocateFullAmountFilter.cs
@@ -1,0 +1,28 @@
+namespace Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
+
+public class CannotAllocateFullAmountFilter : IManufactureErrorFilter
+{
+    public bool CanHandle(Exception exception) =>
+        exception.Message.Contains("Cannot allocate full amount for ingredient");
+
+    public string Transform(Exception exception)
+    {
+        var productCode = ManufactureErrorParsingHelpers.ExtractAfter(
+            exception.Message,
+            "Cannot allocate full amount for ingredient ",
+            ":");
+
+        var remaining = productCode == "?"
+            ? "?"
+            : ManufactureErrorParsingHelpers.ExtractAfter(
+                exception.Message,
+                $"{productCode}: ",
+                " remaining");
+
+        if (productCode == "?")
+            return "Nepodařilo se přidělit dostatečné množství šarží pro jednu z ingrediencí. Zkontrolujte, zda má ingredience ve Flexi evidované šarže.";
+
+        return $"Pro ingredienci {productCode} nelze přidělit dostatečné množství šarží (chybí: {remaining})." +
+               " Zkontrolujte, zda má ingredience ve Flexi evidované šarže s dostatečným množstvím.";
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilter.cs
@@ -1,0 +1,69 @@
+namespace Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
+
+public class InsufficientLotStockFilter : IManufactureErrorFilter
+{
+    private const string FlexiSignal = "Na skladě není dostatek zboží pro vyskladnění požadované šarže";
+
+    public bool CanHandle(Exception exception) =>
+        exception is IHasFailedConsumptionItems &&
+        exception.Message.Contains(FlexiSignal, StringComparison.OrdinalIgnoreCase);
+
+    public string Transform(Exception exception)
+    {
+        // Use ". Požadované šarže " to skip the lowercase "požadované šarže" that appears
+        // earlier in the same Flexi error sentence ("pro vyskladnění požadované šarže nebo expirace").
+        var lotNumber = ManufactureErrorParsingHelpers.ExtractBetween(
+            exception.Message,
+            ". Požadované šarže ",
+            " s ");
+
+        // Try bracket-terminated form first ("… jen 6.59 G. [DoklSklad -1]");
+        // fall back to sentence-terminated form in case Flexi omits the bracket.
+        var available = ManufactureErrorParsingHelpers.ExtractBetween(exception.Message, "máte na skladě jen ", ". [");
+        if (available == "?")
+            available = ManufactureErrorParsingHelpers.ExtractBetween(exception.Message, "máte na skladě jen ", ".");
+
+        var failedItems = (exception as IHasFailedConsumptionItems)?.FailedItems ?? [];
+        var match = FindMatch(failedItems, lotNumber, exception.Message);
+
+        if (match is not null)
+        {
+            var expiration = match.Expiration.HasValue
+                ? match.Expiration.Value.ToString("dd.MM.yyyy")
+                : "?";
+
+            return $"Na skladě chybí materiál {match.ProductName} ({match.ProductCode}) – šarže {match.LotNumber}, expirace {expiration}." +
+                   $" K dispozici {available}. Doplňte šarži na sklad nebo upravte šarži ve výrobě.";
+        }
+
+        return $"Na skladě chybí šarže {lotNumber}. Materiál podle šarže se nepodařilo dohledat.";
+    }
+
+    private static FailedConsumptionItem? FindMatch(
+        IReadOnlyList<FailedConsumptionItem> items,
+        string lotNumber,
+        string rawMessage)
+    {
+        if (items.Count == 0 || lotNumber == "?")
+            return null;
+
+        var candidates = items
+            .Where(i => string.Equals(i.LotNumber, lotNumber, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (candidates.Count == 1)
+            return candidates[0];
+
+        // Multiple candidates with same lot — disambiguate by expiration date in the raw message.
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Expiration.HasValue &&
+                rawMessage.Contains(candidate.Expiration.Value.ToString("dd.MM.yyyy"), StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        return candidates.FirstOrDefault();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/ManufactureErrorParsingHelpers.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/ManufactureErrorParsingHelpers.cs
@@ -26,6 +26,17 @@ internal static class ManufactureErrorParsingHelpers
         return (required.Trim(), available.Trim());
     }
 
+    internal static string ExtractBetween(string text, string startMarker, string endMarker)
+    {
+        var start = text.IndexOf(startMarker, StringComparison.Ordinal);
+        if (start < 0)
+            return "?";
+
+        start += startMarker.Length;
+        var end = text.IndexOf(endMarker, start, StringComparison.Ordinal);
+        return end > start ? text[start..end].Trim() : "?";
+    }
+
     internal static string ExtractAfter(string text, string marker, string? terminator)
     {
         var start = text.IndexOf(marker, StringComparison.Ordinal);

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/CannotAllocateFullAmountFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/CannotAllocateFullAmountFilterTests.cs
@@ -1,0 +1,51 @@
+using Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.ErrorFilters.Filters;
+
+public class CannotAllocateFullAmountFilterTests
+{
+    private readonly CannotAllocateFullAmountFilter _filter = new();
+
+    [Fact]
+    public void CanHandle_WhenMessageIsUnrelated_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException("Some other error");
+
+        _filter.CanHandle(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanHandle_WhenMessageMatchesAllocatorFormat_ReturnsTrue()
+    {
+        var ex = new InvalidOperationException(
+            "Cannot allocate full amount for ingredient HYD013: 21361758.000 remaining");
+
+        _filter.CanHandle(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Transform_ExtractsProductCodeAndRemaining()
+    {
+        var ex = new InvalidOperationException(
+            "Cannot allocate full amount for ingredient HYD013: 21361758.000 remaining");
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("HYD013");
+        result.Should().Contain("21361758.000");
+        result.Should().Contain("šarže");
+    }
+
+    [Fact]
+    public void Transform_WhenMessageFormatUnrecognized_ReturnsFallbackMessage()
+    {
+        var ex = new InvalidOperationException("Cannot allocate full amount for ingredient");
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("ingrediencí");
+        result.Should().Contain("šarže");
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilterTests.cs
@@ -1,0 +1,125 @@
+using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
+using Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.ErrorFilters.Filters;
+
+public class InsufficientLotStockFilterTests
+{
+    private const string RealFlexiError =
+        "Na skladě není dostatek zboží pro vyskladnění požadované šarže nebo expirace. " +
+        "Požadované šarže 171224A7 s expirací 17.12.2027 máte na skladě jen 6.597599 G. [DoklSklad -1]";
+
+    private readonly InsufficientLotStockFilter _filter = new();
+
+    private sealed class EnrichedManufactureException(string message, IReadOnlyList<FailedConsumptionItem>? items = null)
+        : Exception(message), IHasFailedConsumptionItems
+    {
+        public IReadOnlyList<FailedConsumptionItem> FailedItems { get; } = items ?? [];
+    }
+
+    [Fact]
+    public void CanHandle_WhenExceptionIsUnrelated_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException("Some other error");
+
+        _filter.CanHandle(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanHandle_WhenExceptionDoesNotImplementInterface_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException(RealFlexiError);
+
+        _filter.CanHandle(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanHandle_WhenEnrichedExceptionContainsShortageMessage_ReturnsTrue()
+    {
+        var ex = new EnrichedManufactureException(RealFlexiError);
+
+        _filter.CanHandle(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Transform_WhenLotMatchesFailedItem_IncludesMaterialNameAndCode()
+    {
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0)
+        };
+        var ex = new EnrichedManufactureException(RealFlexiError, items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("Levandulový olej");
+        result.Should().Contain("MAT-LAVENDER");
+        result.Should().Contain("171224A7");
+        result.Should().Contain("17.12.2027");
+        result.Should().Contain("6.597599 G");
+    }
+
+    [Fact]
+    public void Transform_WhenNoFailedItems_FallsBackToLotOnlyMessage()
+    {
+        var ex = new EnrichedManufactureException(RealFlexiError, []);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("171224A7");
+        result.Should().Contain("nepodařilo dohledat");
+        result.Should().NotContain("MAT-");
+    }
+
+    [Fact]
+    public void Transform_WhenLotNotInFailedItems_FallsBackToLotOnlyMessage()
+    {
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-OTHER", "Jiný materiál", "999999X1", new DateOnly(2026, 6, 1), 5.0)
+        };
+        var ex = new EnrichedManufactureException(RealFlexiError, items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("171224A7");
+        result.Should().Contain("nepodařilo dohledat");
+    }
+
+    [Fact]
+    public void Transform_WhenMessageFormatUnrecognized_FallsBackToLotOnlyMessage()
+    {
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0)
+        };
+        // Message contains the CanHandle signal but uses a format where the lot cannot be parsed.
+        var ex = new EnrichedManufactureException(
+            "Na skladě není dostatek zboží pro vyskladnění požadované šarže nebo expirace. Unexpected format without lot.",
+            items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("nepodařilo dohledat");
+        result.Should().NotContain("Levandulový olej");
+    }
+
+    [Fact]
+    public void Transform_WhenTwoItemsShareLot_DisambiguatesByExpiration()
+    {
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-A", "Materiál A", "171224A7", new DateOnly(2025, 1, 1), 5.0),
+            new("MAT-B", "Materiál B", "171224A7", new DateOnly(2027, 12, 17), 5.0)
+        };
+        var ex = new EnrichedManufactureException(RealFlexiError, items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("MAT-B");
+        result.Should().Contain("Materiál B");
+        result.Should().NotContain("MAT-A");
+    }
+}


### PR DESCRIPTION
## Summary

- When Flexi rejects a manufacture consumption movement with "Na skladě není dostatek zboží pro vyskladnění požadované šarže", the user now sees the **material name and code** that is short, not just the raw lot number
- No extra Flexi call needed — the lot→material mapping is already in memory at the throw site
- New \`InsufficientLotStockFilter\` slots into the existing error-filter pipeline; auto-registered via Scrutor

## How it works

1. \`FlexiManufactureException\` now implements \`IHasFailedConsumptionItems\` (interface defined in Application layer to avoid circular dep), carrying the list of \`(ProductCode, ProductName, LotNumber, Expiration, Amount)\` items from the failing warehouse batch
2. \`InsufficientLotStockFilter\` matches the Flexi shortage phrasing, extracts the lot id, looks it up in \`FailedItems\`, and emits e.g.:
   > Na skladě chybí materiál Levandulový olej (MAT-LAVENDER) – šarže 171224A7, expirace 17.12.2027. K dispozici 6.597599 G. Doplňte šarži na sklad nebo upravte šarži ve výrobě.
3. Degrades gracefully (lot-only message) when the Flexi format changes or items list is empty

## Test plan

- [x] 8 unit tests in \`InsufficientLotStockFilterTests\` covering: match by lot, no match fallback, unrecognized format fallback, expiration-based disambiguation
- [x] All 2310 backend tests passing
- [x] All 856 frontend tests passing
- [x] \`dotnet format --verify-no-changes\` clean