### PR TITLE
feat: leaflet generation persistence + 1-5 feedback (phase 2) (#932)

### DIFF
--- a/.agents/analyst.md
+++ b/.agents/analyst.md
@@ -3,7 +3,7 @@ id: analyst
 display_name: "Analyst Agent"
 model: claude-opus-4-7
 phase: analyzing
-max_turns: 1
+max_turns: 50
 allowed_tools: []
 output_format: markdown
 visibility_timeout: 600

--- a/.agents/designer.md
+++ b/.agents/designer.md
@@ -3,7 +3,7 @@ id: designer
 display_name: "Designer Agent"
 model: claude-sonnet-4-6
 phase: designing
-max_turns: 1
+max_turns: 50
 allowed_tools: []
 output_format: markdown
 visibility_timeout: 600

--- a/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/arch-review.r1.md
+++ b/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/arch-review.r1.md
@@ -1,0 +1,214 @@
+I've gathered enough context. Let me write the architecture review.
+
+# Architecture Review: Phase 1 — UI Consolidation & SharePoint Link-Back
+
+## Architectural Fit Assessment
+
+This feature is a **surgical, additive change** that fits cleanly into existing patterns:
+
+- **Backend**: MediatR Vertical Slice handlers under `Features/{Module}/UseCases/{UseCase}/`. The change is purely additive — extend two existing response DTOs, populate one new field in two handlers. No interface changes, no new endpoints, no new persistence types. The `Document` navigation property is already eagerly loaded in both `GetChunkByIdAsync` implementations (verified: `KnowledgeBaseRepository.cs:204-209` and `LeafletRepository.cs:218-223` both call `.Include(c => c.Document)`).
+- **Frontend**: A small render addition to two modals + a stateless utility helper + sidebar restructure + one stub page.
+- **Integration risk**: Low. The OpenAPI client regenerates on `npm run build`; new optional field is non-breaking.
+
+**Significant spec drift from current code (must be reconciled before implementation):**
+
+1. There is **no duplicate `marketing` section** in `Sidebar.tsx`. The file has exactly one section with `id: 'marketing'` (lines 140–149), and a separate `id: 'knowledgebase'` section (lines 299–314). The "duplicate-id bug" described in the brief and FR-1 does not exist in the current source.
+2. **No `TrendingUp` import** exists in `Sidebar.tsx` (verified: lines 1–22 show only `LayoutDashboard, Package, ShoppingCart, ChevronDown, ChevronRight, PanelLeftClose, PanelLeftOpen, Menu, DollarSign, Cog, Truck, Bot, Newspaper, Users, ExternalLink, FileText, Database, Megaphone`).
+3. **No `Campaigns` item** in the sidebar; FR-2 has nothing to act on.
+4. **No standalone `GetChunkDetailResponse.cs` file**. The response class is co-located in `GetChunkDetailRequest.cs:12-26` (KB) and `GetLeafletChunkDetailRequest.cs:11-24` (Leaflet). Spec instructions referring to `GetChunkDetailResponse.cs` and `GetLeafletChunkDetailResponse.cs` must edit the request files instead.
+5. **`SourcePath` on the domain entities is `string`, not nullable** (`KnowledgeBaseDocument.cs:7` and `LeafletDocument.cs:7`, both `string SourcePath { get; set; } = string.Empty;`). The "no source path" sentinel is therefore an empty string, not null. The DTO field can still be declared `string?` for defensive nullability, but the handler assignment will never actually produce `null` from current data.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Frontend
+├─ components/layout/Sidebar.tsx          ← consolidate marketing items
+├─ pages/MarketingFeedbackPage.tsx        ← NEW stub
+├─ utils/sharepointLink.ts                ← NEW pure helper (renamed from spec)
+├─ components/knowledge-base/
+│   └─ ChunkDetailModal.tsx               ← render link
+└─ features/leaflet-generator/
+    └─ LeafletChunkDetailModal.tsx        ← render link
+App.tsx                                    ← register /marketing/feedback
+
+Backend
+├─ Features/KnowledgeBase/UseCases/GetChunkDetail/
+│   ├─ GetChunkDetailRequest.cs           ← extend Response (same file)
+│   └─ GetChunkDetailHandler.cs           ← assign SourcePath
+└─ Features/Leaflet/UseCases/GetLeafletChunkDetail/
+    ├─ GetLeafletChunkDetailRequest.cs    ← extend Response (same file)
+    └─ GetLeafletChunkDetailHandler.cs    ← assign SourcePath
+```
+
+No changes to repositories, persistence, or domain layer. The eager-load and DB column already exist.
+
+### Key Design Decisions
+
+#### Decision 1: Where to place the SharePoint link helper
+
+**Options considered:**
+- A. `frontend/src/api/hooks/useSharePointLink.ts` exporting `getSharePointLink` (per spec).
+- B. `frontend/src/utils/sharepointLink.ts` exporting `getSharePointLink`.
+- C. Inline the four-line check inside each modal.
+
+**Chosen approach:** **B — `frontend/src/utils/sharepointLink.ts`**.
+
+**Rationale:** The function is a pure synchronous predicate with no React state, no hooks, no API calls. Filing it under `api/hooks/` and prefixing it `use…` violates the established naming convention (`hasRole`, `useDebounce`, `useChunkDetailQuery`) where `use*` denotes a React hook and `api/hooks/` houses TanStack-Query wrappers (see `useKnowledgeBase.ts`, `useLeaflet.ts`). C is rejected because both modals need the same logic and a tested centralized predicate is cheap. The brief proposes A; that location is misleading and I recommend amending the spec.
+
+#### Decision 2: DTO nullability of `SourcePath`
+
+**Options considered:**
+- A. `public string SourcePath { get; set; } = string.Empty;` — match the entity.
+- B. `public string? SourcePath { get; set; }` — defensive (per spec).
+
+**Chosen approach:** **B — `string?`**.
+
+**Rationale:** The OpenAPI generator emits `sourcePath?: string` on the TS side regardless, and the frontend helper treats null/undefined/empty/upload-prefix all as "no link". B keeps the API contract honest about possible absence and gives flexibility if a future ingestion path leaves `SourcePath` unset. The handler assignment `SourcePath = chunk.Document.SourcePath` will pass empty strings through; the helper handles them correctly. No transformation needed.
+
+#### Decision 3: Sidebar consolidation strategy
+
+**Options considered:**
+- A. Treat the spec's "remove duplicate marketing section" task literally — write code to delete a section that doesn't exist.
+- B. Reinterpret the goal as: merge the existing single `marketing` section with the existing `knowledgebase` section, drop FR-2, and add Articles.
+
+**Chosen approach:** **B**.
+
+**Rationale:** The brief's premise ("two sections share id: 'marketing'") is stale. The actual goal — surfacing all three RAG features under one Marketing group — is achievable by extending the existing `marketing` section and removing the `knowledgebase` section. Spec amendment captures this.
+
+#### Decision 4: Fate of `/knowledge-base/feedback` and `KnowledgeBaseFeedbackPage.tsx`
+
+**Options considered:**
+- A. Leave the existing route registered but orphaned (no sidebar link points to it) until Phase 4.
+- B. Delete the route and the page now.
+- C. Redirect `/knowledge-base/feedback` → `/marketing/feedback`.
+
+**Chosen approach:** **A — leave it untouched**.
+
+**Rationale:** "Surgical changes" rule per project CLAUDE.md. Phase 1 is consolidation + link-back; deleting an unrelated page is out of scope. The orphan route is harmless (still gated by `AuthGuard`); Phase 4 will collapse the two feedback views into one.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**New files:**
+- `frontend/src/utils/sharepointLink.ts` — pure helper.
+- `frontend/src/utils/sharepointLink.test.ts` — unit tests.
+- `frontend/src/pages/MarketingFeedbackPage.tsx` — stub page.
+
+**Modified files:**
+- `frontend/src/components/layout/Sidebar.tsx` — extend marketing section, remove knowledgebase section, drop unused `Database` icon if grep confirms no other usage.
+- `frontend/src/App.tsx` — import + register `/marketing/feedback` route inside the existing `<AuthGuard>`/`<Layout>` block.
+- `frontend/src/components/knowledge-base/ChunkDetailModal.tsx` — insert link after the meta row (line 74 in current file).
+- `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx` — same change after meta row (line 66).
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs` — add `SourcePath` to the colocated `GetChunkDetailResponse` class.
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs` — add `SourcePath = chunk.Document.SourcePath,` to the response init (line 35 area).
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs` — add `SourcePath` to the colocated response class.
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs` — add `SourcePath = chunk.Document.SourcePath,` to the response init.
+
+**Files NOT to modify:** Repositories (`KnowledgeBaseRepository.cs`, `LeafletRepository.cs`) — `.Include(c => c.Document)` is already in place. `IKnowledgeBaseRepository`, `ILeafletRepository` — unchanged.
+
+### Interfaces and Contracts
+
+**Backend DTO (additive, both classes):**
+```csharp
+public string? SourcePath { get; set; }
+```
+
+**Frontend helper (pure, no React):**
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null {
+  if (!sourcePath) return null;
+  if (sourcePath.startsWith("https://")) return sourcePath;
+  return null;
+}
+```
+
+**Modal link block (identical in both modals):**
+```tsx
+{getSharePointLink(data.sourcePath) && (
+  <a
+    href={getSharePointLink(data.sourcePath)!}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+  >
+    Otevřít v SharePoint
+    <ExternalLink className="w-3 h-3" />
+  </a>
+)}
+```
+
+**Sidebar consolidated section (replaces lines 140–149 and removes lines 299–314):**
+```ts
+{
+  id: "marketing",
+  name: "Marketing",
+  icon: Megaphone,
+  type: "section" as const,
+  items: [
+    { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
+    { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+    { id: "articles", name: "Generátor článků", href: "/articles" },
+    { id: "knowledge-base", name: "Poradenství (KB)", href: "/knowledge-base" },
+    ...(hasRole("knowledge_base_manager") || hasRole("leaflet_manager") || hasRole("article_generator")
+      ? [{ id: "marketing-feedback", name: "Feedback", href: "/marketing/feedback" }]
+      : []),
+  ],
+},
+```
+
+### Data Flow
+
+**Chunk detail click → SharePoint link rendering:**
+```
+User clicks chunk row in Documents tab
+  → Modal opens, calls useChunkDetailQuery(chunkId)
+  → API GET /api/knowledge-base/chunks/{id}
+  → MediatR: GetChunkDetailRequest → GetChunkDetailHandler.Handle
+  → repo.GetChunkByIdAsync (already includes Document)
+  → handler maps chunk.Document.SourcePath → response.SourcePath
+  → JSON body now contains "sourcePath": "https://..." or "upload/..." or ""
+  → useChunkDetailQuery returns data with sourcePath populated
+  → Modal calls getSharePointLink(data.sourcePath)
+    → Returns the URL only if it starts with "https://"
+  → Anchor renders or is omitted
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec drift (no duplicate id; no TrendingUp; no Campaigns) leads developer to look for code that doesn't exist and waste cycles. | MEDIUM | Amend the spec (see below) to describe the actual current structure. PR description should explicitly state "no duplicate id existed; consolidation is just a merge of `marketing` + `knowledgebase`". |
+| `SourcePath` empty-string passed through could cause the helper to render an empty/broken link if logic is wrong. | LOW | The helper's `if (!sourcePath)` already covers `""`. Add explicit empty-string test case to `sharepointLink.test.ts`. |
+| Removing the `Database` icon import breaks if used elsewhere in `Sidebar.tsx`. | LOW | Grep `Database` within `Sidebar.tsx` before removal; only drop if zero other usages. |
+| Open-redirect via attacker-controlled `SourcePath` (e.g., `https://evil.com`). | LOW | `SourcePath` is server-controlled (set during ingestion from SharePoint Graph API or upload pipeline) and not user-mutable from the chunk detail surface. `rel="noopener noreferrer"` mitigates window.opener leakage. Acceptable for Phase 1. |
+| OpenAPI client regen drift: stale generated TS file gets committed alongside hand edits. | LOW | The TS client is auto-regenerated on `npm run build`. Confirm post-build diff in `frontend/src/api/generated/api-client.ts` only contains the additive `sourcePath?: string` and commit it. |
+| Orphaned `/knowledge-base/feedback` route confuses users who bookmarked it. | LOW | Out of scope; Phase 4 reconciles. Document the orphan in PR description. |
+| Sidebar `expandedSections` state may show wrong group expanded if a user has the old `knowledgebase` id stored. | NONE | State is in-memory React `useState`; not persisted. No migration needed. |
+
+## Specification Amendments
+
+1. **FR-1 (rewrite premise):** Drop the language about a "duplicate `id: 'marketing'`" and `TrendingUp`-iconned orphan section. The actual change is: extend the existing single `marketing` section (currently containing only Kalendář + Generátor letáků), append Generátor článků, Poradenství (KB), and the conditional Feedback item, then remove the standalone `knowledgebase` section (lines 299–314 in current `Sidebar.tsx`). Remove `Database` from the lucide-react import. `TrendingUp` is already absent.
+
+2. **FR-2 (delete entirely):** No `Campaigns` item exists. Nothing to decide.
+
+3. **FR-4 / FR-5 file paths:** The response class lives in the same file as the request (`GetChunkDetailRequest.cs` and `GetLeafletChunkDetailRequest.cs`). Edit those files; do not create new `*Response.cs` files.
+
+4. **FR-4 / FR-5 nullability note:** The domain entity's `SourcePath` is non-nullable `string` defaulting to empty. DTO field stays `string?` (defensive contract); handler assignment `SourcePath = chunk.Document.SourcePath` will produce `""` rather than `null` when no source is set. The frontend helper already treats `""` as "no link".
+
+5. **FR-6 file location:** Move from `frontend/src/api/hooks/useSharePointLink.ts` to `frontend/src/utils/sharepointLink.ts`. The function is not a React hook and the directory `api/hooks/` is reserved for TanStack-Query wrappers. Update the import path in FR-7 and FR-8 accordingly.
+
+6. **Implicit decision:** `KnowledgeBaseFeedbackPage` and the `/knowledge-base/feedback` route remain registered but are no longer linked from the sidebar. Phase 4 will reconcile. Document in PR.
+
+## Prerequisites
+
+None. All required infrastructure is in place:
+
+- `Document.SourcePath` column already persisted (no migration).
+- Both repositories already eager-load `Document` in `GetChunkByIdAsync`.
+- All five referenced routes (`/marketing/calendar`, `/leaflet-generator`, `/articles`, `/knowledge-base`, plus the new `/marketing/feedback`) — four already exist; the fifth is added in this PR.
+- Roles `knowledge_base_manager`, `leaflet_manager`, `article_generator` queryable via existing `hasRole` helper.
+- `Megaphone` and `ExternalLink` already imported / available from `lucide-react`.
+- OpenAPI generation already wired into `npm run build`.

--- a/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/brief.md
+++ b/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/brief.md
@@ -1,0 +1,211 @@
+# Phase 1 — UI Consolidation & SharePoint Link-Back
+
+## Goal
+All three RAG features reachable from one Marketing sidebar group. Chunk modals link back to the original SharePoint document.
+
+## Context
+- `frontend/src/components/layout/Sidebar.tsx` has a **bug**: two sections share `id: 'marketing'` (lines 141 and 316). They must be merged.
+- KB lives in its own top-level `knowledgebase` group (lines 300-315). Must move under Marketing.
+- Articles has no sidebar entry at all. Must be added.
+- `ChunkDetailModal` and `LeafletChunkDetailModal` do not show `SourcePath` — backend responses don't include it.
+- No code changes to routing (routes stay at `/knowledge-base`, `/leaflet-generator`, `/articles`).
+
+---
+
+## Step 1 — Fix sidebar & merge into one Marketing group
+
+**File**: `frontend/src/components/layout/Sidebar.tsx`
+
+### 1a. Remove icons no longer needed for knowledgebase standalone section
+The `Database` and `TrendingUp` imports can be removed if unused elsewhere — check first with grep.
+
+### 1b. Replace the `navigationSections` array entries
+
+Remove:
+- The standalone `knowledgebase` section (id `'knowledgebase'`, lines ~300-315).
+- The second orphan `marketing` section (id `'marketing'`, icon `TrendingUp`, lines ~316-324) that has only `Campaigns`.
+
+Replace the existing first `marketing` section (id `'marketing'`, icon `Megaphone`, lines ~141-150) with the consolidated version:
+
+```typescript
+{
+  id: "marketing",
+  name: "Marketing",
+  icon: Megaphone,
+  type: "section" as const,
+  items: [
+    { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
+    { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+    { id: "articles", name: "Generátor článků", href: "/articles" },
+    { id: "knowledge-base", name: "Poradenství (KB)", href: "/knowledge-base" },
+    ...(hasRole("knowledge_base_manager") || hasRole("leaflet_manager") || hasRole("article_generator")
+      ? [{ id: "marketing-feedback", name: "Feedback", href: "/marketing/feedback" }]
+      : []),
+  ],
+},
+```
+
+> The Campaigns item that was in the second orphan marketing section: check if `/campaigns` route exists in `App.tsx`. If the route is a stub or broken, omit it; if real, add it to the new merged group. No orphan section should remain.
+
+### 1c. Remove `TrendingUp` from lucide-react import if no longer used
+
+Verify with grep before removing.
+
+**Test**: `npm run build` — no TS errors. Open dev server, confirm single Marketing group expands to the right items.
+
+---
+
+## Step 2 — Add `/marketing/feedback` route (stub for Phase 4)
+
+Add a minimal stub page so the sidebar link works even before Phase 4 completes.
+
+**New file**: `frontend/src/pages/MarketingFeedbackPage.tsx`
+
+```tsx
+export default function MarketingFeedbackPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold text-gray-900">Feedback</h1>
+      <p className="mt-2 text-sm text-gray-500">Přehled zpětné vazby bude dostupný po dokončení integrace.</p>
+    </div>
+  );
+}
+```
+
+**File**: `frontend/src/App.tsx`
+
+Add import + route:
+```tsx
+import MarketingFeedbackPage from "./pages/MarketingFeedbackPage";
+// inside the route tree, inside <AuthGuard> + <Layout>:
+<Route path="/marketing/feedback" element={<MarketingFeedbackPage />} />
+```
+
+---
+
+## Step 3 — Add `SourcePath` to KB chunk detail
+
+### 3a. Backend — response DTO
+
+**File**: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailResponse.cs`
+
+Add field:
+```csharp
+public string? SourcePath { get; set; }
+```
+
+(The field is already `nullable` because manual-upload chunks have a synthetic `upload/{guid}/{filename}` path that should not become a link.)
+
+### 3b. Backend — handler
+
+**File**: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`
+
+In the `Handle` method, the repository call must eagerly load the document (to access `SourcePath`). The existing code already reads `chunk.Document.Filename` and `chunk.Document.IndexedAt`, which means the document is already included via navigation property. Add:
+
+```csharp
+SourcePath = chunk.Document.SourcePath,
+```
+
+### 3c. Backend — repository query
+
+**File**: `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs`
+
+Find `GetChunkByIdAsync`. Verify it uses `.Include(c => c.Document)` (or equivalent JOIN) so `chunk.Document` is populated. If it uses a raw SQL projection, add `d."SourcePath"` to the SELECT and map it.
+
+### 3d. OpenAPI client regeneration
+
+The TypeScript client is auto-generated on `npm run build`. The new `sourcePath?: string` field will appear in the generated `GetChunkDetailResponse` interface automatically.
+
+---
+
+## Step 4 — Add `SourcePath` to Leaflet chunk detail
+
+Same pattern as Step 3.
+
+**Files to touch**:
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailResponse.cs` — add `SourcePath?: string`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs` — add `SourcePath = chunk.Document.SourcePath`
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs` — verify `GetChunkByIdAsync` includes the document (check for `.Include(c => c.Document)`)
+
+---
+
+## Step 5 — Shared `useSharePointLink` hook (frontend)
+
+**New file**: `frontend/src/api/hooks/useSharePointLink.ts`
+
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null {
+  if (!sourcePath) return null;
+  if (sourcePath.startsWith("https://")) return sourcePath;
+  return null;
+}
+```
+
+A pure function is sufficient — no state needed.
+
+---
+
+## Step 6 — Update `ChunkDetailModal` (KB)
+
+**File**: `frontend/src/components/knowledge-base/ChunkDetailModal.tsx`
+
+After the meta row (score/date), add:
+
+```tsx
+import { getSharePointLink } from '../../api/hooks/useSharePointLink';
+import { ExternalLink } from 'lucide-react';
+
+// inside the {data && (...)} block, after the meta row:
+{getSharePointLink(data.sourcePath) && (
+  <a
+    href={getSharePointLink(data.sourcePath)!}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+  >
+    Otevřít v SharePoint
+    <ExternalLink className="w-3 h-3" />
+  </a>
+)}
+```
+
+---
+
+## Step 7 — Update `LeafletChunkDetailModal`
+
+**File**: `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx`
+
+Same change as Step 6 — import `getSharePointLink`, render the link below the meta row.
+
+---
+
+## Step 8 — i18n check
+
+No new Czech labels added except "Otevřít v SharePoint" (hardcoded inline — acceptable for a link label). No changes needed to `frontend/src/i18n.ts`.
+
+---
+
+## Tests to write
+
+### Backend unit tests
+- `GetChunkDetailHandlerTests` (KB) — assert `SourcePath` is returned when document has a SharePoint URL; assert `null` for upload-prefix path.
+- `GetLeafletChunkDetailHandlerTests` — same assertion.
+
+### Frontend unit tests
+- `ChunkDetailModal.test.tsx` — render with `sourcePath: "https://sharepoint.com/..."` → link is visible; render with `sourcePath: "upload/abc/file.pdf"` → link is hidden.
+- `LeafletChunkDetailModal.test.tsx` — same.
+
+---
+
+## Verification
+
+1. `dotnet build` — clean.
+2. `dotnet format` — no changes.
+3. `npm run build` — clean.
+4. `npm run lint` — clean.
+5. Dev server: log in → Marketing group shows: Kalendář, Generátor letáků, Generátor článků, Poradenství (KB), Feedback (for managers).
+6. Click "Poradenství (KB)" → `/knowledge-base` loads, tabs work.
+7. Click "Generátor článků" → `/articles` loads.
+8. Open KB Dokumenty tab → click a row → ChunkDetailModal opens → "Otevřít v SharePoint" link visible for OneDrive items, hidden for manual uploads.
+9. Leaflet Dokumenty tab → same.
+10. `/marketing/feedback` renders the stub page.

--- a/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/design.r1.md
+++ b/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/design.r1.md
@@ -1,0 +1,286 @@
+# Design: Phase 1 — UI Consolidation & SharePoint Link-Back
+
+## UX/UI Design
+
+### Sidebar — Marketing group consolidation
+
+The existing `marketing` section (Kalendář, Generátor letáků) is extended in-place; the standalone `knowledgebase` section is removed. End result is one collapsible Marketing group with five items in order:
+
+```
+┌─────────────────────────────┐
+│ AH  Anela Heblo             │
+├─────────────────────────────┤
+│ ⊞  Dashboard                │
+│ ...                         │
+│ ▼ 📣 Marketing              │  ← Megaphone icon, expanded
+│    Kalendář                 │
+│    Generátor letáků         │
+│    Generátor článků         │  ← added (was unreachable)
+│    Poradenství (KB)         │  ← moved from knowledgebase section
+│    Feedback                 │  ← conditional: managers only
+│ ...                         │
+│ ▶ 🤖 Automatizace           │
+│                             │  ← Knowledgebase section removed
+└─────────────────────────────┘
+```
+
+The `knowledgebase` section (Database icon, "Poradenství" + conditional "Feedback") is deleted. `Database` is removed from the lucide-react import block (verify no other in-file usage before removing). The Feedback item in the merged section is conditioned on `hasRole('knowledge_base_manager') || hasRole('leaflet_manager') || hasRole('article_generator')`.
+
+Collapsed state behaviour is unchanged — icon-only, clicking expands the sidebar.
+
+### Marketing Feedback stub page
+
+Minimal placeholder with standard page wrapper. No interactive elements.
+
+```
+┌────────────────────────────────────────────┐
+│  Feedback                                  │  ← <h1>
+│                                            │
+│  Přehled zpětné vazby bude dostupný        │  ← <p>
+│  po dokončení integrace.                   │
+└────────────────────────────────────────────┘
+```
+
+Wrapper: `<div className="p-6">`. No card, no table, no spinner. Page lives at `/marketing/feedback` inside the existing `<AuthGuard>` + `<Layout>` tree.
+
+### Chunk detail modal — SharePoint link row
+
+The link is inserted between the meta row and the Summary block in both modals. It is omitted entirely when `sourcePath` is null, empty, or starts with `upload/`.
+
+**KB ChunkDetailModal** (current layout is at `ChunkDetailModal.tsx:59-93`):
+
+```
+┌──────────────────────────────────────────────────────┐
+│ filename.docx                               [×]      │
+├──────────────────────────────────────────────────────┤
+│  Dokument  •  Indexováno: 1. 5. 2025  •  87%        │  ← meta row (unchanged)
+│  Otevřít v SharePoint ↗                             │  ← NEW: only when https://
+│                                                      │
+│  SHRNUTÍ                                             │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ ...                                            │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                      │
+│  OBSAH                                               │
+│  ...                                                 │
+└──────────────────────────────────────────────────────┘
+```
+
+**LeafletChunkDetailModal** (`LeafletChunkDetailModal.tsx:59-88`) — identical layout change; the only structural difference from KB modal is the absence of the `documentType` pill and `score` in its meta row (current state, unchanged).
+
+Link element spec:
+- Tag: `<a>` with `target="_blank" rel="noopener noreferrer"`
+- Label: `Otevřít v SharePoint` + trailing `<ExternalLink className="w-3 h-3" />`
+- Classes: `inline-flex items-center gap-1 text-xs text-blue-600 hover:underline`
+- Rendered inside the `data && (...)` block, immediately after the `<div className='flex items-center gap-3 ...'>` meta row
+
+## Component Design
+
+### Frontend
+
+#### `frontend/src/utils/sharepointLink.ts` (NEW)
+
+Pure synchronous function with no side effects, no React imports.
+
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null
+```
+
+Returns the input verbatim when it starts with `"https://"`, `null` in all other cases (null, undefined, empty string, `"upload/..."` prefix).
+
+No default export. Imported by both modals and testable in isolation.
+
+#### `frontend/src/utils/sharepointLink.test.ts` (NEW)
+
+Unit tests covering: `null`, `undefined`, `""`, `"upload/abc/file.pdf"`, `"https://sharepoint.example.com/doc"`.
+
+#### `frontend/src/pages/MarketingFeedbackPage.tsx` (NEW)
+
+Default export. Stateless functional component. No props, no hooks, no data fetching.
+
+```tsx
+export default function MarketingFeedbackPage() {
+  return (
+    <div className="p-6">
+      <h1 ...>Feedback</h1>
+      <p ...>Přehled zpětné vazby bude dostupný po dokončení integrace.</p>
+    </div>
+  );
+}
+```
+
+#### `frontend/src/components/Layout/Sidebar.tsx` (MODIFIED)
+
+**Change 1 — `navigationSections` array:**
+- Extend the `marketing` section (id `"marketing"`) items array from 2 items to 5 (or 4 + conditional spread).
+- Remove the `knowledgebase` section object entirely (currently lines 299–314).
+
+**Change 2 — imports:**
+- Remove `Database` from the lucide-react import (confirmed single usage on line 20 as the knowledgebase section icon).
+- No other import changes required (`Megaphone` and `ExternalLink` are already imported).
+
+No changes to the rendering logic, toggle behaviour, or collapsed state handling.
+
+#### `frontend/src/App.tsx` (MODIFIED)
+
+Add import of `MarketingFeedbackPage` and register route `/marketing/feedback` inside the existing `<AuthGuard>` + `<Layout>` block, alongside the existing `/knowledge-base/feedback` route (lines ~466-474).
+
+#### `frontend/src/components/knowledge-base/ChunkDetailModal.tsx` (MODIFIED)
+
+Add import of `getSharePointLink` from `../../utils/sharepointLink` and `ExternalLink` from `lucide-react`.
+
+Insert the link element after the closing tag of the meta row `<div>` (currently line 74), before the Summary `<div>`:
+
+```tsx
+{getSharePointLink(data.sourcePath) && (
+  <a
+    href={getSharePointLink(data.sourcePath)!}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+  >
+    Otevřít v SharePoint
+    <ExternalLink className="w-3 h-3" />
+  </a>
+)}
+```
+
+#### `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx` (MODIFIED)
+
+Identical change as KB modal above; insertion point is after the meta row `<div>` (currently line 66).
+
+### Backend
+
+#### `GetChunkDetailRequest.cs` — `GetChunkDetailResponse` class (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs`
+
+Add one property to the `GetChunkDetailResponse` class:
+
+```csharp
+public string? SourcePath { get; set; }
+```
+
+#### `GetChunkDetailHandler.cs` (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`
+
+Add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser (after `Content = chunk.Content,`, currently line 34).
+
+#### `GetLeafletChunkDetailRequest.cs` — `GetLeafletChunkDetailResponse` class (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs`
+
+Same additive change:
+
+```csharp
+public string? SourcePath { get; set; }
+```
+
+#### `GetLeafletChunkDetailHandler.cs` (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs`
+
+Add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser.
+
+#### Repositories — no changes
+
+`KnowledgeBaseRepository.GetChunkByIdAsync` and `LeafletRepository.GetChunkByIdAsync` already include `.Include(c => c.Document)`. No repository modifications needed.
+
+### Test files (MODIFIED — existing test classes extended)
+
+**`GetChunkDetailHandlerTests.cs`** — add three facts:
+1. `SourcePath` equals document's SharePoint URL when document has `https://` path.
+2. `SourcePath` equals synthetic path verbatim when document has `upload/...` path.
+3. `SourcePath` is `""` (empty string) when document `SourcePath` defaults to `string.Empty`.
+
+**`GetLeafletChunkDetailHandlerTests.cs`** — same three facts.
+
+**Frontend test files (NEW):**
+- `frontend/src/utils/sharepointLink.test.ts` — five test cases covering all input categories.
+- `frontend/src/components/knowledge-base/ChunkDetailModal.test.tsx` — three cases (SharePoint URL renders link; `upload/...` hides link; `null` hides link).
+- `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.test.tsx` — same three cases.
+
+## Data Schemas
+
+### Backend DTO changes (additive)
+
+**`GetChunkDetailResponse`** — after change:
+
+```csharp
+public class GetChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DocumentType DocumentType { get; set; }
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }           // NEW
+}
+```
+
+**`GetLeafletChunkDetailResponse`** — after change:
+
+```csharp
+public class GetLeafletChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }           // NEW
+}
+```
+
+### API response shapes (JSON)
+
+`GET /api/knowledge-base/chunks/{id}` — additive change:
+```json
+{
+  "chunkId": "...",
+  "documentId": "...",
+  "filename": "example.docx",
+  "documentType": "Document",
+  "indexedAt": "2025-05-01T10:00:00Z",
+  "chunkIndex": 0,
+  "summary": "...",
+  "content": "...",
+  "sourcePath": "https://anelacz.sharepoint.com/..."
+}
+```
+
+`sourcePath` is `null` or an empty string when the document has no SharePoint origin; a `"upload/{guid}/{filename}"` string when manually uploaded; a full `https://` URL when sourced from SharePoint/OneDrive.
+
+`GET /api/leaflet/chunks/{id}` — identical additive change to its response shape.
+
+### Frontend TypeScript shapes
+
+Auto-generated by the OpenAPI client on `npm run build`. After regeneration the generated interfaces gain:
+
+```ts
+// In api-client.ts (auto-generated, do not edit manually)
+interface GetChunkDetailResponse {
+  // ...existing fields...
+  sourcePath?: string;
+}
+
+interface GetLeafletChunkDetailResponse {
+  // ...existing fields...
+  sourcePath?: string;
+}
+```
+
+### `SourcePath` semantics (existing convention, unchanged)
+
+| Value pattern | Origin | UI behaviour |
+|---|---|---|
+| `https://...` | SharePoint / OneDrive ingestion | Render as clickable link |
+| `upload/{guid}/{filename}` | Manual upload pipeline | Omit link (helper returns `null`) |
+| `""` (empty string default) | No source set | Omit link (falsy check catches it) |
+| `null` | Defensive DTO nullability | Omit link |

--- a/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/impl/main.r1.md
+++ b/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/impl/main.r1.md
@@ -1,0 +1,12 @@
+This is a normal repository (not a linked worktree) on branch `feat-phase-1-ui-consolidation-sharepoint-link`. Base branch is `main`.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/spec.r1.md
+++ b/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/spec.r1.md
@@ -1,0 +1,218 @@
+# Specification: Phase 1 — UI Consolidation & SharePoint Link-Back
+
+## Summary
+Consolidate the three RAG-related features (Knowledge Base, Leaflet Generator, Article Generator) under a single Marketing sidebar group, fixing an existing duplicate-id bug. Surface a clickable SharePoint link in chunk detail modals for both KB and Leaflet by propagating the document `SourcePath` from backend through to the UI.
+
+## Background
+The application currently has three knowledge-base-style features (Knowledge Base / "Poradenství", Leaflet Generator, Article Generator) that share a common RAG architecture but are surfaced inconsistently in the sidebar:
+
+- `Sidebar.tsx` defines two sections with the same `id: 'marketing'` (lines ~141 and ~316), which is a latent bug (React key collisions, ambiguous active-state behaviour).
+- Knowledge Base lives in its own top-level `knowledgebase` group (lines ~300-315) instead of under Marketing.
+- Article Generator has no sidebar entry at all and is only reachable by direct URL.
+- Chunk detail modals (`ChunkDetailModal` for KB, `LeafletChunkDetailModal` for Leaflet) cannot link back to the originating SharePoint document because the GetChunkDetail response DTOs do not carry `SourcePath`. Documents have two flavours of `SourcePath`: real SharePoint URLs (`https://...`) for OneDrive/SharePoint-sourced documents, and a synthetic `upload/{guid}/{filename}` prefix for manually uploaded files. Only the former should render as a link.
+
+This phase is purely consolidation and link-back — no routing changes, no new business logic. It also adds a stub `/marketing/feedback` page so the sidebar entry resolves cleanly until Phase 4 implements the real feedback view.
+
+## Functional Requirements
+
+### FR-1: Consolidated Marketing sidebar group
+Merge all marketing-adjacent navigation entries into a single `marketing` section in `frontend/src/components/layout/Sidebar.tsx`. The merged section must contain, in this exact order:
+1. Kalendář → `/marketing/calendar`
+2. Generátor letáků → `/leaflet-generator`
+3. Generátor článků → `/articles`
+4. Poradenství (KB) → `/knowledge-base`
+5. Feedback → `/marketing/feedback` (only when user has at least one of `knowledge_base_manager`, `leaflet_manager`, `article_generator` roles)
+
+The previously standalone `knowledgebase` section and the orphan duplicate `marketing` section (the one icon'd with `TrendingUp` containing only `Campaigns`) must be removed. The merged section uses the `Megaphone` icon.
+
+**Acceptance criteria:**
+- Only one `navigationSections` entry has `id: 'marketing'`.
+- No entry has `id: 'knowledgebase'`.
+- The `Megaphone` icon is used; `TrendingUp` and `Database` imports are removed from `lucide-react` if grep confirms no other in-file usage.
+- Sidebar renders the five items above in order; the Feedback item is conditional on the role check shown in the brief.
+- `npm run build` and `npm run lint` are clean.
+- Visual check: sidebar shows a single Marketing group expanding to the right items.
+
+### FR-2: Disposition of `Campaigns` item
+The orphan duplicate marketing section currently contains a `Campaigns` item. Before removal, verify whether `/campaigns` is a real route in `frontend/src/App.tsx`:
+- If a real, working route exists → include `Campaigns` as an additional item in the merged Marketing group (placement after `Feedback` or before `Kalendář` is at developer discretion; pick the natural marketing workflow order).
+- If the route is absent, a stub, or otherwise broken → omit the item entirely.
+
+No orphan section may remain regardless of outcome.
+
+**Acceptance criteria:**
+- Decision is documented in the PR description with the specific App.tsx evidence (route present yes/no, file:line).
+- No `Campaigns` link points to a missing route.
+
+### FR-3: Marketing Feedback stub page
+Add a minimal stub page so the sidebar `Feedback` link resolves before Phase 4 is implemented.
+
+- New file: `frontend/src/pages/MarketingFeedbackPage.tsx` (default export, body exactly as specified in the brief: heading "Feedback", subtext "Přehled zpětné vazby bude dostupný po dokončení integrace.", standard `p-6` page wrapper).
+- Register `/marketing/feedback` in `frontend/src/App.tsx` inside the existing `<AuthGuard>` + `<Layout>` route tree.
+
+**Acceptance criteria:**
+- Navigating to `/marketing/feedback` while authenticated renders the stub.
+- The route is gated by the same auth guard as sibling marketing routes.
+- No console errors on render.
+
+### FR-4: Backend — KB GetChunkDetail returns `SourcePath`
+Add `SourcePath` to the KB chunk detail pipeline.
+
+- `GetChunkDetailResponse.cs`: add `public string? SourcePath { get; set; }` (nullable, since synthetic upload paths must surface but should be hidden in UI per FR-7).
+- `GetChunkDetailHandler.cs`: populate `SourcePath = chunk.Document.SourcePath` when constructing the response.
+- `KnowledgeBaseRepository.GetChunkByIdAsync`: ensure `chunk.Document` is loaded (`.Include(c => c.Document)` for EF; if the method uses a raw SQL projection, add `d."SourcePath"` to the SELECT and map it).
+
+**Acceptance criteria:**
+- For a chunk whose document has a SharePoint URL, the response contains that URL in `sourcePath`.
+- For a chunk whose document has a synthetic `upload/{guid}/{filename}` path, the response contains that synthetic path verbatim (UI handles hiding — see FR-7).
+- For a chunk with no document association (if such a case exists), `sourcePath` is `null` and the handler does not throw.
+- `dotnet build` and `dotnet format` are clean.
+
+### FR-5: Backend — Leaflet GetLeafletChunkDetail returns `SourcePath`
+Mirror FR-4 for the Leaflet feature:
+- `GetLeafletChunkDetailResponse.cs`: add `public string? SourcePath { get; set; }`.
+- `GetLeafletChunkDetailHandler.cs`: assign `SourcePath = chunk.Document.SourcePath`.
+- `LeafletRepository.GetChunkByIdAsync`: verify document include or extend SQL projection identically to FR-4.
+
+**Acceptance criteria:** same as FR-4, applied to the Leaflet handler.
+
+### FR-6: Shared `getSharePointLink` helper
+New file `frontend/src/api/hooks/useSharePointLink.ts` exporting a pure function:
+
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null {
+  if (!sourcePath) return null;
+  if (sourcePath.startsWith("https://")) return sourcePath;
+  return null;
+}
+```
+
+Used by both chunk detail modals.
+
+**Acceptance criteria:**
+- Returns `null` for `null`, `undefined`, empty string, and any value not starting with `https://` (including the `upload/...` prefix).
+- Returns the input verbatim when it starts with `https://`.
+- Function has no side effects, no React hooks, no state.
+
+### FR-7: KB ChunkDetailModal renders SharePoint link
+In `frontend/src/components/knowledge-base/ChunkDetailModal.tsx`, after the existing meta row (score/date), conditionally render an `<a>` tag that opens the SharePoint URL in a new tab when `getSharePointLink(data.sourcePath)` returns a non-null value.
+
+- Link label (hardcoded): `Otevřít v SharePoint`
+- Trailing `ExternalLink` icon from `lucide-react` (`w-3 h-3`)
+- Classes: `inline-flex items-center gap-1 text-xs text-blue-600 hover:underline`
+- Anchor attributes: `target="_blank" rel="noopener noreferrer"`
+
+**Acceptance criteria:**
+- Link is visible when `sourcePath` is a `https://...` URL.
+- Link is hidden when `sourcePath` is `null`, `undefined`, or starts with `upload/`.
+- Clicking opens a new tab to the SharePoint URL; no in-app navigation occurs.
+- No layout regression in the modal for either branch.
+
+### FR-8: Leaflet LeafletChunkDetailModal renders SharePoint link
+Apply the same change as FR-7 in `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx`.
+
+**Acceptance criteria:** same as FR-7, in the Leaflet modal.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact expected. The added `SourcePath` field is a small string already loaded as part of the `Document` entity (the handlers already read `Filename` and `IndexedAt` from the same navigation property). No new round trips, no additional joins beyond what already exists.
+
+### NFR-2: Security
+- The SharePoint URL is rendered as a normal anchor with `rel="noopener noreferrer"` to prevent reverse-tabnabbing.
+- No new auth surface is introduced; access to chunk detail data continues to use existing endpoint authorisation.
+- `SourcePath` is already persisted server-side and exposed for indexing — no new data is leaving the database.
+- The role check for the Feedback sidebar item uses the existing `hasRole` helper; no new role logic is introduced.
+
+### NFR-3: Accessibility
+- The SharePoint link is keyboard-focusable (default anchor behaviour) and has visible text content; the icon is decorative.
+- The Feedback stub page uses semantic HTML (`<h1>`, `<p>`).
+
+### NFR-4: Internationalisation
+The label "Otevřít v SharePoint" is hardcoded inline. Per the brief, this is acceptable for Phase 1 and `frontend/src/i18n.ts` is not modified. The Feedback stub copy is also Czech and inline. (See Open Questions for the i18n trade-off.)
+
+### NFR-5: Backwards compatibility
+Adding a nullable `SourcePath` field to two response DTOs is additive — existing TypeScript consumers compile without changes once the OpenAPI client regenerates on `npm run build`. No persistence migrations are required (`Document.SourcePath` already exists).
+
+## Data Model
+
+No schema changes. Relevant existing entities:
+
+- `KnowledgeBaseDocument` — has `SourcePath` (string, nullable), `Filename`, `IndexedAt`.
+- `KnowledgeBaseChunk` — has `Document` navigation property to `KnowledgeBaseDocument`.
+- `LeafletDocument` and `LeafletChunk` — analogous shape on the Leaflet side.
+
+`SourcePath` semantics (existing convention):
+- `https://...` → real SharePoint/OneDrive URL.
+- `upload/{guid}/{filename}` → synthetic identifier for manually uploaded files. **Not** a clickable link.
+
+## API / Interface Design
+
+### Backend API contract changes (additive)
+- `GET /api/knowledge-base/chunks/{id}` — response gains optional `sourcePath: string | null`.
+- `GET /api/leaflet/chunks/{id}` — response gains optional `sourcePath: string | null`.
+
+(Exact route paths follow the existing controllers; no new endpoints.)
+
+### Frontend OpenAPI client
+Auto-regenerated on `npm run build`. The generated `GetChunkDetailResponse` and `GetLeafletChunkDetailResponse` interfaces gain `sourcePath?: string`. No manual edits to generated files.
+
+### Sidebar UI flow
+Single `Marketing` group → expanded items: Kalendář, Generátor letáků, Generátor článků, Poradenství (KB), [Feedback for managers].
+
+### Chunk modal UI flow
+Open Documents tab → click a chunk row → modal opens → meta row (score/date) → optional SharePoint link row → existing chunk text/preview content.
+
+## Dependencies
+
+- **lucide-react** — already a dependency; uses `Megaphone` (existing) and `ExternalLink` (existing) icons.
+- **OpenAPI client generator** — already wired into `npm run build`; no new tooling.
+- **Existing roles** (`knowledge_base_manager`, `leaflet_manager`, `article_generator`) — already defined and queryable via the existing `hasRole` helper used in `Sidebar.tsx`.
+- **Existing routes** (`/knowledge-base`, `/leaflet-generator`, `/articles`, `/marketing/calendar`) — present and unchanged.
+- **Existing entity navigation** — `Chunk.Document` is already loaded by current handlers (which read `Filename`, `IndexedAt`); confirming the include in the repository is a verification step, not a new dependency.
+
+## Test Plan
+
+### Backend unit tests
+- **`GetChunkDetailHandlerTests` (KB)**
+  - Returns `SourcePath` populated when the document has a SharePoint URL.
+  - Returns the synthetic `upload/...` path verbatim when the document was manually uploaded.
+  - Returns `null` `SourcePath` if the document has no source path stored.
+- **`GetLeafletChunkDetailHandlerTests`** — same three cases as above.
+
+### Frontend unit tests
+- **`ChunkDetailModal.test.tsx`**
+  - Given `sourcePath: "https://sharepoint.com/foo"` → "Otevřít v SharePoint" link is visible with that `href`, opens in new tab.
+  - Given `sourcePath: "upload/abc/file.pdf"` → link is not in the DOM.
+  - Given `sourcePath: null` / `undefined` → link is not in the DOM.
+- **`LeafletChunkDetailModal.test.tsx`** — same three cases.
+- **`useSharePointLink.test.ts`** — direct unit tests for `getSharePointLink` covering all four input categories (null, undefined, https-prefixed, upload-prefixed).
+
+### Verification (manual / E2E-equivalent smoke)
+1. `dotnet build` clean.
+2. `dotnet format` produces no changes.
+3. `npm run build` clean.
+4. `npm run lint` clean.
+5. Dev server, authenticated as a manager: Marketing group expands to the five items in the specified order.
+6. Navigate to each of `/knowledge-base`, `/leaflet-generator`, `/articles`, `/marketing/calendar`, `/marketing/feedback` — each loads without console error.
+7. KB Dokumenty tab → open a chunk for a SharePoint document → SharePoint link is present and opens a new tab.
+8. KB Dokumenty tab → open a chunk for a manually uploaded document → link is absent.
+9. Leaflet Dokumenty tab → repeat steps 7–8.
+10. Sign in as a non-manager (no relevant roles) → Feedback item is hidden; the four other Marketing items are visible.
+
+## Out of Scope
+
+- Any changes to routing paths (`/knowledge-base`, `/leaflet-generator`, `/articles` stay).
+- The real implementation of `/marketing/feedback` (Phase 4).
+- Any change to how `SourcePath` is persisted, ingested, or generated.
+- i18n extraction of the new inline labels.
+- Restyling or reorganising the chunk detail modal beyond inserting the link row.
+- Permissions changes; only the existing `hasRole` checks are reused.
+- Addition or removal of any feature in Knowledge Base, Leaflet, or Articles beyond surfacing them in the sidebar.
+- Backfill or normalisation of `SourcePath` values (e.g. converting legacy paths into URLs).
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/task-plan.r1.md
+++ b/artifacts/feat-phase-1-ui-consolidation-sharepoint-link/task-plan.r1.md
@@ -1,0 +1,1092 @@
+# Phase 1 — UI Consolidation & SharePoint Link-Back Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate the three RAG features (Knowledge Base, Leaflet Generator, Article Generator) under a single Marketing sidebar group, add a stub Marketing Feedback page, and surface a clickable SharePoint link in chunk detail modals when the document was sourced from SharePoint.
+
+**Architecture:** Additive backend changes — `SourcePath` is added to two existing response DTOs and populated in two existing MediatR handlers (no repository, persistence, or controller changes; both repositories already eager-load `Document`). Frontend adds a stateless `getSharePointLink` helper, a stub page, a sidebar restructure, and inserts a small link element into two chunk detail modals. The TS hook interfaces (`GetChunkDetailResponse`, `GetLeafletChunkDetailResponse`) in `api/hooks/` are **hand-maintained**, not auto-generated — they must be edited manually to match the C# DTO change.
+
+**Tech Stack:** .NET 8 (MediatR Vertical Slice, EF Core), xUnit + Moq + FluentAssertions, React 18 + TypeScript, Tailwind, react-router, lucide-react, Jest + React Testing Library.
+
+---
+
+## Important context discovered before writing
+
+These observations correct or supplement the spec/arch-review:
+
+1. **Spec claim that `Sidebar.tsx` has two sections with `id: 'marketing'` is false.** Verified at `frontend/src/components/Layout/Sidebar.tsx`: only one `marketing` section (lines 140–149) and a separate `knowledgebase` section (lines 299–314). No `TrendingUp` import, no `Campaigns` item. FR-2 from the spec has nothing to act on.
+2. **Sidebar path uses capital `Layout`:** `frontend/src/components/Layout/Sidebar.tsx`. The arch-review document used lowercase `layout` — use capital.
+3. **Response DTOs are co-located in the request files**, not separate `*Response.cs` files. Edit `GetChunkDetailRequest.cs` and `GetLeafletChunkDetailRequest.cs`.
+4. **Domain `SourcePath` is non-nullable `string` defaulting to `string.Empty`** (entity `KnowledgeBaseDocument.SourcePath`). The DTO field is declared `string?` for forward flexibility, but assignment will produce `""` rather than `null` for documents with no source set. The frontend helper's falsy check (`if (!sourcePath)`) handles `""` correctly.
+5. **The TS interfaces consumed by the chunk detail hooks are NOT auto-generated.** `GetChunkDetailResponse` is hand-defined at `frontend/src/api/hooks/useKnowledgeBase.ts:127` and `GetLeafletChunkDetailResponse` at `frontend/src/api/hooks/useLeaflet.ts:43`. The OpenAPI build step regenerates `frontend/src/api/generated/api-client.ts`, but the hooks don't use those generated types. **The hand-defined interfaces must be edited manually** — this is captured as Task 4.
+6. **Existing tests in `GetChunkDetailHandlerTests.cs` use raw xUnit `Assert.*`**, while `GetLeafletChunkDetailHandlerTests.cs` uses FluentAssertions. Match the existing style of each file when adding new tests.
+7. **Repositories already eager-load `Document`** (verified by arch-review). No repository changes are needed.
+8. **`/articles` route already exists** in `App.tsx` (line 474). No new route needed for it.
+9. **Leave `/knowledge-base/feedback` and `KnowledgeBaseFeedbackPage` untouched.** Spec section 4 of the arch-review confirms this is out of scope; Phase 4 will reconcile.
+
+---
+
+## File Structure
+
+**Files created:**
+- `frontend/src/utils/sharepointLink.ts` — pure helper exporting `getSharePointLink`
+- `frontend/src/utils/sharepointLink.test.ts` — Jest unit tests for the helper (5 cases)
+- `frontend/src/pages/MarketingFeedbackPage.tsx` — minimal stub page
+- `frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx` — Jest tests for the leaflet modal's SharePoint link rendering
+
+**Files modified:**
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs` — add `SourcePath` to colocated `GetChunkDetailResponse`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs` — assign `SourcePath` in response init
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs` — add `SourcePath` to colocated `GetLeafletChunkDetailResponse`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs` — assign `SourcePath` in response init
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs` — add 3 tests for `SourcePath`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs` — add 3 tests for `SourcePath`
+- `frontend/src/api/hooks/useKnowledgeBase.ts` — add `sourcePath?: string` to `GetChunkDetailResponse` interface
+- `frontend/src/api/hooks/useLeaflet.ts` — add `sourcePath?: string` to `GetLeafletChunkDetailResponse` interface
+- `frontend/src/components/knowledge-base/ChunkDetailModal.tsx` — render conditional SharePoint link
+- `frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx` — add 3 tests for SharePoint link
+- `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx` — render conditional SharePoint link
+- `frontend/src/components/Layout/Sidebar.tsx` — extend marketing section, remove knowledgebase section, drop unused `Database` import
+- `frontend/src/App.tsx` — register `/marketing/feedback` route
+
+**Files NOT modified:** `KnowledgeBaseRepository.cs`, `LeafletRepository.cs`, `IKnowledgeBaseRepository.cs`, `ILeafletRepository.cs`, `KnowledgeBaseFeedbackPage.tsx`, the `/knowledge-base/feedback` route entry, the auto-generated `api/generated/api-client.ts` (any diff from `npm run build` is committed as-is but not hand-edited).
+
+---
+
+## Task 1: Backend — KB GetChunkDetail returns `SourcePath`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs`
+
+- [ ] **Step 1: Add the three failing tests**
+
+Open `backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs`. The file currently uses raw xUnit `Assert.*` (no FluentAssertions). Match that style.
+
+Insert these three `[Fact]` methods immediately after the existing `Handle_ReturnsNotFound_WhenChunkDoesNotExist` test (before the closing brace of the class):
+
+```csharp
+    [Fact]
+    public async Task Handle_ReturnsSharePointSourcePath_WhenDocumentSourcedFromSharePoint()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = "https://anelacz.sharepoint.com/sites/x/doc.docx";
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://anelacz.sharepoint.com/sites/x/doc.docx", result.SourcePath);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSyntheticUploadPath_WhenDocumentManuallyUploaded()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = "upload/abc-123/file.pdf";
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal("upload/abc-123/file.pdf", result.SourcePath);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmptyString_WhenDocumentHasNoSourcePath()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = string.Empty;
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal(string.Empty, result.SourcePath);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetChunkDetailHandlerTests"
+```
+
+Expected: build error `'GetChunkDetailResponse' does not contain a definition for 'SourcePath'`. (If the build succeeds — which it should not — the assertions would fail.)
+
+- [ ] **Step 3: Add `SourcePath` to the response DTO**
+
+In `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs`, add one property to the `GetChunkDetailResponse` class (after the existing `Content` property, before the constructors):
+
+```csharp
+    public string? SourcePath { get; set; }
+```
+
+Final shape of the class body (for unambiguous reference):
+
+```csharp
+public class GetChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DocumentType DocumentType { get; set; }
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }
+
+    public GetChunkDetailResponse() { }
+
+    public GetChunkDetailResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 4: Populate `SourcePath` in the handler**
+
+In `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`, add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser (after `Content = chunk.Content,`).
+
+Final shape of the response init:
+
+```csharp
+        return new GetChunkDetailResponse
+        {
+            ChunkId = chunk.Id,
+            DocumentId = chunk.DocumentId,
+            Filename = chunk.Document.Filename,
+            DocumentType = chunk.DocumentType,
+            IndexedAt = chunk.Document.IndexedAt,
+            ChunkIndex = chunk.ChunkIndex,
+            Summary = chunk.Summary,
+            Content = chunk.Content,
+            SourcePath = chunk.Document.SourcePath,
+        };
+```
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetChunkDetailHandlerTests"
+```
+
+Expected: 5 tests pass (2 existing + 3 new). Zero failures.
+
+- [ ] **Step 6: Build + format the backend**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: clean build, `dotnet format` exits 0 with no changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs \
+        backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs
+git commit -m "feat: surface SourcePath in KB GetChunkDetail response"
+```
+
+---
+
+## Task 2: Backend — Leaflet GetLeafletChunkDetail returns `SourcePath`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs`
+
+- [ ] **Step 1: Add the three failing tests**
+
+`GetLeafletChunkDetailHandlerTests.cs` currently uses **FluentAssertions**. Match that style. Insert the three `[Fact]` methods at the end of the class, before the closing brace:
+
+```csharp
+    [Fact]
+    public async Task Handle_returns_sharepoint_source_path_when_document_sourced_from_sharepoint()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "leaflet.pdf",
+                SourcePath = "https://anelacz.sharepoint.com/sites/x/leaflet.pdf",
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be("https://anelacz.sharepoint.com/sites/x/leaflet.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_returns_synthetic_upload_path_when_document_manually_uploaded()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "uploaded.pdf",
+                SourcePath = "upload/xyz-9/uploaded.pdf",
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be("upload/xyz-9/uploaded.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_returns_empty_string_when_document_has_no_source_path()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "no-source.pdf",
+                SourcePath = string.Empty,
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be(string.Empty);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetLeafletChunkDetailHandlerTests"
+```
+
+Expected: compilation error — `GetLeafletChunkDetailResponse` does not contain a definition for `SourcePath`.
+
+- [ ] **Step 3: Add `SourcePath` to the response DTO**
+
+In `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs`, add the property to `GetLeafletChunkDetailResponse` (after `Summary`, before the constructors):
+
+```csharp
+    public string? SourcePath { get; set; }
+```
+
+Final class shape:
+
+```csharp
+public class GetLeafletChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }
+
+    public GetLeafletChunkDetailResponse() { }
+
+    public GetLeafletChunkDetailResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 4: Populate `SourcePath` in the handler**
+
+In `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs`, add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser:
+
+```csharp
+        return new GetLeafletChunkDetailResponse
+        {
+            ChunkId = chunk.Id,
+            DocumentId = chunk.DocumentId,
+            Filename = chunk.Document.Filename,
+            IndexedAt = chunk.Document.IndexedAt,
+            ChunkIndex = chunk.ChunkIndex,
+            Content = chunk.Content,
+            Summary = chunk.Summary,
+            SourcePath = chunk.Document.SourcePath,
+        };
+```
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetLeafletChunkDetailHandlerTests"
+```
+
+Expected: 5 tests pass (2 existing + 3 new).
+
+- [ ] **Step 6: Build + format the backend**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: clean build, format exits 0 with no changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs
+git commit -m "feat: surface SourcePath in Leaflet GetLeafletChunkDetail response"
+```
+
+---
+
+## Task 3: Frontend — `getSharePointLink` helper + tests
+
+**Files:**
+- Create: `frontend/src/utils/sharepointLink.ts`
+- Test: `frontend/src/utils/sharepointLink.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/utils/sharepointLink.test.ts` with the following content:
+
+```ts
+import { getSharePointLink } from './sharepointLink';
+
+describe('getSharePointLink', () => {
+  test('returns null for null', () => {
+    expect(getSharePointLink(null)).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(getSharePointLink(undefined)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(getSharePointLink('')).toBeNull();
+  });
+
+  test('returns null for synthetic upload path', () => {
+    expect(getSharePointLink('upload/abc-123/file.pdf')).toBeNull();
+  });
+
+  test('returns the URL verbatim when it starts with https://', () => {
+    const url = 'https://anelacz.sharepoint.com/sites/x/doc.docx';
+    expect(getSharePointLink(url)).toBe(url);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/utils/sharepointLink.test.ts
+```
+
+Expected: test fails with "Cannot find module './sharepointLink'".
+
+- [ ] **Step 3: Implement the helper**
+
+Create `frontend/src/utils/sharepointLink.ts`:
+
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null {
+  if (!sourcePath) return null;
+  if (sourcePath.startsWith('https://')) return sourcePath;
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/utils/sharepointLink.test.ts
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/sharepointLink.ts frontend/src/utils/sharepointLink.test.ts
+git commit -m "feat: add getSharePointLink helper for chunk source URLs"
+```
+
+---
+
+## Task 4: Frontend — extend hand-defined TS interfaces
+
+The chunk detail hooks in `api/hooks/` use **hand-maintained** response interfaces, not the auto-generated client. Add the new optional field to both manual interfaces so subsequent UI work compiles.
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useKnowledgeBase.ts`
+- Modify: `frontend/src/api/hooks/useLeaflet.ts`
+
+- [ ] **Step 1: Add `sourcePath` to `GetChunkDetailResponse` (KB hook)**
+
+Open `frontend/src/api/hooks/useKnowledgeBase.ts`. Locate the interface at line ~127 and add `sourcePath?: string;` as the last field.
+
+Final shape:
+
+```ts
+export interface GetChunkDetailResponse {
+  success: boolean;
+  chunkId: string;
+  documentId: string;
+  filename: string;
+  documentType: 'KnowledgeBase' | 'Conversation';
+  indexedAt: string | null;
+  chunkIndex: number;
+  summary: string;
+  content: string;
+  sourcePath?: string;
+}
+```
+
+- [ ] **Step 2: Add `sourcePath` to `GetLeafletChunkDetailResponse` (Leaflet hook)**
+
+Open `frontend/src/api/hooks/useLeaflet.ts`. Locate the interface at line ~43 and add `sourcePath?: string;` as the last field.
+
+Final shape:
+
+```ts
+export interface GetLeafletChunkDetailResponse {
+  success: boolean;
+  chunkId: string;
+  documentId: string;
+  filename: string;
+  documentType: string;
+  indexedAt: string | null;
+  chunkIndex: number;
+  summary: string;
+  content: string;
+  sourcePath?: string;
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds. (No new code consumes `sourcePath` yet — that arrives in Tasks 5–6.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/hooks/useKnowledgeBase.ts frontend/src/api/hooks/useLeaflet.ts
+git commit -m "feat: add sourcePath to chunk detail response interfaces"
+```
+
+---
+
+## Task 5: Frontend — KB ChunkDetailModal renders SharePoint link
+
+**Files:**
+- Modify: `frontend/src/components/knowledge-base/ChunkDetailModal.tsx`
+- Test: `frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx`
+
+- [ ] **Step 1: Add the three failing test cases**
+
+Append three new tests to `frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx` (after the existing `'calls onClose on Escape key'` test). The file already mocks `useChunkDetailQuery`; reuse the same mock pattern.
+
+```ts
+test('renders SharePoint link when sourcePath is an https URL', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'https://anelacz.sharepoint.com/sites/x/doc.docx' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  const link = screen.getByRole('link', { name: /Otevřít v SharePoint/i });
+  expect(link).toHaveAttribute('href', 'https://anelacz.sharepoint.com/sites/x/doc.docx');
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+test('hides SharePoint link when sourcePath is a synthetic upload path', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'upload/abc/file.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+
+test('hides SharePoint link when sourcePath is missing', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: undefined },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+```
+
+Expected: the three new tests fail (link is not in the DOM yet); the existing four tests still pass.
+
+- [ ] **Step 3: Add the link element + imports**
+
+Edit `frontend/src/components/knowledge-base/ChunkDetailModal.tsx`:
+
+3a. Update the `lucide-react` import to include `ExternalLink`:
+
+```ts
+import { X, ExternalLink } from 'lucide-react';
+```
+
+3b. Add the helper import below the existing `formatDateTime` import:
+
+```ts
+import { getSharePointLink } from '../../utils/sharepointLink';
+```
+
+3c. Insert the link block immediately after the closing tag of the `Meta row` `<div>` (currently line 74) and before the `Summary` `<div>` (currently line 77). The insertion goes inside the `data && (...)` fragment.
+
+```tsx
+              {/* SharePoint link (only when document has a real https:// SourcePath) */}
+              {getSharePointLink(data.sourcePath) && (
+                <a
+                  href={getSharePointLink(data.sourcePath)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                >
+                  Otevřít v SharePoint
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+```
+
+Expected: all 7 tests pass (4 existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/knowledge-base/ChunkDetailModal.tsx \
+        frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+git commit -m "feat: render SharePoint link in KB chunk detail modal"
+```
+
+---
+
+## Task 6: Frontend — Leaflet LeafletChunkDetailModal renders SharePoint link
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx`
+- Create: `frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx`
+
+There is no existing test file for `LeafletChunkDetailModal`; create one mirroring the KB modal's test structure.
+
+- [ ] **Step 1: Create the failing test file**
+
+Create `frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LeafletChunkDetailModal from '../LeafletChunkDetailModal';
+import * as hooks from '../../../api/hooks/useLeaflet';
+
+const mockChunkDetail = {
+  success: true,
+  chunkId: 'chunk-1',
+  documentId: 'doc-1',
+  filename: 'leaflet.pdf',
+  documentType: 'Document',
+  indexedAt: '2024-03-15T10:00:00Z',
+  chunkIndex: 0,
+  summary: 'Summary text.',
+  content: 'Full leaflet content.',
+};
+
+const mockOnClose = jest.fn();
+
+function renderModal() {
+  return render(
+    <LeafletChunkDetailModal chunkId="chunk-1" onClose={mockOnClose} />
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders SharePoint link when sourcePath is an https URL', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'https://anelacz.sharepoint.com/sites/x/leaflet.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  const link = screen.getByRole('link', { name: /Otevřít v SharePoint/i });
+  expect(link).toHaveAttribute('href', 'https://anelacz.sharepoint.com/sites/x/leaflet.pdf');
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+test('hides SharePoint link when sourcePath is a synthetic upload path', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'upload/abc/file.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+
+test('hides SharePoint link when sourcePath is missing', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: undefined },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+```
+
+Expected: all three tests fail.
+
+- [ ] **Step 3: Add the link element + imports**
+
+Edit `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx`:
+
+3a. Update the `lucide-react` import:
+
+```ts
+import { X, ExternalLink } from 'lucide-react';
+```
+
+3b. Add the helper import below the existing `formatDateTime` import:
+
+```ts
+import { getSharePointLink } from '../../utils/sharepointLink';
+```
+
+3c. Insert the link block immediately after the closing tag of the `Meta row` `<div>` (currently line 66) and before the `Summary` `<div>` (currently line 69):
+
+```tsx
+              {/* SharePoint link (only when document has a real https:// SourcePath) */}
+              {getSharePointLink(data.sourcePath) && (
+                <a
+                  href={getSharePointLink(data.sourcePath)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                >
+                  Otevřít v SharePoint
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx \
+        frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+git commit -m "feat: render SharePoint link in Leaflet chunk detail modal"
+```
+
+---
+
+## Task 7: Frontend — Marketing Feedback stub page + route registration
+
+**Files:**
+- Create: `frontend/src/pages/MarketingFeedbackPage.tsx`
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: Create the stub page**
+
+Create `frontend/src/pages/MarketingFeedbackPage.tsx`:
+
+```tsx
+import React from 'react';
+
+const MarketingFeedbackPage: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Feedback</h1>
+      <p className="mt-2 text-sm text-gray-600">
+        Přehled zpětné vazby bude dostupný po dokončení integrace.
+      </p>
+    </div>
+  );
+};
+
+export default MarketingFeedbackPage;
+```
+
+- [ ] **Step 2: Import and register the route in `App.tsx`**
+
+Open `frontend/src/App.tsx`.
+
+2a. Add the import after the existing `KnowledgeBaseFeedbackPage` import (currently line 38):
+
+```ts
+import MarketingFeedbackPage from "./pages/MarketingFeedbackPage";
+```
+
+2b. Inside the `<Routes>` block, register the new route immediately after the existing `/knowledge-base/feedback` route (currently lines 469–472). Insert before the `/articles` route:
+
+```tsx
+                        <Route
+                          path="/marketing/feedback"
+                          element={<MarketingFeedbackPage />}
+                        />
+```
+
+- [ ] **Step 3: Verify the build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds, no TypeScript errors.
+
+- [ ] **Step 4: Smoke test the route in dev**
+
+This is a manual verification step. Start the dev server in one terminal, then verify the route in a browser.
+
+```bash
+cd frontend && npm start
+```
+
+Open `http://localhost:3000/marketing/feedback` while authenticated. Expect to see the heading "Feedback" and the subtitle "Přehled zpětné vazby bude dostupný po dokončení integrace." with no console errors. Then stop the dev server (Ctrl+C).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/MarketingFeedbackPage.tsx frontend/src/App.tsx
+git commit -m "feat: add /marketing/feedback stub page"
+```
+
+---
+
+## Task 8: Frontend — Sidebar consolidation
+
+Merge the existing `marketing` section with the existing `knowledgebase` section into a single `marketing` section containing five items, then remove the now-empty `knowledgebase` section and the `Database` icon import.
+
+**Files:**
+- Modify: `frontend/src/components/Layout/Sidebar.tsx`
+
+- [ ] **Step 1: Replace the `marketing` section block**
+
+Open `frontend/src/components/Layout/Sidebar.tsx`. Find the existing `marketing` section (currently lines 140–149):
+
+```tsx
+    {
+      id: "marketing",
+      name: "Marketing",
+      icon: Megaphone,
+      type: "section" as const,
+      items: [
+        { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
+        { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+      ],
+    },
+```
+
+Replace it with:
+
+```tsx
+    {
+      id: "marketing",
+      name: "Marketing",
+      icon: Megaphone,
+      type: "section" as const,
+      items: [
+        { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
+        { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+        { id: "articles", name: "Generátor článků", href: "/articles" },
+        { id: "knowledge-base", name: "Poradenství (KB)", href: "/knowledge-base" },
+        ...(hasRole("knowledge_base_manager") || hasRole("leaflet_manager") || hasRole("article_generator")
+          ? [{ id: "marketing-feedback", name: "Feedback", href: "/marketing/feedback" }]
+          : []),
+      ],
+    },
+```
+
+- [ ] **Step 2: Remove the `knowledgebase` section block**
+
+In the same file, delete the entire `knowledgebase` section object (currently lines 299–314):
+
+```tsx
+    {
+      id: 'knowledgebase',
+      name: 'Knowledgebase',
+      icon: Database,
+      type: 'section' as const,
+      items: [
+        {
+          id: 'kb-poradenstvi',
+          name: 'Poradenství',
+          href: '/knowledge-base',
+        },
+        ...(hasRole('knowledge_base_manager')
+          ? [{ id: 'kb-feedback', name: 'Feedback', href: '/knowledge-base/feedback' }]
+          : []),
+      ],
+    },
+```
+
+After deletion, the immediately preceding entry (the `automatizace` section, ending with `};` and a closing `,`) should be the last array item. The `]` closing `navigationSections` (currently line 315) immediately follows.
+
+- [ ] **Step 3: Remove the `Database` icon import**
+
+`Database` is only used inside the now-removed `knowledgebase` section. Confirm and remove.
+
+3a. Confirm no other usage in the file:
+
+```bash
+grep -n "Database" frontend/src/components/Layout/Sidebar.tsx
+```
+
+Expected output: zero matches (the previous import line referenced it, but after this step we will have removed the only usage; the import itself is the next match to remove).
+
+3b. In the `lucide-react` import block (currently line 20), remove the line `Database,`. The block should become:
+
+```tsx
+import {
+  LayoutDashboard,
+  Package,
+  ShoppingCart,
+  ChevronDown,
+  ChevronRight,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Menu,
+  DollarSign,
+  Cog,
+  Truck,
+  Bot,
+  Newspaper,
+  Users,
+  ExternalLink,
+  FileText,
+  Megaphone,
+} from "lucide-react";
+```
+
+- [ ] **Step 4: Verify build + lint**
+
+```bash
+cd frontend && npm run build && npm run lint
+```
+
+Expected: clean build, lint reports no new errors. Specifically, no "unused import" error for `Database`.
+
+- [ ] **Step 5: Smoke test the sidebar in dev**
+
+```bash
+cd frontend && npm start
+```
+
+Authenticated as a manager (with one of `knowledge_base_manager`, `leaflet_manager`, `article_generator` roles), expand the sidebar's Marketing group and verify these five items appear in this order:
+
+1. Kalendář
+2. Generátor letáků
+3. Generátor článků
+4. Poradenství (KB)
+5. Feedback
+
+Click each item and verify it navigates without a console error. Confirm there is no "Knowledgebase" group anywhere. Stop the dev server.
+
+If you can also test as a non-manager (no relevant roles), confirm that "Feedback" is hidden but the other four items remain.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Layout/Sidebar.tsx
+git commit -m "feat: consolidate Marketing sidebar group"
+```
+
+---
+
+## Task 9: End-to-end verification
+
+Final verification before merging the branch. All previous tasks must be committed.
+
+- [ ] **Step 1: Backend full build, format, and tests**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: build clean, format reports no changes, all tests pass.
+
+- [ ] **Step 2: Frontend full build, lint, and tests**
+
+```bash
+cd frontend && npm run build && npm run lint && CI=true npx react-scripts test --watchAll=false
+```
+
+Expected: build clean, lint clean, all Jest tests pass (including the new `sharepointLink.test.ts`, the extended `ChunkDetailModal.test.tsx`, and the new `LeafletChunkDetailModal.test.tsx`).
+
+- [ ] **Step 3: Manual smoke checklist**
+
+Run the dev server, sign in as a manager.
+
+```bash
+cd frontend && npm start
+```
+
+Walk through:
+1. Sidebar's Marketing group expands and shows Kalendář, Generátor letáků, Generátor článků, Poradenství (KB), Feedback.
+2. There is no Knowledgebase group.
+3. `/marketing/feedback` renders the stub.
+4. `/knowledge-base` → Dokumenty tab → click a chunk row whose document originated in SharePoint → modal shows "Otevřít v SharePoint" link with `target="_blank"` and the correct URL.
+5. `/knowledge-base` → Dokumenty tab → click a chunk row for a manually uploaded document → modal shows no SharePoint link.
+6. `/leaflet-generator` → Dokumenty tab → repeat steps 4–5 with the Leaflet modal.
+7. No browser console errors.
+
+Stop the dev server.
+
+- [ ] **Step 4: Confirm working tree is clean**
+
+```bash
+git status
+```
+
+Expected: clean working tree (all task commits already in). If the OpenAPI auto-regen produced a diff in `frontend/src/api/generated/api-client.ts` during `npm run build` (the generator may add `sourcePath` to the generated DTO), commit it now:
+
+```bash
+git status
+git add frontend/src/api/generated/api-client.ts
+git diff --cached frontend/src/api/generated/api-client.ts | head -60
+git commit -m "chore: regenerate OpenAPI client for sourcePath addition"
+```
+
+If there is no diff, skip this commit.
+
+---
+
+## Self-Review Outcomes
+
+- **Spec coverage:**
+  - FR-1 (Marketing consolidation) → Task 8.
+  - FR-2 (Campaigns disposition) → no-op; spec premise is false. Plan documents this in the introduction; PR description should restate.
+  - FR-3 (Marketing Feedback stub) → Task 7.
+  - FR-4 (KB SourcePath in DTO + handler) → Task 1.
+  - FR-5 (Leaflet SourcePath in DTO + handler) → Task 2.
+  - FR-6 (`getSharePointLink` helper) → Task 3 (relocated to `frontend/src/utils/` per arch-review Decision 1).
+  - FR-7 (KB modal renders link) → Task 5.
+  - FR-8 (Leaflet modal renders link) → Task 6.
+  - Hidden gap (manual TS interfaces in `api/hooks/`) → Task 4.
+
+- **Type consistency:** Helper signature matches across all consumers: `getSharePointLink(sourcePath: string | null | undefined): string | null`. Both modals call it identically. The DTO field is `string?` in C# and `sourcePath?: string` in TS. The helper's `if (!sourcePath)` check covers `null`, `undefined`, and `""` uniformly.
+
+- **No placeholders:** Each step contains the exact code or command needed; no "add appropriate handling" or "similar to other modal" references.

--- a/artifacts/feat-phase-2-leaflet-generation-persistence-f/arch-review.r1.md
+++ b/artifacts/feat-phase-2-leaflet-generation-persistence-f/arch-review.r1.md
@@ -1,0 +1,1 @@
+Architecture review written to `artifacts/feat-phase-2-leaflet-generation-persistence-f/arch-review.r1.md`.

--- a/artifacts/feat-phase-2-leaflet-generation-persistence-f/brief.md
+++ b/artifacts/feat-phase-2-leaflet-generation-persistence-f/brief.md
@@ -1,0 +1,610 @@
+# Phase 2 — Leaflet Generation Persistence + Feedback
+
+CRITICAL: use branch "feature/genai_consistency" as an integration branch instead of main. New branch must be based on that and also PR must be targeted back to this branch
+
+## Goal
+Every generated leaflet is persisted with its source references. Users can submit a 1–5 precision/style rating and comment. The same owner-only, one-shot feedback pattern as KnowledgeBase applies.
+
+## Dependency
+Phase 1 must be complete (sidebar, routes). Otherwise independent from Phase 3/4.
+
+---
+
+## Step 1 — Domain: new entity `LeafletGeneration`
+
+**New file**: `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs`
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public class LeafletGeneration
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;   // AudienceType enum name
+    public string Length { get; set; } = string.Empty;     // LeafletLength enum name
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}
+```
+
+> No separate `LeafletGenerationSource` table — source counts are sufficient for the feedback story. Individual chunk references can be added later if cross-navigation to chunks is required (Phase 4+ scope).
+
+---
+
+## Step 2 — Domain: update repository interface
+
+**File**: `backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs`
+
+Add methods:
+
+```csharp
+Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken cancellationToken);
+Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken cancellationToken);
+Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+    bool? hasFeedback, string? userId, string sortBy, bool descending,
+    int page, int pageSize, CancellationToken cancellationToken);
+Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken);
+Task SaveChangesAsync(CancellationToken cancellationToken);
+```
+
+**New file**: `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs`
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public sealed record LeafletFeedbackStats(
+    int TotalGenerations,
+    int TotalWithFeedback,
+    double? AvgPrecisionScore,
+    double? AvgStyleScore);
+```
+
+---
+
+## Step 3 — Persistence: EF configuration
+
+**New file**: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs`
+
+```csharp
+using Anela.Heblo.Domain.Features.Leaflet;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Leaflet;
+
+public class LeafletGenerationConfiguration : IEntityTypeConfiguration<LeafletGeneration>
+{
+    public void Configure(EntityTypeBuilder<LeafletGeneration> builder)
+    {
+        builder.ToTable("LeafletGenerations");
+        builder.HasKey(g => g.Id);
+        builder.Property(g => g.Topic).HasMaxLength(200).IsRequired();
+        builder.Property(g => g.Audience).HasMaxLength(50).IsRequired();
+        builder.Property(g => g.Length).HasMaxLength(50).IsRequired();
+        builder.Property(g => g.FinalMarkdown).IsRequired();
+        builder.Property(g => g.UserId).HasMaxLength(200);
+        builder.Property(g => g.FeedbackComment).HasColumnType("text");
+        builder.HasIndex(g => g.CreatedAt);
+        builder.HasIndex(g => g.UserId);
+        builder.HasIndex(g => g.PrecisionScore).HasFilter("\"PrecisionScore\" IS NOT NULL");
+    }
+}
+```
+
+**File**: `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs`
+
+Add DbSet after the existing Leaflet DbSets:
+
+```csharp
+public DbSet<LeafletGeneration> LeafletGenerations { get; set; } = null!;
+```
+
+---
+
+## Step 4 — Persistence: repository implementation
+
+**File**: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs`
+
+Implement the four new interface methods:
+
+```csharp
+public async Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken cancellationToken)
+{
+    _context.LeafletGenerations.Add(generation);
+    await _context.SaveChangesAsync(cancellationToken);
+}
+
+public async Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken cancellationToken)
+    => await _context.LeafletGenerations.FindAsync([id], cancellationToken);
+
+public async Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+    bool? hasFeedback, string? userId, string sortBy, bool descending,
+    int page, int pageSize, CancellationToken cancellationToken)
+{
+    var query = _context.LeafletGenerations.AsQueryable();
+
+    if (hasFeedback == true)
+        query = query.Where(g => g.PrecisionScore != null || g.StyleScore != null);
+    else if (hasFeedback == false)
+        query = query.Where(g => g.PrecisionScore == null && g.StyleScore == null);
+
+    if (!string.IsNullOrWhiteSpace(userId))
+        query = query.Where(g => g.UserId == userId);
+
+    query = (sortBy, descending) switch
+    {
+        ("PrecisionScore", true)  => query.OrderByDescending(g => g.PrecisionScore),
+        ("PrecisionScore", false) => query.OrderBy(g => g.PrecisionScore),
+        ("StyleScore", true)      => query.OrderByDescending(g => g.StyleScore),
+        ("StyleScore", false)     => query.OrderBy(g => g.StyleScore),
+        (_, true)                 => query.OrderByDescending(g => g.CreatedAt),
+        _                         => query.OrderBy(g => g.CreatedAt),
+    };
+
+    var total = await query.CountAsync(cancellationToken);
+    var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
+    return (items, total);
+}
+
+public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+{
+    var total = await _context.LeafletGenerations.CountAsync(cancellationToken);
+    var withFeedback = await _context.LeafletGenerations
+        .CountAsync(g => g.PrecisionScore != null || g.StyleScore != null, cancellationToken);
+    var avgPrecision = await _context.LeafletGenerations
+        .Where(g => g.PrecisionScore != null)
+        .AverageAsync(g => (double?)g.PrecisionScore, cancellationToken);
+    var avgStyle = await _context.LeafletGenerations
+        .Where(g => g.StyleScore != null)
+        .AverageAsync(g => (double?)g.StyleScore, cancellationToken);
+    return new LeafletFeedbackStats(total, withFeedback, avgPrecision, avgStyle);
+}
+
+public Task SaveChangesAsync(CancellationToken cancellationToken)
+    => _context.SaveChangesAsync(cancellationToken);
+```
+
+---
+
+## Step 5 — Migration
+
+Name: `AddLeafletGenerations` (next sequential after `20260505080157_AddSummaryToLeafletChunk`).
+
+```
+dotnet ef migrations add AddLeafletGenerations \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected migration creates table `public."LeafletGenerations"` with all columns and indexes from Step 3.
+
+---
+
+## Step 6 — Application: `GenerateLeafletResponse` — add `Id`
+
+**File**: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`
+
+Add:
+```csharp
+public Guid? Id { get; set; }
+```
+
+(Nullable — if the logging behavior fails to write, the generation still succeeds.)
+
+---
+
+## Step 7 — Application: `LeafletGenerationLoggingBehavior`
+
+**New file**: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs`
+
+Pattern mirrors `QuestionLoggingBehavior` exactly:
+
+```csharp
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehavior
+    : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<LeafletGenerationLoggingBehavior> _logger;
+
+    public LeafletGenerationLoggingBehavior(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService,
+        ILogger<LeafletGenerationLoggingBehavior> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GenerateLeafletResponse> Handle(
+        GenerateLeafletRequest request,
+        RequestHandlerDelegate<GenerateLeafletResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var response = await next();
+        sw.Stop();
+
+        if (!response.Success)
+            return response;
+
+        try
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            var generation = new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = request.Topic,
+                Audience = request.Audience.ToString(),
+                Length = request.Length.ToString(),
+                FinalMarkdown = response.Content ?? string.Empty,
+                KbSourceCount = response.KbSourceCount,
+                LeafletSourceCount = response.LeafletSourceCount,
+                DurationMs = sw.ElapsedMilliseconds,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UserId = currentUser.Id,
+            };
+
+            await _repository.SaveGenerationAsync(generation, cancellationToken);
+            response.Id = generation.Id;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to log leaflet generation. Topic: {Topic}", request.Topic);
+        }
+
+        return response;
+    }
+}
+```
+
+Note: `GenerateLeafletResponse` must expose `KbSourceCount` and `LeafletSourceCount`. Check the current response — if those counts are not there, add them in `GenerateLeafletHandler` when building the response (it already has the `kbHits`/`leafletHits` lists).
+
+---
+
+## Step 8 — Register the behavior
+
+**File**: `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs`
+
+Add (after existing service registrations):
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+// ...
+
+services.AddScoped<
+    IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+    LeafletGenerationLoggingBehavior>();
+```
+
+---
+
+## Step 9 — Application: `SubmitLeafletFeedback`
+
+**New files** under `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/`:
+
+`SubmitLeafletFeedbackRequest.cs`:
+```csharp
+using MediatR;
+using Anela.Heblo.Application.Shared;
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackRequest : IRequest<SubmitLeafletFeedbackResponse>
+{
+    public Guid GenerationId { get; set; }
+    [Range(1, 5)] public int PrecisionScore { get; set; }
+    [Range(1, 5)] public int StyleScore { get; set; }
+    [MaxLength(1000)] public string? Comment { get; set; }
+}
+```
+
+`SubmitLeafletFeedbackResponse.cs`:
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackResponse : BaseResponse
+{
+    public SubmitLeafletFeedbackResponse() { }
+    public SubmitLeafletFeedbackResponse(string errorCode, Dictionary<string, string>? context = null)
+        : base(errorCode, context) { }
+}
+```
+
+`SubmitLeafletFeedbackHandler.cs` — mirror `SubmitFeedbackHandler` from KB exactly:
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackHandler : IRequestHandler<SubmitLeafletFeedbackRequest, SubmitLeafletFeedbackResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public SubmitLeafletFeedbackHandler(ILeafletRepository repository, ICurrentUserService currentUserService)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<SubmitLeafletFeedbackResponse> Handle(
+        SubmitLeafletFeedbackRequest request, CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.GenerationId, cancellationToken);
+        if (generation is null)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.LeafletFeedbackNotFound,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
+        var currentUser = _currentUserService.GetCurrentUser();
+        if (generation.UserId != currentUser.Id)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.Forbidden,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
+        if (generation.PrecisionScore is not null || generation.StyleScore is not null)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.LeafletFeedbackAlreadySubmitted,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
+        generation.PrecisionScore = request.PrecisionScore;
+        generation.StyleScore = request.StyleScore;
+        generation.FeedbackComment = request.Comment;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new SubmitLeafletFeedbackResponse();
+    }
+}
+```
+
+Add error codes to `ErrorCodes` enum/class:
+- `LeafletFeedbackNotFound`
+- `LeafletFeedbackAlreadySubmitted`
+
+---
+
+## Step 10 — Application: `GetLeafletFeedbackList`
+
+**New files** under `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/`:
+
+Follow the exact shape of KB's `GetFeedbackListHandler`, `GetFeedbackListRequest`, `GetFeedbackListResponse`, `FeedbackLogSummary`, `FeedbackStatsDto` — rename with `Leaflet` prefix.
+
+`GetLeafletFeedbackListRequest.cs`:
+```csharp
+public class GetLeafletFeedbackListRequest : IRequest<GetLeafletFeedbackListResponse>
+{
+    public bool? HasFeedback { get; set; }
+    public string? UserId { get; set; }
+    public string SortBy { get; set; } = "CreatedAt";
+    public bool SortDescending { get; set; } = true;
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+}
+```
+
+`GetLeafletFeedbackListResponse.cs`:
+```csharp
+public class GetLeafletFeedbackListResponse : BaseResponse
+{
+    public List<LeafletFeedbackSummary> Logs { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public LeafletFeedbackStatsDto Stats { get; set; } = new();
+}
+
+public class LeafletFeedbackSummary
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}
+
+public class LeafletFeedbackStatsDto
+{
+    public int TotalGenerations { get; set; }
+    public int TotalWithFeedback { get; set; }
+    public double? AvgPrecisionScore { get; set; }
+    public double? AvgStyleScore { get; set; }
+}
+```
+
+Handler follows `GetFeedbackListHandler` exactly, validated sort columns: `["CreatedAt", "PrecisionScore", "StyleScore"]`, allowed page sizes: `[10, 20, 50]`.
+
+---
+
+## Step 11 — API controller additions
+
+**File**: `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`
+
+Add three new actions:
+
+```csharp
+// using ... (add required using statements for new use cases)
+
+[HttpPost("feedback")]
+[ProducesResponseType(typeof(SubmitLeafletFeedbackResponse), 200)]
+[ProducesResponseType(typeof(ProblemDetails), 409)]
+public async Task<ActionResult<SubmitLeafletFeedbackResponse>> SubmitFeedback(
+    [FromBody] SubmitLeafletFeedbackRequest request, CancellationToken ct)
+{
+    var result = await _mediator.Send(request, ct);
+    return HandleResponse(result);
+}
+
+[HttpGet("feedback/list")]
+[Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+public async Task<ActionResult<GetLeafletFeedbackListResponse>> GetFeedbackList(
+    [FromQuery] bool? hasFeedback = null,
+    [FromQuery] string? userId = null,
+    [FromQuery] string sortBy = "CreatedAt",
+    [FromQuery] bool sortDescending = true,
+    [FromQuery] int pageNumber = 1,
+    [FromQuery] int pageSize = 20,
+    CancellationToken ct = default)
+{
+    var result = await _mediator.Send(new GetLeafletFeedbackListRequest
+    {
+        HasFeedback = hasFeedback,
+        UserId = userId,
+        SortBy = sortBy,
+        SortDescending = sortDescending,
+        PageNumber = pageNumber,
+        PageSize = pageSize,
+    }, ct);
+    return HandleResponse(result);
+}
+
+[HttpGet("generations/{id:guid}")]
+public async Task<ActionResult<GetLeafletGenerationResponse>> GetGeneration(Guid id, CancellationToken ct)
+{
+    // Simple handler: load LeafletGeneration by id, return 404 if not found
+    var result = await _mediator.Send(new GetLeafletGenerationRequest { Id = id }, ct);
+    return HandleResponse(result);
+}
+```
+
+> `GetLeafletGenerationRequest/Handler/Response` is a trivial loader — create the three files following the same pattern as `GetArticleHandler`.
+
+---
+
+## Step 12 — Frontend: extract `RagFeedbackForm`
+
+**New file**: `frontend/src/components/feedback/RagFeedbackForm.tsx`
+
+Extract the feedback form from `KnowledgeBaseSearchAskTab.tsx` (lines ~93-163). The component currently knows about KB-specific hook shapes. Generalize via props:
+
+```tsx
+interface RagFeedbackFormProps {
+  onSubmit: (data: { precisionScore: number; styleScore: number; comment: string }) => void;
+  isSubmitting: boolean;
+  alreadySubmitted: boolean;
+  isSuccess: boolean;
+}
+
+export default function RagFeedbackForm({ onSubmit, isSubmitting, alreadySubmitted, isSuccess }: RagFeedbackFormProps) {
+  // ... rating UI, textarea, submit button
+}
+```
+
+Update `KnowledgeBaseSearchAskTab.tsx` to import and use `RagFeedbackForm` instead of the inline form.
+
+---
+
+## Step 13 — Frontend: `LeafletResult.tsx` — add feedback form
+
+**File**: `frontend/src/features/leaflet-generator/LeafletResult.tsx`
+
+Update `LeafletResultProps` to accept an optional `generationId`:
+```tsx
+interface LeafletResultProps {
+  content: string;
+  generationId?: string;
+  onRegenerate: () => void;
+}
+```
+
+Add feedback form below the Copy/Regenerate buttons using `RagFeedbackForm`. Wire to a new `useSubmitLeafletFeedbackMutation` hook.
+
+---
+
+## Step 14 — Frontend: `useLeaflet.ts` — add feedback hooks
+
+**File**: `frontend/src/api/hooks/useLeaflet.ts`
+
+Add:
+```ts
+export function useSubmitLeafletFeedbackMutation() {
+  return useMutation({
+    mutationFn: (data: { generationId: string; precisionScore: number; styleScore: number; comment?: string }) =>
+      client.leaflet_SubmitFeedback(data),
+    // handle HTTP 409 as alreadySubmitted (same pattern as KB)
+  });
+}
+
+export function useLeafletFeedbackListQuery(params: LeafletFeedbackListParams) {
+  return useQuery({
+    queryKey: leafletKeys.feedbackList(params),
+    queryFn: () => client.leaflet_GetFeedbackList(params),
+    staleTime: 30_000,
+  });
+}
+```
+
+---
+
+## Step 15 — i18n
+
+**File**: `frontend/src/i18n.ts`
+
+Add error code translations:
+```ts
+LeafletFeedbackNotFound: {
+  cs: 'Záznam generování letáku nebyl nalezen.',
+  en: 'Leaflet generation log not found.',
+},
+LeafletFeedbackAlreadySubmitted: {
+  cs: 'Zpětná vazba již byla odeslána.',
+  en: 'Feedback has already been submitted.',
+},
+```
+
+---
+
+## Tests to write
+
+### Backend
+- `SubmitLeafletFeedbackHandlerTests` — not found / forbidden / already submitted / success
+- `GetLeafletFeedbackListHandlerTests` — paging, filters, stats
+- `LeafletGenerationLoggingBehaviorTests` — verify generation saved, `response.Id` populated, errors swallowed
+- `LeafletRepositoryIntegrationTests` — `SaveGenerationAsync`, `GetGenerationByIdAsync`, `GetGenerationsPagedAsync`, `GetGenerationStatsAsync`
+
+### Frontend
+- `useLeaflet.test.ts` — `useSubmitLeafletFeedbackMutation` converts 409 → `alreadySubmitted`
+- `RagFeedbackForm.test.tsx` — renders ratings, submits, shows already-submitted state
+
+---
+
+## Verification
+
+1. `dotnet build` + `dotnet format`.
+2. `npm run build` + `npm run lint`.
+3. Run new backend tests: all green.
+4. Migration applies cleanly: `dotnet ef database update` on local dev DB.
+5. Generate a leaflet → inspect DB: row exists in `LeafletGenerations` with correct topic, counts, markdown.
+6. `response.id` returned by API → feedback form shown.
+7. Submit feedback → `PrecisionScore`/`StyleScore` updated in DB.
+8. Submit again → HTTP 409 → UI shows "Zpětná vazba již byla odeslána."
+9. `GET /api/leaflet/feedback/list` (with manager role) → returns paged data + stats.

--- a/artifacts/feat-phase-2-leaflet-generation-persistence-f/design.r1.md
+++ b/artifacts/feat-phase-2-leaflet-generation-persistence-f/design.r1.md
@@ -1,0 +1,9 @@
+`design.r1.md` written to `artifacts/feat-phase-2-leaflet-generation-persistence-f/design.r1.md`.
+
+Here's what it covers:
+
+**UX/UI Design** — ASCII wireframes for the leaflet result panel in all three feedback states (idle, success, already-submitted). Component hierarchy showing `LeafletGenerateTab → LeafletResult → RagFeedbackForm` and the KB tab refactor. `RagFeedbackForm` prop contract `{ onSubmit, isSubmitting, alreadySubmitted, isSuccess }`. State flow in `LeafletGenerateTab` showing when `generationId` resets (on each new generation attempt) vs. when it's populated (on success only).
+
+**Component Design** — Frontend: `RagFeedbackForm` (new, no feature imports), `LeafletResult` (adds `generationId?` prop, owns mutation + feedback state), `LeafletGenerateTab` (adds `generationId` state, wires response), `KnowledgeBaseSearchAskTab` (replaces inline form). Backend: `LeafletGenerationLoggingBehavior` (call `next()` outside try/catch, use `CancellationToken.None` for save), `SubmitLeafletFeedbackHandler` (404→403→409 guard sequence), `GetLeafletFeedbackListHandler`, `GetLeafletGenerationHandler`, repository additions, module registration, and the three controller actions.
+
+**Data Schemas** — Full `public."LeafletGenerations"` table with all columns and index DDL. EF Core configuration with schema and filtered index. All DTO classes (never records). Complete request/response JSON shapes for all three endpoints. `ErrorCodes` additions `2502`–`2504`. Frontend types and i18n keys for both locales.

--- a/artifacts/feat-phase-2-leaflet-generation-persistence-f/spec.r1.md
+++ b/artifacts/feat-phase-2-leaflet-generation-persistence-f/spec.r1.md
@@ -1,0 +1,196 @@
+# Specification: Leaflet Generation Persistence + Feedback (Phase 2)
+
+## Summary
+Persist every generated leaflet (topic, parameters, final markdown, source counts, duration, user) to the database and expose a one-shot, owner-only feedback flow (1–5 precision + style ratings, optional comment) mirroring the existing KnowledgeBase feedback pattern. A manager-gated list endpoint surfaces all generations with aggregated stats.
+
+## Background
+Phase 1 of the Leaflet Generator (sidebar, routes, generation flow) is complete. Generated leaflets currently disappear after rendering — there is no audit trail, no quality signal, and no way to compare runs or improve the underlying RAG pipeline.
+
+KnowledgeBase Q&A already has a proven persistence + feedback pattern (`QuestionLoggingBehavior`, `SubmitFeedbackHandler`, `GetFeedbackListHandler`). Phase 2 ports that pattern to the Leaflet feature so we can:
+- retain generated content per user for later reference,
+- collect explicit quality signals (precision and style),
+- aggregate stats to drive future RAG tuning (Phase 3/4).
+
+Phase 2 is independent from Phase 3/4 and depends only on Phase 1 being merged.
+
+**Branch policy:** integration branch is `feature/genai_consistency` (not `main`). Feature branch must be cut from it, and the PR must target it.
+
+## Functional Requirements
+
+### FR-1: Persist every successful leaflet generation
+After a successful `GenerateLeafletRequest`, a `LeafletGeneration` row is written via a MediatR `IPipelineBehavior` (`LeafletGenerationLoggingBehavior`), capturing topic, audience, length, final markdown, KB and Leaflet source counts, duration, current user id, and creation timestamp. The behavior must mirror `QuestionLoggingBehavior` for KB.
+
+**Acceptance criteria:**
+- A successful generation produces exactly one row in `LeafletGenerations` with all fields populated.
+- A failed generation (`response.Success == false`) writes nothing.
+- Logging failures are caught and logged; the original generation response is still returned to the caller.
+- The newly created `Id` is written back to `GenerateLeafletResponse.Id` so the frontend can attach feedback.
+- `GenerateLeafletResponse.KbSourceCount` and `LeafletSourceCount` are populated by `GenerateLeafletHandler` from the existing KB/leaflet hit lists.
+
+### FR-2: One-shot, owner-only feedback submission
+`POST /api/leaflet/feedback` accepts `{ generationId, precisionScore (1–5), styleScore (1–5), comment? (≤1000 chars) }` and updates the generation row.
+
+**Acceptance criteria:**
+- Returns success when the caller is the owner of the generation and no feedback was previously submitted.
+- Returns `LeafletFeedbackNotFound` (HTTP 404 envelope) when the id is unknown.
+- Returns `Forbidden` when the caller is not the generation owner (`UserId` mismatch).
+- Returns `LeafletFeedbackAlreadySubmitted` (HTTP 409 envelope) when `PrecisionScore` or `StyleScore` is already set.
+- `precisionScore` and `styleScore` validated `[Range(1,5)]`; `comment` validated `[MaxLength(1000)]`.
+- On success, `PrecisionScore`, `StyleScore`, and `FeedbackComment` are persisted in a single `SaveChangesAsync`.
+
+### FR-3: Manager-gated feedback list with stats
+`GET /api/leaflet/feedback/list` returns paged generations with optional filters and aggregated stats. Endpoint is gated by the `LeafletUpload` policy (same policy used elsewhere in the leaflet feature for elevated access).
+
+**Acceptance criteria:**
+- Query parameters: `hasFeedback?`, `userId?`, `sortBy` (default `CreatedAt`), `sortDescending` (default `true`), `pageNumber` (default 1), `pageSize` (default 20).
+- Allowed `sortBy` values: `CreatedAt`, `PrecisionScore`, `StyleScore`. Invalid values rejected.
+- Allowed `pageSize` values: `10`, `20`, `50`. Other values rejected.
+- Response includes: `Logs[]`, `TotalCount`, `PageNumber`, `PageSize`, and `Stats { TotalGenerations, TotalWithFeedback, AvgPrecisionScore?, AvgStyleScore? }`.
+- `hasFeedback=true` filters to rows where `PrecisionScore != null OR StyleScore != null`; `hasFeedback=false` filters to neither set.
+
+### FR-4: Single-generation lookup
+`GET /api/leaflet/generations/{id}` loads a `LeafletGeneration` by id. Returns 404 envelope when not found. Pattern mirrors `GetArticleHandler`.
+
+**Acceptance criteria:**
+- Returns the full generation payload for any caller authenticated by the existing controller-level policy.
+- Returns `LeafletFeedbackNotFound` (or equivalent not-found code consistent with existing leaflet handlers) when missing.
+
+### FR-5: Reusable feedback form component
+Extract the inline feedback form currently in `KnowledgeBaseSearchAskTab.tsx` (≈ lines 93–163) into `frontend/src/components/feedback/RagFeedbackForm.tsx` with a generic prop contract: `{ onSubmit, isSubmitting, alreadySubmitted, isSuccess }`. Update KB tab to use the shared component.
+
+**Acceptance criteria:**
+- KB feedback flow behaves identically before and after extraction (visual + behavior parity).
+- New component has no KB- or leaflet-specific imports.
+- Tests cover: rating selection, comment input, submit invocation, already-submitted state, success state.
+
+### FR-6: Leaflet result UI shows feedback form
+`LeafletResult.tsx` accepts an optional `generationId`. When set, the component renders `RagFeedbackForm` below the Copy/Regenerate buttons and wires it to `useSubmitLeafletFeedbackMutation`.
+
+**Acceptance criteria:**
+- Form is hidden when `generationId` is absent (e.g., logging failed).
+- HTTP 409 from the backend is surfaced as `alreadySubmitted = true`.
+- Successful submission disables the form and shows the success indicator.
+
+### FR-7: i18n entries for new error codes
+Add Czech and English translations for `LeafletFeedbackNotFound` and `LeafletFeedbackAlreadySubmitted` in `frontend/src/i18n.ts`.
+
+**Acceptance criteria:**
+- Czech: "Záznam generování letáku nebyl nalezen." / "Zpětná vazba již byla odeslána."
+- English: "Leaflet generation log not found." / "Feedback has already been submitted."
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Logging behavior must not measurably slow successful generations. Generation latency dominates (LLM call); the DB insert is one row in a try/catch and runs after `next()` returns.
+- `GetGenerationsPagedAsync` must use server-side paging and indexed sorts. Indexes on `CreatedAt`, `UserId`, and a filtered index on `PrecisionScore` (where not null) are required.
+- Stats query is acceptable as four separate aggregates against a single table; no caching required at MVP scale.
+
+### NFR-2: Security
+- Feedback submission is owner-only — enforced by handler comparing `generation.UserId` against `ICurrentUserService.GetCurrentUser().Id`. Do not rely on client-side checks.
+- Feedback list endpoint is gated by `AuthorizationConstants.Policies.LeafletUpload`.
+- Single-generation GET inherits the controller's authentication. (See Open Questions on whether owner-only restriction also applies here.)
+- `FeedbackComment` is stored as `text`; render as plain text on the frontend (no HTML interpretation) to avoid XSS.
+- Validation attributes (`Range`, `MaxLength`) enforced at the request DTO boundary.
+
+### NFR-3: Reliability
+- Logging failures are swallowed and logged via `ILogger` — generation never fails because of a persistence problem.
+- Migration must apply cleanly on the existing dev database without manual SQL.
+- Feedback write is a single `SaveChangesAsync` on a tracked entity (no concurrency token at MVP — last-write-wins is fine because the one-shot guard prevents the second write).
+
+### NFR-4: Maintainability
+- The KB pattern is the source of truth — leaflet handlers, behavior, DTOs, and frontend hooks must structurally mirror their KB counterparts so future changes can be applied to both with minimal divergence.
+- DTOs are classes (not records) per project convention.
+
+## Data Model
+
+### `LeafletGeneration` (domain entity, persisted)
+| Field | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | PK |
+| `Topic` | `string` | required, max 200 |
+| `Audience` | `string` | required, max 50 — `AudienceType` enum name |
+| `Length` | `string` | required, max 50 — `LeafletLength` enum name |
+| `FinalMarkdown` | `string` | required, unbounded |
+| `KbSourceCount` | `int` | |
+| `LeafletSourceCount` | `int` | |
+| `DurationMs` | `long` | total handler time |
+| `CreatedAt` | `DateTimeOffset` | UTC |
+| `UserId` | `string?` | max 200 — null if generation was anonymous (shouldn't occur in practice) |
+| `PrecisionScore` | `int?` | 1–5, null until feedback submitted |
+| `StyleScore` | `int?` | 1–5, null until feedback submitted |
+| `FeedbackComment` | `string?` | `text` column, ≤1000 chars enforced at API layer |
+
+**Indexes:**
+- `CreatedAt`
+- `UserId`
+- `PrecisionScore` filtered on `IS NOT NULL`
+
+**Table name:** `public."LeafletGenerations"`.
+
+### `LeafletFeedbackStats` (record, in-memory only)
+`(int TotalGenerations, int TotalWithFeedback, double? AvgPrecisionScore, double? AvgStyleScore)`.
+
+### Out-of-scope storage
+No separate `LeafletGenerationSource` table — only counts are stored. Per-chunk traceability is deferred to Phase 4+.
+
+## API / Interface Design
+
+### Backend endpoints (controller: `LeafletController`)
+
+| Method | Path | Auth | Body / Query | Response |
+|---|---|---|---|---|
+| `POST` | `/api/leaflet/feedback` | authenticated, owner-only enforced in handler | `SubmitLeafletFeedbackRequest` | `SubmitLeafletFeedbackResponse` (200) / 404 / 409 envelopes |
+| `GET` | `/api/leaflet/feedback/list` | `LeafletUpload` policy | `hasFeedback?`, `userId?`, `sortBy`, `sortDescending`, `pageNumber`, `pageSize` | `GetLeafletFeedbackListResponse` |
+| `GET` | `/api/leaflet/generations/{id:guid}` | controller default | path id | `GetLeafletGenerationResponse` |
+
+The existing `POST /api/leaflet/generate` endpoint continues to return `GenerateLeafletResponse`, now with a populated `Id: Guid?` field.
+
+### MediatR pipeline
+Register `LeafletGenerationLoggingBehavior` as `IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>` in `LeafletModule`.
+
+### Repository (`ILeafletRepository`)
+New methods:
+- `SaveGenerationAsync(LeafletGeneration, CancellationToken)`
+- `GetGenerationByIdAsync(Guid, CancellationToken)`
+- `GetGenerationsPagedAsync(bool? hasFeedback, string? userId, string sortBy, bool descending, int page, int pageSize, CancellationToken)`
+- `GetGenerationStatsAsync(CancellationToken)`
+- `SaveChangesAsync(CancellationToken)`
+
+### Error codes (added to `ErrorCodes`)
+- `LeafletFeedbackNotFound`
+- `LeafletFeedbackAlreadySubmitted`
+
+(`Forbidden` already exists.)
+
+### Frontend
+- Component: `frontend/src/components/feedback/RagFeedbackForm.tsx` (generic, prop-driven).
+- Hooks (added to `frontend/src/api/hooks/useLeaflet.ts`):
+  - `useSubmitLeafletFeedbackMutation()` — converts HTTP 409 → `alreadySubmitted`.
+  - `useLeafletFeedbackListQuery(params)` — `staleTime: 30_000`.
+- Updated component: `LeafletResult.tsx` accepts `generationId?` and renders the form when present.
+- Updated component: `KnowledgeBaseSearchAskTab.tsx` consumes `RagFeedbackForm` instead of its inline form.
+- i18n: two new error code translations (cs/en).
+
+## Dependencies
+- **Phase 1** (sidebar, routes, generation handler) must be merged into `feature/genai_consistency` before Phase 2 starts.
+- `feature/genai_consistency` integration branch — feature branch is cut from it, PR targets it.
+- Existing infrastructure: MediatR, EF Core, `ICurrentUserService`, `BaseResponse`, `ErrorCodes`, `AuthorizationConstants.Policies.LeafletUpload`.
+- Existing OpenAPI client generation pipeline (TypeScript client regenerated on backend build).
+- Reference patterns: `QuestionLoggingBehavior`, `SubmitFeedbackHandler`, `GetFeedbackListHandler`, `GetArticleHandler` (KB feature).
+
+## Out of Scope
+- Per-chunk source tracking (`LeafletGenerationSource` table, cross-navigation to KB chunks).
+- Editing or deleting submitted feedback.
+- Editing or deleting generations.
+- Anonymous generations (`UserId == null` is allowed in the schema but not a primary use case).
+- Caching the stats query.
+- Concurrency tokens on `LeafletGeneration`.
+- Aggregated dashboards / analytics views (consumed via list endpoint only).
+- Phase 3 / Phase 4 enhancements (regeneration with feedback context, prompt tuning loops, etc.).
+- Database migration automation — migrations remain manual per project convention.
+- E2E tests — phase 2 ships unit + integration coverage; E2E lives in nightly suite and can be added later.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-phase-2-leaflet-generation-persistence-f/task-plan.r1.md
+++ b/artifacts/feat-phase-2-leaflet-generation-persistence-f/task-plan.r1.md
@@ -1,0 +1,2514 @@
+# Leaflet Generation Persistence + Feedback (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist every successful leaflet generation to the database and expose a one-shot, owner-only feedback flow with a manager-gated list endpoint, mirroring the proven KnowledgeBase Q&A pattern.
+
+**Architecture:** A new `LeafletGeneration` entity persisted via a MediatR `IPipelineBehavior` after `GenerateLeafletHandler` returns successfully. Three new endpoints on `LeafletController` (`POST /api/leaflet/feedback`, `GET /api/leaflet/feedback/list`, `GET /api/leaflet/generations/{id}`). A shared `RagFeedbackForm` component is extracted from `KnowledgeBaseSearchAskTab` and consumed by both KB and Leaflet result panels.
+
+**Tech Stack:** .NET 8 (MediatR, EF Core, PostgreSQL), React + TanStack Query, Vertical Slice organization. Branch policy: cut from `feature/genai_consistency`, target PR back to `feature/genai_consistency` (NOT `main`).
+
+---
+
+## Prerequisites Checklist
+
+- [ ] Phase 1 (LeafletController.Generate, GenerateLeafletHandler, LeafletResult.tsx, sidebar, route) is merged into `feature/genai_consistency`. Verify with `git log feature/genai_consistency --grep="leaflet"`.
+- [ ] Current branch `feat-phase-2-leaflet-generation-persistence-f` was cut from `feature/genai_consistency`. Verify with `git merge-base feature/genai_consistency HEAD` returns a commit on `feature/genai_consistency`.
+- [ ] `dotnet ef` tool is installed. Verify with `dotnet ef --version`.
+- [ ] Postgres dev DB is reachable.
+
+---
+
+## File Structure
+
+**Backend new files:**
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs` — entity
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs` — sealed record
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs` — EF config
+- `backend/src/Anela.Heblo.Persistence/Migrations/20260506*_AddLeafletGenerations.cs` — migration (auto-generated)
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` — pipeline behavior
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/{Request,Response,Handler}.cs`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/{Request,Response,Handler}.cs`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/{Request,Response,Handler}.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletGenerationHandlerTests.cs`
+- `frontend/src/components/feedback/RagFeedbackForm.tsx` — shared component
+- `frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+
+**Backend modified files:**
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — add 3 codes
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs` — +4 methods
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs` — +4 implementations
+- `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs` — add `DbSet<LeafletGeneration>`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs` — add `Id`, `KbSourceCount`, `LeafletSourceCount`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs` — populate counts
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — register pipeline behavior
+- `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs` — 3 new actions
+
+**Frontend modified files:**
+- `frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx` — use shared form
+- `frontend/src/features/leaflet-generator/LeafletResult.tsx` — accept `generationId?` prop
+- `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx` — pass `generationId` from response
+- `frontend/src/api/hooks/useLeaflet.ts` — add types + `useSubmitLeafletFeedbackMutation`
+- `frontend/src/i18n.ts` — add 3 error code translations (cs + en)
+
+---
+
+## Task 1: Add ErrorCodes for Leaflet feedback flow
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:247-249`
+
+- [ ] **Step 1: Add three new enum values to the Leaflet block (25XX)**
+
+Replace the existing Leaflet block:
+
+```csharp
+    // Leaflet module errors (25XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletChunkNotFound = 2501,
+```
+
+with:
+
+```csharp
+    // Leaflet module errors (25XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletChunkNotFound = 2501,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletFeedbackNotFound = 2502,
+    [HttpStatusCode(HttpStatusCode.Conflict)]
+    LeafletFeedbackAlreadySubmitted = 2503,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletGenerationNotFound = 2504,
+```
+
+- [ ] **Step 2: Build to verify enum compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat: add Leaflet feedback error codes"
+```
+
+---
+
+## Task 2: Add `LeafletGeneration` domain entity and `LeafletFeedbackStats` record
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs`
+
+- [ ] **Step 1: Write `LeafletGeneration.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public class LeafletGeneration
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}
+```
+
+- [ ] **Step 2: Write `LeafletFeedbackStats.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public sealed record LeafletFeedbackStats(
+    int TotalGenerations,
+    int TotalWithFeedback,
+    double? AvgPrecisionScore,
+    double? AvgStyleScore);
+```
+
+- [ ] **Step 3: Build domain project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs \
+        backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs
+git commit -m "feat: add LeafletGeneration entity and LeafletFeedbackStats record"
+```
+
+---
+
+## Task 3: Extend `ILeafletRepository` with 4 new methods
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs`
+
+- [ ] **Step 1: Add four new method signatures before the closing brace**
+
+Insert these lines just before the closing `}` of `ILeafletRepository`:
+
+```csharp
+    Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken ct = default);
+    Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+        bool? hasFeedback,
+        string? userId,
+        string sortBy,
+        bool sortDescending,
+        int pageNumber,
+        int pageSize,
+        CancellationToken ct = default);
+    Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Build domain — implementation will fail (expected)**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: FAIL — `LeafletRepository does not implement interface members SaveGenerationAsync, …`. This is the failing test for the next task.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
+git commit -m "feat: extend ILeafletRepository with generation and feedback methods"
+```
+
+---
+
+## Task 4: Add EF configuration for `LeafletGeneration`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs`
+
+- [ ] **Step 1: Write the configuration**
+
+```csharp
+using Anela.Heblo.Domain.Features.Leaflet;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Leaflet;
+
+public class LeafletGenerationConfiguration : IEntityTypeConfiguration<LeafletGeneration>
+{
+    public void Configure(EntityTypeBuilder<LeafletGeneration> builder)
+    {
+        builder.ToTable("LeafletGenerations", "public");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Topic).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Audience).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.Length).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.FinalMarkdown).IsRequired().HasColumnType("text");
+        builder.Property(x => x.KbSourceCount).IsRequired();
+        builder.Property(x => x.LeafletSourceCount).IsRequired();
+        builder.Property(x => x.DurationMs).IsRequired();
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UserId).IsRequired(false).HasMaxLength(200);
+        builder.Property(x => x.PrecisionScore).IsRequired(false);
+        builder.Property(x => x.StyleScore).IsRequired(false);
+        builder.Property(x => x.FeedbackComment).IsRequired(false).HasColumnType("text");
+
+        builder.HasIndex(x => x.CreatedAt);
+        builder.HasIndex(x => x.UserId);
+        builder.HasIndex(x => x.PrecisionScore).HasFilter("\"PrecisionScore\" IS NOT NULL");
+    }
+}
+```
+
+- [ ] **Step 2: Build persistence project — still fails (interface members missing)**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: still FAILS on `LeafletRepository` interface implementation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs
+git commit -m "feat: add EF configuration for LeafletGenerations table"
+```
+
+---
+
+## Task 5: Add `DbSet<LeafletGeneration>` to `ApplicationDbContext`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs:88-89`
+
+- [ ] **Step 1: Add a new `DbSet` next to `LeafletChunks`**
+
+Replace:
+
+```csharp
+    // Leaflet module
+    public DbSet<LeafletDocument> LeafletDocuments { get; set; } = null!;
+    public DbSet<LeafletChunk> LeafletChunks { get; set; } = null!;
+```
+
+with:
+
+```csharp
+    // Leaflet module
+    public DbSet<LeafletDocument> LeafletDocuments { get; set; } = null!;
+    public DbSet<LeafletChunk> LeafletChunks { get; set; } = null!;
+    public DbSet<LeafletGeneration> LeafletGenerations { get; set; } = null!;
+```
+
+- [ ] **Step 2: Verify build still fails on missing repository methods**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: still FAILS on `LeafletRepository` (interface members not implemented).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+git commit -m "feat: add LeafletGenerations DbSet"
+```
+
+---
+
+## Task 6: Implement repository methods on `LeafletRepository`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs`
+
+- [ ] **Step 1: Add the four new methods just before the closing `}` of the class**
+
+```csharp
+    public async Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken ct = default)
+    {
+        _context.LeafletGenerations.Add(generation);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _context.LeafletGenerations
+            .FirstOrDefaultAsync(g => g.Id == id, ct);
+    }
+
+    public async Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+        bool? hasFeedback,
+        string? userId,
+        string sortBy,
+        bool sortDescending,
+        int pageNumber,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _context.LeafletGenerations.AsNoTracking().AsQueryable();
+
+        if (hasFeedback.HasValue)
+        {
+            query = hasFeedback.Value
+                ? query.Where(g => g.PrecisionScore != null || g.StyleScore != null)
+                : query.Where(g => g.PrecisionScore == null && g.StyleScore == null);
+        }
+
+        if (!string.IsNullOrEmpty(userId))
+            query = query.Where(g => g.UserId == userId);
+
+        query = sortBy switch
+        {
+            "PrecisionScore" => sortDescending
+                ? query.OrderByDescending(g => g.PrecisionScore)
+                : query.OrderBy(g => g.PrecisionScore),
+            "StyleScore" => sortDescending
+                ? query.OrderByDescending(g => g.StyleScore)
+                : query.OrderBy(g => g.StyleScore),
+            _ => sortDescending
+                ? query.OrderByDescending(g => g.CreatedAt)
+                : query.OrderBy(g => g.CreatedAt),
+        };
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, total);
+    }
+
+    // NFR-1: prefer indexed aggregates over loading all rows into memory.
+    public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken ct = default)
+    {
+        var totalGenerations = await _context.LeafletGenerations.CountAsync(ct);
+
+        var totalWithFeedback = await _context.LeafletGenerations
+            .Where(g => g.PrecisionScore != null || g.StyleScore != null)
+            .CountAsync(ct);
+
+        double? avgPrecision = await _context.LeafletGenerations
+            .Where(g => g.PrecisionScore != null)
+            .AverageAsync(g => (double?)g.PrecisionScore, ct);
+
+        double? avgStyle = await _context.LeafletGenerations
+            .Where(g => g.StyleScore != null)
+            .AverageAsync(g => (double?)g.StyleScore, ct);
+
+        return new LeafletFeedbackStats(
+            totalGenerations,
+            totalWithFeedback,
+            avgPrecision.HasValue ? Math.Round(avgPrecision.Value, 1) : null,
+            avgStyle.HasValue ? Math.Round(avgStyle.Value, 1) : null);
+    }
+```
+
+- [ ] **Step 2: Build persistence — should now succeed**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+git commit -m "feat: implement LeafletGeneration repository methods"
+```
+
+---
+
+## Task 7: Generate EF migration `AddLeafletGenerations`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddLeafletGenerations.cs` (auto-generated)
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddLeafletGenerations.Designer.cs` (auto-generated)
+- Modify: `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` (auto-updated)
+
+- [ ] **Step 1: Run the EF migration command from the repo root**
+
+Run:
+```bash
+dotnet ef migrations add AddLeafletGenerations \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API \
+  --output-dir Migrations
+```
+Expected: 2 new files created in `backend/src/Anela.Heblo.Persistence/Migrations/`. Snapshot file is updated.
+
+- [ ] **Step 2: Inspect the generated `Up()` method**
+
+Open the new `*_AddLeafletGenerations.cs` file. Confirm:
+- `schema: "public"` is set on the `CreateTable` call.
+- All 13 columns are present: `Id`, `Topic`, `Audience`, `Length`, `FinalMarkdown`, `KbSourceCount`, `LeafletSourceCount`, `DurationMs`, `CreatedAt`, `UserId`, `PrecisionScore`, `StyleScore`, `FeedbackComment`.
+- Three indexes are created: on `CreatedAt`, on `UserId`, on `PrecisionScore` with filter `"PrecisionScore" IS NOT NULL`.
+
+If any of these are missing, delete both new migration files plus the snapshot diff (`git restore backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`), fix `LeafletGenerationConfiguration.cs`, and re-run Step 1.
+
+- [ ] **Step 3: Apply the migration to the local dev DB**
+
+Run:
+```bash
+dotnet ef database update \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+Expected: migration applies cleanly. Verify with `psql -c '\dt public."LeafletGenerations"'` (table exists with correct columns).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "feat: add LeafletGenerations migration"
+```
+
+---
+
+## Task 8: Extend `GenerateLeafletResponse` with Id and source counts
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`
+
+- [ ] **Step 1: Replace the file contents**
+
+```csharp
+using System.Text.Json.Serialization;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+
+public class GenerateLeafletResponse : BaseResponse
+{
+    [JsonPropertyName("id")]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    [JsonPropertyName("kbSourceCount")]
+    public int KbSourceCount { get; set; }
+
+    [JsonPropertyName("leafletSourceCount")]
+    public int LeafletSourceCount { get; set; }
+}
+```
+
+Note: `Id`, `KbSourceCount`, `LeafletSourceCount` use `set` (not `init`) so the pipeline behavior and handler can write them after construction.
+
+- [ ] **Step 2: Build application project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
+git commit -m "feat: expose Id and source counts on GenerateLeafletResponse"
+```
+
+---
+
+## Task 9: Populate source counts in `GenerateLeafletHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs:134`
+
+- [ ] **Step 1: Replace the final `return` line**
+
+Replace:
+
+```csharp
+        return new GenerateLeafletResponse { Content = leafletResponse.Text ?? string.Empty };
+```
+
+with:
+
+```csharp
+        return new GenerateLeafletResponse
+        {
+            Content = leafletResponse.Text ?? string.Empty,
+            KbSourceCount = kbHits.Count,
+            LeafletSourceCount = leafletHits.Count,
+        };
+```
+
+- [ ] **Step 2: Build application project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
+git commit -m "feat: populate KbSourceCount and LeafletSourceCount in GenerateLeafletHandler"
+```
+
+---
+
+## Task 10: Write `LeafletGenerationLoggingBehaviorTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehaviorTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _userService = new();
+    private readonly Mock<ILogger<LeafletGenerationLoggingBehavior>> _logger = new();
+
+    private LeafletGenerationLoggingBehavior CreateBehavior() =>
+        new(_repository.Object, _userService.Object, _logger.Object);
+
+    [Fact]
+    public async Task Handle_OnSuccess_PersistsRowAndSetsResponseId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "Hyaluronic acid",
+            Audience = AudienceType.EndConsumer,
+            Length = LeafletLength.Medium,
+        };
+        var expected = new GenerateLeafletResponse
+        {
+            Content = "# Final markdown",
+            KbSourceCount = 3,
+            LeafletSourceCount = 2,
+        };
+
+        LeafletGeneration? captured = null;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((g, _) => captured = g)
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateBehavior().Handle(request, () => Task.FromResult(expected), default);
+
+        result.Should().BeSameAs(expected);
+        captured.Should().NotBeNull();
+        captured!.Topic.Should().Be("Hyaluronic acid");
+        captured.Audience.Should().Be("EndConsumer");
+        captured.Length.Should().Be("Medium");
+        captured.FinalMarkdown.Should().Be("# Final markdown");
+        captured.KbSourceCount.Should().Be(3);
+        captured.LeafletSourceCount.Should().Be(2);
+        captured.UserId.Should().Be("user-1");
+        captured.DurationMs.Should().BeGreaterThanOrEqualTo(0);
+        captured.PrecisionScore.Should().BeNull();
+        captured.StyleScore.Should().BeNull();
+        result.Id.Should().Be(captured.Id);
+        result.Id.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task Handle_WhenResponseUnsuccessful_DoesNotPersist()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "X", Audience = AudienceType.B2B, Length = LeafletLength.Short,
+        };
+        var failed = new GenerateLeafletResponse { Content = "" };
+        failed.Success = false;
+
+        var result = await CreateBehavior().Handle(request, () => Task.FromResult(failed), default);
+
+        result.Should().BeSameAs(failed);
+        result.Id.Should().BeNull();
+        _repository.Verify(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSaveThrows_ResponseStillReturned()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB exploded"));
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "X", Audience = AudienceType.B2B, Length = LeafletLength.Short,
+        };
+        var expected = new GenerateLeafletResponse { Content = "ok" };
+
+        var result = await CreateBehavior().Handle(request, () => Task.FromResult(expected), default);
+
+        result.Content.Should().Be("ok");
+        result.Id.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PassesCancellationTokenNoneToSave()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        CancellationToken capturedToken = default;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((_, t) => capturedToken = t)
+            .Returns(Task.CompletedTask);
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "X", Audience = AudienceType.B2B, Length = LeafletLength.Short,
+        };
+        var expected = new GenerateLeafletResponse { Content = "ok" };
+
+        await CreateBehavior().Handle(request, () => Task.FromResult(expected), cts.Token);
+
+        capturedToken.Should().Be(CancellationToken.None);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — they should FAIL (no behavior class yet)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests"`
+Expected: compilation FAIL (`LeafletGenerationLoggingBehavior` not found).
+
+---
+
+## Task 11: Implement `LeafletGenerationLoggingBehavior` (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs`
+
+- [ ] **Step 1: Write the behavior**
+
+```csharp
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehavior
+    : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<LeafletGenerationLoggingBehavior> _logger;
+
+    public LeafletGenerationLoggingBehavior(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService,
+        ILogger<LeafletGenerationLoggingBehavior> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GenerateLeafletResponse> Handle(
+        GenerateLeafletRequest request,
+        RequestHandlerDelegate<GenerateLeafletResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        // next() runs OUTSIDE try/catch — generator failures must propagate.
+        var response = await next();
+        sw.Stop();
+
+        if (!response.Success)
+            return response;
+
+        try
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            var generation = new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = request.Topic,
+                Audience = request.Audience.ToString(),
+                Length = request.Length.ToString(),
+                FinalMarkdown = response.Content,
+                KbSourceCount = response.KbSourceCount,
+                LeafletSourceCount = response.LeafletSourceCount,
+                DurationMs = sw.ElapsedMilliseconds,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UserId = currentUser.Id,
+            };
+
+            // Use CancellationToken.None: avoid losing the audit row on client disconnect.
+            await _repository.SaveGenerationAsync(generation, CancellationToken.None);
+            response.Id = generation.Id;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write leaflet generation log. Topic: {Topic}", request.Topic);
+        }
+
+        return response;
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — they should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests"`
+Expected: 4 PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+git commit -m "feat: add LeafletGenerationLoggingBehavior to persist generations"
+```
+
+---
+
+## Task 12: Register pipeline behavior in `LeafletModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs`
+
+- [ ] **Step 1: Add the registration**
+
+Replace the file contents:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.Services;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Leaflet;
+
+public static class LeafletModule
+{
+    public static IServiceCollection AddLeafletModule(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<LeafletOptions>()
+            .Bind(configuration.GetSection(LeafletOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddScoped<ILeafletChunkSummarizer, LeafletChunkSummarizer>();
+        services.AddScoped<ILeafletIndexingService, LeafletIndexingService>();
+
+        // LeafletIngestionJob is auto-discovered via IRecurringJob assembly scan in AddRecurringJobs()
+        // ILeafletRepository is registered in PersistenceModule
+        // MediatR handlers are auto-registered via AddApplicationServices() assembly scan
+
+        // Persist generation results after a successful response. Scoped — same lifetime as repository.
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationLoggingBehavior>();
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+git commit -m "feat: register LeafletGenerationLoggingBehavior in module"
+```
+
+---
+
+## Task 13: Write `SubmitLeafletFeedbackHandlerTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class SubmitLeafletFeedbackHandlerTests
+{
+    private const string UserId = "user-1";
+
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _currentUserService = new();
+
+    public SubmitLeafletFeedbackHandlerTests()
+    {
+        _currentUserService
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(UserId, "Test User", null, true));
+    }
+
+    private SubmitLeafletFeedbackHandler CreateHandler() =>
+        new(_repository.Object, _currentUserService.Object);
+
+    [Fact]
+    public async Task Handle_WhenGenerationNotFound_ReturnsNotFound()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletGeneration?)null);
+
+        var request = new SubmitLeafletFeedbackRequest
+        {
+            GenerationId = generationId, PrecisionScore = 4, StyleScore = 5,
+        };
+        var result = await CreateHandler().Handle(request, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackNotFound);
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ReturnsForbidden()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LeafletGeneration
+            {
+                Id = generationId,
+                Topic = "T",
+                Audience = "EndConsumer",
+                Length = "Short",
+                FinalMarkdown = "M",
+                UserId = "other-user",
+            });
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 4, StyleScore = 5,
+            },
+            default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPrecisionAlreadySet_ReturnsAlreadySubmitted()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LeafletGeneration
+            {
+                Id = generationId,
+                Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+                UserId = UserId,
+                PrecisionScore = 4,
+            });
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 5, StyleScore = 5,
+            },
+            default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackAlreadySubmitted);
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStyleAlreadySet_ReturnsAlreadySubmitted()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LeafletGeneration
+            {
+                Id = generationId,
+                Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+                UserId = UserId,
+                StyleScore = 3,
+            });
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 5, StyleScore = 5,
+            },
+            default);
+
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackAlreadySubmitted);
+    }
+
+    [Fact]
+    public async Task Handle_WhenValid_PersistsAllFieldsAndReturnsSuccess()
+    {
+        var generationId = Guid.NewGuid();
+        var generation = new LeafletGeneration
+        {
+            Id = generationId,
+            Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+            UserId = UserId,
+        };
+
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(generation);
+        _repository
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId,
+                PrecisionScore = 4,
+                StyleScore = 5,
+                Comment = "Looks good",
+            },
+            default);
+
+        result.Success.Should().BeTrue();
+        generation.PrecisionScore.Should().Be(4);
+        generation.StyleScore.Should().Be(5);
+        generation.FeedbackComment.Should().Be("Looks good");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenValidWithNoComment_PersistsNullComment()
+    {
+        var generationId = Guid.NewGuid();
+        var generation = new LeafletGeneration
+        {
+            Id = generationId,
+            Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+            UserId = UserId,
+        };
+
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(generation);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 3, StyleScore = 4,
+            },
+            default);
+
+        result.Success.Should().BeTrue();
+        generation.FeedbackComment.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — they should FAIL (handler/types missing)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SubmitLeafletFeedbackHandlerTests"`
+Expected: compilation FAIL.
+
+---
+
+## Task 14: Implement `SubmitLeafletFeedback` request, response, handler (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackHandler.cs`
+
+- [ ] **Step 1: Write the request**
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackRequest : IRequest<SubmitLeafletFeedbackResponse>
+{
+    public Guid GenerationId { get; set; }
+
+    [Range(1, 5)]
+    public int PrecisionScore { get; set; }
+
+    [Range(1, 5)]
+    public int StyleScore { get; set; }
+
+    [MaxLength(1000)]
+    public string? Comment { get; set; }
+}
+```
+
+- [ ] **Step 2: Write the response**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackResponse : BaseResponse
+{
+    public SubmitLeafletFeedbackResponse() { }
+
+    public SubmitLeafletFeedbackResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters) { }
+}
+```
+
+- [ ] **Step 3: Write the handler**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackHandler
+    : IRequestHandler<SubmitLeafletFeedbackRequest, SubmitLeafletFeedbackResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public SubmitLeafletFeedbackHandler(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<SubmitLeafletFeedbackResponse> Handle(
+        SubmitLeafletFeedbackRequest request,
+        CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.GenerationId, cancellationToken);
+        if (generation is null)
+        {
+            return new SubmitLeafletFeedbackResponse(
+                ErrorCodes.LeafletFeedbackNotFound,
+                new Dictionary<string, string> { { "generationId", request.GenerationId.ToString() } });
+        }
+
+        // Owner-only check (no policy/middleware — must load entity first to know the owner).
+        var currentUser = _currentUserService.GetCurrentUser();
+        if (generation.UserId != currentUser.Id)
+        {
+            return new SubmitLeafletFeedbackResponse(
+                ErrorCodes.Forbidden,
+                new Dictionary<string, string> { { "generationId", request.GenerationId.ToString() } });
+        }
+
+        if (generation.PrecisionScore is not null || generation.StyleScore is not null)
+        {
+            return new SubmitLeafletFeedbackResponse(
+                ErrorCodes.LeafletFeedbackAlreadySubmitted,
+                new Dictionary<string, string> { { "generationId", request.GenerationId.ToString() } });
+        }
+
+        generation.PrecisionScore = request.PrecisionScore;
+        generation.StyleScore = request.StyleScore;
+        generation.FeedbackComment = request.Comment;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return new SubmitLeafletFeedbackResponse();
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests — they should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SubmitLeafletFeedbackHandlerTests"`
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/ \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs
+git commit -m "feat: add SubmitLeafletFeedback use case"
+```
+
+---
+
+## Task 15: Write `GetLeafletFeedbackListHandlerTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Domain.Features.Leaflet;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class GetLeafletFeedbackListHandlerTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+
+    private static LeafletGeneration MakeGeneration(bool hasFeedback = false) => new()
+    {
+        Id = Guid.NewGuid(),
+        Topic = "Hyaluronic acid",
+        Audience = "EndConsumer",
+        Length = "Medium",
+        FinalMarkdown = "# leaflet",
+        KbSourceCount = 4,
+        LeafletSourceCount = 2,
+        DurationMs = 1234,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UserId = "user-1",
+        PrecisionScore = hasFeedback ? 4 : null,
+        StyleScore = hasFeedback ? 5 : null,
+        FeedbackComment = hasFeedback ? "comment" : null,
+    };
+
+    private static LeafletFeedbackStats DefaultStats() => new(10, 6, 4.2, 4.5);
+
+    private void SetupRepository(IReadOnlyList<LeafletGeneration> rows, int? total = null, LeafletFeedbackStats? stats = null)
+    {
+        _repository
+            .Setup(r => r.GetGenerationsPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((rows, total ?? rows.Count));
+
+        _repository
+            .Setup(r => r.GetGenerationStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats ?? DefaultStats());
+    }
+
+    [Fact]
+    public async Task Handle_MapsRowsToSummaries()
+    {
+        var row = MakeGeneration(hasFeedback: true);
+        SetupRepository(new[] { row });
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        var result = await handler.Handle(new GetLeafletFeedbackListRequest(), default);
+
+        result.Success.Should().BeTrue();
+        result.Logs.Should().HaveCount(1);
+        var dto = result.Logs[0];
+        dto.Id.Should().Be(row.Id);
+        dto.Topic.Should().Be(row.Topic);
+        dto.Audience.Should().Be(row.Audience);
+        dto.Length.Should().Be(row.Length);
+        dto.FinalMarkdown.Should().Be(row.FinalMarkdown);
+        dto.KbSourceCount.Should().Be(row.KbSourceCount);
+        dto.LeafletSourceCount.Should().Be(row.LeafletSourceCount);
+        dto.DurationMs.Should().Be(row.DurationMs);
+        dto.UserId.Should().Be(row.UserId);
+        dto.PrecisionScore.Should().Be(4);
+        dto.StyleScore.Should().Be(5);
+        dto.FeedbackComment.Should().Be("comment");
+        dto.HasFeedback.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsStats()
+    {
+        var stats = new LeafletFeedbackStats(42, 17, 3.7, 4.1);
+        SetupRepository(Array.Empty<LeafletGeneration>(), stats: stats);
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        var result = await handler.Handle(new GetLeafletFeedbackListRequest(), default);
+
+        result.Stats.TotalGenerations.Should().Be(42);
+        result.Stats.TotalWithFeedback.Should().Be(17);
+        result.Stats.AvgPrecisionScore.Should().Be(3.7);
+        result.Stats.AvgStyleScore.Should().Be(4.1);
+    }
+
+    [Theory]
+    [InlineData(15, 20)]
+    [InlineData(0, 20)]
+    [InlineData(-5, 20)]
+    [InlineData(10, 10)]
+    [InlineData(50, 50)]
+    public async Task Handle_NormalizesPaging(int requestedSize, int expectedSize)
+    {
+        SetupRepository(Array.Empty<LeafletGeneration>());
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        var result = await handler.Handle(
+            new GetLeafletFeedbackListRequest { PageSize = requestedSize, PageNumber = 0 },
+            default);
+
+        result.PageSize.Should().Be(expectedSize);
+        result.PageNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_NormalizesInvalidSortBy()
+    {
+        SetupRepository(Array.Empty<LeafletGeneration>());
+        string capturedSortBy = "";
+        _repository
+            .Setup(r => r.GetGenerationsPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<bool?, string?, string, bool, int, int, CancellationToken>(
+                (_, _, sb, _, _, _, _) => capturedSortBy = sb)
+            .ReturnsAsync((Array.Empty<LeafletGeneration>(), 0));
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        await handler.Handle(new GetLeafletFeedbackListRequest { SortBy = "EvilField" }, default);
+
+        capturedSortBy.Should().Be("CreatedAt");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — should FAIL (types missing)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests"`
+Expected: compilation FAIL.
+
+---
+
+## Task 16: Implement `GetLeafletFeedbackList` request/response/handler (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs`
+
+- [ ] **Step 1: Write the request and DTOs in the response file**
+
+`GetLeafletFeedbackListRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListRequest : IRequest<GetLeafletFeedbackListResponse>
+{
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+    public string SortBy { get; set; } = "CreatedAt";
+    public bool SortDescending { get; set; } = true;
+    public bool? HasFeedback { get; set; }
+    public string? UserId { get; set; }
+}
+```
+
+`GetLeafletFeedbackListResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListResponse : BaseResponse
+{
+    public List<LeafletFeedbackSummary> Logs { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages => PageSize > 0 ? (int)Math.Ceiling(TotalCount / (double)PageSize) : 0;
+    public LeafletFeedbackStatsDto Stats { get; set; } = new();
+}
+
+public class LeafletFeedbackSummary
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+    public bool HasFeedback => PrecisionScore.HasValue || StyleScore.HasValue;
+}
+
+public class LeafletFeedbackStatsDto
+{
+    public int TotalGenerations { get; set; }
+    public int TotalWithFeedback { get; set; }
+    public double? AvgPrecisionScore { get; set; }
+    public double? AvgStyleScore { get; set; }
+}
+```
+
+- [ ] **Step 2: Write the handler**
+
+```csharp
+using Anela.Heblo.Domain.Features.Leaflet;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListHandler
+    : IRequestHandler<GetLeafletFeedbackListRequest, GetLeafletFeedbackListResponse>
+{
+    private static readonly int[] AllowedPageSizes = [10, 20, 50];
+    private static readonly string[] AllowedSortColumns = ["CreatedAt", "PrecisionScore", "StyleScore"];
+
+    private readonly ILeafletRepository _repository;
+
+    public GetLeafletFeedbackListHandler(ILeafletRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetLeafletFeedbackListResponse> Handle(
+        GetLeafletFeedbackListRequest request,
+        CancellationToken cancellationToken)
+    {
+        var pageNumber = Math.Max(1, request.PageNumber);
+        var pageSize = AllowedPageSizes.Contains(request.PageSize) ? request.PageSize : 20;
+        var sortBy = AllowedSortColumns.Contains(request.SortBy) ? request.SortBy : "CreatedAt";
+
+        var (rows, totalCount) = await _repository.GetGenerationsPagedAsync(
+            request.HasFeedback,
+            request.UserId,
+            sortBy,
+            request.SortDescending,
+            pageNumber,
+            pageSize,
+            cancellationToken);
+
+        var stats = await _repository.GetGenerationStatsAsync(cancellationToken);
+
+        return new GetLeafletFeedbackListResponse
+        {
+            Logs = rows.Select(g => new LeafletFeedbackSummary
+            {
+                Id = g.Id,
+                Topic = g.Topic,
+                Audience = g.Audience,
+                Length = g.Length,
+                FinalMarkdown = g.FinalMarkdown,
+                KbSourceCount = g.KbSourceCount,
+                LeafletSourceCount = g.LeafletSourceCount,
+                DurationMs = g.DurationMs,
+                CreatedAt = g.CreatedAt,
+                UserId = g.UserId,
+                PrecisionScore = g.PrecisionScore,
+                StyleScore = g.StyleScore,
+                FeedbackComment = g.FeedbackComment,
+            }).ToList(),
+            TotalCount = totalCount,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+            Stats = new LeafletFeedbackStatsDto
+            {
+                TotalGenerations = stats.TotalGenerations,
+                TotalWithFeedback = stats.TotalWithFeedback,
+                AvgPrecisionScore = stats.AvgPrecisionScore,
+                AvgStyleScore = stats.AvgStyleScore,
+            },
+        };
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests"`
+Expected: 8 PASSED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/ \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs
+git commit -m "feat: add GetLeafletFeedbackList use case"
+```
+
+---
+
+## Task 17: Write `GetLeafletGenerationHandlerTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletGenerationHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class GetLeafletGenerationHandlerTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+
+    private GetLeafletGenerationHandler CreateHandler() => new(_repository.Object);
+
+    [Fact]
+    public async Task Handle_WhenNotFound_ReturnsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletGeneration?)null);
+
+        var result = await CreateHandler().Handle(
+            new GetLeafletGenerationRequest { Id = id }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletGenerationNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenFound_ReturnsFullPayload()
+    {
+        var id = Guid.NewGuid();
+        var row = new LeafletGeneration
+        {
+            Id = id,
+            Topic = "Aloe Vera",
+            Audience = "B2B",
+            Length = "Long",
+            FinalMarkdown = "# m",
+            KbSourceCount = 5,
+            LeafletSourceCount = 3,
+            DurationMs = 9999,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UserId = "user-7",
+            PrecisionScore = 4,
+            StyleScore = 5,
+            FeedbackComment = "good",
+        };
+
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(row);
+
+        var result = await CreateHandler().Handle(
+            new GetLeafletGenerationRequest { Id = id }, default);
+
+        result.Success.Should().BeTrue();
+        result.Id.Should().Be(id);
+        result.Topic.Should().Be("Aloe Vera");
+        result.Audience.Should().Be("B2B");
+        result.Length.Should().Be("Long");
+        result.FinalMarkdown.Should().Be("# m");
+        result.KbSourceCount.Should().Be(5);
+        result.LeafletSourceCount.Should().Be(3);
+        result.DurationMs.Should().Be(9999);
+        result.UserId.Should().Be("user-7");
+        result.PrecisionScore.Should().Be(4);
+        result.StyleScore.Should().Be(5);
+        result.FeedbackComment.Should().Be("good");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — should FAIL**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletGenerationHandlerTests"`
+Expected: compilation FAIL.
+
+---
+
+## Task 18: Implement `GetLeafletGeneration` request/response/handler (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationHandler.cs`
+
+- [ ] **Step 1: Write the request**
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationRequest : IRequest<GetLeafletGenerationResponse>
+{
+    public Guid Id { get; set; }
+}
+```
+
+- [ ] **Step 2: Write the response**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationResponse : BaseResponse
+{
+    public GetLeafletGenerationResponse() { }
+
+    public GetLeafletGenerationResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters) { }
+
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}
+```
+
+- [ ] **Step 3: Write the handler**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationHandler
+    : IRequestHandler<GetLeafletGenerationRequest, GetLeafletGenerationResponse>
+{
+    private readonly ILeafletRepository _repository;
+
+    public GetLeafletGenerationHandler(ILeafletRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetLeafletGenerationResponse> Handle(
+        GetLeafletGenerationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.Id, cancellationToken);
+        if (generation is null)
+        {
+            return new GetLeafletGenerationResponse(
+                ErrorCodes.LeafletGenerationNotFound,
+                new Dictionary<string, string> { { "id", request.Id.ToString() } });
+        }
+
+        return new GetLeafletGenerationResponse
+        {
+            Id = generation.Id,
+            Topic = generation.Topic,
+            Audience = generation.Audience,
+            Length = generation.Length,
+            FinalMarkdown = generation.FinalMarkdown,
+            KbSourceCount = generation.KbSourceCount,
+            LeafletSourceCount = generation.LeafletSourceCount,
+            DurationMs = generation.DurationMs,
+            CreatedAt = generation.CreatedAt,
+            UserId = generation.UserId,
+            PrecisionScore = generation.PrecisionScore,
+            StyleScore = generation.StyleScore,
+            FeedbackComment = generation.FeedbackComment,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletGenerationHandlerTests"`
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/ \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletGenerationHandlerTests.cs
+git commit -m "feat: add GetLeafletGeneration use case"
+```
+
+---
+
+## Task 19: Wire the three new endpoints into `LeafletController`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`
+
+- [ ] **Step 1: Add the new `using` directives at the top of the file**
+
+After the existing `using Anela.Heblo.Application.Features.Leaflet.UseCases.UploadLeaflet;` line, add:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+```
+
+- [ ] **Step 2: Append three new actions just before the closing `}` of `LeafletController`**
+
+```csharp
+    [HttpPost("feedback")]
+    public async Task<ActionResult<SubmitLeafletFeedbackResponse>> SubmitFeedback(
+        [FromBody] SubmitLeafletFeedbackRequest request,
+        CancellationToken ct)
+    {
+        var result = await _mediator.Send(request, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpGet("feedback/list")]
+    [Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+    public async Task<ActionResult<GetLeafletFeedbackListResponse>> GetFeedbackList(
+        [FromQuery] bool? hasFeedback = null,
+        [FromQuery] string? userId = null,
+        [FromQuery] string sortBy = "CreatedAt",
+        [FromQuery] bool sortDescending = true,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var result = await _mediator.Send(new GetLeafletFeedbackListRequest
+        {
+            HasFeedback = hasFeedback,
+            UserId = userId,
+            SortBy = sortBy,
+            SortDescending = sortDescending,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+        }, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpGet("generations/{id:guid}")]
+    public async Task<ActionResult<GetLeafletGenerationResponse>> GetGeneration(
+        Guid id,
+        CancellationToken ct)
+    {
+        var result = await _mediator.Send(new GetLeafletGenerationRequest { Id = id }, ct);
+        return HandleResponse(result);
+    }
+```
+
+- [ ] **Step 3: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 4: Format and run all backend tests**
+
+Run: `dotnet format backend/Anela.Heblo.sln && dotnet test backend/Anela.Heblo.sln --no-build`
+Expected: format clean, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
+git commit -m "feat: add leaflet feedback and generation endpoints"
+```
+
+---
+
+## Task 20: Regenerate the OpenAPI TypeScript client
+
+**Files:**
+- Modify: `frontend/src/api/generated/api-client.ts` (auto-generated)
+
+- [ ] **Step 1: Build the API to trigger client regeneration**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+
+The build target regenerates `frontend/src/api/generated/api-client.ts`. Verify with:
+
+Run: `grep -n "leaflet_SubmitFeedback\|leaflet_GetFeedbackList\|leaflet_GetGeneration\|kbSourceCount\|leafletSourceCount" frontend/src/api/generated/api-client.ts | head -20`
+Expected: at least one match for each new method/property.
+
+- [ ] **Step 2: Type-check the frontend**
+
+Run: `cd frontend && npm run build`
+Expected: no errors related to `LeafletResult` (until we update its consumer in Task 25). If any other module breaks because of the `Id`/source-count addition, fix the call site (the new fields are optional/nullable so existing callers should still compile).
+
+- [ ] **Step 3: Commit the regenerated client**
+
+```bash
+git add frontend/src/api/generated/api-client.ts
+git commit -m "chore: regenerate OpenAPI client for leaflet feedback"
+```
+
+---
+
+## Task 21: Write `RagFeedbackForm` component tests (TDD — RED)
+
+**Files:**
+- Create: `frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RagFeedbackForm from '../RagFeedbackForm';
+
+describe('RagFeedbackForm', () => {
+  it('disables submit until both ratings are picked', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    const submit = screen.getByRole('button', { name: /odeslat zpětnou vazbu/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it('enables submit after picking precision and style', async () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '4' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '5' })[1]);
+
+    const submit = screen.getByRole('button', { name: /odeslat zpětnou vazbu/i });
+    expect(submit).toBeEnabled();
+  });
+
+  it('invokes onSubmit with the picked scores and trimmed comment', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <RagFeedbackForm onSubmit={onSubmit} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '3' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '5' })[1]);
+    await userEvent.type(screen.getByPlaceholderText(/volitelný komentář/i), '  hello  ');
+
+    fireEvent.click(screen.getByRole('button', { name: /odeslat zpětnou vazbu/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ precisionScore: 3, styleScore: 5, comment: 'hello' });
+  });
+
+  it('passes undefined comment when textarea is blank', () => {
+    const onSubmit = jest.fn();
+    render(
+      <RagFeedbackForm onSubmit={onSubmit} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '2' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '4' })[1]);
+    fireEvent.click(screen.getByRole('button', { name: /odeslat zpětnou vazbu/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ precisionScore: 2, styleScore: 4, comment: undefined });
+  });
+
+  it('renders the success state when isSuccess is true', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={false} isSuccess={true} />,
+    );
+
+    expect(screen.getByText(/děkujeme za vaši zpětnou vazbu/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /odeslat zpětnou vazbu/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the alreadySubmitted state', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={true} isSuccess={false} />,
+    );
+
+    expect(screen.getByText(/zpětná vazba již byla odeslána/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /odeslat zpětnou vazbu/i })).not.toBeInTheDocument();
+  });
+
+  it('disables submit while submitting', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={true} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '3' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '4' })[1]);
+
+    expect(screen.getByRole('button', { name: /odeslat zpětnou vazbu/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — they should FAIL (no component yet)**
+
+Run: `cd frontend && npx jest src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+Expected: module-not-found error.
+
+---
+
+## Task 22: Implement `RagFeedbackForm` (TDD — GREEN)
+
+**Files:**
+- Create: `frontend/src/components/feedback/RagFeedbackForm.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import React, { useState } from 'react';
+
+const SCORES = [1, 2, 3, 4, 5];
+
+interface ScoreRowProps {
+  label: string;
+  value: number | null;
+  onChange: (value: number) => void;
+}
+
+function ScoreRow({ label, value, onChange }: ScoreRowProps) {
+  return (
+    <div className="space-y-1">
+      <span className="text-sm font-medium text-gray-700">{label}</span>
+      <div className="flex gap-1 flex-wrap">
+        {SCORES.map((s) => (
+          <label key={s} className="cursor-pointer">
+            <input
+              type="radio"
+              name={label}
+              value={s}
+              checked={value === s}
+              onChange={() => onChange(s)}
+              className="sr-only"
+              aria-label={String(s)}
+            />
+            <span
+              className={`inline-flex items-center justify-center w-8 h-8 rounded text-sm font-medium border ${
+                value === s
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              {s}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export interface RagFeedbackSubmission {
+  precisionScore: number;
+  styleScore: number;
+  comment?: string;
+}
+
+export interface RagFeedbackFormProps {
+  onSubmit: (submission: RagFeedbackSubmission) => void;
+  isSubmitting: boolean;
+  alreadySubmitted: boolean;
+  isSuccess: boolean;
+}
+
+export default function RagFeedbackForm({
+  onSubmit,
+  isSubmitting,
+  alreadySubmitted,
+  isSuccess,
+}: RagFeedbackFormProps) {
+  const [precisionScore, setPrecisionScore] = useState<number | null>(null);
+  const [styleScore, setStyleScore] = useState<number | null>(null);
+  const [comment, setComment] = useState('');
+
+  if (isSuccess) {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-sm text-green-700 bg-green-50">
+        Děkujeme za vaši zpětnou vazbu.
+      </div>
+    );
+  }
+
+  if (alreadySubmitted) {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-sm text-gray-600 bg-gray-50">
+        Zpětná vazba již byla odeslána.
+      </div>
+    );
+  }
+
+  const canSubmit = precisionScore !== null && styleScore !== null && !isSubmitting;
+
+  const handleClick = () => {
+    if (precisionScore === null || styleScore === null) return;
+    const trimmed = comment.trim();
+    onSubmit({
+      precisionScore,
+      styleScore,
+      comment: trimmed.length > 0 ? trimmed : undefined,
+    });
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 space-y-3">
+      <p className="text-sm font-medium text-gray-700">Ohodnoťte odpověď</p>
+      <ScoreRow label="Přesnost" value={precisionScore} onChange={setPrecisionScore} />
+      <ScoreRow label="Styl" value={styleScore} onChange={setStyleScore} />
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder="Volitelný komentář..."
+        rows={2}
+        maxLength={1000}
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!canSubmit}
+        className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50"
+      >
+        Odeslat zpětnou vazbu
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run tests — should PASS**
+
+Run: `cd frontend && npx jest src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+Expected: 7 PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/feedback/RagFeedbackForm.tsx \
+        frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx
+git commit -m "feat: extract shared RagFeedbackForm component"
+```
+
+---
+
+## Task 23: Refactor `KnowledgeBaseSearchAskTab` to consume `RagFeedbackForm`
+
+**Files:**
+- Modify: `frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx`
+
+- [ ] **Step 1: Replace the inline `FeedbackForm` (lines 91–163) and the call site at line 231**
+
+Replace the entire region from `const SCORES = [1, 2, 3, 4, 5];` (line 56) through the closing of `FeedbackForm` (line 163) with a single import-driven adapter. The simplest path: rewrite the file. Open `KnowledgeBaseSearchAskTab.tsx` and:
+
+a. Remove the inline `SCORES`, `ScoreRow`, `FeedbackState`, and `FeedbackForm` declarations (lines 56–163).
+
+b. Add `import RagFeedbackForm from '../feedback/RagFeedbackForm';` near the other imports at the top.
+
+c. Add a new local adapter component above `KnowledgeBaseSearchAskTab` (or inline it in the consumer):
+
+```tsx
+interface KnowledgeBaseFeedbackAdapterProps {
+  logId: string;
+}
+
+function KnowledgeBaseFeedbackAdapter({ logId }: KnowledgeBaseFeedbackAdapterProps) {
+  const submitFeedback = useSubmitFeedbackMutation();
+  const [alreadySubmitted, setAlreadySubmitted] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const handleSubmit = ({
+    precisionScore,
+    styleScore,
+    comment,
+  }: {
+    precisionScore: number;
+    styleScore: number;
+    comment?: string;
+  }) => {
+    submitFeedback.mutate(
+      { logId, precisionScore, styleScore, comment },
+      {
+        onSuccess: (result) => {
+          if (result.alreadySubmitted) setAlreadySubmitted(true);
+          else setIsSuccess(true);
+        },
+      },
+    );
+  };
+
+  return (
+    <RagFeedbackForm
+      onSubmit={handleSubmit}
+      isSubmitting={submitFeedback.isPending}
+      alreadySubmitted={alreadySubmitted}
+      isSuccess={isSuccess}
+    />
+  );
+}
+```
+
+d. Replace the existing call site `{ask.data.id && <FeedbackForm logId={ask.data.id} />}` (line 231) with:
+
+```tsx
+{ask.data.id && <KnowledgeBaseFeedbackAdapter logId={ask.data.id} />}
+```
+
+- [ ] **Step 2: Run KB-related tests + the new form tests**
+
+Run: `cd frontend && npx jest src/components/feedback src/components/knowledge-base`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx
+git commit -m "refactor: KB search tab uses shared RagFeedbackForm"
+```
+
+---
+
+## Task 24: Add `useSubmitLeafletFeedbackMutation` hook + types
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useLeaflet.ts`
+
+- [ ] **Step 1: Append types and hook to `useLeaflet.ts`**
+
+Append to the end of the file:
+
+```typescript
+// ---- Feedback types ----
+
+export interface SubmitLeafletFeedbackRequest {
+  generationId: string;
+  precisionScore: number;
+  styleScore: number;
+  comment?: string;
+}
+
+export interface SubmitLeafletFeedbackResult {
+  alreadySubmitted?: true;
+}
+
+// ---- Hooks ----
+
+/**
+ * Submit precision and style feedback for a leaflet generation.
+ * Returns { alreadySubmitted: true } on HTTP 409 instead of throwing.
+ */
+export const useSubmitLeafletFeedbackMutation = () => {
+  return useMutation({
+    mutationFn: async (
+      payload: SubmitLeafletFeedbackRequest,
+    ): Promise<SubmitLeafletFeedbackResult> => {
+      const apiClient = getAuthenticatedApiClient();
+      const fullUrl = `${(apiClient as any).baseUrl}/api/leaflet/feedback`;
+
+      const response = await (apiClient as any).http.fetch(fullUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.status === 409) {
+        return { alreadySubmitted: true };
+      }
+
+      if (!response.ok) {
+        throw new Error(`Submit leaflet feedback failed: ${response.status}`);
+      }
+
+      return {};
+    },
+  });
+};
+```
+
+Do NOT add `useLeafletFeedbackListQuery` — per the architecture review, this hook is YAGNI for Phase 2 (no consumer ships in this phase). It can be added when an admin dashboard is introduced in a later phase.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/hooks/useLeaflet.ts
+git commit -m "feat: add useSubmitLeafletFeedbackMutation hook"
+```
+
+---
+
+## Task 25: Update `LeafletResult` to render `RagFeedbackForm` when `generationId` is set
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletResult.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+```tsx
+import { useState, useRef, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import RagFeedbackForm from '../../components/feedback/RagFeedbackForm';
+import { useSubmitLeafletFeedbackMutation } from '../../api/hooks/useLeaflet';
+
+interface LeafletResultProps {
+  content: string;
+  onRegenerate: () => void;
+  generationId?: string;
+}
+
+export default function LeafletResult({ content, onRegenerate, generationId }: LeafletResultProps) {
+  const [copied, setCopied] = useState(false);
+  const [alreadySubmitted, setAlreadySubmitted] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const submitFeedback = useSubmitLeafletFeedbackMutation();
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  // Reset feedback UI whenever the underlying generation changes.
+  useEffect(() => {
+    setAlreadySubmitted(false);
+    setIsSuccess(false);
+  }, [generationId]);
+
+  if (!content) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable — no feedback change
+    }
+  };
+
+  const handleFeedbackSubmit = ({
+    precisionScore,
+    styleScore,
+    comment,
+  }: {
+    precisionScore: number;
+    styleScore: number;
+    comment?: string;
+  }) => {
+    if (!generationId) return;
+    submitFeedback.mutate(
+      { generationId, precisionScore, styleScore, comment },
+      {
+        onSuccess: (result) => {
+          if (result.alreadySubmitted) setAlreadySubmitted(true);
+          else setIsSuccess(true);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="prose max-w-none">
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          {copied ? 'Zkopírováno' : 'Kopírovat'}
+        </button>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          Generovat znovu
+        </button>
+      </div>
+      {generationId && (
+        <RagFeedbackForm
+          onSubmit={handleFeedbackSubmit}
+          isSubmitting={submitFeedback.isPending}
+          alreadySubmitted={alreadySubmitted}
+          isSuccess={isSuccess}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/leaflet-generator/LeafletResult.tsx
+git commit -m "feat: render feedback form below leaflet result when generationId is present"
+```
+
+---
+
+## Task 26: Update `LeafletGenerateTab` to capture `generationId` from response
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+
+- [ ] **Step 1: Add a `generationId` state and pass it to `LeafletResult`**
+
+Replace the file contents:
+
+```tsx
+import React, { useState } from 'react';
+import LeafletForm from './LeafletForm';
+import LeafletResult from './LeafletResult';
+import { getAuthenticatedApiClient } from '../../api/client';
+import { AudienceType, GenerateLeafletRequest, LeafletLength } from '../../api/generated/api-client';
+
+interface ErrorBanner {
+  kind: 'insufficient' | 'transient';
+  message: string;
+}
+
+interface ApiError {
+  status: number;
+  detail?: string;
+}
+
+function isApiError(err: unknown): err is ApiError {
+  return typeof err === 'object' && err !== null && typeof (err as Record<string, unknown>)['status'] === 'number';
+}
+
+const LeafletGenerateTab: React.FC = () => {
+  const [topic, setTopic] = useState('');
+  const [audience, setAudience] = useState<AudienceType>(AudienceType.EndConsumer);
+  const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
+  const [result, setResult] = useState('');
+  const [generationId, setGenerationId] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
+
+  const generate = async () => {
+    setIsLoading(true);
+    setErrorBanner(null);
+    setGenerationId(undefined);
+    try {
+      const client = getAuthenticatedApiClient();
+      const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
+      setResult(response.content ?? '');
+      setGenerationId(response.id ?? undefined);
+    } catch (err: unknown) {
+      if (isApiError(err) && err.status === 422) {
+        setErrorBanner({
+          kind: 'insufficient',
+          message:
+            err.detail ??
+            'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+        });
+      } else {
+        setErrorBanner({
+          kind: 'transient',
+          message: 'Generování selhalo. Zkuste to prosím znovu.',
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {errorBanner && (
+        <div
+          role="alert"
+          className={`mb-4 rounded p-3 text-sm ${
+            errorBanner.kind === 'insufficient'
+              ? 'bg-amber-100 text-amber-900'
+              : 'bg-red-100 text-red-900'
+          }`}
+        >
+          {errorBanner.message}
+        </div>
+      )}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <LeafletForm
+            topic={topic}
+            audience={audience}
+            length={length}
+            isLoading={isLoading}
+            onTopicChange={setTopic}
+            onAudienceChange={setAudience}
+            onLengthChange={setLength}
+            onSubmit={generate}
+          />
+        </div>
+        <div>
+          {isLoading ? (
+            <div className="animate-pulse space-y-2">
+              <div className="h-4 bg-gray-200 rounded w-3/4" />
+              <div className="h-4 bg-gray-200 rounded" />
+              <div className="h-4 bg-gray-200 rounded w-5/6" />
+            </div>
+          ) : (
+            <LeafletResult content={result} onRegenerate={generate} generationId={generationId} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LeafletGenerateTab;
+```
+
+- [ ] **Step 2: Run existing leaflet tab tests**
+
+Run: `cd frontend && npx jest src/features/leaflet-generator`
+Expected: PASS (existing test cases didn't assert on the new prop, so they should still pass).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
+git commit -m "feat: pass generationId from generate response to LeafletResult"
+```
+
+---
+
+## Task 27: Add i18n translations for new error codes
+
+**Files:**
+- Modify: `frontend/src/i18n.ts`
+
+- [ ] **Step 1: Find the Czech Leaflet errors block at line 197–198 and replace**
+
+Replace:
+
+```typescript
+        // Leaflet module errors
+        LeafletChunkNotFound: "Fragment letáku nebyl nalezen",
+```
+
+with:
+
+```typescript
+        // Leaflet module errors
+        LeafletChunkNotFound: "Fragment letáku nebyl nalezen",
+        LeafletFeedbackNotFound: "Záznam generování letáku nebyl nalezen.",
+        LeafletFeedbackAlreadySubmitted: "Zpětná vazba již byla odeslána.",
+        LeafletGenerationNotFound: "Záznam generování letáku nebyl nalezen.",
+```
+
+- [ ] **Step 2: Locate the matching English Leaflet block**
+
+Open the `en` translation block. Find the section that contains `LeafletChunkNotFound`. After it, append:
+
+```typescript
+        LeafletFeedbackNotFound: "Leaflet generation log not found.",
+        LeafletFeedbackAlreadySubmitted: "Feedback has already been submitted.",
+        LeafletGenerationNotFound: "Leaflet generation log not found.",
+```
+
+If the English block does not yet contain a `LeafletChunkNotFound` line, add the full set there:
+
+```typescript
+        // Leaflet module errors
+        LeafletChunkNotFound: "Leaflet chunk not found",
+        LeafletFeedbackNotFound: "Leaflet generation log not found.",
+        LeafletFeedbackAlreadySubmitted: "Feedback has already been submitted.",
+        LeafletGenerationNotFound: "Leaflet generation log not found.",
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/i18n.ts
+git commit -m "feat: add i18n entries for leaflet feedback error codes"
+```
+
+---
+
+## Task 28: Final verification — backend + frontend full validation
+
+**Files:**
+- None modified.
+
+- [ ] **Step 1: Backend full build, format, test**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln && \
+dotnet format backend/Anela.Heblo.sln --verify-no-changes && \
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: build clean, format clean, all tests PASS.
+
+- [ ] **Step 2: Frontend build, lint, test**
+
+Run:
+```bash
+cd frontend && npm run build && npm run lint && npm test -- --watchAll=false
+```
+Expected: all green.
+
+- [ ] **Step 3: Smoke-test the flow against a local dev environment**
+
+Start the backend and frontend per `docs/development/setup.md`. In the browser:
+1. Open the leaflet generator page, submit a topic.
+2. Confirm the result panel renders the markdown AND the feedback form below the Copy/Regenerate buttons.
+3. Pick precision = 4, style = 5, type a comment, submit. Confirm the form switches to the success state.
+4. Reload the page, generate again, attempt to submit feedback — confirm a fresh form is shown (state resets per `generationId`).
+5. (Optional, manual) `psql -c 'SELECT "Id", "Topic", "PrecisionScore", "StyleScore", "FeedbackComment" FROM public."LeafletGenerations" ORDER BY "CreatedAt" DESC LIMIT 5;'` — confirm two rows from the smoke test, the first with feedback set.
+6. As a user with `leaflet_manager` role, hit `GET /api/leaflet/feedback/list` — confirm 200 with the rows.
+7. As a user without `leaflet_manager`, hit the same endpoint — confirm 403.
+
+- [ ] **Step 4: Final commit (no-op or fixups)**
+
+If verification surfaced fixes, commit them with a `fix:` prefix. Otherwise, this task closes the implementation.
+
+---
+
+## Self-Review Checklist (already applied)
+
+- **FR-1** (persist generations) → Tasks 2, 4, 5, 6, 7, 11, 12.
+- **FR-2** (one-shot owner-only feedback submission) → Tasks 13, 14.
+- **FR-3** (manager-gated feedback list with stats) → Tasks 6, 15, 16, 19.
+- **FR-4** (single-generation lookup) → Tasks 17, 18, 19.
+- **FR-5** (extract `RagFeedbackForm`) → Tasks 21, 22, 23.
+- **FR-6** (leaflet result UI shows form) → Tasks 25, 26.
+- **FR-7** (i18n) → Task 27.
+- **NFR-1** (perf — server-side paging, indexed sorts, indexed aggregates) → Tasks 4 (indexes), 6 (indexed aggregates).
+- **NFR-2** (security — owner check + policy gate + plain-text comment rendering) → Tasks 14 (handler check), 19 (policy on list), 22 (textarea/plain text in form).
+- **NFR-3** (reliability — swallow logging errors, single SaveChanges) → Task 11 (try/catch around save), Task 14 (single SaveChanges).
+- **NFR-4** (maintainability — KB structural mirror, DTOs as classes) → Tasks 14, 16 — match KB shape.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md`.

--- a/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
@@ -4,6 +4,9 @@ using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletChunkDetail;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletDocumentContentTypes;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletDocuments;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
 using Anela.Heblo.Application.Features.Leaflet.UseCases.UploadLeaflet;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Authorization;
@@ -126,6 +129,47 @@ public class LeafletController : BaseApiController
             ContentType = file.ContentType,
             FileSizeBytes = file.Length,
         }, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpPost("feedback")]
+    [ProducesResponseType(typeof(SubmitLeafletFeedbackResponse), 200)]
+    [ProducesResponseType(typeof(ProblemDetails), 404)]
+    [ProducesResponseType(typeof(ProblemDetails), 409)]
+    public async Task<ActionResult<SubmitLeafletFeedbackResponse>> SubmitFeedback(
+        [FromBody] SubmitLeafletFeedbackRequest request, CancellationToken ct)
+    {
+        var result = await _mediator.Send(request, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpGet("feedback/list")]
+    [Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+    public async Task<ActionResult<GetLeafletFeedbackListResponse>> GetFeedbackList(
+        [FromQuery] bool? hasFeedback = null,
+        [FromQuery] string? userId = null,
+        [FromQuery] string sortBy = "CreatedAt",
+        [FromQuery] bool sortDescending = true,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var result = await _mediator.Send(new GetLeafletFeedbackListRequest
+        {
+            HasFeedback = hasFeedback,
+            UserId = userId,
+            SortBy = sortBy,
+            SortDescending = sortDescending,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+        }, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpGet("generations/{id:guid}")]
+    public async Task<ActionResult<GetLeafletGenerationResponse>> GetGeneration(Guid id, CancellationToken ct)
+    {
+        var result = await _mediator.Send(new GetLeafletGenerationRequest { Id = id }, ct);
         return HandleResponse(result);
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs
@@ -32,6 +32,7 @@ public class GetChunkDetailHandler : IRequestHandler<GetChunkDetailRequest, GetC
             ChunkIndex = chunk.ChunkIndex,
             Summary = chunk.Summary,
             Content = chunk.Content,
+            SourcePath = chunk.Document.SourcePath,
         };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs
@@ -19,6 +19,7 @@ public class GetChunkDetailResponse : BaseResponse
     public int ChunkIndex { get; set; }
     public string Summary { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }
 
     public GetChunkDetailResponse() { }
 

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
@@ -1,4 +1,7 @@
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
 using Anela.Heblo.Application.Features.Leaflet.Services;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +20,10 @@ public static class LeafletModule
 
         services.AddScoped<ILeafletChunkSummarizer, LeafletChunkSummarizer>();
         services.AddScoped<ILeafletIndexingService, LeafletIndexingService>();
+
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationLoggingBehavior>();
 
         // LeafletIngestionJob is auto-discovered via IRecurringJob assembly scan in AddRecurringJobs()
         // ILeafletRepository is registered in PersistenceModule

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehavior
+    : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<LeafletGenerationLoggingBehavior> _logger;
+
+    public LeafletGenerationLoggingBehavior(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService,
+        ILogger<LeafletGenerationLoggingBehavior> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GenerateLeafletResponse> Handle(
+        GenerateLeafletRequest request,
+        RequestHandlerDelegate<GenerateLeafletResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var response = await next();
+        sw.Stop();
+
+        if (!response.Success)
+            return response;
+
+        try
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            var generation = new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = request.Topic,
+                Audience = request.Audience.ToString(),
+                Length = request.Length.ToString(),
+                FinalMarkdown = response.Content,
+                KbSourceCount = response.KbSourceCount,
+                LeafletSourceCount = response.LeafletSourceCount,
+                DurationMs = sw.ElapsedMilliseconds,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UserId = currentUser.Id,
+            };
+
+            await _repository.SaveGenerationAsync(generation, cancellationToken);
+            response.Id = generation.Id;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to log leaflet generation. Topic: {Topic}", request.Topic);
+        }
+
+        return response;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
@@ -131,6 +131,11 @@ public class GenerateLeafletHandler : IRequestHandler<GenerateLeafletRequest, Ge
             _logger,
             ct);
 
-        return new GenerateLeafletResponse { Content = leafletResponse.Text ?? string.Empty };
+        return new GenerateLeafletResponse
+        {
+            Content = leafletResponse.Text ?? string.Empty,
+            KbSourceCount = kbHits.Count,
+            LeafletSourceCount = leafletHits.Count,
+        };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
@@ -7,4 +7,13 @@ public class GenerateLeafletResponse : BaseResponse
 {
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
+
+    [JsonPropertyName("id")]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("kbSourceCount")]
+    public int KbSourceCount { get; set; }
+
+    [JsonPropertyName("leafletSourceCount")]
+    public int LeafletSourceCount { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs
@@ -31,6 +31,7 @@ public class GetLeafletChunkDetailHandler : IRequestHandler<GetLeafletChunkDetai
             ChunkIndex = chunk.ChunkIndex,
             Content = chunk.Content,
             Summary = chunk.Summary,
+            SourcePath = chunk.Document.SourcePath,
         };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs
@@ -17,6 +17,7 @@ public class GetLeafletChunkDetailResponse : BaseResponse
     public int ChunkIndex { get; set; }
     public string Content { get; set; } = string.Empty;
     public string Summary { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }
 
     public GetLeafletChunkDetailResponse() { }
 

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs
@@ -1,0 +1,63 @@
+using Anela.Heblo.Domain.Features.Leaflet;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListHandler
+    : IRequestHandler<GetLeafletFeedbackListRequest, GetLeafletFeedbackListResponse>
+{
+    private static readonly int[] AllowedPageSizes = [10, 20, 50];
+    private static readonly string[] AllowedSortColumns = ["CreatedAt", "PrecisionScore", "StyleScore"];
+
+    private readonly ILeafletRepository _repository;
+
+    public GetLeafletFeedbackListHandler(ILeafletRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetLeafletFeedbackListResponse> Handle(
+        GetLeafletFeedbackListRequest request,
+        CancellationToken cancellationToken)
+    {
+        var pageNumber = Math.Max(1, request.PageNumber);
+        var pageSize = AllowedPageSizes.Contains(request.PageSize) ? request.PageSize : 20;
+        var sortBy = AllowedSortColumns.Contains(request.SortBy) ? request.SortBy : "CreatedAt";
+
+        var (items, totalCount) = await _repository.GetGenerationsPagedAsync(
+            request.HasFeedback, request.UserId, sortBy, request.SortDescending,
+            pageNumber, pageSize, cancellationToken);
+
+        var stats = await _repository.GetGenerationStatsAsync(cancellationToken);
+
+        return new GetLeafletFeedbackListResponse
+        {
+            Items = items.Select(g => new LeafletFeedbackSummary
+            {
+                Id = g.Id,
+                Topic = g.Topic,
+                Audience = g.Audience,
+                Length = g.Length,
+                FinalMarkdown = g.FinalMarkdown,
+                KbSourceCount = g.KbSourceCount,
+                LeafletSourceCount = g.LeafletSourceCount,
+                DurationMs = g.DurationMs,
+                CreatedAt = g.CreatedAt,
+                UserId = g.UserId,
+                PrecisionScore = g.PrecisionScore,
+                StyleScore = g.StyleScore,
+                FeedbackComment = g.FeedbackComment,
+            }).ToList(),
+            TotalCount = totalCount,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+            Stats = new LeafletFeedbackStatsDto
+            {
+                TotalGenerations = stats.TotalGenerations,
+                TotalWithFeedback = stats.TotalWithFeedback,
+                AvgPrecisionScore = stats.AvgPrecisionScore,
+                AvgStyleScore = stats.AvgStyleScore,
+            },
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListRequest.cs
@@ -1,0 +1,50 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListRequest : IRequest<GetLeafletFeedbackListResponse>
+{
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+    public string SortBy { get; set; } = "CreatedAt";
+    public bool SortDescending { get; set; } = true;
+    public bool? HasFeedback { get; set; }
+    public string? UserId { get; set; }
+}
+
+public class GetLeafletFeedbackListResponse : BaseResponse
+{
+    public List<LeafletFeedbackSummary> Items { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages => PageSize > 0 ? (int)Math.Ceiling(TotalCount / (double)PageSize) : 0;
+    public LeafletFeedbackStatsDto Stats { get; set; } = new();
+}
+
+public class LeafletFeedbackSummary
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+    public bool HasFeedback => PrecisionScore.HasValue || StyleScore.HasValue;
+}
+
+public class LeafletFeedbackStatsDto
+{
+    public int TotalGenerations { get; set; }
+    public int TotalWithFeedback { get; set; }
+    public double? AvgPrecisionScore { get; set; }
+    public double? AvgStyleScore { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationHandler.cs
@@ -1,0 +1,42 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationHandler
+    : IRequestHandler<GetLeafletGenerationRequest, GetLeafletGenerationResponse>
+{
+    private readonly ILeafletRepository _repository;
+
+    public GetLeafletGenerationHandler(ILeafletRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetLeafletGenerationResponse> Handle(
+        GetLeafletGenerationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.Id, cancellationToken);
+        if (generation is null)
+            return new GetLeafletGenerationResponse(ErrorCodes.LeafletFeedbackNotFound);
+
+        return new GetLeafletGenerationResponse
+        {
+            Id = generation.Id,
+            Topic = generation.Topic,
+            Audience = generation.Audience,
+            Length = generation.Length,
+            FinalMarkdown = generation.FinalMarkdown,
+            KbSourceCount = generation.KbSourceCount,
+            LeafletSourceCount = generation.LeafletSourceCount,
+            DurationMs = generation.DurationMs,
+            CreatedAt = generation.CreatedAt,
+            UserId = generation.UserId,
+            PrecisionScore = generation.PrecisionScore,
+            StyleScore = generation.StyleScore,
+            FeedbackComment = generation.FeedbackComment,
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationRequest.cs
@@ -1,0 +1,29 @@
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationRequest : IRequest<GetLeafletGenerationResponse>
+{
+    public Guid Id { get; set; }
+}
+
+public class GetLeafletGenerationResponse : BaseResponse
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+
+    public GetLeafletGenerationResponse() { }
+    public GetLeafletGenerationResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackHandler.cs
@@ -29,6 +29,10 @@ public class SubmitLeafletFeedbackHandler
                 new() { { "generationId", request.GenerationId.ToString() } });
 
         var currentUser = _currentUserService.GetCurrentUser();
+        if (generation.UserId is null || currentUser.Id is null)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.Forbidden,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
         if (generation.UserId != currentUser.Id)
             return new SubmitLeafletFeedbackResponse(ErrorCodes.Forbidden,
                 new() { { "generationId", request.GenerationId.ToString() } });
@@ -37,6 +41,7 @@ public class SubmitLeafletFeedbackHandler
             return new SubmitLeafletFeedbackResponse(ErrorCodes.LeafletFeedbackAlreadySubmitted,
                 new() { { "generationId", request.GenerationId.ToString() } });
 
+        // Entity is tracked via FindAsync in GetGenerationByIdAsync; direct mutation is intentional.
         generation.PrecisionScore = request.PrecisionScore;
         generation.StyleScore = request.StyleScore;
         generation.FeedbackComment = request.Comment;

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackHandler.cs
@@ -1,0 +1,47 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackHandler
+    : IRequestHandler<SubmitLeafletFeedbackRequest, SubmitLeafletFeedbackResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public SubmitLeafletFeedbackHandler(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<SubmitLeafletFeedbackResponse> Handle(
+        SubmitLeafletFeedbackRequest request,
+        CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.GenerationId, cancellationToken);
+        if (generation is null)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.LeafletFeedbackNotFound,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
+        var currentUser = _currentUserService.GetCurrentUser();
+        if (generation.UserId != currentUser.Id)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.Forbidden,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
+        if (generation.PrecisionScore is not null || generation.StyleScore is not null)
+            return new SubmitLeafletFeedbackResponse(ErrorCodes.LeafletFeedbackAlreadySubmitted,
+                new() { { "generationId", request.GenerationId.ToString() } });
+
+        generation.PrecisionScore = request.PrecisionScore;
+        generation.StyleScore = request.StyleScore;
+        generation.FeedbackComment = request.Comment;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new SubmitLeafletFeedbackResponse();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Shared;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackRequest : IRequest<SubmitLeafletFeedbackResponse>
+{
+    public Guid GenerationId { get; set; }
+
+    [Range(1, 5)]
+    public int PrecisionScore { get; set; }
+
+    [Range(1, 5)]
+    public int StyleScore { get; set; }
+
+    [MaxLength(1000)]
+    public string? Comment { get; set; }
+}
+
+public class SubmitLeafletFeedbackResponse : BaseResponse
+{
+    public SubmitLeafletFeedbackResponse() { }
+
+    public SubmitLeafletFeedbackResponse(ErrorCodes errorCode, Dictionary<string, string>? details = null)
+        : base(errorCode, details) { }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -247,6 +247,10 @@ public enum ErrorCodes
     // Leaflet module errors (25XX)
     [HttpStatusCode(HttpStatusCode.NotFound)]
     LeafletChunkNotFound = 2501,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletFeedbackNotFound = 2502,
+    [HttpStatusCode(HttpStatusCode.Conflict)]
+    LeafletFeedbackAlreadySubmitted = 2503,
 
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]

--- a/backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
@@ -21,4 +21,10 @@ public interface ILeafletRepository
     Task<LeafletChunk?> GetChunkByIdAsync(Guid id, CancellationToken ct = default);
     Task<IReadOnlyDictionary<Guid, Guid>> GetFirstChunkIdsByDocumentIdsAsync(IEnumerable<Guid> ids, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
+    Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken cancellationToken);
+    Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+        bool? hasFeedback, string? userId, string sortBy, bool descending,
+        int page, int pageSize, CancellationToken cancellationToken);
+    Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public sealed record LeafletFeedbackStats(
+    int TotalGenerations,
+    int TotalWithFeedback,
+    double? AvgPrecisionScore,
+    double? AvgStyleScore);

--- a/backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs
@@ -1,0 +1,18 @@
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public class LeafletGeneration
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}

--- a/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+++ b/backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
@@ -87,6 +87,7 @@ public class ApplicationDbContext : DbContext
     // Leaflet module
     public DbSet<LeafletDocument> LeafletDocuments { get; set; } = null!;
     public DbSet<LeafletChunk> LeafletChunks { get; set; } = null!;
+    public DbSet<LeafletGeneration> LeafletGenerations { get; set; } = null!;
 
     // Article module
     public DbSet<Article> Articles { get; set; } = null!;

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs
@@ -1,0 +1,24 @@
+using Anela.Heblo.Domain.Features.Leaflet;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Leaflet;
+
+public class LeafletGenerationConfiguration : IEntityTypeConfiguration<LeafletGeneration>
+{
+    public void Configure(EntityTypeBuilder<LeafletGeneration> builder)
+    {
+        builder.ToTable("LeafletGenerations");
+        builder.HasKey(g => g.Id);
+        builder.Property(g => g.Topic).HasMaxLength(200).IsRequired();
+        builder.Property(g => g.Audience).HasMaxLength(50).IsRequired();
+        builder.Property(g => g.Length).HasMaxLength(50).IsRequired();
+        builder.Property(g => g.FinalMarkdown).IsRequired();
+        builder.Property(g => g.UserId).HasMaxLength(200);
+        builder.Property(g => g.FeedbackComment).HasColumnType("text");
+        builder.HasIndex(g => g.CreatedAt);
+        builder.HasIndex(g => g.UserId);
+        builder.HasIndex(g => g.PrecisionScore)
+            .HasFilter("\"PrecisionScore\" IS NOT NULL");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
@@ -264,12 +264,12 @@ public class LeafletRepository : ILeafletRepository
 
         query = (sortBy, descending) switch
         {
-            ("PrecisionScore", true)  => query.OrderByDescending(g => g.PrecisionScore),
+            ("PrecisionScore", true) => query.OrderByDescending(g => g.PrecisionScore),
             ("PrecisionScore", false) => query.OrderBy(g => g.PrecisionScore),
-            ("StyleScore", true)      => query.OrderByDescending(g => g.StyleScore),
-            ("StyleScore", false)     => query.OrderBy(g => g.StyleScore),
-            (_, true)                 => query.OrderByDescending(g => g.CreatedAt),
-            _                         => query.OrderBy(g => g.CreatedAt),
+            ("StyleScore", true) => query.OrderByDescending(g => g.StyleScore),
+            ("StyleScore", false) => query.OrderBy(g => g.StyleScore),
+            (_, true) => query.OrderByDescending(g => g.CreatedAt),
+            _ => query.OrderBy(g => g.CreatedAt),
         };
 
         var total = await query.CountAsync(cancellationToken);

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
@@ -238,4 +238,56 @@ public class LeafletRepository : ILeafletRepository
     {
         await _context.SaveChangesAsync(ct);
     }
+
+    public async Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken cancellationToken)
+    {
+        _context.LeafletGenerations.Add(generation);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken cancellationToken)
+        => await _context.LeafletGenerations.FindAsync([id], cancellationToken);
+
+    public async Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+        bool? hasFeedback, string? userId, string sortBy, bool descending,
+        int page, int pageSize, CancellationToken cancellationToken)
+    {
+        var query = _context.LeafletGenerations.AsQueryable();
+
+        if (hasFeedback == true)
+            query = query.Where(g => g.PrecisionScore != null || g.StyleScore != null);
+        else if (hasFeedback == false)
+            query = query.Where(g => g.PrecisionScore == null && g.StyleScore == null);
+
+        if (!string.IsNullOrWhiteSpace(userId))
+            query = query.Where(g => g.UserId == userId);
+
+        query = (sortBy, descending) switch
+        {
+            ("PrecisionScore", true)  => query.OrderByDescending(g => g.PrecisionScore),
+            ("PrecisionScore", false) => query.OrderBy(g => g.PrecisionScore),
+            ("StyleScore", true)      => query.OrderByDescending(g => g.StyleScore),
+            ("StyleScore", false)     => query.OrderBy(g => g.StyleScore),
+            (_, true)                 => query.OrderByDescending(g => g.CreatedAt),
+            _                         => query.OrderBy(g => g.CreatedAt),
+        };
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(cancellationToken);
+        return (items, total);
+    }
+
+    public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken cancellationToken)
+    {
+        var total = await _context.LeafletGenerations.CountAsync(cancellationToken);
+        var withFeedback = await _context.LeafletGenerations
+            .CountAsync(g => g.PrecisionScore != null || g.StyleScore != null, cancellationToken);
+        var avgPrecision = await _context.LeafletGenerations
+            .Where(g => g.PrecisionScore != null)
+            .AverageAsync(g => (double?)g.PrecisionScore, cancellationToken);
+        var avgStyle = await _context.LeafletGenerations
+            .Where(g => g.StyleScore != null)
+            .AverageAsync(g => (double?)g.StyleScore, cancellationToken);
+        return new LeafletFeedbackStats(total, withFeedback, avgPrecision, avgStyle);
+    }
 }

--- a/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
@@ -252,7 +252,9 @@ public class LeafletRepository : ILeafletRepository
         bool? hasFeedback, string? userId, string sortBy, bool descending,
         int page, int pageSize, CancellationToken cancellationToken)
     {
-        var query = _context.LeafletGenerations.AsQueryable();
+        var query = _context.LeafletGenerations
+            .AsNoTracking()
+            .AsQueryable();
 
         if (hasFeedback == true)
             query = query.Where(g => g.PrecisionScore != null || g.StyleScore != null);

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260505202743_AddLeafletGenerations.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260505202743_AddLeafletGenerations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505202743_AddLeafletGenerations")]
+    partial class AddLeafletGenerations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260505202743_AddLeafletGenerations.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260505202743_AddLeafletGenerations.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeafletGenerations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ValidationNote",
+                table: "ArticleSources",
+                type: "character varying(10000)",
+                maxLength: 10000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Excerpt",
+                table: "ArticleSources",
+                type: "character varying(10000)",
+                maxLength: 10000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StyleGuideItemPath",
+                table: "Articles",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StyleGuideDriveId",
+                table: "Articles",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "LeafletGenerations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Topic = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Audience = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Length = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    FinalMarkdown = table.Column<string>(type: "text", nullable: false),
+                    KbSourceCount = table.Column<int>(type: "integer", nullable: false),
+                    LeafletSourceCount = table.Column<int>(type: "integer", nullable: false),
+                    DurationMs = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    PrecisionScore = table.Column<int>(type: "integer", nullable: true),
+                    StyleScore = table.Column<int>(type: "integer", nullable: true),
+                    FeedbackComment = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LeafletGenerations", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeafletGenerations_CreatedAt",
+                table: "LeafletGenerations",
+                column: "CreatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeafletGenerations_PrecisionScore",
+                table: "LeafletGenerations",
+                column: "PrecisionScore",
+                filter: "\"PrecisionScore\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LeafletGenerations_UserId",
+                table: "LeafletGenerations",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LeafletGenerations");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ValidationNote",
+                table: "ArticleSources",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(10000)",
+                oldMaxLength: 10000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Excerpt",
+                table: "ArticleSources",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(10000)",
+                oldMaxLength: 10000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StyleGuideItemPath",
+                table: "Articles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "StyleGuideDriveId",
+                table: "Articles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/Infrastructure/ShoptetIntegrationTestFixture.cs
+++ b/backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/Infrastructure/ShoptetIntegrationTestFixture.cs
@@ -31,6 +31,7 @@ public class ShoptetIntegrationTestFixture
         services.AddLogging(builder => builder.AddConsole());
 
         services.AddShoptetApiAdapter(Configuration);
+        services.AddShoptetCsvAdapter(Configuration);
         services.AddCrossCuttingServices();
         services.AddHttpClient();
 

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
@@ -1,0 +1,98 @@
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehaviorTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _userService = new();
+    private readonly Mock<ILogger<LeafletGenerationLoggingBehavior>> _logger = new();
+
+    private LeafletGenerationLoggingBehavior CreateBehavior() =>
+        new(_repository.Object, _userService.Object, _logger.Object);
+
+    private static GenerateLeafletRequest MakeRequest() =>
+        new()
+        {
+            Topic = "Vitamin C serum",
+            Audience = AudienceType.EndConsumer,
+            Length = LeafletLength.Medium,
+        };
+
+    private static GenerateLeafletResponse MakeResponse() =>
+        new()
+        {
+            Content = "# Vitamin C serum\n\nGreat for skin.",
+            KbSourceCount = 3,
+            LeafletSourceCount = 1,
+        };
+
+    [Fact]
+    public async Task Handle_SavesGenerationRow_AndSetsResponseId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+
+        LeafletGeneration? captured = null;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((g, _) => captured = g)
+            .Returns(Task.CompletedTask);
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.NotNull(captured);
+        Assert.Equal("Vitamin C serum", captured.Topic);
+        Assert.Equal("EndConsumer", captured.Audience);
+        Assert.Equal("Medium", captured.Length);
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", captured.FinalMarkdown);
+        Assert.Equal(3, captured.KbSourceCount);
+        Assert.Equal(1, captured.LeafletSourceCount);
+        Assert.Equal("user-1", captured.UserId);
+        Assert.True(captured.DurationMs >= 0);
+        Assert.NotEqual(Guid.Empty, captured.Id);
+        Assert.Equal(captured.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB down"));
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", result.Content);
+        Assert.Null(result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOriginalResponse()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.Equal(response, result);
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", result.Content);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs
@@ -77,4 +77,106 @@ public class GetLeafletChunkDetailHandlerTests
         response.Success.Should().BeFalse();
         response.ErrorCode.Should().Be(ErrorCodes.LeafletChunkNotFound);
     }
+
+    [Fact]
+    public async Task Handle_returns_sharepoint_source_path_when_document_sourced_from_sharepoint()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "leaflet.pdf",
+                SourcePath = "https://anelacz.sharepoint.com/sites/x/leaflet.pdf",
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be("https://anelacz.sharepoint.com/sites/x/leaflet.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_returns_synthetic_upload_path_when_document_manually_uploaded()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "uploaded.pdf",
+                SourcePath = "upload/xyz-9/uploaded.pdf",
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be("upload/xyz-9/uploaded.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_returns_empty_string_when_document_has_no_source_path()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "no-source.pdf",
+                SourcePath = string.Empty,
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be(string.Empty);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs
@@ -1,0 +1,142 @@
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class GetLeafletFeedbackListHandlerTests
+{
+    private readonly Mock<ILeafletRepository> _repo = new();
+
+    private static LeafletGeneration MakeGeneration(bool hasFeedback = false) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Topic = "Retinol cream",
+            Audience = "EndConsumer",
+            Length = "Medium",
+            FinalMarkdown = "# Content",
+            KbSourceCount = 3,
+            LeafletSourceCount = 1,
+            DurationMs = 1200,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UserId = "user-1",
+            PrecisionScore = hasFeedback ? 4 : null,
+            StyleScore = hasFeedback ? 5 : null,
+        };
+
+    private static LeafletFeedbackStats DefaultStats() =>
+        new(TotalGenerations: 10, TotalWithFeedback: 4, AvgPrecisionScore: 3.8, AvgStyleScore: 4.1);
+
+    private void SetupRepo(List<LeafletGeneration> items, int? total = null, LeafletFeedbackStats? stats = null)
+    {
+        _repo.Setup(r => r.GetGenerationsPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((items, total ?? items.Count));
+        _repo.Setup(r => r.GetGenerationStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats ?? DefaultStats());
+    }
+
+    private GetLeafletFeedbackListHandler CreateHandler() => new(_repo.Object);
+
+    [Fact]
+    public async Task Handle_ReturnsMappedGenerations()
+    {
+        var gen = MakeGeneration(hasFeedback: true);
+        SetupRepo([gen]);
+
+        var result = await CreateHandler().Handle(new GetLeafletFeedbackListRequest(), default);
+
+        Assert.True(result.Success);
+        Assert.Single(result.Items);
+        var dto = result.Items[0];
+        Assert.Equal(gen.Id, dto.Id);
+        Assert.Equal(gen.Topic, dto.Topic);
+        Assert.Equal(gen.Audience, dto.Audience);
+        Assert.Equal(gen.Length, dto.Length);
+        Assert.Equal(gen.KbSourceCount, dto.KbSourceCount);
+        Assert.Equal(gen.LeafletSourceCount, dto.LeafletSourceCount);
+        Assert.Equal(gen.PrecisionScore, dto.PrecisionScore);
+        Assert.Equal(gen.StyleScore, dto.StyleScore);
+        Assert.True(dto.HasFeedback);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsStatsFromRepository()
+    {
+        var stats = new LeafletFeedbackStats(42, 17, 3.5, 4.2);
+        SetupRepo([], stats: stats);
+
+        var result = await CreateHandler().Handle(new GetLeafletFeedbackListRequest(), default);
+
+        Assert.Equal(42, result.Stats.TotalGenerations);
+        Assert.Equal(17, result.Stats.TotalWithFeedback);
+        Assert.Equal(3.5, result.Stats.AvgPrecisionScore);
+        Assert.Equal(4.2, result.Stats.AvgStyleScore);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsPaginationMetadata()
+    {
+        var items = Enumerable.Range(1, 10).Select(_ => MakeGeneration()).ToList();
+        SetupRepo(items, total: 35);
+
+        var result = await CreateHandler().Handle(
+            new GetLeafletFeedbackListRequest { PageNumber = 2, PageSize = 10 }, default);
+
+        Assert.Equal(35, result.TotalCount);
+        Assert.Equal(2, result.PageNumber);
+        Assert.Equal(10, result.PageSize);
+        Assert.Equal(4, result.TotalPages);
+    }
+
+    [Theory]
+    [InlineData(5, 20)]
+    [InlineData(0, 20)]
+    [InlineData(100, 20)]
+    [InlineData(10, 10)]
+    [InlineData(50, 50)]
+    public async Task Handle_ClampsInvalidPageSize(int requested, int expected)
+    {
+        SetupRepo([]);
+
+        var result = await CreateHandler().Handle(
+            new GetLeafletFeedbackListRequest { PageSize = requested }, default);
+
+        Assert.Equal(expected, result.PageSize);
+    }
+
+    [Theory]
+    [InlineData("UnknownColumn", "CreatedAt")]
+    [InlineData("", "CreatedAt")]
+    [InlineData("CreatedAt", "CreatedAt")]
+    [InlineData("PrecisionScore", "PrecisionScore")]
+    [InlineData("StyleScore", "StyleScore")]
+    public async Task Handle_FallsBackInvalidSortBy(string requested, string expected)
+    {
+        string? captured = null;
+        _repo.Setup(r => r.GetGenerationsPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<bool>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<bool?, string?, string, bool, int, int, CancellationToken>(
+                (_, _, sb, _, _, _, _) => captured = sb)
+            .ReturnsAsync((new List<LeafletGeneration>(), 0));
+        _repo.Setup(r => r.GetGenerationStatsAsync(default)).ReturnsAsync(DefaultStats());
+
+        await CreateHandler().Handle(new GetLeafletFeedbackListRequest { SortBy = requested }, default);
+
+        Assert.Equal(expected, captured);
+    }
+
+    [Fact]
+    public async Task Handle_ItemWithoutFeedback_HasFeedbackIsFalse()
+    {
+        SetupRepo([MakeGeneration(hasFeedback: false)]);
+
+        var result = await CreateHandler().Handle(new GetLeafletFeedbackListRequest(), default);
+
+        Assert.False(result.Items[0].HasFeedback);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs
@@ -49,6 +49,23 @@ public class SubmitLeafletFeedbackHandlerTests
     }
 
     [Fact]
+    public async Task ReturnsForbidden_WhenGenerationUserIdIsNull()
+    {
+        // Arrange
+        var generation = new LeafletGeneration { Id = Guid.NewGuid(), Topic = "Vitamin C", UserId = null };
+        _repo.Setup(r => r.GetGenerationByIdAsync(generation.Id, default)).ReturnsAsync(generation);
+
+        // Act
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest { GenerationId = generation.Id, PrecisionScore = 4, StyleScore = 3 }, default);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _repo.Verify(r => r.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
     public async Task Handle_WhenUserDoesNotOwnGeneration_ReturnsForbidden()
     {
         var generation = MakeGeneration(userId: "other-user");

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs
@@ -1,0 +1,128 @@
+using Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class SubmitLeafletFeedbackHandlerTests
+{
+    private readonly Mock<ILeafletRepository> _repo = new();
+    private readonly Mock<ICurrentUserService> _userService = new();
+    private const string UserId = "user-123";
+
+    private SubmitLeafletFeedbackHandler CreateHandler() =>
+        new(_repo.Object, _userService.Object);
+
+    public SubmitLeafletFeedbackHandlerTests()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser(UserId, "Test User", "t@test.com", true));
+    }
+
+    private LeafletGeneration MakeGeneration(Guid? id = null, string? userId = null,
+        int? precisionScore = null, int? styleScore = null) =>
+        new()
+        {
+            Id = id ?? Guid.NewGuid(),
+            Topic = "Vitamin C",
+            UserId = userId ?? UserId,
+            PrecisionScore = precisionScore,
+            StyleScore = styleScore,
+        };
+
+    [Fact]
+    public async Task Handle_WhenGenerationNotFound_ReturnsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _repo.Setup(r => r.GetGenerationByIdAsync(id, default)).ReturnsAsync((LeafletGeneration?)null);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest { GenerationId = id, PrecisionScore = 4, StyleScore = 3 }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackNotFound);
+        _repo.Verify(r => r.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserDoesNotOwnGeneration_ReturnsForbidden()
+    {
+        var generation = MakeGeneration(userId: "other-user");
+        _repo.Setup(r => r.GetGenerationByIdAsync(generation.Id, default)).ReturnsAsync(generation);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest { GenerationId = generation.Id, PrecisionScore = 4, StyleScore = 3 }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _repo.Verify(r => r.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenFeedbackAlreadySubmitted_ReturnsConflict()
+    {
+        var generation = MakeGeneration(precisionScore: 5);
+        _repo.Setup(r => r.GetGenerationByIdAsync(generation.Id, default)).ReturnsAsync(generation);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest { GenerationId = generation.Id, PrecisionScore = 4, StyleScore = 3 }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackAlreadySubmitted);
+        _repo.Verify(r => r.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStyleScoreAlreadySet_ReturnsConflict()
+    {
+        var generation = MakeGeneration(styleScore: 2);
+        _repo.Setup(r => r.GetGenerationByIdAsync(generation.Id, default)).ReturnsAsync(generation);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest { GenerationId = generation.Id, PrecisionScore = 4, StyleScore = 3 }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackAlreadySubmitted);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_SavesFeedbackAndReturnsSuccess()
+    {
+        var generation = MakeGeneration();
+        _repo.Setup(r => r.GetGenerationByIdAsync(generation.Id, default)).ReturnsAsync(generation);
+        _repo.Setup(r => r.SaveChangesAsync(default)).Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generation.Id,
+                PrecisionScore = 4,
+                StyleScore = 5,
+                Comment = "Very helpful",
+            }, default);
+
+        result.Success.Should().BeTrue();
+        generation.PrecisionScore.Should().Be(4);
+        generation.StyleScore.Should().Be(5);
+        generation.FeedbackComment.Should().Be("Very helpful");
+        _repo.Verify(r => r.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequestWithNoComment_SavesNullComment()
+    {
+        var generation = MakeGeneration();
+        _repo.Setup(r => r.GetGenerationByIdAsync(generation.Id, default)).ReturnsAsync(generation);
+        _repo.Setup(r => r.SaveChangesAsync(default)).Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest { GenerationId = generation.Id, PrecisionScore = 3, StyleScore = 3 }, default);
+
+        result.Success.Should().BeTrue();
+        generation.FeedbackComment.Should().BeNull();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs
@@ -76,4 +76,58 @@ public class GetChunkDetailHandlerTests
         Assert.False(result.Success);
         Assert.Equal(ErrorCodes.KnowledgeBaseChunkNotFound, result.ErrorCode);
     }
+
+    [Fact]
+    public async Task Handle_ReturnsSharePointSourcePath_WhenDocumentSourcedFromSharePoint()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = "https://anelacz.sharepoint.com/sites/x/doc.docx";
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://anelacz.sharepoint.com/sites/x/doc.docx", result.SourcePath);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSyntheticUploadPath_WhenDocumentManuallyUploaded()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = "upload/abc-123/file.pdf";
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal("upload/abc-123/file.pdf", result.SourcePath);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmptyString_WhenDocumentHasNoSourcePath()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = string.Empty;
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal(string.Empty, result.SourcePath);
+    }
 }

--- a/design.md
+++ b/design.md
@@ -1,0 +1,286 @@
+# Design: Phase 1 — UI Consolidation & SharePoint Link-Back
+
+## UX/UI Design
+
+### Sidebar — Marketing group consolidation
+
+The existing `marketing` section (Kalendář, Generátor letáků) is extended in-place; the standalone `knowledgebase` section is removed. End result is one collapsible Marketing group with five items in order:
+
+```
+┌─────────────────────────────┐
+│ AH  Anela Heblo             │
+├─────────────────────────────┤
+│ ⊞  Dashboard                │
+│ ...                         │
+│ ▼ 📣 Marketing              │  ← Megaphone icon, expanded
+│    Kalendář                 │
+│    Generátor letáků         │
+│    Generátor článků         │  ← added (was unreachable)
+│    Poradenství (KB)         │  ← moved from knowledgebase section
+│    Feedback                 │  ← conditional: managers only
+│ ...                         │
+│ ▶ 🤖 Automatizace           │
+│                             │  ← Knowledgebase section removed
+└─────────────────────────────┘
+```
+
+The `knowledgebase` section (Database icon, "Poradenství" + conditional "Feedback") is deleted. `Database` is removed from the lucide-react import block (verify no other in-file usage before removing). The Feedback item in the merged section is conditioned on `hasRole('knowledge_base_manager') || hasRole('leaflet_manager') || hasRole('article_generator')`.
+
+Collapsed state behaviour is unchanged — icon-only, clicking expands the sidebar.
+
+### Marketing Feedback stub page
+
+Minimal placeholder with standard page wrapper. No interactive elements.
+
+```
+┌────────────────────────────────────────────┐
+│  Feedback                                  │  ← <h1>
+│                                            │
+│  Přehled zpětné vazby bude dostupný        │  ← <p>
+│  po dokončení integrace.                   │
+└────────────────────────────────────────────┘
+```
+
+Wrapper: `<div className="p-6">`. No card, no table, no spinner. Page lives at `/marketing/feedback` inside the existing `<AuthGuard>` + `<Layout>` tree.
+
+### Chunk detail modal — SharePoint link row
+
+The link is inserted between the meta row and the Summary block in both modals. It is omitted entirely when `sourcePath` is null, empty, or starts with `upload/`.
+
+**KB ChunkDetailModal** (current layout is at `ChunkDetailModal.tsx:59-93`):
+
+```
+┌──────────────────────────────────────────────────────┐
+│ filename.docx                               [×]      │
+├──────────────────────────────────────────────────────┤
+│  Dokument  •  Indexováno: 1. 5. 2025  •  87%        │  ← meta row (unchanged)
+│  Otevřít v SharePoint ↗                             │  ← NEW: only when https://
+│                                                      │
+│  SHRNUTÍ                                             │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ ...                                            │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                      │
+│  OBSAH                                               │
+│  ...                                                 │
+└──────────────────────────────────────────────────────┘
+```
+
+**LeafletChunkDetailModal** (`LeafletChunkDetailModal.tsx:59-88`) — identical layout change; the only structural difference from KB modal is the absence of the `documentType` pill and `score` in its meta row (current state, unchanged).
+
+Link element spec:
+- Tag: `<a>` with `target="_blank" rel="noopener noreferrer"`
+- Label: `Otevřít v SharePoint` + trailing `<ExternalLink className="w-3 h-3" />`
+- Classes: `inline-flex items-center gap-1 text-xs text-blue-600 hover:underline`
+- Rendered inside the `data && (...)` block, immediately after the `<div className='flex items-center gap-3 ...'>` meta row
+
+## Component Design
+
+### Frontend
+
+#### `frontend/src/utils/sharepointLink.ts` (NEW)
+
+Pure synchronous function with no side effects, no React imports.
+
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null
+```
+
+Returns the input verbatim when it starts with `"https://"`, `null` in all other cases (null, undefined, empty string, `"upload/..."` prefix).
+
+No default export. Imported by both modals and testable in isolation.
+
+#### `frontend/src/utils/sharepointLink.test.ts` (NEW)
+
+Unit tests covering: `null`, `undefined`, `""`, `"upload/abc/file.pdf"`, `"https://sharepoint.example.com/doc"`.
+
+#### `frontend/src/pages/MarketingFeedbackPage.tsx` (NEW)
+
+Default export. Stateless functional component. No props, no hooks, no data fetching.
+
+```tsx
+export default function MarketingFeedbackPage() {
+  return (
+    <div className="p-6">
+      <h1 ...>Feedback</h1>
+      <p ...>Přehled zpětné vazby bude dostupný po dokončení integrace.</p>
+    </div>
+  );
+}
+```
+
+#### `frontend/src/components/Layout/Sidebar.tsx` (MODIFIED)
+
+**Change 1 — `navigationSections` array:**
+- Extend the `marketing` section (id `"marketing"`) items array from 2 items to 5 (or 4 + conditional spread).
+- Remove the `knowledgebase` section object entirely (currently lines 299–314).
+
+**Change 2 — imports:**
+- Remove `Database` from the lucide-react import (confirmed single usage on line 20 as the knowledgebase section icon).
+- No other import changes required (`Megaphone` and `ExternalLink` are already imported).
+
+No changes to the rendering logic, toggle behaviour, or collapsed state handling.
+
+#### `frontend/src/App.tsx` (MODIFIED)
+
+Add import of `MarketingFeedbackPage` and register route `/marketing/feedback` inside the existing `<AuthGuard>` + `<Layout>` block, alongside the existing `/knowledge-base/feedback` route (lines ~466-474).
+
+#### `frontend/src/components/knowledge-base/ChunkDetailModal.tsx` (MODIFIED)
+
+Add import of `getSharePointLink` from `../../utils/sharepointLink` and `ExternalLink` from `lucide-react`.
+
+Insert the link element after the closing tag of the meta row `<div>` (currently line 74), before the Summary `<div>`:
+
+```tsx
+{getSharePointLink(data.sourcePath) && (
+  <a
+    href={getSharePointLink(data.sourcePath)!}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+  >
+    Otevřít v SharePoint
+    <ExternalLink className="w-3 h-3" />
+  </a>
+)}
+```
+
+#### `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx` (MODIFIED)
+
+Identical change as KB modal above; insertion point is after the meta row `<div>` (currently line 66).
+
+### Backend
+
+#### `GetChunkDetailRequest.cs` — `GetChunkDetailResponse` class (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs`
+
+Add one property to the `GetChunkDetailResponse` class:
+
+```csharp
+public string? SourcePath { get; set; }
+```
+
+#### `GetChunkDetailHandler.cs` (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`
+
+Add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser (after `Content = chunk.Content,`, currently line 34).
+
+#### `GetLeafletChunkDetailRequest.cs` — `GetLeafletChunkDetailResponse` class (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs`
+
+Same additive change:
+
+```csharp
+public string? SourcePath { get; set; }
+```
+
+#### `GetLeafletChunkDetailHandler.cs` (MODIFIED)
+
+File: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs`
+
+Add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser.
+
+#### Repositories — no changes
+
+`KnowledgeBaseRepository.GetChunkByIdAsync` and `LeafletRepository.GetChunkByIdAsync` already include `.Include(c => c.Document)`. No repository modifications needed.
+
+### Test files (MODIFIED — existing test classes extended)
+
+**`GetChunkDetailHandlerTests.cs`** — add three facts:
+1. `SourcePath` equals document's SharePoint URL when document has `https://` path.
+2. `SourcePath` equals synthetic path verbatim when document has `upload/...` path.
+3. `SourcePath` is `""` (empty string) when document `SourcePath` defaults to `string.Empty`.
+
+**`GetLeafletChunkDetailHandlerTests.cs`** — same three facts.
+
+**Frontend test files (NEW):**
+- `frontend/src/utils/sharepointLink.test.ts` — five test cases covering all input categories.
+- `frontend/src/components/knowledge-base/ChunkDetailModal.test.tsx` — three cases (SharePoint URL renders link; `upload/...` hides link; `null` hides link).
+- `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.test.tsx` — same three cases.
+
+## Data Schemas
+
+### Backend DTO changes (additive)
+
+**`GetChunkDetailResponse`** — after change:
+
+```csharp
+public class GetChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DocumentType DocumentType { get; set; }
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }           // NEW
+}
+```
+
+**`GetLeafletChunkDetailResponse`** — after change:
+
+```csharp
+public class GetLeafletChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }           // NEW
+}
+```
+
+### API response shapes (JSON)
+
+`GET /api/knowledge-base/chunks/{id}` — additive change:
+```json
+{
+  "chunkId": "...",
+  "documentId": "...",
+  "filename": "example.docx",
+  "documentType": "Document",
+  "indexedAt": "2025-05-01T10:00:00Z",
+  "chunkIndex": 0,
+  "summary": "...",
+  "content": "...",
+  "sourcePath": "https://anelacz.sharepoint.com/..."
+}
+```
+
+`sourcePath` is `null` or an empty string when the document has no SharePoint origin; a `"upload/{guid}/{filename}"` string when manually uploaded; a full `https://` URL when sourced from SharePoint/OneDrive.
+
+`GET /api/leaflet/chunks/{id}` — identical additive change to its response shape.
+
+### Frontend TypeScript shapes
+
+Auto-generated by the OpenAPI client on `npm run build`. After regeneration the generated interfaces gain:
+
+```ts
+// In api-client.ts (auto-generated, do not edit manually)
+interface GetChunkDetailResponse {
+  // ...existing fields...
+  sourcePath?: string;
+}
+
+interface GetLeafletChunkDetailResponse {
+  // ...existing fields...
+  sourcePath?: string;
+}
+```
+
+### `SourcePath` semantics (existing convention, unchanged)
+
+| Value pattern | Origin | UI behaviour |
+|---|---|---|
+| `https://...` | SharePoint / OneDrive ingestion | Render as clickable link |
+| `upload/{guid}/{filename}` | Manual upload pipeline | Omit link (helper returns `null`) |
+| `""` (empty string default) | No source set | Omit link (falsy check catches it) |
+| `null` | Defensive DTO nullability | Omit link |

--- a/docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md
+++ b/docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md
@@ -1,0 +1,2514 @@
+# Leaflet Generation Persistence + Feedback (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist every successful leaflet generation to the database and expose a one-shot, owner-only feedback flow with a manager-gated list endpoint, mirroring the proven KnowledgeBase Q&A pattern.
+
+**Architecture:** A new `LeafletGeneration` entity persisted via a MediatR `IPipelineBehavior` after `GenerateLeafletHandler` returns successfully. Three new endpoints on `LeafletController` (`POST /api/leaflet/feedback`, `GET /api/leaflet/feedback/list`, `GET /api/leaflet/generations/{id}`). A shared `RagFeedbackForm` component is extracted from `KnowledgeBaseSearchAskTab` and consumed by both KB and Leaflet result panels.
+
+**Tech Stack:** .NET 8 (MediatR, EF Core, PostgreSQL), React + TanStack Query, Vertical Slice organization. Branch policy: cut from `feature/genai_consistency`, target PR back to `feature/genai_consistency` (NOT `main`).
+
+---
+
+## Prerequisites Checklist
+
+- [ ] Phase 1 (LeafletController.Generate, GenerateLeafletHandler, LeafletResult.tsx, sidebar, route) is merged into `feature/genai_consistency`. Verify with `git log feature/genai_consistency --grep="leaflet"`.
+- [ ] Current branch `feat-phase-2-leaflet-generation-persistence-f` was cut from `feature/genai_consistency`. Verify with `git merge-base feature/genai_consistency HEAD` returns a commit on `feature/genai_consistency`.
+- [ ] `dotnet ef` tool is installed. Verify with `dotnet ef --version`.
+- [ ] Postgres dev DB is reachable.
+
+---
+
+## File Structure
+
+**Backend new files:**
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs` — entity
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs` — sealed record
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs` — EF config
+- `backend/src/Anela.Heblo.Persistence/Migrations/20260506*_AddLeafletGenerations.cs` — migration (auto-generated)
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` — pipeline behavior
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/{Request,Response,Handler}.cs`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/{Request,Response,Handler}.cs`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/{Request,Response,Handler}.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletGenerationHandlerTests.cs`
+- `frontend/src/components/feedback/RagFeedbackForm.tsx` — shared component
+- `frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+
+**Backend modified files:**
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — add 3 codes
+- `backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs` — +4 methods
+- `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs` — +4 implementations
+- `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs` — add `DbSet<LeafletGeneration>`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs` — add `Id`, `KbSourceCount`, `LeafletSourceCount`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs` — populate counts
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — register pipeline behavior
+- `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs` — 3 new actions
+
+**Frontend modified files:**
+- `frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx` — use shared form
+- `frontend/src/features/leaflet-generator/LeafletResult.tsx` — accept `generationId?` prop
+- `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx` — pass `generationId` from response
+- `frontend/src/api/hooks/useLeaflet.ts` — add types + `useSubmitLeafletFeedbackMutation`
+- `frontend/src/i18n.ts` — add 3 error code translations (cs + en)
+
+---
+
+## Task 1: Add ErrorCodes for Leaflet feedback flow
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:247-249`
+
+- [ ] **Step 1: Add three new enum values to the Leaflet block (25XX)**
+
+Replace the existing Leaflet block:
+
+```csharp
+    // Leaflet module errors (25XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletChunkNotFound = 2501,
+```
+
+with:
+
+```csharp
+    // Leaflet module errors (25XX)
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletChunkNotFound = 2501,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletFeedbackNotFound = 2502,
+    [HttpStatusCode(HttpStatusCode.Conflict)]
+    LeafletFeedbackAlreadySubmitted = 2503,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    LeafletGenerationNotFound = 2504,
+```
+
+- [ ] **Step 2: Build to verify enum compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat: add Leaflet feedback error codes"
+```
+
+---
+
+## Task 2: Add `LeafletGeneration` domain entity and `LeafletFeedbackStats` record
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs`
+- Create: `backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs`
+
+- [ ] **Step 1: Write `LeafletGeneration.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public class LeafletGeneration
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}
+```
+
+- [ ] **Step 2: Write `LeafletFeedbackStats.cs`**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Leaflet;
+
+public sealed record LeafletFeedbackStats(
+    int TotalGenerations,
+    int TotalWithFeedback,
+    double? AvgPrecisionScore,
+    double? AvgStyleScore);
+```
+
+- [ ] **Step 3: Build domain project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletGeneration.cs \
+        backend/src/Anela.Heblo.Domain/Features/Leaflet/LeafletFeedbackStats.cs
+git commit -m "feat: add LeafletGeneration entity and LeafletFeedbackStats record"
+```
+
+---
+
+## Task 3: Extend `ILeafletRepository` with 4 new methods
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs`
+
+- [ ] **Step 1: Add four new method signatures before the closing brace**
+
+Insert these lines just before the closing `}` of `ILeafletRepository`:
+
+```csharp
+    Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken ct = default);
+    Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+        bool? hasFeedback,
+        string? userId,
+        string sortBy,
+        bool sortDescending,
+        int pageNumber,
+        int pageSize,
+        CancellationToken ct = default);
+    Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Build domain — implementation will fail (expected)**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: FAIL — `LeafletRepository does not implement interface members SaveGenerationAsync, …`. This is the failing test for the next task.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Leaflet/ILeafletRepository.cs
+git commit -m "feat: extend ILeafletRepository with generation and feedback methods"
+```
+
+---
+
+## Task 4: Add EF configuration for `LeafletGeneration`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs`
+
+- [ ] **Step 1: Write the configuration**
+
+```csharp
+using Anela.Heblo.Domain.Features.Leaflet;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.Leaflet;
+
+public class LeafletGenerationConfiguration : IEntityTypeConfiguration<LeafletGeneration>
+{
+    public void Configure(EntityTypeBuilder<LeafletGeneration> builder)
+    {
+        builder.ToTable("LeafletGenerations", "public");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Topic).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Audience).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.Length).IsRequired().HasMaxLength(50);
+        builder.Property(x => x.FinalMarkdown).IsRequired().HasColumnType("text");
+        builder.Property(x => x.KbSourceCount).IsRequired();
+        builder.Property(x => x.LeafletSourceCount).IsRequired();
+        builder.Property(x => x.DurationMs).IsRequired();
+        builder.Property(x => x.CreatedAt).IsRequired();
+        builder.Property(x => x.UserId).IsRequired(false).HasMaxLength(200);
+        builder.Property(x => x.PrecisionScore).IsRequired(false);
+        builder.Property(x => x.StyleScore).IsRequired(false);
+        builder.Property(x => x.FeedbackComment).IsRequired(false).HasColumnType("text");
+
+        builder.HasIndex(x => x.CreatedAt);
+        builder.HasIndex(x => x.UserId);
+        builder.HasIndex(x => x.PrecisionScore).HasFilter("\"PrecisionScore\" IS NOT NULL");
+    }
+}
+```
+
+- [ ] **Step 2: Build persistence project — still fails (interface members missing)**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: still FAILS on `LeafletRepository` interface implementation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletGenerationConfiguration.cs
+git commit -m "feat: add EF configuration for LeafletGenerations table"
+```
+
+---
+
+## Task 5: Add `DbSet<LeafletGeneration>` to `ApplicationDbContext`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs:88-89`
+
+- [ ] **Step 1: Add a new `DbSet` next to `LeafletChunks`**
+
+Replace:
+
+```csharp
+    // Leaflet module
+    public DbSet<LeafletDocument> LeafletDocuments { get; set; } = null!;
+    public DbSet<LeafletChunk> LeafletChunks { get; set; } = null!;
+```
+
+with:
+
+```csharp
+    // Leaflet module
+    public DbSet<LeafletDocument> LeafletDocuments { get; set; } = null!;
+    public DbSet<LeafletChunk> LeafletChunks { get; set; } = null!;
+    public DbSet<LeafletGeneration> LeafletGenerations { get; set; } = null!;
+```
+
+- [ ] **Step 2: Verify build still fails on missing repository methods**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: still FAILS on `LeafletRepository` (interface members not implemented).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/ApplicationDbContext.cs
+git commit -m "feat: add LeafletGenerations DbSet"
+```
+
+---
+
+## Task 6: Implement repository methods on `LeafletRepository`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs`
+
+- [ ] **Step 1: Add the four new methods just before the closing `}` of the class**
+
+```csharp
+    public async Task SaveGenerationAsync(LeafletGeneration generation, CancellationToken ct = default)
+    {
+        _context.LeafletGenerations.Add(generation);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<LeafletGeneration?> GetGenerationByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        return await _context.LeafletGenerations
+            .FirstOrDefaultAsync(g => g.Id == id, ct);
+    }
+
+    public async Task<(IReadOnlyList<LeafletGeneration> Items, int TotalCount)> GetGenerationsPagedAsync(
+        bool? hasFeedback,
+        string? userId,
+        string sortBy,
+        bool sortDescending,
+        int pageNumber,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _context.LeafletGenerations.AsNoTracking().AsQueryable();
+
+        if (hasFeedback.HasValue)
+        {
+            query = hasFeedback.Value
+                ? query.Where(g => g.PrecisionScore != null || g.StyleScore != null)
+                : query.Where(g => g.PrecisionScore == null && g.StyleScore == null);
+        }
+
+        if (!string.IsNullOrEmpty(userId))
+            query = query.Where(g => g.UserId == userId);
+
+        query = sortBy switch
+        {
+            "PrecisionScore" => sortDescending
+                ? query.OrderByDescending(g => g.PrecisionScore)
+                : query.OrderBy(g => g.PrecisionScore),
+            "StyleScore" => sortDescending
+                ? query.OrderByDescending(g => g.StyleScore)
+                : query.OrderBy(g => g.StyleScore),
+            _ => sortDescending
+                ? query.OrderByDescending(g => g.CreatedAt)
+                : query.OrderBy(g => g.CreatedAt),
+        };
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, total);
+    }
+
+    // NFR-1: prefer indexed aggregates over loading all rows into memory.
+    public async Task<LeafletFeedbackStats> GetGenerationStatsAsync(CancellationToken ct = default)
+    {
+        var totalGenerations = await _context.LeafletGenerations.CountAsync(ct);
+
+        var totalWithFeedback = await _context.LeafletGenerations
+            .Where(g => g.PrecisionScore != null || g.StyleScore != null)
+            .CountAsync(ct);
+
+        double? avgPrecision = await _context.LeafletGenerations
+            .Where(g => g.PrecisionScore != null)
+            .AverageAsync(g => (double?)g.PrecisionScore, ct);
+
+        double? avgStyle = await _context.LeafletGenerations
+            .Where(g => g.StyleScore != null)
+            .AverageAsync(g => (double?)g.StyleScore, ct);
+
+        return new LeafletFeedbackStats(
+            totalGenerations,
+            totalWithFeedback,
+            avgPrecision.HasValue ? Math.Round(avgPrecision.Value, 1) : null,
+            avgStyle.HasValue ? Math.Round(avgStyle.Value, 1) : null);
+    }
+```
+
+- [ ] **Step 2: Build persistence — should now succeed**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/Leaflet/LeafletRepository.cs
+git commit -m "feat: implement LeafletGeneration repository methods"
+```
+
+---
+
+## Task 7: Generate EF migration `AddLeafletGenerations`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddLeafletGenerations.cs` (auto-generated)
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_AddLeafletGenerations.Designer.cs` (auto-generated)
+- Modify: `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` (auto-updated)
+
+- [ ] **Step 1: Run the EF migration command from the repo root**
+
+Run:
+```bash
+dotnet ef migrations add AddLeafletGenerations \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API \
+  --output-dir Migrations
+```
+Expected: 2 new files created in `backend/src/Anela.Heblo.Persistence/Migrations/`. Snapshot file is updated.
+
+- [ ] **Step 2: Inspect the generated `Up()` method**
+
+Open the new `*_AddLeafletGenerations.cs` file. Confirm:
+- `schema: "public"` is set on the `CreateTable` call.
+- All 13 columns are present: `Id`, `Topic`, `Audience`, `Length`, `FinalMarkdown`, `KbSourceCount`, `LeafletSourceCount`, `DurationMs`, `CreatedAt`, `UserId`, `PrecisionScore`, `StyleScore`, `FeedbackComment`.
+- Three indexes are created: on `CreatedAt`, on `UserId`, on `PrecisionScore` with filter `"PrecisionScore" IS NOT NULL`.
+
+If any of these are missing, delete both new migration files plus the snapshot diff (`git restore backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`), fix `LeafletGenerationConfiguration.cs`, and re-run Step 1.
+
+- [ ] **Step 3: Apply the migration to the local dev DB**
+
+Run:
+```bash
+dotnet ef database update \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+Expected: migration applies cleanly. Verify with `psql -c '\dt public."LeafletGenerations"'` (table exists with correct columns).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "feat: add LeafletGenerations migration"
+```
+
+---
+
+## Task 8: Extend `GenerateLeafletResponse` with Id and source counts
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs`
+
+- [ ] **Step 1: Replace the file contents**
+
+```csharp
+using System.Text.Json.Serialization;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+
+public class GenerateLeafletResponse : BaseResponse
+{
+    [JsonPropertyName("id")]
+    public Guid? Id { get; set; }
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    [JsonPropertyName("kbSourceCount")]
+    public int KbSourceCount { get; set; }
+
+    [JsonPropertyName("leafletSourceCount")]
+    public int LeafletSourceCount { get; set; }
+}
+```
+
+Note: `Id`, `KbSourceCount`, `LeafletSourceCount` use `set` (not `init`) so the pipeline behavior and handler can write them after construction.
+
+- [ ] **Step 2: Build application project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletResponse.cs
+git commit -m "feat: expose Id and source counts on GenerateLeafletResponse"
+```
+
+---
+
+## Task 9: Populate source counts in `GenerateLeafletHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs:134`
+
+- [ ] **Step 1: Replace the final `return` line**
+
+Replace:
+
+```csharp
+        return new GenerateLeafletResponse { Content = leafletResponse.Text ?? string.Empty };
+```
+
+with:
+
+```csharp
+        return new GenerateLeafletResponse
+        {
+            Content = leafletResponse.Text ?? string.Empty,
+            KbSourceCount = kbHits.Count,
+            LeafletSourceCount = leafletHits.Count,
+        };
+```
+
+- [ ] **Step 2: Build application project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GenerateLeaflet/GenerateLeafletHandler.cs
+git commit -m "feat: populate KbSourceCount and LeafletSourceCount in GenerateLeafletHandler"
+```
+
+---
+
+## Task 10: Write `LeafletGenerationLoggingBehaviorTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehaviorTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _userService = new();
+    private readonly Mock<ILogger<LeafletGenerationLoggingBehavior>> _logger = new();
+
+    private LeafletGenerationLoggingBehavior CreateBehavior() =>
+        new(_repository.Object, _userService.Object, _logger.Object);
+
+    [Fact]
+    public async Task Handle_OnSuccess_PersistsRowAndSetsResponseId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "Hyaluronic acid",
+            Audience = AudienceType.EndConsumer,
+            Length = LeafletLength.Medium,
+        };
+        var expected = new GenerateLeafletResponse
+        {
+            Content = "# Final markdown",
+            KbSourceCount = 3,
+            LeafletSourceCount = 2,
+        };
+
+        LeafletGeneration? captured = null;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((g, _) => captured = g)
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateBehavior().Handle(request, () => Task.FromResult(expected), default);
+
+        result.Should().BeSameAs(expected);
+        captured.Should().NotBeNull();
+        captured!.Topic.Should().Be("Hyaluronic acid");
+        captured.Audience.Should().Be("EndConsumer");
+        captured.Length.Should().Be("Medium");
+        captured.FinalMarkdown.Should().Be("# Final markdown");
+        captured.KbSourceCount.Should().Be(3);
+        captured.LeafletSourceCount.Should().Be(2);
+        captured.UserId.Should().Be("user-1");
+        captured.DurationMs.Should().BeGreaterThanOrEqualTo(0);
+        captured.PrecisionScore.Should().BeNull();
+        captured.StyleScore.Should().BeNull();
+        result.Id.Should().Be(captured.Id);
+        result.Id.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task Handle_WhenResponseUnsuccessful_DoesNotPersist()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "X", Audience = AudienceType.B2B, Length = LeafletLength.Short,
+        };
+        var failed = new GenerateLeafletResponse { Content = "" };
+        failed.Success = false;
+
+        var result = await CreateBehavior().Handle(request, () => Task.FromResult(failed), default);
+
+        result.Should().BeSameAs(failed);
+        result.Id.Should().BeNull();
+        _repository.Verify(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSaveThrows_ResponseStillReturned()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB exploded"));
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "X", Audience = AudienceType.B2B, Length = LeafletLength.Short,
+        };
+        var expected = new GenerateLeafletResponse { Content = "ok" };
+
+        var result = await CreateBehavior().Handle(request, () => Task.FromResult(expected), default);
+
+        result.Content.Should().Be("ok");
+        result.Id.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_PassesCancellationTokenNoneToSave()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test User", null, true));
+
+        CancellationToken capturedToken = default;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((_, t) => capturedToken = t)
+            .Returns(Task.CompletedTask);
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var request = new GenerateLeafletRequest
+        {
+            Topic = "X", Audience = AudienceType.B2B, Length = LeafletLength.Short,
+        };
+        var expected = new GenerateLeafletResponse { Content = "ok" };
+
+        await CreateBehavior().Handle(request, () => Task.FromResult(expected), cts.Token);
+
+        capturedToken.Should().Be(CancellationToken.None);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — they should FAIL (no behavior class yet)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests"`
+Expected: compilation FAIL (`LeafletGenerationLoggingBehavior` not found).
+
+---
+
+## Task 11: Implement `LeafletGenerationLoggingBehavior` (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs`
+
+- [ ] **Step 1: Write the behavior**
+
+```csharp
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationLoggingBehavior
+    : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<LeafletGenerationLoggingBehavior> _logger;
+
+    public LeafletGenerationLoggingBehavior(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService,
+        ILogger<LeafletGenerationLoggingBehavior> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GenerateLeafletResponse> Handle(
+        GenerateLeafletRequest request,
+        RequestHandlerDelegate<GenerateLeafletResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        // next() runs OUTSIDE try/catch — generator failures must propagate.
+        var response = await next();
+        sw.Stop();
+
+        if (!response.Success)
+            return response;
+
+        try
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            var generation = new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = request.Topic,
+                Audience = request.Audience.ToString(),
+                Length = request.Length.ToString(),
+                FinalMarkdown = response.Content,
+                KbSourceCount = response.KbSourceCount,
+                LeafletSourceCount = response.LeafletSourceCount,
+                DurationMs = sw.ElapsedMilliseconds,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UserId = currentUser.Id,
+            };
+
+            // Use CancellationToken.None: avoid losing the audit row on client disconnect.
+            await _repository.SaveGenerationAsync(generation, CancellationToken.None);
+            response.Id = generation.Id;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write leaflet generation log. Topic: {Topic}", request.Topic);
+        }
+
+        return response;
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — they should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests"`
+Expected: 4 PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+git commit -m "feat: add LeafletGenerationLoggingBehavior to persist generations"
+```
+
+---
+
+## Task 12: Register pipeline behavior in `LeafletModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs`
+
+- [ ] **Step 1: Add the registration**
+
+Replace the file contents:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.Services;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Leaflet;
+
+public static class LeafletModule
+{
+    public static IServiceCollection AddLeafletModule(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<LeafletOptions>()
+            .Bind(configuration.GetSection(LeafletOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddScoped<ILeafletChunkSummarizer, LeafletChunkSummarizer>();
+        services.AddScoped<ILeafletIndexingService, LeafletIndexingService>();
+
+        // LeafletIngestionJob is auto-discovered via IRecurringJob assembly scan in AddRecurringJobs()
+        // ILeafletRepository is registered in PersistenceModule
+        // MediatR handlers are auto-registered via AddApplicationServices() assembly scan
+
+        // Persist generation results after a successful response. Scoped — same lifetime as repository.
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationLoggingBehavior>();
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+git commit -m "feat: register LeafletGenerationLoggingBehavior in module"
+```
+
+---
+
+## Task 13: Write `SubmitLeafletFeedbackHandlerTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class SubmitLeafletFeedbackHandlerTests
+{
+    private const string UserId = "user-1";
+
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _currentUserService = new();
+
+    public SubmitLeafletFeedbackHandlerTests()
+    {
+        _currentUserService
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(UserId, "Test User", null, true));
+    }
+
+    private SubmitLeafletFeedbackHandler CreateHandler() =>
+        new(_repository.Object, _currentUserService.Object);
+
+    [Fact]
+    public async Task Handle_WhenGenerationNotFound_ReturnsNotFound()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletGeneration?)null);
+
+        var request = new SubmitLeafletFeedbackRequest
+        {
+            GenerationId = generationId, PrecisionScore = 4, StyleScore = 5,
+        };
+        var result = await CreateHandler().Handle(request, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackNotFound);
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ReturnsForbidden()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LeafletGeneration
+            {
+                Id = generationId,
+                Topic = "T",
+                Audience = "EndConsumer",
+                Length = "Short",
+                FinalMarkdown = "M",
+                UserId = "other-user",
+            });
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 4, StyleScore = 5,
+            },
+            default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPrecisionAlreadySet_ReturnsAlreadySubmitted()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LeafletGeneration
+            {
+                Id = generationId,
+                Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+                UserId = UserId,
+                PrecisionScore = 4,
+            });
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 5, StyleScore = 5,
+            },
+            default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackAlreadySubmitted);
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStyleAlreadySet_ReturnsAlreadySubmitted()
+    {
+        var generationId = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LeafletGeneration
+            {
+                Id = generationId,
+                Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+                UserId = UserId,
+                StyleScore = 3,
+            });
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 5, StyleScore = 5,
+            },
+            default);
+
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletFeedbackAlreadySubmitted);
+    }
+
+    [Fact]
+    public async Task Handle_WhenValid_PersistsAllFieldsAndReturnsSuccess()
+    {
+        var generationId = Guid.NewGuid();
+        var generation = new LeafletGeneration
+        {
+            Id = generationId,
+            Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+            UserId = UserId,
+        };
+
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(generation);
+        _repository
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId,
+                PrecisionScore = 4,
+                StyleScore = 5,
+                Comment = "Looks good",
+            },
+            default);
+
+        result.Success.Should().BeTrue();
+        generation.PrecisionScore.Should().Be(4);
+        generation.StyleScore.Should().Be(5);
+        generation.FeedbackComment.Should().Be("Looks good");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenValidWithNoComment_PersistsNullComment()
+    {
+        var generationId = Guid.NewGuid();
+        var generation = new LeafletGeneration
+        {
+            Id = generationId,
+            Topic = "T", Audience = "EndConsumer", Length = "Short", FinalMarkdown = "M",
+            UserId = UserId,
+        };
+
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(generationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(generation);
+
+        var result = await CreateHandler().Handle(
+            new SubmitLeafletFeedbackRequest
+            {
+                GenerationId = generationId, PrecisionScore = 3, StyleScore = 4,
+            },
+            default);
+
+        result.Success.Should().BeTrue();
+        generation.FeedbackComment.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — they should FAIL (handler/types missing)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SubmitLeafletFeedbackHandlerTests"`
+Expected: compilation FAIL.
+
+---
+
+## Task 14: Implement `SubmitLeafletFeedback` request, response, handler (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/SubmitLeafletFeedbackHandler.cs`
+
+- [ ] **Step 1: Write the request**
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackRequest : IRequest<SubmitLeafletFeedbackResponse>
+{
+    public Guid GenerationId { get; set; }
+
+    [Range(1, 5)]
+    public int PrecisionScore { get; set; }
+
+    [Range(1, 5)]
+    public int StyleScore { get; set; }
+
+    [MaxLength(1000)]
+    public string? Comment { get; set; }
+}
+```
+
+- [ ] **Step 2: Write the response**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackResponse : BaseResponse
+{
+    public SubmitLeafletFeedbackResponse() { }
+
+    public SubmitLeafletFeedbackResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters) { }
+}
+```
+
+- [ ] **Step 3: Write the handler**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+
+public class SubmitLeafletFeedbackHandler
+    : IRequestHandler<SubmitLeafletFeedbackRequest, SubmitLeafletFeedbackResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public SubmitLeafletFeedbackHandler(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<SubmitLeafletFeedbackResponse> Handle(
+        SubmitLeafletFeedbackRequest request,
+        CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.GenerationId, cancellationToken);
+        if (generation is null)
+        {
+            return new SubmitLeafletFeedbackResponse(
+                ErrorCodes.LeafletFeedbackNotFound,
+                new Dictionary<string, string> { { "generationId", request.GenerationId.ToString() } });
+        }
+
+        // Owner-only check (no policy/middleware — must load entity first to know the owner).
+        var currentUser = _currentUserService.GetCurrentUser();
+        if (generation.UserId != currentUser.Id)
+        {
+            return new SubmitLeafletFeedbackResponse(
+                ErrorCodes.Forbidden,
+                new Dictionary<string, string> { { "generationId", request.GenerationId.ToString() } });
+        }
+
+        if (generation.PrecisionScore is not null || generation.StyleScore is not null)
+        {
+            return new SubmitLeafletFeedbackResponse(
+                ErrorCodes.LeafletFeedbackAlreadySubmitted,
+                new Dictionary<string, string> { { "generationId", request.GenerationId.ToString() } });
+        }
+
+        generation.PrecisionScore = request.PrecisionScore;
+        generation.StyleScore = request.StyleScore;
+        generation.FeedbackComment = request.Comment;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return new SubmitLeafletFeedbackResponse();
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests — they should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SubmitLeafletFeedbackHandlerTests"`
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/SubmitLeafletFeedback/ \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/SubmitLeafletFeedbackHandlerTests.cs
+git commit -m "feat: add SubmitLeafletFeedback use case"
+```
+
+---
+
+## Task 15: Write `GetLeafletFeedbackListHandlerTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Domain.Features.Leaflet;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class GetLeafletFeedbackListHandlerTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+
+    private static LeafletGeneration MakeGeneration(bool hasFeedback = false) => new()
+    {
+        Id = Guid.NewGuid(),
+        Topic = "Hyaluronic acid",
+        Audience = "EndConsumer",
+        Length = "Medium",
+        FinalMarkdown = "# leaflet",
+        KbSourceCount = 4,
+        LeafletSourceCount = 2,
+        DurationMs = 1234,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UserId = "user-1",
+        PrecisionScore = hasFeedback ? 4 : null,
+        StyleScore = hasFeedback ? 5 : null,
+        FeedbackComment = hasFeedback ? "comment" : null,
+    };
+
+    private static LeafletFeedbackStats DefaultStats() => new(10, 6, 4.2, 4.5);
+
+    private void SetupRepository(IReadOnlyList<LeafletGeneration> rows, int? total = null, LeafletFeedbackStats? stats = null)
+    {
+        _repository
+            .Setup(r => r.GetGenerationsPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((rows, total ?? rows.Count));
+
+        _repository
+            .Setup(r => r.GetGenerationStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats ?? DefaultStats());
+    }
+
+    [Fact]
+    public async Task Handle_MapsRowsToSummaries()
+    {
+        var row = MakeGeneration(hasFeedback: true);
+        SetupRepository(new[] { row });
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        var result = await handler.Handle(new GetLeafletFeedbackListRequest(), default);
+
+        result.Success.Should().BeTrue();
+        result.Logs.Should().HaveCount(1);
+        var dto = result.Logs[0];
+        dto.Id.Should().Be(row.Id);
+        dto.Topic.Should().Be(row.Topic);
+        dto.Audience.Should().Be(row.Audience);
+        dto.Length.Should().Be(row.Length);
+        dto.FinalMarkdown.Should().Be(row.FinalMarkdown);
+        dto.KbSourceCount.Should().Be(row.KbSourceCount);
+        dto.LeafletSourceCount.Should().Be(row.LeafletSourceCount);
+        dto.DurationMs.Should().Be(row.DurationMs);
+        dto.UserId.Should().Be(row.UserId);
+        dto.PrecisionScore.Should().Be(4);
+        dto.StyleScore.Should().Be(5);
+        dto.FeedbackComment.Should().Be("comment");
+        dto.HasFeedback.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsStats()
+    {
+        var stats = new LeafletFeedbackStats(42, 17, 3.7, 4.1);
+        SetupRepository(Array.Empty<LeafletGeneration>(), stats: stats);
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        var result = await handler.Handle(new GetLeafletFeedbackListRequest(), default);
+
+        result.Stats.TotalGenerations.Should().Be(42);
+        result.Stats.TotalWithFeedback.Should().Be(17);
+        result.Stats.AvgPrecisionScore.Should().Be(3.7);
+        result.Stats.AvgStyleScore.Should().Be(4.1);
+    }
+
+    [Theory]
+    [InlineData(15, 20)]
+    [InlineData(0, 20)]
+    [InlineData(-5, 20)]
+    [InlineData(10, 10)]
+    [InlineData(50, 50)]
+    public async Task Handle_NormalizesPaging(int requestedSize, int expectedSize)
+    {
+        SetupRepository(Array.Empty<LeafletGeneration>());
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        var result = await handler.Handle(
+            new GetLeafletFeedbackListRequest { PageSize = requestedSize, PageNumber = 0 },
+            default);
+
+        result.PageSize.Should().Be(expectedSize);
+        result.PageNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_NormalizesInvalidSortBy()
+    {
+        SetupRepository(Array.Empty<LeafletGeneration>());
+        string capturedSortBy = "";
+        _repository
+            .Setup(r => r.GetGenerationsPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<bool?, string?, string, bool, int, int, CancellationToken>(
+                (_, _, sb, _, _, _, _) => capturedSortBy = sb)
+            .ReturnsAsync((Array.Empty<LeafletGeneration>(), 0));
+
+        var handler = new GetLeafletFeedbackListHandler(_repository.Object);
+        await handler.Handle(new GetLeafletFeedbackListRequest { SortBy = "EvilField" }, default);
+
+        capturedSortBy.Should().Be("CreatedAt");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — should FAIL (types missing)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests"`
+Expected: compilation FAIL.
+
+---
+
+## Task 16: Implement `GetLeafletFeedbackList` request/response/handler (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/GetLeafletFeedbackListHandler.cs`
+
+- [ ] **Step 1: Write the request and DTOs in the response file**
+
+`GetLeafletFeedbackListRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListRequest : IRequest<GetLeafletFeedbackListResponse>
+{
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+    public string SortBy { get; set; } = "CreatedAt";
+    public bool SortDescending { get; set; } = true;
+    public bool? HasFeedback { get; set; }
+    public string? UserId { get; set; }
+}
+```
+
+`GetLeafletFeedbackListResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListResponse : BaseResponse
+{
+    public List<LeafletFeedbackSummary> Logs { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages => PageSize > 0 ? (int)Math.Ceiling(TotalCount / (double)PageSize) : 0;
+    public LeafletFeedbackStatsDto Stats { get; set; } = new();
+}
+
+public class LeafletFeedbackSummary
+{
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+    public bool HasFeedback => PrecisionScore.HasValue || StyleScore.HasValue;
+}
+
+public class LeafletFeedbackStatsDto
+{
+    public int TotalGenerations { get; set; }
+    public int TotalWithFeedback { get; set; }
+    public double? AvgPrecisionScore { get; set; }
+    public double? AvgStyleScore { get; set; }
+}
+```
+
+- [ ] **Step 2: Write the handler**
+
+```csharp
+using Anela.Heblo.Domain.Features.Leaflet;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+
+public class GetLeafletFeedbackListHandler
+    : IRequestHandler<GetLeafletFeedbackListRequest, GetLeafletFeedbackListResponse>
+{
+    private static readonly int[] AllowedPageSizes = [10, 20, 50];
+    private static readonly string[] AllowedSortColumns = ["CreatedAt", "PrecisionScore", "StyleScore"];
+
+    private readonly ILeafletRepository _repository;
+
+    public GetLeafletFeedbackListHandler(ILeafletRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetLeafletFeedbackListResponse> Handle(
+        GetLeafletFeedbackListRequest request,
+        CancellationToken cancellationToken)
+    {
+        var pageNumber = Math.Max(1, request.PageNumber);
+        var pageSize = AllowedPageSizes.Contains(request.PageSize) ? request.PageSize : 20;
+        var sortBy = AllowedSortColumns.Contains(request.SortBy) ? request.SortBy : "CreatedAt";
+
+        var (rows, totalCount) = await _repository.GetGenerationsPagedAsync(
+            request.HasFeedback,
+            request.UserId,
+            sortBy,
+            request.SortDescending,
+            pageNumber,
+            pageSize,
+            cancellationToken);
+
+        var stats = await _repository.GetGenerationStatsAsync(cancellationToken);
+
+        return new GetLeafletFeedbackListResponse
+        {
+            Logs = rows.Select(g => new LeafletFeedbackSummary
+            {
+                Id = g.Id,
+                Topic = g.Topic,
+                Audience = g.Audience,
+                Length = g.Length,
+                FinalMarkdown = g.FinalMarkdown,
+                KbSourceCount = g.KbSourceCount,
+                LeafletSourceCount = g.LeafletSourceCount,
+                DurationMs = g.DurationMs,
+                CreatedAt = g.CreatedAt,
+                UserId = g.UserId,
+                PrecisionScore = g.PrecisionScore,
+                StyleScore = g.StyleScore,
+                FeedbackComment = g.FeedbackComment,
+            }).ToList(),
+            TotalCount = totalCount,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+            Stats = new LeafletFeedbackStatsDto
+            {
+                TotalGenerations = stats.TotalGenerations,
+                TotalWithFeedback = stats.TotalWithFeedback,
+                AvgPrecisionScore = stats.AvgPrecisionScore,
+                AvgStyleScore = stats.AvgStyleScore,
+            },
+        };
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletFeedbackListHandlerTests"`
+Expected: 8 PASSED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletFeedbackList/ \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletFeedbackListHandlerTests.cs
+git commit -m "feat: add GetLeafletFeedbackList use case"
+```
+
+---
+
+## Task 17: Write `GetLeafletGenerationHandlerTests` (TDD — RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletGenerationHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.UseCases;
+
+public class GetLeafletGenerationHandlerTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+
+    private GetLeafletGenerationHandler CreateHandler() => new(_repository.Object);
+
+    [Fact]
+    public async Task Handle_WhenNotFound_ReturnsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LeafletGeneration?)null);
+
+        var result = await CreateHandler().Handle(
+            new GetLeafletGenerationRequest { Id = id }, default);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.LeafletGenerationNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_WhenFound_ReturnsFullPayload()
+    {
+        var id = Guid.NewGuid();
+        var row = new LeafletGeneration
+        {
+            Id = id,
+            Topic = "Aloe Vera",
+            Audience = "B2B",
+            Length = "Long",
+            FinalMarkdown = "# m",
+            KbSourceCount = 5,
+            LeafletSourceCount = 3,
+            DurationMs = 9999,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UserId = "user-7",
+            PrecisionScore = 4,
+            StyleScore = 5,
+            FeedbackComment = "good",
+        };
+
+        _repository
+            .Setup(r => r.GetGenerationByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(row);
+
+        var result = await CreateHandler().Handle(
+            new GetLeafletGenerationRequest { Id = id }, default);
+
+        result.Success.Should().BeTrue();
+        result.Id.Should().Be(id);
+        result.Topic.Should().Be("Aloe Vera");
+        result.Audience.Should().Be("B2B");
+        result.Length.Should().Be("Long");
+        result.FinalMarkdown.Should().Be("# m");
+        result.KbSourceCount.Should().Be(5);
+        result.LeafletSourceCount.Should().Be(3);
+        result.DurationMs.Should().Be(9999);
+        result.UserId.Should().Be("user-7");
+        result.PrecisionScore.Should().Be(4);
+        result.StyleScore.Should().Be(5);
+        result.FeedbackComment.Should().Be("good");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — should FAIL**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletGenerationHandlerTests"`
+Expected: compilation FAIL.
+
+---
+
+## Task 18: Implement `GetLeafletGeneration` request/response/handler (TDD — GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/GetLeafletGenerationHandler.cs`
+
+- [ ] **Step 1: Write the request**
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationRequest : IRequest<GetLeafletGenerationResponse>
+{
+    public Guid Id { get; set; }
+}
+```
+
+- [ ] **Step 2: Write the response**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationResponse : BaseResponse
+{
+    public GetLeafletGenerationResponse() { }
+
+    public GetLeafletGenerationResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters) { }
+
+    public Guid Id { get; set; }
+    public string Topic { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Length { get; set; } = string.Empty;
+    public string FinalMarkdown { get; set; } = string.Empty;
+    public int KbSourceCount { get; set; }
+    public int LeafletSourceCount { get; set; }
+    public long DurationMs { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string? UserId { get; set; }
+    public int? PrecisionScore { get; set; }
+    public int? StyleScore { get; set; }
+    public string? FeedbackComment { get; set; }
+}
+```
+
+- [ ] **Step 3: Write the handler**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Leaflet;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+
+public class GetLeafletGenerationHandler
+    : IRequestHandler<GetLeafletGenerationRequest, GetLeafletGenerationResponse>
+{
+    private readonly ILeafletRepository _repository;
+
+    public GetLeafletGenerationHandler(ILeafletRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetLeafletGenerationResponse> Handle(
+        GetLeafletGenerationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var generation = await _repository.GetGenerationByIdAsync(request.Id, cancellationToken);
+        if (generation is null)
+        {
+            return new GetLeafletGenerationResponse(
+                ErrorCodes.LeafletGenerationNotFound,
+                new Dictionary<string, string> { { "id", request.Id.ToString() } });
+        }
+
+        return new GetLeafletGenerationResponse
+        {
+            Id = generation.Id,
+            Topic = generation.Topic,
+            Audience = generation.Audience,
+            Length = generation.Length,
+            FinalMarkdown = generation.FinalMarkdown,
+            KbSourceCount = generation.KbSourceCount,
+            LeafletSourceCount = generation.LeafletSourceCount,
+            DurationMs = generation.DurationMs,
+            CreatedAt = generation.CreatedAt,
+            UserId = generation.UserId,
+            PrecisionScore = generation.PrecisionScore,
+            StyleScore = generation.StyleScore,
+            FeedbackComment = generation.FeedbackComment,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — should PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetLeafletGenerationHandlerTests"`
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletGeneration/ \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletGenerationHandlerTests.cs
+git commit -m "feat: add GetLeafletGeneration use case"
+```
+
+---
+
+## Task 19: Wire the three new endpoints into `LeafletController`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/LeafletController.cs`
+
+- [ ] **Step 1: Add the new `using` directives at the top of the file**
+
+After the existing `using Anela.Heblo.Application.Features.Leaflet.UseCases.UploadLeaflet;` line, add:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletFeedbackList;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GetLeafletGeneration;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.SubmitLeafletFeedback;
+```
+
+- [ ] **Step 2: Append three new actions just before the closing `}` of `LeafletController`**
+
+```csharp
+    [HttpPost("feedback")]
+    public async Task<ActionResult<SubmitLeafletFeedbackResponse>> SubmitFeedback(
+        [FromBody] SubmitLeafletFeedbackRequest request,
+        CancellationToken ct)
+    {
+        var result = await _mediator.Send(request, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpGet("feedback/list")]
+    [Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+    public async Task<ActionResult<GetLeafletFeedbackListResponse>> GetFeedbackList(
+        [FromQuery] bool? hasFeedback = null,
+        [FromQuery] string? userId = null,
+        [FromQuery] string sortBy = "CreatedAt",
+        [FromQuery] bool sortDescending = true,
+        [FromQuery] int pageNumber = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var result = await _mediator.Send(new GetLeafletFeedbackListRequest
+        {
+            HasFeedback = hasFeedback,
+            UserId = userId,
+            SortBy = sortBy,
+            SortDescending = sortDescending,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
+        }, ct);
+        return HandleResponse(result);
+    }
+
+    [HttpGet("generations/{id:guid}")]
+    public async Task<ActionResult<GetLeafletGenerationResponse>> GetGeneration(
+        Guid id,
+        CancellationToken ct)
+    {
+        var result = await _mediator.Send(new GetLeafletGenerationRequest { Id = id }, ct);
+        return HandleResponse(result);
+    }
+```
+
+- [ ] **Step 3: Build the API project**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 4: Format and run all backend tests**
+
+Run: `dotnet format backend/Anela.Heblo.sln && dotnet test backend/Anela.Heblo.sln --no-build`
+Expected: format clean, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
+git commit -m "feat: add leaflet feedback and generation endpoints"
+```
+
+---
+
+## Task 20: Regenerate the OpenAPI TypeScript client
+
+**Files:**
+- Modify: `frontend/src/api/generated/api-client.ts` (auto-generated)
+
+- [ ] **Step 1: Build the API to trigger client regeneration**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+
+The build target regenerates `frontend/src/api/generated/api-client.ts`. Verify with:
+
+Run: `grep -n "leaflet_SubmitFeedback\|leaflet_GetFeedbackList\|leaflet_GetGeneration\|kbSourceCount\|leafletSourceCount" frontend/src/api/generated/api-client.ts | head -20`
+Expected: at least one match for each new method/property.
+
+- [ ] **Step 2: Type-check the frontend**
+
+Run: `cd frontend && npm run build`
+Expected: no errors related to `LeafletResult` (until we update its consumer in Task 25). If any other module breaks because of the `Id`/source-count addition, fix the call site (the new fields are optional/nullable so existing callers should still compile).
+
+- [ ] **Step 3: Commit the regenerated client**
+
+```bash
+git add frontend/src/api/generated/api-client.ts
+git commit -m "chore: regenerate OpenAPI client for leaflet feedback"
+```
+
+---
+
+## Task 21: Write `RagFeedbackForm` component tests (TDD — RED)
+
+**Files:**
+- Create: `frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RagFeedbackForm from '../RagFeedbackForm';
+
+describe('RagFeedbackForm', () => {
+  it('disables submit until both ratings are picked', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    const submit = screen.getByRole('button', { name: /odeslat zpětnou vazbu/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it('enables submit after picking precision and style', async () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '4' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '5' })[1]);
+
+    const submit = screen.getByRole('button', { name: /odeslat zpětnou vazbu/i });
+    expect(submit).toBeEnabled();
+  });
+
+  it('invokes onSubmit with the picked scores and trimmed comment', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <RagFeedbackForm onSubmit={onSubmit} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '3' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '5' })[1]);
+    await userEvent.type(screen.getByPlaceholderText(/volitelný komentář/i), '  hello  ');
+
+    fireEvent.click(screen.getByRole('button', { name: /odeslat zpětnou vazbu/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ precisionScore: 3, styleScore: 5, comment: 'hello' });
+  });
+
+  it('passes undefined comment when textarea is blank', () => {
+    const onSubmit = jest.fn();
+    render(
+      <RagFeedbackForm onSubmit={onSubmit} isSubmitting={false} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '2' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '4' })[1]);
+    fireEvent.click(screen.getByRole('button', { name: /odeslat zpětnou vazbu/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ precisionScore: 2, styleScore: 4, comment: undefined });
+  });
+
+  it('renders the success state when isSuccess is true', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={false} isSuccess={true} />,
+    );
+
+    expect(screen.getByText(/děkujeme za vaši zpětnou vazbu/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /odeslat zpětnou vazbu/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the alreadySubmitted state', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={false} alreadySubmitted={true} isSuccess={false} />,
+    );
+
+    expect(screen.getByText(/zpětná vazba již byla odeslána/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /odeslat zpětnou vazbu/i })).not.toBeInTheDocument();
+  });
+
+  it('disables submit while submitting', () => {
+    render(
+      <RagFeedbackForm onSubmit={jest.fn()} isSubmitting={true} alreadySubmitted={false} isSuccess={false} />,
+    );
+
+    fireEvent.click(screen.getAllByRole('radio', { name: '3' })[0]);
+    fireEvent.click(screen.getAllByRole('radio', { name: '4' })[1]);
+
+    expect(screen.getByRole('button', { name: /odeslat zpětnou vazbu/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — they should FAIL (no component yet)**
+
+Run: `cd frontend && npx jest src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+Expected: module-not-found error.
+
+---
+
+## Task 22: Implement `RagFeedbackForm` (TDD — GREEN)
+
+**Files:**
+- Create: `frontend/src/components/feedback/RagFeedbackForm.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import React, { useState } from 'react';
+
+const SCORES = [1, 2, 3, 4, 5];
+
+interface ScoreRowProps {
+  label: string;
+  value: number | null;
+  onChange: (value: number) => void;
+}
+
+function ScoreRow({ label, value, onChange }: ScoreRowProps) {
+  return (
+    <div className="space-y-1">
+      <span className="text-sm font-medium text-gray-700">{label}</span>
+      <div className="flex gap-1 flex-wrap">
+        {SCORES.map((s) => (
+          <label key={s} className="cursor-pointer">
+            <input
+              type="radio"
+              name={label}
+              value={s}
+              checked={value === s}
+              onChange={() => onChange(s)}
+              className="sr-only"
+              aria-label={String(s)}
+            />
+            <span
+              className={`inline-flex items-center justify-center w-8 h-8 rounded text-sm font-medium border ${
+                value === s
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              {s}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export interface RagFeedbackSubmission {
+  precisionScore: number;
+  styleScore: number;
+  comment?: string;
+}
+
+export interface RagFeedbackFormProps {
+  onSubmit: (submission: RagFeedbackSubmission) => void;
+  isSubmitting: boolean;
+  alreadySubmitted: boolean;
+  isSuccess: boolean;
+}
+
+export default function RagFeedbackForm({
+  onSubmit,
+  isSubmitting,
+  alreadySubmitted,
+  isSuccess,
+}: RagFeedbackFormProps) {
+  const [precisionScore, setPrecisionScore] = useState<number | null>(null);
+  const [styleScore, setStyleScore] = useState<number | null>(null);
+  const [comment, setComment] = useState('');
+
+  if (isSuccess) {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-sm text-green-700 bg-green-50">
+        Děkujeme za vaši zpětnou vazbu.
+      </div>
+    );
+  }
+
+  if (alreadySubmitted) {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-sm text-gray-600 bg-gray-50">
+        Zpětná vazba již byla odeslána.
+      </div>
+    );
+  }
+
+  const canSubmit = precisionScore !== null && styleScore !== null && !isSubmitting;
+
+  const handleClick = () => {
+    if (precisionScore === null || styleScore === null) return;
+    const trimmed = comment.trim();
+    onSubmit({
+      precisionScore,
+      styleScore,
+      comment: trimmed.length > 0 ? trimmed : undefined,
+    });
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 space-y-3">
+      <p className="text-sm font-medium text-gray-700">Ohodnoťte odpověď</p>
+      <ScoreRow label="Přesnost" value={precisionScore} onChange={setPrecisionScore} />
+      <ScoreRow label="Styl" value={styleScore} onChange={setStyleScore} />
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder="Volitelný komentář..."
+        rows={2}
+        maxLength={1000}
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!canSubmit}
+        className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50"
+      >
+        Odeslat zpětnou vazbu
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run tests — should PASS**
+
+Run: `cd frontend && npx jest src/components/feedback/__tests__/RagFeedbackForm.test.tsx`
+Expected: 7 PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/feedback/RagFeedbackForm.tsx \
+        frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx
+git commit -m "feat: extract shared RagFeedbackForm component"
+```
+
+---
+
+## Task 23: Refactor `KnowledgeBaseSearchAskTab` to consume `RagFeedbackForm`
+
+**Files:**
+- Modify: `frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx`
+
+- [ ] **Step 1: Replace the inline `FeedbackForm` (lines 91–163) and the call site at line 231**
+
+Replace the entire region from `const SCORES = [1, 2, 3, 4, 5];` (line 56) through the closing of `FeedbackForm` (line 163) with a single import-driven adapter. The simplest path: rewrite the file. Open `KnowledgeBaseSearchAskTab.tsx` and:
+
+a. Remove the inline `SCORES`, `ScoreRow`, `FeedbackState`, and `FeedbackForm` declarations (lines 56–163).
+
+b. Add `import RagFeedbackForm from '../feedback/RagFeedbackForm';` near the other imports at the top.
+
+c. Add a new local adapter component above `KnowledgeBaseSearchAskTab` (or inline it in the consumer):
+
+```tsx
+interface KnowledgeBaseFeedbackAdapterProps {
+  logId: string;
+}
+
+function KnowledgeBaseFeedbackAdapter({ logId }: KnowledgeBaseFeedbackAdapterProps) {
+  const submitFeedback = useSubmitFeedbackMutation();
+  const [alreadySubmitted, setAlreadySubmitted] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const handleSubmit = ({
+    precisionScore,
+    styleScore,
+    comment,
+  }: {
+    precisionScore: number;
+    styleScore: number;
+    comment?: string;
+  }) => {
+    submitFeedback.mutate(
+      { logId, precisionScore, styleScore, comment },
+      {
+        onSuccess: (result) => {
+          if (result.alreadySubmitted) setAlreadySubmitted(true);
+          else setIsSuccess(true);
+        },
+      },
+    );
+  };
+
+  return (
+    <RagFeedbackForm
+      onSubmit={handleSubmit}
+      isSubmitting={submitFeedback.isPending}
+      alreadySubmitted={alreadySubmitted}
+      isSuccess={isSuccess}
+    />
+  );
+}
+```
+
+d. Replace the existing call site `{ask.data.id && <FeedbackForm logId={ask.data.id} />}` (line 231) with:
+
+```tsx
+{ask.data.id && <KnowledgeBaseFeedbackAdapter logId={ask.data.id} />}
+```
+
+- [ ] **Step 2: Run KB-related tests + the new form tests**
+
+Run: `cd frontend && npx jest src/components/feedback src/components/knowledge-base`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx
+git commit -m "refactor: KB search tab uses shared RagFeedbackForm"
+```
+
+---
+
+## Task 24: Add `useSubmitLeafletFeedbackMutation` hook + types
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useLeaflet.ts`
+
+- [ ] **Step 1: Append types and hook to `useLeaflet.ts`**
+
+Append to the end of the file:
+
+```typescript
+// ---- Feedback types ----
+
+export interface SubmitLeafletFeedbackRequest {
+  generationId: string;
+  precisionScore: number;
+  styleScore: number;
+  comment?: string;
+}
+
+export interface SubmitLeafletFeedbackResult {
+  alreadySubmitted?: true;
+}
+
+// ---- Hooks ----
+
+/**
+ * Submit precision and style feedback for a leaflet generation.
+ * Returns { alreadySubmitted: true } on HTTP 409 instead of throwing.
+ */
+export const useSubmitLeafletFeedbackMutation = () => {
+  return useMutation({
+    mutationFn: async (
+      payload: SubmitLeafletFeedbackRequest,
+    ): Promise<SubmitLeafletFeedbackResult> => {
+      const apiClient = getAuthenticatedApiClient();
+      const fullUrl = `${(apiClient as any).baseUrl}/api/leaflet/feedback`;
+
+      const response = await (apiClient as any).http.fetch(fullUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.status === 409) {
+        return { alreadySubmitted: true };
+      }
+
+      if (!response.ok) {
+        throw new Error(`Submit leaflet feedback failed: ${response.status}`);
+      }
+
+      return {};
+    },
+  });
+};
+```
+
+Do NOT add `useLeafletFeedbackListQuery` — per the architecture review, this hook is YAGNI for Phase 2 (no consumer ships in this phase). It can be added when an admin dashboard is introduced in a later phase.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/hooks/useLeaflet.ts
+git commit -m "feat: add useSubmitLeafletFeedbackMutation hook"
+```
+
+---
+
+## Task 25: Update `LeafletResult` to render `RagFeedbackForm` when `generationId` is set
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletResult.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+```tsx
+import { useState, useRef, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import RagFeedbackForm from '../../components/feedback/RagFeedbackForm';
+import { useSubmitLeafletFeedbackMutation } from '../../api/hooks/useLeaflet';
+
+interface LeafletResultProps {
+  content: string;
+  onRegenerate: () => void;
+  generationId?: string;
+}
+
+export default function LeafletResult({ content, onRegenerate, generationId }: LeafletResultProps) {
+  const [copied, setCopied] = useState(false);
+  const [alreadySubmitted, setAlreadySubmitted] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const submitFeedback = useSubmitLeafletFeedbackMutation();
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  // Reset feedback UI whenever the underlying generation changes.
+  useEffect(() => {
+    setAlreadySubmitted(false);
+    setIsSuccess(false);
+  }, [generationId]);
+
+  if (!content) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable — no feedback change
+    }
+  };
+
+  const handleFeedbackSubmit = ({
+    precisionScore,
+    styleScore,
+    comment,
+  }: {
+    precisionScore: number;
+    styleScore: number;
+    comment?: string;
+  }) => {
+    if (!generationId) return;
+    submitFeedback.mutate(
+      { generationId, precisionScore, styleScore, comment },
+      {
+        onSuccess: (result) => {
+          if (result.alreadySubmitted) setAlreadySubmitted(true);
+          else setIsSuccess(true);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="prose max-w-none">
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          {copied ? 'Zkopírováno' : 'Kopírovat'}
+        </button>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          Generovat znovu
+        </button>
+      </div>
+      {generationId && (
+        <RagFeedbackForm
+          onSubmit={handleFeedbackSubmit}
+          isSubmitting={submitFeedback.isPending}
+          alreadySubmitted={alreadySubmitted}
+          isSuccess={isSuccess}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/leaflet-generator/LeafletResult.tsx
+git commit -m "feat: render feedback form below leaflet result when generationId is present"
+```
+
+---
+
+## Task 26: Update `LeafletGenerateTab` to capture `generationId` from response
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx`
+
+- [ ] **Step 1: Add a `generationId` state and pass it to `LeafletResult`**
+
+Replace the file contents:
+
+```tsx
+import React, { useState } from 'react';
+import LeafletForm from './LeafletForm';
+import LeafletResult from './LeafletResult';
+import { getAuthenticatedApiClient } from '../../api/client';
+import { AudienceType, GenerateLeafletRequest, LeafletLength } from '../../api/generated/api-client';
+
+interface ErrorBanner {
+  kind: 'insufficient' | 'transient';
+  message: string;
+}
+
+interface ApiError {
+  status: number;
+  detail?: string;
+}
+
+function isApiError(err: unknown): err is ApiError {
+  return typeof err === 'object' && err !== null && typeof (err as Record<string, unknown>)['status'] === 'number';
+}
+
+const LeafletGenerateTab: React.FC = () => {
+  const [topic, setTopic] = useState('');
+  const [audience, setAudience] = useState<AudienceType>(AudienceType.EndConsumer);
+  const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
+  const [result, setResult] = useState('');
+  const [generationId, setGenerationId] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
+
+  const generate = async () => {
+    setIsLoading(true);
+    setErrorBanner(null);
+    setGenerationId(undefined);
+    try {
+      const client = getAuthenticatedApiClient();
+      const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
+      setResult(response.content ?? '');
+      setGenerationId(response.id ?? undefined);
+    } catch (err: unknown) {
+      if (isApiError(err) && err.status === 422) {
+        setErrorBanner({
+          kind: 'insufficient',
+          message:
+            err.detail ??
+            'Knowledge Base zatím toto téma nepokrývá. Zkuste obecnější formulaci.',
+        });
+      } else {
+        setErrorBanner({
+          kind: 'transient',
+          message: 'Generování selhalo. Zkuste to prosím znovu.',
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {errorBanner && (
+        <div
+          role="alert"
+          className={`mb-4 rounded p-3 text-sm ${
+            errorBanner.kind === 'insufficient'
+              ? 'bg-amber-100 text-amber-900'
+              : 'bg-red-100 text-red-900'
+          }`}
+        >
+          {errorBanner.message}
+        </div>
+      )}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <LeafletForm
+            topic={topic}
+            audience={audience}
+            length={length}
+            isLoading={isLoading}
+            onTopicChange={setTopic}
+            onAudienceChange={setAudience}
+            onLengthChange={setLength}
+            onSubmit={generate}
+          />
+        </div>
+        <div>
+          {isLoading ? (
+            <div className="animate-pulse space-y-2">
+              <div className="h-4 bg-gray-200 rounded w-3/4" />
+              <div className="h-4 bg-gray-200 rounded" />
+              <div className="h-4 bg-gray-200 rounded w-5/6" />
+            </div>
+          ) : (
+            <LeafletResult content={result} onRegenerate={generate} generationId={generationId} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default LeafletGenerateTab;
+```
+
+- [ ] **Step 2: Run existing leaflet tab tests**
+
+Run: `cd frontend && npx jest src/features/leaflet-generator`
+Expected: PASS (existing test cases didn't assert on the new prop, so they should still pass).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
+git commit -m "feat: pass generationId from generate response to LeafletResult"
+```
+
+---
+
+## Task 27: Add i18n translations for new error codes
+
+**Files:**
+- Modify: `frontend/src/i18n.ts`
+
+- [ ] **Step 1: Find the Czech Leaflet errors block at line 197–198 and replace**
+
+Replace:
+
+```typescript
+        // Leaflet module errors
+        LeafletChunkNotFound: "Fragment letáku nebyl nalezen",
+```
+
+with:
+
+```typescript
+        // Leaflet module errors
+        LeafletChunkNotFound: "Fragment letáku nebyl nalezen",
+        LeafletFeedbackNotFound: "Záznam generování letáku nebyl nalezen.",
+        LeafletFeedbackAlreadySubmitted: "Zpětná vazba již byla odeslána.",
+        LeafletGenerationNotFound: "Záznam generování letáku nebyl nalezen.",
+```
+
+- [ ] **Step 2: Locate the matching English Leaflet block**
+
+Open the `en` translation block. Find the section that contains `LeafletChunkNotFound`. After it, append:
+
+```typescript
+        LeafletFeedbackNotFound: "Leaflet generation log not found.",
+        LeafletFeedbackAlreadySubmitted: "Feedback has already been submitted.",
+        LeafletGenerationNotFound: "Leaflet generation log not found.",
+```
+
+If the English block does not yet contain a `LeafletChunkNotFound` line, add the full set there:
+
+```typescript
+        // Leaflet module errors
+        LeafletChunkNotFound: "Leaflet chunk not found",
+        LeafletFeedbackNotFound: "Leaflet generation log not found.",
+        LeafletFeedbackAlreadySubmitted: "Feedback has already been submitted.",
+        LeafletGenerationNotFound: "Leaflet generation log not found.",
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/i18n.ts
+git commit -m "feat: add i18n entries for leaflet feedback error codes"
+```
+
+---
+
+## Task 28: Final verification — backend + frontend full validation
+
+**Files:**
+- None modified.
+
+- [ ] **Step 1: Backend full build, format, test**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln && \
+dotnet format backend/Anela.Heblo.sln --verify-no-changes && \
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: build clean, format clean, all tests PASS.
+
+- [ ] **Step 2: Frontend build, lint, test**
+
+Run:
+```bash
+cd frontend && npm run build && npm run lint && npm test -- --watchAll=false
+```
+Expected: all green.
+
+- [ ] **Step 3: Smoke-test the flow against a local dev environment**
+
+Start the backend and frontend per `docs/development/setup.md`. In the browser:
+1. Open the leaflet generator page, submit a topic.
+2. Confirm the result panel renders the markdown AND the feedback form below the Copy/Regenerate buttons.
+3. Pick precision = 4, style = 5, type a comment, submit. Confirm the form switches to the success state.
+4. Reload the page, generate again, attempt to submit feedback — confirm a fresh form is shown (state resets per `generationId`).
+5. (Optional, manual) `psql -c 'SELECT "Id", "Topic", "PrecisionScore", "StyleScore", "FeedbackComment" FROM public."LeafletGenerations" ORDER BY "CreatedAt" DESC LIMIT 5;'` — confirm two rows from the smoke test, the first with feedback set.
+6. As a user with `leaflet_manager` role, hit `GET /api/leaflet/feedback/list` — confirm 200 with the rows.
+7. As a user without `leaflet_manager`, hit the same endpoint — confirm 403.
+
+- [ ] **Step 4: Final commit (no-op or fixups)**
+
+If verification surfaced fixes, commit them with a `fix:` prefix. Otherwise, this task closes the implementation.
+
+---
+
+## Self-Review Checklist (already applied)
+
+- **FR-1** (persist generations) → Tasks 2, 4, 5, 6, 7, 11, 12.
+- **FR-2** (one-shot owner-only feedback submission) → Tasks 13, 14.
+- **FR-3** (manager-gated feedback list with stats) → Tasks 6, 15, 16, 19.
+- **FR-4** (single-generation lookup) → Tasks 17, 18, 19.
+- **FR-5** (extract `RagFeedbackForm`) → Tasks 21, 22, 23.
+- **FR-6** (leaflet result UI shows form) → Tasks 25, 26.
+- **FR-7** (i18n) → Task 27.
+- **NFR-1** (perf — server-side paging, indexed sorts, indexed aggregates) → Tasks 4 (indexes), 6 (indexed aggregates).
+- **NFR-2** (security — owner check + policy gate + plain-text comment rendering) → Tasks 14 (handler check), 19 (policy on list), 22 (textarea/plain text in form).
+- **NFR-3** (reliability — swallow logging errors, single SaveChanges) → Task 11 (try/catch around save), Task 14 (single SaveChanges).
+- **NFR-4** (maintainability — KB structural mirror, DTOs as classes) → Tasks 14, 16 — match KB shape.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md`.

--- a/docs/superpowers/plans/2026-05-05-phase1-ui-consolidation-sharepoint-link.md
+++ b/docs/superpowers/plans/2026-05-05-phase1-ui-consolidation-sharepoint-link.md
@@ -1,0 +1,1092 @@
+# Phase 1 — UI Consolidation & SharePoint Link-Back Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate the three RAG features (Knowledge Base, Leaflet Generator, Article Generator) under a single Marketing sidebar group, add a stub Marketing Feedback page, and surface a clickable SharePoint link in chunk detail modals when the document was sourced from SharePoint.
+
+**Architecture:** Additive backend changes — `SourcePath` is added to two existing response DTOs and populated in two existing MediatR handlers (no repository, persistence, or controller changes; both repositories already eager-load `Document`). Frontend adds a stateless `getSharePointLink` helper, a stub page, a sidebar restructure, and inserts a small link element into two chunk detail modals. The TS hook interfaces (`GetChunkDetailResponse`, `GetLeafletChunkDetailResponse`) in `api/hooks/` are **hand-maintained**, not auto-generated — they must be edited manually to match the C# DTO change.
+
+**Tech Stack:** .NET 8 (MediatR Vertical Slice, EF Core), xUnit + Moq + FluentAssertions, React 18 + TypeScript, Tailwind, react-router, lucide-react, Jest + React Testing Library.
+
+---
+
+## Important context discovered before writing
+
+These observations correct or supplement the spec/arch-review:
+
+1. **Spec claim that `Sidebar.tsx` has two sections with `id: 'marketing'` is false.** Verified at `frontend/src/components/Layout/Sidebar.tsx`: only one `marketing` section (lines 140–149) and a separate `knowledgebase` section (lines 299–314). No `TrendingUp` import, no `Campaigns` item. FR-2 from the spec has nothing to act on.
+2. **Sidebar path uses capital `Layout`:** `frontend/src/components/Layout/Sidebar.tsx`. The arch-review document used lowercase `layout` — use capital.
+3. **Response DTOs are co-located in the request files**, not separate `*Response.cs` files. Edit `GetChunkDetailRequest.cs` and `GetLeafletChunkDetailRequest.cs`.
+4. **Domain `SourcePath` is non-nullable `string` defaulting to `string.Empty`** (entity `KnowledgeBaseDocument.SourcePath`). The DTO field is declared `string?` for forward flexibility, but assignment will produce `""` rather than `null` for documents with no source set. The frontend helper's falsy check (`if (!sourcePath)`) handles `""` correctly.
+5. **The TS interfaces consumed by the chunk detail hooks are NOT auto-generated.** `GetChunkDetailResponse` is hand-defined at `frontend/src/api/hooks/useKnowledgeBase.ts:127` and `GetLeafletChunkDetailResponse` at `frontend/src/api/hooks/useLeaflet.ts:43`. The OpenAPI build step regenerates `frontend/src/api/generated/api-client.ts`, but the hooks don't use those generated types. **The hand-defined interfaces must be edited manually** — this is captured as Task 4.
+6. **Existing tests in `GetChunkDetailHandlerTests.cs` use raw xUnit `Assert.*`**, while `GetLeafletChunkDetailHandlerTests.cs` uses FluentAssertions. Match the existing style of each file when adding new tests.
+7. **Repositories already eager-load `Document`** (verified by arch-review). No repository changes are needed.
+8. **`/articles` route already exists** in `App.tsx` (line 474). No new route needed for it.
+9. **Leave `/knowledge-base/feedback` and `KnowledgeBaseFeedbackPage` untouched.** Spec section 4 of the arch-review confirms this is out of scope; Phase 4 will reconcile.
+
+---
+
+## File Structure
+
+**Files created:**
+- `frontend/src/utils/sharepointLink.ts` — pure helper exporting `getSharePointLink`
+- `frontend/src/utils/sharepointLink.test.ts` — Jest unit tests for the helper (5 cases)
+- `frontend/src/pages/MarketingFeedbackPage.tsx` — minimal stub page
+- `frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx` — Jest tests for the leaflet modal's SharePoint link rendering
+
+**Files modified:**
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs` — add `SourcePath` to colocated `GetChunkDetailResponse`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs` — assign `SourcePath` in response init
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs` — add `SourcePath` to colocated `GetLeafletChunkDetailResponse`
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs` — assign `SourcePath` in response init
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs` — add 3 tests for `SourcePath`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs` — add 3 tests for `SourcePath`
+- `frontend/src/api/hooks/useKnowledgeBase.ts` — add `sourcePath?: string` to `GetChunkDetailResponse` interface
+- `frontend/src/api/hooks/useLeaflet.ts` — add `sourcePath?: string` to `GetLeafletChunkDetailResponse` interface
+- `frontend/src/components/knowledge-base/ChunkDetailModal.tsx` — render conditional SharePoint link
+- `frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx` — add 3 tests for SharePoint link
+- `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx` — render conditional SharePoint link
+- `frontend/src/components/Layout/Sidebar.tsx` — extend marketing section, remove knowledgebase section, drop unused `Database` import
+- `frontend/src/App.tsx` — register `/marketing/feedback` route
+
+**Files NOT modified:** `KnowledgeBaseRepository.cs`, `LeafletRepository.cs`, `IKnowledgeBaseRepository.cs`, `ILeafletRepository.cs`, `KnowledgeBaseFeedbackPage.tsx`, the `/knowledge-base/feedback` route entry, the auto-generated `api/generated/api-client.ts` (any diff from `npm run build` is committed as-is but not hand-edited).
+
+---
+
+## Task 1: Backend — KB GetChunkDetail returns `SourcePath`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs`
+
+- [ ] **Step 1: Add the three failing tests**
+
+Open `backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs`. The file currently uses raw xUnit `Assert.*` (no FluentAssertions). Match that style.
+
+Insert these three `[Fact]` methods immediately after the existing `Handle_ReturnsNotFound_WhenChunkDoesNotExist` test (before the closing brace of the class):
+
+```csharp
+    [Fact]
+    public async Task Handle_ReturnsSharePointSourcePath_WhenDocumentSourcedFromSharePoint()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = "https://anelacz.sharepoint.com/sites/x/doc.docx";
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://anelacz.sharepoint.com/sites/x/doc.docx", result.SourcePath);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSyntheticUploadPath_WhenDocumentManuallyUploaded()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = "upload/abc-123/file.pdf";
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal("upload/abc-123/file.pdf", result.SourcePath);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmptyString_WhenDocumentHasNoSourcePath()
+    {
+        var chunkId = Guid.NewGuid();
+        var chunk = MakeChunk(id: chunkId);
+        chunk.Document.SourcePath = string.Empty;
+
+        _repository
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = new GetChunkDetailHandler(_repository.Object);
+        var result = await handler.Handle(new GetChunkDetailRequest { ChunkId = chunkId }, default);
+
+        Assert.True(result.Success);
+        Assert.Equal(string.Empty, result.SourcePath);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetChunkDetailHandlerTests"
+```
+
+Expected: build error `'GetChunkDetailResponse' does not contain a definition for 'SourcePath'`. (If the build succeeds — which it should not — the assertions would fail.)
+
+- [ ] **Step 3: Add `SourcePath` to the response DTO**
+
+In `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs`, add one property to the `GetChunkDetailResponse` class (after the existing `Content` property, before the constructors):
+
+```csharp
+    public string? SourcePath { get; set; }
+```
+
+Final shape of the class body (for unambiguous reference):
+
+```csharp
+public class GetChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DocumentType DocumentType { get; set; }
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }
+
+    public GetChunkDetailResponse() { }
+
+    public GetChunkDetailResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 4: Populate `SourcePath` in the handler**
+
+In `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs`, add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser (after `Content = chunk.Content,`).
+
+Final shape of the response init:
+
+```csharp
+        return new GetChunkDetailResponse
+        {
+            ChunkId = chunk.Id,
+            DocumentId = chunk.DocumentId,
+            Filename = chunk.Document.Filename,
+            DocumentType = chunk.DocumentType,
+            IndexedAt = chunk.Document.IndexedAt,
+            ChunkIndex = chunk.ChunkIndex,
+            Summary = chunk.Summary,
+            Content = chunk.Content,
+            SourcePath = chunk.Document.SourcePath,
+        };
+```
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetChunkDetailHandlerTests"
+```
+
+Expected: 5 tests pass (2 existing + 3 new). Zero failures.
+
+- [ ] **Step 6: Build + format the backend**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: clean build, `dotnet format` exits 0 with no changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/KnowledgeBase/UseCases/GetChunkDetail/GetChunkDetailHandler.cs \
+        backend/test/Anela.Heblo.Tests/KnowledgeBase/UseCases/GetChunkDetailHandlerTests.cs
+git commit -m "feat: surface SourcePath in KB GetChunkDetail response"
+```
+
+---
+
+## Task 2: Backend — Leaflet GetLeafletChunkDetail returns `SourcePath`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs`
+
+- [ ] **Step 1: Add the three failing tests**
+
+`GetLeafletChunkDetailHandlerTests.cs` currently uses **FluentAssertions**. Match that style. Insert the three `[Fact]` methods at the end of the class, before the closing brace:
+
+```csharp
+    [Fact]
+    public async Task Handle_returns_sharepoint_source_path_when_document_sourced_from_sharepoint()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "leaflet.pdf",
+                SourcePath = "https://anelacz.sharepoint.com/sites/x/leaflet.pdf",
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be("https://anelacz.sharepoint.com/sites/x/leaflet.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_returns_synthetic_upload_path_when_document_manually_uploaded()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "uploaded.pdf",
+                SourcePath = "upload/xyz-9/uploaded.pdf",
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be("upload/xyz-9/uploaded.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_returns_empty_string_when_document_has_no_source_path()
+    {
+        // Arrange
+        var chunkId = Guid.NewGuid();
+        var chunk = new LeafletChunk
+        {
+            Id = chunkId,
+            DocumentId = Guid.NewGuid(),
+            ChunkIndex = 0,
+            Content = "c",
+            Summary = "s",
+            Document = new LeafletDocument
+            {
+                Id = Guid.NewGuid(),
+                Filename = "no-source.pdf",
+                SourcePath = string.Empty,
+            },
+        };
+
+        _repoMock
+            .Setup(r => r.GetChunkByIdAsync(chunkId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(chunk);
+
+        var handler = CreateHandler();
+
+        // Act
+        var response = await handler.Handle(new GetLeafletChunkDetailRequest { ChunkId = chunkId }, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.SourcePath.Should().Be(string.Empty);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetLeafletChunkDetailHandlerTests"
+```
+
+Expected: compilation error — `GetLeafletChunkDetailResponse` does not contain a definition for `SourcePath`.
+
+- [ ] **Step 3: Add `SourcePath` to the response DTO**
+
+In `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs`, add the property to `GetLeafletChunkDetailResponse` (after `Summary`, before the constructors):
+
+```csharp
+    public string? SourcePath { get; set; }
+```
+
+Final class shape:
+
+```csharp
+public class GetLeafletChunkDetailResponse : BaseResponse
+{
+    public Guid ChunkId { get; set; }
+    public Guid DocumentId { get; set; }
+    public string Filename { get; set; } = string.Empty;
+    public DateTime? IndexedAt { get; set; }
+    public int ChunkIndex { get; set; }
+    public string Content { get; set; } = string.Empty;
+    public string Summary { get; set; } = string.Empty;
+    public string? SourcePath { get; set; }
+
+    public GetLeafletChunkDetailResponse() { }
+
+    public GetLeafletChunkDetailResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 4: Populate `SourcePath` in the handler**
+
+In `backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs`, add `SourcePath = chunk.Document.SourcePath,` to the response object initialiser:
+
+```csharp
+        return new GetLeafletChunkDetailResponse
+        {
+            ChunkId = chunk.Id,
+            DocumentId = chunk.DocumentId,
+            Filename = chunk.Document.Filename,
+            IndexedAt = chunk.Document.IndexedAt,
+            ChunkIndex = chunk.ChunkIndex,
+            Content = chunk.Content,
+            Summary = chunk.Summary,
+            SourcePath = chunk.Document.SourcePath,
+        };
+```
+
+- [ ] **Step 5: Run tests to verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetLeafletChunkDetailHandlerTests"
+```
+
+Expected: 5 tests pass (2 existing + 3 new).
+
+- [ ] **Step 6: Build + format the backend**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: clean build, format exits 0 with no changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/Leaflet/UseCases/GetLeafletChunkDetail/GetLeafletChunkDetailHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Leaflet/UseCases/GetLeafletChunkDetailHandlerTests.cs
+git commit -m "feat: surface SourcePath in Leaflet GetLeafletChunkDetail response"
+```
+
+---
+
+## Task 3: Frontend — `getSharePointLink` helper + tests
+
+**Files:**
+- Create: `frontend/src/utils/sharepointLink.ts`
+- Test: `frontend/src/utils/sharepointLink.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/utils/sharepointLink.test.ts` with the following content:
+
+```ts
+import { getSharePointLink } from './sharepointLink';
+
+describe('getSharePointLink', () => {
+  test('returns null for null', () => {
+    expect(getSharePointLink(null)).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(getSharePointLink(undefined)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(getSharePointLink('')).toBeNull();
+  });
+
+  test('returns null for synthetic upload path', () => {
+    expect(getSharePointLink('upload/abc-123/file.pdf')).toBeNull();
+  });
+
+  test('returns the URL verbatim when it starts with https://', () => {
+    const url = 'https://anelacz.sharepoint.com/sites/x/doc.docx';
+    expect(getSharePointLink(url)).toBe(url);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/utils/sharepointLink.test.ts
+```
+
+Expected: test fails with "Cannot find module './sharepointLink'".
+
+- [ ] **Step 3: Implement the helper**
+
+Create `frontend/src/utils/sharepointLink.ts`:
+
+```ts
+export function getSharePointLink(sourcePath: string | null | undefined): string | null {
+  if (!sourcePath) return null;
+  if (sourcePath.startsWith('https://')) return sourcePath;
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/utils/sharepointLink.test.ts
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/sharepointLink.ts frontend/src/utils/sharepointLink.test.ts
+git commit -m "feat: add getSharePointLink helper for chunk source URLs"
+```
+
+---
+
+## Task 4: Frontend — extend hand-defined TS interfaces
+
+The chunk detail hooks in `api/hooks/` use **hand-maintained** response interfaces, not the auto-generated client. Add the new optional field to both manual interfaces so subsequent UI work compiles.
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useKnowledgeBase.ts`
+- Modify: `frontend/src/api/hooks/useLeaflet.ts`
+
+- [ ] **Step 1: Add `sourcePath` to `GetChunkDetailResponse` (KB hook)**
+
+Open `frontend/src/api/hooks/useKnowledgeBase.ts`. Locate the interface at line ~127 and add `sourcePath?: string;` as the last field.
+
+Final shape:
+
+```ts
+export interface GetChunkDetailResponse {
+  success: boolean;
+  chunkId: string;
+  documentId: string;
+  filename: string;
+  documentType: 'KnowledgeBase' | 'Conversation';
+  indexedAt: string | null;
+  chunkIndex: number;
+  summary: string;
+  content: string;
+  sourcePath?: string;
+}
+```
+
+- [ ] **Step 2: Add `sourcePath` to `GetLeafletChunkDetailResponse` (Leaflet hook)**
+
+Open `frontend/src/api/hooks/useLeaflet.ts`. Locate the interface at line ~43 and add `sourcePath?: string;` as the last field.
+
+Final shape:
+
+```ts
+export interface GetLeafletChunkDetailResponse {
+  success: boolean;
+  chunkId: string;
+  documentId: string;
+  filename: string;
+  documentType: string;
+  indexedAt: string | null;
+  chunkIndex: number;
+  summary: string;
+  content: string;
+  sourcePath?: string;
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds. (No new code consumes `sourcePath` yet — that arrives in Tasks 5–6.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/hooks/useKnowledgeBase.ts frontend/src/api/hooks/useLeaflet.ts
+git commit -m "feat: add sourcePath to chunk detail response interfaces"
+```
+
+---
+
+## Task 5: Frontend — KB ChunkDetailModal renders SharePoint link
+
+**Files:**
+- Modify: `frontend/src/components/knowledge-base/ChunkDetailModal.tsx`
+- Test: `frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx`
+
+- [ ] **Step 1: Add the three failing test cases**
+
+Append three new tests to `frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx` (after the existing `'calls onClose on Escape key'` test). The file already mocks `useChunkDetailQuery`; reuse the same mock pattern.
+
+```ts
+test('renders SharePoint link when sourcePath is an https URL', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'https://anelacz.sharepoint.com/sites/x/doc.docx' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  const link = screen.getByRole('link', { name: /Otevřít v SharePoint/i });
+  expect(link).toHaveAttribute('href', 'https://anelacz.sharepoint.com/sites/x/doc.docx');
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+test('hides SharePoint link when sourcePath is a synthetic upload path', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'upload/abc/file.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+
+test('hides SharePoint link when sourcePath is missing', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: undefined },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+```
+
+Expected: the three new tests fail (link is not in the DOM yet); the existing four tests still pass.
+
+- [ ] **Step 3: Add the link element + imports**
+
+Edit `frontend/src/components/knowledge-base/ChunkDetailModal.tsx`:
+
+3a. Update the `lucide-react` import to include `ExternalLink`:
+
+```ts
+import { X, ExternalLink } from 'lucide-react';
+```
+
+3b. Add the helper import below the existing `formatDateTime` import:
+
+```ts
+import { getSharePointLink } from '../../utils/sharepointLink';
+```
+
+3c. Insert the link block immediately after the closing tag of the `Meta row` `<div>` (currently line 74) and before the `Summary` `<div>` (currently line 77). The insertion goes inside the `data && (...)` fragment.
+
+```tsx
+              {/* SharePoint link (only when document has a real https:// SourcePath) */}
+              {getSharePointLink(data.sourcePath) && (
+                <a
+                  href={getSharePointLink(data.sourcePath)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                >
+                  Otevřít v SharePoint
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+```
+
+Expected: all 7 tests pass (4 existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/knowledge-base/ChunkDetailModal.tsx \
+        frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+git commit -m "feat: render SharePoint link in KB chunk detail modal"
+```
+
+---
+
+## Task 6: Frontend — Leaflet LeafletChunkDetailModal renders SharePoint link
+
+**Files:**
+- Modify: `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx`
+- Create: `frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx`
+
+There is no existing test file for `LeafletChunkDetailModal`; create one mirroring the KB modal's test structure.
+
+- [ ] **Step 1: Create the failing test file**
+
+Create `frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LeafletChunkDetailModal from '../LeafletChunkDetailModal';
+import * as hooks from '../../../api/hooks/useLeaflet';
+
+const mockChunkDetail = {
+  success: true,
+  chunkId: 'chunk-1',
+  documentId: 'doc-1',
+  filename: 'leaflet.pdf',
+  documentType: 'Document',
+  indexedAt: '2024-03-15T10:00:00Z',
+  chunkIndex: 0,
+  summary: 'Summary text.',
+  content: 'Full leaflet content.',
+};
+
+const mockOnClose = jest.fn();
+
+function renderModal() {
+  return render(
+    <LeafletChunkDetailModal chunkId="chunk-1" onClose={mockOnClose} />
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders SharePoint link when sourcePath is an https URL', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'https://anelacz.sharepoint.com/sites/x/leaflet.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  const link = screen.getByRole('link', { name: /Otevřít v SharePoint/i });
+  expect(link).toHaveAttribute('href', 'https://anelacz.sharepoint.com/sites/x/leaflet.pdf');
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+test('hides SharePoint link when sourcePath is a synthetic upload path', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'upload/abc/file.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+
+test('hides SharePoint link when sourcePath is missing', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: undefined },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+```
+
+Expected: all three tests fail.
+
+- [ ] **Step 3: Add the link element + imports**
+
+Edit `frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx`:
+
+3a. Update the `lucide-react` import:
+
+```ts
+import { X, ExternalLink } from 'lucide-react';
+```
+
+3b. Add the helper import below the existing `formatDateTime` import:
+
+```ts
+import { getSharePointLink } from '../../utils/sharepointLink';
+```
+
+3c. Insert the link block immediately after the closing tag of the `Meta row` `<div>` (currently line 66) and before the `Summary` `<div>` (currently line 69):
+
+```tsx
+              {/* SharePoint link (only when document has a real https:// SourcePath) */}
+              {getSharePointLink(data.sourcePath) && (
+                <a
+                  href={getSharePointLink(data.sourcePath)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                >
+                  Otevřít v SharePoint
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test --watchAll=false src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx \
+        frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+git commit -m "feat: render SharePoint link in Leaflet chunk detail modal"
+```
+
+---
+
+## Task 7: Frontend — Marketing Feedback stub page + route registration
+
+**Files:**
+- Create: `frontend/src/pages/MarketingFeedbackPage.tsx`
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: Create the stub page**
+
+Create `frontend/src/pages/MarketingFeedbackPage.tsx`:
+
+```tsx
+import React from 'react';
+
+const MarketingFeedbackPage: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold text-gray-900">Feedback</h1>
+      <p className="mt-2 text-sm text-gray-600">
+        Přehled zpětné vazby bude dostupný po dokončení integrace.
+      </p>
+    </div>
+  );
+};
+
+export default MarketingFeedbackPage;
+```
+
+- [ ] **Step 2: Import and register the route in `App.tsx`**
+
+Open `frontend/src/App.tsx`.
+
+2a. Add the import after the existing `KnowledgeBaseFeedbackPage` import (currently line 38):
+
+```ts
+import MarketingFeedbackPage from "./pages/MarketingFeedbackPage";
+```
+
+2b. Inside the `<Routes>` block, register the new route immediately after the existing `/knowledge-base/feedback` route (currently lines 469–472). Insert before the `/articles` route:
+
+```tsx
+                        <Route
+                          path="/marketing/feedback"
+                          element={<MarketingFeedbackPage />}
+                        />
+```
+
+- [ ] **Step 3: Verify the build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds, no TypeScript errors.
+
+- [ ] **Step 4: Smoke test the route in dev**
+
+This is a manual verification step. Start the dev server in one terminal, then verify the route in a browser.
+
+```bash
+cd frontend && npm start
+```
+
+Open `http://localhost:3000/marketing/feedback` while authenticated. Expect to see the heading "Feedback" and the subtitle "Přehled zpětné vazby bude dostupný po dokončení integrace." with no console errors. Then stop the dev server (Ctrl+C).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/MarketingFeedbackPage.tsx frontend/src/App.tsx
+git commit -m "feat: add /marketing/feedback stub page"
+```
+
+---
+
+## Task 8: Frontend — Sidebar consolidation
+
+Merge the existing `marketing` section with the existing `knowledgebase` section into a single `marketing` section containing five items, then remove the now-empty `knowledgebase` section and the `Database` icon import.
+
+**Files:**
+- Modify: `frontend/src/components/Layout/Sidebar.tsx`
+
+- [ ] **Step 1: Replace the `marketing` section block**
+
+Open `frontend/src/components/Layout/Sidebar.tsx`. Find the existing `marketing` section (currently lines 140–149):
+
+```tsx
+    {
+      id: "marketing",
+      name: "Marketing",
+      icon: Megaphone,
+      type: "section" as const,
+      items: [
+        { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
+        { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+      ],
+    },
+```
+
+Replace it with:
+
+```tsx
+    {
+      id: "marketing",
+      name: "Marketing",
+      icon: Megaphone,
+      type: "section" as const,
+      items: [
+        { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
+        { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+        { id: "articles", name: "Generátor článků", href: "/articles" },
+        { id: "knowledge-base", name: "Poradenství (KB)", href: "/knowledge-base" },
+        ...(hasRole("knowledge_base_manager") || hasRole("leaflet_manager") || hasRole("article_generator")
+          ? [{ id: "marketing-feedback", name: "Feedback", href: "/marketing/feedback" }]
+          : []),
+      ],
+    },
+```
+
+- [ ] **Step 2: Remove the `knowledgebase` section block**
+
+In the same file, delete the entire `knowledgebase` section object (currently lines 299–314):
+
+```tsx
+    {
+      id: 'knowledgebase',
+      name: 'Knowledgebase',
+      icon: Database,
+      type: 'section' as const,
+      items: [
+        {
+          id: 'kb-poradenstvi',
+          name: 'Poradenství',
+          href: '/knowledge-base',
+        },
+        ...(hasRole('knowledge_base_manager')
+          ? [{ id: 'kb-feedback', name: 'Feedback', href: '/knowledge-base/feedback' }]
+          : []),
+      ],
+    },
+```
+
+After deletion, the immediately preceding entry (the `automatizace` section, ending with `};` and a closing `,`) should be the last array item. The `]` closing `navigationSections` (currently line 315) immediately follows.
+
+- [ ] **Step 3: Remove the `Database` icon import**
+
+`Database` is only used inside the now-removed `knowledgebase` section. Confirm and remove.
+
+3a. Confirm no other usage in the file:
+
+```bash
+grep -n "Database" frontend/src/components/Layout/Sidebar.tsx
+```
+
+Expected output: zero matches (the previous import line referenced it, but after this step we will have removed the only usage; the import itself is the next match to remove).
+
+3b. In the `lucide-react` import block (currently line 20), remove the line `Database,`. The block should become:
+
+```tsx
+import {
+  LayoutDashboard,
+  Package,
+  ShoppingCart,
+  ChevronDown,
+  ChevronRight,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Menu,
+  DollarSign,
+  Cog,
+  Truck,
+  Bot,
+  Newspaper,
+  Users,
+  ExternalLink,
+  FileText,
+  Megaphone,
+} from "lucide-react";
+```
+
+- [ ] **Step 4: Verify build + lint**
+
+```bash
+cd frontend && npm run build && npm run lint
+```
+
+Expected: clean build, lint reports no new errors. Specifically, no "unused import" error for `Database`.
+
+- [ ] **Step 5: Smoke test the sidebar in dev**
+
+```bash
+cd frontend && npm start
+```
+
+Authenticated as a manager (with one of `knowledge_base_manager`, `leaflet_manager`, `article_generator` roles), expand the sidebar's Marketing group and verify these five items appear in this order:
+
+1. Kalendář
+2. Generátor letáků
+3. Generátor článků
+4. Poradenství (KB)
+5. Feedback
+
+Click each item and verify it navigates without a console error. Confirm there is no "Knowledgebase" group anywhere. Stop the dev server.
+
+If you can also test as a non-manager (no relevant roles), confirm that "Feedback" is hidden but the other four items remain.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Layout/Sidebar.tsx
+git commit -m "feat: consolidate Marketing sidebar group"
+```
+
+---
+
+## Task 9: End-to-end verification
+
+Final verification before merging the branch. All previous tasks must be committed.
+
+- [ ] **Step 1: Backend full build, format, and tests**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: build clean, format reports no changes, all tests pass.
+
+- [ ] **Step 2: Frontend full build, lint, and tests**
+
+```bash
+cd frontend && npm run build && npm run lint && CI=true npx react-scripts test --watchAll=false
+```
+
+Expected: build clean, lint clean, all Jest tests pass (including the new `sharepointLink.test.ts`, the extended `ChunkDetailModal.test.tsx`, and the new `LeafletChunkDetailModal.test.tsx`).
+
+- [ ] **Step 3: Manual smoke checklist**
+
+Run the dev server, sign in as a manager.
+
+```bash
+cd frontend && npm start
+```
+
+Walk through:
+1. Sidebar's Marketing group expands and shows Kalendář, Generátor letáků, Generátor článků, Poradenství (KB), Feedback.
+2. There is no Knowledgebase group.
+3. `/marketing/feedback` renders the stub.
+4. `/knowledge-base` → Dokumenty tab → click a chunk row whose document originated in SharePoint → modal shows "Otevřít v SharePoint" link with `target="_blank"` and the correct URL.
+5. `/knowledge-base` → Dokumenty tab → click a chunk row for a manually uploaded document → modal shows no SharePoint link.
+6. `/leaflet-generator` → Dokumenty tab → repeat steps 4–5 with the Leaflet modal.
+7. No browser console errors.
+
+Stop the dev server.
+
+- [ ] **Step 4: Confirm working tree is clean**
+
+```bash
+git status
+```
+
+Expected: clean working tree (all task commits already in). If the OpenAPI auto-regen produced a diff in `frontend/src/api/generated/api-client.ts` during `npm run build` (the generator may add `sourcePath` to the generated DTO), commit it now:
+
+```bash
+git status
+git add frontend/src/api/generated/api-client.ts
+git diff --cached frontend/src/api/generated/api-client.ts | head -60
+git commit -m "chore: regenerate OpenAPI client for sourcePath addition"
+```
+
+If there is no diff, skip this commit.
+
+---
+
+## Self-Review Outcomes
+
+- **Spec coverage:**
+  - FR-1 (Marketing consolidation) → Task 8.
+  - FR-2 (Campaigns disposition) → no-op; spec premise is false. Plan documents this in the introduction; PR description should restate.
+  - FR-3 (Marketing Feedback stub) → Task 7.
+  - FR-4 (KB SourcePath in DTO + handler) → Task 1.
+  - FR-5 (Leaflet SourcePath in DTO + handler) → Task 2.
+  - FR-6 (`getSharePointLink` helper) → Task 3 (relocated to `frontend/src/utils/` per arch-review Decision 1).
+  - FR-7 (KB modal renders link) → Task 5.
+  - FR-8 (Leaflet modal renders link) → Task 6.
+  - Hidden gap (manual TS interfaces in `api/hooks/`) → Task 4.
+
+- **Type consistency:** Helper signature matches across all consumers: `getSharePointLink(sourcePath: string | null | undefined): string | null`. Both modals call it identically. The DTO field is `string?` in C# and `sourcePath?: string` in TS. The helper's `if (!sourcePath)` check covers `null`, `undefined`, and `""` uniformly.
+
+- **No placeholders:** Each step contains the exact code or command needed; no "add appropriate handling" or "similar to other modal" references.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import StockOperationsPage from "./pages/StockOperationsPage";
 import RecurringJobsPage from "./pages/RecurringJobsPage";
 import KnowledgeBasePage from "./pages/KnowledgeBasePage";
 import KnowledgeBaseFeedbackPage from "./pages/KnowledgeBaseFeedbackPage";
+import MarketingFeedbackPage from "./pages/MarketingFeedbackPage";
 import ArticlesPage from "./pages/ArticlesPage";
 import ExpeditionListArchivePage from "./pages/ExpeditionListArchivePage";
 import MarketingCalendarPage from "./components/marketing/pages/MarketingCalendarPage";
@@ -469,6 +470,10 @@ function App() {
                         <Route
                           path="/knowledge-base/feedback"
                           element={<KnowledgeBaseFeedbackPage />}
+                        />
+                        <Route
+                          path="/marketing/feedback"
+                          element={<MarketingFeedbackPage />}
                         />
                         <Route
                           path="/articles"

--- a/frontend/src/api/hooks/useKnowledgeBase.ts
+++ b/frontend/src/api/hooks/useKnowledgeBase.ts
@@ -134,6 +134,7 @@ export interface GetChunkDetailResponse {
   chunkIndex: number;
   summary: string;
   content: string;
+  sourcePath?: string;
 }
 
 export interface GetFeedbackListParams {

--- a/frontend/src/api/hooks/useLeaflet.ts
+++ b/frontend/src/api/hooks/useLeaflet.ts
@@ -50,6 +50,7 @@ export interface GetLeafletChunkDetailResponse {
   chunkIndex: number;
   summary: string;
   content: string;
+  sourcePath?: string;
 }
 
 export interface DeleteLeafletDocumentResponse {

--- a/frontend/src/api/hooks/useLeaflet.ts
+++ b/frontend/src/api/hooks/useLeaflet.ts
@@ -62,6 +62,21 @@ export interface UploadLeafletDocumentResponse {
   document: LeafletDocumentSummary | null;
 }
 
+export interface SubmitLeafletFeedbackResult {
+  success: boolean;
+  errorCode?: string | null;
+  alreadySubmitted?: boolean;
+}
+
+export interface LeafletFeedbackListParams {
+  hasFeedback?: boolean;
+  userId?: string;
+  sortBy?: string;
+  sortDescending?: boolean;
+  pageNumber?: number;
+  pageSize?: number;
+}
+
 // ---- Permission hook ----
 
 /**
@@ -92,6 +107,10 @@ export const leafletKeys = {
   contentTypes: () => [...QUERY_KEYS.leaflet, 'content-types'] as const,
   chunkDetail: (chunkId: string) =>
     [...QUERY_KEYS.leaflet, 'chunk-detail', chunkId] as const,
+  feedbackList: (params?: LeafletFeedbackListParams) =>
+    [...QUERY_KEYS.leaflet, 'feedback-list', params ?? {}] as const,
+  generation: (id: string) =>
+    [...QUERY_KEYS.leaflet, 'generation', id] as const,
 };
 
 // ---- Hooks ----
@@ -252,5 +271,75 @@ export const useUploadLeafletDocumentMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: leafletKeys.all });
     },
+  });
+};
+
+/**
+ * Submit precision/style feedback for a leaflet generation.
+ * HTTP 409 is treated as already-submitted (not an error throw).
+ */
+export const useSubmitLeafletFeedbackMutation = () => {
+  return useMutation({
+    mutationFn: async (params: {
+      generationId: string;
+      precisionScore: number;
+      styleScore: number;
+      comment?: string;
+    }): Promise<SubmitLeafletFeedbackResult> => {
+      const apiClient = getAuthenticatedApiClient();
+      const fullUrl = `${(apiClient as any).baseUrl}/api/leaflet/feedback`;
+
+      const response = await (apiClient as any).http.fetch(fullUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(params),
+      });
+
+      if (response.status === 409) {
+        return { success: false, alreadySubmitted: true };
+      }
+
+      if (!response.ok) {
+        throw new Error(`Submit feedback failed: ${response.status}`);
+      }
+
+      return response.json();
+    },
+  });
+};
+
+/**
+ * Fetch paginated leaflet generation feedback list (admin only).
+ */
+export const useLeafletFeedbackListQuery = (params: LeafletFeedbackListParams = {}) => {
+  return useQuery({
+    queryKey: leafletKeys.feedbackList(params),
+    queryFn: async () => {
+      const apiClient = getAuthenticatedApiClient();
+      const searchParams = new URLSearchParams();
+
+      if (params.hasFeedback !== undefined)
+        searchParams.append('hasFeedback', params.hasFeedback.toString());
+      if (params.userId) searchParams.append('userId', params.userId);
+      if (params.sortBy) searchParams.append('sortBy', params.sortBy);
+      if (params.sortDescending !== undefined)
+        searchParams.append('sortDescending', params.sortDescending.toString());
+      if (params.pageNumber !== undefined)
+        searchParams.append('pageNumber', params.pageNumber.toString());
+      if (params.pageSize !== undefined)
+        searchParams.append('pageSize', params.pageSize.toString());
+
+      const query = searchParams.toString();
+      const fullUrl = `${(apiClient as any).baseUrl}/api/leaflet/feedback/list${query ? `?${query}` : ''}`;
+
+      const response = await (apiClient as any).http.fetch(fullUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+
+      if (!response.ok) throw new Error(`Failed to fetch feedback list: ${response.status}`);
+      return response.json();
+    },
+    staleTime: 30_000,
   });
 };

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -17,7 +17,6 @@ import {
   Users,
   ExternalLink,
   FileText,
-  Database,
   Megaphone,
 } from "lucide-react";
 import UserProfile from "../auth/UserProfile";
@@ -145,6 +144,11 @@ const Sidebar: React.FC<SidebarProps> = ({
       items: [
         { id: "marketing-calendar", name: "Kalendář", href: "/marketing/calendar" },
         { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
+        { id: "articles", name: "Generátor článků", href: "/articles" },
+        { id: "knowledge-base", name: "Poradenství (KB)", href: "/knowledge-base" },
+        ...(hasRole("knowledge_base_manager") || hasRole("leaflet_manager") || hasRole("article_generator")
+          ? [{ id: "marketing-feedback", name: "Feedback", href: "/marketing/feedback" }]
+          : []),
       ],
     },
     {
@@ -294,22 +298,6 @@ const Sidebar: React.FC<SidebarProps> = ({
           name: "Kvalita dat",
           href: "/automation/data-quality",
         },
-      ],
-    },
-    {
-      id: 'knowledgebase',
-      name: 'Knowledgebase',
-      icon: Database,
-      type: 'section' as const,
-      items: [
-        {
-          id: 'kb-poradenstvi',
-          name: 'Poradenství',
-          href: '/knowledge-base',
-        },
-        ...(hasRole('knowledge_base_manager')
-          ? [{ id: 'kb-feedback', name: 'Feedback', href: '/knowledge-base/feedback' }]
-          : []),
       ],
     },
   ];

--- a/frontend/src/components/feedback/RagFeedbackForm.tsx
+++ b/frontend/src/components/feedback/RagFeedbackForm.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+
+export type FeedbackState = 'idle' | 'submitted' | 'alreadySubmitted';
+
+interface RagFeedbackFormProps {
+  onSubmit: (data: { precisionScore: number; styleScore: number; comment: string }) => void;
+  isSubmitting: boolean;
+  isError: boolean;
+  feedbackState: FeedbackState;
+}
+
+const SCORES = [1, 2, 3, 4, 5];
+
+const ScoreRow: React.FC<{
+  label: string;
+  value: number | null;
+  onChange: (v: number) => void;
+}> = ({ label, value, onChange }) => (
+  <div className="space-y-1">
+    <span className="text-sm font-medium text-gray-700">{label}</span>
+    <div className="flex gap-1 flex-wrap">
+      {SCORES.map((s) => (
+        <label key={s} className="cursor-pointer">
+          <input
+            type="radio"
+            name={label}
+            value={s}
+            checked={value === s}
+            onChange={() => onChange(s)}
+            className="sr-only"
+          />
+          <span
+            className={`inline-flex items-center justify-center w-8 h-8 rounded text-sm font-medium border ${
+              value === s
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            {s}
+          </span>
+        </label>
+      ))}
+    </div>
+  </div>
+);
+
+export default function RagFeedbackForm({
+  onSubmit,
+  isSubmitting,
+  isError,
+  feedbackState,
+}: RagFeedbackFormProps) {
+  const [precisionScore, setPrecisionScore] = useState<number | null>(null);
+  const [styleScore, setStyleScore] = useState<number | null>(null);
+  const [comment, setComment] = useState('');
+
+  if (feedbackState === 'submitted') {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-sm text-green-700 bg-green-50">
+        Děkujeme za vaši zpětnou vazbu.
+      </div>
+    );
+  }
+
+  if (feedbackState === 'alreadySubmitted') {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-sm text-gray-600 bg-gray-50">
+        Zpětná vazba již byla odeslána.
+      </div>
+    );
+  }
+
+  const canSubmit = precisionScore !== null && styleScore !== null;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit({ precisionScore: precisionScore!, styleScore: styleScore!, comment: comment.trim() });
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 space-y-3">
+      <p className="text-sm font-medium text-gray-700">Ohodnoťte odpověď</p>
+      <ScoreRow label="Přesnost" value={precisionScore} onChange={setPrecisionScore} />
+      <ScoreRow label="Styl" value={styleScore} onChange={setStyleScore} />
+      <textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        placeholder="Volitelný komentář..."
+        rows={2}
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+      />
+      {isError && (
+        <p className="text-red-600 text-sm">Odeslání selhalo. Zkuste to znovu.</p>
+      )}
+      <button
+        onClick={handleSubmit}
+        disabled={!canSubmit || isSubmitting}
+        className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50"
+      >
+        Odeslat zpětnou vazbu
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx
+++ b/frontend/src/components/feedback/__tests__/RagFeedbackForm.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RagFeedbackForm from '../RagFeedbackForm';
+
+describe('RagFeedbackForm', () => {
+  const noop = jest.fn();
+
+  it('renders precision and style score buttons', () => {
+    render(
+      <RagFeedbackForm
+        onSubmit={noop}
+        isSubmitting={false}
+        isError={false}
+        feedbackState="idle"
+      />
+    );
+    expect(screen.getByText('Přesnost')).toBeInTheDocument();
+    expect(screen.getByText('Styl')).toBeInTheDocument();
+  });
+
+  it('submit button is disabled until both scores are selected', () => {
+    render(
+      <RagFeedbackForm
+        onSubmit={noop}
+        isSubmitting={false}
+        isError={false}
+        feedbackState="idle"
+      />
+    );
+    const submit = screen.getByRole('button', { name: /odeslat/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it('calls onSubmit with scores and comment when submitted', () => {
+    const handleSubmit = jest.fn();
+    render(
+      <RagFeedbackForm
+        onSubmit={handleSubmit}
+        isSubmitting={false}
+        isError={false}
+        feedbackState="idle"
+      />
+    );
+
+    // Select precision score 4
+    const precisionRadios = screen.getAllByRole('radio');
+    fireEvent.click(precisionRadios[3]); // score 4 (index 3)
+
+    // Select style score 5
+    const styleRadios = screen.getAllByRole('radio');
+    fireEvent.click(styleRadios[9]); // score 5 in style row (index 4 + 5 = 9)
+
+    fireEvent.click(screen.getByRole('button', { name: /odeslat/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ precisionScore: 4, styleScore: 5 })
+    );
+  });
+
+  it('shows success message when feedbackState is submitted', () => {
+    render(
+      <RagFeedbackForm
+        onSubmit={noop}
+        isSubmitting={false}
+        isError={false}
+        feedbackState="submitted"
+      />
+    );
+    expect(screen.getByText(/děkujeme/i)).toBeInTheDocument();
+  });
+
+  it('shows already-submitted message when feedbackState is alreadySubmitted', () => {
+    render(
+      <RagFeedbackForm
+        onSubmit={noop}
+        isSubmitting={false}
+        isError={false}
+        feedbackState="alreadySubmitted"
+      />
+    );
+    expect(screen.getByText(/zpětná vazba již byla odeslána/i)).toBeInTheDocument();
+  });
+
+  it('shows error message when isError is true', () => {
+    render(
+      <RagFeedbackForm
+        onSubmit={noop}
+        isSubmitting={false}
+        isError={true}
+        feedbackState="idle"
+      />
+    );
+    expect(screen.getByText(/odeslání selhalo/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/knowledge-base/ChunkDetailModal.tsx
+++ b/frontend/src/components/knowledge-base/ChunkDetailModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { X, ExternalLink } from 'lucide-react';
 import { useChunkDetailQuery } from '../../api/hooks/useKnowledgeBase';
 import { formatDateTime } from '../../utils/formatters';
+import { getSharePointLink } from '../../utils/sharepointLink';
 
 interface ChunkDetailModalProps {
   chunkId: string;
@@ -72,6 +73,18 @@ const ChunkDetailModal: React.FC<ChunkDetailModalProps> = ({ chunkId, score, onC
                   </span>
                 )}
               </div>
+
+              {getSharePointLink(data.sourcePath) && (
+                <a
+                  href={getSharePointLink(data.sourcePath)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                >
+                  Otevřít v SharePoint
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
 
               {/* Summary */}
               <div>

--- a/frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx
+++ b/frontend/src/components/knowledge-base/KnowledgeBaseSearchAskTab.tsx
@@ -7,6 +7,7 @@ import {
   SourceReference,
 } from '../../api/hooks/useKnowledgeBase';
 import ChunkDetailModal from './ChunkDetailModal';
+import RagFeedbackForm, { FeedbackState } from '../feedback/RagFeedbackForm';
 
 interface SourceAccordionProps {
   sources: SourceReference[];
@@ -53,120 +54,13 @@ const SourceAccordion: React.FC<SourceAccordionProps> = ({ sources, onViewSource
   );
 };
 
-const SCORES = [1, 2, 3, 4, 5];
-
-const ScoreRow: React.FC<{
-  label: string;
-  value: number | null;
-  onChange: (v: number) => void;
-}> = ({ label, value, onChange }) => (
-  <div className="space-y-1">
-    <span className="text-sm font-medium text-gray-700">{label}</span>
-    <div className="flex gap-1 flex-wrap">
-      {SCORES.map((s) => (
-        <label key={s} className="cursor-pointer">
-          <input
-            type="radio"
-            name={label}
-            value={s}
-            checked={value === s}
-            onChange={() => onChange(s)}
-            className="sr-only"
-          />
-          <span
-            className={`inline-flex items-center justify-center w-8 h-8 rounded text-sm font-medium border ${
-              value === s
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
-            }`}
-          >
-            {s}
-          </span>
-        </label>
-      ))}
-    </div>
-  </div>
-);
-
-type FeedbackState = 'idle' | 'submitted' | 'alreadySubmitted';
-
-const FeedbackForm: React.FC<{ logId: string }> = ({ logId }) => {
-  const [precisionScore, setPrecisionScore] = useState<number | null>(null);
-  const [styleScore, setStyleScore] = useState<number | null>(null);
-  const [comment, setComment] = useState('');
-  const [feedbackState, setFeedbackState] = useState<FeedbackState>('idle');
-  const submitFeedback = useSubmitFeedbackMutation();
-
-  if (feedbackState === 'submitted') {
-    return (
-      <div className="border border-gray-200 rounded-lg p-4 text-sm text-green-700 bg-green-50">
-        Děkujeme za vaši zpětnou vazbu.
-      </div>
-    );
-  }
-
-  if (feedbackState === 'alreadySubmitted') {
-    return (
-      <div className="border border-gray-200 rounded-lg p-4 text-sm text-gray-600 bg-gray-50">
-        Zpětná vazba již byla odeslána.
-      </div>
-    );
-  }
-
-  const canSubmit = precisionScore !== null && styleScore !== null;
-
-  const handleSubmit = () => {
-    if (!canSubmit) return;
-    submitFeedback.mutate(
-      {
-        logId,
-        precisionScore: precisionScore!,
-        styleScore: styleScore!,
-        comment: comment.trim() || undefined,
-      },
-      {
-        onSuccess: (result) => {
-          if (result.alreadySubmitted) {
-            setFeedbackState('alreadySubmitted');
-          } else {
-            setFeedbackState('submitted');
-          }
-        },
-      },
-    );
-  };
-
-  return (
-    <div className="border border-gray-200 rounded-lg p-4 space-y-3">
-      <p className="text-sm font-medium text-gray-700">Ohodnoťte odpověď</p>
-      <ScoreRow label="Přesnost" value={precisionScore} onChange={setPrecisionScore} />
-      <ScoreRow label="Styl" value={styleScore} onChange={setStyleScore} />
-      <textarea
-        value={comment}
-        onChange={(e) => setComment(e.target.value)}
-        placeholder="Volitelný komentář..."
-        rows={2}
-        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-      />
-      {submitFeedback.isError && (
-        <p className="text-red-600 text-sm">Odeslání selhalo. Zkuste to znovu.</p>
-      )}
-      <button
-        onClick={handleSubmit}
-        disabled={!canSubmit || submitFeedback.isPending}
-        className="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 disabled:opacity-50"
-      >
-        Odeslat zpětnou vazbu
-      </button>
-    </div>
-  );
-};
-
 const KnowledgeBaseSearchAskTab: React.FC = () => {
   const [query, setQuery] = useState('');
   const [selectedChunkId, setSelectedChunkId] = useState<string | null>(null);
   const [selectedScore, setSelectedScore] = useState<number | undefined>(undefined);
+  const [feedbackState, setFeedbackState] = useState<FeedbackState>('idle');
   const ask = useKnowledgeBaseAskMutation();
+  const submitFeedback = useSubmitFeedbackMutation();
 
   const handleViewSource = (chunkId: string, score: number) => {
     setSelectedChunkId(chunkId);
@@ -179,7 +73,10 @@ const KnowledgeBaseSearchAskTab: React.FC = () => {
   };
 
   const handleSubmit = () => {
-    if (query.trim()) ask.mutate({ question: query.trim() });
+    if (query.trim()) {
+      ask.mutate({ question: query.trim() });
+      setFeedbackState('idle');
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -187,6 +84,27 @@ const KnowledgeBaseSearchAskTab: React.FC = () => {
       e.preventDefault();
       handleSubmit();
     }
+  };
+
+  const handleFeedbackSubmit = (data: {
+    precisionScore: number;
+    styleScore: number;
+    comment: string;
+  }) => {
+    if (!ask.data?.id) return;
+    submitFeedback.mutate(
+      {
+        logId: ask.data.id,
+        precisionScore: data.precisionScore,
+        styleScore: data.styleScore,
+        comment: data.comment || undefined,
+      },
+      {
+        onSuccess: (result) => {
+          setFeedbackState(result.alreadySubmitted ? 'alreadySubmitted' : 'submitted');
+        },
+      },
+    );
   };
 
   return (
@@ -228,7 +146,14 @@ const KnowledgeBaseSearchAskTab: React.FC = () => {
             <ReactMarkdown>{ask.data.answer}</ReactMarkdown>
           </div>
           <SourceAccordion sources={ask.data.sources} onViewSource={handleViewSource} />
-          {ask.data.id && <FeedbackForm logId={ask.data.id} />}
+          {ask.data.id && (
+            <RagFeedbackForm
+              onSubmit={handleFeedbackSubmit}
+              isSubmitting={submitFeedback.isPending}
+              isError={submitFeedback.isError}
+              feedbackState={feedbackState}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
+++ b/frontend/src/components/knowledge-base/__tests__/ChunkDetailModal.test.tsx
@@ -80,3 +80,42 @@ test('calls onClose on Escape key', () => {
   fireEvent.keyDown(document, { key: 'Escape' });
   expect(mockOnClose).toHaveBeenCalledTimes(1);
 });
+
+test('renders SharePoint link when sourcePath is an https URL', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'https://anelacz.sharepoint.com/sites/x/doc.docx' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  const link = screen.getByRole('link', { name: /Otevřít v SharePoint/i });
+  expect(link).toHaveAttribute('href', 'https://anelacz.sharepoint.com/sites/x/doc.docx');
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+test('hides SharePoint link when sourcePath is a synthetic upload path', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'upload/abc/file.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+
+test('hides SharePoint link when sourcePath is missing', () => {
+  jest.spyOn(hooks, 'useChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: undefined },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});

--- a/frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletChunkDetailModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { X } from 'lucide-react';
+import { X, ExternalLink } from 'lucide-react';
 import { useLeafletChunkDetailQuery } from '../../api/hooks/useLeaflet';
 import { formatDateTime } from '../../utils/formatters';
+import { getSharePointLink } from '../../utils/sharepointLink';
 
 interface LeafletChunkDetailModalProps {
   chunkId: string;
@@ -64,6 +65,18 @@ const LeafletChunkDetailModal: React.FC<LeafletChunkDetailModalProps> = ({ chunk
                   <span>Indexováno: {formatDateTime(data.indexedAt)}</span>
                 )}
               </div>
+
+              {getSharePointLink(data.sourcePath) && (
+                <a
+                  href={getSharePointLink(data.sourcePath)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+                >
+                  Otevřít v SharePoint
+                  <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
 
               {/* Summary */}
               <div>

--- a/frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletGenerateTab.tsx
@@ -24,15 +24,18 @@ const LeafletGenerateTab: React.FC = () => {
   const [length, setLength] = useState<LeafletLength>(LeafletLength.Medium);
   const [result, setResult] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [generationId, setGenerationId] = useState<string | null>(null);
   const [errorBanner, setErrorBanner] = useState<ErrorBanner | null>(null);
 
   const generate = async () => {
     setIsLoading(true);
+    setGenerationId(null);
     setErrorBanner(null);
     try {
       const client = getAuthenticatedApiClient();
       const response = await client.leaflet_Generate(new GenerateLeafletRequest({ topic, audience, length }));
       setResult(response.content ?? '');
+      setGenerationId((response as any).id ?? null);
     } catch (err: unknown) {
       if (isApiError(err) && err.status === 422) {
         setErrorBanner({
@@ -87,7 +90,7 @@ const LeafletGenerateTab: React.FC = () => {
               <div className="h-4 bg-gray-200 rounded w-5/6" />
             </div>
           ) : (
-            <LeafletResult content={result} onRegenerate={generate} />
+            <LeafletResult content={result} generationId={generationId} onRegenerate={generate} />
           )}
         </div>
       </div>

--- a/frontend/src/features/leaflet-generator/LeafletResult.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletResult.tsx
@@ -1,14 +1,23 @@
 import { useState, useRef, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
+import RagFeedbackForm, { FeedbackState } from '../../components/feedback/RagFeedbackForm';
+import { useSubmitLeafletFeedbackMutation } from '../../api/hooks/useLeaflet';
 
 interface LeafletResultProps {
   content: string;
+  generationId?: string | null;
   onRegenerate: () => void;
 }
 
-export default function LeafletResult({ content, onRegenerate }: LeafletResultProps) {
+export default function LeafletResult({ content, generationId, onRegenerate }: LeafletResultProps) {
   const [copied, setCopied] = useState(false);
+  const [feedbackState, setFeedbackState] = useState<FeedbackState>('idle');
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const submitFeedback = useSubmitLeafletFeedbackMutation();
+
+  useEffect(() => {
+    setFeedbackState('idle');
+  }, [generationId]);
 
   useEffect(() => {
     return () => {
@@ -27,6 +36,18 @@ export default function LeafletResult({ content, onRegenerate }: LeafletResultPr
     } catch {
       // clipboard unavailable — no feedback change
     }
+  };
+
+  const handleFeedbackSubmit = (data: { precisionScore: number; styleScore: number; comment: string }) => {
+    if (!generationId) return;
+    submitFeedback.mutate(
+      { generationId, precisionScore: data.precisionScore, styleScore: data.styleScore, comment: data.comment || undefined },
+      {
+        onSuccess: (result) => {
+          setFeedbackState(result.alreadySubmitted ? 'alreadySubmitted' : 'submitted');
+        },
+      }
+    );
   };
 
   return (
@@ -50,6 +71,14 @@ export default function LeafletResult({ content, onRegenerate }: LeafletResultPr
           Generovat znovu
         </button>
       </div>
+      {generationId && (
+        <RagFeedbackForm
+          onSubmit={handleFeedbackSubmit}
+          isSubmitting={submitFeedback.isPending}
+          isError={submitFeedback.isError}
+          feedbackState={feedbackState}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
+++ b/frontend/src/features/leaflet-generator/__tests__/LeafletChunkDetailModal.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LeafletChunkDetailModal from '../LeafletChunkDetailModal';
+import * as hooks from '../../../api/hooks/useLeaflet';
+
+const mockChunkDetail = {
+  success: true,
+  chunkId: 'chunk-1',
+  documentId: 'doc-1',
+  filename: 'leaflet.pdf',
+  documentType: 'Document',
+  indexedAt: '2024-03-15T10:00:00Z',
+  chunkIndex: 0,
+  summary: 'Summary text.',
+  content: 'Full leaflet content.',
+};
+
+const mockOnClose = jest.fn();
+
+function renderModal() {
+  return render(
+    <LeafletChunkDetailModal chunkId="chunk-1" onClose={mockOnClose} />
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders SharePoint link when sourcePath is an https URL', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'https://anelacz.sharepoint.com/sites/x/leaflet.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  const link = screen.getByRole('link', { name: /Otevřít v SharePoint/i });
+  expect(link).toHaveAttribute('href', 'https://anelacz.sharepoint.com/sites/x/leaflet.pdf');
+  expect(link).toHaveAttribute('target', '_blank');
+  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+});
+
+test('hides SharePoint link when sourcePath is a synthetic upload path', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: 'upload/abc/file.pdf' },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});
+
+test('hides SharePoint link when sourcePath is missing', () => {
+  jest.spyOn(hooks, 'useLeafletChunkDetailQuery').mockReturnValue({
+    data: { ...mockChunkDetail, sourcePath: undefined },
+    isLoading: false,
+    isError: false,
+  } as any);
+
+  renderModal();
+
+  expect(screen.queryByRole('link', { name: /Otevřít v SharePoint/i })).not.toBeInTheDocument();
+});

--- a/frontend/src/features/leaflet-generator/__tests__/LeafletResult.test.tsx
+++ b/frontend/src/features/leaflet-generator/__tests__/LeafletResult.test.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import LeafletResult from '../LeafletResult';
 
+jest.mock('../../../api/hooks/useLeaflet', () => ({
+  useSubmitLeafletFeedbackMutation: () => ({
+    mutate: jest.fn(),
+    isPending: false,
+    isError: false,
+  }),
+}));
+
 jest.mock('react-markdown', () => ({
   __esModule: true,
-  default: ({ children }: { children: string }) => {
+  default: ({ children }) => {
     const lines = children.split('\n');
     return (
       <div>
@@ -93,5 +101,21 @@ describe('LeafletResult', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Generovat znovu' }));
 
     expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render feedback form when generationId is absent', () => {
+    render(<LeafletResult content="Some content" onRegenerate={jest.fn()} />);
+    expect(screen.queryByText('Ohodnoťte odpověď')).not.toBeInTheDocument();
+  });
+
+  it('renders feedback form when generationId is provided', () => {
+    render(
+      <LeafletResult
+        content="Some content"
+        generationId="gen-abc-123"
+        onRegenerate={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Ohodnoťte odpověď')).toBeInTheDocument();
   });
 });

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -196,6 +196,8 @@ const resources = {
 
         // Leaflet module errors
         LeafletChunkNotFound: "Fragment letáku nebyl nalezen",
+        LeafletFeedbackNotFound: "Zpětná vazba k letáku nebyla nalezena",
+        LeafletFeedbackAlreadySubmitted: "Zpětná vazba k letáku již byla odeslána",
 
         // ShoptetOrders module errors
         ShoptetOrderInvalidSourceState: "Objednávku nelze zablokovat – není ve povoleném stavu",

--- a/frontend/src/pages/MarketingFeedbackPage.tsx
+++ b/frontend/src/pages/MarketingFeedbackPage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { MessageSquare } from 'lucide-react';
+
+const MarketingFeedbackPage: React.FC = () => {
+  return (
+    <div className="flex flex-col h-full">
+      {/* Page header */}
+      <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-3 flex-shrink-0">
+        <MessageSquare className="w-6 h-6 text-blue-600" />
+        <h1 className="text-2xl font-semibold text-gray-900">Feedback</h1>
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto p-6">
+        <p className="text-sm text-gray-600">
+          Přehled zpětné vazby bude dostupný po dokončení integrace.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default MarketingFeedbackPage;

--- a/frontend/src/utils/__tests__/sharepointLink.test.ts
+++ b/frontend/src/utils/__tests__/sharepointLink.test.ts
@@ -1,0 +1,24 @@
+import { getSharePointLink } from '../sharepointLink';
+
+describe('getSharePointLink', () => {
+  test('returns null for null', () => {
+    expect(getSharePointLink(null)).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(getSharePointLink(undefined)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(getSharePointLink('')).toBeNull();
+  });
+
+  test('returns null for synthetic upload path', () => {
+    expect(getSharePointLink('upload/abc-123/file.pdf')).toBeNull();
+  });
+
+  test('returns the URL verbatim when it starts with https://', () => {
+    const url = 'https://anelacz.sharepoint.com/sites/x/doc.docx';
+    expect(getSharePointLink(url)).toBe(url);
+  });
+});

--- a/frontend/src/utils/sharepointLink.ts
+++ b/frontend/src/utils/sharepointLink.ts
@@ -1,0 +1,5 @@
+export function getSharePointLink(sourcePath: string | null | undefined): string | null {
+  if (!sourcePath) return null;
+  if (sourcePath.startsWith('https://')) return sourcePath;
+  return null;
+}


### PR DESCRIPTION
## Summary

- Every generated leaflet is now persisted to `LeafletGenerations` table via a MediatR pipeline behavior (`LeafletGenerationLoggingBehavior`), recording topic, audience, length, source counts, duration, and user ID
- Users can submit a one-shot 1–5 precision/style rating with optional comment via `POST /api/leaflet/feedback` (owner-only, conflict-guarded, same pattern as KnowledgeBase)
- `GET /api/leaflet/feedback/list` (admin) returns paged generations with stats (avg scores, total count)
- Frontend: `RagFeedbackForm` extracted from `KnowledgeBaseSearchAskTab` as a reusable component; `LeafletResult` shows the feedback form when a `generationId` is available; `LeafletGenerateTab` wires the new `id` from the generate response

## Key design decisions

- Pipeline behavior saves non-fatally — a DB failure swallows the error and returns the leaflet without an ID (feedback unavailable but generation succeeds)
- Null `UserId` on either side of the ownership check returns `Forbidden` immediately (guards against null == null bypass)
- `GetGenerationByIdAsync` uses `FindAsync` (tracked entity); feedback submit mutates it directly — documented with comment in handler
- `GetGenerationsPagedAsync` uses `AsNoTracking()` for read-only list queries

## Test plan

- [ ] `SubmitLeafletFeedbackHandlerTests` — not-found, forbidden, null-userId forbidden, already-submitted, success (7 tests)
- [ ] `GetLeafletFeedbackListHandlerTests` — mapping, stats, pagination, page-size clamping, sort validation (14 tests)
- [ ] `LeafletGenerationLoggingBehaviorTests` — saves + sets Id, DB fail → null Id, returns response (3 tests)
- [ ] `RagFeedbackForm.test.tsx` — renders ratings, submits, shows already-submitted state
- [ ] `LeafletResult.test.tsx` — with/without generationId prop
- [ ] `dotnet build` + `dotnet format --verify-no-changes` + `npm run build` all pass

Closes #932

@claude