### PR TITLE
feat: photobank thumbnail proxy — fix broken thumbnails via BE proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ design.r*.md
 spec.md
 spec.r*.md
 task-plan.r*.md
-brief.md
+brief.mdfrontend/node_modules

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Features.Photobank.Services;
 using Anela.Heblo.Domain.Features.Authorization;
+using Anela.Heblo.Domain.Features.Photobank;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -16,10 +19,17 @@ namespace Anela.Heblo.API.Controllers
     public class PhotobankController : BaseApiController
     {
         private readonly IMediator _mediator;
+        private readonly IPhotobankRepository _photobankRepository;
+        private readonly IPhotobankGraphService _photobankGraphService;
 
-        public PhotobankController(IMediator mediator)
+        public PhotobankController(
+            IMediator mediator,
+            IPhotobankRepository photobankRepository,
+            IPhotobankGraphService photobankGraphService)
         {
             _mediator = mediator;
+            _photobankRepository = photobankRepository;
+            _photobankGraphService = photobankGraphService;
         }
 
         /// <summary>
@@ -90,6 +100,52 @@ namespace Anela.Heblo.API.Controllers
             var request = new RemovePhotoTagRequest { PhotoId = id, TagId = tagId };
             var response = await _mediator.Send(request, cancellationToken);
             return HandleResponse(response);
+        }
+
+        [HttpGet("photos/{id:int}/thumbnail/{size}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<IActionResult> GetThumbnail(
+            int id,
+            ThumbnailSize size,
+            CancellationToken cancellationToken = default)
+        {
+            var locator = await _photobankRepository.GetLocatorAsync(id, cancellationToken);
+            if (locator is null)
+            {
+                return NotFound();
+            }
+
+            GraphThumbnail? thumbnail;
+            try
+            {
+                thumbnail = await _photobankGraphService.GetThumbnailAsync(
+                    locator.DriveId, locator.SharePointFileId, size, cancellationToken);
+            }
+            catch (GraphThrottledException ex)
+            {
+                if (ex.RetryAfter.HasValue)
+                {
+                    Response.Headers["Retry-After"] = ((long)ex.RetryAfter.Value.TotalSeconds).ToString();
+                }
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+            catch (HttpRequestException ex)
+            {
+                Logger.LogWarning(ex, "Upstream HTTP error fetching thumbnail for photo {PhotoId}", id);
+                return StatusCode(StatusCodes.Status502BadGateway);
+            }
+
+            if (thumbnail is null)
+            {
+                return NotFound();
+            }
+
+            Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
+
+            return new FileStreamResult(thumbnail.Content, thumbnail.ContentType);
         }
     }
 

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -118,17 +118,19 @@ namespace Anela.Heblo.API.Controllers
                 return NotFound();
             }
 
-            GraphThumbnail? thumbnail;
+            GraphThumbnail? rawThumbnail;
             try
             {
-                thumbnail = await _photobankGraphService.GetThumbnailAsync(
+                rawThumbnail = await _photobankGraphService.GetThumbnailAsync(
                     locator.DriveId, locator.SharePointFileId, size, cancellationToken);
             }
             catch (GraphThrottledException ex)
             {
+                Logger.LogWarning("Microsoft Graph thumbnail request throttled for photo {PhotoId}. RetryAfter: {RetryAfter}",
+                    id, ex.RetryAfter);
                 if (ex.RetryAfter.HasValue)
                 {
-                    Response.Headers["Retry-After"] = ((long)ex.RetryAfter.Value.TotalSeconds).ToString();
+                    Response.Headers["Retry-After"] = ((long)Math.Ceiling(ex.RetryAfter.Value.TotalSeconds)).ToString();
                 }
                 return StatusCode(StatusCodes.Status503ServiceUnavailable);
             }
@@ -138,12 +140,16 @@ namespace Anela.Heblo.API.Controllers
                 return StatusCode(StatusCodes.Status502BadGateway);
             }
 
-            if (thumbnail is null)
+            if (rawThumbnail is null)
             {
                 return NotFound();
             }
 
+            using var thumbnail = rawThumbnail;
+
             Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
+            if (thumbnail.ContentLength.HasValue)
+                Response.ContentLength = thumbnail.ContentLength;
 
             return new FileStreamResult(thumbnail.Content, thumbnail.ContentType);
         }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -17,7 +17,13 @@ public static class PhotobankModule
 
         if (!useMockAuth && !bypassJwtValidation)
         {
-            services.AddHttpClient("MicrosoftGraph");
+            services.AddHttpClient("MicrosoftGraph", client =>
+            {
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
+            }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                AllowAutoRedirect = true,
+            });
             services.AddScoped<IPhotobankGraphService, PhotobankGraphService>();
         }
         else

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -17,10 +17,8 @@ public static class PhotobankModule
 
         if (!useMockAuth && !bypassJwtValidation)
         {
-            services.AddHttpClient("MicrosoftGraph", client =>
-            {
-                client.DefaultRequestHeaders.Add("Accept", "application/json");
-            }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            services.AddHttpClient("MicrosoftGraph", _ => { })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
             {
                 AllowAutoRedirect = true,
             });

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/IPhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/IPhotobankGraphService.cs
@@ -49,7 +49,7 @@ public class GraphDeltaResult
 
 public interface IPhotobankGraphService
 {
-    Task<GraphDeltaResult> GetDeltaAsync(string driveId, string rootItemId, string? deltaLink, CancellationToken ct = default);
-    Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default);
-    Task<GraphThumbnail?> GetThumbnailAsync(string driveId, string fileId, ThumbnailSize size, CancellationToken ct = default);
+    Task<GraphDeltaResult> GetDeltaAsync(string driveId, string rootItemId, string? deltaLink, CancellationToken cancellationToken = default);
+    Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken cancellationToken = default);
+    Task<GraphThumbnail?> GetThumbnailAsync(string driveId, string fileId, ThumbnailSize size, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/IPhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/IPhotobankGraphService.cs
@@ -1,5 +1,20 @@
 namespace Anela.Heblo.Application.Features.Photobank.Services;
 
+public enum ThumbnailSize { Medium, Large }
+
+public sealed record GraphThumbnail(Stream Content, string ContentType, long? ContentLength);
+
+public sealed class GraphThrottledException : Exception
+{
+    public TimeSpan? RetryAfter { get; }
+
+    public GraphThrottledException(TimeSpan? retryAfter)
+        : base("Microsoft Graph API rate limit exceeded (HTTP 429).")
+    {
+        RetryAfter = retryAfter;
+    }
+}
+
 public class GraphPhotoItem
 {
     public string ItemId { get; set; } = string.Empty;
@@ -22,4 +37,5 @@ public interface IPhotobankGraphService
 {
     Task<GraphDeltaResult> GetDeltaAsync(string driveId, string rootItemId, string? deltaLink, CancellationToken ct = default);
     Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default);
+    Task<GraphThumbnail?> GetThumbnailAsync(string driveId, string fileId, ThumbnailSize size, CancellationToken ct = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/IPhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/IPhotobankGraphService.cs
@@ -2,7 +2,21 @@ namespace Anela.Heblo.Application.Features.Photobank.Services;
 
 public enum ThumbnailSize { Medium, Large }
 
-public sealed record GraphThumbnail(Stream Content, string ContentType, long? ContentLength);
+public sealed class GraphThumbnail : IDisposable
+{
+    public Stream Content { get; }
+    public string ContentType { get; }
+    public long? ContentLength { get; }
+
+    public GraphThumbnail(Stream content, string contentType, long? contentLength)
+    {
+        Content = content;
+        ContentType = contentType;
+        ContentLength = contentLength;
+    }
+
+    public void Dispose() => Content.Dispose();
+}
 
 public sealed class GraphThrottledException : Exception
 {

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/MockPhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/MockPhotobankGraphService.cs
@@ -6,6 +6,19 @@ namespace Anela.Heblo.Application.Features.Photobank.Services;
 /// </summary>
 public class MockPhotobankGraphService : IPhotobankGraphService
 {
+    private static readonly byte[] MinimalPng =
+    [
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+        0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41,
+        0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+        0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC,
+        0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+        0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
     public Task<GraphDeltaResult> GetDeltaAsync(
         string driveId,
         string rootItemId,
@@ -21,4 +34,17 @@ public class MockPhotobankGraphService : IPhotobankGraphService
 
     public Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default)
         => Task.FromResult("mock-item-id");
+
+    public Task<GraphThumbnail?> GetThumbnailAsync(
+        string driveId,
+        string fileId,
+        ThumbnailSize size,
+        CancellationToken ct = default)
+    {
+        GraphThumbnail? result = new GraphThumbnail(
+            new MemoryStream(MinimalPng),
+            "image/png",
+            MinimalPng.Length);
+        return Task.FromResult(result);
+    }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/MockPhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/MockPhotobankGraphService.cs
@@ -23,7 +23,7 @@ public class MockPhotobankGraphService : IPhotobankGraphService
         string driveId,
         string rootItemId,
         string? deltaLink,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         return Task.FromResult(new GraphDeltaResult
         {
@@ -32,14 +32,14 @@ public class MockPhotobankGraphService : IPhotobankGraphService
         });
     }
 
-    public Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default)
+    public Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken cancellationToken = default)
         => Task.FromResult("mock-item-id");
 
     public Task<GraphThumbnail?> GetThumbnailAsync(
         string driveId,
         string fileId,
         ThumbnailSize size,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         GraphThumbnail? result = new GraphThumbnail(
             new MemoryStream(MinimalPng),

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
@@ -47,7 +47,7 @@ public class PhotobankGraphService : IPhotobankGraphService
         string driveId,
         string rootItemId,
         string? deltaLink,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         var token = await _tokenAcquisition.GetAccessTokenForAppAsync(GraphScope);
         using var client = _httpClientFactory.CreateClient("MicrosoftGraph");
@@ -64,10 +64,10 @@ public class PhotobankGraphService : IPhotobankGraphService
         {
             var request = CreateRequest(HttpMethod.Get, nextUrl, token);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            var response = await client.SendAsync(request, ct);
+            var response = await client.SendAsync(request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            var page = await DeserializeAsync<GraphDeltaPage>(response, ct);
+            var page = await DeserializeAsync<GraphDeltaPage>(response, cancellationToken);
 
             foreach (var item in page.Value)
             {
@@ -153,7 +153,7 @@ public class PhotobankGraphService : IPhotobankGraphService
         string driveId,
         string fileId,
         ThumbnailSize size,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         var token = await _tokenAcquisition.GetAccessTokenForAppAsync(GraphScope);
         var sizeSegment = size switch
@@ -166,7 +166,7 @@ public class PhotobankGraphService : IPhotobankGraphService
 
         var client = _httpClientFactory.CreateClient("MicrosoftGraph");
         var request = CreateRequest(HttpMethod.Get, url, token);
-        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             return null;
@@ -190,13 +190,13 @@ public class PhotobankGraphService : IPhotobankGraphService
         var contentLength = response.Content.Headers.ContentLength;
 
         var ms = new MemoryStream();
-        await response.Content.CopyToAsync(ms, ct);
+        await response.Content.CopyToAsync(ms, cancellationToken);
         ms.Position = 0;
 
         return new GraphThumbnail(ms, contentType, contentLength);
     }
 
-    public async Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default)
+    public async Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken cancellationToken = default)
     {
         var token = await _tokenAcquisition.GetAccessTokenForAppAsync(GraphScope);
         using var client = _httpClientFactory.CreateClient("MicrosoftGraph");
@@ -207,10 +207,10 @@ public class PhotobankGraphService : IPhotobankGraphService
 
         var request = CreateRequest(HttpMethod.Get, url, token);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        var response = await client.SendAsync(request, ct);
+        var response = await client.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        var item = await DeserializeAsync<GraphItemWithId>(response, ct);
+        var item = await DeserializeAsync<GraphItemWithId>(response, cancellationToken);
         return item.Id;
     }
 

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
@@ -63,6 +63,7 @@ public class PhotobankGraphService : IPhotobankGraphService
         while (!string.IsNullOrEmpty(nextUrl))
         {
             var request = CreateRequest(HttpMethod.Get, nextUrl, token);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             var response = await client.SendAsync(request, ct);
             response.EnsureSuccessStatusCode();
 
@@ -155,17 +156,22 @@ public class PhotobankGraphService : IPhotobankGraphService
         CancellationToken ct = default)
     {
         var token = await _tokenAcquisition.GetAccessTokenForAppAsync(GraphScope);
-        var sizeSegment = size == ThumbnailSize.Large ? "large" : "medium";
+        var sizeSegment = size switch
+        {
+            ThumbnailSize.Medium => "medium",
+            ThumbnailSize.Large  => "large",
+            _ => throw new ArgumentOutOfRangeException(nameof(size), size, null),
+        };
         var url = $"{GraphBaseUrl}/drives/{Uri.EscapeDataString(driveId)}/items/{Uri.EscapeDataString(fileId)}/thumbnails/0/{sizeSegment}/content";
 
-        using var client = _httpClientFactory.CreateClient("MicrosoftGraph");
+        var client = _httpClientFactory.CreateClient("MicrosoftGraph");
         var request = CreateRequest(HttpMethod.Get, url, token);
-        var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
 
         if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             return null;
 
-        if ((int)response.StatusCode == 429)
+        if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
         {
             TimeSpan? retryAfter = null;
             if (response.Headers.TryGetValues("Retry-After", out var values))
@@ -182,9 +188,12 @@ public class PhotobankGraphService : IPhotobankGraphService
 
         var contentType = response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
         var contentLength = response.Content.Headers.ContentLength;
-        var stream = await response.Content.ReadAsStreamAsync(ct);
 
-        return new GraphThumbnail(stream, contentType, contentLength);
+        var ms = new MemoryStream();
+        await response.Content.CopyToAsync(ms, ct);
+        ms.Position = 0;
+
+        return new GraphThumbnail(ms, contentType, contentLength);
     }
 
     public async Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default)
@@ -197,6 +206,7 @@ public class PhotobankGraphService : IPhotobankGraphService
         var url = $"{GraphBaseUrl}/drives/{Uri.EscapeDataString(driveId)}/root:/{encodedPath}:";
 
         var request = CreateRequest(HttpMethod.Get, url, token);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         var response = await client.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
 

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
@@ -159,7 +159,7 @@ public class PhotobankGraphService : IPhotobankGraphService
         var sizeSegment = size switch
         {
             ThumbnailSize.Medium => "medium",
-            ThumbnailSize.Large  => "large",
+            ThumbnailSize.Large => "large",
             _ => throw new ArgumentOutOfRangeException(nameof(size), size, null),
         };
         var url = $"{GraphBaseUrl}/drives/{Uri.EscapeDataString(driveId)}/items/{Uri.EscapeDataString(fileId)}/thumbnails/0/{sizeSegment}/content";

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Services/PhotobankGraphService.cs
@@ -148,6 +148,45 @@ public class PhotobankGraphService : IPhotobankGraphService
         };
     }
 
+    public async Task<GraphThumbnail?> GetThumbnailAsync(
+        string driveId,
+        string fileId,
+        ThumbnailSize size,
+        CancellationToken ct = default)
+    {
+        var token = await _tokenAcquisition.GetAccessTokenForAppAsync(GraphScope);
+        var sizeSegment = size == ThumbnailSize.Large ? "large" : "medium";
+        var url = $"{GraphBaseUrl}/drives/{Uri.EscapeDataString(driveId)}/items/{Uri.EscapeDataString(fileId)}/thumbnails/0/{sizeSegment}/content";
+
+        using var client = _httpClientFactory.CreateClient("MicrosoftGraph");
+        var request = CreateRequest(HttpMethod.Get, url, token);
+        var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return null;
+
+        if ((int)response.StatusCode == 429)
+        {
+            TimeSpan? retryAfter = null;
+            if (response.Headers.TryGetValues("Retry-After", out var values))
+            {
+                var headerValue = values.FirstOrDefault();
+                if (headerValue != null && int.TryParse(headerValue, out var seconds))
+                    retryAfter = TimeSpan.FromSeconds(seconds);
+            }
+
+            throw new GraphThrottledException(retryAfter);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var contentType = response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
+        var contentLength = response.Content.Headers.ContentLength;
+        var stream = await response.Content.ReadAsStreamAsync(ct);
+
+        return new GraphThumbnail(stream, contentType, contentLength);
+    }
+
     public async Task<string> ResolveItemIdAsync(string driveId, string folderPath, CancellationToken ct = default)
     {
         var token = await _tokenAcquisition.GetAccessTokenForAppAsync(GraphScope);

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 namespace Anela.Heblo.Domain.Features.Photobank
 {
+    public sealed record PhotoLocator(string DriveId, string SharePointFileId, DateTime ModifiedAt);
+
     public interface IPhotobankRepository
     {
         // Photos
@@ -12,6 +14,8 @@ namespace Anela.Heblo.Domain.Features.Photobank
             CancellationToken cancellationToken);
 
         Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken);
+
+        Task<PhotoLocator?> GetLocatorAsync(int id, CancellationToken cancellationToken);
 
         // Tags
         Task<List<(Tag Tag, int Count)>> GetTagsWithCountsAsync(CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Photobank/PhotobankRepository.cs
@@ -66,6 +66,19 @@ namespace Anela.Heblo.Persistence.Photobank
                 .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
         }
 
+        public async Task<PhotoLocator?> GetLocatorAsync(int id, CancellationToken cancellationToken)
+        {
+            var projection = await _context.Photos
+                .Where(p => p.Id == id)
+                .Select(p => new { p.DriveId, p.SharePointFileId, p.ModifiedAt })
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (projection == null || projection.DriveId == null)
+                return null;
+
+            return new PhotoLocator(projection.DriveId, projection.SharePointFileId, projection.ModifiedAt);
+        }
+
         // Tags
 
         public async Task<List<(Tag Tag, int Count)>> GetTagsWithCountsAsync(CancellationToken cancellationToken)

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
@@ -1,0 +1,202 @@
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Security.Claims;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public sealed class PhotobankControllerThumbnailTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly Mock<IPhotobankGraphService> _graphServiceMock;
+    private readonly PhotobankController _controller;
+
+    public PhotobankControllerThumbnailTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _graphServiceMock = new Mock<IPhotobankGraphService>();
+
+        _controller = new PhotobankController(
+            _mediatorMock.Object,
+            _repositoryMock.Object,
+            _graphServiceMock.Object);
+
+        SetupHttpContext();
+    }
+
+    private void SetupHttpContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, "test-user") })),
+            RequestServices = services.BuildServiceProvider()
+        };
+
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+    }
+
+    [Fact]
+    public async Task GetThumbnail_ReturnsNotFound_WhenPhotoNotInDatabase()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PhotoLocator?)null);
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_ReturnsNotFound_WhenGraphReturnsNullThumbnail()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GraphThumbnail?)null);
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503WithRetryAfter_WhenGraphThrottles()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GraphThrottledException(TimeSpan.FromSeconds(30)));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers["Retry-After"].ToString().Should().Be("30");
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503WithoutRetryAfter_WhenThrottledWithNullRetryAfter()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GraphThrottledException(null));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers.ContainsKey("Retry-After").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns502_WhenGraphThrowsHttpRequestException()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("upstream error"));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns200WithCacheHeaders_WhenSuccessful()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        var imageBytes = new byte[] { 1, 2, 3, 4, 5 };
+        var stream = new MemoryStream(imageBytes);
+        var thumbnail = new GraphThumbnail(stream, "image/jpeg", null);
+
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thumbnail);
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var fileResult = result.Should().BeOfType<FileStreamResult>().Subject;
+        fileResult.ContentType.Should().Be("image/jpeg");
+        _controller.Response.Headers["Cache-Control"].ToString().Should().Be("public, max-age=31536000, immutable");
+    }
+
+    [Fact]
+    public async Task GetThumbnail_ForwardsContentLength_WhenAvailable()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var thumbnail = new GraphThumbnail(stream, "image/jpeg", 12345L);
+
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thumbnail);
+
+        // Act
+        await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        _controller.Response.ContentLength.Should().Be(12345L);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
@@ -195,7 +195,7 @@ public sealed class PhotobankControllerThumbnailTests
             .ReturnsAsync(thumbnail);
 
         // Act
-        await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
 
         // Assert
         result.Should().BeOfType<FileStreamResult>();

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
@@ -95,7 +95,7 @@ public sealed class PhotobankControllerThumbnailTests
 
         _graphServiceMock
             .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new GraphThrottledException(TimeSpan.FromSeconds(30)));
+            .ThrowsAsync(new GraphThrottledException(TimeSpan.FromSeconds(29.3)));
 
         // Act
         var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
@@ -174,6 +174,7 @@ public sealed class PhotobankControllerThumbnailTests
         // Assert
         var fileResult = result.Should().BeOfType<FileStreamResult>().Subject;
         fileResult.ContentType.Should().Be("image/jpeg");
+        fileResult.FileStream.Should().BeSameAs(stream);
         _controller.Response.Headers["Cache-Control"].ToString().Should().Be("public, max-age=31536000, immutable");
     }
 
@@ -197,6 +198,7 @@ public sealed class PhotobankControllerThumbnailTests
         await _controller.GetThumbnail(1, ThumbnailSize.Medium);
 
         // Assert
+        result.Should().BeOfType<FileStreamResult>();
         _controller.Response.ContentLength.Should().Be(12345L);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankGraphServiceThumbnailTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankGraphServiceThumbnailTests.cs
@@ -1,0 +1,236 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Anela.Heblo.Application.Features.Photobank.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Web;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class PhotobankGraphServiceThumbnailTests
+{
+    private const string DriveId = "drive-abc";
+    private const string FileId = "file-xyz";
+
+    private static PhotobankGraphService CreateService(
+        Mock<HttpMessageHandler> handlerMock,
+        Mock<ITokenAcquisition> tokenMock)
+    {
+        tokenMock
+            .Setup(t => t.GetAccessTokenForAppAsync(It.IsAny<string>(), null, null))
+            .ReturnsAsync("test-token");
+
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("https://graph.microsoft.com/")
+        };
+
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(httpClient);
+
+        return new PhotobankGraphService(
+            tokenMock.Object,
+            factoryMock.Object,
+            NullLogger<PhotobankGraphService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_ReturnsGraphThumbnail_WhenGraphReturns200()
+    {
+        // Arrange
+        var imageBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }; // minimal JPEG header bytes
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(imageBytes)
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+        response.Content.Headers.ContentLength = imageBytes.Length;
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        var result = await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.ContentType.Should().Be("image/jpeg");
+        result.ContentLength.Should().Be(imageBytes.Length);
+        result.Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_BuildsCorrectUrl_ForMediumSize()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([])
+            });
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+
+        // Assert
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.RequestUri!.ToString().Should().Contain("thumbnails/0/medium/content");
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_BuildsCorrectUrl_ForLargeSize()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([])
+            });
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Large);
+
+        // Assert
+        capturedRequest!.RequestUri!.ToString().Should().Contain("thumbnails/0/large/content");
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_ReturnsNull_WhenGraphReturns404()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        var result = await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_ThrowsGraphThrottledException_WhenGraphReturns429()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        var response429 = new HttpResponseMessage((HttpStatusCode)429);
+        response429.Headers.Add("Retry-After", "30");
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response429);
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        var act = async () => await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+
+        // Assert
+        var ex = await act.Should().ThrowAsync<GraphThrottledException>();
+        ex.Which.RetryAfter.Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_ThrowsGraphThrottledException_WhenGraphReturns429_WithNoRetryAfterHeader()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage((HttpStatusCode)429));
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        var act = async () => await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+
+        // Assert
+        var ex = await act.Should().ThrowAsync<GraphThrottledException>();
+        ex.Which.RetryAfter.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetThumbnailAsync_ThrowsHttpRequestException_WhenGraphReturns500()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var tokenMock = new Mock<ITokenAcquisition>();
+
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var service = CreateService(handlerMock, tokenMock);
+
+        // Act
+        var act = async () => await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankGraphServiceThumbnailTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankGraphServiceThumbnailTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Photobank;
 
-public class PhotobankGraphServiceThumbnailTests
+public sealed class PhotobankGraphServiceThumbnailTests
 {
     private const string DriveId = "drive-abc";
     private const string FileId = "file-xyz";
@@ -74,8 +74,10 @@ public class PhotobankGraphServiceThumbnailTests
         result.Content.Should().NotBeNull();
     }
 
-    [Fact]
-    public async Task GetThumbnailAsync_BuildsCorrectUrl_ForMediumSize()
+    [Theory]
+    [InlineData(ThumbnailSize.Medium, "thumbnails/0/medium/content")]
+    [InlineData(ThumbnailSize.Large,  "thumbnails/0/large/content")]
+    public async Task GetThumbnailAsync_BuildsCorrectUrl(ThumbnailSize size, string expectedSegment)
     {
         // Arrange
         HttpRequestMessage? capturedRequest = null;
@@ -97,40 +99,11 @@ public class PhotobankGraphServiceThumbnailTests
         var service = CreateService(handlerMock, tokenMock);
 
         // Act
-        await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Medium);
+        await service.GetThumbnailAsync(DriveId, FileId, size);
 
         // Assert
         capturedRequest.Should().NotBeNull();
-        capturedRequest!.RequestUri!.ToString().Should().Contain("thumbnails/0/medium/content");
-    }
-
-    [Fact]
-    public async Task GetThumbnailAsync_BuildsCorrectUrl_ForLargeSize()
-    {
-        // Arrange
-        HttpRequestMessage? capturedRequest = null;
-        var handlerMock = new Mock<HttpMessageHandler>();
-        var tokenMock = new Mock<ITokenAcquisition>();
-
-        handlerMock
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new ByteArrayContent([])
-            });
-
-        var service = CreateService(handlerMock, tokenMock);
-
-        // Act
-        await service.GetThumbnailAsync(DriveId, FileId, ThumbnailSize.Large);
-
-        // Assert
-        capturedRequest!.RequestUri!.ToString().Should().Contain("thumbnails/0/large/content");
+        capturedRequest!.RequestUri!.ToString().Should().Contain(expectedSegment);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankGraphServiceThumbnailTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankGraphServiceThumbnailTests.cs
@@ -76,7 +76,7 @@ public sealed class PhotobankGraphServiceThumbnailTests
 
     [Theory]
     [InlineData(ThumbnailSize.Medium, "thumbnails/0/medium/content")]
-    [InlineData(ThumbnailSize.Large,  "thumbnails/0/large/content")]
+    [InlineData(ThumbnailSize.Large, "thumbnails/0/large/content")]
     public async Task GetThumbnailAsync_BuildsCorrectUrl(ThumbnailSize size, string expectedSegment)
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetLocatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetLocatorTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Photobank;
 
-public class PhotobankRepositoryGetLocatorTests : IDisposable
+public sealed class PhotobankRepositoryGetLocatorTests : IAsyncLifetime
 {
     private readonly ApplicationDbContext _context;
     private readonly PhotobankRepository _repository;
@@ -82,8 +82,7 @@ public class PhotobankRepositoryGetLocatorTests : IDisposable
         result.Should().BeNull();
     }
 
-    public void Dispose()
-    {
-        _context.Dispose();
-    }
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _context.DisposeAsync();
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetLocatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetLocatorTests.cs
@@ -1,0 +1,89 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Photobank;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class PhotobankRepositoryGetLocatorTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly PhotobankRepository _repository;
+
+    public PhotobankRepositoryGetLocatorTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"PhotobankLocatorTests_{Guid.NewGuid()}")
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new PhotobankRepository(_context);
+    }
+
+    [Fact]
+    public async Task GetLocatorAsync_ReturnsLocator_WhenPhotoExists()
+    {
+        // Arrange
+        var modifiedAt = new DateTime(2026, 3, 15, 10, 0, 0, DateTimeKind.Utc);
+        var photo = new Photo
+        {
+            SharePointFileId = "sp-file-001",
+            DriveId = "drive-abc",
+            FileName = "photo.jpg",
+            FolderPath = "/Fotky",
+            ModifiedAt = modifiedAt,
+            IndexedAt = DateTime.UtcNow,
+        };
+        _context.Photos.Add(photo);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetLocatorAsync(photo.Id, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.DriveId.Should().Be("drive-abc");
+        result.SharePointFileId.Should().Be("sp-file-001");
+        result.ModifiedAt.Should().Be(modifiedAt);
+    }
+
+    [Fact]
+    public async Task GetLocatorAsync_ReturnsNull_WhenPhotoDoesNotExist()
+    {
+        // Act
+        var result = await _repository.GetLocatorAsync(99999, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetLocatorAsync_ReturnsNull_WhenPhotoHasNullDriveId()
+    {
+        // Arrange
+        var photo = new Photo
+        {
+            SharePointFileId = "sp-file-no-drive",
+            DriveId = null,
+            FileName = "photo.jpg",
+            FolderPath = "/Fotky",
+            ModifiedAt = DateTime.UtcNow,
+            IndexedAt = DateTime.UtcNow,
+        };
+        _context.Photos.Add(photo);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _repository.GetLocatorAsync(photo.Id, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
@@ -80,8 +80,8 @@ const PhotoDrawer: React.FC<PhotoDrawerProps> = ({ photo, onClose }) => {
       {/* Thumbnail */}
       <div className="p-3 border-b border-gray-100">
         <PhotoThumbnail
-          driveId={photo.driveId}
-          fileId={photo.sharePointFileId}
+          photoId={photo.id}
+          modifiedAt={photo.lastModifiedAt}
           alt={photo.name}
           className="w-full aspect-square"
           size="large"

--- a/frontend/src/components/marketing/photobank/PhotoGrid.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoGrid.tsx
@@ -72,8 +72,8 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                 aria-label={photo.name}
               >
                 <PhotoThumbnail
-                  driveId={photo.driveId}
-                  fileId={photo.sharePointFileId}
+                  photoId={photo.id}
+                  modifiedAt={photo.lastModifiedAt}
                   alt={photo.name}
                   className="w-full h-full"
                   size="medium"

--- a/frontend/src/components/marketing/photobank/PhotoThumbnail.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoThumbnail.tsx
@@ -1,110 +1,28 @@
-import React, { useEffect, useState } from "react";
-import { useMsal } from "@azure/msal-react";
-import { InteractionRequiredAuthError } from "@azure/msal-browser";
+import React, { useState } from "react";
 import { ImageIcon } from "lucide-react";
+import { getConfig } from "../../../config/runtimeConfig";
 
 interface PhotoThumbnailProps {
-  driveId: string | null;
-  fileId: string;
+  photoId: number;
+  modifiedAt: string;
   alt: string;
   className?: string;
   size?: "medium" | "large";
 }
 
-const FILES_READ_SCOPE = "Files.Read.All";
-
-const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({
-  driveId,
-  fileId,
+function PhotoThumbnail({
+  photoId,
+  modifiedAt,
   alt,
   className = "",
   size = "medium",
-}) => {
-  const { instance, accounts } = useMsal();
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+}: PhotoThumbnailProps) {
   const [hasError, setHasError] = useState(false);
 
-  useEffect(() => {
-    if (!driveId) {
-      setIsLoading(false);
-      setHasError(true);
-      return;
-    }
+  const version = new Date(modifiedAt).getTime();
+  const url = `${getConfig().apiUrl}/api/photobank/photos/${photoId}/thumbnail/${size}?v=${version}`;
 
-    let cancelled = false;
-    let createdObjectUrl: string | null = null;
-
-    const fetchThumbnail = async () => {
-      setIsLoading(true);
-      setHasError(false);
-
-      try {
-        const account = accounts[0];
-        if (!account) {
-          setHasError(true);
-          return;
-        }
-
-        let tokenResponse = null;
-        try {
-          tokenResponse = await instance.acquireTokenSilent({
-            scopes: [FILES_READ_SCOPE],
-            account,
-          });
-        } catch (err) {
-          if (err instanceof InteractionRequiredAuthError) {
-            setHasError(true);
-            return;
-          }
-          throw err;
-        }
-
-        const url =
-          `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${fileId}` +
-          `/thumbnails/0/${size}/content`;
-
-        const response = await fetch(url, {
-          headers: { Authorization: `Bearer ${tokenResponse.accessToken}` },
-        });
-
-        if (!response.ok) {
-          setHasError(true);
-          return;
-        }
-
-        const blob = await response.blob();
-        if (cancelled) return;
-
-        createdObjectUrl = URL.createObjectURL(blob);
-        setObjectUrl(createdObjectUrl);
-      } catch {
-        if (!cancelled) setHasError(true);
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    };
-
-    fetchThumbnail();
-
-    return () => {
-      cancelled = true;
-      if (createdObjectUrl) {
-        URL.revokeObjectURL(createdObjectUrl);
-      }
-    };
-  }, [driveId, fileId, size, instance, accounts]);
-
-  if (isLoading) {
-    return (
-      <div
-        className={`animate-pulse bg-gray-200 rounded ${className}`}
-        aria-label="Načítání náhledu..."
-      />
-    );
-  }
-
-  if (hasError || !objectUrl) {
+  if (hasError) {
     return (
       <div
         className={`flex items-center justify-center bg-gray-100 rounded text-gray-400 ${className}`}
@@ -117,11 +35,13 @@ const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({
 
   return (
     <img
-      src={objectUrl}
+      src={url}
       alt={alt}
+      loading="lazy"
+      onError={() => setHasError(true)}
       className={`object-cover rounded ${className}`}
     />
   );
-};
+}
 
 export default PhotoThumbnail;

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoThumbnail.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoThumbnail.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PhotoThumbnail from "../PhotoThumbnail";
+
+jest.mock("../../../../config/runtimeConfig", () => ({
+  getConfig: () => ({ apiUrl: "http://localhost:5001" }),
+}));
+
+describe("PhotoThumbnail", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders img with correct URL including photoId, size, and cache-bust param", () => {
+    // Arrange
+    const modifiedAt = "2026-01-15T10:00:00Z";
+    const expectedVersion = new Date(modifiedAt).getTime();
+
+    // Act
+    render(
+      <PhotoThumbnail
+        photoId={42}
+        modifiedAt={modifiedAt}
+        alt="Test photo"
+        size="medium"
+      />,
+    );
+
+    // Assert
+    const img = screen.getByRole("img", { name: "Test photo" });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute(
+      "src",
+      expect.stringContaining("/api/photobank/photos/42/thumbnail/medium"),
+    );
+    expect(img).toHaveAttribute(
+      "src",
+      expect.stringContaining(`?v=${expectedVersion}`),
+    );
+    expect(img).toHaveAttribute("loading", "lazy");
+  });
+
+  test("renders large size URL when size is large", () => {
+    // Arrange & Act
+    render(
+      <PhotoThumbnail
+        photoId={10}
+        modifiedAt="2026-01-15T10:00:00Z"
+        alt="Large photo"
+        size="large"
+      />,
+    );
+
+    // Assert
+    const img = screen.getByRole("img", { name: "Large photo" });
+    expect(img).toHaveAttribute(
+      "src",
+      expect.stringContaining("/thumbnail/large"),
+    );
+  });
+
+  test("shows placeholder when img fires onError", () => {
+    // Arrange
+    render(
+      <PhotoThumbnail
+        photoId={7}
+        modifiedAt="2026-01-15T10:00:00Z"
+        alt="Error photo"
+        size="medium"
+      />,
+    );
+
+    const img = screen.getByRole("img", { name: "Error photo" });
+
+    // Act
+    fireEvent.error(img);
+
+    // Assert
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Náhled není k dispozici"),
+    ).toBeInTheDocument();
+  });
+
+  test("uses modifiedAt as cache-bust version parameter", () => {
+    // Arrange
+    const modifiedAt1 = "2026-01-15T10:00:00Z";
+    const modifiedAt2 = "2026-03-20T12:30:00Z";
+    const version1 = new Date(modifiedAt1).getTime();
+    const version2 = new Date(modifiedAt2).getTime();
+
+    // Act
+    const { rerender } = render(
+      <PhotoThumbnail photoId={1} modifiedAt={modifiedAt1} alt="photo" />,
+    );
+    const img1 = screen.getByRole("img", { name: "photo" });
+    const src1 = img1.getAttribute("src") ?? "";
+
+    rerender(
+      <PhotoThumbnail photoId={1} modifiedAt={modifiedAt2} alt="photo" />,
+    );
+    const img2 = screen.getByRole("img", { name: "photo" });
+    const src2 = img2.getAttribute("src") ?? "";
+
+    // Assert
+    expect(src1).toContain(`?v=${version1}`);
+    expect(src2).toContain(`?v=${version2}`);
+    expect(src1).not.toBe(src2);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixes broken thumbnails** — replaces the MSAL-based client-side Graph fetch (broken due to unconsented `Files.Read.All` scope and no HTTP cache) with a thin BE proxy endpoint that uses the existing app-level token
- **New endpoint** `GET /api/photobank/photos/{id}/thumbnail/{size}?v={modifiedAtMs}` — streams Graph thumbnail bytes back to browser with `Cache-Control: public, max-age=31536000, immutable` + `Retry-After` forwarding on 429
- **Frontend simplified** — `PhotoThumbnail.tsx` collapses from ~130 to ~35 LOC: plain `<img loading="lazy">`, no MSAL, no `useEffect`, no blob URLs; cache-busting via `?v={modifiedAt}` query param

## Changes

### Backend
- `IPhotobankGraphService` — added `ThumbnailSize` enum, `GraphThumbnail` (IDisposable), `GraphThrottledException` (with `RetryAfter`), `GetThumbnailAsync`
- `PhotobankGraphService` — streams Graph response via `HttpCompletionOption.ResponseHeadersRead` → `MemoryStream`, handles 404/429/5xx
- `IPhotobankRepository` + `PhotobankRepository` — added `PhotoLocator` record and `GetLocatorAsync(int id)` (projection query, no Tags loaded)
- `PhotobankController` — new `GetThumbnail` endpoint with cache headers, throttle forwarding, and structured logging

### Frontend
- `PhotoThumbnail.tsx` — rewritten to `<img src={proxyUrl} loading="lazy" onError>`, dropped all MSAL/Graph dependencies
- `PhotoGrid.tsx`, `PhotoDrawer.tsx` — updated call sites: `driveId` + `fileId` → `photoId` + `modifiedAt`

### Tests
- `PhotobankGraphServiceThumbnailTests` — 10 unit tests (URL shape, null on 404, GraphThrottledException on 429, stream pass-through)
- `PhotobankRepositoryGetLocatorTests` — 3 unit tests (found, not found, null DriveId)
- `PhotobankControllerThumbnailTests` — 7 unit tests (all status code paths, cache headers, Retry-After, ContentLength)
- `PhotoThumbnail.test.tsx` — 4 tests (URL construction, lazy loading, onError placeholder, cache-bust variation)

## Test Plan

- [ ] `dotnet test` — 2704 passing, 0 failing
- [ ] `npm test` — PhotoThumbnail + PhotoGrid tests pass
- [ ] `npm run build && npm run lint` — clean
- [ ] Manual: navigate to `/marketing/photobank` — all thumbnails render (no placeholder icons)
- [ ] Manual: DevTools → Network → reload → thumbnails served from disk cache on second load
- [ ] Manual: drawer opens with `large` thumbnail
- [ ] Manual: inspect response headers → `Cache-Control: public, max-age=31536000, immutable`