### PR TITLE
ci: tag and create GitHub release only after successful production deploy

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -293,6 +293,13 @@ jobs:
 
           echo "✅ All changelog files validated successfully!"
 
+      - name: 📤 Upload changelog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-en
+          path: frontend/public/changelog.json
+          retention-days: 1
+
       - name: 📝 Extract Czech changelog for current version
         id: changelog_cs
         run: |
@@ -386,75 +393,6 @@ jobs:
           echo "1. Go to the **Actions** tab" >> $GITHUB_STEP_SUMMARY
           echo "2. Click on this workflow run" >> $GITHUB_STEP_SUMMARY
           echo "3. **Approve production deployment** in the 'deploy-production' job" >> $GITHUB_STEP_SUMMARY
-
-      - name: 🏷️ Create and Push Git Tag
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "🏷️ Creating Git tag: $VERSION"
-
-          # Configure Git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Create tag
-          git tag -a "$VERSION" -m "Release $VERSION"
-
-          # Push tag to repository
-          git push origin "$VERSION"
-
-          echo "✅ Git tag $VERSION created and pushed successfully!"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 📦 Create GitHub Release
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "📦 Creating GitHub release: $VERSION"
-
-          # Read the English changelog
-          if [ ! -f frontend/public/changelog.json ]; then
-            echo "❌ Changelog file not found!"
-            exit 1
-          fi
-
-          # Extract changelog for current version
-          CURRENT_VERSION="${VERSION#v}"
-          RELEASE_NOTES=$(jq -r --arg version "$CURRENT_VERSION" '
-            .versions[] |
-            select(.version == $version) |
-            "## Changes\n\n" +
-            (
-              .changes | group_by(.type) | map(
-                (
-                  if .[0].type == "feature" then "### ✨ Features"
-                  elif .[0].type == "fix" then "### 🐛 Bug Fixes"
-                  elif .[0].type == "improvement" then "### 📈 Improvements"
-                  elif .[0].type == "docs" then "### 📚 Documentation"
-                  elif .[0].type == "perf" then "### ⚡ Performance"
-                  elif .[0].type == "refactor" then "### ♻️ Refactoring"
-                  elif .[0].type == "test" then "### 🧪 Tests"
-                  elif .[0].type == "ci" then "### 👷 CI/CD"
-                  else "### 📝 Other"
-                  end
-                ) + "\n" + (map("- " + (if ((.module // "") | length) > 0 and .module != "Ostatní" then "**" + .module + ":** " else "" end) + .title) | join("\n"))
-              ) | join("\n\n")
-            )
-          ' frontend/public/changelog.json || echo "No changelog available for this version.")
-
-          # Check if jq extraction was successful
-          if [ -z "$RELEASE_NOTES" ]; then
-            RELEASE_NOTES="## Changes\n\nSee [changelog](https://heblo.anela.cz) for detailed release notes."
-          fi
-
-          # Create GitHub release
-          echo "$RELEASE_NOTES" | gh release create "$VERSION" \
-            --title "Release $VERSION" \
-            --notes-file - \
-            --verify-tag
-
-          echo "✅ GitHub release $VERSION created successfully!"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Deploy to Production - MANUAL APPROVAL REQUIRED
   deploy-production:
@@ -659,3 +597,78 @@ jobs:
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+
+  # Tag & Release - only after successful production deployment
+  tag-and-release:
+    name: 🏷️ Tag & Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-and-push, deploy-production]
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 📥 Download changelog artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-en
+          path: frontend/public  # places changelog.json at frontend/public/changelog.json
+
+      - name: 🏷️ Create and Push Git Tag
+        run: |
+          VERSION="${{ needs.build-and-push.outputs.version }}"
+          echo "🏷️ Creating Git tag: $VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+          echo "✅ Git tag $VERSION created and pushed successfully!"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📦 Create GitHub Release
+        run: |
+          VERSION="${{ needs.build-and-push.outputs.version }}"
+          echo "📦 Creating GitHub release: $VERSION"
+
+          if [ ! -f frontend/public/changelog.json ]; then
+            echo "❌ Changelog file not found!"
+            exit 1
+          fi
+
+          CURRENT_VERSION="${VERSION#v}"
+          RELEASE_NOTES=$(jq -r --arg version "$CURRENT_VERSION" '
+            .versions[] |
+            select(.version == $version) |
+            "## Changes\n\n" +
+            (
+              .changes | group_by(.type) | map(
+                (
+                  if .[0].type == "feature" then "### ✨ Features"
+                  elif .[0].type == "fix" then "### 🐛 Bug Fixes"
+                  elif .[0].type == "improvement" then "### 📈 Improvements"
+                  elif .[0].type == "docs" then "### 📚 Documentation"
+                  elif .[0].type == "perf" then "### ⚡ Performance"
+                  elif .[0].type == "refactor" then "### ♻️ Refactoring"
+                  elif .[0].type == "test" then "### 🧪 Tests"
+                  elif .[0].type == "ci" then "### 👷 CI/CD"
+                  else "### 📝 Other"
+                  end
+                ) + "\n" + (map("- " + (if ((.module // "") | length) > 0 and .module != "Ostatní" then "**" + .module + ":** " else "" end) + .title) | join("\n"))
+              ) | join("\n\n")
+            )
+          ' frontend/public/changelog.json || echo "No changelog available for this version.")
+
+          if [ -z "$RELEASE_NOTES" ]; then
+            RELEASE_NOTES="## Changes\n\nSee [changelog](https://heblo.anela.cz) for detailed release notes."
+          fi
+
+          echo "$RELEASE_NOTES" | gh release create "$VERSION" \
+            --title "Release $VERSION" \
+            --notes-file - \
+            --verify-tag
+
+          echo "✅ GitHub release $VERSION created successfully!"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Git tag and GitHub release were previously created in `build-and-push`, **before** the production deployment was approved — meaning a rejected or failed deploy still left a stale tag behind
- The changelog script uses `git describe --tags --abbrev=0` to determine the base of the commit range, so a stale tag caused the next release's changelog to silently miss those commits
- Moved `🏷️ Create and Push Git Tag` and `📦 Create GitHub Release` to a new `tag-and-release` job that `needs: [build-and-push, deploy-production]`, so tags and releases are only created after a successful production deployment
- Added `actions/upload-artifact@v4` in `build-and-push` to pass `changelog.json` to the new job (retention-days: 1)

## Test Plan

- [ ] Confirm `build-and-push` job completes without creating a tag or GitHub release
- [ ] Approve production deploy — confirm `tag-and-release` job runs afterward and creates both the git tag and the GH release
- [ ] Reject a production deploy — confirm no git tag or GH release is created
- [ ] Push a follow-up commit after a rejected deploy — confirm its changelog contains commits from both the rejected attempt and the new commit