### PR TITLE
feat: add folder path filter to photobank gallery

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -30,6 +30,7 @@ namespace Anela.Heblo.API.Controllers
         public async Task<ActionResult<GetPhotosResponse>> GetPhotos(
             [FromQuery] List<string>? tags,
             [FromQuery] string? search,
+            [FromQuery] string? folderPath,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 48,
             CancellationToken cancellationToken = default)
@@ -38,6 +39,7 @@ namespace Anela.Heblo.API.Controllers
             {
                 Tags = tags,
                 Search = search,
+                FolderPath = folderPath,
                 Page = page,
                 PageSize = pageSize,
             };

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/GetPhotosRequest.cs
@@ -8,6 +8,7 @@ namespace Anela.Heblo.Application.Features.Photobank.Contracts
     {
         public List<string>? Tags { get; set; }
         public string? Search { get; set; }
+        public string? FolderPath { get; set; }
         public int Page { get; set; } = 1;
         public int PageSize { get; set; } = 48;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -21,6 +21,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
             var (items, total) = await _repository.GetPhotosAsync(
                 request.Tags,
                 request.Search,
+                request.FolderPath,
                 request.Page,
                 request.PageSize,
                 cancellationToken);

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -8,7 +8,7 @@ namespace Anela.Heblo.Domain.Features.Photobank
     {
         // Photos
         Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, int page, int pageSize,
+            List<string>? tags, string? search, string? folderPath, int page, int pageSize,
             CancellationToken cancellationToken);
 
         Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankRepository.cs
@@ -20,7 +20,7 @@ namespace Anela.Heblo.Persistence.Photobank
         // Photos
 
         public async Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, int page, int pageSize,
+            List<string>? tags, string? search, string? folderPath, int page, int pageSize,
             CancellationToken cancellationToken)
         {
             var query = _context.Photos
@@ -32,6 +32,12 @@ namespace Anela.Heblo.Persistence.Photobank
             {
                 var term = search.Trim().ToLowerInvariant();
                 query = query.Where(p => p.FileName.ToLower().Contains(term));
+            }
+
+            if (!string.IsNullOrWhiteSpace(folderPath))
+            {
+                var pathTerm = folderPath.Trim().ToLowerInvariant();
+                query = query.Where(p => p.FolderPath.ToLower().Contains(pathTerm));
             }
 
             if (tags != null && tags.Count > 0)

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -46,7 +46,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, null, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 2));
 
         var request = new GetPhotosRequest();
@@ -77,7 +77,7 @@ public class GetPhotosHandlerTests
         var tagFilter = new List<string> { "products" };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(tagFilter, null, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(tagFilter, null, null, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Tags = tagFilter };
@@ -91,7 +91,7 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].Tags.Should().ContainSingle(t => t.Name == "products");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, null, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, "ruze", 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, "ruze", null, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Search = "ruze" };
@@ -123,7 +123,7 @@ public class GetPhotosHandlerTests
     {
         // Arrange
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<string?>(), 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((new List<Photo>(), 0));
 
         var request = new GetPhotosRequest { Tags = new List<string> { "nonexistent" } };
@@ -135,5 +135,31 @@ public class GetPhotosHandlerTests
         result.Success.Should().BeTrue();
         result.Total.Should().Be(0);
         result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_FilterByFolderPath_PassesFolderPathToRepository()
+    {
+        // Arrange
+        var photos = new List<Photo>
+        {
+            BuildPhoto(1, "ruze-cervena.jpg", "Marketing/Produkty/Ruze"),
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, null, "Produkty", 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((photos, 1));
+
+        var request = new GetPhotosRequest { FolderPath = "Produkty" };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Items.Should().HaveCount(1);
+        result.Items[0].FolderPath.Should().Be("Marketing/Produkty/Ruze");
+
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, "Produkty", 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Photobank;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class PhotobankRepositoryFilterTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly PhotobankRepository _repository;
+
+    public PhotobankRepositoryFilterTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new PhotobankRepository(_context);
+
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        var photos = new List<Photo>
+        {
+            new() { Id = 1, SharePointFileId = "sp-1", FileName = "ruze-cervena.jpg",    FolderPath = "Marketing/Produkty/Ruze",    ModifiedAt = DateTime.UtcNow },
+            new() { Id = 2, SharePointFileId = "sp-2", FileName = "levandule.jpg",       FolderPath = "Marketing/Produkty/Levandule", ModifiedAt = DateTime.UtcNow },
+            new() { Id = 3, SharePointFileId = "sp-3", FileName = "banner-homepage.png", FolderPath = "Marketing/Web",              ModifiedAt = DateTime.UtcNow },
+            new() { Id = 4, SharePointFileId = "sp-4", FileName = "vyrobek-01.jpg",      FolderPath = "Vyrobky/2025",               ModifiedAt = DateTime.UtcNow },
+        };
+
+        _context.Photos.AddRange(photos);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_filtersByFolderPath_substringMatch()
+    {
+        // Arrange — "Produkty" is a substring of two folder paths
+        var folderPath = "Produkty";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, null, folderPath, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(2);
+        items.Should().OnlyContain(p => p.FolderPath.Contains("Produkty", StringComparison.OrdinalIgnoreCase));
+        items.Should().NotContain(p => p.FileName == "banner-homepage.png");
+        items.Should().NotContain(p => p.FileName == "vyrobek-01.jpg");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_filterByFolderPath_caseInsensitive()
+    {
+        // Arrange — uppercase input, lowercase stored path
+        var folderPath = "MARKETING/WEB";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, null, folderPath, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(1);
+        items.Should().ContainSingle(p => p.FileName == "banner-homepage.png");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_combinesFolderPathWithFilename()
+    {
+        // Arrange — folderPath matches two photos, filename narrows to one
+        var folderPath = "Produkty";
+        var search = "ruze";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, search, folderPath, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(1);
+        items.Should().ContainSingle(p => p.FileName == "ruze-cervena.jpg");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_combinesFolderPathWithTag()
+    {
+        // Arrange — seed a tag on one of the two "Produkty" photos
+        var tag = new Tag { Id = 10, Name = "featured" };
+        _context.PhotobankTags.Add(tag);
+
+        var photoTag = new PhotoTag
+        {
+            PhotoId = 1, // ruze-cervena.jpg
+            TagId = 10,
+            Source = PhotoTagSource.Manual,
+            CreatedAt = DateTime.UtcNow,
+        };
+        _context.PhotoTags.Add(photoTag);
+        await _context.SaveChangesAsync(CancellationToken.None);
+
+        // Act — folderPath "Produkty" matches photos 1 & 2; tag "featured" is only on photo 1
+        var (items, total) = await _repository.GetPhotosAsync(
+            new List<string> { "featured" }, null, "Produkty", 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(1);
+        items.Should().ContainSingle(p => p.FileName == "ruze-cervena.jpg");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async System.Threading.Tasks.Task GetPhotosAsync_emptyFolderPath_doesNotFilter(string? folderPath)
+    {
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, null, folderPath, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(4);
+        items.Should().HaveCount(4);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
@@ -98,6 +98,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
     {
         // Arrange — seed a tag on one of the two "Produkty" photos
         var tag = new Tag { Id = 10, Name = "featured" };
+        // Safe: each test gets its own in-memory DB (Guid name + per-instance constructor).
         _context.PhotobankTags.Add(tag);
 
         var photoTag = new PhotoTag

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -37,6 +37,7 @@ export interface GetPhotosResponse {
 export interface GetPhotosParams {
   tags?: string[];
   search?: string;
+  folderPath?: string;
   page?: number;
   pageSize?: number;
 }
@@ -80,6 +81,7 @@ async function apiDelete(apiClient: ReturnType<typeof getAuthenticatedApiClient>
 function buildPhotosUrl(baseUrl: string, params: GetPhotosParams): string {
   const qs = new URLSearchParams();
   if (params.search) qs.set("search", params.search);
+  if (params.folderPath) qs.set("folderPath", params.folderPath);
   if (params.page != null) qs.set("page", String(params.page));
   if (params.pageSize != null) qs.set("pageSize", String(params.pageSize));
   (params.tags ?? []).forEach((t) => qs.append("tags", String(t)));

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -26,6 +26,7 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
   onClearFilters,
 }) => {
   const [inputValue, setInputValue] = useState(search);
+  const [folderPathValue, setFolderPathValue] = useState(folderPath);
 
   // Sync external search value to local input
   useEffect(() => {
@@ -54,8 +55,6 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     setInputValue("");
     onSearchChange("");
   }, [onSearchChange]);
-
-  const [folderPathValue, setFolderPathValue] = useState(folderPath);
 
   // Sync external folderPath value to local input
   useEffect(() => {

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -1,13 +1,15 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Search, X, Tag } from "lucide-react";
+import { Search, X, Tag, Folder } from "lucide-react";
 import type { TagWithCountDto } from "../../../api/hooks/usePhotobank";
 
 interface TagSidebarProps {
   tags: TagWithCountDto[];
   selectedTagIds: number[];
   search: string;
+  folderPath: string;
   onTagToggle: (tagId: number) => void;
   onSearchChange: (value: string) => void;
+  onFolderPathChange: (value: string) => void;
   onClearFilters: () => void;
 }
 
@@ -17,8 +19,10 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
   tags,
   selectedTagIds,
   search,
+  folderPath,
   onTagToggle,
   onSearchChange,
+  onFolderPathChange,
   onClearFilters,
 }) => {
   const [inputValue, setInputValue] = useState(search);
@@ -51,7 +55,37 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     onSearchChange("");
   }, [onSearchChange]);
 
-  const hasActiveFilters = search.length > 0 || selectedTagIds.length > 0;
+  const [folderPathValue, setFolderPathValue] = useState(folderPath);
+
+  // Sync external folderPath value to local input
+  useEffect(() => {
+    setFolderPathValue(folderPath);
+  }, [folderPath]);
+
+  // Debounce folder path input changes
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (folderPathValue !== folderPath) {
+        onFolderPathChange(folderPathValue);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [folderPathValue, folderPath, onFolderPathChange]);
+
+  const handleFolderPathInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFolderPathValue(e.target.value);
+    },
+    [],
+  );
+
+  const handleClearFolderPath = useCallback(() => {
+    setFolderPathValue("");
+    onFolderPathChange("");
+  }, [onFolderPathChange]);
+
+  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0;
 
   return (
     <aside className="flex flex-col h-full bg-white border-r border-gray-200 overflow-hidden">
@@ -88,6 +122,28 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
               onClick={handleClearSearch}
               className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
               aria-label="Vymazat hledání"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        {/* Folder path input */}
+        <div className="relative mt-2">
+          <Folder className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400 pointer-events-none" />
+          <input
+            type="text"
+            value={folderPathValue}
+            onChange={handleFolderPathInputChange}
+            placeholder="Hledat ve složkách..."
+            className="w-full pl-8 pr-7 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-transparent"
+            aria-label="Hledat ve složkách"
+          />
+          {folderPathValue && (
+            <button
+              onClick={handleClearFolderPath}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              aria-label="Vymazat složku"
             >
               <X className="w-3.5 h-3.5" />
             </button>

--- a/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
@@ -14,8 +14,10 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof TagSidebar
     tags: mockTags,
     selectedTagIds: [],
     search: "",
+    folderPath: "",
     onTagToggle: jest.fn(),
     onSearchChange: jest.fn(),
+    onFolderPathChange: jest.fn(),
     onClearFilters: jest.fn(),
     ...overrides,
   };
@@ -145,5 +147,50 @@ describe("TagSidebar", () => {
 
     // Assert
     expect(screen.getByText("Žádné štítky")).toBeInTheDocument();
+  });
+
+  test("folder path input is rendered with correct placeholder", () => {
+    // Arrange & Act
+    renderSidebar();
+
+    // Assert
+    expect(screen.getByPlaceholderText("Hledat ve složkách...")).toBeInTheDocument();
+  });
+
+  test("folder path input change calls onFolderPathChange after debounce", async () => {
+    // Arrange
+    const onFolderPathChange = jest.fn();
+    renderSidebar({ onFolderPathChange });
+
+    const input = screen.getByPlaceholderText("Hledat ve složkách...");
+
+    // Act
+    fireEvent.change(input, { target: { value: "Marketing" } });
+
+    // Assert: not called immediately
+    expect(onFolderPathChange).not.toHaveBeenCalled();
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(onFolderPathChange).toHaveBeenCalledWith("Marketing");
+  });
+
+  test("'Clear filters' button appears when folderPath is active", () => {
+    // Arrange
+    renderSidebar({ folderPath: "Marketing" });
+
+    // Assert
+    expect(screen.getByText("Vymazat")).toBeInTheDocument();
+  });
+
+  test("'Clear filters' button is absent when no filters active including folderPath", () => {
+    // Arrange
+    renderSidebar({ selectedTagIds: [], search: "", folderPath: "" });
+
+    // Assert
+    expect(screen.queryByText("Vymazat")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
@@ -193,4 +193,11 @@ describe("TagSidebar", () => {
     // Assert
     expect(screen.queryByText("Vymazat")).not.toBeInTheDocument();
   });
+
+  test("X button on folder path input clears it immediately", () => {
+    const onFolderPathChange = jest.fn();
+    renderSidebar({ folderPath: "Marketing", onFolderPathChange });
+    fireEvent.click(screen.getByRole("button", { name: "Vymazat složku" }));
+    expect(onFolderPathChange).toHaveBeenCalledWith("");
+  });
 });

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -20,6 +20,7 @@ const PhotobankPage: React.FC = () => {
 
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
   const [search, setSearch] = useState("");
+  const [folderPath, setFolderPath] = useState("");
   const [page, setPage] = useState(1);
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoDto | null>(null);
 
@@ -36,6 +37,7 @@ const PhotobankPage: React.FC = () => {
   const { data: photosData, isLoading: photosLoading } = usePhotos({
     tags: selectedTagNames.length > 0 ? selectedTagNames : undefined,
     search: search || undefined,
+    folderPath: folderPath || undefined,
     page,
     pageSize: DEFAULT_PAGE_SIZE,
   });
@@ -52,9 +54,15 @@ const PhotobankPage: React.FC = () => {
     setPage(1);
   }, []);
 
+  const handleFolderPathChange = useCallback((value: string) => {
+    setFolderPath(value);
+    setPage(1);
+  }, []);
+
   const handleClearFilters = useCallback(() => {
     setSelectedTagIds([]);
     setSearch("");
+    setFolderPath("");
     setPage(1);
   }, []);
 
@@ -94,8 +102,10 @@ const PhotobankPage: React.FC = () => {
           tags={tagsData ?? []}
           selectedTagIds={selectedTagIds}
           search={search}
+          folderPath={folderPath}
           onTagToggle={handleTagToggle}
           onSearchChange={handleSearchChange}
+          onFolderPathChange={handleFolderPathChange}
           onClearFilters={handleClearFilters}
         />
       </div>


### PR DESCRIPTION
## Summary

- Adds a `FolderPath` substring filter end-to-end: `GetPhotosRequest` DTO → `IPhotobankRepository` → `PhotobankRepository` → `GetPhotosHandler` → `PhotobankController` → `usePhotobank` hook → `PhotobankPage` state → `TagSidebar` UI
- Filter is case-insensitive substring match (`ToLower().Contains()`), AND-combined with existing filename and tag filters
- New debounced text input appears below the filename search in the left sidebar, with a `Folder` icon and Czech placeholder "Hledat ve složkách..."
- Clearing filters ("Vymazat filtry") resets the folder path field alongside tags and filename

## Test plan

- [x] 5 new `PhotobankRepository` filter tests: substring match, case-insensitive, AND with filename, AND with tag, empty/null no-op
- [x] 1 new `GetPhotosHandler` test: verifies `FolderPath` is forwarded to the repository
- [x] 4 new `TagSidebar` component tests: placeholder render, debounce, "Vymazat" visibility, X clear button
- [x] `dotnet build` — 0 errors
- [x] `dotnet format` — clean
- [x] `dotnet test --filter Photobank` — 32/32 passing
- [x] `npm run build` — 0 errors (regenerates OpenAPI client with new field)
- [x] `npm run lint` — clean on all modified files

## Manual verification

Navigate to `/marketing/photobank`, confirm two text inputs appear in the sidebar (filename + folder path), type a folder fragment and verify the grid filters down, combine with a tag click to verify AND behaviour, click "Vymazat filtry" to confirm both inputs and tags clear.