### PR TITLE
fix: return empty lots when Flexi has no sarze-expirace records

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Lots/FlexiLotsClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Lots/FlexiLotsClient.cs
@@ -13,7 +13,16 @@ public class FlexiLotsClient : ILotsClient
 
     public async Task<IReadOnlyList<CatalogLot>> GetAsync(string? productCode = null, int limit = 0, int skip = 0, CancellationToken cancellationToken = default)
     {
-        var lots = await _lotsClient.GetAsync(productCode, limit, skip, cancellationToken);
+        IReadOnlyList<Rem.FlexiBeeSDK.Model.Products.Lots.ProductLot> lots;
+        try
+        {
+            lots = await _lotsClient.GetAsync(productCode, limit, skip, cancellationToken);
+        }
+        catch (KeyNotFoundException ex) when (ex.Message == "Entity LotsItem not found")
+        {
+            return Array.Empty<CatalogLot>();
+        }
+
         return lots.Select(s => new CatalogLot()
         {
             Id = s.Id,

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Lots/FlexiLotsClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Lots/FlexiLotsClientTests.cs
@@ -1,0 +1,83 @@
+using Anela.Heblo.Adapters.Flexi.Lots;
+using FluentAssertions;
+using Moq;
+using Rem.FlexiBeeSDK.Client.Clients.Products.StockToDate;
+using Rem.FlexiBeeSDK.Model.Products.Lots;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Lots;
+
+public class FlexiLotsClientTests
+{
+    private readonly Mock<ILotsClient> _mockSdkClient;
+    private readonly FlexiLotsClient _client;
+
+    public FlexiLotsClientTests()
+    {
+        _mockSdkClient = new Mock<ILotsClient>();
+        _client = new FlexiLotsClient(_mockSdkClient.Object);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsEmptyList_WhenSdkThrowsLotsItemNotFound()
+    {
+        // Arrange
+        _mockSdkClient
+            .Setup(x => x.GetAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("Entity LotsItem not found"));
+
+        // Act
+        var result = await _client.GetAsync("INGR-001");
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_PropagatesOtherKeyNotFoundExceptions()
+    {
+        // Arrange
+        _mockSdkClient
+            .Setup(x => x.GetAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("Some other entity not found"));
+
+        // Act
+        var act = async () => await _client.GetAsync("INGR-001");
+
+        // Assert
+        await act.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("Some other entity not found");
+    }
+
+    [Fact]
+    public async Task GetAsync_MapsProductLotsToCorrectCatalogLots()
+    {
+        // Arrange
+        var expiration = new DateTime(2025, 12, 31);
+        var sdkLots = new List<ProductLot>
+        {
+            new() { Id = 1, ProductCode = "INGR-001", Amount = 5.5m, Expiration = expiration, Lot = "LOT-A" },
+            new() { Id = 2, ProductCode = "INGR-001", Amount = 3.0m, Expiration = null, Lot = null }
+        };
+
+        _mockSdkClient
+            .Setup(x => x.GetAsync(It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sdkLots);
+
+        // Act
+        var result = await _client.GetAsync("INGR-001");
+
+        // Assert
+        result.Should().HaveCount(2);
+
+        result[0].Id.Should().Be(1);
+        result[0].ProductCode.Should().Be("INGR-001");
+        result[0].Amount.Should().Be(5.5m);
+        result[0].Expiration.Should().Be(DateOnly.FromDateTime(expiration.Date));
+        result[0].Lot.Should().Be("LOT-A");
+
+        result[1].Id.Should().Be(2);
+        result[1].Expiration.Should().BeNull();
+        result[1].Lot.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

When submitting manufacture for a product whose recipe contains a lot-tracked ingredient that currently has no `sarze-expirace` records in Abra Flexi, users see this confusing English-leaking error in the order note:

> Při zpracování výroby došlo k neočekávané chybě. Technické detaily: **Entity LotsItem not found**

`Entity LotsItem not found` is a raw `KeyNotFoundException` from the FlexiBeeSDK — `LotsItem` is an internal SDK DTO class name, not a Flexi entity name. It appears when the `sarze-expirace` REST resource returns zero rows for the queried product code.

## Root cause

`FlexiBeeSDK.LotsClient.GetAsync` throws `KeyNotFoundException("Entity LotsItem not found")` instead of returning an empty list when Flexi has no lot records. `FlexiLotsClient` (our adapter) propagated this exception untouched, bypassing the existing `ManufactureErrorTransformer` filter chain (no filter matched `KeyNotFoundException`), so the raw SDK message fell through to the user.

## Fix

Catch the specific `KeyNotFoundException` at the adapter boundary in `FlexiLotsClient.GetAsync` and return `Array.Empty<CatalogLot>()`. This routes the failure through the existing path:

```
FefoConsumptionAllocator → "Cannot allocate full amount for ingredient {code}..."
  → CannotAllocateFullAmountFilter → localized Czech message naming the culprit ingredient
```

The user now sees:
> Pro ingredienci `{code}` nelze přidělit dostatečné množství šarží (chybí: `{qty}`). Zkontrolujte, zda má ingredience ve Flexi evidované šarže s dostatečným množstvím.

This is fully localized **and** identifies which ingredient has missing lot data, so the user knows whether to fix the Flexi data (add lot records) or change the ingredient's lot-tracking flag.

Other `KeyNotFoundException`s (from other SDK clients) still propagate — the catch is scoped to the exact SDK message.

## Test plan

- [x] `GetAsync_ReturnsEmptyList_WhenSdkThrowsLotsItemNotFound` — primary behavior
- [x] `GetAsync_PropagatesOtherKeyNotFoundExceptions` — other exceptions not swallowed
- [x] `GetAsync_MapsProductLotsToCorrectCatalogLots` — happy-path mapping not regressed
- [x] Full backend test suite: 2438 passed, 0 failed
- [x] `dotnet format --verify-no-changes` clean
- [ ] Manual: submit manufacture for `durin` against staging and confirm localized Czech error with ingredient code