### PR TITLE
feat: include Czech changelog in Teams deployment notification

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -165,6 +165,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       image-tags: ${{ steps.meta.outputs.tags }}
+      changelog-cs: ${{ steps.changelog_cs.outputs.markdown }}
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
@@ -290,6 +291,46 @@ jobs:
           fi
 
           echo "✅ All changelog files validated successfully!"
+
+      - name: 📝 Extract Czech changelog for current version
+        id: changelog_cs
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CURRENT_VERSION="${VERSION#v}"
+
+          MARKDOWN=$(jq -r --arg version "$CURRENT_VERSION" '
+            .versions[]
+            | select(.version == $version)
+            | .changes
+            | if length == 0 then "" else
+                group_by(.type) | map(
+                  (
+                    if .[0].type == "feature" then "### ✨ Novinky"
+                    elif .[0].type == "fix" then "### 🐛 Opravy"
+                    elif .[0].type == "improvement" then "### 📈 Vylepšení"
+                    elif .[0].type == "docs" then "### 📚 Dokumentace"
+                    elif .[0].type == "perf" then "### ⚡ Zrychlení"
+                    elif .[0].type == "refactor" then "### ♻️ Refaktoring"
+                    elif .[0].type == "test" then "### 🧪 Interní"
+                    elif .[0].type == "ci" then "### 👷 CI/CD"
+                    else "### 📝 Ostatní"
+                    end
+                  ) + "\n" + (map("- " + .title) | join("\n"))
+                ) | join("\n\n")
+              end
+          ' frontend/public/changelog.cs.json)
+
+          {
+            echo "markdown<<CHANGELOG_EOF"
+            echo "$MARKDOWN"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$MARKDOWN" ]; then
+            echo "✅ Czech changelog block prepared ($(echo "$MARKDOWN" | wc -l) lines)"
+          else
+            echo "ℹ️ No user-facing changes for $VERSION — Teams will use compact payload"
+          fi
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -551,69 +592,55 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           HOSTNAME="${{ steps.deploy.outputs.hostname }}"
+          CHANGELOG_CS="${{ needs.build-and-push.outputs.changelog-cs }}"
+          TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          APP_URL="https://${HOSTNAME}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           echo "📢 Sending Teams notification for version $VERSION..."
 
-          # Create Teams message payload
-          TEAMS_MESSAGE=$(cat <<EOF
-          {
-            "@type": "MessageCard",
-            "@context": "https://schema.org/extensions",
-            "summary": "Heblo ${VERSION} úspěšně nasazeno",
-            "themeColor": "00AA00",
-            "title": "🚀 Heblo ${VERSION} úspěšně nasazeno",
-            "sections": [
-              {
-                "activityTitle": "Produkční nasazení dokončeno",
-                "activitySubtitle": "$(date '+%Y-%m-%d %H:%M:%S UTC')",
-                "facts": [
+          TEAMS_MESSAGE=$(jq -n \
+            --arg version "$VERSION" \
+            --arg timestamp "$TIMESTAMP" \
+            --arg app_url "$APP_URL" \
+            --arg run_url "$RUN_URL" \
+            --arg workflow "$GITHUB_WORKFLOW" \
+            --arg changelog "$CHANGELOG_CS" \
+            '{
+              "@type": "MessageCard",
+              "@context": "https://schema.org/extensions",
+              "summary": "Heblo \($version) úspěšně nasazeno",
+              "themeColor": "00AA00",
+              "title": "🚀 Heblo \($version) úspěšně nasazeno",
+              "sections": (
+                [
                   {
-                    "name": "Verze:",
-                    "value": "${VERSION}"
-                  },
-                  {
-                    "name": "Prostředí:",
-                    "value": "Production"
-                  },
-                  {
-                    "name": "URL:",
-                    "value": "https://${HOSTNAME}"
-                  },
-                  {
-                    "name": "Workflow:",
-                    "value": "${GITHUB_WORKFLOW}"
-                  }
-                ],
-                "markdown": true
-              }
-            ],
-            "potentialAction": [
-              {
-                "@type": "OpenUri",
-                "name": "Zobrazit aplikaci",
-                "targets": [
-                  {
-                    "os": "default",
-                    "uri": "https://${HOSTNAME}"
+                    "activityTitle": "Produkční nasazení dokončeno",
+                    "activitySubtitle": $timestamp,
+                    "facts": [
+                      { "name": "Verze:",      "value": $version },
+                      { "name": "Prostředí:",  "value": "Production" },
+                      { "name": "URL:",        "value": $app_url },
+                      { "name": "Workflow:",   "value": $workflow }
+                    ],
+                    "markdown": true
                   }
                 ]
-              },
-              {
-                "@type": "OpenUri",
-                "name": "Zobrazit workflow run",
-                "targets": [
-                  {
-                    "os": "default",
-                    "uri": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
-          )
+                + (
+                  if ($changelog | length) > 0
+                  then [{ "title": "**📋 Změny ve verzi**", "text": $changelog, "markdown": true }]
+                  else []
+                  end
+                )
+              ),
+              "potentialAction": [
+                { "@type": "OpenUri", "name": "Zobrazit aplikaci",
+                  "targets": [{ "os": "default", "uri": $app_url }] },
+                { "@type": "OpenUri", "name": "Zobrazit workflow run",
+                  "targets": [{ "os": "default", "uri": $run_url }] }
+              ]
+            }')
 
-          # Send to Teams webhook
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Content-Type: application/json" \
             -d "$TEAMS_MESSAGE" \

--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -320,15 +320,16 @@ jobs:
               end
           ' frontend/public/changelog.cs.json)
 
-          {
-            echo "markdown<<CHANGELOG_EOF"
-            echo "$MARKDOWN"
-            echo "CHANGELOG_EOF"
-          } >> "$GITHUB_OUTPUT"
-
           if [ -n "$MARKDOWN" ]; then
+            DELIM="$(openssl rand -hex 8)"
+            {
+              printf 'markdown<<%s\n' "$DELIM"
+              printf '%s\n' "$MARKDOWN"
+              printf '%s\n' "$DELIM"
+            } >> "$GITHUB_OUTPUT"
             echo "✅ Czech changelog block prepared ($(echo "$MARKDOWN" | wc -l) lines)"
           else
+            echo "markdown=" >> "$GITHUB_OUTPUT"
             echo "ℹ️ No user-facing changes for $VERSION — Teams will use compact payload"
           fi
 
@@ -592,7 +593,6 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           HOSTNAME="${{ steps.deploy.outputs.hostname }}"
-          CHANGELOG_CS="${{ needs.build-and-push.outputs.changelog-cs }}"
           TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
           APP_URL="https://${HOSTNAME}"
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -653,6 +653,7 @@ jobs:
             echo "Note: This is not a critical failure, continuing workflow..."
           fi
         env:
+          CHANGELOG_CS: ${{ needs.build-and-push.outputs.changelog-cs }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Adds a **Czech changelog section** (Změny ve verzi) to the Teams deployment notification card after each successful production deploy
- Passes the already-generated `changelog.cs.json` content as a job output from `build-and-push` to `deploy-production` — no extra API calls, no new secrets
- Replaces the shell-heredoc JSON builder in the Teams step with `jq -n` to safely handle Markdown content (newlines, quotes) and conditionally omit the section when there are no user-facing changes

## Security improvements included

- `CHANGELOG_CS` is passed via `env:` block (not inline expression interpolation), preventing shell injection from LLM-generated content
- `$GITHUB_OUTPUT` multiline write uses a random delimiter (`openssl rand -hex 8`) instead of a fixed string, preventing delimiter collision with translated text
- Empty changelog case writes `markdown=` (empty string) rather than a blank line, so the Teams card correctly falls back to the compact layout

## Test Plan

- [ ] Trigger a deploy to production with user-facing commits — Teams notification should show a second section "📋 Změny ve verzi" with Czech bullet points grouped under emoji headers (✨ Novinky, 🐛 Opravy, etc.)
- [ ] Trigger a hotfix deploy with only excluded commits (bumps, lint, merge) — Teams card should look identical to today (no changelog section)
- [ ] Confirm all existing fields are preserved: Verze, Prostředí, URL, Workflow facts + both action buttons