### PR TITLE
docs: slim CLAUDE.md from 437 → 77 lines, extract MCP block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,436 +1,77 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repository.
 
-## Project Overview
+## Project
 
-**Anela Heblo** - A cosmetics company workspace application built with Clean Architecture principles.
+**Anela Heblo** — cosmetics company workspace, Clean Architecture monorepo (.NET 8 + React).
+MediatR + MVC controllers, Vertical Slice organization, single Docker image, Azure Web App for Containers.
 
-**Stack**: Monorepo (.NET 8 + React), Clean Architecture with Vertical Slice organization, MediatR + MVC Controllers, Single Docker image deployment, Azure Web App for Containers.
+## Documentation map
 
-## Quick Reference Documentation
+Read the relevant doc **before** implementation work touches that area. No architectural changes without consulting these first — when in doubt, ask.
 
-### Architecture & Structure
-- **📘 Core Architecture**: `docs/📘 Architecture Documentation – MVP Work.md` - Module definitions, data flow, business logic
-- **🗂️ Filesystem Structure**: `docs/architecture/filesystem.md` - Directory organization, component placement rules
-- **🏗️ Infrastructure**: `docs/architecture/application_infrastructure.md` - Deployment, CI/CD, Docker
-- **🌐 Environments**: `docs/architecture/environments.md` - Port mappings, CORS, Azure settings
+**Architecture**
+- `docs/📘 Architecture Documentation – MVP Work.md` — modules, data flow, business logic
+- `docs/architecture/filesystem.md` — directory layout, component placement, naming conventions
+- `docs/architecture/development_guidelines.md` — DTO/contract rules, module boundaries, persistence
+- `docs/architecture/infrastructure.md` — deployment, CI/CD, Docker
+- `docs/architecture/environments.md` — port mappings, CORS, Azure config
+- `docs/architecture/testing-strategy.md` — BE/FE/E2E testing approach
 
-### Development
-- **🚀 Setup & Commands**: `docs/development/setup.md` - Development commands, authentication setup, Docker
-- **🔌 API Client Generation**: `docs/development/api-client-generation.md` - OpenAPI client generation (C# & TypeScript)
+**Development**
+- `docs/development/setup.md` — commands, auth setup, Docker, code formatting
+- `docs/development/api-client-generation.md` — OpenAPI client generation (C# + TypeScript)
 
-### Design & UI
-- **🎨 UI Design System**: `docs/design/ui_design_document.md` - Design system, colors, typography, components
-- **📐 Layout Definition**: `docs/design/layout_definition.md` - Page layout standards (CRITICAL for UI work)
+**Design**
+- `docs/design/ui_design_document.md` — design system, colors, typography, components
+- `docs/design/layout_definition.md` — page layout standards (read before any UI work)
 
-### Testing
-- **🎭 Playwright E2E Testing**: `docs/testing/playwright-e2e-testing.md` - E2E testing setup, authentication, commands
-- **📊 Test Data Fixtures**: `docs/testing/test-data-fixtures.md` - Available test data for E2E tests
+**Testing**
+- `docs/testing/playwright-e2e-testing.md` — E2E setup, authentication, commands
+- `docs/testing/test-data-fixtures.md` — available test data for E2E tests
+- `docs/testing/e2e-module-guide.md` — module boundaries for parallel E2E execution
 
-### MCP & Integration
-- **🔌 MCP Server**: See "MCP Server" section below - 15 tools across Catalog, Manufacturing, and Batch Planning
-- **🛒 Shoptet API**: `docs/integrations/shoptet-api.md` - All findings about Shoptet REST API (orders, statuses, shipping, ShoptetPay, test seeding)
-
-## MCP Server
-
-**Model Context Protocol Integration** - The application exposes MCP tools for AI assistants to query catalog data, manufacturing orders, and perform batch calculations.
+**Integrations**
+- `docs/integrations/mcp-server.md` — MCP tools, endpoints, client config (15 tools)
+- `docs/integrations/shoptet-api.md` — Shoptet REST API findings
 
-**Available Tools:**
+**Features** — `docs/features/` has per-feature specs.
 
-**Catalog Tools (7):**
-- `GetCatalogList` - List products with filtering/pagination
-- `GetCatalogDetail` - Get detailed product information
-- `GetProductComposition` - Get product composition/ingredients
-- `GetMaterialsForPurchase` - Get materials needed for purchase
-- `GetAutocomplete` - Search products for autocomplete
-- `GetProductUsage` - Get product usage in compositions
-- `GetWarehouseStatistics` - Get warehouse statistics
+## Project-specific rules
 
-**Manufacture Order Tools (4):**
-- `GetManufactureOrders` - List manufacture orders with filtering
-- `GetManufactureOrder` - Get single manufacture order details
-- `GetCalendarView` - Get calendar view of manufacture orders
-- `GetResponsiblePersons` - Get responsible persons from Entra ID
+These encode **project-specific** gotchas not covered by the global rules in `~/.claude/rules/`.
 
-**Manufacture Batch Tools (4):**
-- `GetBatchTemplate` - Get batch template for product
-- `CalculateBatchBySize` - Calculate batch by desired size
-- `CalculateBatchByIngredient` - Calculate batch by ingredient quantity
-- `CalculateBatchPlan` - Calculate batch plan for multiple products
+- **DTOs are classes, never C# records.** OpenAPI client generators mishandle record parameter order. Internal domain types may still be records. (See `docs/architecture/development_guidelines.md`.)
+- **API hooks use absolute URLs.** Construct as `${apiClient.baseUrl}${relativeUrl}` — relative URLs hit port 3001 instead of 5001. (See `docs/development/api-client-generation.md`.)
+- **E2E tests auth via `navigateToApp()`.** Using `createE2EAuthSession()` alone skips the frontend session and triggers the Entra ID login screen. (See `docs/testing/playwright-e2e-testing.md`.)
+- **E2E tests use fixtures from `frontend/test/e2e/fixtures/test-data.ts`.** Throw (don't skip) when expected data is missing. (See `docs/testing/test-data-fixtures.md`.)
+- **E2E tests live in their module folder** under `frontend/test/e2e/<module>/`. (See `docs/testing/e2e-module-guide.md`.)
+- **Shoptet API findings must be documented before use.** No sandbox — every call hits a live store. Write new endpoints, status values, and quirks to `docs/integrations/shoptet-api.md` before relying on them.
 
-**Knowledge Base Tools (2):**
-- `SearchKnowledgeBase` - Semantic search over ingested documents, returns ranked chunks with source references
-- `AskKnowledgeBase` - AI-generated answer grounded in company documents, returns prose answer with cited sources
-
-**Implementation:**
-- Tool classes: `backend/src/Anela.Heblo.API/MCP/Tools/`
-- Registration: `McpModule.cs` (AddMcpServer + WithHttpTransport + WithTools)
-- Pattern: Thin wrappers around MediatR handlers
-- Error handling: `McpException` from `ModelContextProtocol` namespace for protocol errors
-- Authentication: Uses existing Microsoft Entra ID authentication
+## Validation before completion
 
-**Testing:**
-- Test location: `backend/test/Anela.Heblo.Tests/MCP/Tools/`
-- Total tests: 29 (comprehensive coverage including parameter mapping, JSON serialization, and error handling)
-- See existing test files for examples of MCP tool testing patterns
+Before declaring any task done:
 
-**Status:** ✅ Active - MCP server running on /mcp endpoint using official ModelContextProtocol.AspNetCore SDK
+- BE: `dotnet build` + `dotnet format`
+- FE: `npm run build` + `npm run lint`
+- All tests touched by the change must pass
+- E2E: `./scripts/run-playwright-tests.sh` against staging
 
-**Endpoint:** `/mcp` (requires Microsoft Entra ID authentication)
+## Project facts
 
-**Transport:** SSE (Server-Sent Events) for web-based MCP clients
-
-**SDK:** Official MCP C# SDK from https://github.com/modelcontextprotocol/csharp-sdk
-
-**Tool Pattern:**
-- Tools decorated with `[McpServerToolType]` (class) and `[McpServerTool]` (methods)
-- Parameters use `[Description]` attribute for documentation
-- Methods return `Task<string>` with JSON-serialized responses
-- Errors thrown as `McpException` (handled by SDK)
-
-**Configuration:**
-
-Available endpoints by environment:
-- **Production**: `https://heblo.anela.cz/mcp`
-- **Staging**: `https://heblo.stg.anela.cz/mcp`
-- **Local Development**: `https://localhost:5001/mcp`
-
-**MCP Client Setup:**
-
-Add to your MCP client configuration (e.g., Claude Desktop `claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "anela-heblo": {
-      "url": "https://heblo.anela.cz/mcp",
-      "transport": "sse",
-      "authentication": {
-        "type": "bearer",
-        "token": "YOUR_ENTRA_ID_TOKEN"
-      }
-    }
-  }
-}
-```
-
-For local development, use `https://localhost:5001/mcp` as the URL.
-
-## Architecture Principles
-
-**Clean Architecture with Vertical Slice Organization:**
-- **Domain Layer** (`Anela.Heblo.Domain`): Entities, repository interfaces, domain services
-- **Application Layer** (`Anela.Heblo.Application`): MediatR handlers, business logic, DTOs
-- **Infrastructure Layer** (`Anela.Heblo.Persistence`): EF Core contexts, entity configurations, repositories
-- **API Layer** (`Anela.Heblo.API`): MVC Controllers (NOT FastEndpoints), authentication, serves React app
-
-**Key Principles:**
-- **Vertical organization**: Each feature contains all its layers
-- **MediatR pattern**: Controllers send requests to handlers via MediatR
-- **Standard API Pattern**: All endpoints follow `/api/{controller}` REST conventions
-- **Feature autonomy**: Each feature manages its own contracts, services, and infrastructure
-- **SOLID principles**: Applied within each vertical slice
-
-See `docs/architecture/filesystem.md` for detailed structure and component placement rules.
-
-## CRITICAL RULES - Must Follow Always
-
-### 1. Security Rules
-
-**NEVER commit credentials to source control:**
-- ❌ No real passwords, API keys, or tokens in any committed files
-- ❌ No hardcoded credentials in test files
-- ❌ No authentication secrets in configuration files
-
-**Required approach:**
-- ✅ Use local `.env.test` files (always gitignored)
-- ✅ Load credentials via secure utility functions like `loadTestCredentials()`
-- ✅ Exit with error if credentials file is missing
-
-### 2. Code Formatting Standards
-
-**Backend (.NET)**:
-- **MANDATORY**: All C# code MUST pass `dotnet format` validation
-- Indentation: 4 spaces (never tabs)
-- Brace style: Allman style (opening braces on new line)
-- Run `dotnet format` before commits
-- CI/CD validates formatting and fails on violations
-
-**Frontend (React/TypeScript)**:
-- Use Prettier for consistent formatting
-- 2 spaces indentation for TypeScript/JSX
-- Semicolons required, single quotes for strings
-- Run `npm run lint` before commits
-
-### 3. Backend DTO Rules
-
-**CRITICAL: OpenAPI Client Generation Compatibility**
-
-**Use Classes Instead of Records for API DTOs:**
-- ❌ **NEVER use C# records for API request/response DTOs** - OpenAPI generators have issues with parameter order
-- ✅ **ALWAYS use classes with properties for API DTOs** - ensures reliable OpenAPI schema generation
-- ✅ **Add proper validation attributes** - `[Required]`, `[JsonPropertyName]`, etc.
-
-**Enforcement:**
-- All MediatR requests/responses for API endpoints must use classes
-- Internal domain objects can still use records if not exposed via API
-
-### 4. API Client URL Construction
-
-**MANDATORY**: All API hooks MUST use absolute URLs with baseUrl to avoid calling wrong endpoints.
-
-**❌ WRONG - Relative URL (calls wrong port)**:
-```typescript
-const url = `/api/catalog`; // Calls localhost:3001 instead of localhost:5001
-const response = await (apiClient as any).http.fetch(url, {method: 'GET'});
-```
-
-**✅ CORRECT - Absolute URL with baseUrl**:
-```typescript
-const relativeUrl = `/api/catalog`;
-const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`; // http://localhost:5001/api/catalog
-const response = await (apiClient as any).http.fetch(fullUrl, {method: 'GET'});
-```
-
-**Enforcement:**
-- NEVER use relative URLs directly in fetch calls
-- Use generated API client via `getAuthenticatedApiClient()`
-
-See `docs/development/api-client-generation.md` for details.
-
-### 5. E2E Test Authentication
-
-**MANDATORY**: All E2E tests MUST use proper authentication setup to avoid Microsoft Entra ID login screen.
-
-**✅ CORRECT - Use navigateToApp() for full authentication:**
-```typescript
-import { navigateToApp } from './helpers/e2e-auth-helper';
-
-test.beforeEach(async ({ page }) => {
-  await navigateToApp(page); // Full auth: backend + frontend session
-  await page.goto('/your-page');
-});
-```
-
-**✅ CORRECT - Use navigation helpers (include auth internally):**
-```typescript
-import { navigateToCatalog, navigateToTransportBoxes } from './helpers/e2e-auth-helper';
-
-test.beforeEach(async ({ page }) => {
-  await navigateToCatalog(page); // Includes full auth setup
-});
-```
-
-**❌ WRONG - Never use createE2EAuthSession() alone:**
-```typescript
-await createE2EAuthSession(page); // ❌ Only backend session, missing frontend
-await page.goto('/your-page');    // ❌ Will show Microsoft login screen!
-```
-
-**Why this matters:**
-- `createE2EAuthSession()` - Only backend auth (service principal token)
-- `navigateToApp()` - Full setup: backend + frontend session (cookies, sessionStorage, E2E flag)
-- Without frontend session → Microsoft Entra ID sign-in screen → test failure
-
-See `docs/testing/playwright-e2e-testing.md` for complete authentication flow.
-
-### 6. Test Data Fixtures
-
-**MANDATORY**: When writing E2E tests that require consistent, reliable data, ALWAYS use test data fixtures.
-
-**Usage Rules:**
-- ✅ Use fixtures from `frontend/test/e2e/fixtures/test-data.ts`
-- ✅ Reference `docs/testing/test-data-fixtures.md` for available test data
-- ✅ Tests MUST fail (not skip) when expected data is missing - throw clear error messages
-- ✅ Example: Use `TestCatalogItems.bisabolol` instead of hardcoding "AKL001"
-
-**Fail, don't skip:**
-```typescript
-import { TestCatalogItems } from './fixtures/test-data';
-
-test('should filter by product', async ({ page }) => {
-  const product = TestCatalogItems.bisabolol;
-  await searchForProduct(page, product.name);
-
-  const rowCount = await getRowCount(page);
-  if (rowCount === 0) {
-    throw new Error(
-      `Test data missing: Expected to find "${product.name}" (${product.code})`
-    );
-  }
-  // Continue with assertions...
-});
-```
-
-### 7. E2E Test Modular Structure
-
-**MANDATORY**: All E2E test files MUST be organized into modular structure for parallel execution.
-
-**Module Structure:**
-Tests are organized into 6 logical modules:
-- `catalog/` - Catalog page tests (filters, sorting, pagination, charts)
-- `issued-invoices/` - Issued invoices tests (filters, import, navigation, badges)
-- `stock-operations/` - Stock operations tests (filters, retry, badges, panel)
-- `transport/` - Transport box tests (creation, management, workflow, EAN)
-- `manufacturing/` - Manufacturing tests (batch planning, order creation)
-- `core/` - Core functionality tests (dashboard, changelog, navigation, auth)
-
-**Shared directories:**
-- `helpers/` - Test helper functions and utilities
-- `fixtures/` - Test data fixtures
-
-**✅ CORRECT - Modular structure:**
-```
-frontend/test/e2e/
-├── helpers/                              # ✅ Shared test utilities
-├── fixtures/                             # ✅ Test data fixtures
-├── catalog/                              # ✅ Catalog module tests
-│   ├── clear-filters.spec.ts
-│   ├── combined-filters.spec.ts
-│   └── ...
-├── issued-invoices/                      # ✅ Issued invoices module tests
-│   ├── filters.spec.ts
-│   ├── import-modal.spec.ts
-│   └── ...
-└── stock-operations/                     # ✅ Stock operations module tests
-    ├── filters.spec.ts
-    ├── retry.spec.ts
-    └── ...
-```
-
-**Import paths with modular structure:**
-```typescript
-// ✅ CORRECT - Tests in modules use relative paths
-import { navigateToApp } from '../helpers/e2e-auth-helper';
-import { TestCatalogItems } from '../fixtures/test-data';
-```
-
-**Running tests:**
-```bash
-# Run all modules
-./scripts/run-playwright-tests.sh
-
-# Run specific module
-./scripts/run-playwright-tests.sh catalog
-./scripts/run-playwright-tests.sh issued-invoices
-./scripts/run-playwright-tests.sh stock-operations
-
-# Run by pattern
-./scripts/run-playwright-tests.sh auth
-```
-
-**Enforcement:**
-- Tests MUST be placed in appropriate module directory
-- Module selection enables parallel CI/CD execution (3-4x speedup)
-- See `docs/testing/playwright-e2e-testing.md` for complete testing guide
-- See `docs/testing/e2e-module-guide.md` for module definitions and boundaries
-
-### 8. Design Document Alignment
-
-**MANDATORY**: All implementation work MUST align with design documents in `/docs`.
-
-**Before ANY implementation:**
-- Read and understand relevant design documents
-- Verify proposed changes align with documented architecture
-- If conflicts arise, ask for clarification rather than making assumptions
-
-**Required documents for different change types:**
-- **Backend/API changes**: `docs/📘 Architecture Documentation – MVP Work.md`
-- **Infrastructure/deployment**: `docs/architecture/application_infrastructure.md`
-- **Environment/config**: `docs/architecture/environments.md`
-- **Filesystem/structure**: `docs/architecture/filesystem.md`
-- **Frontend/UI**: `docs/design/ui_design_document.md`
-- **Page layouts**: `docs/design/layout_definition.md` (CRITICAL for UI work)
-
-**Enforcement:**
-- NO implementation without consultation
-- NO architectural deviations without approval
-- MANDATORY documentation updates when implementation changes
-
-### 9. Shoptet API Knowledge Base
-
-**MANDATORY**: Any new finding about the Shoptet REST API MUST be documented in `docs/integrations/shoptet-api.md` before being used in code or tests.
-
-This includes:
-- New endpoints used or discovered
-- Order status values and their meaning
-- Shipping/payment method GUIDs per environment
-- Quirks, gotchas, or undocumented behaviors
-- Test environment constraints or workarounds
-
-**Why:** Shoptet has no sandbox — everything runs against a live store. Undocumented assumptions cause data corruption or flaky tests.
-
-## Testing Strategy
-
-**Three types of tests:**
-1. **BE (Backend)**: .NET unit/integration tests - Run with `dotnet test`
-2. **FE (Frontend)**: Jest + React Testing Library - Run with `npm test`
-3. **UI (E2E)**: Playwright against staging - Run with `./scripts/run-playwright-tests.sh`
-
-**Test Organization:**
-- **Unit/Integration**: Co-located in `__tests__/` folders next to components
-- **E2E Tests**: Located in `/frontend/test/e2e/` directory (MUST use flat structure - see rule 7)
-
-**Playwright Testing:**
-- **Target**: Always run against staging environment (https://heblo.stg.anela.cz)
-- **Authentication**: Real Microsoft Entra ID (not mock)
-- **Commands**: See `docs/testing/playwright-e2e-testing.md`
-
-**CI/CD Testing Strategy:**
-- **In CI**: Frontend Jest + Backend .NET tests (fast feedback, 15-20 min)
-- **Nightly**: Full Playwright E2E suite against staging (comprehensive, 10-15 min)
-- **E2E tests do NOT run in PR CI** - only nightly regression
-
-## Implementation Guidelines
-
-### When Creating New Features:
-1. **Start with Domain**: Define entities and repository interfaces in `Domain/Features/{Feature}/`
-2. **Add Application Logic**: Create handlers in `Application/Features/{Feature}/UseCases/`
-3. **Configure Persistence**: Create entity configurations in `Persistence/{Feature}/`
-4. **Expose via API**: Create controller in `API/Controllers/{Feature}Controller.cs`
-5. **Register Dependencies**: Update `{Feature}Module.cs` and `PersistenceModule.cs`
-
-### Naming Conventions:
-- **Controllers**: `{Feature}Controller` (e.g., `CatalogController`)
-- **Handlers**: `{Action}{Entity}Handler` (e.g., `GetCatalogListHandler`)
-- **Requests/Responses**: `{Action}{Entity}Request/Response`
-- **DTOs**: `{Entity}Dto` (e.g., `CatalogItemDto`)
-- **Services**: `{Entity}Service` and `I{Entity}Service`
-- **Entity Configurations**: `{Entity}Configuration`
-- **Repositories**: `{Entity}Repository`
-
-See `docs/architecture/filesystem.md` for complete feature organization patterns.
-
-## Development Workflow
-
-1. **Make changes** to code
-2. **For UI changes**: Test locally with `npm start` (port 3000)
-3. **For E2E testing**: Use staging environment (`./scripts/run-playwright-tests.sh`)
-4. **Validate builds**: Run `dotnet build` (BE) or `npm run build` (FE) before finishing
-5. **Format code**: Run `dotnet format` (BE) or `npm run lint` (FE)
-6. **Follow best practices**: YAGNI, SOLID, KISS, DRY
-7. **Ask for clarification** if unsure about implementation details
-
-See `docs/development/setup.md` for detailed development commands and setup instructions.
-
-## Important Notes
-
-- Solo developer project with AI-assisted PR reviews
-- Database migrations are manual (not automated in deployment)
-- OpenAPI client auto-generated on build
-- All Docker images pushed to Docker Hub
-- Backend follows Clean Architecture with Vertical Slice organization
-- To run Playwright tests: Always use `./scripts/run-playwright-tests.sh` script
-- Validate builds before claiming completion
+- Solo developer + AI-assisted PR review.
+- Database migrations are manual (not automated in deployment).
+- OpenAPI TypeScript client is auto-generated on build.
+- Docker images are pushed to Docker Hub.
+- E2E suite runs **nightly**, not in PR CI.
+- GitHub access via `gh` CLI only — never use MCP GitHub tools.
 
 ## Memory
 
-Cross-session knowledge lives in `memory/`. Read relevant files at the start of each session. Write new learnings, decisions, and patterns during the session.
+Cross-session knowledge lives in `memory/`. Read relevant files at session start; write learnings during the session.
 
 - `memory/decisions/` — architectural and library choices with reasoning
 - `memory/patterns/` — confirmed implementation patterns for this codebase
-- `memory/gotchas/` — bugs, edge cases, and hard-won lessons
-- `memory/context/` — current project state, active work, pending decisions
-
-Update `memory/context/state.md` at the end of significant sessions with: current branch, what was completed, what is pending, any blockers.
+- `memory/gotchas/` — bugs, edge cases, hard-won lessons
+- `memory/context/state.md` — current branch, in-flight work, blockers (update at session end)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,14 @@ Read the relevant doc **before** implementation work touches that area. No archi
 
 **Features** — `docs/features/` has per-feature specs.
 
+## Coding behavior
+
+**Think before coding.** State assumptions explicitly before starting. If multiple interpretations exist, present them — don't pick silently. If something is unclear, stop, name what's confusing, and ask. Push back when a simpler approach exists.
+
+**Surgical changes.** Touch only what the task requires. Don't improve adjacent code, comments, or formatting. Match existing style even if you'd do it differently. If you notice unrelated dead code, mention it — don't delete it. Every changed line should trace directly to the request.
+
+**Goal-driven execution.** For multi-step tasks, state a brief plan with a verifiable check per step before writing code. Strong success criteria let you loop independently; weak criteria require constant clarification.
+
 ## Project-specific rules
 
 These encode **project-specific** gotchas not covered by the global rules in `~/.claude/rules/`.

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -1,0 +1,91 @@
+# MCP Server
+
+The application exposes MCP tools for AI assistants to query catalog data, manufacturing orders, and perform batch calculations.
+
+## Available Tools
+
+**Catalog (7)**
+- `GetCatalogList` — list products with filtering/pagination
+- `GetCatalogDetail` — detailed product information
+- `GetProductComposition` — product composition/ingredients
+- `GetMaterialsForPurchase` — materials needed for purchase
+- `GetAutocomplete` — product search for autocomplete
+- `GetProductUsage` — product usage in compositions
+- `GetWarehouseStatistics` — warehouse statistics
+
+**Manufacture Orders (4)**
+- `GetManufactureOrders` — list manufacture orders with filtering
+- `GetManufactureOrder` — single manufacture order details
+- `GetCalendarView` — calendar view of manufacture orders
+- `GetResponsiblePersons` — responsible persons from Entra ID
+
+**Manufacture Batch (4)**
+- `GetBatchTemplate` — batch template for product
+- `CalculateBatchBySize` — calculate batch by desired size
+- `CalculateBatchByIngredient` — calculate batch by ingredient quantity
+- `CalculateBatchPlan` — batch plan for multiple products
+
+**Knowledge Base (2)**
+- `SearchKnowledgeBase` — semantic search over ingested documents, returns ranked chunks with source references
+- `AskKnowledgeBase` — AI-generated answer grounded in company documents, returns prose answer with cited sources
+
+## Implementation
+
+- Tool classes: `backend/src/Anela.Heblo.API/MCP/Tools/`
+- Registration: `McpModule.cs` (`AddMcpServer` + `WithHttpTransport` + `WithTools`)
+- Pattern: thin wrappers around MediatR handlers
+- Error handling: `McpException` from `ModelContextProtocol` namespace
+- Authentication: Microsoft Entra ID (same as the rest of the API)
+
+## Tool Pattern
+
+```csharp
+[McpServerToolType]
+public class CatalogTools
+{
+    [McpServerTool]
+    public async Task<string> GetCatalogList([Description("...")] string query)
+    {
+        // Call MediatR, return JSON-serialized result
+        // Throw McpException on errors
+    }
+}
+```
+
+## Endpoints
+
+| Environment | URL |
+|---|---|
+| Production | `https://heblo.anela.cz/mcp` |
+| Staging | `https://heblo.stg.anela.cz/mcp` |
+| Local | `https://localhost:5001/mcp` |
+
+Transport: SSE (Server-Sent Events)  
+SDK: [modelcontextprotocol/csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk)
+
+## Client Setup
+
+Add to `claude_desktop_config.json` (or equivalent MCP client config):
+
+```json
+{
+  "mcpServers": {
+    "anela-heblo": {
+      "url": "https://heblo.anela.cz/mcp",
+      "transport": "sse",
+      "authentication": {
+        "type": "bearer",
+        "token": "YOUR_ENTRA_ID_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For local development use `https://localhost:5001/mcp`.
+
+## Tests
+
+- Location: `backend/test/Anela.Heblo.Tests/MCP/Tools/`
+- Coverage: 29 tests (parameter mapping, JSON serialization, error handling)
+- See existing test files for patterns.


### PR DESCRIPTION
## Summary

- Reduced CLAUDE.md from **437 → 77 lines** (~82% reduction) by removing content already enforced by global `~/.claude/rules/*` or already present in `docs/`
- Extracted the 80-line MCP server reference block to **`docs/integrations/mcp-server.md`** (new file) — tools, endpoints, JSON client config, transport, SDK notes
- Retained only project-specific gotchas: DTO classes-not-records (OpenAPI generator quirk), absolute API URLs, E2E auth via `navigateToApp()`, Shoptet live-store documentation rule

**Dropped from CLAUDE.md (covered elsewhere):**
- Security rules → `~/.claude/rules/security.md`
- Code formatting detail → `docs/development/setup.md`
- SOLID/KISS/DRY/YAGNI → `~/.claude/rules/coding-style.md`
- Architecture Principles → `docs/architecture/filesystem.md` + `development_guidelines.md`
- Testing Strategy section → `docs/architecture/testing-strategy.md`
- Implementation Guidelines + Naming Conventions → `docs/architecture/filesystem.md`
- Development Workflow → `~/.claude/rules/development-workflow.md`

## Test plan

- [ ] Verify `docs/integrations/mcp-server.md` contains all 15 tools, all environment endpoints, JSON client config, and implementation notes from the old block
- [ ] Open a fresh Claude Code session and confirm orientation still works from the doc-index alone (ask "where do I find API DTO rules?")
- [ ] Confirm no project-specific rule was silently removed (each dropped rule exists verbatim in the linked doc)