### PR TITLE
fix: return correct HTTP status codes from ConfirmSemiProductManufacture

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/ManufactureOrderController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/ManufactureOrderController.cs
@@ -125,9 +125,12 @@ public class ManufactureOrderController : BaseApiController
             }
             else
             {
-                var response = new ConfirmSemiProductManufactureResponse(ErrorCodes.InvalidOperation);
+                var errorCode = result.ErrorCode ?? ErrorCodes.InvalidOperation;
+                Logger.LogWarning("ConfirmSemiProductManufacture failed for order {OrderId}: {ErrorCode} — {Message}",
+                    id, errorCode, result.Message);
+                var response = new ConfirmSemiProductManufactureResponse(errorCode);
                 response.Message = result.Message;
-                return BadRequest(response);
+                return HandleResponse(response);
             }
         }
         catch (Exception ex)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/ConfirmSemiProductManufactureResult.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/ConfirmSemiProductManufactureResult.cs
@@ -1,13 +1,17 @@
+using Anela.Heblo.Application.Shared;
+
 namespace Anela.Heblo.Application.Features.Manufacture.Contracts;
 
 public class ConfirmSemiProductManufactureResult
 {
     public bool Success { get; }
     public string Message { get; }
+    public ErrorCodes? ErrorCode { get; }
 
-    public ConfirmSemiProductManufactureResult(bool success, string message)
+    public ConfirmSemiProductManufactureResult(bool success, string message, ErrorCodes? errorCode = null)
     {
         Success = success;
         Message = message;
+        ErrorCode = errorCode;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmSemiProductManufactureWorkflow.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmSemiProductManufactureWorkflow.cs
@@ -2,6 +2,7 @@ using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufacture;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrder;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
@@ -57,7 +58,9 @@ public class ConfirmSemiProductManufactureWorkflow : IConfirmSemiProductManufact
             {
                 _logger.LogError("Failed to update actual quantity for order {OrderId}: {ErrorCode}",
                     orderId, updateResult.ErrorCode);
-                return new ConfirmSemiProductManufactureResult(false, string.Format(ManufactureMessages.QuantityUpdateErrorFormat, updateResult.ErrorCode));
+                return new ConfirmSemiProductManufactureResult(false,
+                    string.Format(ManufactureMessages.QuantityUpdateErrorFormat, updateResult.ErrorCode),
+                    updateResult.ErrorCode ?? ErrorCodes.InternalServerError);
             }
 
             // Step 2: Create manufacture via external client
@@ -70,17 +73,24 @@ public class ConfirmSemiProductManufactureWorkflow : IConfirmSemiProductManufact
             {
                 _logger.LogError("Failed to update status for order {OrderId}: {ErrorCode}",
                     orderId, result.ErrorCode);
-                return new ConfirmSemiProductManufactureResult(false, string.Format(ManufactureMessages.StatusChangeErrorFormat, result.ErrorCode));
+                return new ConfirmSemiProductManufactureResult(false,
+                    string.Format(ManufactureMessages.StatusChangeErrorFormat, result.ErrorCode),
+                    result.ErrorCode ?? ErrorCodes.InternalServerError);
             }
 
             _logger.LogInformation("Successfully confirmed semi-product manufacture for order {OrderId}", orderId);
             return new ConfirmSemiProductManufactureResult(true,
                 string.Format(ManufactureMessages.SemiProductManufacturedSuccessFormat, actualQuantity));
         }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogError(ex, "ERP submission was cancelled (timeout) for order {OrderId}", orderId);
+            return new ConfirmSemiProductManufactureResult(false, ManufactureMessages.UnexpectedSemiProductError, ErrorCodes.ErpGatewayError);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error confirming semi-product manufacture for order {OrderId}", orderId);
-            return new ConfirmSemiProductManufactureResult(false, ManufactureMessages.UnexpectedSemiProductError);
+            return new ConfirmSemiProductManufactureResult(false, ManufactureMessages.UnexpectedSemiProductError, ErrorCodes.InternalServerError);
         }
     }
 

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -241,4 +241,6 @@ public enum ErrorCodes
     ShoptetApiError = 9003,
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
     PaymentGatewayError = 9004,
+    [HttpStatusCode(HttpStatusCode.BadGateway)]
+    ErpGatewayError = 9005,
 }

--- a/backend/test/Anela.Heblo.Tests/Controllers/ManufactureOrderControllerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Controllers/ManufactureOrderControllerTests.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrd
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.DuplicateManufactureOrder;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetCalendarView;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.UserManagement.UseCases.GetGroupMembers;
 using Anela.Heblo.Application.Features.UserManagement.Contracts;
@@ -724,6 +725,84 @@ public class ManufactureOrderControllerTests
         // Assert
         result.Result.Should().BeOfType<NotFoundObjectResult>();
         _mediatorMock.Verify(m => m.Send(It.Is<GetGroupMembersRequest>(r => r.GroupId == groupId), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region ConfirmSemiProductManufacture Tests
+
+    [Fact]
+    public async Task ConfirmSemiProductManufacture_Should_Return_Ok_When_Successful()
+    {
+        // Arrange
+        var orderId = 1;
+        var request = new ConfirmSemiProductManufactureRequest { Id = orderId, ActualQuantity = 10m };
+        var result = new ConfirmSemiProductManufactureResult(true, "Potvrzeno se skutečným množstvím 10");
+
+        _applicationServiceMock
+            .Setup(s => s.ConfirmSemiProductManufactureAsync(orderId, request.ActualQuantity, request.ChangeReason, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        // Act
+        var actionResult = await _controller.ConfirmSemiProductManufacture(orderId, request);
+
+        // Assert
+        actionResult.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task ConfirmSemiProductManufacture_Should_Return_500_When_InternalServerError()
+    {
+        // Arrange
+        var orderId = 1;
+        var request = new ConfirmSemiProductManufactureRequest { Id = orderId, ActualQuantity = 10m };
+        var result = new ConfirmSemiProductManufactureResult(false, "DB error", ErrorCodes.InternalServerError);
+
+        _applicationServiceMock
+            .Setup(s => s.ConfirmSemiProductManufactureAsync(orderId, request.ActualQuantity, request.ChangeReason, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        // Act
+        var actionResult = await _controller.ConfirmSemiProductManufacture(orderId, request);
+
+        // Assert
+        var statusResult = actionResult.Result.Should().BeOfType<ObjectResult>().Subject;
+        statusResult.StatusCode.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task ConfirmSemiProductManufacture_Should_Return_502_When_ErpGatewayError()
+    {
+        // Arrange
+        var orderId = 1;
+        var request = new ConfirmSemiProductManufactureRequest { Id = orderId, ActualQuantity = 10m };
+        var result = new ConfirmSemiProductManufactureResult(false, "ERP timeout", ErrorCodes.ErpGatewayError);
+
+        _applicationServiceMock
+            .Setup(s => s.ConfirmSemiProductManufactureAsync(orderId, request.ActualQuantity, request.ChangeReason, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        // Act
+        var actionResult = await _controller.ConfirmSemiProductManufacture(orderId, request);
+
+        // Assert
+        var statusResult = actionResult.Result.Should().BeOfType<ObjectResult>().Subject;
+        statusResult.StatusCode.Should().Be(502);
+    }
+
+    [Fact]
+    public async Task ConfirmSemiProductManufacture_Should_Return_BadRequest_When_Id_Mismatch()
+    {
+        // Arrange
+        var request = new ConfirmSemiProductManufactureRequest { Id = 2, ActualQuantity = 10m };
+
+        // Act
+        var actionResult = await _controller.ConfirmSemiProductManufacture(1, request);
+
+        // Assert
+        actionResult.Result.Should().BeOfType<BadRequestObjectResult>();
+        _applicationServiceMock.Verify(s => s.ConfirmSemiProductManufactureAsync(
+            It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     #endregion

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/Workflows/ConfirmSemiProductManufactureWorkflowTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/Workflows/ConfirmSemiProductManufactureWorkflowTests.cs
@@ -112,6 +112,7 @@ public class ConfirmSemiProductManufactureWorkflowTests
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.Message.Should().Contain("Chyba při aktualizaci množství");
+        result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
 
         _mediatorMock.Verify(x => x.Send(It.IsAny<SubmitManufactureRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         _mediatorMock.Verify(x => x.Send(It.IsAny<UpdateManufactureOrderStatusRequest>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -164,6 +165,7 @@ public class ConfirmSemiProductManufactureWorkflowTests
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.Message.Should().Contain("Chyba při změně stavu");
+        result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
 
         _mediatorMock.Verify(x => x.Send(
             It.Is<UpdateManufactureOrderStatusRequest>(r =>
@@ -186,11 +188,12 @@ public class ConfirmSemiProductManufactureWorkflowTests
         // Act
         var result = await _workflow.ExecuteAsync(ValidOrderId, ValidQuantity, ValidChangeReason, cts.Token);
 
-        // Assert — OperationCanceledException is caught by the outer catch and returns a generic failure
-        // The workflow catches all exceptions and returns a failure result to avoid unhandled exceptions bubbling to the caller
+        // Assert — OperationCanceledException is caught by the specific catch and returns ErpGatewayError
+        // The workflow catches OperationCanceledException separately to distinguish ERP timeout from generic errors
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.Message.Should().Be("Došlo k neočekávané chybě při potvrzení výroby polotovaru");
+        result.ErrorCode.Should().Be(ErrorCodes.ErpGatewayError);
 
         _loggerMock.Verify(
             x => x.Log(
@@ -217,6 +220,7 @@ public class ConfirmSemiProductManufactureWorkflowTests
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.Message.Should().Be("Došlo k neočekávané chybě při potvrzení výroby polotovaru");
+        result.ErrorCode.Should().Be(ErrorCodes.InternalServerError);
 
         _loggerMock.Verify(
             x => x.Log(
@@ -270,6 +274,34 @@ public class ConfirmSemiProductManufactureWorkflowTests
         capturedStatusRequest.FlexiDocSemiProductIssueForProduct.Should().BeNull();
         capturedStatusRequest.FlexiDocMaterialIssueForProduct.Should().BeNull();
         capturedStatusRequest.FlexiDocProductReceipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HappyPath_HasNullErrorCode()
+    {
+        var updateOrderResponse = CreateSuccessfulUpdateOrderResponse();
+        var submitManufactureResponse = CreateSuccessfulSubmitManufactureResponse("ERP_SEMI_123");
+        var updateStatusResponse = CreateSuccessfulUpdateStatusResponse();
+        SetupMediatorResponses(updateOrderResponse, submitManufactureResponse, updateStatusResponse);
+
+        var result = await _workflow.ExecuteAsync(ValidOrderId, ValidQuantity, ValidChangeReason, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOperationCancelled_ReturnsErpGatewayError()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateManufactureOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("ERP timeout"));
+
+        var result = await _workflow.ExecuteAsync(ValidOrderId, ValidQuantity, ValidChangeReason, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ErpGatewayError);
     }
 
     #region Helper Methods

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -207,6 +207,7 @@ const resources = {
         FlexiApiError: "Chyba ABRA Flexi API",
         ShoptetApiError: "Chyba Shoptet API",
         PaymentGatewayError: "Chyba platební brány",
+        ErpGatewayError: "Chyba ERP brány (časový limit nebo nedostupnost)",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Controller was returning HTTP 400 for all workflow failures; now returns appropriate status codes based on failure type
- Added `ErrorCode?` to `ConfirmSemiProductManufactureResult` so the controller knows what kind of failure occurred
- `OperationCanceledException` (ERP/FlexiBee timeout) now returns 502 via new `ErpGatewayError = 9005`; infrastructure failures return 500; business logic failures propagate their existing error codes

## Test plan

- [x] Bug is no longer reproducible via the steps in #873
- [x] New regression tests added (controller: 4 new tests; workflow: 3 new tests)
- [x] All BE tests pass (`dotnet test`) — 2525 passed, 10 pre-existing integration failures requiring Docker
- [x] Both builds succeed (`dotnet build`)

Fixes #873