### PR TITLE
fix: parse lot from newline-separated Flexi error and enrich fallback message

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilter.cs
@@ -1,8 +1,12 @@
+using System.Text.RegularExpressions;
+
 namespace Anela.Heblo.Application.Features.Manufacture.ErrorFilters.Filters;
 
 public class InsufficientLotStockFilter : IManufactureErrorFilter
 {
     private const string FlexiSignal = "Na skladě není dostatek zboží pro vyskladnění požadované šarže";
+
+    private static readonly Regex _whitespaceRun = new(@"\s+", RegexOptions.Compiled);
 
     public bool CanHandle(Exception exception) =>
         exception is IHasFailedConsumptionItems &&
@@ -10,18 +14,22 @@ public class InsufficientLotStockFilter : IManufactureErrorFilter
 
     public string Transform(Exception exception)
     {
+        // Normalize whitespace first so ". Požadované šarže " reliably matches even when
+        // Flexi inserts a newline (or \r\n) between the two sentences.
+        var normalized = _whitespaceRun.Replace(exception.Message, " ");
+
         // Use ". Požadované šarže " to skip the lowercase "požadované šarže" that appears
         // earlier in the same Flexi error sentence ("pro vyskladnění požadované šarže nebo expirace").
         var lotNumber = ManufactureErrorParsingHelpers.ExtractBetween(
-            exception.Message,
+            normalized,
             ". Požadované šarže ",
             " s ");
 
         // Try bracket-terminated form first ("… jen 6.59 G. [DoklSklad -1]");
         // fall back to sentence-terminated form in case Flexi omits the bracket.
-        var available = ManufactureErrorParsingHelpers.ExtractBetween(exception.Message, "máte na skladě jen ", ". [");
+        var available = ManufactureErrorParsingHelpers.ExtractBetween(normalized, "máte na skladě jen ", ". [");
         if (available == "?")
-            available = ManufactureErrorParsingHelpers.ExtractBetween(exception.Message, "máte na skladě jen ", ".");
+            available = ManufactureErrorParsingHelpers.ExtractBetween(normalized, "máte na skladě jen ", ".");
 
         var failedItems = (exception as IHasFailedConsumptionItems)?.FailedItems ?? [];
         var match = FindMatch(failedItems, lotNumber, exception.Message);
@@ -36,7 +44,38 @@ public class InsufficientLotStockFilter : IManufactureErrorFilter
                    $" K dispozici {available}. Doplňte šarži na sklad nebo upravte šarži ve výrobě.";
         }
 
-        return $"Na skladě chybí šarže {lotNumber}. Materiál podle šarže se nepodařilo dohledat.";
+        return BuildFallback(failedItems, lotNumber);
+    }
+
+    private static string BuildFallback(IReadOnlyList<FailedConsumptionItem> items, string lotNumber)
+    {
+        if (items.Count == 0)
+        {
+            return lotNumber == "?"
+                ? "Na skladě chybí šarže. Materiál podle šarže se nepodařilo dohledat."
+                : $"Na skladě chybí šarže {lotNumber}. Materiál podle šarže se nepodařilo dohledat.";
+        }
+
+        if (items.Count == 1)
+        {
+            var item = items[0];
+            var exp = item.Expiration?.ToString("dd.MM.yyyy") ?? "?";
+            var lot = string.IsNullOrWhiteSpace(item.LotNumber) ? "bez šarže" : $"šarže {item.LotNumber}";
+            var code = item.ProductCode ?? "?";
+            return $"Na skladě chybí materiál {item.ProductName} ({code}) – {lot}, expirace {exp}." +
+                   " Šarži se nepodařilo přesně určit z chybové zprávy. Doplňte šarži na sklad nebo upravte šarži ve výrobě.";
+        }
+
+        var itemList = string.Join(", ", items.Select(FormatItem));
+        return $"Na skladě chybí šarže pro některý z materiálů: {itemList}. Šarži se nepodařilo přesně určit z chybové zprávy.";
+    }
+
+    private static string FormatItem(FailedConsumptionItem item)
+    {
+        var lot = string.IsNullOrWhiteSpace(item.LotNumber) ? "bez šarže" : $"šarže {item.LotNumber}";
+        var exp = item.Expiration?.ToString("dd.MM.yyyy") ?? "?";
+        var code = item.ProductCode ?? "?";
+        return $"{item.ProductName} ({code}, {lot}, expirace {exp})";
     }
 
     private static FailedConsumptionItem? FindMatch(

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilterTests.cs
@@ -8,7 +8,7 @@ namespace Anela.Heblo.Tests.Features.Manufacture.ErrorFilters.Filters;
 public class InsufficientLotStockFilterTests
 {
     private const string RealFlexiError =
-        "Na skladě není dostatek zboží pro vyskladnění požadované šarže nebo expirace. " +
+        "Na skladě není dostatek zboží pro vyskladnění požadované šarže nebo expirace.\n" +
         "Požadované šarže 171224A7 s expirací 17.12.2027 máte na skladě jen 6.597599 G. [DoklSklad -1]";
 
     private readonly InsufficientLotStockFilter _filter = new();
@@ -74,7 +74,7 @@ public class InsufficientLotStockFilterTests
     }
 
     [Fact]
-    public void Transform_WhenLotNotInFailedItems_FallsBackToLotOnlyMessage()
+    public void Transform_WhenLotNotInFailedItems_FallsBackToSingleItemMessage()
     {
         var items = new List<FailedConsumptionItem>
         {
@@ -84,12 +84,12 @@ public class InsufficientLotStockFilterTests
 
         var result = _filter.Transform(ex);
 
-        result.Should().Contain("171224A7");
-        result.Should().Contain("nepodařilo dohledat");
+        result.Should().Contain("Jiný materiál");
+        result.Should().Contain("MAT-OTHER");
     }
 
     [Fact]
-    public void Transform_WhenMessageFormatUnrecognized_FallsBackToLotOnlyMessage()
+    public void Transform_WhenMessageFormatUnrecognized_FallsBackToSingleItemMessage()
     {
         var items = new List<FailedConsumptionItem>
         {
@@ -102,8 +102,8 @@ public class InsufficientLotStockFilterTests
 
         var result = _filter.Transform(ex);
 
-        result.Should().Contain("nepodařilo dohledat");
-        result.Should().NotContain("Levandulový olej");
+        result.Should().Contain("Levandulový olej");
+        result.Should().Contain("MAT-LAVENDER");
     }
 
     [Fact]
@@ -121,5 +121,64 @@ public class InsufficientLotStockFilterTests
         result.Should().Contain("MAT-B");
         result.Should().Contain("Materiál B");
         result.Should().NotContain("MAT-A");
+    }
+
+    [Fact]
+    public void Transform_WhenMessageHasFlexiManufactureExceptionPrefix_StillExtractsMaterialDetails()
+    {
+        var message = "Failed to create consumption stock movement for warehouse 5: " + RealFlexiError;
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0)
+        };
+        var ex = new EnrichedManufactureException(message, items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("Levandulový olej");
+        result.Should().Contain("MAT-LAVENDER");
+        result.Should().Contain("171224A7");
+        result.Should().Contain("17.12.2027");
+        result.Should().Contain("6.597599 G");
+    }
+
+    [Fact]
+    public void Transform_WhenSentenceSeparatorIsCarriageReturnNewline_StillExtractsMaterialDetails()
+    {
+        var message =
+            "Na skladě není dostatek zboží pro vyskladnění požadované šarže nebo expirace.\r\n" +
+            "Požadované šarže 171224A7 s expirací 17.12.2027 máte na skladě jen 6.597599 G. [DoklSklad -1]";
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0)
+        };
+        var ex = new EnrichedManufactureException(message, items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("Levandulový olej");
+        result.Should().Contain("MAT-LAVENDER");
+        result.Should().Contain("171224A7");
+        result.Should().Contain("17.12.2027");
+        result.Should().Contain("6.597599 G");
+    }
+
+    [Fact]
+    public void Transform_WhenMatchFailsAndMultipleFailedItems_ListsAllProducts()
+    {
+        var items = new List<FailedConsumptionItem>
+        {
+            new("MAT-A", "Materiál Alfa", "AAAA01", new DateOnly(2025, 3, 1), 3.0),
+            new("MAT-B", "Materiál Beta", "BBBB02", new DateOnly(2025, 6, 1), 7.0)
+        };
+        // RealFlexiError mentions lot 171224A7 — neither item matches, so fallback fires.
+        var ex = new EnrichedManufactureException(RealFlexiError, items);
+
+        var result = _filter.Transform(ex);
+
+        result.Should().Contain("Materiál Alfa");
+        result.Should().Contain("MAT-A");
+        result.Should().Contain("Materiál Beta");
+        result.Should().Contain("MAT-B");
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `InsufficientLotStockFilter` parsed the lot number using `". Požadované šarže "` (period + space) as a boundary marker, but FlexiBee separates the two Czech error sentences with `\n`. The parser returned sentinel `"?"`, `FindMatch` short-circuited, and the user saw `"Na skladě chybí šarže ?. Materiál podle šarže se nepodařilo dohledat."` instead of the detailed message.
- **Fix:** Normalize whitespace runs (`\s+` → single space) at the top of `Transform` before any string extraction. `FindMatch` still receives the raw message for expiration disambiguation.
- **Fallback enriched:** When no `FailedConsumptionItem` matches the parsed lot, the fallback now shows product info from the items already in the exception (0 items: lot-only message; 1 item: best-guess with disclaimer; 2+ items: full list). Previously it always showed `"šarže ?"` with no context.
- **Tests corrected:** `RealFlexiError` fixture updated to use `\n` (actual production format from FlexiBee). New tests cover the full `FlexiManufactureException.Message` prefix format, `\r\n` separator, and multi-item fallback.

## Test Plan

- [x] 11/11 `InsufficientLotStockFilter` unit tests pass (8 existing + 3 new)
- [x] Full backend suite: 2532 passed, 0 failed, 3 pre-existing skips
- [ ] Verify in staging: trigger a manufacture that fails with insufficient lot stock and confirm the UI shows the detailed message (material name, code, lot, expiration, available quantity)