### PR TITLE
fix: decimal lot quantities end-to-end, truncate to 6dp at FlexiBee boundary

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-flexi-sdk" value="/tmp/flexi-sdk-local" />
+  </packageSources>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local-flexi-sdk" value="/tmp/flexi-sdk-local" />
-  </packageSources>
-</configuration>

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.1.3" />
+    <!-- SDK 0.1.135 required: ensure Rem.FlexiBeeSDK.Client@0.1.135 is published to NuGet before merging -->
     <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.135" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.4.1" />

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Anela.Heblo.Adapters.Flexi.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.1.3" />
-    <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.134" />
+    <PackageReference Include="Rem.FlexiBeeSDK.Client" Version="0.1.135" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.4.1" />
     <ProjectReference Include="..\..\Anela.Heblo.Application\Anela.Heblo.Application.csproj" />

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/FlexiManufactureClient.cs
@@ -132,7 +132,7 @@ internal class FlexiManufactureClient : IManufactureClient
                             ProductCode = existing.ProductCode,
                             ProductName = existing.ProductName,
                             ProductType = existing.ProductType,
-                            RequiredAmount = (double)distributionEntry.AdjustedConsumption,
+                            RequiredAmount = distributionEntry.AdjustedConsumption,
                             HasLots = existing.HasLots
                         };
                     }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FefoConsumptionAllocator.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FefoConsumptionAllocator.cs
@@ -4,7 +4,7 @@ namespace Anela.Heblo.Adapters.Flexi.Manufacture.Internal;
 
 internal sealed class FefoConsumptionAllocator : IFefoConsumptionAllocator
 {
-    public const double AllocationEpsilon = 0.001;
+    public const decimal AllocationEpsilon = 0.001m;
 
     public List<ConsumptionItem> Allocate(
         Dictionary<string, IngredientRequirement> ingredientRequirements,
@@ -37,7 +37,7 @@ internal sealed class FefoConsumptionAllocator : IFefoConsumptionAllocator
                 .OrderBy(l => l.Expiration ?? DateOnly.MaxValue)
                 .ThenBy(s => s.Id)
                 .ToList();
-            double remainingToAllocate = requirement.RequiredAmount;
+            var remainingToAllocate = requirement.RequiredAmount;
 
             foreach (var lot in sortedLots)
             {
@@ -46,7 +46,7 @@ internal sealed class FefoConsumptionAllocator : IFefoConsumptionAllocator
                     break;
                 }
 
-                var amountFromThisLot = Math.Min(remainingToAllocate, (double)lot.Amount);
+                var amountFromThisLot = Math.Min(remainingToAllocate, lot.Amount);
 
                 consumptionItems.Add(new ConsumptionItem
                 {

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiIngredientRequirementAggregator.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiIngredientRequirementAggregator.cs
@@ -26,7 +26,7 @@ internal sealed class FlexiIngredientRequirementAggregator : IFlexiIngredientReq
 
             foreach (var ingredient in template.Ingredients.Where(w => w.ProductType != ProductType.UNDEFINED))
             {
-                var scaledAmount = ingredient.Amount * scaleFactor;
+                var scaledAmount = (decimal)(ingredient.Amount * scaleFactor);
 
                 if (ingredientRequirements.TryGetValue(ingredient.ProductCode, out var existing))
                 {

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiIngredientRequirementAggregator.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiIngredientRequirementAggregator.cs
@@ -26,6 +26,8 @@ internal sealed class FlexiIngredientRequirementAggregator : IFlexiIngredientReq
 
             foreach (var ingredient in template.Ingredients.Where(w => w.ProductType != ProductType.UNDEFINED))
             {
+                // BoM amounts are double; cast to decimal at boundary — drift here is acceptable
+                // since lot quantities are capped by RoundForFlexi at the FlexiBee submission boundary.
                 var scaledAmount = (decimal)(ingredient.Amount * scaleFactor);
 
                 if (ingredientRequirements.TryGetValue(ingredient.ProductCode, out var existing))

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiIngredientStockValidator.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiIngredientStockValidator.cs
@@ -26,7 +26,7 @@ internal sealed class FlexiIngredientStockValidator : IFlexiIngredientStockValid
 
             var stockItems = await _stockClient.StockToDateAsync(stockDate, warehouseId, cancellationToken);
             var ingredientStock = stockItems.FirstOrDefault(s => s.ProductCode == ingredientCode);
-            var availableStock = ingredientStock != null ? (double)ingredientStock.Stock : 0;
+            var availableStock = ingredientStock != null ? (decimal)ingredientStock.Stock : 0m;
 
             if (availableStock < requirement.RequiredAmount)
             {

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureDocumentService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureDocumentService.cs
@@ -263,6 +263,7 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
             capturedDocCode = consumptionResult?.Result?.Results?.FirstOrDefault()?.Code;
         }
 
+        // totalConsumptionCost is double (cost arithmetic) — rounds to 4dp for invoice precision, not stock precision.
         return new ConsumptionResult(Math.Round(totalConsumptionCost, 4), capturedDocCode);
     }
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureDocumentService.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/FlexiManufactureDocumentService.cs
@@ -57,14 +57,14 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
                 var stockItem = stockItems.FirstOrDefault(s => s.ProductCode == consumptionItem.ProductCode);
                 var unitPrice = stockItem != null ? (double)stockItem.Price : 0;
 
-                // Round to 4 decimal places to eliminate double-precision drift that
-                // originates from (decimal -> double) conversions accumulating across
-                // FEFO lot allocations. Without this, Flexi rejects movements like
-                // 5800.0000000000009 > 5800.0 available. See PR #572 / commit fba995e1.
-                var amount = Math.Round(consumptionItem.Amount, 4);
+                // Truncate to 6 decimal places so we never submit more than available stock.
+                // Truncation (MidpointRounding.ToZero) is used deliberately — rounding up
+                // could produce a value exceeding the lot quantity on record in FlexiBee.
+                // See PR #572 / commit fba995e1.
+                var amount = RoundForFlexi(consumptionItem.Amount);
 
                 // Track cost per manufactured product
-                productCosts[consumptionItem.SourceProductCode] += unitPrice * amount;
+                productCosts[consumptionItem.SourceProductCode] += unitPrice * (double)amount;
 
                 stockMovementItems.Add(new StockItemsMovementUpsertRequestItemFlexiDto
                 {
@@ -140,8 +140,8 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
                 {
                     ProductCode = item.ProductCode,
                     ProductName = item.ProductName,
-                    Amount = (double)item.Amount,
-                    AmountIssued = (double)item.Amount,
+                    Amount = RoundForFlexi(item.Amount),
+                    AmountIssued = RoundForFlexi(item.Amount),
                     LotNumber = request.LotNumber,
                     Expiration = request.ExpirationDate?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
                     UnitPrice = unitPrice
@@ -211,10 +211,10 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
                 var stockItem = stockItems.FirstOrDefault(s => s.ProductCode == consumptionItem.ProductCode);
                 var unitPrice = stockItem != null ? (double)stockItem.Price : 0;
 
-                // Round to 4 decimal places — see SubmitConsolidatedConsumptionAsync above.
-                var amount = Math.Round(consumptionItem.Amount, 4);
+                // Truncate to 6 decimal places — see SubmitConsolidatedConsumptionAsync above.
+                var amount = RoundForFlexi(consumptionItem.Amount);
 
-                totalConsumptionCost += unitPrice * amount;
+                totalConsumptionCost += unitPrice * (double)amount;
 
                 stockMovementItems.Add(new StockItemsMovementUpsertRequestItemFlexiDto
                 {
@@ -276,15 +276,15 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
             : FlexiStockClient.ProductsWarehouseId;
 
         var documentType = GetProductionDocumentType(request.ManufactureType);
-        var totalManufacturedAmount = request.Items.Sum(i => (double)i.Amount);
+        var totalManufacturedAmount = (double)request.Items.Sum(i => i.Amount);
         var manufacturedUnitPrice = totalManufacturedAmount > 0 ? totalConsumptionCost / totalManufacturedAmount : 0;
 
         var productMovementItems = request.Items.Select(item => new StockItemsMovementUpsertRequestItemFlexiDto
         {
             ProductCode = item.ProductCode,
             ProductName = item.ProductName,
-            Amount = (double)item.Amount,
-            AmountIssued = (double)item.Amount,
+            Amount = RoundForFlexi(item.Amount),
+            AmountIssued = RoundForFlexi(item.Amount),
             LotNumber = request.LotNumber,
             Expiration = request.ExpirationDate?.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc),
             UnitPrice = manufacturedUnitPrice
@@ -327,7 +327,7 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
         var stockItem = stockItems.FirstOrDefault(s => s.ProductCode == request.DirectSemiProductOutputCode);
         var unitPrice = stockItem != null ? (double)stockItem.Price : 0;
 
-        var amount = Math.Round((double)request.DirectSemiProductOutputAmount, 4);
+        var amount = RoundForFlexi(request.DirectSemiProductOutputAmount);
 
         var movementItem = new StockItemsMovementUpsertRequestItemFlexiDto
         {
@@ -364,7 +364,7 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
                     request.DirectSemiProductOutputName ?? request.DirectSemiProductOutputCode!,
                     request.LotNumber,
                     request.ExpirationDate,
-                    (double)request.DirectSemiProductOutputAmount)
+                    request.DirectSemiProductOutputAmount)
             ];
 
             throw new FlexiManufactureException(
@@ -377,6 +377,8 @@ internal sealed class FlexiManufactureDocumentService : IFlexiManufactureDocumen
 
         return result?.Result?.Results?.FirstOrDefault()?.Code;
     }
+
+    private static decimal RoundForFlexi(decimal x) => Math.Round(x, 6, MidpointRounding.ToZero);
 
     private static string GetProductionDocumentType(ErpManufactureType manufactureType)
     {

--- a/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/ManufactureWorkItems.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Manufacture/Internal/ManufactureWorkItems.cs
@@ -7,7 +7,7 @@ internal sealed class IngredientRequirement
     public required string ProductCode { get; init; }
     public required string ProductName { get; init; }
     public required ProductType ProductType { get; init; }
-    public required double RequiredAmount { get; init; }
+    public required decimal RequiredAmount { get; init; }
     public required bool HasLots { get; init; }
 }
 
@@ -18,7 +18,7 @@ internal sealed class ConsumptionItem
     public required ProductType ProductType { get; init; }
     public string? LotNumber { get; init; }
     public DateOnly? Expiration { get; init; }
-    public required double Amount { get; init; }
+    public required decimal Amount { get; init; }
     public required string SourceProductCode { get; init; }
 }
 

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/FailedConsumptionItem.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ErrorFilters/FailedConsumptionItem.cs
@@ -5,7 +5,7 @@ public sealed record FailedConsumptionItem(
     string ProductName,
     string? LotNumber,
     DateOnly? Expiration,
-    double Amount);
+    decimal Amount);
 
 public interface IHasFailedConsumptionItems
 {

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/FlexiManufactureClientTests.cs
@@ -141,13 +141,13 @@ public class FlexiManufactureClientTests
     }
 
     [Fact]
-    public async Task SubmitManufactureAsync_Product_ConsumptionAmountsRoundedToFourDecimals()
+    public async Task SubmitManufactureAsync_Product_ConsumptionAmountsTruncatedToSixDecimals()
     {
         // Arrange — template: 5800.0 of Bisabolol per 1 unit of ConfidentBar.
         // Requesting 1.0000000000001m units forces (decimal -> double) drift:
         // the FEFO allocator computes 5800.0 * (double)1.0000000000001m which
-        // produces something like 5800.0000000000009 — more than 4 decimal places.
-        // Without Math.Round, this gets posted to Flexi and gets rejected.
+        // produces something like 5800.0000000000009 — more than 6 decimal places.
+        // Without truncation, this gets posted to Flexi and gets rejected.
         SetupSuccessfulManufacture(
             ManufactureTestData.Products.ConfidentBar,
             ManufactureTestData.Materials.Bisabolol,
@@ -162,19 +162,19 @@ public class FlexiManufactureClientTests
         await _client.SubmitManufactureAsync(request);
 
         // Assert — every Out-direction stock movement must have all amounts
-        // rounded to exactly 4 decimal places (amount == Math.Round(amount, 4)).
+        // truncated to exactly 6 decimal places (truncation, not rounding).
         _mockStockMovementClient.Verify(
             m => m.SaveAsync(
                 It.Is<StockItemsMovementUpsertRequestFlexiDto>(req =>
                     req.StockMovementDirection == StockMovementDirection.Out &&
-                    req.StockItems.All(i => i.Amount == Math.Round((double)i.Amount!, 4)) &&
-                    req.StockItems.All(i => i.AmountIssued == Math.Round((double)i.AmountIssued!, 4))),
+                    req.StockItems.All(i => i.Amount == Math.Round(i.Amount, 6, MidpointRounding.ToZero)) &&
+                    req.StockItems.All(i => i.AmountIssued == Math.Round(i.AmountIssued!.Value, 6, MidpointRounding.ToZero))),
                 It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
     }
 
     [Fact]
-    public async Task SubmitManufactureAsync_SemiProduct_ConsumptionAmountsRoundedToFourDecimals()
+    public async Task SubmitManufactureAsync_SemiProduct_ConsumptionAmountsTruncatedToSixDecimals()
     {
         // Arrange — SemiProduct path uses SubmitConsumptionAsync (aggregated).
         SetupSuccessfulManufacture(
@@ -190,15 +190,68 @@ public class FlexiManufactureClientTests
         // Act
         await _client.SubmitManufactureAsync(request);
 
-        // Assert — same rounding invariant on the semi-product path.
+        // Assert — same 6 decimal places (truncation) invariant on the semi-product path.
         _mockStockMovementClient.Verify(
             m => m.SaveAsync(
                 It.Is<StockItemsMovementUpsertRequestFlexiDto>(req =>
                     req.StockMovementDirection == StockMovementDirection.Out &&
-                    req.StockItems.All(i => i.Amount == Math.Round((double)i.Amount!, 4)) &&
-                    req.StockItems.All(i => i.AmountIssued == Math.Round((double)i.AmountIssued!, 4))),
+                    req.StockItems.All(i => i.Amount == Math.Round(i.Amount, 6, MidpointRounding.ToZero)) &&
+                    req.StockItems.All(i => i.AmountIssued == Math.Round(i.AmountIssued!.Value, 6, MidpointRounding.ToZero))),
                 It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task SubmitManufactureAsync_LotAmountWithSixDecimalPlaces_IsNotTruncatedOrExpanded()
+    {
+        // Arrange — this is the exact original bug scenario:
+        // CatalogLot.Amount = 6.597599m was being drifted via double arithmetic to
+        // 6.5975999999999999 or rounded up to 6.5976 before submission to FlexiBee.
+        // The lot quantity must survive the full pipeline without any drift.
+        var ingredient = ManufactureTestData.Materials.Bisabolol;
+
+        // Template: ingredient amount 6.597599 per 10 units, so RequiredAmount = 6.597599m exactly.
+        // This matches the lot quantity — all of it is consumed, preserving the exact decimal value.
+        var template = ManufactureTestData.CreateTemplate(
+            ManufactureTestData.Products.ConfidentBar, 10.0,
+            (ingredient, 6.597599, true)); // hasLots: true → FEFO path
+
+        _mockTemplateService
+            .Setup(x => x.GetManufactureTemplateAsync(ManufactureTestData.Products.ConfidentBar.Code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(template);
+
+        SetupStockDataForIngredients((ingredient, 100m, 10m, hasLots: true));
+
+        // Single lot whose Amount has exactly 6 decimal places
+        var lots = new List<CatalogLot>
+        {
+            ManufactureTestData.CreateLot(ingredient, 6.597599m, "LOT-EXACT6DP", new DateOnly(2025, 6, 1))
+        };
+
+        _mockLotsClient
+            .Setup(x => x.GetAsync(ingredient.Code, 0, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lots);
+
+        StockItemsMovementUpsertRequestFlexiDto? capturedRequest = null;
+        _mockStockMovementClient
+            .Setup(x => x.SaveAsync(
+                It.Is<StockItemsMovementUpsertRequestFlexiDto>(r => r.StockMovementDirection == StockMovementDirection.Out),
+                It.IsAny<CancellationToken>()))
+            .Callback<StockItemsMovementUpsertRequestFlexiDto, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync((StockItemsMovementUpsertRequestFlexiDto _, CancellationToken _) => null!);
+
+        var request = ManufactureTestData.CreateManufactureRequest(
+            ManufactureTestData.Products.ConfidentBar, amount: 10m);
+        request.ManufactureType = ErpManufactureType.Product;
+
+        // Act
+        await _client.SubmitManufactureAsync(request);
+
+        // Assert — the exact lot quantity must survive the round-trip without drift
+        Assert.NotNull(capturedRequest);
+        var item = capturedRequest!.StockItems.Single(i => i.LotNumber == "LOT-EXACT6DP");
+        Assert.Equal(6.597599m, item.Amount);
+        Assert.Equal(6.597599m, item.AmountIssued);
     }
 
     #endregion
@@ -295,8 +348,8 @@ public class FlexiManufactureClientTests
         _mockStockMovementClient.Verify(x => x.SaveAsync(
             It.Is<StockItemsMovementUpsertRequestFlexiDto>(req =>
                 req.StockMovementDirection == StockMovementDirection.Out &&
-                req.StockItems.Any(i => i.ProductCode == ManufactureTestData.Materials.Bisabolol.Code && i.Amount == 10.0) &&
-                req.StockItems.Any(i => i.ProductCode == ManufactureTestData.Materials.Glycerol.Code && i.Amount == 6.0)),
+                req.StockItems.Any(i => i.ProductCode == ManufactureTestData.Materials.Bisabolol.Code && i.Amount == 10.0m) &&
+                req.StockItems.Any(i => i.ProductCode == ManufactureTestData.Materials.Glycerol.Code && i.Amount == 6.0m)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -421,7 +474,7 @@ public class FlexiManufactureClientTests
                 req.StockItems.Any(i =>
                     i.ProductCode == ManufactureTestData.Materials.Bisabolol.Code &&
                     i.LotNumber == "LOT-001" &&
-                    i.Amount == 5.0)),
+                    i.Amount == 5.0m)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -465,9 +518,9 @@ public class FlexiManufactureClientTests
             It.Is<StockItemsMovementUpsertRequestFlexiDto>(req =>
                 req.StockMovementDirection == StockMovementDirection.Out &&
                 req.StockItems.Count(i => i.ProductCode == ManufactureTestData.Materials.Bisabolol.Code) == 3 &&
-                req.StockItems.Any(i => i.LotNumber == "LOT-001" && i.Amount == 5.0) &&
-                req.StockItems.Any(i => i.LotNumber == "LOT-002" && i.Amount == 5.0) &&
-                req.StockItems.Any(i => i.LotNumber == "LOT-003" && i.Amount == 2.0)),
+                req.StockItems.Any(i => i.LotNumber == "LOT-001" && i.Amount == 5.0m) &&
+                req.StockItems.Any(i => i.LotNumber == "LOT-002" && i.Amount == 5.0m) &&
+                req.StockItems.Any(i => i.LotNumber == "LOT-003" && i.Amount == 2.0m)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -541,7 +594,7 @@ public class FlexiManufactureClientTests
                 req.StockItems.Any(i =>
                     i.ProductCode == ManufactureTestData.Materials.Bisabolol.Code &&
                     i.LotNumber == null &&
-                    i.Amount == 5.0)),
+                    i.Amount == 5.0m)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -1141,7 +1194,7 @@ public class FlexiManufactureClientTests
                 req.WarehouseId == FlexiStockClient.SemiProductsWarehouseId.ToString() &&
                 req.StockItems.Count == 1 &&
                 req.StockItems[0].ProductCode == ManufactureTestData.SemiProducts.SilkBar.Code &&
-                req.StockItems[0].Amount == 500.0 &&
+                req.StockItems[0].Amount == 500.0m &&
                 req.StockItems[0].LotNumber == "LOT123"),
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/Internal/FefoConsumptionAllocatorTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/Internal/FefoConsumptionAllocatorTests.cs
@@ -23,7 +23,7 @@ public class FefoConsumptionAllocatorTests
                 ProductCode = ingredient.Code,
                 ProductName = ingredient.Name,
                 ProductType = ingredient.Type,
-                RequiredAmount = 5.0,
+                RequiredAmount = 5.0m,
                 HasLots = true
             }
         };
@@ -43,7 +43,7 @@ public class FefoConsumptionAllocatorTests
         var item = result[0];
         Assert.Equal(ingredient.Code, item.ProductCode);
         Assert.Equal("LOT-A", item.LotNumber);
-        Assert.Equal(5.0, item.Amount);
+        Assert.Equal(5.0m, item.Amount);
         Assert.Equal("PROD001", item.SourceProductCode);
     }
 
@@ -59,7 +59,7 @@ public class FefoConsumptionAllocatorTests
                 ProductCode = ingredient.Code,
                 ProductName = ingredient.Name,
                 ProductType = ingredient.Type,
-                RequiredAmount = 15.0,
+                RequiredAmount = 15.0m,
                 HasLots = true
             }
         };
@@ -80,9 +80,9 @@ public class FefoConsumptionAllocatorTests
         // Assert
         Assert.Equal(2, result.Count);
         Assert.Equal("LOT-A", result[0].LotNumber); // Earlier expiry consumed first
-        Assert.Equal(10.0, result[0].Amount);
+        Assert.Equal(10.0m, result[0].Amount);
         Assert.Equal("LOT-B", result[1].LotNumber); // Later expiry consumed second
-        Assert.Equal(5.0, result[1].Amount);
+        Assert.Equal(5.0m, result[1].Amount);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class FefoConsumptionAllocatorTests
                 ProductCode = ingredient.Code,
                 ProductName = ingredient.Name,
                 ProductType = ingredient.Type,
-                RequiredAmount = 20.0,
+                RequiredAmount = 20.0m,
                 HasLots = true
             }
         };
@@ -129,7 +129,7 @@ public class FefoConsumptionAllocatorTests
                 ProductCode = ingredient.Code,
                 ProductName = ingredient.Name,
                 ProductType = ingredient.Type,
-                RequiredAmount = 5.0,
+                RequiredAmount = 5.0m,
                 HasLots = true
             }
         };
@@ -148,6 +148,6 @@ public class FefoConsumptionAllocatorTests
 
         // Assert
         Assert.Single(result);
-        Assert.Equal(4.9995, result[0].Amount, precision: 4);
+        Assert.Equal(4.9995m, result[0].Amount);
     }
 }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/Internal/FlexiIngredientStockValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Manufacture/Internal/FlexiIngredientStockValidatorTests.cs
@@ -35,7 +35,7 @@ public class FlexiIngredientStockValidatorTests
                 ProductCode = ingredient1.Code,
                 ProductName = ingredient1.Name,
                 ProductType = ProductType.SemiProduct,
-                RequiredAmount = 5.0,
+                RequiredAmount = 5.0m,
                 HasLots = false
             },
             [ingredient2.Code] = new IngredientRequirement
@@ -43,7 +43,7 @@ public class FlexiIngredientStockValidatorTests
                 ProductCode = ingredient2.Code,
                 ProductName = ingredient2.Name,
                 ProductType = ProductType.SemiProduct,
-                RequiredAmount = 10.0,
+                RequiredAmount = 10.0m,
                 HasLots = false
             },
             [ingredient3.Code] = new IngredientRequirement
@@ -51,7 +51,7 @@ public class FlexiIngredientStockValidatorTests
                 ProductCode = ingredient3.Code,
                 ProductName = ingredient3.Name,
                 ProductType = ProductType.SemiProduct,
-                RequiredAmount = 8.0,
+                RequiredAmount = 8.0m,
                 HasLots = false
             }
         };

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/ErrorFilters/Filters/InsufficientLotStockFilterTests.cs
@@ -48,7 +48,7 @@ public class InsufficientLotStockFilterTests
     {
         var items = new List<FailedConsumptionItem>
         {
-            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0)
+            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0m)
         };
         var ex = new EnrichedManufactureException(RealFlexiError, items);
 
@@ -78,7 +78,7 @@ public class InsufficientLotStockFilterTests
     {
         var items = new List<FailedConsumptionItem>
         {
-            new("MAT-OTHER", "Jiný materiál", "999999X1", new DateOnly(2026, 6, 1), 5.0)
+            new("MAT-OTHER", "Jiný materiál", "999999X1", new DateOnly(2026, 6, 1), 5.0m)
         };
         var ex = new EnrichedManufactureException(RealFlexiError, items);
 
@@ -93,7 +93,7 @@ public class InsufficientLotStockFilterTests
     {
         var items = new List<FailedConsumptionItem>
         {
-            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0)
+            new("MAT-LAVENDER", "Levandulový olej", "171224A7", new DateOnly(2027, 12, 17), 10.0m)
         };
         // Message contains the CanHandle signal but uses a format where the lot cannot be parsed.
         var ex = new EnrichedManufactureException(
@@ -111,8 +111,8 @@ public class InsufficientLotStockFilterTests
     {
         var items = new List<FailedConsumptionItem>
         {
-            new("MAT-A", "Materiál A", "171224A7", new DateOnly(2025, 1, 1), 5.0),
-            new("MAT-B", "Materiál B", "171224A7", new DateOnly(2027, 12, 17), 5.0)
+            new("MAT-A", "Materiál A", "171224A7", new DateOnly(2025, 1, 1), 5.0m),
+            new("MAT-B", "Materiál B", "171224A7", new DateOnly(2027, 12, 17), 5.0m)
         };
         var ex = new EnrichedManufactureException(RealFlexiError, items);
 


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `CatalogLot.Amount` (`decimal`) was cast to `double` inside `FefoConsumptionAllocator`, turning `6.597599` into `6.5975999999999999`. FlexiBee then rejected the submission as exceeding available lot stock.
- **Decimal end-to-end:** `IngredientRequirement.RequiredAmount`, `ConsumptionItem.Amount`, and `FailedConsumptionItem.Amount` migrated from `double` to `decimal`. The `(double)` casts on `lot.Amount` and `distributionEntry.AdjustedConsumption` are removed.
- **Boundary guard:** Replaced `Math.Round(.., 4)` with `RoundForFlexi` (truncates to 6 dp via `MidpointRounding.ToZero`) across all 5 FlexiBee stock movement submission methods, including production paths. Truncation ensures we never submit more than the available lot balance.
- **SDK:** `StockItemsMovementUpsertRequestItemFlexiDto.Amount` and `AmountIssued` changed from `double`/`double?` to `decimal`/`decimal?` in `Rem.FlexiBeeSDK`. SDK change committed at `d33d4ea` — **must be published as `Rem.FlexiBeeSDK.Client@0.1.135` before this PR is merged** (see `.csproj` comment).

## What is not changing

- `Ingredient.Amount`, `ManufactureTemplate.Amount` and other BoM domain types remain `double` — BoM-scale drift is absorbed by the boundary truncation.
- Cost fields (`productCosts`, `unitPrice`, `totalConsumptionCost`, `ConsumptionResult.TotalCost`) remain `double`.

## Test Plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 2868 passed, 9 skipped, 0 failed (all three test projects)
- [x] New regression test `SubmitManufactureAsync_LotAmountWithSixDecimalPlaces_IsNotTruncatedOrExpanded` — feeds `CatalogLot.Amount = 6.597599m` through real allocator + document service, asserts DTO `Amount == 6.597599m` (no drift, no over-truncation)
- [x] Existing rounding tests renamed to `*TruncatedToSixDecimals` and assertions updated to verify 6dp truncation
- [ ] Manual smoke test: submit manufacture order consuming lot `171224A7` (6.597599 G) against FlexiBee staging — should no longer get "máte na skladě jen 6.597599 G" rejection
- [ ] Ensure `Rem.FlexiBeeSDK.Client@0.1.135` is published to NuGet before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)