### PR TITLE
fix: use stable Graph item IDs for ingested document identity

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
@@ -92,8 +92,8 @@ public class KnowledgeBaseIngestionJob : IRecurringJob
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex,
-                            "File {Name} was moved to archive but SourcePath update failed for document {DocumentId}. Manual correction required.",
-                            file.Name, result.DocumentId);
+                            "File {Name} was moved to archive {ArchiveUrl} but SourcePath update failed for document {DocumentId}. Manual correction required.",
+                            file.Name, archiveUrl, result.DocumentId);
                     }
 
                     if (result.WasDuplicate)

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
@@ -81,7 +81,20 @@ public class KnowledgeBaseIngestionJob : IRecurringJob
                     }, cancellationToken);
 
                     var archiveUrl = await _oneDrive.MoveToArchivedAsync(mapping.DriveId, file.Id, file.Name, mapping.ArchivedPath, cancellationToken);
-                    await _knowledgeBaseRepository.UpdateDocumentSourcePathAsync(result.DocumentId, archiveUrl, cancellationToken);
+
+                    // UpdateDocumentSourcePathAsync is called for both new and duplicate documents — intentional.
+                    // For duplicates the matched document's SourcePath is updated to the new archive location
+                    // so the DB link stays current even when the same content arrives again.
+                    try
+                    {
+                        await _knowledgeBaseRepository.UpdateDocumentSourcePathAsync(result.DocumentId, archiveUrl, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "File {Name} was moved to archive but SourcePath update failed for document {DocumentId}. Manual correction required.",
+                            file.Name, result.DocumentId);
+                    }
 
                     if (result.WasDuplicate)
                     {

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
@@ -75,7 +75,7 @@ public class KnowledgeBaseIngestionJob : IRecurringJob
                         DocumentType = mapping.DocumentType
                     }, cancellationToken);
 
-                    await _oneDrive.MoveToArchivedAsync(mapping.DriveId, file.Id, file.Name, mapping.ArchivedPath, cancellationToken);
+                    _ = await _oneDrive.MoveToArchivedAsync(mapping.DriveId, file.Id, file.Name, mapping.ArchivedPath, cancellationToken);
 
                     if (result.WasDuplicate)
                     {

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/Jobs/KnowledgeBaseIngestionJob.cs
@@ -13,6 +13,7 @@ public class KnowledgeBaseIngestionJob : IRecurringJob
     private readonly IOneDriveService _oneDrive;
     private readonly IMediator _mediator;
     private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly IKnowledgeBaseRepository _knowledgeBaseRepository;
     private readonly KnowledgeBaseOptions _options;
     private readonly ILogger<KnowledgeBaseIngestionJob> _logger;
 
@@ -29,12 +30,14 @@ public class KnowledgeBaseIngestionJob : IRecurringJob
         IOneDriveService oneDrive,
         IMediator mediator,
         IRecurringJobStatusChecker statusChecker,
+        IKnowledgeBaseRepository knowledgeBaseRepository,
         IOptions<KnowledgeBaseOptions> options,
         ILogger<KnowledgeBaseIngestionJob> logger)
     {
         _oneDrive = oneDrive;
         _mediator = mediator;
         _statusChecker = statusChecker;
+        _knowledgeBaseRepository = knowledgeBaseRepository;
         _options = options.Value;
         _logger = logger;
     }
@@ -72,10 +75,13 @@ public class KnowledgeBaseIngestionJob : IRecurringJob
                         SourcePath = file.Path,
                         ContentType = file.ContentType,
                         Content = content,
-                        DocumentType = mapping.DocumentType
+                        DocumentType = mapping.DocumentType,
+                        DriveId = mapping.DriveId,
+                        GraphItemId = file.Id
                     }, cancellationToken);
 
-                    _ = await _oneDrive.MoveToArchivedAsync(mapping.DriveId, file.Id, file.Name, mapping.ArchivedPath, cancellationToken);
+                    var archiveUrl = await _oneDrive.MoveToArchivedAsync(mapping.DriveId, file.Id, file.Name, mapping.ArchivedPath, cancellationToken);
+                    await _knowledgeBaseRepository.UpdateDocumentSourcePathAsync(result.DocumentId, archiveUrl, cancellationToken);
 
                     if (result.WasDuplicate)
                     {

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/GraphOneDriveService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/GraphOneDriveService.cs
@@ -77,7 +77,7 @@ public class GraphOneDriveService : IOneDriveService
         return await response.Content.ReadAsByteArrayAsync(ct);
     }
 
-    public async Task MoveToArchivedAsync(string driveId, string fileId, string filename, string archivedPath, CancellationToken ct = default)
+    public async Task<string> MoveToArchivedAsync(string driveId, string fileId, string filename, string archivedPath, CancellationToken ct = default)
     {
         _logger.LogDebug("Moving file {Filename} ({FileId}) to {ArchivedPath} in drive {DriveId}", filename, fileId, archivedPath, driveId);
 
@@ -104,5 +104,8 @@ public class GraphOneDriveService : IOneDriveService
 
         var response = await client.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
+
+        var movedItem = await GraphApiHelpers.DeserializeAsync<GraphDriveItem>(response, ct);
+        return movedItem.WebUrl;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/GraphOneDriveService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/GraphOneDriveService.cs
@@ -106,6 +106,11 @@ public class GraphOneDriveService : IOneDriveService
         response.EnsureSuccessStatusCode();
 
         var movedItem = await GraphApiHelpers.DeserializeAsync<GraphDriveItem>(response, ct);
+
+        if (string.IsNullOrEmpty(movedItem.WebUrl))
+            throw new InvalidOperationException(
+                $"Graph PATCH response for item '{fileId}' in drive '{driveId}' did not include a webUrl.");
+
         return movedItem.WebUrl;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/IOneDriveService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/IOneDriveService.cs
@@ -6,5 +6,5 @@ public interface IOneDriveService
 {
     Task<List<OneDriveFile>> ListInboxFilesAsync(string driveId, string inboxPath, CancellationToken ct = default);
     Task<byte[]> DownloadFileAsync(string driveId, string fileId, CancellationToken ct = default);
-    Task MoveToArchivedAsync(string driveId, string fileId, string filename, string archivedPath, CancellationToken ct = default);
+    Task<string> MoveToArchivedAsync(string driveId, string fileId, string filename, string archivedPath, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/MockOneDriveService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/MockOneDriveService.cs
@@ -27,9 +27,9 @@ public class MockOneDriveService : IOneDriveService
         return Task.FromResult(Array.Empty<byte>());
     }
 
-    public Task MoveToArchivedAsync(string driveId, string fileId, string filename, string archivedPath, CancellationToken ct = default)
+    public Task<string> MoveToArchivedAsync(string driveId, string fileId, string filename, string archivedPath, CancellationToken ct = default)
     {
         _logger.LogInformation("Mock OneDriveService: simulated archive for file {Filename} to {Path} in drive {DriveId}", filename, archivedPath, driveId);
-        return Task.CompletedTask;
+        return Task.FromResult($"https://mock.sharepoint.com/archived/{filename}");
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
@@ -29,6 +29,8 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
         var contentType = ResolveContentType(request.ContentType, request.Filename);
         var contentHash = Convert.ToHexString(SHA256.HashData(request.Content));
 
+        var useGraphIdentity = !string.IsNullOrEmpty(request.GraphItemId) && !string.IsNullOrEmpty(request.DriveId);
+
         // Duplicate detection by hash — same content already indexed, skip
         var existingByHash = await _repository.GetDocumentByHashAsync(contentHash, cancellationToken);
         if (existingByHash is not null)
@@ -42,6 +44,15 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
             else
             {
                 _logger.LogDebug("Skipping already-indexed document {Filename} (hash match)", request.Filename);
+            }
+
+            if (useGraphIdentity && existingByHash.GraphItemId is null)
+            {
+                _logger.LogInformation(
+                    "Backfilling DriveId/GraphItemId for legacy document {Id}",
+                    existingByHash.Id);
+                await _repository.UpdateDocumentGraphItemIdAsync(
+                    existingByHash.Id, request.DriveId!, request.GraphItemId!, cancellationToken);
             }
 
             return new IndexDocumentResponse
@@ -58,9 +69,9 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
 
         // Duplicate detection by identity: use stable GraphItemId for OneDrive-sourced docs,
         // fall back to SourcePath for manually uploaded docs (upload flow).
-        var existingByIdentity = string.IsNullOrEmpty(request.GraphItemId)
-            ? await _repository.GetDocumentBySourcePathAsync(request.SourcePath, cancellationToken)
-            : await _repository.GetDocumentByGraphItemIdAsync(request.DriveId!, request.GraphItemId, cancellationToken);
+        var existingByIdentity = useGraphIdentity
+            ? await _repository.GetDocumentByGraphItemIdAsync(request.DriveId!, request.GraphItemId!, cancellationToken)
+            : await _repository.GetDocumentBySourcePathAsync(request.SourcePath, cancellationToken);
 
         if (existingByIdentity is not null)
         {
@@ -80,8 +91,8 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
             DocumentType = request.DocumentType,
             Status = DocumentStatus.Processing,
             CreatedAt = DateTime.UtcNow,
-            DriveId = request.DriveId,
-            GraphItemId = request.GraphItemId,
+            DriveId = useGraphIdentity ? request.DriveId : null,
+            GraphItemId = useGraphIdentity ? request.GraphItemId : null,
         };
 
         await _repository.AddDocumentAsync(document, cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentHandler.cs
@@ -56,14 +56,18 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
             };
         }
 
-        // Duplicate detection by path — same path but new content, delete old document before re-indexing
-        var existingByPath = await _repository.GetDocumentBySourcePathAsync(request.SourcePath, cancellationToken);
-        if (existingByPath is not null)
+        // Duplicate detection by identity: use stable GraphItemId for OneDrive-sourced docs,
+        // fall back to SourcePath for manually uploaded docs (upload flow).
+        var existingByIdentity = string.IsNullOrEmpty(request.GraphItemId)
+            ? await _repository.GetDocumentBySourcePathAsync(request.SourcePath, cancellationToken)
+            : await _repository.GetDocumentByGraphItemIdAsync(request.DriveId!, request.GraphItemId, cancellationToken);
+
+        if (existingByIdentity is not null)
         {
             _logger.LogInformation(
-                "Document at {Path} has new content (hash changed). Deleting old document {Id} before re-indexing.",
-                request.SourcePath, existingByPath.Id);
-            await _repository.DeleteDocumentAsync(existingByPath.Id, cancellationToken);
+                "Replacing old document {Id} (identity match) before re-indexing.",
+                existingByIdentity.Id);
+            await _repository.DeleteDocumentAsync(existingByIdentity.Id, cancellationToken);
         }
 
         var document = new KnowledgeBaseDocument
@@ -75,7 +79,9 @@ public class IndexDocumentHandler : IRequestHandler<IndexDocumentRequest, IndexD
             ContentHash = contentHash,
             DocumentType = request.DocumentType,
             Status = DocumentStatus.Processing,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            DriveId = request.DriveId,
+            GraphItemId = request.GraphItemId,
         };
 
         await _repository.AddDocumentAsync(document, cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/IndexDocument/IndexDocumentRequest.cs
@@ -12,4 +12,7 @@ public class IndexDocumentRequest : IRequest<IndexDocumentResponse>
 
     /// <summary>Document type determined by the source folder. Drives indexing strategy selection.</summary>
     public DocumentType DocumentType { get; set; } = DocumentType.KnowledgeBase;
+
+    public string? DriveId { get; set; }
+    public string? GraphItemId { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
@@ -74,7 +74,7 @@ public class LeafletIngestionJob : IRecurringJob
                         Content = content
                     }, cancellationToken);
 
-                    await _oneDrive.MoveToArchivedAsync(folder.DriveId, file.Id, file.Name, folder.ArchivedPath, cancellationToken);
+                    _ = await _oneDrive.MoveToArchivedAsync(folder.DriveId, file.Id, file.Name, folder.ArchivedPath, cancellationToken);
 
                     if (result.WasDuplicate)
                     {

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.IndexLeaflet;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
+using Anela.Heblo.Domain.Features.Leaflet;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,7 @@ public class LeafletIngestionJob : IRecurringJob
     private readonly IOneDriveService _oneDrive;
     private readonly IMediator _mediator;
     private readonly IRecurringJobStatusChecker _statusChecker;
+    private readonly ILeafletRepository _leafletRepository;
     private readonly LeafletOptions _options;
     private readonly ILogger<LeafletIngestionJob> _logger;
 
@@ -22,12 +24,14 @@ public class LeafletIngestionJob : IRecurringJob
         IOneDriveService oneDrive,
         IMediator mediator,
         IRecurringJobStatusChecker statusChecker,
+        ILeafletRepository leafletRepository,
         IOptions<LeafletOptions> options,
         ILogger<LeafletIngestionJob> logger)
     {
         _oneDrive = oneDrive;
         _mediator = mediator;
         _statusChecker = statusChecker;
+        _leafletRepository = leafletRepository;
         _options = options.Value;
         _logger = logger;
 
@@ -71,10 +75,13 @@ public class LeafletIngestionJob : IRecurringJob
                         Filename = file.Name,
                         SourcePath = file.Path,
                         ContentType = file.ContentType,
-                        Content = content
+                        Content = content,
+                        DriveId = folder.DriveId,
+                        GraphItemId = file.Id
                     }, cancellationToken);
 
-                    _ = await _oneDrive.MoveToArchivedAsync(folder.DriveId, file.Id, file.Name, folder.ArchivedPath, cancellationToken);
+                    var archiveUrl = await _oneDrive.MoveToArchivedAsync(folder.DriveId, file.Id, file.Name, folder.ArchivedPath, cancellationToken);
+                    await _leafletRepository.UpdateSourcePathAsync(result.DocumentId, archiveUrl, cancellationToken);
 
                     if (result.WasDuplicate)
                     {

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
@@ -92,8 +92,8 @@ public class LeafletIngestionJob : IRecurringJob
                     catch (Exception ex)
                     {
                         _logger.LogWarning(ex,
-                            "File {Name} was moved to archive but SourcePath update failed for document {DocumentId}. Manual correction required.",
-                            file.Name, result.DocumentId);
+                            "File {Name} was moved to archive {ArchiveUrl} but SourcePath update failed for document {DocumentId}. Manual correction required.",
+                            file.Name, archiveUrl, result.DocumentId);
                     }
 
                     if (result.WasDuplicate)

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/Infrastructure/Jobs/LeafletIngestionJob.cs
@@ -81,7 +81,20 @@ public class LeafletIngestionJob : IRecurringJob
                     }, cancellationToken);
 
                     var archiveUrl = await _oneDrive.MoveToArchivedAsync(folder.DriveId, file.Id, file.Name, folder.ArchivedPath, cancellationToken);
-                    await _leafletRepository.UpdateSourcePathAsync(result.DocumentId, archiveUrl, cancellationToken);
+
+                    // UpdateSourcePathAsync is called for both new and duplicate documents — intentional.
+                    // For duplicates the matched document's SourcePath is updated to the new archive location
+                    // so the DB link stays current even when the same content arrives again.
+                    try
+                    {
+                        await _leafletRepository.UpdateSourcePathAsync(result.DocumentId, archiveUrl, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "File {Name} was moved to archive but SourcePath update failed for document {DocumentId}. Manual correction required.",
+                            file.Name, result.DocumentId);
+                    }
 
                     if (result.WasDuplicate)
                     {

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/IndexLeaflet/IndexLeafletHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/IndexLeaflet/IndexLeafletHandler.cs
@@ -38,11 +38,14 @@ public class IndexLeafletHandler : IRequestHandler<IndexLeafletRequest, IndexLea
             return new IndexLeafletResponse { DocumentId = existing.Id, WasDuplicate = true };
         }
 
-        var byPath = await _repo.GetBySourcePathAsync(request.SourcePath, ct);
-        if (byPath is not null)
+        var existingByIdentity = string.IsNullOrEmpty(request.GraphItemId)
+            ? await _repo.GetBySourcePathAsync(request.SourcePath, ct)
+            : await _repo.GetByGraphItemIdAsync(request.DriveId!, request.GraphItemId, ct);
+
+        if (existingByIdentity is not null)
         {
-            _logger.LogInformation("Source path collision, replacing old document {Id}", byPath.Id);
-            await _repo.DeleteDocumentAsync(byPath.Id, ct);
+            _logger.LogInformation("Replacing old document {Id} (identity match)", existingByIdentity.Id);
+            await _repo.DeleteDocumentAsync(existingByIdentity.Id, ct);
         }
 
         var extractor = _extractors.FirstOrDefault(e => e.CanHandle(request.ContentType))
@@ -59,6 +62,8 @@ public class IndexLeafletHandler : IRequestHandler<IndexLeafletRequest, IndexLea
             ContentHash = hash,
             IngestedAt = DateTime.UtcNow,
             WordCount = 0,
+            DriveId = request.DriveId,
+            GraphItemId = request.GraphItemId,
         };
 
         await _repo.AddDocumentAsync(doc, ct);

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/IndexLeaflet/IndexLeafletHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/IndexLeaflet/IndexLeafletHandler.cs
@@ -28,6 +28,7 @@ public class IndexLeafletHandler : IRequestHandler<IndexLeafletRequest, IndexLea
     public async Task<IndexLeafletResponse> Handle(IndexLeafletRequest request, CancellationToken ct)
     {
         var hash = ComputeHash(request.Content);
+        var useGraphIdentity = !string.IsNullOrEmpty(request.GraphItemId) && !string.IsNullOrEmpty(request.DriveId);
 
         var existing = await _repo.GetByHashAsync(hash, ct);
         if (existing is not null)
@@ -35,12 +36,21 @@ public class IndexLeafletHandler : IRequestHandler<IndexLeafletRequest, IndexLea
             _logger.LogInformation(
                 "Duplicate leaflet content detected, hash={Hash}, document={Id}",
                 hash, existing.Id);
+
+            if (useGraphIdentity && existing.GraphItemId is null)
+            {
+                _logger.LogInformation(
+                    "Backfilling DriveId/GraphItemId for legacy leaflet document {Id}",
+                    existing.Id);
+                await _repo.UpdateGraphItemIdAsync(existing.Id, request.DriveId!, request.GraphItemId!, ct);
+            }
+
             return new IndexLeafletResponse { DocumentId = existing.Id, WasDuplicate = true };
         }
 
-        var existingByIdentity = string.IsNullOrEmpty(request.GraphItemId)
-            ? await _repo.GetBySourcePathAsync(request.SourcePath, ct)
-            : await _repo.GetByGraphItemIdAsync(request.DriveId!, request.GraphItemId, ct);
+        var existingByIdentity = useGraphIdentity
+            ? await _repo.GetByGraphItemIdAsync(request.DriveId!, request.GraphItemId!, ct)
+            : await _repo.GetBySourcePathAsync(request.SourcePath, ct);
 
         if (existingByIdentity is not null)
         {
@@ -62,8 +72,8 @@ public class IndexLeafletHandler : IRequestHandler<IndexLeafletRequest, IndexLea
             ContentHash = hash,
             IngestedAt = DateTime.UtcNow,
             WordCount = 0,
-            DriveId = request.DriveId,
-            GraphItemId = request.GraphItemId,
+            DriveId = useGraphIdentity ? request.DriveId : null,
+            GraphItemId = useGraphIdentity ? request.GraphItemId : null,
         };
 
         await _repo.AddDocumentAsync(doc, ct);

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/IndexLeaflet/IndexLeafletRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/IndexLeaflet/IndexLeafletRequest.cs
@@ -8,4 +8,6 @@ public class IndexLeafletRequest : IRequest<IndexLeafletResponse>
     public string Filename { get; set; } = string.Empty;
     public string SourcePath { get; set; } = string.Empty;
     public string ContentType { get; set; } = string.Empty;
+    public string? DriveId { get; set; }
+    public string? GraphItemId { get; set; }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/IKnowledgeBaseRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/IKnowledgeBaseRepository.cs
@@ -20,6 +20,7 @@ public interface IKnowledgeBaseRepository
         CancellationToken ct = default);
     Task<KnowledgeBaseDocument?> GetDocumentByHashAsync(string contentHash, CancellationToken ct = default);
     Task<KnowledgeBaseDocument?> GetDocumentBySourcePathAsync(string sourcePath, CancellationToken ct = default);
+    Task<KnowledgeBaseDocument?> GetDocumentByGraphItemIdAsync(string driveId, string graphItemId, CancellationToken ct = default);
     Task DeleteDocumentAsync(Guid documentId, CancellationToken ct = default);
     Task<KnowledgeBaseChunk?> GetChunkByIdAsync(Guid chunkId, CancellationToken ct = default);
     Task<Dictionary<Guid, Guid>> GetFirstChunkIdsByDocumentIdsAsync(IEnumerable<Guid> documentIds, CancellationToken ct = default);

--- a/backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/IKnowledgeBaseRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/IKnowledgeBaseRepository.cs
@@ -25,6 +25,7 @@ public interface IKnowledgeBaseRepository
     Task<KnowledgeBaseChunk?> GetChunkByIdAsync(Guid chunkId, CancellationToken ct = default);
     Task<Dictionary<Guid, Guid>> GetFirstChunkIdsByDocumentIdsAsync(IEnumerable<Guid> documentIds, CancellationToken ct = default);
     Task UpdateDocumentSourcePathAsync(Guid documentId, string newSourcePath, CancellationToken ct = default);
+    Task UpdateDocumentGraphItemIdAsync(Guid documentId, string driveId, string graphItemId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
     Task SaveQuestionLogAsync(KnowledgeBaseQuestionLog log, CancellationToken ct = default);
     Task<KnowledgeBaseQuestionLog?> GetQuestionLogByIdAsync(Guid id, CancellationToken ct = default);

--- a/backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/KnowledgeBaseDocument.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/KnowledgeBaseDocument.cs
@@ -11,6 +11,8 @@ public class KnowledgeBaseDocument
     public DocumentType DocumentType { get; set; } = DocumentType.KnowledgeBase;
     public DateTime CreatedAt { get; set; }
     public DateTime? IndexedAt { get; set; }
+    public string? DriveId { get; set; }
+    public string? GraphItemId { get; set; }
 
     public ICollection<KnowledgeBaseChunk> Chunks { get; set; } = new List<KnowledgeBaseChunk>();
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
@@ -6,6 +6,7 @@ public interface ILeafletRepository
     Task AddChunksAsync(IEnumerable<LeafletChunk> chunks, CancellationToken ct = default);
     Task<LeafletDocument?> GetByHashAsync(string contentHash, CancellationToken ct = default);
     Task<LeafletDocument?> GetBySourcePathAsync(string sourcePath, CancellationToken ct = default);
+    Task<LeafletDocument?> GetByGraphItemIdAsync(string driveId, string graphItemId, CancellationToken ct = default);
     Task DeleteDocumentAsync(Guid id, CancellationToken ct = default);
     Task<List<(LeafletChunk Chunk, double Score)>> SearchSimilarAsync(
         float[] queryEmbedding, int topK, CancellationToken ct = default);

--- a/backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
@@ -11,5 +11,6 @@ public interface ILeafletRepository
     Task<List<(LeafletChunk Chunk, double Score)>> SearchSimilarAsync(
         float[] queryEmbedding, int topK, CancellationToken ct = default);
     Task UpdateSourcePathAsync(Guid documentId, string newPath, CancellationToken ct = default);
+    Task UpdateGraphItemIdAsync(Guid documentId, string driveId, string graphItemId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletDocument.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletDocument.cs
@@ -9,5 +9,7 @@ public class LeafletDocument
     public string ContentHash { get; set; } = string.Empty; // SHA-256 hex (64 chars)
     public DateTime IngestedAt { get; set; }
     public int WordCount { get; set; }
+    public string? DriveId { get; set; }
+    public string? GraphItemId { get; set; }
     public ICollection<LeafletChunk> Chunks { get; set; } = new List<LeafletChunk>();
 }

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletDocumentConfiguration.cs
@@ -16,13 +16,16 @@ public class LeafletDocumentConfiguration : IEntityTypeConfiguration<LeafletDocu
         builder.Property(x => x.ContentHash).IsRequired().HasMaxLength(64);
         builder.Property(x => x.IngestedAt).IsRequired().HasColumnType("timestamp without time zone");
         builder.Property(x => x.WordCount).IsRequired();
+        builder.Property(x => x.DriveId).IsRequired(false);
+        builder.Property(x => x.GraphItemId).IsRequired(false);
 
         builder.HasIndex(x => x.ContentHash)
             .HasDatabaseName("IX_LeafletDocuments_ContentHash");
 
-        builder.HasIndex(x => x.SourcePath)
+        builder.HasIndex(d => new { d.DriveId, d.GraphItemId })
             .IsUnique()
-            .HasDatabaseName("IX_LeafletDocuments_SourcePath");
+            .HasFilter("\"GraphItemId\" IS NOT NULL")
+            .HasDatabaseName("IX_LeafletDocuments_DriveId_GraphItemId");
 
         builder.HasMany(x => x.Chunks)
             .WithOne(x => x.Document)

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
@@ -64,6 +64,13 @@ public class LeafletRepository : ILeafletRepository
             .FirstOrDefaultAsync(x => x.SourcePath == sourcePath, ct);
     }
 
+    public async Task<LeafletDocument?> GetByGraphItemIdAsync(string driveId, string graphItemId, CancellationToken ct = default)
+    {
+        return await _context.LeafletDocuments
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.DriveId == driveId && x.GraphItemId == graphItemId, ct);
+    }
+
     public async Task DeleteDocumentAsync(Guid id, CancellationToken ct = default)
     {
         await _context.LeafletDocuments

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
@@ -143,6 +143,15 @@ public class LeafletRepository : ILeafletRepository
             .ExecuteUpdateAsync(s => s.SetProperty(d => d.SourcePath, newPath), ct);
     }
 
+    public async Task UpdateGraphItemIdAsync(Guid documentId, string driveId, string graphItemId, CancellationToken ct = default)
+    {
+        await _context.LeafletDocuments
+            .Where(x => x.Id == documentId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(d => d.DriveId, driveId)
+                .SetProperty(d => d.GraphItemId, graphItemId), ct);
+    }
+
     public async Task SaveChangesAsync(CancellationToken ct = default)
     {
         await _context.SaveChangesAsync(ct);

--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseDocumentConfiguration.cs
@@ -46,6 +46,9 @@ public class KnowledgeBaseDocumentConfiguration : IEntityTypeConfiguration<Knowl
             .IsRequired()
             .HasMaxLength(64);
 
+        builder.Property(e => e.DriveId).IsRequired(false);
+        builder.Property(e => e.GraphItemId).IsRequired(false);
+
         builder.HasIndex(e => e.ContentHash)
             .IsUnique();
 
@@ -54,8 +57,10 @@ public class KnowledgeBaseDocumentConfiguration : IEntityTypeConfiguration<Knowl
             .HasForeignKey(e => e.DocumentId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        builder.HasIndex(e => e.SourcePath)
-            .IsUnique();
+        builder.HasIndex(e => new { e.DriveId, e.GraphItemId })
+            .IsUnique()
+            .HasFilter("\"GraphItemId\" IS NOT NULL")
+            .HasDatabaseName("IX_KnowledgeBaseDocuments_DriveId_GraphItemId");
 
         builder.HasIndex(e => e.Status);
 

--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
@@ -227,6 +227,15 @@ public class KnowledgeBaseRepository : IKnowledgeBaseRepository
             .ExecuteUpdateAsync(s => s.SetProperty(d => d.SourcePath, newSourcePath), ct);
     }
 
+    public async Task UpdateDocumentGraphItemIdAsync(Guid documentId, string driveId, string graphItemId, CancellationToken ct = default)
+    {
+        await _context.KnowledgeBaseDocuments
+            .Where(d => d.Id == documentId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(d => d.DriveId, driveId)
+                .SetProperty(d => d.GraphItemId, graphItemId), ct);
+    }
+
     public async Task SaveChangesAsync(CancellationToken ct = default)
     {
         await _context.SaveChangesAsync(ct);

--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
@@ -176,18 +176,21 @@ public class KnowledgeBaseRepository : IKnowledgeBaseRepository
     public async Task<KnowledgeBaseDocument?> GetDocumentByHashAsync(string contentHash, CancellationToken ct = default)
     {
         return await _context.KnowledgeBaseDocuments
+            .AsNoTracking()
             .FirstOrDefaultAsync(d => d.ContentHash == contentHash, ct);
     }
 
     public async Task<KnowledgeBaseDocument?> GetDocumentBySourcePathAsync(string sourcePath, CancellationToken ct = default)
     {
         return await _context.KnowledgeBaseDocuments
+            .AsNoTracking()
             .FirstOrDefaultAsync(d => d.SourcePath == sourcePath, ct);
     }
 
     public async Task<KnowledgeBaseDocument?> GetDocumentByGraphItemIdAsync(string driveId, string graphItemId, CancellationToken ct = default)
     {
         return await _context.KnowledgeBaseDocuments
+            .AsNoTracking()
             .FirstOrDefaultAsync(d => d.DriveId == driveId && d.GraphItemId == graphItemId, ct);
     }
 

--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
@@ -185,6 +185,12 @@ public class KnowledgeBaseRepository : IKnowledgeBaseRepository
             .FirstOrDefaultAsync(d => d.SourcePath == sourcePath, ct);
     }
 
+    public async Task<KnowledgeBaseDocument?> GetDocumentByGraphItemIdAsync(string driveId, string graphItemId, CancellationToken ct = default)
+    {
+        return await _context.KnowledgeBaseDocuments
+            .FirstOrDefaultAsync(d => d.DriveId == driveId && d.GraphItemId == graphItemId, ct);
+    }
+
     public async Task DeleteDocumentAsync(Guid documentId, CancellationToken ct = default)
     {
         await _context.KnowledgeBaseDocuments

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260504132739_AddGraphItemIdToIngestedDocuments.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260504132739_AddGraphItemIdToIngestedDocuments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504132739_AddGraphItemIdToIngestedDocuments")]
+    partial class AddGraphItemIdToIngestedDocuments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260504132739_AddGraphItemIdToIngestedDocuments.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260504132739_AddGraphItemIdToIngestedDocuments.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGraphItemIdToIngestedDocuments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_LeafletDocuments_SourcePath",
+                table: "LeafletDocuments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_KnowledgeBaseDocuments_SourcePath",
+                schema: "public",
+                table: "KnowledgeBaseDocuments");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DriveId",
+                table: "LeafletDocuments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GraphItemId",
+                table: "LeafletDocuments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DriveId",
+                schema: "public",
+                table: "KnowledgeBaseDocuments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GraphItemId",
+                schema: "public",
+                table: "KnowledgeBaseDocuments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeafletDocuments_DriveId_GraphItemId",
+                table: "LeafletDocuments",
+                columns: new[] { "DriveId", "GraphItemId" },
+                unique: true,
+                filter: "\"GraphItemId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KnowledgeBaseDocuments_DriveId_GraphItemId",
+                schema: "public",
+                table: "KnowledgeBaseDocuments",
+                columns: new[] { "DriveId", "GraphItemId" },
+                unique: true,
+                filter: "\"GraphItemId\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_LeafletDocuments_DriveId_GraphItemId",
+                table: "LeafletDocuments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_KnowledgeBaseDocuments_DriveId_GraphItemId",
+                schema: "public",
+                table: "KnowledgeBaseDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "DriveId",
+                table: "LeafletDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "GraphItemId",
+                table: "LeafletDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "DriveId",
+                schema: "public",
+                table: "KnowledgeBaseDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "GraphItemId",
+                schema: "public",
+                table: "KnowledgeBaseDocuments");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeafletDocuments_SourcePath",
+                table: "LeafletDocuments",
+                column: "SourcePath",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KnowledgeBaseDocuments_SourcePath",
+                schema: "public",
+                table: "KnowledgeBaseDocuments",
+                column: "SourcePath",
+                unique: true);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Application.Features.Leaflet.UseCases.IndexLeaflet;
 using Anela.Heblo.Application.Shared.Rag;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
+using Anela.Heblo.Domain.Features.Leaflet;
 using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -18,6 +19,7 @@ public class LeafletIngestionJobTests
     private readonly Mock<IOneDriveService> _oneDrive = new();
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
+    private readonly Mock<ILeafletRepository> _leafletRepository = new();
 
     private static LeafletOptions DefaultLeafletOptions() => new()
     {
@@ -45,6 +47,7 @@ public class LeafletIngestionJobTests
             _oneDrive.Object,
             _mediator.Object,
             _statusChecker.Object,
+            _leafletRepository.Object,
             Options.Create(opts),
             NullLogger<LeafletIngestionJob>.Instance);
     }
@@ -63,6 +66,9 @@ public class LeafletIngestionJobTests
         _oneDrive
             .Setup(s => s.DownloadFileAsync("test-drive", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/file.pdf");
         _mediator
             .Setup(m => m.Send(It.IsAny<IndexLeafletRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new IndexLeafletResponse { WasDuplicate = false });
@@ -96,6 +102,9 @@ public class LeafletIngestionJobTests
         _oneDrive
             .Setup(s => s.DownloadFileAsync("test-drive", "id-dup", It.IsAny<CancellationToken>()))
             .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/duplicate.pdf");
         _mediator
             .Setup(m => m.Send(It.IsAny<IndexLeafletRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new IndexLeafletResponse { WasDuplicate = true });
@@ -145,6 +154,9 @@ public class LeafletIngestionJobTests
         _oneDrive
             .Setup(s => s.DownloadFileAsync("test-drive", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/good.pdf");
         _mediator
             .Setup(m => m.Send(It.Is<IndexLeafletRequest>(r => r.Filename == "broken.pdf"), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Transient failure"));
@@ -173,6 +185,7 @@ public class LeafletIngestionJobTests
             _oneDrive.Object,
             _mediator.Object,
             _statusChecker.Object,
+            _leafletRepository.Object,
             Options.Create(DefaultLeafletOptions()),
             NullLogger<LeafletIngestionJob>.Instance);
 
@@ -189,5 +202,65 @@ public class LeafletIngestionJobTests
         var job = CreateJob();
 
         Assert.Equal("leaflet-ingestion", job.Metadata.JobName);
+    }
+
+    [Fact]
+    public async Task Execute_passes_DriveId_and_GraphItemId_in_request()
+    {
+        var job = CreateJob();
+
+        var file = new OneDriveFile("graph-item-id-abc", "leaflet.pdf", "application/pdf", "/Leaflets/Inbox/leaflet.pdf");
+
+        _oneDrive
+            .Setup(s => s.ListInboxFilesAsync("test-drive", "/Leaflets/Inbox", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([file]);
+        _oneDrive
+            .Setup(s => s.DownloadFileAsync("test-drive", "graph-item-id-abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/leaflet.pdf");
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IndexLeafletRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexLeafletResponse { WasDuplicate = false });
+
+        await job.ExecuteAsync();
+
+        _mediator.Verify(
+            m => m.Send(
+                It.Is<IndexLeafletRequest>(r =>
+                    r.DriveId == "test-drive" &&
+                    r.GraphItemId == "graph-item-id-abc"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_calls_UpdateSourcePathAsync_with_archive_url_after_move()
+    {
+        var documentId = Guid.NewGuid();
+        const string archiveUrl = "https://mock.sharepoint.com/archived/leaflet.pdf";
+        var job = CreateJob();
+
+        var file = new OneDriveFile("graph-item-id-xyz", "leaflet.pdf", "application/pdf", "/Leaflets/Inbox/leaflet.pdf");
+
+        _oneDrive
+            .Setup(s => s.ListInboxFilesAsync("test-drive", "/Leaflets/Inbox", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([file]);
+        _oneDrive
+            .Setup(s => s.DownloadFileAsync("test-drive", "graph-item-id-xyz", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync("test-drive", "graph-item-id-xyz", "leaflet.pdf", "/Leaflets/Archived", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archiveUrl);
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IndexLeafletRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexLeafletResponse { DocumentId = documentId, WasDuplicate = false });
+
+        await job.ExecuteAsync();
+
+        _leafletRepository.Verify(
+            r => r.UpdateSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
@@ -330,11 +330,12 @@ public class LeafletIngestionJobTests
         await job.ExecuteAsync();
 
         // Warning logged with "Manual correction required" marker — distinct from generic "Failed to index"
+        // Verify it includes the archiveUrl in the log message
         _logger.Verify(
             x => x.Log(
                 LogLevel.Warning,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Manual correction required")),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Manual correction required") && v.ToString()!.Contains(archiveUrl)),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.AtLeastOnce);

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Infrastructure/LeafletIngestionJobTests.cs
@@ -7,7 +7,7 @@ using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using Anela.Heblo.Domain.Features.Leaflet;
 using MediatR;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -20,6 +20,7 @@ public class LeafletIngestionJobTests
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
     private readonly Mock<ILeafletRepository> _leafletRepository = new();
+    private readonly Mock<ILogger<LeafletIngestionJob>> _logger = new();
 
     private static LeafletOptions DefaultLeafletOptions() => new()
     {
@@ -49,7 +50,7 @@ public class LeafletIngestionJobTests
             _statusChecker.Object,
             _leafletRepository.Object,
             Options.Create(opts),
-            NullLogger<LeafletIngestionJob>.Instance);
+            _logger.Object);
     }
 
     [Fact]
@@ -187,7 +188,7 @@ public class LeafletIngestionJobTests
             _statusChecker.Object,
             _leafletRepository.Object,
             Options.Create(DefaultLeafletOptions()),
-            NullLogger<LeafletIngestionJob>.Instance);
+            _logger.Object);
 
         await job.ExecuteAsync();
 
@@ -261,6 +262,86 @@ public class LeafletIngestionJobTests
 
         _leafletRepository.Verify(
             r => r.UpdateSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_calls_UpdateSourcePathAsync_for_duplicate_document()
+    {
+        // UpdateSourcePathAsync must run even for duplicates so the DB SourcePath
+        // points to the new archive location, not the stale inbox path.
+        var documentId = Guid.NewGuid();
+        const string archiveUrl = "https://mock.sharepoint.com/archived/duplicate.pdf";
+        var job = CreateJob();
+
+        var file = new OneDriveFile("id-dup", "duplicate.pdf", "application/pdf", "/Leaflets/Inbox/duplicate.pdf");
+
+        _oneDrive
+            .Setup(s => s.ListInboxFilesAsync("test-drive", "/Leaflets/Inbox", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([file]);
+        _oneDrive
+            .Setup(s => s.DownloadFileAsync("test-drive", "id-dup", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync("test-drive", "id-dup", "duplicate.pdf", "/Leaflets/Archived", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archiveUrl);
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IndexLeafletRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexLeafletResponse { DocumentId = documentId, WasDuplicate = true });
+
+        await job.ExecuteAsync();
+
+        _leafletRepository.Verify(
+            r => r.UpdateSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_logs_warning_and_continues_when_UpdateSourcePathAsync_throws()
+    {
+        // If MoveToArchivedAsync succeeds but UpdateSourcePathAsync throws, the job should:
+        // - log a targeted warning (not the generic "Failed to index" error)
+        // - continue processing the next file without incrementing failed
+        var documentId = Guid.NewGuid();
+        const string archiveUrl = "https://mock.sharepoint.com/archived/leaflet.pdf";
+
+        var file1 = new OneDriveFile("id-fail-path", "leaflet-a.pdf", "application/pdf", "/Leaflets/Inbox/leaflet-a.pdf");
+        var file2 = new OneDriveFile("id-ok", "leaflet-b.pdf", "application/pdf", "/Leaflets/Inbox/leaflet-b.pdf");
+
+        var job = CreateJob();
+
+        _oneDrive
+            .Setup(s => s.ListInboxFilesAsync("test-drive", "/Leaflets/Inbox", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([file1, file2]);
+        _oneDrive
+            .Setup(s => s.DownloadFileAsync("test-drive", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archiveUrl);
+        _mediator
+            .Setup(m => m.Send(It.IsAny<IndexLeafletRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexLeafletResponse { DocumentId = documentId, WasDuplicate = false });
+
+        _leafletRepository
+            .Setup(r => r.UpdateSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB connection lost"));
+
+        await job.ExecuteAsync();
+
+        // Warning logged with "Manual correction required" marker — distinct from generic "Failed to index"
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Manual correction required")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+
+        // Both files were attempted — job continued past the SourcePath failure
+        _mediator.Verify(
+            m => m.Send(It.Is<IndexLeafletRequest>(r => r.Filename == "leaflet-b.pdf"), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/LeafletRepositoryTests.cs
@@ -59,6 +59,73 @@ public class LeafletRepositoryTests : IDisposable
         Assert.Equal(document.ContentHash, result.ContentHash);
     }
 
+    [Fact]
+    public async Task GetByGraphItemIdAsync_returns_null_when_missing()
+    {
+        // Act
+        var result = await _repository.GetByGraphItemIdAsync("nonexistent-drive-id", "nonexistent-item-id");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByGraphItemIdAsync_returns_document_when_driveId_and_graphItemId_match()
+    {
+        // Arrange
+        var document = new LeafletDocument
+        {
+            Id = Guid.NewGuid(),
+            Filename = "graph-test.pdf",
+            SourcePath = "/leaflets/graph-test.pdf",
+            ContentType = "application/pdf",
+            ContentHash = "graphhash001",
+            IngestedAt = DateTime.UtcNow,
+            WordCount = 100,
+            DriveId = "drive-abc",
+            GraphItemId = "item-xyz"
+        };
+
+        await _context.LeafletDocuments.AddAsync(document);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetByGraphItemIdAsync("drive-abc", "item-xyz");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(document.Id, result.Id);
+        Assert.Equal("drive-abc", result.DriveId);
+        Assert.Equal("item-xyz", result.GraphItemId);
+    }
+
+    [Fact]
+    public async Task GetByGraphItemIdAsync_returns_null_when_only_driveId_matches()
+    {
+        // Arrange
+        var document = new LeafletDocument
+        {
+            Id = Guid.NewGuid(),
+            Filename = "graph-partial.pdf",
+            SourcePath = "/leaflets/graph-partial.pdf",
+            ContentType = "application/pdf",
+            ContentHash = "graphhash002",
+            IngestedAt = DateTime.UtcNow,
+            WordCount = 100,
+            DriveId = "drive-abc",
+            GraphItemId = "item-xyz"
+        };
+
+        await _context.LeafletDocuments.AddAsync(document);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetByGraphItemIdAsync("drive-abc", "item-different");
+
+        // Assert
+        Assert.Null(result);
+    }
+
     [Fact(Skip = "ExecuteDeleteAsync is a relational operation not supported by the in-memory EF provider. Verified against real PostgreSQL.")]
     public async Task DeleteDocumentAsync_removes_document()
     {

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/IndexLeafletHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/IndexLeafletHandlerTests.cs
@@ -189,4 +189,151 @@ public class IndexLeafletHandlerTests
             s => s.IndexAsync(It.IsAny<string>(), It.IsAny<LeafletDocument>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_graphItemId_provided_and_doc_exists_reuses_existing_document()
+    {
+        // Arrange
+        var existingId = Guid.NewGuid();
+        var existingDoc = new LeafletDocument
+        {
+            Id = existingId,
+            ContentHash = "differenthash",
+            DriveId = "drive-123",
+            GraphItemId = "item-abc",
+        };
+
+        _repoMock
+            .Setup(r => r.GetByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+        _repoMock
+            .Setup(r => r.GetByGraphItemIdAsync("drive-123", "item-abc", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDoc);
+
+        _extractorMock.Setup(e => e.CanHandle("application/pdf")).Returns(true);
+        _extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("text");
+
+        var request = new IndexLeafletRequest
+        {
+            Content = new byte[] { 1, 2, 3 },
+            Filename = "file.pdf",
+            SourcePath = "https://inbox.example.com/file.pdf",
+            ContentType = "application/pdf",
+            DriveId = "drive-123",
+            GraphItemId = "item-abc",
+        };
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert: existing doc reused, no new doc added
+        _repoMock.Verify(
+            r => r.GetByGraphItemIdAsync("drive-123", "item-abc", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repoMock.Verify(
+            r => r.GetBySourcePathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repoMock.Verify(
+            r => r.DeleteDocumentAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repoMock.Verify(
+            r => r.AddDocumentAsync(It.IsAny<LeafletDocument>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        response.DocumentId.Should().NotBeEmpty();
+        response.WasDuplicate.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_graphItemId_provided_and_doc_does_not_exist_creates_new_doc_with_driveId_and_graphItemId()
+    {
+        // Arrange
+        _repoMock
+            .Setup(r => r.GetByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+        _repoMock
+            .Setup(r => r.GetByGraphItemIdAsync("drive-456", "item-xyz", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+
+        _extractorMock.Setup(e => e.CanHandle("application/pdf")).Returns(true);
+        _extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("extracted text");
+
+        var request = new IndexLeafletRequest
+        {
+            Content = new byte[] { 10, 20, 30 },
+            Filename = "catalog.pdf",
+            SourcePath = "https://onedrive.example.com/catalog.pdf",
+            ContentType = "application/pdf",
+            DriveId = "drive-456",
+            GraphItemId = "item-xyz",
+        };
+
+        LeafletDocument? capturedDoc = null;
+        _repoMock
+            .Setup(r => r.AddDocumentAsync(It.IsAny<LeafletDocument>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletDocument, CancellationToken>((doc, _) => capturedDoc = doc);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _repoMock.Verify(
+            r => r.GetByGraphItemIdAsync("drive-456", "item-xyz", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repoMock.Verify(
+            r => r.GetBySourcePathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        capturedDoc.Should().NotBeNull();
+        capturedDoc!.DriveId.Should().Be("drive-456");
+        capturedDoc.GraphItemId.Should().Be("item-xyz");
+        response.WasDuplicate.Should().BeFalse();
+        response.DocumentId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_graphItemId_null_falls_back_to_getBySourcePath_upload_flow()
+    {
+        // Arrange
+        _repoMock
+            .Setup(r => r.GetByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+        _repoMock
+            .Setup(r => r.GetBySourcePathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+
+        _extractorMock.Setup(e => e.CanHandle("application/pdf")).Returns(true);
+        _extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("text");
+
+        var request = new IndexLeafletRequest
+        {
+            Content = new byte[] { 5, 6, 7 },
+            Filename = "upload.pdf",
+            SourcePath = "upload/some-guid/upload.pdf",
+            ContentType = "application/pdf",
+            // DriveId and GraphItemId intentionally omitted (upload flow)
+        };
+
+        var handler = CreateHandler();
+
+        // Act
+        await handler.Handle(request, CancellationToken.None);
+
+        // Assert: upload flow uses GetBySourcePathAsync, never GetByGraphItemIdAsync
+        _repoMock.Verify(
+            r => r.GetBySourcePathAsync("upload/some-guid/upload.pdf", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repoMock.Verify(
+            r => r.GetByGraphItemIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/IndexLeafletHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/IndexLeafletHandlerTests.cs
@@ -336,4 +336,124 @@ public class IndexLeafletHandlerTests
             r => r.GetByGraphItemIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    [Fact]
+    public async Task Handle_graphItemId_provided_but_driveId_null_falls_back_to_getBySourcePath()
+    {
+        // Arrange
+        _repoMock
+            .Setup(r => r.GetByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+        _repoMock
+            .Setup(r => r.GetBySourcePathAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletDocument?)null);
+
+        _extractorMock.Setup(e => e.CanHandle("application/pdf")).Returns(true);
+        _extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("text");
+
+        var request = new IndexLeafletRequest
+        {
+            Content = new byte[] { 1, 2, 3 },
+            Filename = "partial.pdf",
+            SourcePath = "/inbox/partial.pdf",
+            ContentType = "application/pdf",
+            GraphItemId = "item-abc",
+            // DriveId intentionally omitted — should not crash or call GetByGraphItemIdAsync
+        };
+
+        var handler = CreateHandler();
+
+        // Act
+        await handler.Handle(request, CancellationToken.None);
+
+        // Assert: falls back to source path, GraphItemId lookup never called
+        _repoMock.Verify(
+            r => r.GetBySourcePathAsync("/inbox/partial.pdf", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repoMock.Verify(
+            r => r.GetByGraphItemIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_hash_match_legacy_doc_with_graph_identity_backfills_graph_item_id()
+    {
+        // Arrange
+        var content = new byte[] { 10, 20, 30 };
+        var existingId = Guid.NewGuid();
+        var legacyDoc = new LeafletDocument
+        {
+            Id = existingId,
+            ContentHash = "anyhash",
+            // DriveId/GraphItemId null — legacy row
+        };
+
+        _repoMock
+            .Setup(r => r.GetByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(legacyDoc);
+
+        var request = new IndexLeafletRequest
+        {
+            Content = content,
+            Filename = "legacy.pdf",
+            SourcePath = "/inbox/legacy.pdf",
+            ContentType = "application/pdf",
+            DriveId = "drive-backfill",
+            GraphItemId = "item-backfill",
+        };
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert: returned as duplicate and GraphItemId backfilled
+        response.WasDuplicate.Should().BeTrue();
+        response.DocumentId.Should().Be(existingId);
+        _repoMock.Verify(
+            r => r.UpdateGraphItemIdAsync(existingId, "drive-backfill", "item-backfill", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_hash_match_doc_already_has_graph_item_id_does_not_backfill()
+    {
+        // Arrange
+        var content = new byte[] { 10, 20, 30 };
+        var existingId = Guid.NewGuid();
+        var existingDoc = new LeafletDocument
+        {
+            Id = existingId,
+            ContentHash = "anyhash",
+            DriveId = "drive-existing",
+            GraphItemId = "item-existing",
+        };
+
+        _repoMock
+            .Setup(r => r.GetByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDoc);
+
+        var request = new IndexLeafletRequest
+        {
+            Content = content,
+            Filename = "existing.pdf",
+            SourcePath = "/inbox/existing.pdf",
+            ContentType = "application/pdf",
+            DriveId = "drive-existing",
+            GraphItemId = "item-existing",
+        };
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert: no backfill call when GraphItemId already set
+        response.WasDuplicate.Should().BeTrue();
+        _repoMock.Verify(
+            r => r.UpdateGraphItemIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
@@ -220,11 +220,12 @@ public class KnowledgeBaseIngestionJobTests
         await job.ExecuteAsync();
 
         // Warning logged with "Manual correction required" marker — distinct from generic "Failed to index"
+        // Verify it includes the archiveUrl in the log message
         _logger.Verify(
             x => x.Log(
                 LogLevel.Warning,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Manual correction required")),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Manual correction required") && v.ToString()!.Contains(archiveUrl)),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.AtLeastOnce);

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
@@ -5,7 +5,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.IndexDocument;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Domain.Features.KnowledgeBase;
 using MediatR;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -18,6 +18,7 @@ public class KnowledgeBaseIngestionJobTests
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
     private readonly Mock<IKnowledgeBaseRepository> _knowledgeBaseRepository = new();
+    private readonly Mock<ILogger<KnowledgeBaseIngestionJob>> _logger = new();
 
     private KnowledgeBaseIngestionJob CreateJob(KnowledgeBaseOptions options)
     {
@@ -28,7 +29,7 @@ public class KnowledgeBaseIngestionJobTests
             _statusChecker.Object,
             _knowledgeBaseRepository.Object,
             Options.Create(options),
-            NullLogger<KnowledgeBaseIngestionJob>.Instance);
+            _logger.Object);
     }
 
     private static KnowledgeBaseOptions OptionsWithTwoMappings() => new()
@@ -159,6 +160,78 @@ public class KnowledgeBaseIngestionJobTests
 
         _knowledgeBaseRepository.Verify(
             r => r.UpdateDocumentSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_calls_UpdateDocumentSourcePathAsync_for_duplicate_document()
+    {
+        // UpdateDocumentSourcePathAsync must run even for duplicates so the DB SourcePath
+        // points to the new archive location, not the stale inbox path.
+        var documentId = Guid.NewGuid();
+        const string archiveUrl = "https://mock.sharepoint.com/archived/doc.pdf";
+        var options = OptionsWithTwoMappings();
+        var job = CreateJob(options);
+
+        var file = new OneDriveFile("id-dup-kb", "doc.pdf", "application/pdf", "/KnowledgeBase/Inbox/doc.pdf");
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([file]);
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _oneDrive.Setup(s => s.DownloadFileAsync("drive-kb", "id-dup-kb", It.IsAny<CancellationToken>())).ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync("drive-kb", "id-dup-kb", "doc.pdf", "/KnowledgeBase/Archived", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archiveUrl);
+        _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexDocumentResponse { DocumentId = documentId, WasDuplicate = true });
+
+        await job.ExecuteAsync();
+
+        _knowledgeBaseRepository.Verify(
+            r => r.UpdateDocumentSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_logs_warning_and_continues_when_UpdateDocumentSourcePathAsync_throws()
+    {
+        // If MoveToArchivedAsync succeeds but UpdateDocumentSourcePathAsync throws, the job should:
+        // - log a targeted warning (not the generic "Failed to index" error)
+        // - continue processing the next file without incrementing failed
+        var documentId = Guid.NewGuid();
+        const string archiveUrl = "https://mock.sharepoint.com/archived/manual.pdf";
+        var options = OptionsWithTwoMappings();
+        var job = CreateJob(options);
+
+        var file1 = new OneDriveFile("id-fail-path", "manual.pdf", "application/pdf", "/KnowledgeBase/Inbox/manual.pdf");
+        var file2 = new OneDriveFile("id-ok", "other.pdf", "application/pdf", "/KnowledgeBase/Inbox/other.pdf");
+
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([file1, file2]);
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _oneDrive.Setup(s => s.DownloadFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archiveUrl);
+        _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexDocumentResponse { DocumentId = documentId, WasDuplicate = false });
+
+        _knowledgeBaseRepository
+            .Setup(r => r.UpdateDocumentSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB connection lost"));
+
+        await job.ExecuteAsync();
+
+        // Warning logged with "Manual correction required" marker — distinct from generic "Failed to index"
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Manual correction required")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+
+        // Both files were attempted — job continued past the SourcePath failure
+        _mediator.Verify(
+            m => m.Send(It.Is<IndexDocumentRequest>(r => r.Filename == "other.pdf"), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Infrastructure/KnowledgeBaseIngestionJobTests.cs
@@ -17,6 +17,7 @@ public class KnowledgeBaseIngestionJobTests
     private readonly Mock<IOneDriveService> _oneDrive = new();
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IRecurringJobStatusChecker> _statusChecker = new();
+    private readonly Mock<IKnowledgeBaseRepository> _knowledgeBaseRepository = new();
 
     private KnowledgeBaseIngestionJob CreateJob(KnowledgeBaseOptions options)
     {
@@ -25,6 +26,7 @@ public class KnowledgeBaseIngestionJobTests
             _oneDrive.Object,
             _mediator.Object,
             _statusChecker.Object,
+            _knowledgeBaseRepository.Object,
             Options.Create(options),
             NullLogger<KnowledgeBaseIngestionJob>.Instance);
     }
@@ -48,6 +50,8 @@ public class KnowledgeBaseIngestionJobTests
         _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([kbFile]);
         _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
         _oneDrive.Setup(s => s.DownloadFileAsync("drive-kb", "id-kb-1", It.IsAny<CancellationToken>())).ReturnsAsync([1, 2, 3]);
+        _oneDrive.Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/manual.pdf");
         _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new IndexDocumentResponse { WasDuplicate = false });
 
@@ -71,6 +75,8 @@ public class KnowledgeBaseIngestionJobTests
         _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
         _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([convFile]);
         _oneDrive.Setup(s => s.DownloadFileAsync("drive-conv", "id-conv-1", It.IsAny<CancellationToken>())).ReturnsAsync([4, 5, 6]);
+        _oneDrive.Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/chat.txt");
         _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new IndexDocumentResponse { WasDuplicate = false });
 
@@ -94,6 +100,8 @@ public class KnowledgeBaseIngestionJobTests
         _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([file]);
         _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
         _oneDrive.Setup(s => s.DownloadFileAsync("drive-kb", "id-1", It.IsAny<CancellationToken>())).ReturnsAsync([1, 2, 3]);
+        _oneDrive.Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/doc.pdf");
         _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new IndexDocumentResponse { WasDuplicate = true });
 
@@ -101,5 +109,56 @@ public class KnowledgeBaseIngestionJobTests
 
         _mediator.Verify(m => m.Send(It.IsAny<IndexDocumentRequest>(), default), Times.Once);
         _oneDrive.Verify(s => s.MoveToArchivedAsync("drive-kb", "id-1", "doc.pdf", "/KnowledgeBase/Archived", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_passes_DriveId_and_GraphItemId_in_request()
+    {
+        var options = OptionsWithTwoMappings();
+        var job = CreateJob(options);
+
+        var file = new OneDriveFile("graph-item-id-kb", "manual.pdf", "application/pdf", "/KnowledgeBase/Inbox/manual.pdf");
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([file]);
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _oneDrive.Setup(s => s.DownloadFileAsync("drive-kb", "graph-item-id-kb", It.IsAny<CancellationToken>())).ReturnsAsync([1, 2, 3]);
+        _oneDrive.Setup(s => s.MoveToArchivedAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("https://mock.sharepoint.com/archived/manual.pdf");
+        _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexDocumentResponse { WasDuplicate = false });
+
+        await job.ExecuteAsync();
+
+        _mediator.Verify(
+            m => m.Send(
+                It.Is<IndexDocumentRequest>(r =>
+                    r.DriveId == "drive-kb" &&
+                    r.GraphItemId == "graph-item-id-kb"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_calls_UpdateDocumentSourcePathAsync_with_archive_url_after_move()
+    {
+        var documentId = Guid.NewGuid();
+        const string archiveUrl = "https://mock.sharepoint.com/archived/manual.pdf";
+        var options = OptionsWithTwoMappings();
+        var job = CreateJob(options);
+
+        var file = new OneDriveFile("graph-item-id-kb", "manual.pdf", "application/pdf", "/KnowledgeBase/Inbox/manual.pdf");
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-kb", "/KnowledgeBase/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([file]);
+        _oneDrive.Setup(s => s.ListInboxFilesAsync("drive-conv", "/Conversation/Inbox", It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _oneDrive.Setup(s => s.DownloadFileAsync("drive-kb", "graph-item-id-kb", It.IsAny<CancellationToken>())).ReturnsAsync([1, 2, 3]);
+        _oneDrive
+            .Setup(s => s.MoveToArchivedAsync("drive-kb", "graph-item-id-kb", "manual.pdf", "/KnowledgeBase/Archived", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(archiveUrl);
+        _mediator.Setup(m => m.Send(It.IsAny<IndexDocumentRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IndexDocumentResponse { DocumentId = documentId, WasDuplicate = false });
+
+        await job.ExecuteAsync();
+
+        _knowledgeBaseRepository.Verify(
+            r => r.UpdateDocumentSourcePathAsync(documentId, archiveUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
@@ -61,13 +61,15 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
             CREATE TABLE IF NOT EXISTS public."KnowledgeBaseDocuments" (
                 "Id"           uuid NOT NULL PRIMARY KEY,
                 "Filename"     varchar(500) NOT NULL,
-                "SourcePath"   varchar(1000) NOT NULL UNIQUE,
+                "SourcePath"   varchar(1000) NOT NULL,
                 "ContentType"  varchar(100) NOT NULL,
                 "ContentHash"  varchar(64) NOT NULL UNIQUE,
                 "Status"       varchar(50) NOT NULL,
                 "DocumentType" integer NOT NULL DEFAULT 0,
                 "CreatedAt"    timestamp NOT NULL,
-                "IndexedAt"    timestamp NULL
+                "IndexedAt"    timestamp NULL,
+                "DriveId"      text NULL,
+                "GraphItemId"  text NULL
             );
 
             CREATE TABLE IF NOT EXISTS public."KnowledgeBaseChunks" (
@@ -88,7 +90,11 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
         await cmd.ExecuteNonQueryAsync();
     }
 
-    private static KnowledgeBaseDocument MakeDocument(string filename = "test.pdf", string hash = "abc123") =>
+    private static KnowledgeBaseDocument MakeDocument(
+        string filename = "test.pdf",
+        string hash = "abc123",
+        string? driveId = null,
+        string? graphItemId = null) =>
         new()
         {
             Id = Guid.NewGuid(),
@@ -98,7 +104,9 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
             ContentHash = hash,
             Status = DocumentStatus.Indexed,
             CreatedAt = DateTime.UtcNow,
-            IndexedAt = DateTime.UtcNow
+            IndexedAt = DateTime.UtcNow,
+            DriveId = driveId,
+            GraphItemId = graphItemId
         };
 
     [Fact]
@@ -250,6 +258,41 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
     public async Task GetChunkByIdAsync_ReturnsNull_WhenNotExists()
     {
         var result = await _repository.GetChunkByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDocumentByGraphItemIdAsync_ReturnsNull_WhenMissing()
+    {
+        var result = await _repository.GetDocumentByGraphItemIdAsync("drive-x", "item-y");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDocumentByGraphItemIdAsync_ReturnsDocument_WhenBothFieldsMatch()
+    {
+        var doc = MakeDocument("graph-kb.pdf", "deadbeef007", driveId: "drive-kb", graphItemId: "item-kb-001");
+        await _repository.AddDocumentAsync(doc);
+        await _repository.SaveChangesAsync();
+
+        var result = await _repository.GetDocumentByGraphItemIdAsync("drive-kb", "item-kb-001");
+
+        Assert.NotNull(result);
+        Assert.Equal(doc.Id, result!.Id);
+        Assert.Equal("drive-kb", result.DriveId);
+        Assert.Equal("item-kb-001", result.GraphItemId);
+    }
+
+    [Fact]
+    public async Task GetDocumentByGraphItemIdAsync_ReturnsNull_WhenOnlyDriveIdMatches()
+    {
+        var doc = MakeDocument("graph-kb-partial.pdf", "deadbeef008", driveId: "drive-kb", graphItemId: "item-kb-002");
+        await _repository.AddDocumentAsync(doc);
+        await _repository.SaveChangesAsync();
+
+        var result = await _repository.GetDocumentByGraphItemIdAsync("drive-kb", "item-different");
 
         Assert.Null(result);
     }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Services/GraphOneDriveServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Services/GraphOneDriveServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Text;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Web;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.KnowledgeBase.Services;
+
+public class GraphOneDriveServiceTests
+{
+    private static GraphOneDriveService CreateService(HttpMessageHandler handler)
+    {
+        var tokenAcquisition = new Mock<ITokenAcquisition>();
+        tokenAcquisition
+            .Setup(t => t.GetAccessTokenForAppAsync(It.IsAny<string>(), null, null))
+            .ReturnsAsync("fake-token");
+
+        var httpClient = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("MicrosoftGraph")).Returns(httpClient);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        return new GraphOneDriveService(
+            tokenAcquisition.Object,
+            factory.Object,
+            cache,
+            NullLogger<GraphOneDriveService>.Instance);
+    }
+
+    [Fact]
+    public async Task MoveToArchivedAsync_ReturnsWebUrl_FromGraphPatchResponse()
+    {
+        // Arrange
+        const string expectedWebUrl = "https://example.sharepoint.com/sites/anela/archived/doc.pdf";
+
+        var folderJson = """{"id":"folder-id","name":"Archived","webUrl":"https://example.sharepoint.com/sites/anela/Archived"}""";
+        var movedItemJson = $$$"""{"id":"item-id","name":"doc.pdf","webUrl":"{{{expectedWebUrl}}}"}""";
+
+        var handler = new SequentialResponseHandler(
+            // First call: GET folder item (path lookup) — the service does GET /root:/{path} to resolve folder id
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(folderJson, Encoding.UTF8, "application/json")
+            },
+            // Second call: PATCH drive item (the actual move)
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(movedItemJson, Encoding.UTF8, "application/json")
+            });
+
+        var service = CreateService(handler);
+
+        // Act
+        var result = await service.MoveToArchivedAsync(
+            driveId: "drive-id",
+            fileId: "file-id",
+            filename: "doc.pdf",
+            archivedPath: "Archived");
+
+        // Assert
+        Assert.Equal(expectedWebUrl, result);
+    }
+
+    /// <summary>
+    /// Feeds HTTP responses in sequence, one per call.
+    /// </summary>
+    private sealed class SequentialResponseHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public SequentialResponseHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (!_responses.TryDequeue(out var response))
+                throw new InvalidOperationException("No more queued HTTP responses.");
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Services/GraphOneDriveServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Services/GraphOneDriveServiceTests.cs
@@ -65,6 +65,36 @@ public class GraphOneDriveServiceTests
         Assert.Equal(expectedWebUrl, result);
     }
 
+    [Fact]
+    public async Task MoveToArchivedAsync_ThrowsInvalidOperationException_WhenWebUrlMissingFromPatchResponse()
+    {
+        // Arrange
+        var folderJson = """{"id":"folder-id","name":"Archived","webUrl":"https://example.sharepoint.com/sites/anela/Archived"}""";
+        var movedItemJson = """{"id":"item-id","name":"doc.pdf"}""";
+
+        var handler = new SequentialResponseHandler(
+            // First call: GET folder item (path lookup)
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(folderJson, Encoding.UTF8, "application/json")
+            },
+            // Second call: PATCH drive item — response is missing webUrl
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(movedItemJson, Encoding.UTF8, "application/json")
+            });
+
+        var service = CreateService(handler);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.MoveToArchivedAsync(
+                driveId: "drive-id",
+                fileId: "file-id",
+                filename: "doc.pdf",
+                archivedPath: "Archived"));
+    }
+
     /// <summary>
     /// Feeds HTTP responses in sequence, one per call.
     /// </summary>

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/IndexDocumentHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/IndexDocumentHandlerTests.cs
@@ -249,4 +249,104 @@ public class IndexDocumentHandlerTests
         Assert.NotNull(savedDoc);
         Assert.Equal("text/plain", savedDoc!.ContentType);
     }
+
+    [Fact]
+    public async Task Handle_GraphItemId_Provided_And_DocExists_ReusesExistingDocument()
+    {
+        // Arrange
+        var existingId = Guid.NewGuid();
+        var existing = new KnowledgeBaseDocument
+        {
+            Id = existingId,
+            Filename = "kb.pdf",
+            SourcePath = "https://inbox.example.com/kb.pdf",
+            ContentType = "application/pdf",
+            ContentHash = "oldhash",
+            DriveId = "drive-kb",
+            GraphItemId = "item-kb",
+            Status = DocumentStatus.Indexed,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        _repository.Setup(r => r.GetDocumentByHashAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+        _repository.Setup(r => r.GetDocumentByGraphItemIdAsync("drive-kb", "item-kb", default))
+            .ReturnsAsync(existing);
+
+        // Act
+        var response = await CreateHandler().Handle(new IndexDocumentRequest
+        {
+            Filename = "kb.pdf",
+            SourcePath = "https://inbox.example.com/kb.pdf",
+            ContentType = "application/pdf",
+            Content = [1, 2, 3],
+            DriveId = "drive-kb",
+            GraphItemId = "item-kb",
+        }, default);
+
+        // Assert: existing doc replaced (delete + re-add), GetBySourcePath never called
+        _repository.Verify(r => r.GetDocumentByGraphItemIdAsync("drive-kb", "item-kb", default), Times.Once);
+        _repository.Verify(r => r.GetDocumentBySourcePathAsync(It.IsAny<string>(), default), Times.Never);
+        _repository.Verify(r => r.DeleteDocumentAsync(existingId, default), Times.Once);
+        _repository.Verify(r => r.AddDocumentAsync(It.IsAny<KnowledgeBaseDocument>(), default), Times.Once);
+        Assert.NotEqual(Guid.Empty, response.DocumentId);
+        Assert.False(response.WasDuplicate);
+    }
+
+    [Fact]
+    public async Task Handle_GraphItemId_Provided_And_DocDoesNotExist_CreatesNewDocWithDriveIdAndGraphItemId()
+    {
+        // Arrange
+        _repository.Setup(r => r.GetDocumentByHashAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+        _repository.Setup(r => r.GetDocumentByGraphItemIdAsync("drive-new", "item-new", default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+
+        KnowledgeBaseDocument? savedDoc = null;
+        _repository.Setup(r => r.AddDocumentAsync(It.IsAny<KnowledgeBaseDocument>(), default))
+            .Callback<KnowledgeBaseDocument, CancellationToken>((doc, _) => savedDoc = doc);
+
+        // Act
+        await CreateHandler().Handle(new IndexDocumentRequest
+        {
+            Filename = "guide.pdf",
+            SourcePath = "https://onedrive.example.com/guide.pdf",
+            ContentType = "application/pdf",
+            Content = [10, 20, 30],
+            DriveId = "drive-new",
+            GraphItemId = "item-new",
+        }, default);
+
+        // Assert
+        _repository.Verify(r => r.GetDocumentByGraphItemIdAsync("drive-new", "item-new", default), Times.Once);
+        _repository.Verify(r => r.GetDocumentBySourcePathAsync(It.IsAny<string>(), default), Times.Never);
+
+        Assert.NotNull(savedDoc);
+        Assert.Equal("drive-new", savedDoc!.DriveId);
+        Assert.Equal("item-new", savedDoc.GraphItemId);
+    }
+
+    [Fact]
+    public async Task Handle_GraphItemId_Null_FallsBackToGetBySourcePath_UploadFlow()
+    {
+        // Arrange
+        _repository.Setup(r => r.GetDocumentByHashAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+        _repository.Setup(r => r.GetDocumentBySourcePathAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+
+        // Act
+        await CreateHandler().Handle(new IndexDocumentRequest
+        {
+            Filename = "upload.pdf",
+            SourcePath = "upload/some-guid/upload.pdf",
+            ContentType = "application/pdf",
+            Content = [5, 6, 7],
+            // DriveId and GraphItemId intentionally omitted (upload flow)
+        }, default);
+
+        // Assert: upload flow uses GetDocumentBySourcePathAsync, never GetDocumentByGraphItemIdAsync
+        _repository.Verify(r => r.GetDocumentBySourcePathAsync("upload/some-guid/upload.pdf", default), Times.Once);
+        _repository.Verify(r => r.GetDocumentByGraphItemIdAsync(It.IsAny<string>(), It.IsAny<string>(), default), Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/IndexDocumentHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/IndexDocumentHandlerTests.cs
@@ -349,4 +349,111 @@ public class IndexDocumentHandlerTests
         _repository.Verify(r => r.GetDocumentBySourcePathAsync("upload/some-guid/upload.pdf", default), Times.Once);
         _repository.Verify(r => r.GetDocumentByGraphItemIdAsync(It.IsAny<string>(), It.IsAny<string>(), default), Times.Never);
     }
+
+    [Fact]
+    public async Task Handle_GraphItemId_Provided_But_DriveId_Null_FallsBackToGetBySourcePath()
+    {
+        // Arrange
+        _repository.Setup(r => r.GetDocumentByHashAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+        _repository.Setup(r => r.GetDocumentBySourcePathAsync(It.IsAny<string>(), default))
+            .ReturnsAsync((KnowledgeBaseDocument?)null);
+
+        // Act
+        await CreateHandler().Handle(new IndexDocumentRequest
+        {
+            Filename = "partial.pdf",
+            SourcePath = "/inbox/partial.pdf",
+            ContentType = "application/pdf",
+            Content = [1, 2, 3],
+            GraphItemId = "item-abc",
+            // DriveId intentionally omitted — should not crash or call GetDocumentByGraphItemIdAsync
+        }, default);
+
+        // Assert: falls back to source path, GraphItemId lookup never called
+        _repository.Verify(r => r.GetDocumentBySourcePathAsync("/inbox/partial.pdf", default), Times.Once);
+        _repository.Verify(r => r.GetDocumentByGraphItemIdAsync(It.IsAny<string>(), It.IsAny<string>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HashMatch_LegacyDoc_WithGraphIdentity_BackfillsGraphItemId()
+    {
+        // Arrange
+        var content = new byte[] { 10, 20, 30 };
+        var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(content));
+        var existingId = Guid.NewGuid();
+        var legacyDoc = new KnowledgeBaseDocument
+        {
+            Id = existingId,
+            Filename = "old.pdf",
+            SourcePath = "/inbox/old.pdf",
+            ContentType = "application/pdf",
+            ContentHash = contentHash,
+            Status = DocumentStatus.Indexed,
+            CreatedAt = DateTime.UtcNow,
+            // DriveId/GraphItemId null — legacy row
+        };
+
+        _repository.Setup(r => r.GetDocumentByHashAsync(contentHash, default))
+            .ReturnsAsync(legacyDoc);
+
+        // Act
+        var response = await CreateHandler().Handle(new IndexDocumentRequest
+        {
+            Filename = "old.pdf",
+            SourcePath = "/inbox/old.pdf",
+            ContentType = "application/pdf",
+            Content = content,
+            DriveId = "drive-backfill",
+            GraphItemId = "item-backfill",
+        }, default);
+
+        // Assert: returned as duplicate and GraphItemId backfilled
+        Assert.True(response.WasDuplicate);
+        Assert.Equal(existingId, response.DocumentId);
+        _repository.Verify(
+            r => r.UpdateDocumentGraphItemIdAsync(existingId, "drive-backfill", "item-backfill", default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HashMatch_DocAlreadyHasGraphItemId_DoesNotBackfill()
+    {
+        // Arrange
+        var content = new byte[] { 10, 20, 30 };
+        var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(content));
+        var existingId = Guid.NewGuid();
+        var existingDoc = new KnowledgeBaseDocument
+        {
+            Id = existingId,
+            Filename = "already.pdf",
+            SourcePath = "/inbox/already.pdf",
+            ContentType = "application/pdf",
+            ContentHash = contentHash,
+            Status = DocumentStatus.Indexed,
+            CreatedAt = DateTime.UtcNow,
+            DriveId = "drive-existing",
+            GraphItemId = "item-existing",
+        };
+
+        _repository.Setup(r => r.GetDocumentByHashAsync(contentHash, default))
+            .ReturnsAsync(existingDoc);
+
+        // Act
+        var response = await CreateHandler().Handle(new IndexDocumentRequest
+        {
+            Filename = "already.pdf",
+            SourcePath = "/inbox/already.pdf",
+            ContentType = "application/pdf",
+            Content = content,
+            DriveId = "drive-existing",
+            GraphItemId = "item-existing",
+        }, default);
+
+        // Assert: no backfill call when GraphItemId already set
+        Assert.True(response.WasDuplicate);
+        _repository.Verify(
+            r => r.UpdateDocumentGraphItemIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), default),
+            Times.Never);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes stale `SourcePath` bug where both ingestion jobs stored the SharePoint inbox `webUrl` in DB, then moved the file to archive (invalidating that URL). Source links in `SearchKnowledgeBase` MCP tool and `POST /api/KnowledgeBase/search` were returning broken URLs.
- Adds nullable `DriveId` + `GraphItemId` to `LeafletDocument` and `KnowledgeBaseDocument`. Graph item IDs are stable across SharePoint moves/renames and replace `SourcePath` as the de-dupe key for OneDrive-sourced documents.
- After each archive move, captures the post-PATCH `webUrl` from the Graph response and updates `SourcePath` in DB so source links remain valid. Upload flow (no Graph ID) is unchanged.

## Key changes

- **Domain + Persistence**: new `DriveId`/`GraphItemId` nullable columns; filtered unique index on `(DriveId, GraphItemId) WHERE GraphItemId IS NOT NULL`; `GetByGraphItemIdAsync` + `UpdateGraphItemIdAsync` on both repos; EF Core migration `AddGraphItemIdToIngestedDocuments`
- **OneDrive service**: `MoveToArchivedAsync` now returns `Task<string>` (archive `webUrl`); throws `InvalidOperationException` if Graph response lacks `webUrl`
- **Handlers**: `IndexLeafletHandler` + `IndexDocumentHandler` switch de-dupe to `(DriveId, GraphItemId)` when both are present; persist new fields on creation; backfill `GraphItemId` on hash-match re-ingest of legacy rows
- **Jobs**: `LeafletIngestionJob` + `KnowledgeBaseIngestionJob` pass `DriveId`/`GraphItemId` in requests, capture archive URL after move, call `UpdateSourcePathAsync`; `UpdateSourcePathAsync` failure is isolated in its own try/catch with a targeted warning log (not absorbed by the generic catch)

## Test Plan

- [x] `dotnet test` — 2597 passing, 0 failed (3 skipped — Docker-dependent pgvector tests)
- [x] Migration: nullable columns added, old SourcePath unique index dropped, filtered unique on `(DriveId, GraphItemId)` created for both tables
- [ ] Drop a test PDF in `/AI/Leaflets/Inbox` on staging, wait for 15-min cron — verify file moves to archive and `SourcePath` in DB equals the archive `webUrl`
- [ ] Query `POST /api/KnowledgeBase/search` — verify `ChunkResult.SourcePath` returns a working archive URL