### PR TITLE
feat: auto-apply EF Core migrations on Production startup

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using HealthChecks.UI.Client;
 using Anela.Heblo.Domain.Features.Configuration;
@@ -7,6 +8,8 @@ using Microsoft.AspNetCore.HttpLogging;
 using Anela.Heblo.API.Infrastructure.Authentication;
 using Anela.Heblo.API.MCP;
 using ModelContextProtocol.AspNetCore;
+using Microsoft.EntityFrameworkCore;
+using Anela.Heblo.Persistence;
 
 namespace Anela.Heblo.API.Extensions;
 
@@ -268,6 +271,50 @@ public static class ApplicationBuilderExtensions
         }
 
         return app;
+    }
+
+    /// <summary>
+    /// Applies any pending EF Core migrations to the database.
+    /// Should only be called in Production; other environments use <c>dotnet ef database update</c>.
+    /// Fails fast (rethrows) on error so the app does not start with an out-of-date schema.
+    /// </summary>
+    public static async Task MigrateDatabaseAsync(this WebApplication app)
+    {
+        var logger = app.Services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("DatabaseMigration");
+
+        try
+        {
+            using var scope = app.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var pending = (await db.Database.GetPendingMigrationsAsync()).ToList();
+
+            if (pending.Count == 0)
+            {
+                logger.LogInformation("Database schema is up to date; no pending migrations.");
+                return;
+            }
+
+            foreach (var migration in pending)
+            {
+                logger.LogInformation("Pending migration: {MigrationName}", migration);
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            await db.Database.MigrateAsync();
+            stopwatch.Stop();
+
+            logger.LogInformation(
+                "Applied {Count} migration(s) in {Elapsed} ms.",
+                pending.Count,
+                stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "Database migration failed.");
+            throw;
+        }
     }
 
     /// <summary>

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -109,10 +109,15 @@ public partial class Program
         // Initialize tile registry with all registered tiles
         app.InitializeTileRegistry();
 
-        // Seed default recurring job configurations from discovered IRecurringJob implementations
-        // Note: Database creation and migrations are handled automatically by EF Core during first connection
-        // This seeding runs after app.Build() to ensure the DI container is ready, but before pipeline
-        // configuration and Hangfire startup. This guarantees job configurations exist before recurring jobs start.
+        // Apply pending EF Core migrations in Production only.
+        // Other environments (Dev/Test/Staging/Automation) keep the manual `dotnet ef database update` workflow.
+        if (app.Environment.IsProduction())
+        {
+            await app.MigrateDatabaseAsync();
+        }
+
+        // Seed default recurring job configurations from discovered IRecurringJob implementations.
+        // Runs before pipeline configuration and Hangfire startup to guarantee job configurations exist before recurring jobs start.
         await app.SeedRecurringJobConfigurationsAsync();
 
         // Configure pipeline

--- a/docs/architecture/cicd.md
+++ b/docs/architecture/cicd.md
@@ -317,7 +317,7 @@ graph TD
 ## ⚠️ Important Notes
 
 1. **CI Validation**: Deployment workflows no longer wait for CI to pass by default
-2. **Manual Database Migrations**: EF Core migrations are not part of automated deployment
+2. **Database Migrations**: Migrations apply automatically on Production startup (`MigrateDatabaseAsync` runs when `app.Environment.IsProduction()`). Development, Test, and Staging environments still require manual `dotnet ef database update`.
 3. **AI Code Reviews**: PRs reviewed by AI agent for solo developer workflow
 4. **Container Ports**: Internal port 80, Azure maps to 443 (HTTPS)
 5. **Static Files**: Served by ASP.NET Core in production, React dev server in development

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -93,7 +93,7 @@ Development:           Production/Test:
 - Migrations are stored in `backend/src/Anela.Heblo.Persistence/Migrations/`.
 - Single `ApplicationDbContext` in `Anela.Heblo.Persistence` (initially).
 - Migration naming convention: `AddXyzTable`, `AddIndexToProductName`, etc.
-- **Migrations are applied manually** – not part of automated CI/CD.
+- **Migrations apply automatically on Production startup; Development, Test, and Staging remain manual.**
 - Future evolution: Can move to module-specific DbContexts as needed.
 
 ### Applied Migrations

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -272,7 +272,8 @@ dotnet ef database update --project backend/src/Anela.Heblo.Persistence --startu
 dotnet test
 
 # 6. Commit migration files to git
-# Note: Migrations are applied manually in staging/production (not automated)
+# Note: Migrations are applied manually in Development/Test/Staging.
+#       In Production, migrations are applied automatically at app startup.
 ```
 
 ### Generating API Client
@@ -422,17 +423,24 @@ E2E_BASE_URL=https://heblo.stg.anela.cz
 
 ## Database Migrations Runbook
 
-Database migrations in this project are **manual**. They are not applied by the deployment pipeline. Code that depends on a new migration MUST NOT be deployed before the migration is applied to the target environment, or the application will return HTTP 500 with `Npgsql.PostgresException: 42P01: relation "<table>" does not exist`.
+Database migrations are applied differently depending on environment:
 
-### Pre-deploy checklist
+- **Production**: Migrations are applied **automatically at app startup** via `MigrateDatabaseAsync`. No manual step is required. The app will apply any pending migrations before accepting traffic.
+- **Development / Test / Staging**: Migrations remain **manual**. They are not applied by the deployment pipeline. Code that depends on a new migration MUST NOT be deployed before the migration is applied to the target environment, or the application will return HTTP 500 with `Npgsql.PostgresException: 42P01: relation "<table>" does not exist`.
 
-Before merging or deploying code that introduces or depends on a new EF Core migration:
+> **Developer dry-run tool**: `scripts/migration-dryrun.sh` is still useful as a local preview of what SQL EF Core would generate. It is no longer a production deploy gate — it is a developer convenience.
+
+### Pre-deploy checklist (Development / Test / Staging)
+
+Before merging or deploying code that introduces or depends on a new EF Core migration to a non-Production environment:
 
 1. Identify the migration(s) the new code depends on (look at `backend/src/Anela.Heblo.Persistence/Migrations/` and `dotnet ef migrations list`).
 2. Connect to the target environment's database using your authorized read-only credentials. Do NOT embed credentials in source control or scripts.
 3. Run the diagnostic SQL pair below (substitute the `LIKE` patterns and table names for the migration in question).
 4. Confirm the migration ID is present in `__EFMigrationsHistory` AND the expected post-migration physical schema is in place.
-5. If the migration is missing, apply it via the project's standard manual migration procedure BEFORE rolling out the dependent application code.
+5. If the migration is missing, apply it via `dotnet ef database update` BEFORE rolling out the dependent application code.
+
+For Production, skip steps 2–5 — the application handles migration automatically on startup.
 
 ### Post-deploy verification
 

--- a/docs/features/knowledge-base-rag.md
+++ b/docs/features/knowledge-base-rag.md
@@ -435,7 +435,7 @@ When `UseMockAuth=true` or `BypassJwtValidation=true`, `MockOneDriveService` is 
 | `20260302163014_AddKnowledgeBase` | 2026-03-02 | Creates `KnowledgeBaseDocuments` and `KnowledgeBaseChunks` tables, enables `vector` extension, adds `Embedding vector(1536)` column via raw SQL, creates HNSW index |
 | `20260306192831_AddContentHashToKnowledgeBaseDocument` | 2026-03-06 | Adds `ContentHash varchar(64)` column with UNIQUE index to `KnowledgeBaseDocuments` |
 
-> **Note:** Migrations are applied manually (not automated in deployment), consistent with the rest of the project.
+> **Note:** Migrations apply automatically on Production startup; Development, Test, and Staging remain manual.
 
 ---
 


### PR DESCRIPTION
## Summary

- Added `MigrateDatabaseAsync` extension method that calls `db.Database.MigrateAsync()` at app startup — only when `app.Environment.IsProduction()`
- Wired the call in `Program.cs` before `SeedRecurringJobConfigurationsAsync`, so seeding always runs against an up-to-date schema
- Removed the misleading comment that claimed migrations were applied automatically (they weren't)
- Updated four documentation files to reflect the new behavior: Production auto-applies, Dev/Test/Staging remain manual

## Behavior

- **No pending migrations:** logs `"Database schema is up to date; no pending migrations."` and continues startup normally
- **Pending migrations found:** logs each migration name, applies them, logs count + elapsed ms
- **Migration failure:** logs `Critical` with full exception (stack trace preserved) and rethrows — app fails to start, CI smoke test catches it

## Test Plan

- [x] 2780 unit tests pass, 0 failures (`Automation` env → `IsProduction()` is false, test fixtures unaffected)
- [ ] Verify `dotnet build` is clean (0 errors)
- [ ] Smoke locally with `ASPNETCORE_ENVIRONMENT=Production` against a fresh DB: confirm migration log lines appear, app reaches `/health/live`
- [ ] Second startup against same DB: confirm "up to date" log, no migrations re-applied
- [ ] Confirm staging Web App env variable is **not** `Production` (if it is, decide whether to change it to `Staging` before merge)