### PR TITLE
feat: replace leaflet_manager and article_generator with unified genai_user role

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/ArticlesController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/ArticlesController.cs
@@ -24,7 +24,7 @@ public sealed class ArticlesController : BaseApiController
     }
 
     [HttpPost("generate")]
-    [Authorize(Policy = AuthorizationConstants.Policies.ArticleGenerator)]
+    [Authorize(Policy = AuthorizationConstants.Policies.GenAiUser)]
     public async Task<ActionResult<GenerateArticleResponse>> Generate(
         [FromBody] GenerateArticleRequest request,
         CancellationToken ct = default)
@@ -70,7 +70,7 @@ public sealed class ArticlesController : BaseApiController
     }
 
     [HttpGet("feedback/list")]
-    [Authorize(Policy = AuthorizationConstants.Policies.ArticleGenerator)]
+    [Authorize(Policy = AuthorizationConstants.Policies.GenAiUser)]
     public async Task<ActionResult<GetArticleFeedbackListResponse>> FeedbackList(
         [FromQuery] bool? hasFeedback = null,
         [FromQuery] string? requestedBy = null,

--- a/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/LeafletController.cs
@@ -30,6 +30,7 @@ public class LeafletController : BaseApiController
     }
 
     [HttpPost("generate")]
+    [Authorize(Policy = AuthorizationConstants.Policies.GenAiUser)]
     [ProducesResponseType(typeof(GenerateLeafletResponse), 200)]
     [ProducesResponseType(typeof(ProblemDetails), 400)]
     [ProducesResponseType(typeof(ProblemDetails), 422)]
@@ -105,7 +106,7 @@ public class LeafletController : BaseApiController
     }
 
     [HttpDelete("documents/{id:guid}")]
-    [Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+    [Authorize(Policy = AuthorizationConstants.Policies.GenAiUser)]
     public async Task<ActionResult<DeleteLeafletDocumentResponse>> DeleteDocument(Guid id, CancellationToken ct)
     {
         var result = await _mediator.Send(new DeleteLeafletDocumentRequest { DocumentId = id }, ct);
@@ -113,7 +114,7 @@ public class LeafletController : BaseApiController
     }
 
     [HttpPost("documents/upload")]
-    [Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+    [Authorize(Policy = AuthorizationConstants.Policies.GenAiUser)]
     public async Task<ActionResult<UploadLeafletResponse>> UploadDocument(
         IFormFile file,
         CancellationToken ct = default)
@@ -144,7 +145,7 @@ public class LeafletController : BaseApiController
     }
 
     [HttpGet("feedback/list")]
-    [Authorize(Policy = AuthorizationConstants.Policies.LeafletUpload)]
+    [Authorize(Policy = AuthorizationConstants.Policies.GenAiUser)]
     public async Task<ActionResult<GetLeafletFeedbackListResponse>> GetFeedbackList(
         [FromQuery] bool? hasFeedback = null,
         [FromQuery] string? userId = null,

--- a/backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/AuthenticationExtensions.cs
@@ -110,13 +110,9 @@ public static class AuthenticationExtensions
                 policy.RequireAuthenticatedUser()
                       .RequireRole(AuthorizationConstants.Roles.KnowledgeBaseManager));
 
-            options.AddPolicy(AuthorizationConstants.Policies.LeafletUpload, policy =>
+            options.AddPolicy(AuthorizationConstants.Policies.GenAiUser, policy =>
                 policy.RequireAuthenticatedUser()
-                      .RequireRole(AuthorizationConstants.Roles.LeafletManager));
-
-            options.AddPolicy(AuthorizationConstants.Policies.ArticleGenerator, policy =>
-                policy.RequireAuthenticatedUser()
-                      .RequireRole(AuthorizationConstants.Roles.ArticleGenerator));
+                      .RequireRole(AuthorizationConstants.Roles.GenAiUser));
         });
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Authorization/AuthorizationConstants.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Authorization/AuthorizationConstants.cs
@@ -46,14 +46,9 @@ public static class AuthorizationConstants
         public const string KnowledgeBaseManager = "knowledge_base_manager";
 
         /// <summary>
-        /// Role required for managing Leaflet documents (upload, process, index documents)
+        /// Role required for generating leaflets and articles (GenAI features)
         /// </summary>
-        public const string LeafletManager = "leaflet_manager";
-
-        /// <summary>
-        /// Role required for generating articles
-        /// </summary>
-        public const string ArticleGenerator = "article_generator";
+        public const string GenAiUser = "genai_user";
     }
 
     /// <summary>
@@ -67,13 +62,8 @@ public static class AuthorizationConstants
         public const string KnowledgeBaseUpload = "KnowledgeBaseUpload";
 
         /// <summary>
-        /// Policy required for uploading and managing Leaflet documents
+        /// Policy required for generating leaflets and articles
         /// </summary>
-        public const string LeafletUpload = "LeafletUpload";
-
-        /// <summary>
-        /// Policy required for generating articles
-        /// </summary>
-        public const string ArticleGenerator = "ArticleGenerator";
+        public const string GenAiUser = "GenAiUser";
     }
 }

--- a/docs/features/2026-04-30-leaflet-generator-design.md
+++ b/docs/features/2026-04-30-leaflet-generator-design.md
@@ -98,7 +98,7 @@ length:   Short (~200 words) | Medium (~400 words) | Long (~700 words)
 
 ### `POST /api/leaflet/generate`
 
-Authentication: `[Authorize]` — Microsoft Entra ID JWT.
+Authentication: `[Authorize(Roles = "genai_user")]` — Microsoft Entra ID JWT. Requires the `genai_user` role for generation access.
 
 **Request:**
 ```json

--- a/docs/features/article-generation.md
+++ b/docs/features/article-generation.md
@@ -140,7 +140,7 @@ public enum SourceType   { Web = 0, KnowledgeBase = 1, StyleGuide = 2 }
 
 ## 7. REST API
 
-All endpoints `[Authorize]`. POST `/generate` requires role `article_generator`; reads require `heblo_user`.
+All endpoints `[Authorize]`. POST `/generate` requires role `genai_user`; reads require `heblo_user`.
 
 ### `POST /api/Articles/generate`
 Request body (class, not record — OpenAPI codegen requirement):
@@ -343,10 +343,11 @@ MediatR handlers are auto-discovered. Hangfire job is a regular class with `[Aut
 
 ## 14. Auth & Roles
 
-- New role `article_generator` — assigned to Heblo human users with content-creation responsibilities (admin assigns)
-- `[Authorize(Roles = "article_generator")]` on `POST /generate`
+- Uses the unified `genai_user` role — assigned to Heblo human users with content-creation responsibilities (admin assigns)
+- `[Authorize(Roles = "genai_user")]` on `POST /generate`
 - `[Authorize]` (default `heblo_user`) on `GET` and feedback endpoints
 - `KnowledgeBaseUpload` policy is **not** reused — articles are a separate concern
+- **Note:** The earlier `article_generator` role was removed and replaced by the unified `genai_user` role.
 
 ---
 

--- a/docs/features/leaflet-generator.md
+++ b/docs/features/leaflet-generator.md
@@ -139,6 +139,7 @@ Common supported formats (verify with extractor registrations in `LeafletModule.
 POST /api/leaflet/generate
 Content-Type: application/json
 Authorization: Bearer <Entra ID token>
+Requires: genai_user role
 ```
 
 **Request body:**

--- a/frontend/src/api/hooks/useArticles.ts
+++ b/frontend/src/api/hooks/useArticles.ts
@@ -1,8 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useMsal } from '@azure/msal-react';
 import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
-import { shouldUseMockAuth } from '../../config/runtimeConfig';
-import { mockAuthService } from '../../auth/mockAuth';
 import {
   ArticleStatus,
   GenerateArticleRequest,
@@ -111,23 +108,6 @@ export const IN_PROGRESS_STATUSES = new Set<ArticleStatus>([
   ArticleStatus.Researching,
   ArticleStatus.Writing,
 ]);
-
-// ---- Permission hook ----
-
-export const useArticleGeneratorPermission = (): boolean => {
-  const { accounts } = useMsal();
-
-  if (shouldUseMockAuth()) {
-    const user = mockAuthService.getUser();
-    return !!(Array.isArray(user?.roles) && user?.roles.includes('article_generator'));
-  }
-
-  const account = accounts[0];
-  if (!account) return false;
-  const claims = account.idTokenClaims as Record<string, unknown> | undefined;
-  const roles = claims?.['roles'];
-  return Array.isArray(roles) && roles.includes('article_generator');
-};
 
 // ---- Query key factory ----
 

--- a/frontend/src/api/hooks/useGenAiUserPermission.ts
+++ b/frontend/src/api/hooks/useGenAiUserPermission.ts
@@ -1,0 +1,18 @@
+import { useMsal } from '@azure/msal-react';
+import { shouldUseMockAuth } from '../../config/runtimeConfig';
+import { mockAuthService } from '../../auth/mockAuth';
+
+export const useGenAiUserPermission = (): boolean => {
+  const { accounts } = useMsal();
+
+  if (shouldUseMockAuth()) {
+    const user = mockAuthService.getUser();
+    return !!(Array.isArray(user?.roles) && user?.roles.includes('genai_user'));
+  }
+
+  const account = accounts[0];
+  if (!account) return false;
+  const claims = account.idTokenClaims as Record<string, unknown> | undefined;
+  const roles = claims?.['roles'];
+  return Array.isArray(roles) && roles.includes('genai_user');
+};

--- a/frontend/src/api/hooks/useLeaflet.ts
+++ b/frontend/src/api/hooks/useLeaflet.ts
@@ -1,8 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useMsal } from '@azure/msal-react';
 import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
-import { shouldUseMockAuth } from '../../config/runtimeConfig';
-import { mockAuthService } from '../../auth/mockAuth';
 
 // ---- Types ----
 
@@ -107,27 +104,6 @@ export interface LeafletFeedbackListResponse {
     avgStyleScore: number | null;
   };
 }
-
-// ---- Permission hook ----
-
-/**
- * Returns true when the current MSAL account has the leaflet_manager role.
- * Controls visibility of the Upload tab and delete buttons.
- */
-export const useLeafletUploadPermission = (): boolean => {
-  const { accounts } = useMsal();
-
-  if (shouldUseMockAuth()) {
-    const user = mockAuthService.getUser();
-    return !!(Array.isArray(user?.roles) && user?.roles.includes('leaflet_manager'));
-  }
-
-  const account = accounts[0];
-  if (!account) return false;
-  const claims = account.idTokenClaims as Record<string, unknown> | undefined;
-  const roles = claims?.['roles'];
-  return Array.isArray(roles) && roles.includes('leaflet_manager');
-};
 
 // ---- Query key factory ----
 

--- a/frontend/src/auth/mockAuth.ts
+++ b/frontend/src/auth/mockAuth.ts
@@ -23,7 +23,7 @@ export const createMockUser = (): MockUser => {
     name: "Mock User",
     email: "mock@anela-heblo.com",
     initials: "MU",
-    roles: ["finance_reader", "knowledge_base_manager"],
+    roles: ["finance_reader", "knowledge_base_manager", "genai_user"],
   };
 };
 

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -148,7 +148,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         { id: "leaflet-generator", name: "Generátor letáků", href: "/leaflet-generator" },
         { id: "articles", name: "Generátor článků", href: "/articles" },
         
-        ...(hasRole("knowledge_base_manager") || hasRole("leaflet_manager") || hasRole("article_generator")
+        ...(hasRole("knowledge_base_manager") || hasRole("genai_user")
           ? [{ id: "marketing-feedback", name: "Feedback", href: "/marketing/feedback" }]
           : []),
       ],

--- a/frontend/src/features/articles/ArticleGenerationForm.tsx
+++ b/frontend/src/features/articles/ArticleGenerationForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { GenerateArticleRequest } from '../../api/generated/api-client';
-import { useGenerateArticleMutation, useArticleGeneratorPermission } from '../../api/hooks/useArticles';
+import { useGenerateArticleMutation } from '../../api/hooks/useArticles';
+import { useGenAiUserPermission } from '../../api/hooks/useGenAiUserPermission';
 
 interface ArticleGenerationFormProps {
   onArticleCreated: (articleId: string) => void;
@@ -21,7 +22,7 @@ const LENGTH_OPTIONS = [
 ];
 
 export default function ArticleGenerationForm({ onArticleCreated }: ArticleGenerationFormProps) {
-  const canGenerate = useArticleGeneratorPermission();
+  const canGenerate = useGenAiUserPermission();
   const { mutate: generate, isPending, error } = useGenerateArticleMutation();
 
   const [topic, setTopic] = useState('');

--- a/frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx
@@ -3,12 +3,12 @@ import { FileText } from 'lucide-react';
 import LeafletGenerateTab from './LeafletGenerateTab';
 import LeafletDocumentsTab from './LeafletDocumentsTab';
 import LeafletUploadTab from './LeafletUploadTab';
-import { useLeafletUploadPermission } from '../../api/hooks/useLeaflet';
+import { useGenAiUserPermission } from '../../api/hooks/useGenAiUserPermission';
 
 type Tab = 'generate' | 'documents' | 'upload';
 
 export default function LeafletGeneratorPage() {
-  const canUpload = useLeafletUploadPermission();
+  const canUpload = useGenAiUserPermission();
   const [activeTab, setActiveTab] = useState<Tab>('generate');
 
   const tabs: { id: Tab; label: string }[] = [

--- a/frontend/src/features/leaflet-generator/__tests__/LeafletGeneratorPage.test.tsx
+++ b/frontend/src/features/leaflet-generator/__tests__/LeafletGeneratorPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import LeafletGeneratorPage from '../LeafletGeneratorPage';
-import * as useLeafletHooks from '../../../api/hooks/useLeaflet';
+import * as useGenAiHooks from '../../../api/hooks/useGenAiUserPermission';
 
 jest.mock('../LeafletGenerateTab', () => ({
   __esModule: true,
@@ -21,11 +21,11 @@ jest.mock('../LeafletUploadTab', () => ({
   default: () => <div data-testid="upload-tab-content">UploadTab</div>,
 }));
 
-jest.mock('../../../api/hooks/useLeaflet', () => ({
-  useLeafletUploadPermission: jest.fn(),
+jest.mock('../../../api/hooks/useGenAiUserPermission', () => ({
+  useGenAiUserPermission: jest.fn(),
 }));
 
-const mockUseLeafletUploadPermission = useLeafletHooks.useLeafletUploadPermission as jest.Mock;
+const mockUseGenAiUserPermission = useGenAiHooks.useGenAiUserPermission as jest.Mock;
 
 function renderPage() {
   return render(
@@ -41,13 +41,13 @@ beforeEach(() => {
 
 describe('LeafletGeneratorPage', () => {
   it('renders heading Generátor letáků', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(false);
+    mockUseGenAiUserPermission.mockReturnValue(false);
     renderPage();
     expect(screen.getByRole('heading', { level: 1, name: 'Generátor letáků' })).toBeInTheDocument();
   });
 
   it('shows Generovat and Dokumenty tabs when user cannot upload', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(false);
+    mockUseGenAiUserPermission.mockReturnValue(false);
     renderPage();
     expect(screen.getByRole('button', { name: 'Generovat' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Dokumenty' })).toBeInTheDocument();
@@ -55,19 +55,19 @@ describe('LeafletGeneratorPage', () => {
   });
 
   it('shows Nahrát soubor tab when user has upload permission', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(true);
+    mockUseGenAiUserPermission.mockReturnValue(true);
     renderPage();
     expect(screen.getByRole('button', { name: 'Nahrát soubor' })).toBeInTheDocument();
   });
 
   it('renders generate tab content by default', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(false);
+    mockUseGenAiUserPermission.mockReturnValue(false);
     renderPage();
     expect(screen.getByTestId('generate-tab-content')).toBeInTheDocument();
   });
 
   it('switches to documents tab when Dokumenty is clicked', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(false);
+    mockUseGenAiUserPermission.mockReturnValue(false);
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Dokumenty' }));
     expect(screen.getByTestId('documents-tab-content')).toBeInTheDocument();
@@ -75,21 +75,21 @@ describe('LeafletGeneratorPage', () => {
   });
 
   it('passes canDelete=false to documents tab when user cannot upload', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(false);
+    mockUseGenAiUserPermission.mockReturnValue(false);
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Dokumenty' }));
     expect(screen.getByTestId('documents-tab-content')).toHaveTextContent('canDelete=false');
   });
 
   it('passes canDelete=true to documents tab when user can upload', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(true);
+    mockUseGenAiUserPermission.mockReturnValue(true);
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Dokumenty' }));
     expect(screen.getByTestId('documents-tab-content')).toHaveTextContent('canDelete=true');
   });
 
   it('switches to upload tab when Nahrát soubor is clicked', () => {
-    mockUseLeafletUploadPermission.mockReturnValue(true);
+    mockUseGenAiUserPermission.mockReturnValue(true);
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Nahrát soubor' }));
     expect(screen.getByTestId('upload-tab-content')).toBeInTheDocument();

--- a/frontend/src/pages/MarketingFeedbackPage.tsx
+++ b/frontend/src/pages/MarketingFeedbackPage.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { MessageSquare } from 'lucide-react';
 import { useKnowledgeBaseUploadPermission } from '../api/hooks/useKnowledgeBase';
-import { useLeafletUploadPermission } from '../api/hooks/useLeaflet';
-import { useArticleGeneratorPermission } from '../api/hooks/useArticles';
+import { useGenAiUserPermission } from '../api/hooks/useGenAiUserPermission';
 import { useKbFeedbackAdapter } from '../components/feedback/adapters/useKbFeedbackAdapter';
 import { useLeafletFeedbackAdapter } from '../components/feedback/adapters/useLeafletFeedbackAdapter';
 import { useArticleFeedbackAdapter } from '../components/feedback/adapters/useArticleFeedbackAdapter';
@@ -45,8 +44,7 @@ const SECONDARY_LABELS: Record<FeatureTab, string> = {
 
 const MarketingFeedbackPage: React.FC = () => {
   const hasKb = useKnowledgeBaseUploadPermission();
-  const hasLeaflet = useLeafletUploadPermission();
-  const hasArticle = useArticleGeneratorPermission();
+  const hasGenAi = useGenAiUserPermission();
 
   const [activeTab, setActiveTab] = useState<FeatureTab>('kb');
   const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
@@ -58,7 +56,7 @@ const MarketingFeedbackPage: React.FC = () => {
   const leaflet = useLeafletFeedbackAdapter(leafletParams);
   const article = useArticleFeedbackAdapter(articleParams);
 
-  if (!hasKb && !hasLeaflet && !hasArticle) {
+  if (!hasKb && !hasGenAi) {
     return <div className="p-6 text-sm text-gray-500">Přístup odepřen.</div>;
   }
 

--- a/frontend/src/pages/__tests__/MarketingFeedbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/MarketingFeedbackPage.test.tsx
@@ -90,6 +90,15 @@ test('switching tabs resets selected row', () => {
   expect(screen.queryByText('Detail záznamu')).not.toBeInTheDocument();
 });
 
+test('allows access when user has only GenAI role', () => {
+  setupMocks({ hasKb: false, hasGenAi: true });
+  render(<MarketingFeedbackPage />);
+  expect(screen.getByRole('button', { name: /poradenství/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /letáky/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /články/i })).toBeInTheDocument();
+  expect(screen.queryByText('Přístup odepřen.')).not.toBeInTheDocument();
+});
+
 test('shows access denied when user has no roles', () => {
   setupMocks({ hasKb: false, hasGenAi: false });
   render(<MarketingFeedbackPage />);

--- a/frontend/src/pages/__tests__/MarketingFeedbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/MarketingFeedbackPage.test.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import MarketingFeedbackPage from '../MarketingFeedbackPage';
 import * as kbHooks from '../../api/hooks/useKnowledgeBase';
-import * as leafletHooks from '../../api/hooks/useLeaflet';
-import * as articleHooks from '../../api/hooks/useArticles';
+import * as genAiHooks from '../../api/hooks/useGenAiUserPermission';
 import * as kbAdapter from '../../components/feedback/adapters/useKbFeedbackAdapter';
 import * as leafletAdapter from '../../components/feedback/adapters/useLeafletFeedbackAdapter';
 import * as articleAdapter from '../../components/feedback/adapters/useArticleFeedbackAdapter';
 import type { FeedbackDetail, GenericFeedbackStats } from '../../components/feedback/types';
 
 jest.mock('../../api/hooks/useKnowledgeBase');
-jest.mock('../../api/hooks/useLeaflet');
-jest.mock('../../api/hooks/useArticles');
+jest.mock('../../api/hooks/useGenAiUserPermission');
 jest.mock('../../components/feedback/adapters/useKbFeedbackAdapter');
 jest.mock('../../components/feedback/adapters/useLeafletFeedbackAdapter');
 jest.mock('../../components/feedback/adapters/useArticleFeedbackAdapter');
@@ -42,12 +40,10 @@ const leafletRow: FeedbackDetail = {
 
 function setupMocks({
   hasKb = true,
-  hasLeaflet = false,
-  hasArticle = false,
-}: { hasKb?: boolean; hasLeaflet?: boolean; hasArticle?: boolean } = {}) {
+  hasGenAi = false,
+}: { hasKb?: boolean; hasGenAi?: boolean } = {}) {
   jest.spyOn(kbHooks, 'useKnowledgeBaseUploadPermission').mockReturnValue(hasKb);
-  jest.spyOn(leafletHooks, 'useLeafletUploadPermission').mockReturnValue(hasLeaflet);
-  jest.spyOn(articleHooks, 'useArticleGeneratorPermission').mockReturnValue(hasArticle);
+  jest.spyOn(genAiHooks, 'useGenAiUserPermission').mockReturnValue(hasGenAi);
 
   jest.spyOn(kbAdapter, 'useKbFeedbackAdapter').mockReturnValue({
     ...emptyAdapterResult,
@@ -95,7 +91,7 @@ test('switching tabs resets selected row', () => {
 });
 
 test('shows access denied when user has no roles', () => {
-  setupMocks({ hasKb: false, hasLeaflet: false, hasArticle: false });
+  setupMocks({ hasKb: false, hasGenAi: false });
   render(<MarketingFeedbackPage />);
   expect(screen.getByText('Přístup odepřen.')).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: /poradenství/i })).not.toBeInTheDocument();

--- a/frontend/test/e2e/leaflet-generator/leaflet-doc-management.spec.ts
+++ b/frontend/test/e2e/leaflet-generator/leaflet-doc-management.spec.ts
@@ -10,7 +10,7 @@ const LEAFLET_GENERATOR_PATH = '/leaflet-generator';
  *
  * These tests verify the tabbed UI for leaflet document management:
  * - Dokumenty tab shows the document table
- * - Nahrát soubor tab (leaflet_manager only) allows file upload and subsequent
+ * - Nahrát soubor tab (genai_user only) allows file upload and subsequent
  *   document appearance and deletion in Dokumenty tab
  */
 test.describe('Leaflet document management', () => {
@@ -46,13 +46,13 @@ test.describe('Leaflet document management', () => {
 });
 
 /**
- * Upload flow tests require a user with the `leaflet_manager` role.
+ * Upload flow tests require a user with the `genai_user` role.
  * The E2E test user is a service principal that does not have this role,
  * so these tests cannot run against staging with the current credentials.
- * To enable: provision a test user account with `leaflet_manager` role
+ * To enable: provision a test user account with `genai_user` role
  * and configure separate E2E credentials for it.
  */
-test.describe.skip('Leaflet upload flow (requires leaflet_manager role)', () => {
+test.describe.skip('Leaflet upload flow (requires genai_user role)', () => {
   test.beforeEach(async ({ page }) => {
     await navigateToApp(page);
     const baseUrl =
@@ -64,7 +64,7 @@ test.describe.skip('Leaflet upload flow (requires leaflet_manager role)', () => 
     await waitForLoadingComplete(page);
   });
 
-  test('upload tab is visible for leaflet_manager users', async ({ page }) => {
+  test('upload tab is visible for genai_user users', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'Nahrát soubor' })).toBeVisible({ timeout: 10_000 });
   });
 


### PR DESCRIPTION
## Summary

- Introduces a single `genai_user` Azure AD role that gates all generative AI features (leaflet generation, article generation, and their management/feedback endpoints)
- Removes the two feature-specific roles `leaflet_manager` and `article_generator` along with their `LeafletUpload` and `ArticleGenerator` policies
- Tightens `POST /api/leaflet/generate` which was previously accessible to any authenticated `heblo_user` — it now requires `genai_user`
- Consolidates the frontend from two permission hooks into a single `useGenAiUserPermission` hook

## Changes

**Backend**
- `AuthorizationConstants.cs`: removed `LeafletManager` + `ArticleGenerator` roles/policies; added `GenAiUser` role + policy
- `AuthenticationExtensions.cs`: replaced two `AddPolicy` blocks with single `GenAiUser` policy
- `LeafletController.cs`: added `genai_user` gate to `POST /generate`; migrated 3 existing endpoints from `LeafletUpload` → `GenAiUser`
- `ArticlesController.cs`: migrated 2 endpoints from `ArticleGenerator` → `GenAiUser`

**Frontend**
- New `useGenAiUserPermission.ts` hook (single source of truth)
- Removed `useLeafletUploadPermission` from `useLeaflet.ts` and `useArticleGeneratorPermission` from `useArticles.ts`
- Updated `ArticleGenerationForm`, `LeafletGeneratorPage`, `MarketingFeedbackPage`, `Sidebar`
- Mock auth seed updated to include `genai_user`

**Tests & Docs**
- 3 unit test files updated; 1 E2E spec updated; 1 new test added for `genai_user`-only access path
- Feature docs updated: `article-generation.md`, `leaflet-generator.md`, `2026-04-30-leaflet-generator-design.md`

## ⚠️ Azure AD migration required (manual, before deploy)

1. Add App Role `genai_user` in Azure AD (Anela.Heblo app registration)
2. Assign users currently in `leaflet_manager` or `article_generator` roles to `genai_user`
3. After deployment verified: remove the orphaned `leaflet_manager` and `article_generator` App Roles

> **Deployment order matters:** Azure AD role migration should happen BEFORE deploying this code to avoid 403s for existing users.

## Test Plan

- [ ] `dotnet build` passes (0 errors)
- [ ] `npm test` passes (1121 tests, 120 suites)
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Manual: mock user (has `genai_user`) can generate leaflets and articles, upload/delete leaflet docs, and access Marketing → Feedback
- [ ] Manual: user without `genai_user` gets 403 on protected endpoints; generate forms hidden in UI

@claude