### PR TITLE
fix: photobank side panel stays visible while scrolling

### DIFF
--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -40,8 +40,8 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
 
         {/* Page content */}
         <main className="flex-1 relative overflow-auto">
-          <div className="p-3 md:p-4 bg-gray-50">
-            <div className="w-full">{children}</div>
+          <div className="p-3 md:p-4 bg-gray-50 min-h-full flex flex-col">
+            <div className="w-full flex-1 flex flex-col min-h-0">{children}</div>
           </div>
         </main>
       </div>


### PR DESCRIPTION
## Summary

- The photobank detail drawer (file name, thumbnail, metadata) was scrolling out of the viewport when the user scrolled the photo list
- Root cause: `Layout.tsx` wrapped all routes in two `auto`-height divs, breaking the `h-full` chain that `PhotobankPage` relies on for its fixed-viewport layout
- Fix: add `min-h-full flex flex-col` to the outer padding wrapper and `flex-1 flex flex-col min-h-0` to the inner wrapper — this gives pages that use `h-full overflow-hidden` a definite parent height, while pages with naturally tall content still grow the wrapper and trigger `<main>`'s page-level scroll unchanged

## Test plan

- [ ] Open photobank, select a photo (drawer opens on the right), scroll the photo list — drawer must stay fully visible throughout
- [ ] Open any long-content admin page (e.g. PackingMaterials, StockOperations) — page-level scroll must still work normally
- [ ] Open a short page — no unexpected whitespace or layout shift
- [ ] Mobile width: TopBar + MobileNotice render correctly, pages still scroll