### PR TITLE
fix: compute Hangfire next-run in Europe/Prague timezone

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs
@@ -47,14 +47,23 @@ public class GetRecurringJobsListHandler : IRequestHandler<GetRecurringJobsListR
 
             try
             {
-                dto.NextRunAt = DateTime.SpecifyKind(
-                    CrontabSchedule.Parse(dto.CronExpression).GetNextOccurrence(utcNow),
-                    DateTimeKind.Utc);
+                var tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
+                var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(utcNow, tz);
+                var nextLocal = CrontabSchedule.Parse(dto.CronExpression).GetNextOccurrence(nowLocal);
+                var nextUtc = TimeZoneInfo.ConvertTimeToUtc(
+                    DateTime.SpecifyKind(nextLocal, DateTimeKind.Unspecified), tz);
+                dto.NextRunAt = DateTime.SpecifyKind(nextUtc, DateTimeKind.Utc);
             }
             catch (CrontabException ex)
             {
                 _logger.LogWarning(ex, "Invalid CRON expression '{CronExpression}' for job '{JobName}', NextRunAt will be null",
                     dto.CronExpression, dto.JobName);
+                dto.NextRunAt = null;
+            }
+            catch (TimeZoneNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'",
+                    RecurringJobMetadata.DefaultTimeZoneId, dto.JobName);
                 dto.NextRunAt = null;
             }
         }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/GetRecurringJobsList/GetRecurringJobsListHandler.cs
@@ -37,6 +37,18 @@ public class GetRecurringJobsListHandler : IRequestHandler<GetRecurringJobsListR
         var jobDtos = _mapper.Map<List<RecurringJobDto>>(jobs);
 
         var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+
+        TimeZoneInfo? tz = null;
+        try
+        {
+            tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
+        }
+        catch (TimeZoneNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for all jobs",
+                RecurringJobMetadata.DefaultTimeZoneId);
+        }
+
         foreach (var dto in jobDtos)
         {
             if (!dto.IsEnabled)
@@ -45,9 +57,14 @@ public class GetRecurringJobsListHandler : IRequestHandler<GetRecurringJobsListR
                 continue;
             }
 
+            if (tz is null)
+            {
+                dto.NextRunAt = null;
+                continue;
+            }
+
             try
             {
-                var tz = TimeZoneInfo.FindSystemTimeZoneById(RecurringJobMetadata.DefaultTimeZoneId);
                 var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(utcNow, tz);
                 var nextLocal = CrontabSchedule.Parse(dto.CronExpression).GetNextOccurrence(nowLocal);
                 var nextUtc = TimeZoneInfo.ConvertTimeToUtc(
@@ -58,12 +75,6 @@ public class GetRecurringJobsListHandler : IRequestHandler<GetRecurringJobsListR
             {
                 _logger.LogWarning(ex, "Invalid CRON expression '{CronExpression}' for job '{JobName}', NextRunAt will be null",
                     dto.CronExpression, dto.JobName);
-                dto.NextRunAt = null;
-            }
-            catch (TimeZoneNotFoundException ex)
-            {
-                _logger.LogWarning(ex, "Timezone '{TimeZoneId}' not found on host, NextRunAt will be null for job '{JobName}'",
-                    RecurringJobMetadata.DefaultTimeZoneId, dto.JobName);
                 dto.NextRunAt = null;
             }
         }

--- a/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs
@@ -31,7 +31,12 @@ public class RecurringJobMetadata
     public bool DefaultIsEnabled { get; init; } = true;
 
     /// <summary>
+    /// Default timezone for cron expressions
+    /// </summary>
+    public const string DefaultTimeZoneId = "Europe/Prague";
+
+    /// <summary>
     /// Timezone for cron expression (defaults to Europe/Prague)
     /// </summary>
-    public string TimeZoneId { get; init; } = "Europe/Prague";
+    public string TimeZoneId { get; init; } = DefaultTimeZoneId;
 }

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobsListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobsListHandlerTests.cs
@@ -138,7 +138,8 @@ public class GetRecurringJobsListHandlerTests
     [Fact]
     public async Task Handle_WhenJobIsEnabled_SetsNextRunAtToFutureUtcDateTime()
     {
-        // Fixed time is 2026-03-30 12:00:00 UTC; cron "0 13 * * *" next fires at 13:00 same day
+        // Fixed time is 2026-03-30 12:00:00 UTC = 14:00 CEST (UTC+2, DST already in effect)
+        // cron "0 13 * * *" fires at 13:00 Prague; next occurrence after 14:00 Prague is 2026-03-31 13:00 CEST = 11:00 UTC
         var request = new GetRecurringJobsListRequest();
         var jobs = new List<RecurringJobConfiguration>
         {
@@ -153,7 +154,7 @@ public class GetRecurringJobsListHandlerTests
 
         var result = await _handler.Handle(request, CancellationToken.None);
 
-        var expectedNextRun = new DateTime(2026, 3, 30, 13, 0, 0, DateTimeKind.Utc);
+        var expectedNextRun = new DateTime(2026, 3, 31, 11, 0, 0, DateTimeKind.Utc);
         result.Jobs[0].NextRunAt.Should().Be(expectedNextRun);
         result.Jobs[0].NextRunAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
     }
@@ -197,7 +198,7 @@ public class GetRecurringJobsListHandlerTests
 
         var result = await _handler.Handle(request, CancellationToken.None);
 
-        result.Jobs[0].NextRunAt.Should().Be(new DateTime(2026, 3, 30, 13, 0, 0, DateTimeKind.Utc));
+        result.Jobs[0].NextRunAt.Should().Be(new DateTime(2026, 3, 31, 11, 0, 0, DateTimeKind.Utc));
         result.Jobs[0].NextRunAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
         result.Jobs[1].NextRunAt.Should().BeNull();
     }
@@ -235,5 +236,89 @@ public class GetRecurringJobsListHandlerTests
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsEnabled_NextRunAt_UsesEuropePragueTimezone_Summer()
+    {
+        // "now" is 2026-04-29 12:00 UTC = 14:00 CEST (UTC+2)
+        // cron "15 4 * * *" fires at 04:15 Prague, next occurrence after 14:00 is next day 04:15 CEST = 02:15 UTC
+        var summerTimeProvider = new Mock<TimeProvider>();
+        summerTimeProvider.Setup(tp => tp.GetUtcNow())
+            .Returns(new DateTimeOffset(2026, 4, 29, 12, 0, 0, TimeSpan.Zero));
+        var handler = new GetRecurringJobsListHandler(
+            _repositoryMock.Object, _mapperMock.Object, _loggerMock.Object, summerTimeProvider.Object);
+
+        var request = new GetRecurringJobsListRequest();
+        var jobs = new List<RecurringJobConfiguration>
+        {
+            new RecurringJobConfiguration("czk-import", "CZK Import", "Desc", "15 4 * * *", true, "System")
+        };
+        var jobDtos = new List<RecurringJobDto>
+        {
+            new RecurringJobDto { JobName = "czk-import", CronExpression = "15 4 * * *", IsEnabled = true }
+        };
+        _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
+        _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // 04:15 Prague CEST = 02:15 UTC
+        result.Jobs[0].NextRunAt.Should().Be(new DateTime(2026, 4, 30, 2, 15, 0, DateTimeKind.Utc));
+        result.Jobs[0].NextRunAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsEnabled_NextRunAt_UsesEuropePragueTimezone_Winter()
+    {
+        // "now" is 2026-01-15 12:00 UTC = 13:00 CET (UTC+1)
+        // cron "15 4 * * *" fires at 04:15 Prague CET, next occurrence after 13:00 is next day 04:15 CET = 03:15 UTC
+        var winterTimeProvider = new Mock<TimeProvider>();
+        winterTimeProvider.Setup(tp => tp.GetUtcNow())
+            .Returns(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+        var handler = new GetRecurringJobsListHandler(
+            _repositoryMock.Object, _mapperMock.Object, _loggerMock.Object, winterTimeProvider.Object);
+
+        var request = new GetRecurringJobsListRequest();
+        var jobs = new List<RecurringJobConfiguration>
+        {
+            new RecurringJobConfiguration("czk-import", "CZK Import", "Desc", "15 4 * * *", true, "System")
+        };
+        var jobDtos = new List<RecurringJobDto>
+        {
+            new RecurringJobDto { JobName = "czk-import", CronExpression = "15 4 * * *", IsEnabled = true }
+        };
+        _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
+        _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // 04:15 Prague CET = 03:15 UTC
+        result.Jobs[0].NextRunAt.Should().Be(new DateTime(2026, 1, 16, 3, 15, 0, DateTimeKind.Utc));
+        result.Jobs[0].NextRunAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCronExpressionIsInvalid_SetsNextRunAtToNull_AndLogsTimezoneWarning()
+    {
+        // Arrange — "INVALID_CRON" is syntactically invalid and will cause CrontabSchedule.Parse to throw
+        // The TimeZoneNotFoundException catch is defensive; the CrontabException is what fires here
+        var request = new GetRecurringJobsListRequest();
+        var jobs = new List<RecurringJobConfiguration>
+        {
+            new RecurringJobConfiguration("Job1", "Display 1", "Desc", "INVALID_CRON", true, "User1")
+        };
+        var jobDtos = new List<RecurringJobDto>
+        {
+            new RecurringJobDto { JobName = "Job1", CronExpression = "INVALID_CRON", IsEnabled = true }
+        };
+        _repositoryMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
+        _mapperMock.Setup(m => m.Map<List<RecurringJobDto>>(jobs)).Returns(jobDtos);
+
+        // Act — must not throw
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Jobs[0].NextRunAt.Should().BeNull();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobsListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/GetRecurringJobsListHandlerTests.cs
@@ -299,7 +299,7 @@ public class GetRecurringJobsListHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenCronExpressionIsInvalid_SetsNextRunAtToNull_AndLogsTimezoneWarning()
+    public async Task Handle_WhenCronExpressionIsInvalid_SetsNextRunAtToNull_DoesNotThrow()
     {
         // Arrange — "INVALID_CRON" is syntactically invalid and will cause CrontabSchedule.Parse to throw
         // The TimeZoneNotFoundException catch is defensive; the CrontabException is what fires here


### PR DESCRIPTION
## Summary

- `GetRecurringJobsListHandler` was computing \"Next Run\" by calling `CrontabSchedule.GetNextOccurrence(utcNow)`, treating the cron as UTC. But Hangfire registers all jobs with `Europe/Prague` TZ, so the displayed time was always +2h off in summer and +1h in winter.
- Fixed by converting UTC now → Prague local, computing the next occurrence, then converting back to UTC before returning. The frontend's existing `toLocaleString('cs-CZ', …)` then renders the correct local time.
- Extracted `RecurringJobMetadata.DefaultTimeZoneId = "Europe/Prague"` as a public const so the handler and the metadata definition share one source of truth.
- Hoisted the `TimeZoneInfo.FindSystemTimeZoneById` call above the job loop so a missing timezone logs once (not per job) and short-circuits cleanly.

## Test Plan

- [x] 2369 unit tests pass (`dotnet test`)
- [x] `dotnet format` clean
- [ ] Open `/recurring-jobs` in the management UI — verify that `daily-invoice-import-czk` (cron `15 4 * * *`) now shows **Next Run: 04:15** (Prague local), matching the actual Hangfire execution time visible in the `/hangfire` dashboard
- [ ] Toggle a job off → "Next Run" shows `—`
- [ ] Edit cron via inline editor to an invalid value → "Next Run" shows `—`, no 500 in logs