### PR TITLE
fix: parallelize invoice fetches in ClassifyInvoicesHandler

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/ClassifyInvoices/ClassifyInvoicesHandler.cs
@@ -35,16 +35,19 @@ public class ClassifyInvoicesHandler : IRequestHandler<ClassifyInvoicesRequest, 
 
             if (request.InvoiceIds != null && request.InvoiceIds.Count > 0)
             {
-                // Single/specific invoices mode
+                // Single/specific invoices mode — fetch in parallel
+                var fetchTasks = request.InvoiceIds.Select(id => _invoicesClient.GetInvoiceByIdAsync(id)).ToList();
+                var fetchedInvoices = await Task.WhenAll(fetchTasks);
+
                 invoicesToClassify = new List<ReceivedInvoiceDto>();
-                foreach (var invoiceId in request.InvoiceIds)
+                for (var i = 0; i < request.InvoiceIds.Count; i++)
                 {
-                    var invoice = await _invoicesClient.GetInvoiceByIdAsync(invoiceId);
+                    var invoice = fetchedInvoices[i];
                     if (invoice == null)
                     {
                         response.Errors++;
-                        errorMessages.Add($"Invoice {invoiceId} not found");
-                        _logger.LogWarning("Invoice {InvoiceId} not found", invoiceId);
+                        errorMessages.Add($"Invoice {request.InvoiceIds[i]} not found");
+                        _logger.LogWarning("Invoice {InvoiceId} not found", request.InvoiceIds[i]);
                     }
                     else
                     {

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/ClassifyInvoicesHandlerTests.cs
@@ -1,0 +1,128 @@
+using Anela.Heblo.Application.Features.InvoiceClassification.Services;
+using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.ClassifyInvoices;
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification;
+
+public class ClassifyInvoicesHandlerTests
+{
+    private readonly Mock<IReceivedInvoicesClient> _invoicesClientMock;
+    private readonly Mock<IInvoiceClassificationService> _classificationServiceMock;
+    private readonly Mock<IClassificationRuleRepository> _ruleRepositoryMock;
+    private readonly Mock<ILogger<ClassifyInvoicesHandler>> _loggerMock;
+    private readonly ClassifyInvoicesHandler _handler;
+
+    public ClassifyInvoicesHandlerTests()
+    {
+        _invoicesClientMock = new Mock<IReceivedInvoicesClient>();
+        _classificationServiceMock = new Mock<IInvoiceClassificationService>();
+        _ruleRepositoryMock = new Mock<IClassificationRuleRepository>();
+        _loggerMock = new Mock<ILogger<ClassifyInvoicesHandler>>();
+
+        _handler = new ClassifyInvoicesHandler(
+            _invoicesClientMock.Object,
+            _classificationServiceMock.Object,
+            _ruleRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithMultipleInvoiceIds_FetchesAllInvoicesInParallel()
+    {
+        // Reproduces bug from issue #969: sequential foreach caused N sequential Flexi API calls.
+        // Fix: use Task.WhenAll to fetch all invoices concurrently.
+
+        var invoiceId1 = "INV-001";
+        var invoiceId2 = "INV-002";
+        var invoiceId3 = "INV-003";
+
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(invoiceId1))
+            .ReturnsAsync(new ReceivedInvoiceDto { InvoiceNumber = invoiceId1, Labels = Array.Empty<string>() });
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(invoiceId2))
+            .ReturnsAsync(new ReceivedInvoiceDto { InvoiceNumber = invoiceId2, Labels = Array.Empty<string>() });
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(invoiceId3))
+            .ReturnsAsync(new ReceivedInvoiceDto { InvoiceNumber = invoiceId3, Labels = Array.Empty<string>() });
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoiceDto>()))
+            .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
+
+        var request = new ClassifyInvoicesRequest
+        {
+            InvoiceIds = new List<string> { invoiceId1, invoiceId2, invoiceId3 }
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.TotalInvoicesProcessed.Should().Be(3);
+        response.SuccessfulClassifications.Should().Be(3);
+        response.Errors.Should().Be(0);
+
+        // Verify all three invoices were fetched (regardless of order — parallel execution)
+        _invoicesClientMock.Verify(x => x.GetInvoiceByIdAsync(invoiceId1), Times.Once);
+        _invoicesClientMock.Verify(x => x.GetInvoiceByIdAsync(invoiceId2), Times.Once);
+        _invoicesClientMock.Verify(x => x.GetInvoiceByIdAsync(invoiceId3), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSomeInvoicesNotFound_CountsThemAsErrors()
+    {
+        var foundId = "INV-001";
+        var missingId = "INV-999";
+
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(foundId))
+            .ReturnsAsync(new ReceivedInvoiceDto { InvoiceNumber = foundId, Labels = Array.Empty<string>() });
+        _invoicesClientMock
+            .Setup(x => x.GetInvoiceByIdAsync(missingId))
+            .ReturnsAsync((ReceivedInvoiceDto?)null);
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoiceDto>()))
+            .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
+
+        var request = new ClassifyInvoicesRequest
+        {
+            InvoiceIds = new List<string> { foundId, missingId }
+        };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.TotalInvoicesProcessed.Should().Be(1);
+        response.SuccessfulClassifications.Should().Be(1);
+        response.Errors.Should().Be(1);
+        response.ErrorMessages.Should().ContainSingle(m => m.Contains(missingId));
+    }
+
+    [Fact]
+    public async Task Handle_WithNoInvoiceIds_FetchesAllUnclassifiedInvoices()
+    {
+        var unclassifiedInvoices = new List<ReceivedInvoiceDto>
+        {
+            new() { InvoiceNumber = "UNCLASSIFIED-001", Labels = Array.Empty<string>() }
+        };
+
+        _invoicesClientMock
+            .Setup(x => x.GetUnclassifiedInvoicesAsync())
+            .ReturnsAsync(unclassifiedInvoices);
+
+        _classificationServiceMock
+            .Setup(x => x.ClassifyInvoiceAsync(It.IsAny<ReceivedInvoiceDto>()))
+            .ReturnsAsync(new InvoiceClassificationResult { Result = ClassificationResult.Success });
+
+        var request = new ClassifyInvoicesRequest { InvoiceIds = null };
+
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        response.TotalInvoicesProcessed.Should().Be(1);
+        response.SuccessfulClassifications.Should().Be(1);
+        _invoicesClientMock.Verify(x => x.GetUnclassifiedInvoicesAsync(), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Root cause: `ClassifyInvoicesHandler` fetched each invoice via a sequential `await` inside a `foreach`, resulting in N round-trips to the Flexi API one after another (~15s for multiple invoices)
- Fix: replaced the `foreach` with `Task.WhenAll` so all fetches fire concurrently and complete in roughly the time of one request
- Error handling is preserved: invoices that return `null` are still counted as errors with the correct ID in the message

## Test plan

- [x] New regression test `Handle_WithMultipleInvoiceIds_FetchesAllInvoicesInParallel` verifies all 3 `GetInvoiceByIdAsync` calls are made exactly once and response totals are correct
- [x] `Handle_WhenSomeInvoicesNotFound_CountsThemAsErrors` verifies null-return invoices are counted as errors
- [x] `Handle_WithNoInvoiceIds_FetchesAllUnclassifiedInvoices` verifies the bulk path is unaffected
- [x] All BE tests pass (`dotnet test` — 2755 passed, 14 pre-existing integration test failures require Docker/Testcontainers)
- [x] Build succeeds (`dotnet build` — 0 errors)
- [x] `dotnet format --verify-no-changes` passes

Fixes #969