### PR TITLE
fix(dqt): Shoptet invoice totals always 0 in DQT comparison

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/IssuedInvoices/IssuedInvoiceMapping.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Shoptet/IssuedInvoices/IssuedInvoiceMapping.cs
@@ -29,22 +29,30 @@ namespace Anela.Heblo.Adapters.Shoptet.IssuedInvoices
 
                     if (i.InvoiceSummary.ForeignCurrency != null)
                     {
+                        var withVatFc = i.InvoiceSummary.ForeignCurrency.PriceSum;
+                        var withoutVatFc = ii.Items.Sum(s => s.ItemPrice.WithoutVat);
                         ii.Price = new InvoicePrice()
                         {
-                            WithVat = i.InvoiceSummary.ForeignCurrency.PriceSum,
+                            WithVat = withVatFc,
                             Vat = ii.Items.Sum(s => s.ItemPrice.Vat),
-                            WithoutVat = ii.Items.Sum(s => s.ItemPrice.WithoutVat),
+                            WithoutVat = withoutVatFc,
+                            TotalWithVat = withVatFc,
+                            TotalWithoutVat = withoutVatFc,
                             CurrencyCode = i.InvoiceSummary.ForeignCurrency.Currency.Ids,
                             ExchangeRate = i.InvoiceSummary.ForeignCurrency.Rate
                         };
                     }
                     else
                     {
+                        var withVatHc = i.InvoiceSummary.HomeCurrency.PriceHighSum;
+                        var withoutVatHc = ii.Items.Sum(s => s.ItemPrice.WithoutVat);
                         ii.Price = new InvoicePrice()
                         {
-                            WithVat = i.InvoiceSummary.HomeCurrency.PriceHighSum,
+                            WithVat = withVatHc,
                             Vat = ii.Items.Sum(s => s.ItemPrice.Vat),
-                            WithoutVat = ii.Items.Sum(s => s.ItemPrice.WithoutVat),
+                            WithoutVat = withoutVatHc,
+                            TotalWithVat = withVatHc,
+                            TotalWithoutVat = withoutVatHc,
                             CurrencyCode = "CZK",
                             ExchangeRate = 1,
                         };

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/ShoptetInvoiceMapper.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/ShoptetInvoiceMapper.cs
@@ -66,9 +66,13 @@ public class ShoptetInvoiceMapper
         }
 
         var price = MapInvoicePrice(src.Price);
-        price.WithVat = products.Where(i => i.ItemPrice.VatRate != "none").Sum(i => i.ItemPrice.TotalWithVat);
-        price.WithoutVat = products.Sum(i => i.ItemPrice.TotalWithoutVat);
-        price.Vat = price.WithVat - price.WithoutVat;
+        var totalWithVat = products.Where(i => i.ItemPrice.VatRate != "none").Sum(i => i.ItemPrice.TotalWithVat);
+        var totalWithoutVat = products.Sum(i => i.ItemPrice.TotalWithoutVat);
+        price.WithVat = totalWithVat;
+        price.WithoutVat = totalWithoutVat;
+        price.TotalWithVat = totalWithVat;
+        price.TotalWithoutVat = totalWithoutVat;
+        price.Vat = totalWithVat - totalWithoutVat;
 
         return new IssuedInvoiceDetail
         {

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/IssuedInvoices/ShoptetInvoiceMapperTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/IssuedInvoices/ShoptetInvoiceMapperTests.cs
@@ -101,6 +101,8 @@ public class ShoptetInvoiceMapperTests
         var detail = BuildSut().Map(BuildMinimalDto());
         detail.Price.WithVat.Should().Be(242m);
         detail.Price.WithoutVat.Should().Be(200m, "sums line totals (TotalWithoutVat) for all items");
+        detail.Price.TotalWithVat.Should().Be(242m, "header TotalWithVat must equal sum of item TotalWithVat for DQT");
+        detail.Price.TotalWithoutVat.Should().Be(200m, "header TotalWithoutVat must equal sum of item TotalWithoutVat for DQT");
         // Vat = WithVat - WithoutVat = 242 - 200 = 42.
         detail.Price.Vat.Should().Be(42m);
         detail.Price.CurrencyCode.Should().Be("CZK");
@@ -170,6 +172,8 @@ public class ShoptetInvoiceMapperTests
 
         detail.Price.WithVat.Should().Be(363m);
         detail.Price.WithoutVat.Should().Be(300m, "must sum line totals (TotalWithoutVat) for all items");
+        detail.Price.TotalWithVat.Should().Be(363m, "header TotalWithVat must equal sum of item TotalWithVat for DQT");
+        detail.Price.TotalWithoutVat.Should().Be(300m, "header TotalWithoutVat must equal sum of item TotalWithoutVat for DQT");
         // Vat = WithVat - WithoutVat = 363 - 300 = 63.
         detail.Price.Vat.Should().Be(63m);
     }
@@ -312,6 +316,8 @@ public class ShoptetInvoiceMapperTests
         result.Items.Single(i => i.Code == "P2").ItemPrice.WithoutVat.Should().Be(180m);
         result.Price.WithoutVat.Should().Be(450m);
         result.Price.WithVat.Should().Be(544.5m);
+        result.Price.TotalWithoutVat.Should().Be(450m, "header TotalWithoutVat must mirror WithoutVat for DQT");
+        result.Price.TotalWithVat.Should().Be(544.5m, "header TotalWithVat must mirror WithVat for DQT");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Both Shoptet adapters (RestApi + Playwright fallback) populated `Price.WithVat`/`Price.WithoutVat` on the invoice header but never set `Price.TotalWithVat`/`Price.TotalWithoutVat`, which defaulted to `0m`
- `InvoiceDqtComparer` reads `Price.TotalWithVat`/`Price.TotalWithoutVat` — Flexi populated these correctly, so every comparison showed Shoptet=`0.00` vs Flexi=`<real value>` regardless of the actual invoice total
- Fix: compute header totals once in both mappers and assign to both field pairs; existing callers (`InvoiceImportService`, `InvoicesMappingProfile`) that read `Price.WithVat` are unaffected

## Test Plan

- [ ] New assertions in `ShoptetInvoiceMapperTests` pin `Price.TotalWithVat` and `Price.TotalWithoutVat` for all price paths (minimal, multi-qty, discount-fold)
- [ ] Run `dotnet test` — 2657 tests passing, 0 failures
- [ ] After staging deploy: trigger a DQT run at `/automation/data-quality` and confirm Shoptet column shows real invoice totals (not 0) where invoices genuinely match Flexi