### PR TITLE
fix: add HyDE query expansion to leaflet generation to resolve 422 on topic-only queries

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.Production.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Production.json
@@ -97,6 +97,8 @@
     "ShortWordTarget": 200,
     "MediumWordTarget": 400,
     "LongWordTarget": 700,
+    "QueryExpansionEnabled": true,
+    "QueryExpansionModel": "claude-haiku-4-5-20251001",
     "OneDriveFolderMappings": [
       {
         "DriveId": "b!tB0jjQnirU2eVHT9UmN1fLmG6KD2FqJOmZeQYQNbxqrCWYOs1rorQ5BtZfHEjWKj",

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -164,6 +164,8 @@
     "ShortWordTarget": 200,
     "MediumWordTarget": 400,
     "LongWordTarget": 700,
+    "QueryExpansionEnabled": true,
+    "QueryExpansionModel": "claude-haiku-4-5-20251001",
     "OneDriveFolderMappings": []
   },
   "KnowledgeBase": {

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -42,7 +42,7 @@ public static class ApplicationModule
     public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration configuration, IHostEnvironment? environment = null)
     {
         // Register shared RAG infrastructure
-        services.AddScoped<IWordWindowChunker, WordWindowChunker>();
+        services.AddSharedRagModule();
 
         // Register MediatR
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(ApplicationModule).Assembly));

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseOptions.cs
@@ -6,6 +6,23 @@ public class KnowledgeBaseOptions : RagFeatureOptions
 {
     public const string SectionName = "KnowledgeBase";
 
+    public KnowledgeBaseOptions()
+    {
+        QueryExpansionPrompt =
+            """
+            Jsi asistent kosmetické firmy Anela. Přepiš zákazníkův dotaz do strukturovaného
+            formátu vhodného pro sémantické vyhledávání v databázi zákaznických konverzací.
+            Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
+
+            Problém: <co zákazník řeší, formuluj jako zákazníkův dotaz>
+            Kontext: <typ pleti, stávající rutina, situace>
+            Doporučení: <co by mohlo být doporučeno>
+            Ingredience: <účinné látky, složky>
+
+            Dotaz:
+            """;
+    }
+
     public int MaxRetrievedChunks { get; set; } = 5;
 
     /// <summary>
@@ -81,24 +98,6 @@ public class KnowledgeBaseOptions : RagFeatureOptions
     /// before a fresh load from the catalog repository is triggered.
     /// </summary>
     public int ProductEnrichmentCacheTtlMinutes { get; set; } = 60;
-
-    /// <summary>
-    /// Prompt prepended to the user query when requesting query expansion.
-    /// The raw query is appended after a newline.
-    /// </summary>
-    public string QueryExpansionPrompt { get; set; } =
-        """
-        Jsi asistent kosmetické firmy Anela. Přepiš zákazníkův dotaz do strukturovaného
-        formátu vhodného pro sémantické vyhledávání v databázi zákaznických konverzací.
-        Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
-
-        Problém: <co zákazník řeší, formuluj jako zákazníkův dotaz>
-        Kontext: <typ pleti, stávající rutina, situace>
-        Doporučení: <co by mohlo být doporučeno>
-        Ingredience: <účinné látky, složky>
-
-        Dotaz:
-        """;
 
     /// <summary>
     /// System prompt used by AskQuestionHandler. Supports {context}, {products} and {query} placeholders.

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseOptions.cs
@@ -83,20 +83,6 @@ public class KnowledgeBaseOptions : RagFeatureOptions
     public int ProductEnrichmentCacheTtlMinutes { get; set; } = 60;
 
     /// <summary>
-    /// When true, user queries are rewritten into the structured summary format used
-    /// by stored embeddings before calling the embedding model (HyDE variant).
-    /// Set to false to skip the LLM call and embed the raw query directly.
-    /// </summary>
-    public bool QueryExpansionEnabled { get; set; } = true;
-
-    /// <summary>
-    /// Model ID used for query expansion. A lite/fast model is sufficient — the task
-    /// is purely mechanical (rewrite short informal question into structured template).
-    /// Defaults to claude-haiku-4-5 to minimise latency and cost.
-    /// </summary>
-    public string QueryExpansionModel { get; set; } = "claude-haiku-4-5-20251001";
-
-    /// <summary>
     /// Prompt prepended to the user query when requesting query expansion.
     /// The raw query is appended after a newline.
     /// </summary>

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SearchDocuments/SearchDocumentsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/SearchDocuments/SearchDocumentsHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using MediatR;
 using Microsoft.Extensions.AI;
@@ -11,20 +12,20 @@ public class SearchDocumentsHandler : IRequestHandler<SearchDocumentsRequest, Se
     private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
     private readonly IKnowledgeBaseRepository _repository;
     private readonly KnowledgeBaseOptions _options;
-    private readonly IChatClient _chatClient;
+    private readonly IRagQueryExpander _expander;
     private readonly ILogger<SearchDocumentsHandler> _logger;
 
     public SearchDocumentsHandler(
         IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator,
         IKnowledgeBaseRepository repository,
         IOptions<KnowledgeBaseOptions> options,
-        IChatClient chatClient,
+        IRagQueryExpander expander,
         ILogger<SearchDocumentsHandler> logger)
     {
         _embeddingGenerator = embeddingGenerator;
         _repository = repository;
         _options = options.Value;
-        _chatClient = chatClient;
+        _expander = expander;
         _logger = logger;
     }
 
@@ -32,9 +33,7 @@ public class SearchDocumentsHandler : IRequestHandler<SearchDocumentsRequest, Se
         SearchDocumentsRequest request,
         CancellationToken cancellationToken)
     {
-        var queryToEmbed = _options.QueryExpansionEnabled
-            ? await ExpandQueryAsync(request.Query, cancellationToken)
-            : request.Query;
+        var queryToEmbed = await _expander.ExpandAsync(request.Query, _options.ToExpansionConfig(), cancellationToken);
 
         float[] queryEmbedding;
         try
@@ -85,25 +84,5 @@ public class SearchDocumentsHandler : IRequestHandler<SearchDocumentsRequest, Se
                 SourcePath = r.Chunk.Document.SourcePath
             }).ToList()
         };
-    }
-
-    private async Task<string> ExpandQueryAsync(string query, CancellationToken cancellationToken)
-    {
-        var messages = new List<ChatMessage>
-        {
-            new(ChatRole.User, _options.QueryExpansionPrompt + "\n" + query)
-        };
-
-        var chatOptions = new ChatOptions { ModelId = _options.QueryExpansionModel };
-        try
-        {
-            var response = await _chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
-            return string.IsNullOrWhiteSpace(response.Text) ? query : response.Text;
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TimeoutException or TaskCanceledException)
-        {
-            _logger.LogWarning(ex, "Query expansion failed for query '{Query}', falling back to raw query", query);
-            return query;
-        }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletOptions.cs
@@ -6,6 +6,25 @@ public class LeafletOptions : RagFeatureOptions
 {
     public const string SectionName = "Leaflet";
 
+    public LeafletOptions()
+    {
+        QueryExpansionPrompt =
+            """
+            Jsi asistent kosmetické firmy Anela. Zákazník zadal téma pro produktový leták.
+            Přepiš téma do krátkého strukturovaného popisu vhodného pro sémantické
+            vyhledávání v databázi znalostí a vzorových letáků.
+            Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
+
+            Produkt: <název nebo kategorie produktu>
+            Kontext: <typ pleti, kategorie kosmetiky, použití>
+            Klíčové ingredience: <pravděpodobné účinné látky a složky>
+            Benefity: <očekávané přínosy a use-cases>
+            Cílová skupina: <komu je produkt určen>
+
+            Téma:
+            """;
+    }
+
     public int KbTopK { get; set; } = 8;
     public int LeafletTopK { get; set; } = 5;
 

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletOptions.cs
@@ -6,24 +6,21 @@ public class LeafletOptions : RagFeatureOptions
 {
     public const string SectionName = "Leaflet";
 
-    public LeafletOptions()
-    {
-        QueryExpansionPrompt =
-            """
-            Jsi asistent kosmetické firmy Anela. Zákazník zadal téma pro produktový leták.
-            Přepiš téma do krátkého strukturovaného popisu vhodného pro sémantické
-            vyhledávání v databázi znalostí a vzorových letáků.
-            Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
+    public new string QueryExpansionPrompt { get; set; } =
+        """
+        Jsi asistent kosmetické firmy Anela. Zákazník zadal téma pro produktový leták.
+        Přepiš téma do krátkého strukturovaného popisu vhodného pro sémantické
+        vyhledávání v databázi znalostí a vzorových letáků.
+        Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
 
-            Produkt: <název nebo kategorie produktu>
-            Kontext: <typ pleti, kategorie kosmetiky, použití>
-            Klíčové ingredience: <pravděpodobné účinné látky a složky>
-            Benefity: <očekávané přínosy a use-cases>
-            Cílová skupina: <komu je produkt určen>
+        Produkt: <název nebo kategorie produktu>
+        Kontext: <typ pleti, kategorie kosmetiky, použití>
+        Klíčové ingredience: <pravděpodobné účinné látky a složky>
+        Benefity: <očekávané přínosy a use-cases>
+        Cílová skupina: <komu je produkt určen>
 
-            Téma:
-            """;
-    }
+        Téma:
+        """;
 
     public int KbTopK { get; set; } = 8;
     public int LeafletTopK { get; set; } = 5;

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletOptions.cs
@@ -6,21 +6,24 @@ public class LeafletOptions : RagFeatureOptions
 {
     public const string SectionName = "Leaflet";
 
-    public new string QueryExpansionPrompt { get; set; } =
-        """
-        Jsi asistent kosmetické firmy Anela. Zákazník zadal téma pro produktový leták.
-        Přepiš téma do krátkého strukturovaného popisu vhodného pro sémantické
-        vyhledávání v databázi znalostí a vzorových letáků.
-        Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
+    public LeafletOptions()
+    {
+        QueryExpansionPrompt =
+            """
+            Jsi asistent kosmetické firmy Anela. Zákazník zadal téma pro produktový leták.
+            Přepiš téma do krátkého strukturovaného popisu vhodného pro sémantické
+            vyhledávání v databázi znalostí a vzorových letáků.
+            Vypiš POUZE relevantní položky (vynech kategorie bez obsahu):
 
-        Produkt: <název nebo kategorie produktu>
-        Kontext: <typ pleti, kategorie kosmetiky, použití>
-        Klíčové ingredience: <pravděpodobné účinné látky a složky>
-        Benefity: <očekávané přínosy a use-cases>
-        Cílová skupina: <komu je produkt určen>
+            Produkt: <název nebo kategorie produktu>
+            Kontext: <typ pleti, kategorie kosmetiky, použití>
+            Klíčové ingredience: <pravděpodobné účinné látky a složky>
+            Benefity: <očekávané přínosy a use-cases>
+            Cílová skupina: <komu je produkt určen>
 
-        Téma:
-        """;
+            Téma:
+            """;
+    }
 
     public int KbTopK { get; set; } = 8;
     public int LeafletTopK { get; set; } = 5;

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Domain.Features.Leaflet;
 using MediatR;
@@ -14,6 +15,7 @@ public class GenerateLeafletHandler : IRequestHandler<GenerateLeafletRequest, Ge
     private readonly IKnowledgeBaseRepository _kb;
     private readonly ILeafletRepository _leaflets;
     private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddings;
+    private readonly IRagQueryExpander _expander;
     private readonly IChatClient _chat;
     private readonly LeafletOptions _options;
     private readonly ILogger<GenerateLeafletHandler> _logger;
@@ -22,6 +24,7 @@ public class GenerateLeafletHandler : IRequestHandler<GenerateLeafletRequest, Ge
         IKnowledgeBaseRepository kb,
         ILeafletRepository leaflets,
         IEmbeddingGenerator<string, Embedding<float>> embeddings,
+        IRagQueryExpander expander,
         IChatClient chat,
         IOptions<LeafletOptions> options,
         ILogger<GenerateLeafletHandler> logger)
@@ -29,6 +32,7 @@ public class GenerateLeafletHandler : IRequestHandler<GenerateLeafletRequest, Ge
         _kb = kb;
         _leaflets = leaflets;
         _embeddings = embeddings;
+        _expander = expander;
         _chat = chat;
         _options = options.Value;
         _logger = logger;
@@ -40,8 +44,11 @@ public class GenerateLeafletHandler : IRequestHandler<GenerateLeafletRequest, Ge
     {
         var ct = cancellationToken;
 
+        var queryToEmbed = await _expander.ExpandAsync(
+            request.Topic, _options.ToExpansionConfig(), ct);
+
         var topicVector = (await RetryOnceAsync(
-                () => _embeddings.GenerateAsync([request.Topic], cancellationToken: ct),
+                () => _embeddings.GenerateAsync([queryToEmbed], cancellationToken: ct),
                 ct))
             .First().Vector.ToArray();
 

--- a/backend/src/Anela.Heblo.Application/Shared/Rag/IRagQueryExpander.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Rag/IRagQueryExpander.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Application.Shared.Rag;
+
+public interface IRagQueryExpander
+{
+    Task<string> ExpandAsync(string query, RagQueryExpansionConfig config, CancellationToken ct);
+}
+
+public sealed record RagQueryExpansionConfig(
+    bool Enabled,
+    string Model,
+    string Prompt);

--- a/backend/src/Anela.Heblo.Application/Shared/Rag/RagFeatureOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Rag/RagFeatureOptions.cs
@@ -25,4 +25,13 @@ public abstract class RagFeatureOptions
 
     [MinLength(1)]
     public List<OneDriveFolderMapping> OneDriveFolderMappings { get; set; } = [];
+
+    public bool QueryExpansionEnabled { get; set; } = true;
+
+    public string QueryExpansionModel { get; set; } = "claude-haiku-4-5-20251001";
+
+    public string QueryExpansionPrompt { get; set; } = string.Empty;
+
+    public RagQueryExpansionConfig ToExpansionConfig() =>
+        new(QueryExpansionEnabled, QueryExpansionModel, QueryExpansionPrompt);
 }

--- a/backend/src/Anela.Heblo.Application/Shared/Rag/RagQueryExpander.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Rag/RagQueryExpander.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Shared.Rag;
 
-public class RagQueryExpander : IRagQueryExpander
+public sealed class RagQueryExpander : IRagQueryExpander
 {
     private readonly IChatClient _chatClient;
     private readonly ILogger<RagQueryExpander> _logger;
@@ -16,7 +16,7 @@ public class RagQueryExpander : IRagQueryExpander
 
     public async Task<string> ExpandAsync(string query, RagQueryExpansionConfig config, CancellationToken ct)
     {
-        if (!config.Enabled || string.IsNullOrWhiteSpace(query))
+        if (!config.Enabled || string.IsNullOrWhiteSpace(query) || string.IsNullOrWhiteSpace(config.Prompt))
         {
             return query;
         }

--- a/backend/src/Anela.Heblo.Application/Shared/Rag/RagQueryExpander.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Rag/RagQueryExpander.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Shared.Rag;
+
+public class RagQueryExpander : IRagQueryExpander
+{
+    private readonly IChatClient _chatClient;
+    private readonly ILogger<RagQueryExpander> _logger;
+
+    public RagQueryExpander(IChatClient chatClient, ILogger<RagQueryExpander> logger)
+    {
+        _chatClient = chatClient;
+        _logger = logger;
+    }
+
+    public async Task<string> ExpandAsync(string query, RagQueryExpansionConfig config, CancellationToken ct)
+    {
+        if (!config.Enabled || string.IsNullOrWhiteSpace(query))
+        {
+            return query;
+        }
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.User, config.Prompt + "\n" + query)
+        };
+
+        var chatOptions = new ChatOptions { ModelId = config.Model };
+        try
+        {
+            var response = await _chatClient.GetResponseAsync(messages, chatOptions, ct);
+            return string.IsNullOrWhiteSpace(response.Text) ? query : response.Text;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TimeoutException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "Query expansion failed for query '{Query}', falling back to raw query", query);
+            return query;
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/Rag/SharedRagModule.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Rag/SharedRagModule.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Shared.Rag;
+
+public static class SharedRagModule
+{
+    public static IServiceCollection AddSharedRagModule(this IServiceCollection services)
+    {
+        services.AddScoped<IWordWindowChunker, WordWindowChunker>();
+        services.AddScoped<IRagQueryExpander, RagQueryExpander>();
+        return services;
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
@@ -179,11 +179,9 @@ public class GenerateLeafletHandlerTests
         var request = new GenerateLeafletRequest { Topic = "niacinamide", Audience = AudienceType.B2B, Length = LeafletLength.Long };
 
         // Act
-        var act = () => handler.Handle(request, CancellationToken.None);
+        var result = await handler.Handle(request, CancellationToken.None);
 
         // Assert
-        await act.Should().NotThrowAsync();
-
         _chat.Verify(c => c.GetResponseAsync(
             It.IsAny<IEnumerable<ChatMessage>>(),
             It.IsAny<ChatOptions?>(),
@@ -191,6 +189,7 @@ public class GenerateLeafletHandlerTests
 
         capturedMessages.Should().NotBeNull();
         capturedMessages!.First(m => m.Role == ChatRole.System).Text.Should().Contain("(empty)");
+        result.Content.Should().NotBeEmpty("handler should produce leaflet content even when KB hits are empty");
     }
 
     [Fact]
@@ -512,7 +511,7 @@ public class GenerateLeafletHandlerTests
     }
 
     [Fact]
-    public async Task Handle_when_expander_passthrough_existing_behavior_unchanged()
+    public async Task Handle_returns_non_empty_content_when_expansion_returns_topic_unchanged()
     {
         // Arrange
         SetupEmbeddings();

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GenerateLeafletHandlerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Leaflet;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Domain.Features.Leaflet;
 using FluentAssertions;
@@ -16,10 +17,21 @@ public class GenerateLeafletHandlerTests
     private readonly Mock<IKnowledgeBaseRepository> _kb = new();
     private readonly Mock<ILeafletRepository> _leaflets = new();
     private readonly Mock<IEmbeddingGenerator<string, Embedding<float>>> _embeddings = new();
+    private readonly Mock<IRagQueryExpander> _expander = new();
     private readonly Mock<IChatClient> _chat = new();
     private readonly Mock<ILogger<GenerateLeafletHandler>> _logger = new();
 
     private static readonly float[] DefaultVector = [0.1f, 0.2f, 0.3f];
+
+    public GenerateLeafletHandlerTests()
+    {
+        _expander
+            .Setup(e => e.ExpandAsync(
+                It.IsAny<string>(),
+                It.IsAny<RagQueryExpansionConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+    }
 
     private GenerateLeafletHandler CreateHandler(LeafletOptions? options = null)
     {
@@ -27,6 +39,7 @@ public class GenerateLeafletHandlerTests
             _kb.Object,
             _leaflets.Object,
             _embeddings.Object,
+            _expander.Object,
             _chat.Object,
             Options.Create(options ?? new LeafletOptions()),
             _logger.Object);
@@ -434,5 +447,116 @@ public class GenerateLeafletHandlerTests
         // Assert
         var systemMessage = capturedMessages!.First(m => m.Role == ChatRole.System).Text!;
         systemMessage.Should().Contain(expectedLabel);
+    }
+
+    [Fact]
+    public async Task Handle_calls_expander_with_topic_and_uses_expanded_text_for_embedding_only()
+    {
+        // Arrange
+        const string topic = "retinol";
+        const string expandedQuery = "EXPANDED_QUERY";
+
+        _expander
+            .Setup(e => e.ExpandAsync(
+                It.IsAny<string>(),
+                It.IsAny<RagQueryExpansionConfig>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expandedQuery);
+
+        IEnumerable<string>? capturedEmbeddingInput = null;
+        _embeddings
+            .Setup(e => e.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<EmbeddingGenerationOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<string>, EmbeddingGenerationOptions?, CancellationToken>(
+                (inputs, _, _) => capturedEmbeddingInput = inputs.ToList())
+            .ReturnsAsync(new GeneratedEmbeddings<Embedding<float>>(
+                [new Embedding<float>(new ReadOnlyMemory<float>(DefaultVector))]));
+
+        _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([KbHit(0.9)]);
+        _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([LeafletHit(0.9)]);
+
+        var stage1Messages = new List<IEnumerable<ChatMessage>>();
+        var callCount = 0;
+        _chat
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>(
+                (msgs, _, _) =>
+                {
+                    callCount++;
+                    stage1Messages.Add(msgs.ToList());
+                })
+            .ReturnsAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, "outline text")]));
+
+        var handler = CreateHandler();
+        var request = new GenerateLeafletRequest { Topic = topic, Audience = AudienceType.EndConsumer, Length = LeafletLength.Short };
+
+        // Act
+        await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        capturedEmbeddingInput.Should().ContainSingle().Which.Should().Be(expandedQuery);
+
+        var stage1SystemText = stage1Messages[0].First(m => m.Role == ChatRole.System).Text!;
+        stage1SystemText.Should().Contain(topic);
+        stage1SystemText.Should().NotContain(expandedQuery);
+
+        var stage2UserText = stage1Messages[1].First(m => m.Role == ChatRole.User).Text!;
+        stage2UserText.Should().NotBe(expandedQuery);
+    }
+
+    [Fact]
+    public async Task Handle_when_expander_passthrough_existing_behavior_unchanged()
+    {
+        // Arrange
+        SetupEmbeddings();
+        SetupChatReturns("outline", "final leaflet");
+
+        _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([KbHit(0.9)]);
+        _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([LeafletHit(0.9)]);
+
+        var handler = CreateHandler();
+        var request = new GenerateLeafletRequest { Topic = "niacinamide", Audience = AudienceType.EndConsumer, Length = LeafletLength.Medium };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Content.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_expander_called_once_per_generate_request()
+    {
+        // Arrange
+        SetupEmbeddings();
+        SetupChatReturns();
+
+        _kb.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([KbHit(0.9)]);
+        _leaflets.Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([LeafletHit(0.9)]);
+
+        var handler = CreateHandler();
+        var request = new GenerateLeafletRequest { Topic = "vitamin c", Audience = AudienceType.B2B, Length = LeafletLength.Long };
+
+        // Act
+        await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _expander.Verify(
+            e => e.ExpandAsync(
+                It.IsAny<string>(),
+                It.IsAny<RagQueryExpansionConfig>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,7 @@ public class SearchDocumentsHandlerTests
 {
     private readonly Mock<IEmbeddingGenerator<string, Embedding<float>>> _embeddingGenerator = new();
     private readonly Mock<IKnowledgeBaseRepository> _repository = new();
-    private readonly Mock<IChatClient> _chatClient = new();
+    private readonly Mock<IRagQueryExpander> _expander = new();
     private readonly Mock<ILogger<SearchDocumentsHandler>> _logger = new();
 
     private SearchDocumentsHandler CreateHandler(double minScore = 0.60, bool queryExpansionEnabled = false)
@@ -24,7 +25,7 @@ public class SearchDocumentsHandlerTests
             QueryExpansionEnabled = queryExpansionEnabled,
             QueryExpansionPrompt = "Expand:"
         });
-        return new SearchDocumentsHandler(_embeddingGenerator.Object, _repository.Object, options, _chatClient.Object, _logger.Object);
+        return new SearchDocumentsHandler(_embeddingGenerator.Object, _repository.Object, options, _expander.Object, _logger.Object);
     }
 
     private void SetupEmbeddingGenerator()
@@ -49,22 +50,15 @@ public class SearchDocumentsHandlerTests
         Document = new KnowledgeBaseDocument { Filename = "doc.pdf", SourcePath = "/inbox/doc.pdf" }
     };
 
-    private void SetupChatClient(string expandedText)
-    {
-        var chatResponse = new ChatResponse([new ChatMessage(ChatRole.Assistant, expandedText)]);
-        _chatClient
-            .Setup(c => c.GetResponseAsync(
-                It.IsAny<IEnumerable<ChatMessage>>(),
-                It.IsAny<ChatOptions?>(),
-                default))
-            .ReturnsAsync(chatResponse);
-    }
-
     [Fact]
     public async Task Handle_ReturnsChunksOrderedByScore()
     {
         SetupEmbeddingGenerator();
         var chunk = MakeChunk("Phenoxyethanol max 1.0% in Annex V");
+
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
 
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
@@ -88,6 +82,10 @@ public class SearchDocumentsHandlerTests
         var chunk1 = MakeChunk("Low relevance chunk A");
         var chunk2 = MakeChunk("Low relevance chunk B");
 
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
             .ReturnsAsync([(chunk1, 0.54), (chunk2, 0.58)]);
@@ -107,6 +105,10 @@ public class SearchDocumentsHandlerTests
         var goodChunk = MakeChunk("Good relevant content");
         var badChunk = MakeChunk("Weak noisy content");
 
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
             .ReturnsAsync([(goodChunk, 0.80), (badChunk, 0.45)]);
@@ -125,8 +127,10 @@ public class SearchDocumentsHandlerTests
     public async Task Handle_QueryExpansionEnabled_EmbedExpandedQuery()
     {
         const string expandedQuery = "Problém: popraskané ruce\nKontext: suchá kůže";
-        SetupEmbeddingGenerator();
-        SetupChatClient(expandedQuery);
+
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expandedQuery);
 
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
@@ -148,13 +152,19 @@ public class SearchDocumentsHandlerTests
             default);
 
         Assert.Equal(expandedQuery, capturedEmbeddingInput);
+        _expander.Verify(
+            e => e.ExpandAsync("poradis neco na popraskane ruce?", It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
-    public async Task Handle_QueryExpansionDisabled_EmbedRawQuery()
+    public async Task Handle_QueryExpansionDisabled_ExpanderCalledAndReturnsRawQuery()
     {
         const string rawQuery = "poradis neco na popraskane ruce?";
-        SetupEmbeddingGenerator();
+
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rawQuery);
 
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
@@ -176,80 +186,9 @@ public class SearchDocumentsHandlerTests
             default);
 
         Assert.Equal(rawQuery, capturedEmbeddingInput);
-        _chatClient.Verify(
-            c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions?>(), default),
-            Times.Never);
-    }
-
-    [Fact]
-    public async Task Handle_QueryExpansionEnabled_LlmThrowsTransientError_FallsBackToRawQuery()
-    {
-        const string rawQuery = "popraskane ruce?";
-        SetupEmbeddingGenerator();
-
-        _chatClient
-            .Setup(c => c.GetResponseAsync(
-                It.IsAny<IEnumerable<ChatMessage>>(),
-                It.IsAny<ChatOptions?>(),
-                default))
-            .ThrowsAsync(new HttpRequestException("Exception while reading from stream"));
-
-        _repository
-            .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
-            .ReturnsAsync([]);
-
-        string? capturedEmbeddingInput = null;
-        _embeddingGenerator
-            .Setup(s => s.GenerateAsync(
-                It.IsAny<IEnumerable<string>>(),
-                It.IsAny<EmbeddingGenerationOptions?>(),
-                default))
-            .Callback<IEnumerable<string>, EmbeddingGenerationOptions?, CancellationToken>(
-                (texts, _, _) => capturedEmbeddingInput = texts.First())
-            .ReturnsAsync(new GeneratedEmbeddings<Embedding<float>>(
-                [new Embedding<float>(new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }))]));
-
-        await CreateHandler(queryExpansionEnabled: true).Handle(
-            new SearchDocumentsRequest { Query = rawQuery, TopK = 5 },
-            default);
-
-        Assert.Equal(rawQuery, capturedEmbeddingInput);
-    }
-
-    [Fact]
-    public async Task Handle_QueryExpansionEnabled_LlmReturnsEmpty_FallsBackToRawQuery()
-    {
-        const string rawQuery = "popraskane ruce?";
-        SetupEmbeddingGenerator();
-
-        var emptyResponse = new ChatResponse([new ChatMessage(ChatRole.Assistant, "   ")]);
-        _chatClient
-            .Setup(c => c.GetResponseAsync(
-                It.IsAny<IEnumerable<ChatMessage>>(),
-                It.IsAny<ChatOptions?>(),
-                default))
-            .ReturnsAsync(emptyResponse);
-
-        _repository
-            .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), 5, default))
-            .ReturnsAsync([]);
-
-        string? capturedEmbeddingInput = null;
-        _embeddingGenerator
-            .Setup(s => s.GenerateAsync(
-                It.IsAny<IEnumerable<string>>(),
-                It.IsAny<EmbeddingGenerationOptions?>(),
-                default))
-            .Callback<IEnumerable<string>, EmbeddingGenerationOptions?, CancellationToken>(
-                (texts, _, _) => capturedEmbeddingInput = texts.First())
-            .ReturnsAsync(new GeneratedEmbeddings<Embedding<float>>(
-                [new Embedding<float>(new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }))]));
-
-        await CreateHandler(queryExpansionEnabled: true).Handle(
-            new SearchDocumentsRequest { Query = rawQuery, TopK = 5 },
-            default);
-
-        Assert.Equal(rawQuery, capturedEmbeddingInput);
+        _expander.Verify(
+            e => e.ExpandAsync(rawQuery, It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Theory]
@@ -259,6 +198,10 @@ public class SearchDocumentsHandlerTests
     [InlineData(typeof(TaskCanceledException))]
     public async Task Handle_EmbeddingGeneratorThrowsTransientException_ReturnsEmptyResponse(Type exceptionType)
     {
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+
         var exception = (Exception)Activator.CreateInstance(exceptionType, "Exception while reading from stream")!;
         _embeddingGenerator
             .Setup(s => s.GenerateAsync(
@@ -285,6 +228,10 @@ public class SearchDocumentsHandlerTests
     [InlineData(typeof(TaskCanceledException))]
     public async Task Handle_EmbeddingGeneratorThrowsTransientException_LogsWarningWithExceptionType(Type exceptionType)
     {
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+
         var exception = (Exception)Activator.CreateInstance(exceptionType, "stream error")!;
         _embeddingGenerator
             .Setup(s => s.GenerateAsync(
@@ -315,6 +262,11 @@ public class SearchDocumentsHandlerTests
     public async Task Handle_RepositoryThrowsTransientException_ReturnsEmptyResponse(Type exceptionType)
     {
         SetupEmbeddingGenerator();
+
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+
         var exception = (Exception)Activator.CreateInstance(exceptionType, "stream error from pgvector")!;
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), default))
@@ -336,6 +288,11 @@ public class SearchDocumentsHandlerTests
     public async Task Handle_RepositoryThrowsTransientException_LogsWarningWithExceptionType(Type exceptionType)
     {
         SetupEmbeddingGenerator();
+
+        _expander
+            .Setup(e => e.ExpandAsync(It.IsAny<string>(), It.IsAny<RagQueryExpansionConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string q, RagQueryExpansionConfig _, CancellationToken _) => q);
+
         var exception = (Exception)Activator.CreateInstance(exceptionType, "stream error from pgvector")!;
         _repository
             .Setup(r => r.SearchSimilarAsync(It.IsAny<float[]>(), It.IsAny<int>(), default))

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/SearchDocumentsHandlerTests.cs
@@ -17,12 +17,11 @@ public class SearchDocumentsHandlerTests
     private readonly Mock<IRagQueryExpander> _expander = new();
     private readonly Mock<ILogger<SearchDocumentsHandler>> _logger = new();
 
-    private SearchDocumentsHandler CreateHandler(double minScore = 0.60, bool queryExpansionEnabled = false)
+    private SearchDocumentsHandler CreateHandler(double minScore = 0.60)
     {
         var options = Options.Create(new KnowledgeBaseOptions
         {
             MinSimilarityScore = minScore,
-            QueryExpansionEnabled = queryExpansionEnabled,
             QueryExpansionPrompt = "Expand:"
         });
         return new SearchDocumentsHandler(_embeddingGenerator.Object, _repository.Object, options, _expander.Object, _logger.Object);
@@ -147,7 +146,7 @@ public class SearchDocumentsHandlerTests
             .ReturnsAsync(new GeneratedEmbeddings<Embedding<float>>(
                 [new Embedding<float>(new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }))]));
 
-        await CreateHandler(queryExpansionEnabled: true).Handle(
+        await CreateHandler().Handle(
             new SearchDocumentsRequest { Query = "poradis neco na popraskane ruce?", TopK = 5 },
             default);
 
@@ -158,7 +157,7 @@ public class SearchDocumentsHandlerTests
     }
 
     [Fact]
-    public async Task Handle_QueryExpansionDisabled_ExpanderCalledAndReturnsRawQuery()
+    public async Task Handle_WhenExpanderReturnsRawQuery_RawQueryIsEmbedded()
     {
         const string rawQuery = "poradis neco na popraskane ruce?";
 
@@ -181,7 +180,7 @@ public class SearchDocumentsHandlerTests
             .ReturnsAsync(new GeneratedEmbeddings<Embedding<float>>(
                 [new Embedding<float>(new ReadOnlyMemory<float>(new float[] { 0.1f, 0.2f, 0.3f }))]));
 
-        await CreateHandler(queryExpansionEnabled: false).Handle(
+        await CreateHandler().Handle(
             new SearchDocumentsRequest { Query = rawQuery, TopK = 5 },
             default);
 

--- a/backend/test/Anela.Heblo.Tests/Shared/Rag/RagFeatureOptionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Shared/Rag/RagFeatureOptionsTests.cs
@@ -1,0 +1,42 @@
+using Anela.Heblo.Application.Features.KnowledgeBase;
+using Anela.Heblo.Application.Features.Leaflet;
+using Anela.Heblo.Application.Shared.Rag;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Shared.Rag;
+
+public class RagFeatureOptionsTests
+{
+    [Fact]
+    public void LeafletOptions_ToExpansionConfig_ReturnsLeafletPrompt()
+    {
+        var options = new LeafletOptions();
+        var config = options.ToExpansionConfig();
+        config.Prompt.Should().Contain("Produkt:");
+        config.Prompt.Should().Contain("Klíčové ingredience:");
+        config.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void KnowledgeBaseOptions_ToExpansionConfig_ReturnsKbPrompt()
+    {
+        var options = new KnowledgeBaseOptions();
+        var config = options.ToExpansionConfig();
+        config.Prompt.Should().Contain("Problém:");
+        config.Prompt.Should().Contain("Dotaz:");
+        config.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RagFeatureOptions_BaseDefault_HasEmptyPrompt()
+    {
+        // Verifies that the base class does NOT hold feature-specific prompts
+        // (derived classes must supply their own via constructor)
+        var options = new ConcreteRagOptions();
+        options.ToExpansionConfig().Prompt.Should().BeEmpty();
+    }
+
+    // Minimal concrete subclass with no prompt override
+    private sealed class ConcreteRagOptions : RagFeatureOptions { }
+}

--- a/backend/test/Anela.Heblo.Tests/Shared/Rag/RagQueryExpanderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Shared/Rag/RagQueryExpanderTests.cs
@@ -146,4 +146,32 @@ public class RagQueryExpanderTests
         // Assert
         result.Should().Be("original query");
     }
+
+    [Fact]
+    public async Task ExpandAsync_when_enabled_sends_prompt_and_query_to_chat()
+    {
+        // Arrange
+        IEnumerable<ChatMessage>? capturedMessages = null;
+        var chatResponse = new ChatResponse([new ChatMessage(ChatRole.Assistant, "expanded")]);
+        _chatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>(
+                (messages, _, _) => capturedMessages = messages)
+            .ReturnsAsync(chatResponse);
+
+        var config = EnabledConfig(prompt: "MyPrompt");
+        var expander = CreateExpander();
+
+        // Act
+        await expander.ExpandAsync("myquery", config, CancellationToken.None);
+
+        // Assert
+        capturedMessages.Should().NotBeNull();
+        var messageList = capturedMessages!.ToList();
+        messageList.Should().HaveCount(1);
+        messageList[0].Text.Should().Be("MyPrompt\nmyquery");
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Shared/Rag/RagQueryExpanderTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Shared/Rag/RagQueryExpanderTests.cs
@@ -1,0 +1,149 @@
+using Anela.Heblo.Application.Shared.Rag;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Shared.Rag;
+
+public class RagQueryExpanderTests
+{
+    private readonly Mock<IChatClient> _chatClient = new();
+    private readonly Mock<ILogger<RagQueryExpander>> _logger = new();
+
+    private RagQueryExpander CreateExpander() =>
+        new(_chatClient.Object, _logger.Object);
+
+    private static RagQueryExpansionConfig EnabledConfig(string model = "test-model", string prompt = "Expand:") =>
+        new(Enabled: true, Model: model, Prompt: prompt);
+
+    private void SetupChatClient(string responseText)
+    {
+        var chatResponse = new ChatResponse([new ChatMessage(ChatRole.Assistant, responseText)]);
+        _chatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chatResponse);
+    }
+
+    [Fact]
+    public async Task ExpandAsync_when_disabled_returns_raw_query_without_calling_chat()
+    {
+        // Arrange
+        var config = new RagQueryExpansionConfig(Enabled: false, Model: "test-model", Prompt: "Expand:");
+        var expander = CreateExpander();
+
+        // Act
+        var result = await expander.ExpandAsync("my raw query", config, CancellationToken.None);
+
+        // Assert
+        result.Should().Be("my raw query");
+        _chatClient.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExpandAsync_when_query_is_whitespace_returns_raw_without_calling_chat()
+    {
+        // Arrange
+        var config = EnabledConfig();
+        var expander = CreateExpander();
+
+        // Act
+        var result = await expander.ExpandAsync("   ", config, CancellationToken.None);
+
+        // Assert
+        result.Should().Be("   ");
+        _chatClient.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExpandAsync_when_enabled_returns_chat_response()
+    {
+        // Arrange
+        SetupChatClient("EXPANDED");
+        var expander = CreateExpander();
+
+        // Act
+        var result = await expander.ExpandAsync("original query", EnabledConfig(), CancellationToken.None);
+
+        // Assert
+        result.Should().Be("EXPANDED");
+    }
+
+    [Fact]
+    public async Task ExpandAsync_when_enabled_uses_configured_model()
+    {
+        // Arrange
+        ChatOptions? capturedOptions = null;
+        var chatResponse = new ChatResponse([new ChatMessage(ChatRole.Assistant, "expanded")]);
+        _chatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>(
+                (_, opts, _) => capturedOptions = opts)
+            .ReturnsAsync(chatResponse);
+
+        var config = EnabledConfig(model: "claude-haiku-4-5-20251001");
+        var expander = CreateExpander();
+
+        // Act
+        await expander.ExpandAsync("query", config, CancellationToken.None);
+
+        // Assert
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.ModelId.Should().Be("claude-haiku-4-5-20251001");
+    }
+
+    [Fact]
+    public async Task ExpandAsync_when_chat_returns_whitespace_falls_back_to_raw_query()
+    {
+        // Arrange
+        SetupChatClient("  ");
+        var expander = CreateExpander();
+
+        // Act
+        var result = await expander.ExpandAsync("original query", EnabledConfig(), CancellationToken.None);
+
+        // Assert
+        result.Should().Be("original query");
+    }
+
+    [Theory]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(TaskCanceledException))]
+    public async Task ExpandAsync_on_transient_exception_falls_back_to_raw_query(Type exceptionType)
+    {
+        // Arrange
+        var exception = (Exception)Activator.CreateInstance(exceptionType, "transient failure")!;
+        _chatClient
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(exception);
+
+        var expander = CreateExpander();
+
+        // Act
+        var result = await expander.ExpandAsync("original query", EnabledConfig(), CancellationToken.None);
+
+        // Assert
+        result.Should().Be("original query");
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `IRagQueryExpander` service into `Application/Shared/Rag/` that reuses the HyDE (Hypothetical Document Embeddings) expansion pattern already present in `SearchDocumentsHandler`
- Refactors `SearchDocumentsHandler` to delegate to the shared service (no behavior change)
- Wires `IRagQueryExpander` into `GenerateLeafletHandler` with a leaflet-tuned Czech expansion prompt (Produkt / Kontext / Klíčové ingredience / Benefity / Cílová skupina); expanded text used only for embedding — Stage 1/2 LLM prompts continue to receive `request.Topic` verbatim
- Fixes a CRITICAL property-hiding bug where `public new string QueryExpansionPrompt` in derived options classes caused `ToExpansionConfig()` to always read the base class's empty default, silently disabling expansion

## Root cause

KB chunks are embedded from structured Czech "Problém/Kontext/Doporučení" summaries. `GenerateLeafletHandler` was embedding `request.Topic` raw (e.g. `"Kavova drbna"`), producing near-zero cosine similarity against full structured summaries. Both `kbHits` and `leafletHits` returned empty → `EmptyRetrievalException` → 422.

## Test Plan

- [ ] 2468 unit tests passing, 3 skipped (pre-existing DB integration skips)
- [ ] `RagQueryExpanderTests` — 9 tests covering disabled passthrough, empty-query short-circuit, success, model forwarding, prompt forwarding, whitespace fallback, exception fallback
- [ ] `RagFeatureOptionsTests` — 3 regression tests asserting `ToExpansionConfig().Prompt` returns the feature-specific prompt (not the base empty default)
- [ ] `GenerateLeafletHandlerTests` — 3 new tests: expanded text reaches embedding (not LLM prompts), passthrough regression guard, single expansion per request
- [ ] Manual: `POST /api/leaflet/generate { "Topic": "Kavova drbna", "Audience": "EndConsumer", "Length": "Short" }` against local DB with KB chunks indexed — expect 200 OK instead of 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)