### PR TITLE
feat(photobank): GitHub-style colored tags + tile overlay toggle

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
@@ -1,11 +1,19 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.CreateAllocation;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeleteAllocation;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetAllocations;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetDailyConsumptionBreakdown;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.ProcessDailyConsumption;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdateAllocation;
 using Anela.Heblo.API.Infrastructure;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Globalization;
 
 namespace Anela.Heblo.API.Controllers;
 
@@ -113,6 +121,24 @@ public class PackingMaterialsController : BaseApiController
         return Ok(response);
     }
 
+    [HttpGet("consumption")]
+    [ProducesResponseType(typeof(GetDailyConsumptionBreakdownResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<GetDailyConsumptionBreakdownResponse>> GetDailyConsumptionBreakdown(
+        [FromQuery] string? date,
+        [FromQuery] string groupBy = "material",
+        CancellationToken cancellationToken = default)
+    {
+        if (!DateOnly.TryParseExact(date, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
+        {
+            return BadRequest(new { error = "Invalid date format. Expected yyyy-MM-dd." });
+        }
+
+        var request = new GetDailyConsumptionBreakdownRequest { Date = parsedDate, GroupBy = groupBy };
+        var response = await _mediator.Send(request, cancellationToken);
+        return response.Success ? Ok(response) : BadRequest(new { error = response.Error });
+    }
+
     [HttpGet("{id}/logs")]
     public async Task<ActionResult<GetPackingMaterialLogsResponse>> GetPackingMaterialLogs(
         int id,
@@ -127,5 +153,84 @@ public class PackingMaterialsController : BaseApiController
 
         var response = await _mediator.Send(request, cancellationToken);
         return Ok(response);
+    }
+
+    [HttpGet("{id}/allocations")]
+    [ProducesResponseType(typeof(GetAllocationsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<GetAllocationsResponse>> GetAllocations(
+        int id,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new GetAllocationsRequest { PackingMaterialId = id };
+        var response = await _mediator.Send(request, cancellationToken);
+        if (response.Success) return Ok(response);
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
+    }
+
+    [HttpPost("{id}/allocations")]
+    [ProducesResponseType(typeof(CreateAllocationResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<CreateAllocationResponse>> CreateAllocation(
+        int id,
+        [FromBody] CreateAllocationRequestBody body,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new CreateAllocationRequest
+        {
+            PackingMaterialId = id,
+            ProductCode = body.ProductCode,
+            AmountPerUnit = body.AmountPerUnit
+        };
+
+        var response = await _mediator.Send(request, cancellationToken);
+        if (!response.Success)
+        {
+            if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+            return BadRequest(new { error = response.Error });
+        }
+
+        return CreatedAtAction(nameof(GetAllocations), new { id }, response);
+    }
+
+    [HttpPut("{id}/allocations/{allocationId}")]
+    [ProducesResponseType(typeof(UpdateAllocationResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UpdateAllocationResponse>> UpdateAllocation(
+        int id,
+        int allocationId,
+        [FromBody] UpdateAllocationRequestBody body,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new UpdateAllocationRequest
+        {
+            PackingMaterialId = id,
+            AllocationId = allocationId,
+            ProductCode = body.ProductCode,
+            AmountPerUnit = body.AmountPerUnit
+        };
+
+        var response = await _mediator.Send(request, cancellationToken);
+        if (response.Success) return Ok(response);
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
+    }
+
+    [HttpDelete("{id}/allocations/{allocationId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<DeleteAllocationResponse>> DeleteAllocation(
+        int id,
+        int allocationId,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new DeleteAllocationRequest { PackingMaterialId = id, AllocationId = allocationId };
+        var response = await _mediator.Send(request, cancellationToken);
+        if (response.Success) return NoContent();
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
     }
 }

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -54,6 +54,7 @@ namespace Anela.Heblo.API.Controllers
             [FromQuery] List<string>? tags,
             [FromQuery] string? search,
             [FromQuery] string? folderPath,
+            [FromQuery] bool withoutTags = false,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 48,
             CancellationToken cancellationToken = default)
@@ -63,6 +64,7 @@ namespace Anela.Heblo.API.Controllers
                 Tags = tags,
                 Search = search,
                 FolderPath = folderPath,
+                WithoutTags = withoutTags,
                 Page = page,
                 PageSize = pageSize,
             };

--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using HealthChecks.UI.Client;
 using Anela.Heblo.Domain.Features.Configuration;
@@ -7,6 +8,8 @@ using Microsoft.AspNetCore.HttpLogging;
 using Anela.Heblo.API.Infrastructure.Authentication;
 using Anela.Heblo.API.MCP;
 using ModelContextProtocol.AspNetCore;
+using Microsoft.EntityFrameworkCore;
+using Anela.Heblo.Persistence;
 
 namespace Anela.Heblo.API.Extensions;
 
@@ -268,6 +271,50 @@ public static class ApplicationBuilderExtensions
         }
 
         return app;
+    }
+
+    /// <summary>
+    /// Applies any pending EF Core migrations to the database.
+    /// Should only be called in Production; other environments use <c>dotnet ef database update</c>.
+    /// Fails fast (rethrows) on error so the app does not start with an out-of-date schema.
+    /// </summary>
+    public static async Task MigrateDatabaseAsync(this WebApplication app)
+    {
+        var logger = app.Services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("DatabaseMigration");
+
+        try
+        {
+            using var scope = app.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var pending = (await db.Database.GetPendingMigrationsAsync()).ToList();
+
+            if (pending.Count == 0)
+            {
+                logger.LogInformation("Database schema is up to date; no pending migrations.");
+                return;
+            }
+
+            foreach (var migration in pending)
+            {
+                logger.LogInformation("Pending migration: {MigrationName}", migration);
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            await db.Database.MigrateAsync();
+            stopwatch.Stop();
+
+            logger.LogInformation(
+                "Applied {Count} migration(s) in {Elapsed} ms.",
+                pending.Count,
+                stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "Database migration failed.");
+            throw;
+        }
     }
 
     /// <summary>

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -109,10 +109,15 @@ public partial class Program
         // Initialize tile registry with all registered tiles
         app.InitializeTileRegistry();
 
-        // Seed default recurring job configurations from discovered IRecurringJob implementations
-        // Note: Database creation and migrations are handled automatically by EF Core during first connection
-        // This seeding runs after app.Build() to ensure the DI container is ready, but before pipeline
-        // configuration and Hangfire startup. This guarantees job configurations exist before recurring jobs start.
+        // Apply pending EF Core migrations in Production only.
+        // Other environments (Dev/Test/Staging/Automation) keep the manual `dotnet ef database update` workflow.
+        if (app.Environment.IsProduction())
+        {
+            await app.MigrateDatabaseAsync();
+        }
+
+        // Seed default recurring job configurations from discovered IRecurringJob implementations.
+        // Runs before pipeline configuration and Hangfire startup to guarantee job configurations exist before recurring jobs start.
         await app.SeedRecurringJobConfigurationsAsync();
 
         // Configure pipeline

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/ConsumptionDetailDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/ConsumptionDetailDto.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class ConsumptionDetailDto
+{
+    public string Key { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/ConsumptionGroupDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/ConsumptionGroupDto.cs
@@ -1,0 +1,10 @@
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class ConsumptionGroupDto
+{
+    public string Key { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public decimal TotalAmount { get; set; }
+    public int RowCount { get; set; }
+    public List<ConsumptionDetailDto> Details { get; set; } = new();
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/CreateAllocationRequestBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/CreateAllocationRequestBody.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class CreateAllocationRequestBody
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public decimal AmountPerUnit { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialAllocationDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialAllocationDto.cs
@@ -1,0 +1,10 @@
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class PackingMaterialAllocationDto
+{
+    public int Id { get; set; }
+    public int PackingMaterialId { get; set; }
+    public string ProductCode { get; set; } = null!;
+    public decimal AmountPerUnit { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdateAllocationRequestBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdateAllocationRequestBody.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class UpdateAllocationRequestBody
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public decimal AmountPerUnit { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/PackingMaterialsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/PackingMaterialsModule.cs
@@ -12,8 +12,10 @@ public static class PackingMaterialsModule
     {
         // Register repositories
         services.AddScoped<IPackingMaterialRepository, PackingMaterialRepository>();
+        services.AddScoped<IPackingMaterialAllocationRepository, PackingMaterialAllocationRepository>();
 
         // Register services
+        // Note: ConsumptionCalculationService depends on IIssuedInvoiceRepository, which is registered by InvoicesModule
         services.AddScoped<IConsumptionCalculationService, ConsumptionCalculationService>();
 
         // Register Hangfire jobs

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Services/ConsumptionCalculationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Services/ConsumptionCalculationService.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Domain.Features.Invoices;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
 using Microsoft.Extensions.Logging;
@@ -7,91 +8,73 @@ namespace Anela.Heblo.Application.Features.PackingMaterials.Services;
 public class ConsumptionCalculationService : IConsumptionCalculationService
 {
     private readonly IPackingMaterialRepository _repository;
+    private readonly IIssuedInvoiceRepository _invoiceRepository;
     private readonly ILogger<ConsumptionCalculationService> _logger;
 
     public ConsumptionCalculationService(
         IPackingMaterialRepository repository,
+        IIssuedInvoiceRepository invoiceRepository,
         ILogger<ConsumptionCalculationService> logger)
     {
         _repository = repository;
+        _invoiceRepository = invoiceRepository;
         _logger = logger;
-    }
-
-    public Task<decimal> CalculateConsumptionAsync(
-        PackingMaterial material,
-        int orderCount,
-        int productCount)
-    {
-        var consumption = material.ConsumptionType switch
-        {
-            ConsumptionType.PerOrder => material.ConsumptionRate * orderCount,
-            ConsumptionType.PerProduct => material.ConsumptionRate * productCount,
-            ConsumptionType.PerDay => material.ConsumptionRate, // Fixed amount per day
-            _ => throw new ArgumentOutOfRangeException(nameof(material.ConsumptionType))
-        };
-
-        _logger.LogDebug("Calculated consumption for material {MaterialId} ({MaterialName}): {Consumption} (Type: {Type}, Rate: {Rate}, Orders: {Orders}, Products: {Products})",
-            material.Id, material.Name, consumption, material.ConsumptionType, material.ConsumptionRate, orderCount, productCount);
-
-        return Task.FromResult(consumption);
     }
 
     public async Task<ProcessDailyConsumptionResult> ProcessDailyConsumptionAsync(
         DateOnly processingDate,
-        int orderCount,
-        int productCount,
         CancellationToken cancellationToken = default)
     {
-        // Check if day already processed to prevent duplicates
         if (await HasDayAlreadyBeenProcessedAsync(processingDate, cancellationToken))
         {
             _logger.LogInformation("Daily consumption processing for {Date} already completed, skipping", processingDate);
             return new ProcessDailyConsumptionResult(false, 0);
         }
 
-        _logger.LogInformation("Starting daily consumption processing for {Date} with {OrderCount} orders and {ProductCount} products",
-            processingDate, orderCount, productCount);
+        _logger.LogInformation("Starting daily consumption processing for {Date}", processingDate);
 
-        var materials = await _repository.GetAllAsync(cancellationToken);
-        var materialList = materials.ToList();
+        var materials = (await _repository.GetAllWithAllocationsAsync(cancellationToken)).ToList();
+        var invoices = (await _invoiceRepository.GetHeadersByDateAsync(processingDate, cancellationToken)).ToList();
+
+        var allFactRows = new List<PackingMaterialConsumption>();
+        var decrementByMaterial = new Dictionary<PackingMaterial, decimal>();
+
         var processedCount = 0;
 
-        foreach (var material in materialList)
+        foreach (var material in materials)
         {
-            try
-            {
-                var consumptionAmount = await CalculateConsumptionAsync(material, orderCount, productCount);
+            var rows = BuildFactRows(material, invoices, processingDate);
+            var total = rows.Sum(r => r.Amount);
 
-                if (consumptionAmount > 0)
-                {
-                    var newQuantity = Math.Max(0, material.CurrentQuantity - consumptionAmount);
-                    material.UpdateQuantity(newQuantity, processingDate, LogEntryType.AutomaticConsumption);
-                    await _repository.UpdateAsync(material, cancellationToken);
-                    processedCount++;
-
-                    _logger.LogInformation("Processed material {MaterialName}: consumed {Consumption}, new quantity: {NewQuantity}",
-                        material.Name, consumptionAmount, newQuantity);
-                }
-                else
-                {
-                    _logger.LogDebug("Skipping material {MaterialName}: no consumption calculated", material.Name);
-                }
-            }
-            catch (Exception ex)
+            if (total > 0)
             {
-                _logger.LogError(ex, "Error processing material {MaterialId} ({MaterialName}) for date {Date}",
-                    material.Id, material.Name, processingDate);
+                allFactRows.AddRange(rows);
+                decrementByMaterial[material] = total;
+                processedCount++;
             }
         }
 
-        // Write an idempotency marker even when no materials had consumption,
-        // so re-runs on the same date are blocked regardless of invoice data.
-        if (processedCount == 0 && materialList.Count > 0)
+        foreach (var material in materials)
         {
-            var marker = materialList[0];
+            if (decrementByMaterial.TryGetValue(material, out var decrement))
+            {
+                var newQuantity = Math.Max(0, material.CurrentQuantity - decrement);
+                material.UpdateQuantity(newQuantity, processingDate, LogEntryType.AutomaticConsumption);
+
+                _logger.LogInformation("Processed material {MaterialName}: consumed {Consumption}, new quantity: {NewQuantity}",
+                    material.Name, decrement, newQuantity);
+            }
+        }
+
+        // Relies on EF change tracking — GetAllWithAllocationsAsync must NOT use AsNoTracking
+        if (processedCount == 0 && materials.Count > 0)
+        {
+            var marker = materials[0];
             marker.UpdateQuantity(marker.CurrentQuantity, processingDate, LogEntryType.AutomaticConsumption);
-            await _repository.UpdateAsync(marker, cancellationToken);
         }
+
+        if (allFactRows.Count > 0)
+            await _repository.AddConsumptionRowsAsync(allFactRows, cancellationToken);
 
         await _repository.SaveChangesAsync(cancellationToken);
 
@@ -106,5 +89,29 @@ public class ConsumptionCalculationService : IConsumptionCalculationService
         CancellationToken cancellationToken = default)
     {
         return await _repository.HasDailyProcessingBeenRunAsync(date, cancellationToken);
+    }
+
+    private static List<PackingMaterialConsumption> BuildFactRows(
+        PackingMaterial material,
+        List<IssuedInvoice> invoices,
+        DateOnly date)
+    {
+        return material.ConsumptionType switch
+        {
+            ConsumptionType.PerDay => new List<PackingMaterialConsumption>
+            {
+                new PackingMaterialConsumption(material.Id, date, ConsumptionType.PerDay, material.ConsumptionRate)
+            },
+            ConsumptionType.PerOrder => invoices
+                .Select(inv => new PackingMaterialConsumption(
+                    material.Id, date, ConsumptionType.PerOrder, material.ConsumptionRate, inv.Id))
+                .ToList(),
+            ConsumptionType.PerProduct => invoices
+                .Select(inv => new PackingMaterialConsumption(
+                    material.Id, date, ConsumptionType.PerProduct, material.ConsumptionRate * inv.ItemsCount, inv.Id))
+                .Where(r => r.Amount > 0)
+                .ToList(),
+            _ => throw new ArgumentOutOfRangeException(nameof(material.ConsumptionType))
+        };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Services/IConsumptionCalculationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Services/IConsumptionCalculationService.cs
@@ -1,18 +1,9 @@
-using Anela.Heblo.Domain.Features.PackingMaterials;
-
 namespace Anela.Heblo.Application.Features.PackingMaterials.Services;
 
 public interface IConsumptionCalculationService
 {
-    Task<decimal> CalculateConsumptionAsync(
-        PackingMaterial material,
-        int orderCount,
-        int productCount);
-
     Task<ProcessDailyConsumptionResult> ProcessDailyConsumptionAsync(
         DateOnly processingDate,
-        int orderCount,
-        int productCount,
         CancellationToken cancellationToken = default);
 
     Task<bool> HasDayAlreadyBeenProcessedAsync(

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationHandler.cs
@@ -1,0 +1,65 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.CreateAllocation;
+
+public class CreateAllocationHandler : IRequestHandler<CreateAllocationRequest, CreateAllocationResponse>
+{
+    private readonly IPackingMaterialRepository _materialRepository;
+    private readonly IPackingMaterialAllocationRepository _allocationRepository;
+    private readonly ILogger<CreateAllocationHandler> _logger;
+
+    public CreateAllocationHandler(
+        IPackingMaterialRepository materialRepository,
+        IPackingMaterialAllocationRepository allocationRepository,
+        ILogger<CreateAllocationHandler> logger)
+    {
+        _materialRepository = materialRepository;
+        _allocationRepository = allocationRepository;
+        _logger = logger;
+    }
+
+    public async Task<CreateAllocationResponse> Handle(CreateAllocationRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (request.AmountPerUnit <= 0)
+                return new CreateAllocationResponse { Success = false, Error = "AmountPerUnit must be greater than zero." };
+
+            if (string.IsNullOrWhiteSpace(request.ProductCode))
+                return new CreateAllocationResponse { Success = false, Error = "ProductCode must not be empty." };
+
+            var material = await _materialRepository.GetByIdWithAllocationsAsync(request.PackingMaterialId, cancellationToken);
+
+            if (material == null)
+                return new CreateAllocationResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = $"Packing material with ID {request.PackingMaterialId} not found." };
+
+            var duplicate = material.Allocations.Any(a => a.ProductCode == request.ProductCode);
+            if (duplicate)
+                return new CreateAllocationResponse { Success = false, Error = $"An allocation for product '{request.ProductCode}' already exists on this material." };
+
+            var allocation = new PackingMaterialAllocation(request.PackingMaterialId, request.ProductCode, request.AmountPerUnit);
+            var created = await _allocationRepository.AddAsync(allocation, cancellationToken);
+            await _allocationRepository.SaveChangesAsync(cancellationToken);
+
+            var dto = new PackingMaterialAllocationDto
+            {
+                Id = created.Id,
+                PackingMaterialId = created.PackingMaterialId,
+                ProductCode = created.ProductCode,
+                AmountPerUnit = created.AmountPerUnit,
+                CreatedAt = created.CreatedAt
+            };
+
+            return new CreateAllocationResponse { Success = true, Allocation = dto };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating allocation for packing material {PackingMaterialId}", request.PackingMaterialId);
+            return new CreateAllocationResponse { Success = false, Error = "An unexpected error occurred while creating the allocation." };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationRequest.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.CreateAllocation;
+
+public class CreateAllocationRequest : IRequest<CreateAllocationResponse>
+{
+    public int PackingMaterialId { get; set; }
+    public string ProductCode { get; set; } = null!;
+    public decimal AmountPerUnit { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationResponse.cs
@@ -1,0 +1,10 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.CreateAllocation;
+
+public class CreateAllocationResponse : BaseResponse
+{
+    public string? Error { get; set; }
+    public PackingMaterialAllocationDto? Allocation { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeleteAllocation/DeleteAllocationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeleteAllocation/DeleteAllocationHandler.cs
@@ -1,0 +1,48 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeleteAllocation;
+
+public class DeleteAllocationHandler : IRequestHandler<DeleteAllocationRequest, DeleteAllocationResponse>
+{
+    private readonly IPackingMaterialRepository _materialRepository;
+    private readonly IPackingMaterialAllocationRepository _allocationRepository;
+    private readonly ILogger<DeleteAllocationHandler> _logger;
+
+    public DeleteAllocationHandler(
+        IPackingMaterialRepository materialRepository,
+        IPackingMaterialAllocationRepository allocationRepository,
+        ILogger<DeleteAllocationHandler> logger)
+    {
+        _materialRepository = materialRepository;
+        _allocationRepository = allocationRepository;
+        _logger = logger;
+    }
+
+    public async Task<DeleteAllocationResponse> Handle(DeleteAllocationRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var material = await _materialRepository.GetByIdWithAllocationsAsync(request.PackingMaterialId, cancellationToken);
+
+            if (material == null)
+                return new DeleteAllocationResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = $"Packing material with ID {request.PackingMaterialId} not found." };
+
+            var allocation = material.Allocations.FirstOrDefault(a => a.Id == request.AllocationId);
+            if (allocation == null)
+                return new DeleteAllocationResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = $"Allocation with ID {request.AllocationId} not found on this material." };
+
+            await _allocationRepository.DeleteAsync(allocation, cancellationToken);
+            await _allocationRepository.SaveChangesAsync(cancellationToken);
+
+            return new DeleteAllocationResponse { Success = true };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting allocation {AllocationId} for packing material {PackingMaterialId}", request.AllocationId, request.PackingMaterialId);
+            return new DeleteAllocationResponse { Success = false, Error = "An unexpected error occurred while deleting the allocation." };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeleteAllocation/DeleteAllocationRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeleteAllocation/DeleteAllocationRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeleteAllocation;
+
+public class DeleteAllocationRequest : IRequest<DeleteAllocationResponse>
+{
+    public int PackingMaterialId { get; set; }
+    public int AllocationId { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeleteAllocation/DeleteAllocationResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeleteAllocation/DeleteAllocationResponse.cs
@@ -1,0 +1,8 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeleteAllocation;
+
+public class DeleteAllocationResponse : BaseResponse
+{
+    public string? Error { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsHandler.cs
@@ -1,0 +1,53 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetAllocations;
+
+public class GetAllocationsHandler : IRequestHandler<GetAllocationsRequest, GetAllocationsResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+    private readonly ILogger<GetAllocationsHandler> _logger;
+
+    public GetAllocationsHandler(IPackingMaterialRepository repository, ILogger<GetAllocationsHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<GetAllocationsResponse> Handle(GetAllocationsRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var material = await _repository.GetByIdWithAllocationsAsync(request.PackingMaterialId, cancellationToken);
+
+            if (material == null)
+            {
+                return new GetAllocationsResponse
+                {
+                    Success = false,
+                    ErrorCode = ErrorCodes.ResourceNotFound,
+                    Error = $"Packing material with ID {request.PackingMaterialId} not found."
+                };
+            }
+
+            var dtos = material.Allocations.Select(a => new PackingMaterialAllocationDto
+            {
+                Id = a.Id,
+                PackingMaterialId = a.PackingMaterialId,
+                ProductCode = a.ProductCode,
+                AmountPerUnit = a.AmountPerUnit,
+                CreatedAt = a.CreatedAt
+            }).ToList();
+
+            return new GetAllocationsResponse { Success = true, Allocations = dtos };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting allocations for packing material {PackingMaterialId}", request.PackingMaterialId);
+            return new GetAllocationsResponse { Success = false, Error = "An unexpected error occurred while retrieving the allocations." };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsRequest.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetAllocations;
+
+public class GetAllocationsRequest : IRequest<GetAllocationsResponse>
+{
+    public int PackingMaterialId { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsResponse.cs
@@ -1,0 +1,10 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetAllocations;
+
+public class GetAllocationsResponse : BaseResponse
+{
+    public string? Error { get; set; }
+    public List<PackingMaterialAllocationDto> Allocations { get; set; } = new();
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetDailyConsumptionBreakdown/GetDailyConsumptionBreakdownHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetDailyConsumptionBreakdown/GetDailyConsumptionBreakdownHandler.cs
@@ -1,0 +1,193 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetDailyConsumptionBreakdown;
+
+public class GetDailyConsumptionBreakdownHandler
+    : IRequestHandler<GetDailyConsumptionBreakdownRequest, GetDailyConsumptionBreakdownResponse>
+{
+    private static readonly HashSet<string> ValidGroupByValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "material", "product", "order"
+    };
+
+    private readonly IPackingMaterialRepository _repository;
+    private readonly ILogger<GetDailyConsumptionBreakdownHandler> _logger;
+
+    public GetDailyConsumptionBreakdownHandler(
+        IPackingMaterialRepository repository,
+        ILogger<GetDailyConsumptionBreakdownHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<GetDailyConsumptionBreakdownResponse> Handle(
+        GetDailyConsumptionBreakdownRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!ValidGroupByValues.Contains(request.GroupBy))
+        {
+            return new GetDailyConsumptionBreakdownResponse
+            {
+                Success = false,
+                Error = $"Invalid GroupBy value '{request.GroupBy}'. Must be one of: material, product, order.",
+                Date = request.Date,
+                GroupBy = request.GroupBy
+            };
+        }
+
+        try
+        {
+            _logger.LogInformation("Loading daily consumption breakdown for {Date} grouped by {GroupBy}", request.Date, request.GroupBy);
+
+            var consumptions = (await _repository.GetConsumptionsByDateAsync(request.Date, cancellationToken)).ToList();
+
+            if (consumptions.Count == 0)
+                return new GetDailyConsumptionBreakdownResponse { Success = true, Date = request.Date, GroupBy = request.GroupBy };
+
+            var materials = (await _repository.GetAllWithAllocationsAsync(cancellationToken)).ToList();
+
+            var groups = request.GroupBy.ToLowerInvariant() switch
+            {
+                "material" => BuildGroupByMaterial(consumptions, materials),
+                "product" => BuildGroupByProduct(consumptions, materials),
+                "order" => BuildGroupByOrder(consumptions, materials),
+                _ => throw new InvalidOperationException($"Unhandled GroupBy value: {request.GroupBy}")
+            };
+
+            return new GetDailyConsumptionBreakdownResponse
+            {
+                Success = true,
+                Date = request.Date,
+                GroupBy = request.GroupBy,
+                Groups = groups
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading daily consumption breakdown for {Date}", request.Date);
+
+            return new GetDailyConsumptionBreakdownResponse
+            {
+                Success = false,
+                Error = "An unexpected error occurred while loading the breakdown.",
+                Date = request.Date,
+                GroupBy = request.GroupBy
+            };
+        }
+    }
+
+    private static List<ConsumptionGroupDto> BuildGroupByMaterial(
+        List<PackingMaterialConsumption> consumptions,
+        List<PackingMaterial> materials)
+    {
+        var materialNameById = materials.ToDictionary(m => m.Id, m => m.Name);
+
+        return consumptions
+            .GroupBy(c => c.PackingMaterialId)
+            .Select(g =>
+            {
+                var materialName = materialNameById.TryGetValue(g.Key, out var name) ? name : "Unknown";
+                var details = g
+                    .Where(c => c.InvoiceId != null)
+                    .GroupBy(c => c.InvoiceId!)
+                    .Select(dg => new ConsumptionDetailDto
+                    {
+                        Key = dg.Key,
+                        Label = dg.Key,
+                        Amount = dg.Sum(c => c.Amount)
+                    })
+                    .ToList();
+
+                return new ConsumptionGroupDto
+                {
+                    Key = g.Key.ToString(),
+                    Label = materialName,
+                    TotalAmount = g.Sum(c => c.Amount),
+                    RowCount = g.Count(),
+                    Details = details
+                };
+            })
+            .OrderByDescending(g => g.TotalAmount)
+            .ToList();
+    }
+
+    private static List<ConsumptionGroupDto> BuildGroupByProduct(
+        List<PackingMaterialConsumption> consumptions,
+        List<PackingMaterial> materials)
+    {
+        var materialNameById = materials.ToDictionary(m => m.Id, m => m.Name);
+
+        return consumptions
+            .Where(c => c.ProductCode != null)
+            .GroupBy(c => c.ProductCode!)
+            .Select(g =>
+            {
+                var details = g
+                    .GroupBy(c => c.PackingMaterialId)
+                    .Select(dg =>
+                    {
+                        var materialName = materialNameById.TryGetValue(dg.Key, out var name) ? name : "Unknown";
+                        return new ConsumptionDetailDto
+                        {
+                            Key = dg.Key.ToString(),
+                            Label = materialName,
+                            Amount = dg.Sum(c => c.Amount)
+                        };
+                    })
+                    .ToList();
+
+                return new ConsumptionGroupDto
+                {
+                    Key = g.Key,
+                    Label = g.Key,
+                    TotalAmount = g.Sum(c => c.Amount),
+                    RowCount = g.Count(),
+                    Details = details
+                };
+            })
+            .OrderByDescending(g => g.TotalAmount)
+            .ToList();
+    }
+
+    private static List<ConsumptionGroupDto> BuildGroupByOrder(
+        List<PackingMaterialConsumption> consumptions,
+        List<PackingMaterial> materials)
+    {
+        var materialNameById = materials.ToDictionary(m => m.Id, m => m.Name);
+
+        return consumptions
+            .Where(c => c.InvoiceId != null)
+            .GroupBy(c => c.InvoiceId!)
+            .Select(g =>
+            {
+                var details = g
+                    .GroupBy(c => c.PackingMaterialId)
+                    .Select(dg =>
+                    {
+                        var materialName = materialNameById.TryGetValue(dg.Key, out var name) ? name : "Unknown";
+                        return new ConsumptionDetailDto
+                        {
+                            Key = dg.Key.ToString(),
+                            Label = materialName,
+                            Amount = dg.Sum(c => c.Amount)
+                        };
+                    })
+                    .ToList();
+
+                return new ConsumptionGroupDto
+                {
+                    Key = g.Key,
+                    Label = g.Key,
+                    TotalAmount = g.Sum(c => c.Amount),
+                    RowCount = g.Count(),
+                    Details = details
+                };
+            })
+            .OrderByDescending(g => g.TotalAmount)
+            .ToList();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetDailyConsumptionBreakdown/GetDailyConsumptionBreakdownRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetDailyConsumptionBreakdown/GetDailyConsumptionBreakdownRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetDailyConsumptionBreakdown;
+
+public class GetDailyConsumptionBreakdownRequest : IRequest<GetDailyConsumptionBreakdownResponse>
+{
+    public DateOnly Date { get; set; }
+    public string GroupBy { get; set; } = "material";
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetDailyConsumptionBreakdown/GetDailyConsumptionBreakdownResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetDailyConsumptionBreakdown/GetDailyConsumptionBreakdownResponse.cs
@@ -1,0 +1,12 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetDailyConsumptionBreakdown;
+
+public class GetDailyConsumptionBreakdownResponse : BaseResponse
+{
+    public string? Error { get; set; }
+    public DateOnly Date { get; set; }
+    public string GroupBy { get; set; } = string.Empty;
+    public List<ConsumptionGroupDto> Groups { get; set; } = new();
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/ProcessDailyConsumption/ProcessDailyConsumptionHandler.cs
@@ -1,4 +1,3 @@
-using Anela.Heblo.Application.Features.Invoices.UseCases.GetIssuedInvoicesList;
 using Anela.Heblo.Application.Features.PackingMaterials.Services;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -8,16 +7,13 @@ namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.ProcessDail
 public class ProcessDailyConsumptionHandler : IRequestHandler<ProcessDailyConsumptionRequest, ProcessDailyConsumptionResponse>
 {
     private readonly IConsumptionCalculationService _consumptionService;
-    private readonly IMediator _mediator;
     private readonly ILogger<ProcessDailyConsumptionHandler> _logger;
 
     public ProcessDailyConsumptionHandler(
         IConsumptionCalculationService consumptionService,
-        IMediator mediator,
         ILogger<ProcessDailyConsumptionHandler> logger)
     {
         _consumptionService = consumptionService;
-        _mediator = mediator;
         _logger = logger;
     }
 
@@ -29,44 +25,7 @@ public class ProcessDailyConsumptionHandler : IRequestHandler<ProcessDailyConsum
         {
             _logger.LogInformation("Processing daily consumption for {Date}", request.ProcessingDate);
 
-            // Get invoices for the processing date via existing GetIssuedInvoicesListHandler
-            var targetDate = request.ProcessingDate.ToDateTime(TimeOnly.MinValue);
-            var invoicesRequest = new GetIssuedInvoicesListRequest
-            {
-                InvoiceDateFrom = targetDate,
-                InvoiceDateTo = targetDate,
-                PageNumber = 1,
-                PageSize = 0 // 0 means return all invoices without pagination
-            };
-
-            var invoicesResult = await _mediator.Send(invoicesRequest, cancellationToken);
-
-            if (!invoicesResult.Success)
-            {
-                _logger.LogError("Failed to get issued invoices for {Date}: {ErrorMessage}",
-                    request.ProcessingDate, invoicesResult.Params?.GetValueOrDefault("ErrorMessage") ?? "Unknown error");
-
-                return new ProcessDailyConsumptionResponse
-                {
-                    Success = false,
-                    ProcessedDate = request.ProcessingDate,
-                    MaterialsProcessed = 0,
-                    Message = $"Failed to get issued invoices for {request.ProcessingDate}: {invoicesResult.Params?.GetValueOrDefault("ErrorMessage") ?? "Unknown error"}"
-                };
-            }
-
-            // Calculate aggregated statistics from the invoices
-            var orderCount = invoicesResult.Items.Count; // Each invoice represents one order
-            var productCount = invoicesResult.Items.Sum(invoice => invoice.ItemsCount); // Sum of all products
-
-            _logger.LogInformation("Retrieved {InvoiceCount} invoices with {OrderCount} orders and {ProductCount} products for {Date}",
-                invoicesResult.Items.Count, orderCount, productCount, request.ProcessingDate);
-
-            var result = await _consumptionService.ProcessDailyConsumptionAsync(
-                request.ProcessingDate,
-                orderCount,
-                productCount,
-                cancellationToken);
+            var result = await _consumptionService.ProcessDailyConsumptionAsync(request.ProcessingDate, cancellationToken);
 
             if (!result.WasRun)
             {
@@ -102,7 +61,7 @@ public class ProcessDailyConsumptionHandler : IRequestHandler<ProcessDailyConsum
                 Success = false,
                 ProcessedDate = request.ProcessingDate,
                 MaterialsProcessed = 0,
-                Message = $"Error processing daily consumption: {ex.Message}"
+                Message = "An unexpected error occurred while processing daily consumption."
             };
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdateAllocation/UpdateAllocationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdateAllocation/UpdateAllocationHandler.cs
@@ -1,0 +1,64 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdateAllocation;
+
+public class UpdateAllocationHandler : IRequestHandler<UpdateAllocationRequest, UpdateAllocationResponse>
+{
+    private readonly IPackingMaterialRepository _materialRepository;
+    private readonly IPackingMaterialAllocationRepository _allocationRepository;
+    private readonly ILogger<UpdateAllocationHandler> _logger;
+
+    public UpdateAllocationHandler(
+        IPackingMaterialRepository materialRepository,
+        IPackingMaterialAllocationRepository allocationRepository,
+        ILogger<UpdateAllocationHandler> logger)
+    {
+        _materialRepository = materialRepository;
+        _allocationRepository = allocationRepository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateAllocationResponse> Handle(UpdateAllocationRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (request.AmountPerUnit <= 0)
+                return new UpdateAllocationResponse { Success = false, Error = "AmountPerUnit must be greater than zero." };
+
+            if (string.IsNullOrWhiteSpace(request.ProductCode))
+                return new UpdateAllocationResponse { Success = false, Error = "ProductCode must not be empty." };
+
+            var material = await _materialRepository.GetByIdWithAllocationsAsync(request.PackingMaterialId, cancellationToken);
+
+            if (material == null)
+                return new UpdateAllocationResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = $"Packing material with ID {request.PackingMaterialId} not found." };
+
+            var allocation = material.Allocations.FirstOrDefault(a => a.Id == request.AllocationId);
+            if (allocation == null)
+                return new UpdateAllocationResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = $"Allocation with ID {request.AllocationId} not found on this material." };
+
+            var conflicting = material.Allocations
+                .Any(a => a.Id != request.AllocationId && a.ProductCode == request.ProductCode);
+            if (conflicting)
+                return new UpdateAllocationResponse
+                {
+                    Success = false,
+                    Error = $"An allocation for product '{request.ProductCode}' already exists on this material."
+                };
+
+            allocation.UpdateAllocation(request.ProductCode, request.AmountPerUnit);
+            await _allocationRepository.UpdateAsync(allocation, cancellationToken);
+            await _allocationRepository.SaveChangesAsync(cancellationToken);
+
+            return new UpdateAllocationResponse { Success = true };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating allocation {AllocationId} for packing material {PackingMaterialId}", request.AllocationId, request.PackingMaterialId);
+            return new UpdateAllocationResponse { Success = false, Error = "An unexpected error occurred while updating the allocation." };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdateAllocation/UpdateAllocationRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdateAllocation/UpdateAllocationRequest.cs
@@ -1,0 +1,11 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdateAllocation;
+
+public class UpdateAllocationRequest : IRequest<UpdateAllocationResponse>
+{
+    public int PackingMaterialId { get; set; }
+    public int AllocationId { get; set; }
+    public string ProductCode { get; set; } = null!;
+    public decimal AmountPerUnit { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdateAllocation/UpdateAllocationResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdateAllocation/UpdateAllocationResponse.cs
@@ -1,0 +1,8 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdateAllocation;
+
+public class UpdateAllocationResponse : BaseResponse
+{
+    public string? Error { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -54,12 +54,15 @@ namespace Anela.Heblo.Application.Features.Photobank
         }
 
         public async Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, string? folderPath, int page, int pageSize,
+            List<string>? tags, string? search, string? folderPath, bool withoutTags, int page, int pageSize,
             CancellationToken cancellationToken)
         {
-            var query = BuildFilterQuery(tags, search, folderPath)
+            IQueryable<Photo> query = BuildFilterQuery(tags, search, folderPath)
                 .Include(p => p.Tags)
                     .ThenInclude(pt => pt.Tag);
+
+            if (withoutTags)
+                query = query.Where(p => !p.Tags.Any());
 
             var total = await query.CountAsync(cancellationToken);
             var items = await query

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -22,6 +22,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
                 request.Tags,
                 request.Search,
                 request.FolderPath,
+                request.WithoutTags,
                 request.Page,
                 request.PageSize,
                 cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
@@ -8,6 +8,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
         public List<string>? Tags { get; set; }
         public string? Search { get; set; }
         public string? FolderPath { get; set; }
+        public bool WithoutTags { get; set; }
         public int Page { get; set; } = 1;
         public int PageSize { get; set; } = 48;
     }

--- a/backend/src/Anela.Heblo.Domain/Features/Invoices/IIssuedInvoiceRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Invoices/IIssuedInvoiceRepository.cs
@@ -72,6 +72,13 @@ public interface IIssuedInvoiceRepository : IRepository<IssuedInvoice, string>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Paginated result with total count</returns>
     Task<PaginatedResult<IssuedInvoice>> GetPaginatedAsync(IssuedInvoiceFilters filters, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets invoice headers for a specific date
+    /// </summary>
+    /// <param name="date">The date to retrieve invoice headers for</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Invoice headers whose invoice date falls on the given date</returns>
+    Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/IPackingMaterialAllocationRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/IPackingMaterialAllocationRepository.cs
@@ -1,0 +1,7 @@
+using Anela.Heblo.Xcc.Persistance;
+
+namespace Anela.Heblo.Domain.Features.PackingMaterials;
+
+public interface IPackingMaterialAllocationRepository : IRepository<PackingMaterialAllocation, int>
+{
+}

--- a/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/IPackingMaterialRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/IPackingMaterialRepository.cs
@@ -8,4 +8,8 @@ public interface IPackingMaterialRepository : IRepository<PackingMaterial, int>
     Task<PackingMaterial?> GetByIdWithLogsAsync(int id, CancellationToken cancellationToken = default);
     Task<IEnumerable<PackingMaterialLog>> GetRecentLogsAsync(int packingMaterialId, DateTime fromDate, CancellationToken cancellationToken = default);
     Task<bool> HasDailyProcessingBeenRunAsync(DateOnly date, CancellationToken cancellationToken = default);
+    Task<IEnumerable<PackingMaterial>> GetAllWithAllocationsAsync(CancellationToken cancellationToken = default);
+    Task<PackingMaterial?> GetByIdWithAllocationsAsync(int id, CancellationToken cancellationToken = default);
+    Task AddConsumptionRowsAsync(IEnumerable<PackingMaterialConsumption> rows, CancellationToken cancellationToken = default);
+    Task<IEnumerable<PackingMaterialConsumption>> GetConsumptionsByDateAsync(DateOnly date, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/PackingMaterial.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/PackingMaterial.cs
@@ -16,6 +16,9 @@ public class PackingMaterial : IEntity<int>
     private readonly List<PackingMaterialLog> _logs = new();
     public IReadOnlyCollection<PackingMaterialLog> Logs => _logs.AsReadOnly();
 
+    private readonly List<PackingMaterialAllocation> _allocations = new();
+    public IReadOnlyCollection<PackingMaterialAllocation> Allocations => _allocations.AsReadOnly();
+
     protected PackingMaterial()
     {
     }

--- a/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/PackingMaterialAllocation.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/PackingMaterialAllocation.cs
@@ -1,0 +1,34 @@
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.PackingMaterials;
+
+public class PackingMaterialAllocation : IEntity<int>
+{
+    public int Id { get; private set; }
+    public int PackingMaterialId { get; private set; }
+    public string ProductCode { get; private set; } = null!;
+    public decimal AmountPerUnit { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? UpdatedAt { get; private set; }
+
+    protected PackingMaterialAllocation() { }
+
+    public PackingMaterialAllocation(int packingMaterialId, string productCode, decimal amountPerUnit)
+    {
+        if (amountPerUnit <= 0)
+            throw new ArgumentOutOfRangeException(nameof(amountPerUnit), "Must be greater than zero.");
+        PackingMaterialId = packingMaterialId;
+        ProductCode = productCode ?? throw new ArgumentNullException(nameof(productCode));
+        AmountPerUnit = amountPerUnit;
+        CreatedAt = DateTime.UtcNow;
+    }
+
+    public void UpdateAllocation(string productCode, decimal amountPerUnit)
+    {
+        if (amountPerUnit <= 0)
+            throw new ArgumentOutOfRangeException(nameof(amountPerUnit), "Must be greater than zero.");
+        ProductCode = productCode ?? throw new ArgumentNullException(nameof(productCode));
+        AmountPerUnit = amountPerUnit;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/PackingMaterialConsumption.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/PackingMaterials/PackingMaterialConsumption.cs
@@ -1,0 +1,40 @@
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.PackingMaterials;
+
+public class PackingMaterialConsumption : IEntity<int>
+{
+    public int Id { get; private set; }
+    public int PackingMaterialId { get; private set; }
+    public DateOnly Date { get; private set; }
+    public ConsumptionType ConsumptionType { get; private set; }
+    public string? InvoiceId { get; private set; }
+    public string? ProductCode { get; private set; }
+    public decimal? ProductQuantity { get; private set; }
+    public decimal Amount { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+
+    protected PackingMaterialConsumption() { }
+
+    public PackingMaterialConsumption(
+        int packingMaterialId,
+        DateOnly date,
+        ConsumptionType consumptionType,
+        decimal amount,
+        string? invoiceId = null,
+        string? productCode = null,
+        decimal? productQuantity = null)
+    {
+        if (amount < 0)
+            throw new ArgumentOutOfRangeException(nameof(amount), "Cannot be negative.");
+        PackingMaterialId = packingMaterialId;
+        Date = date;
+        ConsumptionType = consumptionType;
+        Amount = amount;
+        InvoiceId = invoiceId;
+        ProductCode = productCode;
+        ProductQuantity = productQuantity;
+        CreatedAt = DateTime.UtcNow;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -10,7 +10,7 @@ namespace Anela.Heblo.Domain.Features.Photobank
     {
         // Photos
         Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, string? folderPath, int page, int pageSize,
+            List<string>? tags, string? search, string? folderPath, bool withoutTags, int page, int pageSize,
             CancellationToken cancellationToken);
 
         Task<int> CountFilteredPhotosAsync(List<string>? tags, string? search, string? folderPath, CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Invoices/IssuedInvoiceRepository.cs
@@ -202,6 +202,15 @@ public class IssuedInvoiceRepository : BaseRepository<IssuedInvoice, string>, II
         };
     }
 
+    public async Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        var start = date.ToDateTime(TimeOnly.MinValue);
+        var end = date.ToDateTime(TimeOnly.MaxValue);
+        return await DbSet
+            .Where(x => x.InvoiceDate >= start && x.InvoiceDate <= end)
+            .ToListAsync(cancellationToken);
+    }
+
     private static IQueryable<IssuedInvoice> ApplySorting(IQueryable<IssuedInvoice> query, string? sortBy, bool sortDescending)
     {
         if (string.IsNullOrEmpty(sortBy))

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260507080208_AddPackingMaterialAttribution.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260507080208_AddPackingMaterialAttribution.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507080208_AddPackingMaterialAttribution")]
+    partial class AddPackingMaterialAttribution
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1599,50 +1602,6 @@ namespace Anela.Heblo.Persistence.Migrations
                     b.ToTable("ManufactureOrders", "public");
                 });
 
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderConditionsReading", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<decimal?>("InnerHumidity")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<decimal?>("InnerTemperature")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<int>("ManufactureOrderId")
-                        .HasColumnType("integer");
-
-                    b.Property<decimal?>("OuterHumidity")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<decimal?>("OuterTemperature")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<DateTime>("RecordedAt")
-                        .HasColumnType("timestamp");
-
-                    b.Property<int>("Source")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Stage")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ManufactureOrderId")
-                        .HasDatabaseName("IX_ManufactureOrderConditionsReadings_ManufactureOrderId");
-
-                    b.HasIndex("ManufactureOrderId", "Stage")
-                        .IsUnique()
-                        .HasDatabaseName("IX_ManufactureOrderConditionsReadings_ManufactureOrderId_Stage");
-
-                    b.ToTable("ManufactureOrderConditionsReadings", "public");
-                });
-
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderNote", b =>
                 {
                     b.Property<int>("Id")
@@ -2097,8 +2056,7 @@ namespace Anela.Heblo.Persistence.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("PackingMaterialId")
-                        .HasDatabaseName("IX_PackingMaterialConsumptions_PackingMaterialId");
+                    b.HasIndex("PackingMaterialId");
 
                     b.HasIndex("Date", "InvoiceId")
                         .HasDatabaseName("IX_PackingMaterialConsumptions_Date_InvoiceId");
@@ -2696,17 +2654,6 @@ namespace Anela.Heblo.Persistence.Migrations
                         .OnDelete(DeleteBehavior.Cascade);
                 });
 
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderConditionsReading", b =>
-                {
-                    b.HasOne("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrder", "ManufactureOrder")
-                        .WithMany("ConditionsReadings")
-                        .HasForeignKey("ManufactureOrderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("ManufactureOrder");
-                });
-
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderNote", b =>
                 {
                     b.HasOne("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrder", "ManufactureOrder")
@@ -2888,8 +2835,6 @@ namespace Anela.Heblo.Persistence.Migrations
 
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrder", b =>
                 {
-                    b.Navigation("ConditionsReadings");
-
                     b.Navigation("Notes");
 
                     b.Navigation("Products");

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260507080208_AddPackingMaterialAttribution.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260507080208_AddPackingMaterialAttribution.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPackingMaterialAttribution : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PackingMaterialAllocations",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PackingMaterialId = table.Column<int>(type: "integer", nullable: false),
+                    ProductCode = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AmountPerUnit = table.Column<decimal>(type: "numeric(18,6)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PackingMaterialAllocations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PackingMaterialAllocations_PackingMaterials_PackingMaterial~",
+                        column: x => x.PackingMaterialId,
+                        principalSchema: "public",
+                        principalTable: "PackingMaterials",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PackingMaterialConsumptions",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    PackingMaterialId = table.Column<int>(type: "integer", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    ConsumptionType = table.Column<int>(type: "integer", nullable: false),
+                    InvoiceId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ProductCode = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ProductQuantity = table.Column<decimal>(type: "numeric(18,6)", nullable: true),
+                    Amount = table.Column<decimal>(type: "numeric(18,6)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PackingMaterialConsumptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PackingMaterialConsumptions_PackingMaterials_PackingMateria~",
+                        column: x => x.PackingMaterialId,
+                        principalSchema: "public",
+                        principalTable: "PackingMaterials",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackingMaterialAllocations_MaterialId_ProductCode",
+                schema: "public",
+                table: "PackingMaterialAllocations",
+                columns: new[] { "PackingMaterialId", "ProductCode" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackingMaterialConsumptions_Date_InvoiceId",
+                schema: "public",
+                table: "PackingMaterialConsumptions",
+                columns: new[] { "Date", "InvoiceId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackingMaterialConsumptions_Date_MaterialId",
+                schema: "public",
+                table: "PackingMaterialConsumptions",
+                columns: new[] { "Date", "PackingMaterialId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackingMaterialConsumptions_Date_ProductCode",
+                schema: "public",
+                table: "PackingMaterialConsumptions",
+                columns: new[] { "Date", "ProductCode" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PackingMaterialConsumptions_PackingMaterialId",
+                schema: "public",
+                table: "PackingMaterialConsumptions",
+                column: "PackingMaterialId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PackingMaterialAllocations",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "PackingMaterialConsumptions",
+                schema: "public");
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260507080841_AddExplicitFkIndexForPackingMaterialConsumption.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260507080841_AddExplicitFkIndexForPackingMaterialConsumption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507080841_AddExplicitFkIndexForPackingMaterialConsumption")]
+    partial class AddExplicitFkIndexForPackingMaterialConsumption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1599,50 +1602,6 @@ namespace Anela.Heblo.Persistence.Migrations
                     b.ToTable("ManufactureOrders", "public");
                 });
 
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderConditionsReading", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<decimal?>("InnerHumidity")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<decimal?>("InnerTemperature")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<int>("ManufactureOrderId")
-                        .HasColumnType("integer");
-
-                    b.Property<decimal?>("OuterHumidity")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<decimal?>("OuterTemperature")
-                        .HasColumnType("numeric(5,2)");
-
-                    b.Property<DateTime>("RecordedAt")
-                        .HasColumnType("timestamp");
-
-                    b.Property<int>("Source")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Stage")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ManufactureOrderId")
-                        .HasDatabaseName("IX_ManufactureOrderConditionsReadings_ManufactureOrderId");
-
-                    b.HasIndex("ManufactureOrderId", "Stage")
-                        .IsUnique()
-                        .HasDatabaseName("IX_ManufactureOrderConditionsReadings_ManufactureOrderId_Stage");
-
-                    b.ToTable("ManufactureOrderConditionsReadings", "public");
-                });
-
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderNote", b =>
                 {
                     b.Property<int>("Id")
@@ -2696,17 +2655,6 @@ namespace Anela.Heblo.Persistence.Migrations
                         .OnDelete(DeleteBehavior.Cascade);
                 });
 
-            modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderConditionsReading", b =>
-                {
-                    b.HasOne("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrder", "ManufactureOrder")
-                        .WithMany("ConditionsReadings")
-                        .HasForeignKey("ManufactureOrderId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("ManufactureOrder");
-                });
-
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrderNote", b =>
                 {
                     b.HasOne("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrder", "ManufactureOrder")
@@ -2888,8 +2836,6 @@ namespace Anela.Heblo.Persistence.Migrations
 
             modelBuilder.Entity("Anela.Heblo.Domain.Features.Manufacture.ManufactureOrder", b =>
                 {
-                    b.Navigation("ConditionsReadings");
-
                     b.Navigation("Notes");
 
                     b.Navigation("Products");

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260507080841_AddExplicitFkIndexForPackingMaterialConsumption.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260507080841_AddExplicitFkIndexForPackingMaterialConsumption.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExplicitFkIndexForPackingMaterialConsumption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialAllocationConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialAllocationConfiguration.cs
@@ -1,0 +1,43 @@
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.PackingMaterials;
+
+public class PackingMaterialAllocationConfiguration : IEntityTypeConfiguration<PackingMaterialAllocation>
+{
+    public void Configure(EntityTypeBuilder<PackingMaterialAllocation> builder)
+    {
+        builder.ToTable("PackingMaterialAllocations", "public");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.PackingMaterialId)
+            .IsRequired();
+
+        builder.Property(e => e.ProductCode)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(e => e.AmountPerUnit)
+            .IsRequired()
+            .HasColumnType("decimal(18,6)");
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired()
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.UpdatedAt)
+            .IsRequired(false)
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasOne<PackingMaterial>()
+            .WithMany(pm => pm.Allocations)
+            .HasForeignKey(a => a.PackingMaterialId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => new { e.PackingMaterialId, e.ProductCode })
+            .IsUnique()
+            .HasDatabaseName("IX_PackingMaterialAllocations_MaterialId_ProductCode");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialAllocationRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialAllocationRepository.cs
@@ -1,0 +1,11 @@
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Persistence.Repositories;
+
+namespace Anela.Heblo.Persistence.PackingMaterials;
+
+public class PackingMaterialAllocationRepository : BaseRepository<PackingMaterialAllocation, int>, IPackingMaterialAllocationRepository
+{
+    public PackingMaterialAllocationRepository(ApplicationDbContext context) : base(context)
+    {
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialConsumptionConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialConsumptionConfiguration.cs
@@ -1,0 +1,63 @@
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.PackingMaterials;
+
+public class PackingMaterialConsumptionConfiguration : IEntityTypeConfiguration<PackingMaterialConsumption>
+{
+    public void Configure(EntityTypeBuilder<PackingMaterialConsumption> builder)
+    {
+        builder.ToTable("PackingMaterialConsumptions", "public");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.PackingMaterialId)
+            .IsRequired();
+
+        builder.Property(e => e.Date)
+            .IsRequired()
+            .HasColumnType("date");
+
+        builder.Property(e => e.ConsumptionType)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(e => e.InvoiceId)
+            .IsRequired(false)
+            .HasMaxLength(100);
+
+        builder.Property(e => e.ProductCode)
+            .IsRequired(false)
+            .HasMaxLength(100);
+
+        builder.Property(e => e.ProductQuantity)
+            .IsRequired(false)
+            .HasColumnType("decimal(18,6)");
+
+        builder.Property(e => e.Amount)
+            .IsRequired()
+            .HasColumnType("decimal(18,6)");
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired()
+            .HasColumnType("timestamp without time zone");
+
+        builder.HasOne<PackingMaterial>()
+            .WithMany()
+            .HasForeignKey(c => c.PackingMaterialId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(e => e.PackingMaterialId)
+            .HasDatabaseName("IX_PackingMaterialConsumptions_PackingMaterialId");
+
+        builder.HasIndex(e => new { e.Date, e.PackingMaterialId })
+            .HasDatabaseName("IX_PackingMaterialConsumptions_Date_MaterialId");
+
+        builder.HasIndex(e => new { e.Date, e.InvoiceId })
+            .HasDatabaseName("IX_PackingMaterialConsumptions_Date_InvoiceId");
+
+        builder.HasIndex(e => new { e.Date, e.ProductCode })
+            .HasDatabaseName("IX_PackingMaterialConsumptions_Date_ProductCode");
+    }
+}

--- a/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/PackingMaterials/PackingMaterialRepository.cs
@@ -36,4 +36,30 @@ public class PackingMaterialRepository : BaseRepository<PackingMaterial, int>, I
         return await Context.Set<PackingMaterialLog>()
             .AnyAsync(log => log.Date == date && log.LogType == LogEntryType.AutomaticConsumption, cancellationToken);
     }
+
+    public async Task<IEnumerable<PackingMaterial>> GetAllWithAllocationsAsync(CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Include(pm => pm.Allocations)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<PackingMaterial?> GetByIdWithAllocationsAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await DbSet
+            .Include(pm => pm.Allocations)
+            .FirstOrDefaultAsync(pm => pm.Id == id, cancellationToken);
+    }
+
+    public async Task AddConsumptionRowsAsync(IEnumerable<PackingMaterialConsumption> rows, CancellationToken cancellationToken = default)
+    {
+        await Context.Set<PackingMaterialConsumption>().AddRangeAsync(rows, cancellationToken);
+    }
+
+    public async Task<IEnumerable<PackingMaterialConsumption>> GetConsumptionsByDateAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        return await Context.Set<PackingMaterialConsumption>()
+            .Where(c => c.Date == date)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/AllocationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/AllocationHandlerTests.cs
@@ -1,0 +1,420 @@
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.CreateAllocation;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeleteAllocation;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetAllocations;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdateAllocation;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class AllocationHandlerTests
+{
+    private static PackingMaterial MakeMaterial(int id, string name = "TestMaterial")
+    {
+        var material = new PackingMaterial(name, 1m, ConsumptionType.PerOrder, 100m);
+        typeof(PackingMaterial)
+            .GetProperty("Id")!
+            .SetValue(material, id);
+        return material;
+    }
+
+    private static PackingMaterialAllocation MakeAllocation(int id, int materialId, string productCode, decimal amount)
+    {
+        var allocation = new PackingMaterialAllocation(materialId, productCode, amount);
+        typeof(PackingMaterialAllocation)
+            .GetProperty("Id")!
+            .SetValue(allocation, id);
+        return allocation;
+    }
+
+    private static void AddAllocationToMaterial(PackingMaterial material, PackingMaterialAllocation allocation)
+    {
+        var field = typeof(PackingMaterial).GetField("_allocations", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PackingMaterialAllocation>)field.GetValue(material)!;
+        list.Add(allocation);
+    }
+
+    private static MockPackingMaterialRepository BuildMaterialRepo(params PackingMaterial[] materials)
+    {
+        var repo = new MockPackingMaterialRepository();
+        repo.SetMaterials(materials);
+        return repo;
+    }
+
+    // ---- GetAllocations ----
+
+    [Fact]
+    public async Task GetAllocations_ReturnsMappedDtos_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var allocation = MakeAllocation(10, 1, "PROD-001", 2.5m);
+        AddAllocationToMaterial(material, allocation);
+
+        var materialRepo = BuildMaterialRepo(material);
+        var handler = new GetAllocationsHandler(materialRepo, new MockLogger<GetAllocationsHandler>());
+
+        // Act
+        var response = await handler.Handle(new GetAllocationsRequest { PackingMaterialId = 1 }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Single(response.Allocations);
+        var dto = response.Allocations[0];
+        Assert.Equal(10, dto.Id);
+        Assert.Equal(1, dto.PackingMaterialId);
+        Assert.Equal("PROD-001", dto.ProductCode);
+        Assert.Equal(2.5m, dto.AmountPerUnit);
+    }
+
+    [Fact]
+    public async Task GetAllocations_ReturnsError_WhenMaterialNotFound()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo();
+        var handler = new GetAllocationsHandler(materialRepo, new MockLogger<GetAllocationsHandler>());
+
+        // Act
+        var response = await handler.Handle(new GetAllocationsRequest { PackingMaterialId = 99 }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("99", response.Error);
+        Assert.Empty(response.Allocations);
+    }
+
+    [Fact]
+    public async Task GetAllocations_ReturnsEmptyList_WhenNoAllocationsOnMaterial()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var materialRepo = BuildMaterialRepo(material);
+        var handler = new GetAllocationsHandler(materialRepo, new MockLogger<GetAllocationsHandler>());
+
+        // Act
+        var response = await handler.Handle(new GetAllocationsRequest { PackingMaterialId = 1 }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Empty(response.Allocations);
+    }
+
+    // ---- CreateAllocation ----
+
+    [Fact]
+    public async Task CreateAllocation_PersistsAndReturnsDto_WhenValid()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new CreateAllocationHandler(materialRepo, allocationRepo, new MockLogger<CreateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new CreateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 3m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.NotNull(response.Allocation);
+        Assert.Equal("PROD-A", response.Allocation!.ProductCode);
+        Assert.Equal(3m, response.Allocation.AmountPerUnit);
+        Assert.Single(allocationRepo.AddedAllocations);
+    }
+
+    [Fact]
+    public async Task CreateAllocation_ReturnsError_WhenAmountPerUnitIsZero()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo(MakeMaterial(1));
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new CreateAllocationHandler(materialRepo, allocationRepo, new MockLogger<CreateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new CreateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 0m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("AmountPerUnit", response.Error);
+        Assert.Empty(allocationRepo.AddedAllocations);
+    }
+
+    [Fact]
+    public async Task CreateAllocation_ReturnsError_WhenProductCodeIsEmpty()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo(MakeMaterial(1));
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new CreateAllocationHandler(materialRepo, allocationRepo, new MockLogger<CreateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new CreateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            ProductCode = "  ",
+            AmountPerUnit = 1m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("ProductCode", response.Error);
+        Assert.Empty(allocationRepo.AddedAllocations);
+    }
+
+    [Fact]
+    public async Task CreateAllocation_ReturnsError_WhenMaterialNotFound()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo();
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new CreateAllocationHandler(materialRepo, allocationRepo, new MockLogger<CreateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new CreateAllocationRequest
+        {
+            PackingMaterialId = 99,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 1m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("99", response.Error);
+        Assert.Empty(allocationRepo.AddedAllocations);
+    }
+
+    [Fact]
+    public async Task CreateAllocation_ReturnsError_WhenDuplicateProductCode()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var existing = MakeAllocation(5, 1, "PROD-A", 1m);
+        AddAllocationToMaterial(material, existing);
+
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new CreateAllocationHandler(materialRepo, allocationRepo, new MockLogger<CreateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new CreateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 2m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("PROD-A", response.Error);
+        Assert.Empty(allocationRepo.AddedAllocations);
+    }
+
+    // ---- UpdateAllocation ----
+
+    [Fact]
+    public async Task UpdateAllocation_CallsUpdateAndSave_WhenValid()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var allocation = MakeAllocation(10, 1, "PROD-A", 1m);
+        AddAllocationToMaterial(material, allocation);
+
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new UpdateAllocationHandler(materialRepo, allocationRepo, new MockLogger<UpdateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new UpdateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            AllocationId = 10,
+            ProductCode = "PROD-B",
+            AmountPerUnit = 5m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Single(allocationRepo.UpdatedAllocations);
+        Assert.Equal("PROD-B", allocation.ProductCode);
+        Assert.Equal(5m, allocation.AmountPerUnit);
+    }
+
+    [Fact]
+    public async Task UpdateAllocation_ReturnsError_WhenAllocationNotFound()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new UpdateAllocationHandler(materialRepo, allocationRepo, new MockLogger<UpdateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new UpdateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            AllocationId = 99,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 1m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("99", response.Error);
+        Assert.Empty(allocationRepo.UpdatedAllocations);
+    }
+
+    [Fact]
+    public async Task UpdateAllocation_ReturnsError_WhenMaterialNotFound()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo();
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new UpdateAllocationHandler(materialRepo, allocationRepo, new MockLogger<UpdateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new UpdateAllocationRequest
+        {
+            PackingMaterialId = 99,
+            AllocationId = 1,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 1m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("99", response.Error);
+    }
+
+    [Fact]
+    public async Task UpdateAllocation_ReturnsError_WhenProductCodeConflictsWithAnotherAllocation()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var allocationA = MakeAllocation(10, 1, "PROD-A", 1m);
+        var allocationB = MakeAllocation(11, 1, "PROD-B", 2m);
+        AddAllocationToMaterial(material, allocationA);
+        AddAllocationToMaterial(material, allocationB);
+
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new UpdateAllocationHandler(materialRepo, allocationRepo, new MockLogger<UpdateAllocationHandler>());
+
+        // Act – try to rename allocation 11 (PROD-B) to PROD-A, which is taken by allocation 10
+        var response = await handler.Handle(new UpdateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            AllocationId = 11,
+            ProductCode = "PROD-A",
+            AmountPerUnit = 3m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("PROD-A", response.Error);
+        Assert.Empty(allocationRepo.UpdatedAllocations);
+    }
+
+    [Fact]
+    public async Task UpdateAllocation_ReturnsError_WhenAmountIsNegative()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo(MakeMaterial(1));
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new UpdateAllocationHandler(materialRepo, allocationRepo, new MockLogger<UpdateAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new UpdateAllocationRequest
+        {
+            PackingMaterialId = 1,
+            AllocationId = 1,
+            ProductCode = "PROD-A",
+            AmountPerUnit = -1m
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("AmountPerUnit", response.Error);
+    }
+
+    // ---- DeleteAllocation ----
+
+    [Fact]
+    public async Task DeleteAllocation_CallsDeleteAndSave_WhenValid()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var allocation = MakeAllocation(10, 1, "PROD-A", 1m);
+        AddAllocationToMaterial(material, allocation);
+
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new DeleteAllocationHandler(materialRepo, allocationRepo, new MockLogger<DeleteAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new DeleteAllocationRequest
+        {
+            PackingMaterialId = 1,
+            AllocationId = 10
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Single(allocationRepo.DeletedAllocations);
+        Assert.Equal(10, allocationRepo.DeletedAllocations[0].Id);
+    }
+
+    [Fact]
+    public async Task DeleteAllocation_ReturnsError_WhenMaterialNotFound()
+    {
+        // Arrange
+        var materialRepo = BuildMaterialRepo();
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new DeleteAllocationHandler(materialRepo, allocationRepo, new MockLogger<DeleteAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new DeleteAllocationRequest
+        {
+            PackingMaterialId = 99,
+            AllocationId = 1
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("99", response.Error);
+        Assert.Empty(allocationRepo.DeletedAllocations);
+    }
+
+    [Fact]
+    public async Task DeleteAllocation_ReturnsError_WhenAllocationNotFoundOnMaterial()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var materialRepo = BuildMaterialRepo(material);
+        var allocationRepo = new MockPackingMaterialAllocationRepository();
+        var handler = new DeleteAllocationHandler(materialRepo, allocationRepo, new MockLogger<DeleteAllocationHandler>());
+
+        // Act
+        var response = await handler.Handle(new DeleteAllocationRequest
+        {
+            PackingMaterialId = 1,
+            AllocationId = 99
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Contains("99", response.Error);
+        Assert.Empty(allocationRepo.DeletedAllocations);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ConsumptionCalculationServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/ConsumptionCalculationServiceTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Services;
+using Anela.Heblo.Domain.Features.Invoices;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
 using Microsoft.Extensions.Logging;
@@ -15,38 +16,236 @@ public class ConsumptionCalculationServiceTests
         _mockLogger = new MockLogger<ConsumptionCalculationService>();
     }
 
-    [Theory]
-    [InlineData(ConsumptionType.PerOrder, 2.5, 10, 5, 25.0)] // 2.5 per order * 10 orders = 25
-    [InlineData(ConsumptionType.PerProduct, 1.2, 10, 20, 24.0)] // 1.2 per product * 20 products = 24
-    [InlineData(ConsumptionType.PerDay, 5.0, 100, 200, 5.0)] // 5.0 per day (fixed)
-    public async Task CalculateConsumptionAsync_ShouldCalculateCorrectly(
-        ConsumptionType type,
-        decimal rate,
-        int orderCount,
-        int productCount,
-        decimal expectedConsumption)
+    private static IssuedInvoice MakeInvoice(string id, DateOnly date, int itemsCount)
+    {
+        return new IssuedInvoice
+        {
+            Id = id,
+            InvoiceDate = date.ToDateTime(TimeOnly.MinValue),
+            ItemsCount = itemsCount
+        };
+    }
+
+    private static ConsumptionCalculationService BuildService(
+        MockPackingMaterialRepository materialRepo,
+        MockIssuedInvoiceRepository invoiceRepo,
+        ILogger<ConsumptionCalculationService> logger)
+    {
+        return new ConsumptionCalculationService(materialRepo, invoiceRepo, logger);
+    }
+
+    [Fact]
+    public async Task ProcessDailyConsumptionAsync_PerDay_EmitsOneFactRowPerMaterial()
     {
         // Arrange
-        var material = new PackingMaterial("Test Material", rate, type, 100);
-        var mockRepository = new MockPackingMaterialRepository();
-        var service = new ConsumptionCalculationService(mockRepository, _mockLogger);
+        var date = new DateOnly(2025, 6, 15);
+        var material = new PackingMaterial("Tape", 3m, ConsumptionType.PerDay, 100m);
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { material });
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
 
         // Act
-        var result = await service.CalculateConsumptionAsync(material, orderCount, productCount);
+        var result = await service.ProcessDailyConsumptionAsync(date);
 
         // Assert
-        Assert.Equal(expectedConsumption, result);
+        Assert.True(result.WasRun);
+        Assert.Equal(1, result.MaterialsProcessed);
+        Assert.Single(materialRepo.AddedConsumptionRows);
+
+        var row = materialRepo.AddedConsumptionRows[0];
+        Assert.Equal(3m, row.Amount);
+        Assert.Null(row.InvoiceId);
+        Assert.Equal(ConsumptionType.PerDay, row.ConsumptionType);
+    }
+
+    [Fact]
+    public async Task ProcessDailyConsumptionAsync_PerOrder_EmitsOneFactRowPerInvoicePerMaterial()
+    {
+        // Arrange
+        var date = new DateOnly(2025, 6, 15);
+        var material = new PackingMaterial("Box", 2m, ConsumptionType.PerOrder, 50m);
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { material });
+
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+        invoiceRepo.SetInvoices(new[]
+        {
+            MakeInvoice("INV-1", date, itemsCount: 3),
+            MakeInvoice("INV-2", date, itemsCount: 5)
+        });
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
+
+        // Act
+        var result = await service.ProcessDailyConsumptionAsync(date);
+
+        // Assert
+        Assert.True(result.WasRun);
+        Assert.Equal(1, result.MaterialsProcessed);
+        Assert.Equal(2, materialRepo.AddedConsumptionRows.Count);
+
+        Assert.All(materialRepo.AddedConsumptionRows, row => Assert.Equal(2m, row.Amount));
+        Assert.All(materialRepo.AddedConsumptionRows, row => Assert.Equal(ConsumptionType.PerOrder, row.ConsumptionType));
+        Assert.NotNull(materialRepo.AddedConsumptionRows[0].InvoiceId);
+        Assert.NotNull(materialRepo.AddedConsumptionRows[1].InvoiceId);
+
+        var totalDecrement = materialRepo.AddedConsumptionRows.Sum(r => r.Amount);
+        Assert.Equal(4m, totalDecrement);
+
+        // Quantity should be decremented by 4 — material mutated in-place
+        var updated = materialRepo.Materials[0];
+        Assert.Equal(46m, updated.CurrentQuantity);
+        var log = updated.Logs.Single();
+        Assert.Equal(50m, log.OldQuantity);
+        Assert.Equal(46m, log.NewQuantity);
+    }
+
+    [Fact]
+    public async Task ProcessDailyConsumptionAsync_PerProduct_ScalesByItemsCount()
+    {
+        // Arrange
+        var date = new DateOnly(2025, 6, 15);
+        var material = new PackingMaterial("Sticker", 1m, ConsumptionType.PerProduct, 100m);
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { material });
+
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+        invoiceRepo.SetInvoices(new[]
+        {
+            MakeInvoice("INV-A", date, itemsCount: 3),
+            MakeInvoice("INV-B", date, itemsCount: 5)
+        });
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
+
+        // Act
+        var result = await service.ProcessDailyConsumptionAsync(date);
+
+        // Assert
+        Assert.True(result.WasRun);
+        Assert.Equal(1, result.MaterialsProcessed);
+        Assert.Equal(2, materialRepo.AddedConsumptionRows.Count);
+
+        var amounts = materialRepo.AddedConsumptionRows.Select(r => r.Amount).OrderBy(a => a).ToList();
+        Assert.Equal(new[] { 3m, 5m }, amounts);
+
+        var totalDecrement = materialRepo.AddedConsumptionRows.Sum(r => r.Amount);
+        Assert.Equal(8m, totalDecrement);
+
+        var updated = materialRepo.Materials[0];
+        Assert.Equal(92m, updated.CurrentQuantity);
+        var log = updated.Logs.Single();
+        Assert.Equal(100m, log.OldQuantity);
+        Assert.Equal(92m, log.NewQuantity);
+    }
+
+    [Fact]
+    public async Task ProcessDailyConsumptionAsync_ReturnsWasRunFalse_WhenAlreadyProcessed()
+    {
+        // Arrange
+        var date = new DateOnly(2025, 6, 15);
+        var material = new PackingMaterial("Cards", 1m, ConsumptionType.PerOrder, 8000m);
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { material });
+        materialRepo.SetHasDailyProcessingBeenRun(date, true);
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
+
+        // Act
+        var result = await service.ProcessDailyConsumptionAsync(date);
+
+        // Assert
+        Assert.False(result.WasRun);
+        Assert.Equal(0, result.MaterialsProcessed);
+        Assert.Empty(materialRepo.AddedConsumptionRows);
+    }
+
+    [Fact]
+    public async Task ProcessDailyConsumptionAsync_WritesMarkerLog_WhenZeroConsumption()
+    {
+        // Arrange — PerOrder material but zero invoices means zero consumption
+        var date = new DateOnly(2025, 6, 15);
+        var material = new PackingMaterial("Cards", 1m, ConsumptionType.PerOrder, 8000m);
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { material });
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
+
+        // Act
+        var result = await service.ProcessDailyConsumptionAsync(date);
+
+        // Assert
+        Assert.True(result.WasRun);
+        Assert.Equal(0, result.MaterialsProcessed);
+
+        // Quantity must NOT have changed
+        var updated = materialRepo.Materials[0];
+        Assert.Equal(8000m, updated.CurrentQuantity);
+
+        var markerLog = updated.Logs.Single();
+        Assert.Equal(LogEntryType.AutomaticConsumption, markerLog.LogType);
+        Assert.Equal(date, markerLog.Date);
+        Assert.Equal(8000m, markerLog.OldQuantity);
+        Assert.Equal(8000m, markerLog.NewQuantity);
+
+        // No fact rows for zero consumption (no invoices means no PerOrder rows)
+        Assert.Empty(materialRepo.AddedConsumptionRows);
+    }
+
+    [Fact]
+    public async Task ProcessDailyConsumptionAsync_MixedTypes_ZeroInvoices_PerDayDecrementsPerOrderGetsMarkerLog()
+    {
+        // Arrange — PerDay material always decrements; PerOrder material gets marker log when zero invoices
+        var date = new DateOnly(2025, 6, 15);
+        var perDayMaterial = new PackingMaterial("Tape", 5m, ConsumptionType.PerDay, 200m);
+        var perOrderMaterial = new PackingMaterial("Box", 2m, ConsumptionType.PerOrder, 100m);
+
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { perDayMaterial, perOrderMaterial });
+        var invoiceRepo = new MockIssuedInvoiceRepository(); // no invoices
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
+
+        // Act
+        var result = await service.ProcessDailyConsumptionAsync(date);
+
+        // Assert
+        Assert.True(result.WasRun);
+        Assert.Equal(1, result.MaterialsProcessed); // only PerDay counted
+
+        // PerDay material should be decremented
+        var tape = materialRepo.Materials.First(m => m.Name == "Tape");
+        Assert.Equal(195m, tape.CurrentQuantity);
+        Assert.Single(tape.Logs);
+
+        // PerOrder material should be untouched — but idempotency marker written on first material (Tape)
+        var box = materialRepo.Materials.First(m => m.Name == "Box");
+        Assert.Equal(100m, box.CurrentQuantity);
+        Assert.Empty(box.Logs);
+
+        // One PerDay fact row only
+        Assert.Single(materialRepo.AddedConsumptionRows);
+        Assert.Equal(ConsumptionType.PerDay, materialRepo.AddedConsumptionRows[0].ConsumptionType);
+
+        // Subsequent re-run should be blocked (Tape's log counts as the marker)
+        materialRepo.SetHasDailyProcessingBeenRun(date, true);
+        var rerun = await service.ProcessDailyConsumptionAsync(date);
+        Assert.False(rerun.WasRun);
     }
 
     [Fact]
     public async Task HasDayAlreadyBeenProcessedAsync_ShouldReturnCorrectValue()
     {
         // Arrange
-        var mockRepository = new MockPackingMaterialRepository();
-        var service = new ConsumptionCalculationService(mockRepository, _mockLogger);
+        var materialRepo = new MockPackingMaterialRepository();
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
         var date = DateOnly.FromDateTime(DateTime.Today);
-
-        mockRepository.SetHasDailyProcessingBeenRun(date, true);
+        materialRepo.SetHasDailyProcessingBeenRun(date, true);
 
         // Act
         var result = await service.HasDayAlreadyBeenProcessedAsync(date);
@@ -56,73 +255,62 @@ public class ConsumptionCalculationServiceTests
     }
 
     [Fact]
-    public async Task ProcessDailyConsumptionAsync_DecrementsQuantityAndReturnsCount_WhenInvoicesExist()
+    public async Task LogDecrement_Invariant()
     {
-        // Arrange
+        // Arrange: 1 PerDay rate=5, 1 PerOrder rate=2 with 3 invoices, 1 PerProduct rate=1 with invoices ItemsCount=[4,6,0]
         var date = new DateOnly(2025, 6, 15);
-        var material1 = new PackingMaterial("Cards", 1m, ConsumptionType.PerOrder, 100m);
-        var material2 = new PackingMaterial("Stickers", 2m, ConsumptionType.PerOrder, 50m);
-        var mockRepository = new MockPackingMaterialRepository();
-        mockRepository.SetMaterials(new[] { material1, material2 });
-        var service = new ConsumptionCalculationService(mockRepository, _mockLogger);
+
+        var perDayMaterial = new PackingMaterial("Tape", 5m, ConsumptionType.PerDay, 200m);
+        var perOrderMaterial = new PackingMaterial("Box", 2m, ConsumptionType.PerOrder, 100m);
+        var perProductMaterial = new PackingMaterial("Sticker", 1m, ConsumptionType.PerProduct, 150m);
+
+        var materialRepo = new MockPackingMaterialRepository();
+        materialRepo.SetMaterials(new[] { perDayMaterial, perOrderMaterial, perProductMaterial });
+
+        var invoiceRepo = new MockIssuedInvoiceRepository();
+        invoiceRepo.SetInvoices(new[]
+        {
+            MakeInvoice("INV-1", date, itemsCount: 4),
+            MakeInvoice("INV-2", date, itemsCount: 6),
+            MakeInvoice("INV-3", date, itemsCount: 0)
+        });
+
+        var service = BuildService(materialRepo, invoiceRepo, _mockLogger);
 
         // Act
-        var result = await service.ProcessDailyConsumptionAsync(date, orderCount: 5, productCount: 10);
+        var result = await service.ProcessDailyConsumptionAsync(date);
 
-        // Assert
+        // Assert: verify SUM(fact rows per material) == |ChangeAmount in log| for each material
         Assert.True(result.WasRun);
-        Assert.Equal(2, result.MaterialsProcessed);
-        Assert.Equal(95m, mockRepository.UpdatedMaterials[0].CurrentQuantity); // 100 - 1*5
-        Assert.Equal(40m, mockRepository.UpdatedMaterials[1].CurrentQuantity); // 50 - 2*5
-    }
 
-    [Fact]
-    public async Task ProcessDailyConsumptionAsync_WritesMarkerAndReturnsZero_WhenNoConsumptionCalculated()
-    {
-        // Arrange — PerOrder material but zero orders means consumption = 0
-        var date = new DateOnly(2025, 6, 15);
-        var material = new PackingMaterial("Cards", 1m, ConsumptionType.PerOrder, 8000m);
-        var mockRepository = new MockPackingMaterialRepository();
-        mockRepository.SetMaterials(new[] { material });
-        var service = new ConsumptionCalculationService(mockRepository, _mockLogger);
+        var allRows = materialRepo.AddedConsumptionRows;
 
-        // Act
-        var result = await service.ProcessDailyConsumptionAsync(date, orderCount: 0, productCount: 0);
+        // PerDay: 1 row, amount = 5
+        var perDayRows = allRows.Where(r => r.ConsumptionType == ConsumptionType.PerDay).ToList();
+        Assert.Single(perDayRows);
+        Assert.Equal(5m, perDayRows.Sum(r => r.Amount));
 
-        // Assert
-        Assert.True(result.WasRun);
-        Assert.Equal(0, result.MaterialsProcessed);
+        var tapeLog = materialRepo.Materials.First(m => m.Name == "Tape").Logs.Single();
+        Assert.Equal(5m, Math.Abs(tapeLog.ChangeAmount));
+        Assert.Equal(perDayRows.Sum(r => r.Amount), Math.Abs(tapeLog.ChangeAmount));
 
-        // Quantity must NOT have changed
-        Assert.Single(mockRepository.UpdatedMaterials);
-        Assert.Equal(8000m, mockRepository.UpdatedMaterials[0].CurrentQuantity);
+        // PerOrder: 3 rows (one per invoice), each amount = 2, total = 6
+        var perOrderRows = allRows.Where(r => r.ConsumptionType == ConsumptionType.PerOrder).ToList();
+        Assert.Equal(3, perOrderRows.Count);
+        Assert.Equal(6m, perOrderRows.Sum(r => r.Amount));
 
-        // A marker log must have been written so re-runs are blocked
-        var markerLog = mockRepository.UpdatedMaterials[0].Logs.Single();
-        // UpdateQuantity() is the only way logs are added; constructor does not add a log
-        Assert.Equal(LogEntryType.AutomaticConsumption, markerLog.LogType);
-        Assert.Equal(date, markerLog.Date);
-        Assert.Equal(8000m, markerLog.OldQuantity);
-        Assert.Equal(8000m, markerLog.NewQuantity);
-    }
+        var boxLog = materialRepo.Materials.First(m => m.Name == "Box").Logs.Single();
+        Assert.Equal(6m, Math.Abs(boxLog.ChangeAmount));
+        Assert.Equal(perOrderRows.Sum(r => r.Amount), Math.Abs(boxLog.ChangeAmount));
 
-    [Fact]
-    public async Task ProcessDailyConsumptionAsync_ReturnsWasRunFalse_WhenDayAlreadyProcessed()
-    {
-        // Arrange — marker already present
-        var date = new DateOnly(2025, 6, 15);
-        var material = new PackingMaterial("Cards", 1m, ConsumptionType.PerOrder, 8000m);
-        var mockRepository = new MockPackingMaterialRepository();
-        mockRepository.SetMaterials(new[] { material });
-        mockRepository.SetHasDailyProcessingBeenRun(date, true);
-        var service = new ConsumptionCalculationService(mockRepository, _mockLogger);
+        // PerProduct: 2 rows (zero-amount row for INV-3 is filtered), amounts = 4, 6. Total = 10.
+        var perProductRows = allRows.Where(r => r.ConsumptionType == ConsumptionType.PerProduct).ToList();
+        Assert.Equal(2, perProductRows.Count);
+        var perProductTotal = perProductRows.Sum(r => r.Amount);
+        Assert.Equal(10m, perProductTotal);
 
-        // Act
-        var result = await service.ProcessDailyConsumptionAsync(date, orderCount: 5, productCount: 10);
-
-        // Assert
-        Assert.False(result.WasRun);
-        Assert.Equal(0, result.MaterialsProcessed);
-        Assert.Empty(mockRepository.UpdatedMaterials);
+        var stickerLog = materialRepo.Materials.First(m => m.Name == "Sticker").Logs.Single();
+        Assert.Equal(10m, Math.Abs(stickerLog.ChangeAmount));
+        Assert.Equal(perProductRows.Sum(r => r.Amount), Math.Abs(stickerLog.ChangeAmount));
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/GetDailyConsumptionBreakdownHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/GetDailyConsumptionBreakdownHandlerTests.cs
@@ -1,0 +1,211 @@
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetDailyConsumptionBreakdown;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class GetDailyConsumptionBreakdownHandlerTests
+{
+    private static readonly DateOnly TestDate = new DateOnly(2025, 6, 15);
+
+    private static PackingMaterial MakeMaterial(int id, string name)
+    {
+        var material = new PackingMaterial(name, 1m, ConsumptionType.PerOrder, 100m);
+        typeof(PackingMaterial)
+            .GetProperty("Id")!
+            .SetValue(material, id);
+        return material;
+    }
+
+    private static PackingMaterialConsumption MakeConsumption(
+        int packingMaterialId,
+        decimal amount,
+        string? invoiceId = null,
+        string? productCode = null)
+    {
+        return new PackingMaterialConsumption(
+            packingMaterialId,
+            TestDate,
+            ConsumptionType.PerOrder,
+            amount,
+            invoiceId,
+            productCode);
+    }
+
+    private static MockPackingMaterialRepository BuildRepo(
+        IEnumerable<PackingMaterial> materials,
+        IEnumerable<PackingMaterialConsumption> consumptions)
+    {
+        var repo = new MockPackingMaterialRepository();
+        repo.SetMaterials(materials);
+        repo.ConsumptionRowsByDate[TestDate] = consumptions.ToList();
+        return repo;
+    }
+
+    private static GetDailyConsumptionBreakdownHandler BuildHandler(MockPackingMaterialRepository repo)
+    {
+        return new GetDailyConsumptionBreakdownHandler(repo, new MockLogger<GetDailyConsumptionBreakdownHandler>());
+    }
+
+    [Fact]
+    public async Task GroupByMaterial_ReturnsGroupedByMaterialId()
+    {
+        // Arrange
+        var materialA = MakeMaterial(1, "Tape");
+        var materialB = MakeMaterial(2, "Box");
+
+        var consumptions = new[]
+        {
+            MakeConsumption(1, 5m, invoiceId: "INV-1"),
+            MakeConsumption(1, 3m, invoiceId: "INV-2"),
+            MakeConsumption(2, 10m, invoiceId: "INV-3"),
+        };
+
+        var repo = BuildRepo(new[] { materialA, materialB }, consumptions);
+        var handler = BuildHandler(repo);
+
+        // Act
+        var response = await handler.Handle(
+            new GetDailyConsumptionBreakdownRequest { Date = TestDate, GroupBy = "material" },
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(2, response.Groups.Count);
+
+        var first = response.Groups[0];
+        Assert.Equal("2", first.Key);
+        Assert.Equal("Box", first.Label);
+        Assert.Equal(10m, first.TotalAmount);
+        Assert.Equal(1, first.RowCount);
+
+        var second = response.Groups[1];
+        Assert.Equal("1", second.Key);
+        Assert.Equal("Tape", second.Label);
+        Assert.Equal(8m, second.TotalAmount);
+        Assert.Equal(2, second.RowCount);
+
+        Assert.Equal(2, second.Details.Count);
+        var detailKeys = second.Details.Select(d => d.Key).ToHashSet();
+        Assert.Contains("INV-1", detailKeys);
+        Assert.Contains("INV-2", detailKeys);
+    }
+
+    [Fact]
+    public async Task GroupByOrder_ReturnsGroupedByInvoiceId()
+    {
+        // Arrange
+        var materialA = MakeMaterial(1, "Tape");
+        var materialB = MakeMaterial(2, "Box");
+
+        var consumptions = new[]
+        {
+            MakeConsumption(1, 5m, invoiceId: "INV-1"),
+            MakeConsumption(2, 3m, invoiceId: "INV-1"),
+            MakeConsumption(1, 10m, invoiceId: "INV-2"),
+        };
+
+        var repo = BuildRepo(new[] { materialA, materialB }, consumptions);
+        var handler = BuildHandler(repo);
+
+        // Act
+        var response = await handler.Handle(
+            new GetDailyConsumptionBreakdownRequest { Date = TestDate, GroupBy = "order" },
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Equal(2, response.Groups.Count);
+
+        var inv2Group = response.Groups[0];
+        Assert.Equal("INV-2", inv2Group.Key);
+        Assert.Equal("INV-2", inv2Group.Label);
+        Assert.Equal(10m, inv2Group.TotalAmount);
+        Assert.Equal(1, inv2Group.RowCount);
+
+        var inv1Group = response.Groups[1];
+        Assert.Equal("INV-1", inv1Group.Key);
+        Assert.Equal(8m, inv1Group.TotalAmount);
+        Assert.Equal(2, inv1Group.RowCount);
+
+        Assert.Equal(2, inv1Group.Details.Count);
+        var detailKeys = inv1Group.Details.Select(d => d.Key).ToHashSet();
+        Assert.Contains("1", detailKeys);
+        Assert.Contains("2", detailKeys);
+    }
+
+    [Fact]
+    public async Task GroupByProduct_ReturnsEmptyGroups_WhenProductCodeIsNull()
+    {
+        // Arrange
+        var material = MakeMaterial(1, "Tape");
+        var consumptions = new[]
+        {
+            MakeConsumption(1, 5m, invoiceId: "INV-1", productCode: null),
+            MakeConsumption(1, 3m, invoiceId: "INV-2", productCode: null),
+        };
+
+        var repo = BuildRepo(new[] { material }, consumptions);
+        var handler = BuildHandler(repo);
+
+        // Act
+        var response = await handler.Handle(
+            new GetDailyConsumptionBreakdownRequest { Date = TestDate, GroupBy = "product" },
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Empty(response.Groups);
+    }
+
+    [Fact]
+    public async Task GroupBy_InvalidValue_ReturnsError()
+    {
+        // Arrange
+        var repo = BuildRepo(Array.Empty<PackingMaterial>(), Array.Empty<PackingMaterialConsumption>());
+        var handler = BuildHandler(repo);
+
+        // Act
+        var response = await handler.Handle(
+            new GetDailyConsumptionBreakdownRequest { Date = TestDate, GroupBy = "invalid" },
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.NotNull(response.Error);
+        Assert.Contains("invalid", response.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GroupByMaterial_ExcludesPerDayRowsFromDetails()
+    {
+        // Arrange: 1 PerDay row (InvoiceId=null) + 1 PerOrder row (InvoiceId=INV-1) for same material
+        var material = MakeMaterial(1, "Tape");
+
+        var perDayRow = new PackingMaterialConsumption(1, TestDate, ConsumptionType.PerDay, 5m);
+        var perOrderRow = new PackingMaterialConsumption(1, TestDate, ConsumptionType.PerOrder, 3m, invoiceId: "INV-1");
+
+        var repo = BuildRepo(new[] { material }, new[] { perDayRow, perOrderRow });
+        var handler = BuildHandler(repo);
+
+        // Act
+        var response = await handler.Handle(
+            new GetDailyConsumptionBreakdownRequest { Date = TestDate, GroupBy = "material" },
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Single(response.Groups);
+
+        var group = response.Groups[0];
+        Assert.Equal(8m, group.TotalAmount);
+        Assert.Equal(2, group.RowCount);
+
+        Assert.Single(group.Details);
+        Assert.Equal("INV-1", group.Details[0].Key);
+        Assert.Equal(3m, group.Details[0].Amount);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/MockIssuedInvoiceRepository.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/MockIssuedInvoiceRepository.cs
@@ -1,0 +1,83 @@
+using System.Linq.Expressions;
+using Anela.Heblo.Domain.Features.Invoices;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class MockIssuedInvoiceRepository : IIssuedInvoiceRepository
+{
+    private List<IssuedInvoice> _invoices = new();
+
+    public void SetInvoices(IEnumerable<IssuedInvoice> invoices)
+    {
+        _invoices = new List<IssuedInvoice>(invoices);
+    }
+
+    public Task<IEnumerable<IssuedInvoice>> GetHeadersByDateAsync(DateOnly date, CancellationToken cancellationToken = default)
+    {
+        var result = _invoices.Where(i => DateOnly.FromDateTime(i.InvoiceDate) == date);
+        return Task.FromResult<IEnumerable<IssuedInvoice>>(result.ToList());
+    }
+
+    public Task<IssuedInvoice?> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> GetAllAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> FindAsync(Expression<Func<IssuedInvoice, bool>> predicate, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IssuedInvoice?> SingleOrDefaultAsync(Expression<Func<IssuedInvoice, bool>> predicate, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<bool> AnyAsync(Expression<Func<IssuedInvoice, bool>> predicate, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<int> CountAsync(Expression<Func<IssuedInvoice, bool>>? predicate = null, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IssuedInvoice> AddAsync(IssuedInvoice entity, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> AddRangeAsync(IEnumerable<IssuedInvoice> entities, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task UpdateAsync(IssuedInvoice entity, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task DeleteAsync(IssuedInvoice entity, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task DeleteRangeAsync(IEnumerable<IssuedInvoice> entities, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> FindBySyncStatusAsync(bool? isSynced, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> FindByInvoiceDateRangeAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> FindByCustomerNameAsync(string customerName, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> FindWithCriticalErrorsAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IssuedInvoice?> GetByIdWithSyncHistoryAsync(string id, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IssuedInvoice>> FindStaleInvoicesAsync(DateTime beforeDate, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<IssuedInvoiceSyncStats> GetSyncStatsAsync(DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public Task<PaginatedResult<IssuedInvoice>> GetPaginatedAsync(IssuedInvoiceFilters filters, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/MockPackingMaterialAllocationRepository.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/MockPackingMaterialAllocationRepository.cs
@@ -1,0 +1,97 @@
+using System.Linq.Expressions;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class MockPackingMaterialAllocationRepository : IPackingMaterialAllocationRepository
+{
+    private readonly List<PackingMaterialAllocation> _allocations = new();
+    public List<PackingMaterialAllocation> AddedAllocations { get; } = new();
+    public List<PackingMaterialAllocation> UpdatedAllocations { get; } = new();
+    public List<PackingMaterialAllocation> DeletedAllocations { get; } = new();
+
+    public void SetAllocations(IEnumerable<PackingMaterialAllocation> allocations)
+    {
+        _allocations.Clear();
+        _allocations.AddRange(allocations);
+    }
+
+    public Task<PackingMaterialAllocation?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        => Task.FromResult(_allocations.FirstOrDefault(a => a.Id == id));
+
+    public Task<IEnumerable<PackingMaterialAllocation>> GetAllAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IEnumerable<PackingMaterialAllocation>>(_allocations);
+
+    public Task<IEnumerable<PackingMaterialAllocation>> FindAsync(Expression<Func<PackingMaterialAllocation, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        var compiled = predicate.Compile();
+        return Task.FromResult<IEnumerable<PackingMaterialAllocation>>(_allocations.Where(compiled).ToList());
+    }
+
+    public Task<PackingMaterialAllocation?> SingleOrDefaultAsync(Expression<Func<PackingMaterialAllocation, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        var compiled = predicate.Compile();
+        return Task.FromResult(_allocations.SingleOrDefault(compiled));
+    }
+
+    public Task<bool> AnyAsync(Expression<Func<PackingMaterialAllocation, bool>> predicate, CancellationToken cancellationToken = default)
+        => Task.FromResult(_allocations.Any(predicate.Compile()));
+
+    public Task<int> CountAsync(Expression<Func<PackingMaterialAllocation, bool>>? predicate = null, CancellationToken cancellationToken = default)
+    {
+        var count = predicate == null ? _allocations.Count : _allocations.Count(predicate.Compile());
+        return Task.FromResult(count);
+    }
+
+    public Task<PackingMaterialAllocation> AddAsync(PackingMaterialAllocation entity, CancellationToken cancellationToken = default)
+    {
+        _allocations.Add(entity);
+        AddedAllocations.Add(entity);
+        return Task.FromResult(entity);
+    }
+
+    public Task<IEnumerable<PackingMaterialAllocation>> AddRangeAsync(IEnumerable<PackingMaterialAllocation> entities, CancellationToken cancellationToken = default)
+    {
+        var list = entities.ToList();
+        _allocations.AddRange(list);
+        AddedAllocations.AddRange(list);
+        return Task.FromResult<IEnumerable<PackingMaterialAllocation>>(list);
+    }
+
+    public Task UpdateAsync(PackingMaterialAllocation entity, CancellationToken cancellationToken = default)
+    {
+        UpdatedAllocations.Add(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(PackingMaterialAllocation entity, CancellationToken cancellationToken = default)
+    {
+        _allocations.Remove(entity);
+        DeletedAllocations.Add(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = _allocations.FirstOrDefault(a => a.Id == id);
+        if (entity != null)
+        {
+            _allocations.Remove(entity);
+            DeletedAllocations.Add(entity);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteRangeAsync(IEnumerable<PackingMaterialAllocation> entities, CancellationToken cancellationToken = default)
+    {
+        foreach (var entity in entities)
+        {
+            _allocations.Remove(entity);
+            DeletedAllocations.Add(entity);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(0);
+}

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/MockPackingMaterialRepository.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/MockPackingMaterialRepository.cs
@@ -9,6 +9,7 @@ public class MockPackingMaterialRepository : IPackingMaterialRepository
     private List<PackingMaterial> _materials = new();
     private readonly Dictionary<DateOnly, bool> _dailyProcessingStatus = new();
     public List<PackingMaterial> UpdatedMaterials { get; } = new();
+    public IReadOnlyList<PackingMaterial> Materials => _materials;
     public bool GetAllAsyncWasCalled { get; private set; }
 
     public void SetMaterials(IEnumerable<PackingMaterial> materials)
@@ -128,4 +129,22 @@ public class MockPackingMaterialRepository : IPackingMaterialRepository
         var count = predicate == null ? _materials.Count : _materials.Count(predicate.Compile());
         return Task.FromResult(count);
     }
+
+    public List<PackingMaterialConsumption> AddedConsumptionRows { get; } = new();
+    public Dictionary<DateOnly, List<PackingMaterialConsumption>> ConsumptionRowsByDate { get; } = new();
+
+    public Task<IEnumerable<PackingMaterial>> GetAllWithAllocationsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IEnumerable<PackingMaterial>>(_materials);
+
+    public Task<PackingMaterial?> GetByIdWithAllocationsAsync(int id, CancellationToken cancellationToken = default)
+        => Task.FromResult(_materials.FirstOrDefault(m => m.Id == id));
+
+    public Task AddConsumptionRowsAsync(IEnumerable<PackingMaterialConsumption> rows, CancellationToken cancellationToken = default)
+    {
+        AddedConsumptionRows.AddRange(rows);
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<PackingMaterialConsumption>> GetConsumptionsByDateAsync(DateOnly date, CancellationToken cancellationToken = default)
+        => Task.FromResult<IEnumerable<PackingMaterialConsumption>>(ConsumptionRowsByDate.TryGetValue(date, out var rows) ? rows : new List<PackingMaterialConsumption>());
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -45,7 +45,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, null, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, null, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 2));
 
         var request = new GetPhotosRequest();
@@ -76,7 +76,7 @@ public class GetPhotosHandlerTests
         var tagFilter = new List<string> { "products" };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(tagFilter, null, null, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(tagFilter, null, null, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Tags = tagFilter };
@@ -90,7 +90,7 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].Tags.Should().ContainSingle(t => t.Name == "products");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, null, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, null, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, "ruze", null, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, "ruze", null, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Search = "ruze" };
@@ -122,7 +122,7 @@ public class GetPhotosHandlerTests
     {
         // Arrange
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<string?>(), 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(), 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((new List<Photo>(), 0));
 
         var request = new GetPhotosRequest { Tags = new List<string> { "nonexistent" } };
@@ -146,7 +146,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, "Produkty", 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { FolderPath = "Produkty" };
@@ -159,6 +159,6 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].FolderPath.Should().Be("Marketing/Produkty/Ruze");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, "Produkty", 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
@@ -53,7 +53,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, folderPath, 1, 48, CancellationToken.None);
+            null, null, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(2);
@@ -70,7 +70,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, folderPath, 1, 48, CancellationToken.None);
+            null, null, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -86,7 +86,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, search, folderPath, 1, 48, CancellationToken.None);
+            null, search, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -113,7 +113,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act — folderPath "Produkty" matches photos 1 & 2; tag "featured" is only on photo 1
         var (items, total) = await _repository.GetPhotosAsync(
-            new List<string> { "featured" }, null, "Produkty", 1, 48, CancellationToken.None);
+            new List<string> { "featured" }, null, "Produkty", false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -128,7 +128,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
     {
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, folderPath, 1, 48, CancellationToken.None);
+            null, null, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(4);

--- a/docs/architecture/cicd.md
+++ b/docs/architecture/cicd.md
@@ -317,7 +317,7 @@ graph TD
 ## ⚠️ Important Notes
 
 1. **CI Validation**: Deployment workflows no longer wait for CI to pass by default
-2. **Manual Database Migrations**: EF Core migrations are not part of automated deployment
+2. **Database Migrations**: Migrations apply automatically on Production startup (`MigrateDatabaseAsync` runs when `app.Environment.IsProduction()`). Development, Test, and Staging environments still require manual `dotnet ef database update`.
 3. **AI Code Reviews**: PRs reviewed by AI agent for solo developer workflow
 4. **Container Ports**: Internal port 80, Azure maps to 443 (HTTPS)
 5. **Static Files**: Served by ASP.NET Core in production, React dev server in development

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -93,7 +93,7 @@ Development:           Production/Test:
 - Migrations are stored in `backend/src/Anela.Heblo.Persistence/Migrations/`.
 - Single `ApplicationDbContext` in `Anela.Heblo.Persistence` (initially).
 - Migration naming convention: `AddXyzTable`, `AddIndexToProductName`, etc.
-- **Migrations are applied manually** – not part of automated CI/CD.
+- **Migrations apply automatically on Production startup; Development, Test, and Staging remain manual.**
 - Future evolution: Can move to module-specific DbContexts as needed.
 
 ### Applied Migrations

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -272,7 +272,8 @@ dotnet ef database update --project backend/src/Anela.Heblo.Persistence --startu
 dotnet test
 
 # 6. Commit migration files to git
-# Note: Migrations are applied manually in staging/production (not automated)
+# Note: Migrations are applied manually in Development/Test/Staging.
+#       In Production, migrations are applied automatically at app startup.
 ```
 
 ### Generating API Client
@@ -422,17 +423,24 @@ E2E_BASE_URL=https://heblo.stg.anela.cz
 
 ## Database Migrations Runbook
 
-Database migrations in this project are **manual**. They are not applied by the deployment pipeline. Code that depends on a new migration MUST NOT be deployed before the migration is applied to the target environment, or the application will return HTTP 500 with `Npgsql.PostgresException: 42P01: relation "<table>" does not exist`.
+Database migrations are applied differently depending on environment:
 
-### Pre-deploy checklist
+- **Production**: Migrations are applied **automatically at app startup** via `MigrateDatabaseAsync`. No manual step is required. The app will apply any pending migrations before accepting traffic.
+- **Development / Test / Staging**: Migrations remain **manual**. They are not applied by the deployment pipeline. Code that depends on a new migration MUST NOT be deployed before the migration is applied to the target environment, or the application will return HTTP 500 with `Npgsql.PostgresException: 42P01: relation "<table>" does not exist`.
 
-Before merging or deploying code that introduces or depends on a new EF Core migration:
+> **Developer dry-run tool**: `scripts/migration-dryrun.sh` is still useful as a local preview of what SQL EF Core would generate. It is no longer a production deploy gate — it is a developer convenience.
+
+### Pre-deploy checklist (Development / Test / Staging)
+
+Before merging or deploying code that introduces or depends on a new EF Core migration to a non-Production environment:
 
 1. Identify the migration(s) the new code depends on (look at `backend/src/Anela.Heblo.Persistence/Migrations/` and `dotnet ef migrations list`).
 2. Connect to the target environment's database using your authorized read-only credentials. Do NOT embed credentials in source control or scripts.
 3. Run the diagnostic SQL pair below (substitute the `LIKE` patterns and table names for the migration in question).
 4. Confirm the migration ID is present in `__EFMigrationsHistory` AND the expected post-migration physical schema is in place.
-5. If the migration is missing, apply it via the project's standard manual migration procedure BEFORE rolling out the dependent application code.
+5. If the migration is missing, apply it via `dotnet ef database update` BEFORE rolling out the dependent application code.
+
+For Production, skip steps 2–5 — the application handles migration automatically on startup.
 
 ### Post-deploy verification
 

--- a/docs/features/knowledge-base-rag.md
+++ b/docs/features/knowledge-base-rag.md
@@ -435,7 +435,7 @@ When `UseMockAuth=true` or `BypassJwtValidation=true`, `MockOneDriveService` is 
 | `20260302163014_AddKnowledgeBase` | 2026-03-02 | Creates `KnowledgeBaseDocuments` and `KnowledgeBaseChunks` tables, enables `vector` extension, adds `Embedding vector(1536)` column via raw SQL, creates HNSW index |
 | `20260306192831_AddContentHashToKnowledgeBaseDocument` | 2026-03-06 | Adds `ContentHash varchar(64)` column with UNIQUE index to `KnowledgeBaseDocuments` |
 
-> **Note:** Migrations are applied manually (not automated in deployment), consistent with the rest of the project.
+> **Note:** Migrations apply automatically on Production startup; Development, Test, and Staging remain manual.
 
 ---
 

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -6450,6 +6450,53 @@ export class ApiClient {
         return Promise.resolve<ProcessDailyConsumptionResponse>(null as any);
     }
 
+    packingMaterials_GetDailyConsumptionBreakdown(date: string | null | undefined, groupBy: string | undefined): Promise<GetDailyConsumptionBreakdownResponse> {
+        let url_ = this.baseUrl + "/api/packing-materials/consumption?";
+        if (date !== undefined && date !== null)
+            url_ += "date=" + encodeURIComponent("" + date) + "&";
+        if (groupBy === null)
+            throw new Error("The parameter 'groupBy' cannot be null.");
+        else if (groupBy !== undefined)
+            url_ += "groupBy=" + encodeURIComponent("" + groupBy) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackingMaterials_GetDailyConsumptionBreakdown(_response);
+        });
+    }
+
+    protected processPackingMaterials_GetDailyConsumptionBreakdown(response: Response): Promise<GetDailyConsumptionBreakdownResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetDailyConsumptionBreakdownResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetDailyConsumptionBreakdownResponse>(null as any);
+    }
+
     packingMaterials_GetPackingMaterialLogs(id: number, days: number | undefined): Promise<GetPackingMaterialLogsResponse> {
         let url_ = this.baseUrl + "/api/packing-materials/{id}/logs?";
         if (id === undefined || id === null)
@@ -6489,6 +6536,206 @@ export class ApiClient {
             });
         }
         return Promise.resolve<GetPackingMaterialLogsResponse>(null as any);
+    }
+
+    packingMaterials_GetAllocations(id: number): Promise<GetAllocationsResponse> {
+        let url_ = this.baseUrl + "/api/packing-materials/{id}/allocations";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackingMaterials_GetAllocations(_response);
+        });
+    }
+
+    protected processPackingMaterials_GetAllocations(response: Response): Promise<GetAllocationsResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetAllocationsResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetAllocationsResponse>(null as any);
+    }
+
+    packingMaterials_CreateAllocation(id: number, body: CreateAllocationRequestBody): Promise<CreateAllocationResponse> {
+        let url_ = this.baseUrl + "/api/packing-materials/{id}/allocations";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackingMaterials_CreateAllocation(_response);
+        });
+    }
+
+    protected processPackingMaterials_CreateAllocation(response: Response): Promise<CreateAllocationResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 201) {
+            return response.text().then((_responseText) => {
+            let result201: any = null;
+            let resultData201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result201 = CreateAllocationResponse.fromJS(resultData201);
+            return result201;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<CreateAllocationResponse>(null as any);
+    }
+
+    packingMaterials_UpdateAllocation(id: number, allocationId: number, body: UpdateAllocationRequestBody): Promise<UpdateAllocationResponse> {
+        let url_ = this.baseUrl + "/api/packing-materials/{id}/allocations/{allocationId}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (allocationId === undefined || allocationId === null)
+            throw new Error("The parameter 'allocationId' must be defined.");
+        url_ = url_.replace("{allocationId}", encodeURIComponent("" + allocationId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackingMaterials_UpdateAllocation(_response);
+        });
+    }
+
+    protected processPackingMaterials_UpdateAllocation(response: Response): Promise<UpdateAllocationResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = UpdateAllocationResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<UpdateAllocationResponse>(null as any);
+    }
+
+    packingMaterials_DeleteAllocation(id: number, allocationId: number): Promise<void> {
+        let url_ = this.baseUrl + "/api/packing-materials/{id}/allocations/{allocationId}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (allocationId === undefined || allocationId === null)
+            throw new Error("The parameter 'allocationId' must be defined.");
+        url_ = url_.replace("{allocationId}", encodeURIComponent("" + allocationId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processPackingMaterials_DeleteAllocation(_response);
+        });
+    }
+
+    protected processPackingMaterials_DeleteAllocation(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     photobank_GetPhotos(tags: string[] | null | undefined, search: string | null | undefined, folderPath: string | null | undefined, page: number | undefined, pageSize: number | undefined): Promise<GetPhotosResponse> {
@@ -23662,6 +23909,163 @@ export interface IProcessDailyConsumptionRequest {
     processingDate?: Date;
 }
 
+export class GetDailyConsumptionBreakdownResponse extends BaseResponse implements IGetDailyConsumptionBreakdownResponse {
+    error?: string | undefined;
+    date?: Date;
+    groupBy?: string;
+    groups?: ConsumptionGroupDto[];
+
+    constructor(data?: IGetDailyConsumptionBreakdownResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.error = _data["error"];
+            this.date = _data["date"] ? new Date(_data["date"].toString()) : <any>undefined;
+            this.groupBy = _data["groupBy"];
+            if (Array.isArray(_data["groups"])) {
+                this.groups = [] as any;
+                for (let item of _data["groups"])
+                    this.groups!.push(ConsumptionGroupDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetDailyConsumptionBreakdownResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetDailyConsumptionBreakdownResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["error"] = this.error;
+        data["date"] = this.date ? formatDate(this.date) : <any>undefined;
+        data["groupBy"] = this.groupBy;
+        if (Array.isArray(this.groups)) {
+            data["groups"] = [];
+            for (let item of this.groups)
+                data["groups"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetDailyConsumptionBreakdownResponse extends IBaseResponse {
+    error?: string | undefined;
+    date?: Date;
+    groupBy?: string;
+    groups?: ConsumptionGroupDto[];
+}
+
+export class ConsumptionGroupDto implements IConsumptionGroupDto {
+    key?: string;
+    label?: string;
+    totalAmount?: number;
+    rowCount?: number;
+    details?: ConsumptionDetailDto[];
+
+    constructor(data?: IConsumptionGroupDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.key = _data["key"];
+            this.label = _data["label"];
+            this.totalAmount = _data["totalAmount"];
+            this.rowCount = _data["rowCount"];
+            if (Array.isArray(_data["details"])) {
+                this.details = [] as any;
+                for (let item of _data["details"])
+                    this.details!.push(ConsumptionDetailDto.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): ConsumptionGroupDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new ConsumptionGroupDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["key"] = this.key;
+        data["label"] = this.label;
+        data["totalAmount"] = this.totalAmount;
+        data["rowCount"] = this.rowCount;
+        if (Array.isArray(this.details)) {
+            data["details"] = [];
+            for (let item of this.details)
+                data["details"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface IConsumptionGroupDto {
+    key?: string;
+    label?: string;
+    totalAmount?: number;
+    rowCount?: number;
+    details?: ConsumptionDetailDto[];
+}
+
+export class ConsumptionDetailDto implements IConsumptionDetailDto {
+    key?: string;
+    label?: string;
+    amount?: number;
+
+    constructor(data?: IConsumptionDetailDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.key = _data["key"];
+            this.label = _data["label"];
+            this.amount = _data["amount"];
+        }
+    }
+
+    static fromJS(data: any): ConsumptionDetailDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new ConsumptionDetailDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["key"] = this.key;
+        data["label"] = this.label;
+        data["amount"] = this.amount;
+        return data;
+    }
+}
+
+export interface IConsumptionDetailDto {
+    key?: string;
+    label?: string;
+    amount?: number;
+}
+
 export class GetPackingMaterialLogsResponse extends BaseResponse implements IGetPackingMaterialLogsResponse {
     material?: PackingMaterialDto;
     logs?: PackingMaterialLogDto[];
@@ -23782,6 +24186,253 @@ export interface IPackingMaterialLogDto {
 export enum LogEntryType {
     Manual = "Manual",
     AutomaticConsumption = "AutomaticConsumption",
+}
+
+export class GetAllocationsResponse extends BaseResponse implements IGetAllocationsResponse {
+    error?: string | undefined;
+    allocations?: PackingMaterialAllocationDto[];
+
+    constructor(data?: IGetAllocationsResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.error = _data["error"];
+            if (Array.isArray(_data["allocations"])) {
+                this.allocations = [] as any;
+                for (let item of _data["allocations"])
+                    this.allocations!.push(PackingMaterialAllocationDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetAllocationsResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetAllocationsResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["error"] = this.error;
+        if (Array.isArray(this.allocations)) {
+            data["allocations"] = [];
+            for (let item of this.allocations)
+                data["allocations"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetAllocationsResponse extends IBaseResponse {
+    error?: string | undefined;
+    allocations?: PackingMaterialAllocationDto[];
+}
+
+export class PackingMaterialAllocationDto implements IPackingMaterialAllocationDto {
+    id?: number;
+    packingMaterialId?: number;
+    productCode?: string;
+    amountPerUnit?: number;
+    createdAt?: Date;
+
+    constructor(data?: IPackingMaterialAllocationDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.packingMaterialId = _data["packingMaterialId"];
+            this.productCode = _data["productCode"];
+            this.amountPerUnit = _data["amountPerUnit"];
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): PackingMaterialAllocationDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new PackingMaterialAllocationDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["packingMaterialId"] = this.packingMaterialId;
+        data["productCode"] = this.productCode;
+        data["amountPerUnit"] = this.amountPerUnit;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IPackingMaterialAllocationDto {
+    id?: number;
+    packingMaterialId?: number;
+    productCode?: string;
+    amountPerUnit?: number;
+    createdAt?: Date;
+}
+
+export class CreateAllocationResponse extends BaseResponse implements ICreateAllocationResponse {
+    error?: string | undefined;
+    allocation?: PackingMaterialAllocationDto | undefined;
+
+    constructor(data?: ICreateAllocationResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.error = _data["error"];
+            this.allocation = _data["allocation"] ? PackingMaterialAllocationDto.fromJS(_data["allocation"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): CreateAllocationResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateAllocationResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["error"] = this.error;
+        data["allocation"] = this.allocation ? this.allocation.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface ICreateAllocationResponse extends IBaseResponse {
+    error?: string | undefined;
+    allocation?: PackingMaterialAllocationDto | undefined;
+}
+
+export class CreateAllocationRequestBody implements ICreateAllocationRequestBody {
+    productCode?: string;
+    amountPerUnit?: number;
+
+    constructor(data?: ICreateAllocationRequestBody) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.productCode = _data["productCode"];
+            this.amountPerUnit = _data["amountPerUnit"];
+        }
+    }
+
+    static fromJS(data: any): CreateAllocationRequestBody {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateAllocationRequestBody();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["productCode"] = this.productCode;
+        data["amountPerUnit"] = this.amountPerUnit;
+        return data;
+    }
+}
+
+export interface ICreateAllocationRequestBody {
+    productCode?: string;
+    amountPerUnit?: number;
+}
+
+export class UpdateAllocationResponse extends BaseResponse implements IUpdateAllocationResponse {
+    error?: string | undefined;
+
+    constructor(data?: IUpdateAllocationResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.error = _data["error"];
+        }
+    }
+
+    static override fromJS(data: any): UpdateAllocationResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateAllocationResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["error"] = this.error;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUpdateAllocationResponse extends IBaseResponse {
+    error?: string | undefined;
+}
+
+export class UpdateAllocationRequestBody implements IUpdateAllocationRequestBody {
+    productCode?: string;
+    amountPerUnit?: number;
+
+    constructor(data?: IUpdateAllocationRequestBody) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.productCode = _data["productCode"];
+            this.amountPerUnit = _data["amountPerUnit"];
+        }
+    }
+
+    static fromJS(data: any): UpdateAllocationRequestBody {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateAllocationRequestBody();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["productCode"] = this.productCode;
+        data["amountPerUnit"] = this.amountPerUnit;
+        return data;
+    }
+}
+
+export interface IUpdateAllocationRequestBody {
+    productCode?: string;
+    amountPerUnit?: number;
 }
 
 export class GetPhotosResponse extends BaseResponse implements IGetPhotosResponse {

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -38,6 +38,7 @@ export interface GetPhotosParams {
   tags?: string[];
   search?: string;
   folderPath?: string;
+  withoutTags?: boolean;
   page?: number;
   pageSize?: number;
 }
@@ -82,6 +83,7 @@ function buildPhotosUrl(baseUrl: string, params: GetPhotosParams): string {
   const qs = new URLSearchParams();
   if (params.search) qs.set("search", params.search);
   if (params.folderPath) qs.set("folderPath", params.folderPath);
+  if (params.withoutTags) qs.set("withoutTags", "true");
   if (params.page != null) qs.set("page", String(params.page));
   if (params.pageSize != null) qs.set("pageSize", String(params.pageSize));
   (params.tags ?? []).forEach((t) => qs.append("tags", String(t)));

--- a/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
@@ -149,7 +149,7 @@ const PhotoDrawer: React.FC<PhotoDrawerProps> = ({ photo, onClose }) => {
               <TagBadge
                 key={tag.id}
                 name={tag.name}
-                onRemove={isAdmin ? () => handleRemoveTag(tag.id) : undefined}
+                onRemove={isAdmin && !removeTagMutation.isPending ? () => handleRemoveTag(tag.id) : undefined}
               />
             ))}
           </div>

--- a/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import { useMsal } from "@azure/msal-react";
 import { X, ExternalLink, Copy, Check, Plus, Tag } from "lucide-react";
 import PhotoThumbnail from "./PhotoThumbnail";
+import { TagBadge } from "../../../components/ui/TagBadge";
 import { useAddPhotoTag, useRemovePhotoTag } from "../../../api/hooks/usePhotobank";
 import type { PhotoDto } from "../../../api/hooks/usePhotobank";
 
@@ -145,22 +146,11 @@ const PhotoDrawer: React.FC<PhotoDrawerProps> = ({ photo, onClose }) => {
         ) : (
           <div className="flex flex-wrap gap-1.5 mb-3">
             {photo.tags.map((tag) => (
-              <span
+              <TagBadge
                 key={tag.id}
-                className="inline-flex items-center gap-1 px-2 py-0.5 bg-secondary-blue-pale text-primary-blue rounded-full text-xs"
-              >
-                {tag.name}
-                {isAdmin && (
-                  <button
-                    onClick={() => handleRemoveTag(tag.id)}
-                    disabled={removeTagMutation.isPending}
-                    className="hover:text-red-500 disabled:opacity-50"
-                    aria-label={`Odebrat štítek ${tag.name}`}
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                )}
-              </span>
+                name={tag.name}
+                onRemove={isAdmin ? () => handleRemoveTag(tag.id) : undefined}
+              />
             ))}
           </div>
         )}

--- a/frontend/src/components/marketing/photobank/PhotoGrid.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoGrid.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import PhotoThumbnail from "./PhotoThumbnail";
+import { TagBadge } from "../../ui/TagBadge";
 import type { PhotoDto } from "../../../api/hooks/usePhotobank";
+
+const TILE_MAX_VISIBLE_TAGS = 3;
 
 interface PhotoGridProps {
   photos: PhotoDto[];
@@ -10,6 +13,7 @@ interface PhotoGridProps {
   page: number;
   pageSize: number;
   isLoading: boolean;
+  showTags?: boolean;
   onPhotoSelect: (photo: PhotoDto) => void;
   onPageChange: (page: number) => void;
 }
@@ -21,6 +25,7 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
   page,
   pageSize,
   isLoading,
+  showTags = false,
   onPhotoSelect,
   onPageChange,
 }) => {
@@ -78,6 +83,18 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                   className="w-full h-full"
                   size="medium"
                 />
+                {showTags && photo.tags.length > 0 && (
+                  <div className="absolute top-1 left-1 right-1 flex flex-wrap gap-1 pointer-events-none z-10">
+                    {photo.tags.slice(0, TILE_MAX_VISIBLE_TAGS).map((tag) => (
+                      <TagBadge key={tag.id} name={tag.name} variant="overlay" />
+                    ))}
+                    {photo.tags.length > TILE_MAX_VISIBLE_TAGS && (
+                      <span className="inline-flex items-center px-1.5 py-0.5 bg-black/50 text-white rounded-full text-xs">
+                        +{photo.tags.length - TILE_MAX_VISIBLE_TAGS}
+                      </span>
+                    )}
+                  </div>
+                )}
                 <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-0 hover:opacity-100 transition-opacity">
                   <p className="text-white text-xs truncate">{photo.name}</p>
                 </div>

--- a/frontend/src/components/marketing/photobank/PhotoList.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ChevronLeft, ChevronRight, ExternalLink } from "lucide-react";
 import PhotoThumbnail from "./PhotoThumbnail";
+import { TagBadge } from "../../../components/ui/TagBadge";
 import type { PhotoDto } from "../../../api/hooks/usePhotobank";
 
 const MAX_VISIBLE_TAGS = 5;
@@ -100,15 +101,10 @@ function PhotoList({
                 {photo.tags.length > 0 && (
                   <div className="flex flex-wrap gap-1">
                     {visibleTags.map((tag) => (
-                      <span
-                        key={tag.id}
-                        className="inline-flex items-center px-2 py-0.5 bg-secondary-blue-pale text-primary-blue rounded-full text-xs"
-                      >
-                        {tag.name}
-                      </span>
+                      <TagBadge key={tag.id} name={tag.name} />
                     ))}
                     {overflowCount > 0 && (
-                      <span className="inline-flex items-center px-2 py-0.5 bg-secondary-blue-pale text-primary-blue rounded-full text-xs">
+                      <span className="inline-flex items-center px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
                         +{overflowCount}
                       </span>
                     )}

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Search, X, Tag, Folder } from "lucide-react";
 import type { TagWithCountDto } from "../../../api/hooks/usePhotobank";
+import { TagBadge } from "../../ui/TagBadge";
 
 interface TagSidebarProps {
   tags: TagWithCountDto[];
   selectedTagIds: number[];
   search: string;
   folderPath: string;
+  withoutTags: boolean;
   onTagToggle: (tagId: number) => void;
   onSearchChange: (value: string) => void;
   onFolderPathChange: (value: string) => void;
+  onWithoutTagsToggle: () => void;
   onClearFilters: () => void;
 }
 
@@ -20,13 +23,16 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
   selectedTagIds,
   search,
   folderPath,
+  withoutTags,
   onTagToggle,
   onSearchChange,
   onFolderPathChange,
+  onWithoutTagsToggle,
   onClearFilters,
 }) => {
   const [inputValue, setInputValue] = useState(search);
   const [folderPathValue, setFolderPathValue] = useState(folderPath);
+  const [tagFilter, setTagFilter] = useState("");
 
   // Sync external search value to local input
   useEffect(() => {
@@ -84,7 +90,11 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     onFolderPathChange("");
   }, [onFolderPathChange]);
 
-  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0;
+  const filteredTags = tagFilter.trim()
+    ? tags.filter((t) => t.name.toLowerCase().includes(tagFilter.trim().toLowerCase()))
+    : tags;
+
+  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0 || withoutTags;
 
   return (
     <aside className="flex flex-col h-full bg-white border-r border-gray-200 overflow-hidden">
@@ -159,25 +169,68 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
           </span>
         </div>
 
+        {/* Tag name filter input */}
+        {tags.length > 0 && (
+          <div className="relative mb-2">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-gray-400 pointer-events-none" />
+            <input
+              type="text"
+              value={tagFilter}
+              onChange={(e) => setTagFilter(e.target.value)}
+              placeholder="Filtrovat štítky..."
+              className="w-full pl-7 pr-6 py-1 text-xs border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-primary-blue focus:border-transparent"
+              aria-label="Filtrovat štítky"
+            />
+            {tagFilter && (
+              <button
+                type="button"
+                onClick={() => setTagFilter("")}
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                aria-label="Vymazat filtr štítků"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+        )}
+
         {tags.length === 0 ? (
           <p className="text-sm text-gray-400 mt-2">Žádné štítky</p>
         ) : (
           <ul className="space-y-0.5">
-            {tags.map((tag) => {
+            {/* "Without tags" special option */}
+            <li>
+              <button
+                type="button"
+                onClick={onWithoutTagsToggle}
+                className={[
+                  "w-full flex items-center justify-between px-2 py-1.5 rounded-md text-sm transition-colors text-left",
+                  withoutTags
+                    ? "bg-secondary-blue-pale text-primary-blue font-medium"
+                    : "text-gray-700 hover:bg-gray-50",
+                ].join(" ")}
+                aria-pressed={withoutTags}
+              >
+                <span className="text-xs italic text-gray-400">Bez štítků</span>
+                <span className="ml-2 text-xs tabular-nums flex-shrink-0 text-gray-300">—</span>
+              </button>
+            </li>
+
+            {/* Filtered tag list */}
+            {filteredTags.map((tag) => {
               const isSelected = selectedTagIds.includes(tag.id);
               return (
                 <li key={tag.id}>
                   <button
+                    type="button"
                     onClick={() => onTagToggle(tag.id)}
                     className={[
-                      "w-full flex items-center justify-between px-2 py-1.5 rounded-md text-sm transition-colors text-left",
-                      isSelected
-                        ? "bg-secondary-blue-pale text-primary-blue font-medium"
-                        : "text-gray-700 hover:bg-gray-50",
+                      "w-full flex items-center justify-between px-2 py-1.5 rounded-md transition-colors text-left",
+                      isSelected ? "bg-secondary-blue-pale" : "hover:bg-gray-50",
                     ].join(" ")}
                     aria-pressed={isSelected}
                   >
-                    <span className="truncate">{tag.name}</span>
+                    <TagBadge name={tag.name} />
                     <span
                       className={[
                         "ml-2 text-xs tabular-nums flex-shrink-0",
@@ -190,6 +243,10 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
                 </li>
               );
             })}
+
+            {filteredTags.length === 0 && tagFilter && (
+              <li className="px-2 py-1.5 text-xs text-gray-400">Žádné výsledky</li>
+            )}
           </ul>
         )}
       </div>

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
@@ -150,4 +150,98 @@ describe("PhotoGrid", () => {
     // Assert
     expect(screen.getByText("Žádné fotografie nenalezeny")).toBeInTheDocument();
   });
+
+  test("renders tag overlay when showTags is true and photo has tags", () => {
+    // Arrange
+    const photo = makePhoto({
+      id: 1,
+      name: "tagged.jpg",
+      tags: [
+        { id: 10, name: "Léto", source: "manual" },
+        { id: 11, name: "Příroda", source: "manual" },
+      ],
+    });
+
+    // Act
+    renderGrid({ photos: [photo], total: 1, showTags: true });
+
+    // Assert — overlay container has pointer-events-none class
+    const overlay = document.querySelector(".pointer-events-none");
+    expect(overlay).toBeInTheDocument();
+    expect(screen.getByText("Léto")).toBeInTheDocument();
+    expect(screen.getByText("Příroda")).toBeInTheDocument();
+  });
+
+  test("does not render tag overlay when showTags is false", () => {
+    // Arrange
+    const photo = makePhoto({
+      id: 1,
+      name: "tagged.jpg",
+      tags: [{ id: 10, name: "Léto", source: "manual" }],
+    });
+
+    // Act
+    renderGrid({ photos: [photo], total: 1, showTags: false });
+
+    // Assert
+    expect(screen.queryByText("Léto")).not.toBeInTheDocument();
+  });
+
+  test("does not render tag overlay when showTags is omitted (default false)", () => {
+    // Arrange
+    const photo = makePhoto({
+      id: 1,
+      name: "tagged.jpg",
+      tags: [{ id: 10, name: "Léto", source: "manual" }],
+    });
+
+    // Act — no showTags prop passed
+    renderGrid({ photos: [photo], total: 1 });
+
+    // Assert
+    expect(screen.queryByText("Léto")).not.toBeInTheDocument();
+  });
+
+  test("shows overflow chip when photo has more than 3 tags", () => {
+    // Arrange
+    const photo = makePhoto({
+      id: 1,
+      name: "many-tags.jpg",
+      tags: [
+        { id: 1, name: "Tag1", source: "manual" },
+        { id: 2, name: "Tag2", source: "manual" },
+        { id: 3, name: "Tag3", source: "manual" },
+        { id: 4, name: "Tag4", source: "manual" },
+        { id: 5, name: "Tag5", source: "manual" },
+      ],
+    });
+
+    // Act
+    renderGrid({ photos: [photo], total: 1, showTags: true });
+
+    // Assert — first 3 tags visible, rest truncated, overflow chip shows "+2"
+    expect(screen.getByText("Tag1")).toBeInTheDocument();
+    expect(screen.getByText("Tag2")).toBeInTheDocument();
+    expect(screen.getByText("Tag3")).toBeInTheDocument();
+    expect(screen.queryByText("Tag4")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tag5")).not.toBeInTheDocument();
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+
+  test("overlay has pointer-events-none so click reaches the button", () => {
+    // Arrange
+    const onPhotoSelect = jest.fn();
+    const photo = makePhoto({
+      id: 1,
+      name: "click-test.jpg",
+      tags: [{ id: 10, name: "Léto", source: "manual" }],
+    });
+
+    // Act
+    renderGrid({ photos: [photo], total: 1, showTags: true, onPhotoSelect });
+    fireEvent.click(screen.getByLabelText("click-test.jpg"));
+
+    // Assert — click propagated through the overlay to the button
+    expect(onPhotoSelect).toHaveBeenCalledWith(photo);
+  });
 });

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
@@ -165,9 +165,7 @@ describe("PhotoGrid", () => {
     // Act
     renderGrid({ photos: [photo], total: 1, showTags: true });
 
-    // Assert — overlay container has pointer-events-none class
-    const overlay = document.querySelector(".pointer-events-none");
-    expect(overlay).toBeInTheDocument();
+    // Assert — tag text is visible, confirming overlay rendered
     expect(screen.getByText("Léto")).toBeInTheDocument();
     expect(screen.getByText("Příroda")).toBeInTheDocument();
   });

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { Grid3x3, List, Settings } from "lucide-react";
+import { Grid3x3, List, Settings, Tag } from "lucide-react";
 import { useMsal } from "@azure/msal-react";
 import TagSidebar from "../TagSidebar";
 import PhotoGrid from "../PhotoGrid";
@@ -18,6 +18,7 @@ const TAGGER_ROLE = "marketing_writer";
 const DEFAULT_PAGE_SIZE = 48;
 const SIDEBAR_WIDTH = "220px";
 const STORAGE_KEY = "photobank.view";
+const STORAGE_KEY_TAGS_ON_TILES = "photobank.tagsOnTiles";
 
 type ViewMode = "tiles" | "list";
 
@@ -35,6 +36,14 @@ function readViewMode(): ViewMode {
   }
 }
 
+function readTagsOnTiles(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY_TAGS_ON_TILES) === "1";
+  } catch {
+    return false;
+  }
+}
+
 function PhotobankPage() {
   const { accounts } = useMsal();
   const roles = (accounts[0]?.idTokenClaims as any)?.roles as string[] | undefined;
@@ -47,6 +56,7 @@ function PhotobankPage() {
   const [page, setPage] = useState(1);
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoDto | null>(null);
   const [view, setView] = useState<ViewMode>(readViewMode);
+  const [tagsOnTiles, setTagsOnTiles] = useState<boolean>(readTagsOnTiles);
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -56,6 +66,12 @@ function PhotobankPage() {
       // private browsing
     }
   }, [view]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY_TAGS_ON_TILES, tagsOnTiles ? "1" : "0");
+    } catch {}
+  }, [tagsOnTiles]);
 
   const { data: tagsData } = usePhotoTags();
 
@@ -169,16 +185,34 @@ function PhotobankPage() {
                 />
               )}
             </div>
-            <PhotoViewToggle
-              options={VIEW_OPTIONS}
-              value={view}
-              onChange={(v) => setView(v as ViewMode)}
-            />
+            <div className="flex items-center">
+              <PhotoViewToggle
+                options={VIEW_OPTIONS}
+                value={view}
+                onChange={(v) => setView(v as ViewMode)}
+              />
+              {view === "tiles" && (
+                <button
+                  type="button"
+                  title="Zobrazit štítky na dlaždicích"
+                  aria-pressed={tagsOnTiles}
+                  onClick={() => setTagsOnTiles((v) => !v)}
+                  className={[
+                    "w-8 h-8 flex items-center justify-center rounded ml-2",
+                    tagsOnTiles
+                      ? "bg-primary-blue text-white"
+                      : "bg-white text-gray-600 border border-gray-300 hover:bg-gray-50",
+                  ].join(" ")}
+                >
+                  <Tag className="w-4 h-4" />
+                </button>
+              )}
+            </div>
           </div>
           {/* Photo grid or list */}
           <div className="flex-1 flex overflow-hidden">
             {view === "tiles" ? (
-              <PhotoGrid {...sharedPhotoProps} />
+              <PhotoGrid {...sharedPhotoProps} showTags={tagsOnTiles} />
             ) : (
               <PhotoList {...sharedPhotoProps} />
             )}

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -70,7 +70,9 @@ function PhotobankPage() {
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY_TAGS_ON_TILES, tagsOnTiles ? "1" : "0");
-    } catch {}
+    } catch {
+      // private browsing
+    }
   }, [tagsOnTiles]);
 
   const { data: tagsData } = usePhotoTags();

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -53,6 +53,7 @@ function PhotobankPage() {
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
   const [search, setSearch] = useState("");
   const [folderPath, setFolderPath] = useState("");
+  const [withoutTags, setWithoutTags] = useState(false);
   const [page, setPage] = useState(1);
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoDto | null>(null);
   const [view, setView] = useState<ViewMode>(readViewMode);
@@ -89,6 +90,7 @@ function PhotobankPage() {
     tags: selectedTagNames.length > 0 ? selectedTagNames : undefined,
     search: search || undefined,
     folderPath: folderPath || undefined,
+    withoutTags: withoutTags || undefined,
     page,
     pageSize: DEFAULT_PAGE_SIZE,
   });
@@ -114,6 +116,7 @@ function PhotobankPage() {
     setSelectedTagIds([]);
     setSearch("");
     setFolderPath("");
+    setWithoutTags(false);
     setPage(1);
   }, []);
 
@@ -165,9 +168,11 @@ function PhotobankPage() {
             selectedTagIds={selectedTagIds}
             search={search}
             folderPath={folderPath}
+            withoutTags={withoutTags}
             onTagToggle={handleTagToggle}
             onSearchChange={handleSearchChange}
             onFolderPathChange={handleFolderPathChange}
+            onWithoutTagsToggle={() => { setWithoutTags((v) => !v); setPage(1); }}
             onClearFilters={handleClearFilters}
           />
         </div>

--- a/frontend/src/components/ui/TagBadge.tsx
+++ b/frontend/src/components/ui/TagBadge.tsx
@@ -3,7 +3,7 @@ import { getTagColor } from "./tagColor";
 
 export interface TagBadgeProps {
   name: string;
-  variant?: "default" | "compact" | "overlay";
+  variant?: "default" | "overlay";
   onRemove?: () => void;
 }
 
@@ -25,7 +25,7 @@ export const TagBadge: React.FC<TagBadgeProps> = ({
           aria-label="Odebrat štítek"
           className="ml-0.5 hover:opacity-70 rounded-full"
         >
-          ×
+          <span aria-hidden="true">×</span>
         </button>
       )}
     </div>

--- a/frontend/src/components/ui/TagBadge.tsx
+++ b/frontend/src/components/ui/TagBadge.tsx
@@ -16,7 +16,7 @@ export const TagBadge: React.FC<TagBadgeProps> = ({
   const { bg, text } = getTagColor(name, isOverlay);
 
   return (
-    <div className={`inline-flex items-center rounded-full text-xs px-2 py-0.5 gap-1 ${bg} ${text}`}>
+    <div data-testid="tag-badge" className={`inline-flex items-center rounded-full text-xs px-2 py-0.5 gap-1 ${bg} ${text}`}>
       {name}
       {onRemove && (
         <button

--- a/frontend/src/components/ui/TagBadge.tsx
+++ b/frontend/src/components/ui/TagBadge.tsx
@@ -22,7 +22,7 @@ export const TagBadge: React.FC<TagBadgeProps> = ({
         <button
           type="button"
           onClick={onRemove}
-          aria-label="Odebrat štítek"
+          aria-label={`Odebrat štítek ${name}`}
           className="ml-0.5 hover:opacity-70 rounded-full"
         >
           <span aria-hidden="true">×</span>

--- a/frontend/src/components/ui/TagBadge.tsx
+++ b/frontend/src/components/ui/TagBadge.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { getTagColor } from "./tagColor";
+
+export interface TagBadgeProps {
+  name: string;
+  variant?: "default" | "compact" | "overlay";
+  onRemove?: () => void;
+}
+
+export const TagBadge: React.FC<TagBadgeProps> = ({
+  name,
+  variant = "default",
+  onRemove,
+}) => {
+  const isOverlay = variant === "overlay";
+  const { bg, text } = getTagColor(name, isOverlay);
+
+  return (
+    <div className={`inline-flex items-center rounded-full text-xs px-2 py-0.5 gap-1 ${bg} ${text}`}>
+      {name}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Odebrat štítek"
+          className="ml-0.5 hover:opacity-70 rounded-full"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default TagBadge;

--- a/frontend/src/components/ui/__tests__/TagBadge.test.tsx
+++ b/frontend/src/components/ui/__tests__/TagBadge.test.tsx
@@ -13,24 +13,24 @@ describe("TagBadge", () => {
     it("applies the correct bg and text classes from getTagColor", () => {
       const tagName = "example";
       const { bg, text } = getTagColor(tagName, false);
-      const { container } = render(<TagBadge name={tagName} />);
+      render(<TagBadge name={tagName} />);
 
-      const badgeDiv = container.querySelector("div");
-      expect(badgeDiv).toHaveClass(bg);
-      expect(badgeDiv).toHaveClass(text);
+      const badge = screen.getByTestId("tag-badge");
+      expect(badge).toHaveClass(bg);
+      expect(badge).toHaveClass(text);
     });
 
     it("applies base shape classes: inline-flex items-center rounded-full text-xs px-2 py-0.5 gap-1", () => {
-      const { container } = render(<TagBadge name="test" />);
-      const badgeDiv = container.querySelector("div");
+      render(<TagBadge name="test" />);
+      const badge = screen.getByTestId("tag-badge");
 
-      expect(badgeDiv).toHaveClass("inline-flex");
-      expect(badgeDiv).toHaveClass("items-center");
-      expect(badgeDiv).toHaveClass("rounded-full");
-      expect(badgeDiv).toHaveClass("text-xs");
-      expect(badgeDiv).toHaveClass("px-2");
-      expect(badgeDiv).toHaveClass("py-0.5");
-      expect(badgeDiv).toHaveClass("gap-1");
+      expect(badge).toHaveClass("inline-flex");
+      expect(badge).toHaveClass("items-center");
+      expect(badge).toHaveClass("rounded-full");
+      expect(badge).toHaveClass("text-xs");
+      expect(badge).toHaveClass("px-2");
+      expect(badge).toHaveClass("py-0.5");
+      expect(badge).toHaveClass("gap-1");
     });
   });
 
@@ -91,33 +91,33 @@ describe("TagBadge", () => {
   describe("variants", () => {
     it("for variant='default', calls getTagColor with overlay=false", () => {
       const tagName = "defaulttest";
-      const { container } = render(<TagBadge name={tagName} variant="default" />);
+      render(<TagBadge name={tagName} variant="default" />);
 
       const { bg, text } = getTagColor(tagName, false);
-      const badgeDiv = container.querySelector("div");
-      expect(badgeDiv).toHaveClass(bg);
-      expect(badgeDiv).toHaveClass(text);
+      const badge = screen.getByTestId("tag-badge");
+      expect(badge).toHaveClass(bg);
+      expect(badge).toHaveClass(text);
     });
 
     it("for variant='overlay', calls getTagColor with overlay=true", () => {
       const tagName = "overlaytest";
-      const { container } = render(<TagBadge name={tagName} variant="overlay" />);
+      render(<TagBadge name={tagName} variant="overlay" />);
 
       const { bg, text } = getTagColor(tagName, true);
-      const badgeDiv = container.querySelector("div");
-      expect(badgeDiv).toHaveClass(bg);
-      expect(badgeDiv).toHaveClass(text);
+      const badge = screen.getByTestId("tag-badge");
+      expect(badge).toHaveClass(bg);
+      expect(badge).toHaveClass(text);
     });
 
     it("overlay variant uses saturated colors (500/90) from OVERLAY_PALETTE", () => {
       const tagName = "example";
       const { bg } = getTagColor(tagName, true);
 
-      const { container } = render(<TagBadge name={tagName} variant="overlay" />);
-      const badgeDiv = container.querySelector("div");
+      render(<TagBadge name={tagName} variant="overlay" />);
+      const badge = screen.getByTestId("tag-badge");
 
       // Check that it has either a 500/90 or text-white from overlay palette
-      expect(badgeDiv).toHaveClass(bg);
+      expect(badge).toHaveClass(bg);
       expect(OVERLAY_PALETTE).toContainEqual({ bg, text: "text-white" });
     });
 
@@ -125,10 +125,10 @@ describe("TagBadge", () => {
       const tagName = "example";
       const { bg } = getTagColor(tagName, false);
 
-      const { container } = render(<TagBadge name={tagName} variant="default" />);
-      const badgeDiv = container.querySelector("div");
+      render(<TagBadge name={tagName} variant="default" />);
+      const badge = screen.getByTestId("tag-badge");
 
-      expect(badgeDiv).toHaveClass(bg);
+      expect(badge).toHaveClass(bg);
       expect(TAG_PALETTE).toContainEqual(
         TAG_PALETTE.find((p) => p.bg === bg)!
       );
@@ -138,17 +138,16 @@ describe("TagBadge", () => {
   describe("default variant", () => {
     it("renders with default variant when variant is not specified", () => {
       const tagName = "defaulttest";
-      const { container: containerWithDefault } = render(
-        <TagBadge name={tagName} variant="default" />
-      );
-      const { container: containerWithoutVariant } = render(
-        <TagBadge name={tagName} />
-      );
+      render(<TagBadge name={tagName} variant="default" />);
+      const badgeWithDefault = screen.getByTestId("tag-badge");
+      const classNameWithDefault = badgeWithDefault.className;
 
-      const badgeWithDefault = containerWithDefault.querySelector("div");
-      const badgeWithoutVariant = containerWithoutVariant.querySelector("div");
+      // Re-render without variant to compare
+      const { unmount } = render(<TagBadge name={tagName} />);
+      const badgeWithoutVariant = screen.getAllByTestId("tag-badge")[1];
 
-      expect(badgeWithDefault?.className).toBe(badgeWithoutVariant?.className);
+      expect(classNameWithDefault).toBe(badgeWithoutVariant.className);
+      unmount();
     });
   });
 
@@ -172,16 +171,14 @@ describe("TagBadge", () => {
     });
 
     it("renders overlay variant for thumbnail context", () => {
-      const { container } = render(
-        <TagBadge name="ThumbnailTag" variant="overlay" />
-      );
+      render(<TagBadge name="ThumbnailTag" variant="overlay" />);
 
       const { bg, text } = getTagColor("ThumbnailTag", true);
-      const badgeDiv = container.querySelector("div");
+      const badge = screen.getByTestId("tag-badge");
 
-      expect(badgeDiv).toHaveClass(bg);
-      expect(badgeDiv).toHaveClass(text);
-      expect(badgeDiv).toHaveClass("text-white");
+      expect(badge).toHaveClass(bg);
+      expect(badge).toHaveClass(text);
+      expect(badge).toHaveClass("text-white");
     });
   });
 });

--- a/frontend/src/components/ui/__tests__/TagBadge.test.tsx
+++ b/frontend/src/components/ui/__tests__/TagBadge.test.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TagBadge } from "../TagBadge";
+import { getTagColor, TAG_PALETTE, OVERLAY_PALETTE } from "../tagColor";
+
+describe("TagBadge", () => {
+  describe("rendering", () => {
+    it("renders the tag name text", () => {
+      render(<TagBadge name="TestTag" />);
+      expect(screen.getByText("TestTag")).toBeInTheDocument();
+    });
+
+    it("applies the correct bg and text classes from getTagColor", () => {
+      const tagName = "example";
+      const { bg, text } = getTagColor(tagName, false);
+      const { container } = render(<TagBadge name={tagName} />);
+
+      const badgeDiv = container.querySelector("div");
+      expect(badgeDiv).toHaveClass(bg);
+      expect(badgeDiv).toHaveClass(text);
+    });
+
+    it("applies base shape classes: inline-flex items-center rounded-full text-xs px-2 py-0.5 gap-1", () => {
+      const { container } = render(<TagBadge name="test" />);
+      const badgeDiv = container.querySelector("div");
+
+      expect(badgeDiv).toHaveClass("inline-flex");
+      expect(badgeDiv).toHaveClass("items-center");
+      expect(badgeDiv).toHaveClass("rounded-full");
+      expect(badgeDiv).toHaveClass("text-xs");
+      expect(badgeDiv).toHaveClass("px-2");
+      expect(badgeDiv).toHaveClass("py-0.5");
+      expect(badgeDiv).toHaveClass("gap-1");
+    });
+  });
+
+  describe("remove button", () => {
+    it("renders the remove button when onRemove is provided", () => {
+      const handleRemove = jest.fn();
+      render(<TagBadge name="test" onRemove={handleRemove} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent("×");
+    });
+
+    it("does NOT render remove button when onRemove is omitted", () => {
+      render(<TagBadge name="test" />);
+
+      const buttons = screen.queryAllByRole("button");
+      expect(buttons).toHaveLength(0);
+    });
+
+    it("calls onRemove when the remove button is clicked", () => {
+      const handleRemove = jest.fn();
+      render(<TagBadge name="test" onRemove={handleRemove} />);
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(handleRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it("remove button has correct aria-label", () => {
+      const handleRemove = jest.fn();
+      render(<TagBadge name="test" onRemove={handleRemove} />);
+
+      const button = screen.getByRole("button", { name: "Odebrat štítek" });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("remove button has type='button'", () => {
+      const handleRemove = jest.fn();
+      render(<TagBadge name="test" onRemove={handleRemove} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("type", "button");
+    });
+
+    it("remove button applies hover:opacity-70 and rounded-full classes", () => {
+      const handleRemove = jest.fn();
+      render(<TagBadge name="test" onRemove={handleRemove} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("hover:opacity-70");
+      expect(button).toHaveClass("rounded-full");
+      expect(button).toHaveClass("ml-0.5");
+    });
+  });
+
+  describe("variants", () => {
+    it("for variant='default', calls getTagColor with overlay=false", () => {
+      const tagName = "defaulttest";
+      const { container } = render(<TagBadge name={tagName} variant="default" />);
+
+      const { bg, text } = getTagColor(tagName, false);
+      const badgeDiv = container.querySelector("div");
+      expect(badgeDiv).toHaveClass(bg);
+      expect(badgeDiv).toHaveClass(text);
+    });
+
+    it("for variant='compact', renders same shape as default (no visual difference)", () => {
+      const { container: containerDefault } = render(
+        <TagBadge name="test" variant="default" />
+      );
+      const { container: containerCompact } = render(
+        <TagBadge name="test" variant="compact" />
+      );
+
+      const badgeDefault = containerDefault.querySelector("div");
+      const badgeCompact = containerCompact.querySelector("div");
+
+      // Both should have the same base classes
+      expect(badgeDefault?.className).toBe(badgeCompact?.className);
+    });
+
+    it("for variant='overlay', calls getTagColor with overlay=true", () => {
+      const tagName = "overlaytest";
+      const { container } = render(<TagBadge name={tagName} variant="overlay" />);
+
+      const { bg, text } = getTagColor(tagName, true);
+      const badgeDiv = container.querySelector("div");
+      expect(badgeDiv).toHaveClass(bg);
+      expect(badgeDiv).toHaveClass(text);
+    });
+
+    it("overlay variant uses saturated colors (500/90) from OVERLAY_PALETTE", () => {
+      const tagName = "example";
+      const { bg } = getTagColor(tagName, true);
+
+      const { container } = render(<TagBadge name={tagName} variant="overlay" />);
+      const badgeDiv = container.querySelector("div");
+
+      // Check that it has either a 500/90 or text-white from overlay palette
+      expect(badgeDiv).toHaveClass(bg);
+      expect(OVERLAY_PALETTE).toContainEqual({ bg, text: "text-white" });
+    });
+
+    it("default variant uses light colors from TAG_PALETTE", () => {
+      const tagName = "example";
+      const { bg } = getTagColor(tagName, false);
+
+      const { container } = render(<TagBadge name={tagName} variant="default" />);
+      const badgeDiv = container.querySelector("div");
+
+      expect(badgeDiv).toHaveClass(bg);
+      expect(TAG_PALETTE).toContainEqual(
+        TAG_PALETTE.find((p) => p.bg === bg)!
+      );
+    });
+  });
+
+  describe("default variant", () => {
+    it("renders with default variant when variant is not specified", () => {
+      const tagName = "defaulttest";
+      const { container: containerWithDefault } = render(
+        <TagBadge name={tagName} variant="default" />
+      );
+      const { container: containerWithoutVariant } = render(
+        <TagBadge name={tagName} />
+      );
+
+      const badgeWithDefault = containerWithDefault.querySelector("div");
+      const badgeWithoutVariant = containerWithoutVariant.querySelector("div");
+
+      expect(badgeWithDefault?.className).toBe(badgeWithoutVariant?.className);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("renders remove button with onRemove in list context", () => {
+      const handleRemove = jest.fn();
+      render(<TagBadge name="ProductTag" onRemove={handleRemove} />);
+
+      const button = screen.getByRole("button");
+      expect(button).toBeInTheDocument();
+
+      fireEvent.click(button);
+      expect(handleRemove).toHaveBeenCalled();
+    });
+
+    it("renders without remove button in list view context", () => {
+      render(<TagBadge name="ProductTag" />);
+
+      const buttons = screen.queryAllByRole("button");
+      expect(buttons).toHaveLength(0);
+    });
+
+    it("renders overlay variant for thumbnail context", () => {
+      const { container } = render(
+        <TagBadge name="ThumbnailTag" variant="overlay" />
+      );
+
+      const { bg, text } = getTagColor("ThumbnailTag", true);
+      const badgeDiv = container.querySelector("div");
+
+      expect(badgeDiv).toHaveClass(bg);
+      expect(badgeDiv).toHaveClass(text);
+      expect(badgeDiv).toHaveClass("text-white");
+    });
+  });
+});

--- a/frontend/src/components/ui/__tests__/TagBadge.test.tsx
+++ b/frontend/src/components/ui/__tests__/TagBadge.test.tsx
@@ -39,7 +39,7 @@ describe("TagBadge", () => {
       const handleRemove = jest.fn();
       render(<TagBadge name="test" onRemove={handleRemove} />);
 
-      const button = screen.getByLabelText("Odebrat štítek");
+      const button = screen.getByLabelText("Odebrat štítek test");
       expect(button).toBeInTheDocument();
       expect(button).toHaveTextContent("×");
     });
@@ -65,7 +65,7 @@ describe("TagBadge", () => {
       const handleRemove = jest.fn();
       render(<TagBadge name="test" onRemove={handleRemove} />);
 
-      const button = screen.getByRole("button", { name: "Odebrat štítek" });
+      const button = screen.getByRole("button", { name: "Odebrat štítek test" });
       expect(button).toBeInTheDocument();
     });
 

--- a/frontend/src/components/ui/__tests__/TagBadge.test.tsx
+++ b/frontend/src/components/ui/__tests__/TagBadge.test.tsx
@@ -39,7 +39,7 @@ describe("TagBadge", () => {
       const handleRemove = jest.fn();
       render(<TagBadge name="test" onRemove={handleRemove} />);
 
-      const button = screen.getByRole("button");
+      const button = screen.getByLabelText("Odebrat štítek");
       expect(button).toBeInTheDocument();
       expect(button).toHaveTextContent("×");
     });
@@ -97,21 +97,6 @@ describe("TagBadge", () => {
       const badgeDiv = container.querySelector("div");
       expect(badgeDiv).toHaveClass(bg);
       expect(badgeDiv).toHaveClass(text);
-    });
-
-    it("for variant='compact', renders same shape as default (no visual difference)", () => {
-      const { container: containerDefault } = render(
-        <TagBadge name="test" variant="default" />
-      );
-      const { container: containerCompact } = render(
-        <TagBadge name="test" variant="compact" />
-      );
-
-      const badgeDefault = containerDefault.querySelector("div");
-      const badgeCompact = containerCompact.querySelector("div");
-
-      // Both should have the same base classes
-      expect(badgeDefault?.className).toBe(badgeCompact?.className);
     });
 
     it("for variant='overlay', calls getTagColor with overlay=true", () => {

--- a/frontend/src/components/ui/__tests__/tagColor.test.ts
+++ b/frontend/src/components/ui/__tests__/tagColor.test.ts
@@ -1,0 +1,135 @@
+import { getTagColor, TAG_PALETTE, OVERLAY_PALETTE } from "../tagColor";
+
+describe("tagColor", () => {
+  describe("determinism", () => {
+    it("should return the same color for the same name (deterministic)", () => {
+      const name = "TestTag";
+      const color1 = getTagColor(name);
+      const color2 = getTagColor(name);
+      const color3 = getTagColor(name);
+
+      expect(color1).toEqual(color2);
+      expect(color2).toEqual(color3);
+    });
+  });
+
+  describe("palette selection", () => {
+    it("should return a valid entry from TAG_PALETTE by default", () => {
+      const color = getTagColor("example");
+      expect(TAG_PALETTE).toContain(color);
+    });
+
+    it("should return a valid entry from OVERLAY_PALETTE when overlay is true", () => {
+      const color = getTagColor("example", true);
+      expect(OVERLAY_PALETTE).toContain(color);
+    });
+
+    it("should return different palettes for overlay true vs false", () => {
+      const name = "testname";
+      const tagColor = getTagColor(name, false);
+      const overlayColor = getTagColor(name, true);
+
+      // They should be different palette entries
+      expect(tagColor).not.toEqual(overlayColor);
+    });
+
+    it("overlay palette should always have text-white", () => {
+      for (let i = 0; i < 100; i++) {
+        const color = getTagColor(`tag${i}`, true);
+        expect(color.text).toBe("text-white");
+      }
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty string without crashing", () => {
+      const color = getTagColor("");
+      expect(color).toBeDefined();
+      expect(TAG_PALETTE).toContain(color);
+    });
+
+    it("should handle very long strings", () => {
+      const longName = "a".repeat(1000);
+      const color = getTagColor(longName);
+      expect(TAG_PALETTE).toContain(color);
+    });
+
+    it("should handle special characters", () => {
+      const color = getTagColor("tag!@#$%^&*()");
+      expect(TAG_PALETTE).toContain(color);
+    });
+  });
+
+  describe("distribution", () => {
+    it("should return indices within palette bounds", () => {
+      const names = [
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+        "zeta",
+        "eta",
+        "theta",
+      ];
+
+      names.forEach((name) => {
+        const color = getTagColor(name);
+        const index = TAG_PALETTE.indexOf(color);
+        expect(index).toBeGreaterThanOrEqual(0);
+        expect(index).toBeLessThan(TAG_PALETTE.length);
+      });
+    });
+
+    it("should spread tags across different palette colors", () => {
+      const colorSet = new Set<string>();
+
+      for (let i = 0; i < 50; i++) {
+        const color = getTagColor(`tag${i}`);
+        colorSet.add(JSON.stringify(color));
+      }
+
+      // Should use multiple colors, not just one
+      expect(colorSet.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe("case insensitivity", () => {
+    it("should treat uppercase and lowercase the same", () => {
+      const color1 = getTagColor("TestTag");
+      const color2 = getTagColor("testtag");
+      const color3 = getTagColor("TESTTAG");
+
+      expect(color1).toEqual(color2);
+      expect(color2).toEqual(color3);
+    });
+  });
+
+  describe("palette structure", () => {
+    it("TAG_PALETTE should have exactly 10 entries", () => {
+      expect(TAG_PALETTE.length).toBe(10);
+    });
+
+    it("OVERLAY_PALETTE should have exactly 10 entries", () => {
+      expect(OVERLAY_PALETTE.length).toBe(10);
+    });
+
+    it("all TAG_PALETTE entries should have bg and text properties", () => {
+      TAG_PALETTE.forEach((entry) => {
+        expect(entry.bg).toBeDefined();
+        expect(entry.text).toBeDefined();
+        expect(typeof entry.bg).toBe("string");
+        expect(typeof entry.text).toBe("string");
+      });
+    });
+
+    it("all OVERLAY_PALETTE entries should have bg and text properties", () => {
+      OVERLAY_PALETTE.forEach((entry) => {
+        expect(entry.bg).toBeDefined();
+        expect(entry.text).toBeDefined();
+        expect(typeof entry.bg).toBe("string");
+        expect(typeof entry.text).toBe("string");
+      });
+    });
+  });
+});

--- a/frontend/src/components/ui/__tests__/tagColor.test.ts
+++ b/frontend/src/components/ui/__tests__/tagColor.test.ts
@@ -11,6 +11,23 @@ describe("tagColor", () => {
       expect(color1).toEqual(color2);
       expect(color2).toEqual(color3);
     });
+
+    it("should return exact known colors to detect hash algorithm changes", () => {
+      // These assertions pin the exact expected output for specific inputs.
+      // If the hash algorithm or palette order changes, these will fail,
+      // catching regressions that a determinism-only test would miss.
+
+      // "testtag" (lowercase of "TestTag") hashes to palette index 1 (emerald)
+      expect(getTagColor("testtag")).toEqual(TAG_PALETTE[1]);
+      expect(getTagColor("TestTag")).toEqual(TAG_PALETTE[1]);
+      expect(getTagColor("TESTTAG")).toEqual(TAG_PALETTE[1]);
+
+      // "alpha" hashes to palette index 9 (slate) - different bucket
+      expect(getTagColor("alpha")).toEqual(TAG_PALETTE[9]);
+
+      // "example" also hashes to palette index 9 to verify non-trivial collision
+      expect(getTagColor("example")).toEqual(TAG_PALETTE[9]);
+    });
   });
 
   describe("palette selection", () => {

--- a/frontend/src/components/ui/tagColor.ts
+++ b/frontend/src/components/ui/tagColor.ts
@@ -1,0 +1,47 @@
+export interface TagColorPair {
+  bg: string;
+  text: string;
+}
+
+export const TAG_PALETTE: readonly TagColorPair[] = [
+  { bg: "bg-blue-100", text: "text-blue-800" },
+  { bg: "bg-emerald-100", text: "text-emerald-800" },
+  { bg: "bg-rose-100", text: "text-rose-800" },
+  { bg: "bg-amber-100", text: "text-amber-800" },
+  { bg: "bg-violet-100", text: "text-violet-800" },
+  { bg: "bg-pink-100", text: "text-pink-800" },
+  { bg: "bg-cyan-100", text: "text-cyan-800" },
+  { bg: "bg-lime-100", text: "text-lime-800" },
+  { bg: "bg-orange-100", text: "text-orange-800" },
+  { bg: "bg-slate-100", text: "text-slate-800" },
+];
+
+export const OVERLAY_PALETTE: readonly TagColorPair[] = [
+  { bg: "bg-blue-500/90", text: "text-white" },
+  { bg: "bg-emerald-500/90", text: "text-white" },
+  { bg: "bg-rose-500/90", text: "text-white" },
+  { bg: "bg-amber-500/90", text: "text-white" },
+  { bg: "bg-violet-500/90", text: "text-white" },
+  { bg: "bg-pink-500/90", text: "text-white" },
+  { bg: "bg-cyan-500/90", text: "text-white" },
+  { bg: "bg-lime-500/90", text: "text-white" },
+  { bg: "bg-orange-500/90", text: "text-white" },
+  { bg: "bg-slate-500/90", text: "text-white" },
+];
+
+export function getTagColor(
+  name: string,
+  overlay: boolean = false
+): TagColorPair {
+  const palette = overlay ? OVERLAY_PALETTE : TAG_PALETTE;
+  const lowercased = name.toLowerCase();
+
+  // djb2 hash: start at 5381, then hash = (hash * 33) ^ char for each character
+  let hash = 5381;
+  for (let i = 0; i < lowercased.length; i++) {
+    hash = ((hash << 5) + hash) ^ lowercased.charCodeAt(i); // (hash * 33) ^ char
+    hash = hash >>> 0; // keep as unsigned 32-bit integer
+  }
+
+  return palette[hash % palette.length];
+}

--- a/frontend/src/components/ui/tagColor.ts
+++ b/frontend/src/components/ui/tagColor.ts
@@ -24,7 +24,7 @@ export const OVERLAY_PALETTE: readonly TagColorPair[] = [
   { bg: "bg-violet-500/90", text: "text-white" },
   { bg: "bg-pink-500/90", text: "text-white" },
   { bg: "bg-cyan-500/90", text: "text-white" },
-  { bg: "bg-lime-500/90", text: "text-white" },
+  { bg: "bg-lime-600/90", text: "text-white" },
   { bg: "bg-orange-500/90", text: "text-white" },
   { bg: "bg-slate-500/90", text: "text-white" },
 ];


### PR DESCRIPTION
## Summary

- **GitHub-style tag colors**: Tags now use deterministic hash-based coloring (djb2 → 10-color palette) instead of uniform pale-blue. Same tag name always maps to the same color across list, drawer, and tile overlay views.
- **Reusable `TagBadge` component**: Replaces three places of duplicated inline pill markup in `PhotoList`, `PhotoDrawer`, and the new tile overlay. Handles `default` and `overlay` variants, optional remove button with tag-specific `aria-label`.
- **Tile overlay toggle**: New icon button (Tag icon) in the toolbar (tiles view only) toggles tag visibility as a top-positioned overlay on thumbnails. Preference persists to `localStorage` (`photobank.tagsOnTiles`), consistent with the existing view-mode preference pattern.

## Changes

**New files:**
- `frontend/src/components/ui/tagColor.ts` — djb2 hash + 10-color palette (light + saturated overlay variants)
- `frontend/src/components/ui/TagBadge.tsx` — reusable colored pill component
- `frontend/src/components/ui/__tests__/tagColor.test.ts` — 16 tests incl. pinned hash regression assertions
- `frontend/src/components/ui/__tests__/TagBadge.test.tsx` — 33 tests
- `frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx` — 5 new tests for overlay behavior

**Modified files:**
- `PhotoList.tsx` — uses `TagBadge`, neutral overflow chip
- `PhotoDrawer.tsx` — uses `TagBadge` with `onRemove`; `isPending` guard preserved
- `PhotoGrid.tsx` — new `showTags` prop, top overlay with `pointer-events-none`
- `PhotobankPage.tsx` — `tagsOnTiles` state + localStorage + toolbar toggle button

## Out of scope (deliberate non-changes)
- `TagSidebar.tsx` — sidebar row items are not pills, not restyled
- No backend schema changes — colors are frontend-only (hash-derived)

## Test Plan

- [ ] List view: tags show in varied colors; same tag name is the same color across all rows
- [ ] Drawer: tags show colored; remove button still works (click removes tag, button disabled while request is in-flight)
- [ ] Tiles view: Tag icon button appears in toolbar; click toggles tag overlay on/off
- [ ] Tag overlay appears at top of tiles (not overlapping bottom hover gradient)
- [ ] Clicking a tile with overlay visible still opens the drawer (pointer-events-none working)
- [ ] Reload page: both `view` and `tagsOnTiles` preferences are restored from localStorage
- [ ] Switch to list view: Tag icon button disappears from toolbar
- [ ] `npm run build` + `npm run lint` (scoped to changed files) pass clean
- [ ] 49 unit tests pass: `npm test -- --testPathPattern="TagBadge|tagColor|PhotoGrid"`