### PR TITLE
feat(photobank): multi-select photos and bulk-tag by ID

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -144,7 +144,7 @@ namespace Anela.Heblo.API.Controllers
         }
 
         /// <summary>
-        /// Bulk-add a manual tag to an explicit list of photos by ID. Requires administrator role.
+        /// Bulk-add a manual tag to an explicit list of photos by ID. Requires MarketingWriter role.
         /// Capped at 5 000 photo IDs per call. Idempotent: photos already carrying the tag are counted
         /// in AlreadyTaggedCount and not modified.
         /// </summary>

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -8,6 +8,7 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
 using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTag;
+using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRule;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
@@ -136,6 +137,29 @@ namespace Anela.Heblo.API.Controllers
                 Tags = body.Tags,
                 Search = body.Search,
                 FolderPath = body.FolderPath,
+                TagName = body.TagName,
+            };
+            var response = await _mediator.Send(request, cancellationToken);
+            return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Bulk-add a manual tag to an explicit list of photos by ID. Requires administrator role.
+        /// Capped at 5 000 photo IDs per call. Idempotent: photos already carrying the tag are counted
+        /// in AlreadyTaggedCount and not modified.
+        /// </summary>
+        [HttpPost("photos/tag-by-ids")]
+        [Authorize(Roles = AuthorizationConstants.Roles.MarketingWriter)]
+        [ProducesResponseType(typeof(BulkAddPhotoTagByIdsResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<BulkAddPhotoTagByIdsResponse>> BulkAddPhotoTagByIds(
+            [FromBody] BulkAddPhotoTagByIdsBody body,
+            CancellationToken cancellationToken = default)
+        {
+            var request = new BulkAddPhotoTagByIdsRequest
+            {
+                PhotoIds = body.PhotoIds,
                 TagName = body.TagName,
             };
             var response = await _mediator.Send(request, cancellationToken);
@@ -343,6 +367,12 @@ namespace Anela.Heblo.API.Controllers
         public List<string>? Tags { get; set; }
         public string? Search { get; set; }
         public string? FolderPath { get; set; }
+        public string TagName { get; set; } = null!;
+    }
+
+    public class BulkAddPhotoTagByIdsBody
+    {
+        public List<int> PhotoIds { get; set; } = [];
         public string TagName { get; set; } = null!;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Application.Features.Photobank.Services;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
+using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRule;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
@@ -49,6 +50,7 @@ public static class PhotobankModule
         services.AddScoped<IValidator<RemovePhotoTagRequest>, RemovePhotoTagRequestValidator>();
         services.AddScoped<IValidator<GetPhotosRequest>, GetPhotosRequestValidator>();
         services.AddScoped<IValidator<UpdateRuleRequest>, UpdateRuleRequestValidator>();
+        services.AddScoped<IValidator<BulkAddPhotoTagByIdsRequest>, BulkAddPhotoTagByIdsRequestValidator>();
 
         // Register MediatR validation behavior for photobank requests
         services.AddScoped<IPipelineBehavior<AddPhotoTagRequest, AddPhotoTagResponse>, ValidationBehavior<AddPhotoTagRequest, AddPhotoTagResponse>>();
@@ -59,6 +61,7 @@ public static class PhotobankModule
         services.AddScoped<IPipelineBehavior<RemovePhotoTagRequest, RemovePhotoTagResponse>, ValidationBehavior<RemovePhotoTagRequest, RemovePhotoTagResponse>>();
         services.AddScoped<IPipelineBehavior<GetPhotosRequest, GetPhotosResponse>, ValidationBehavior<GetPhotosRequest, GetPhotosResponse>>();
         services.AddScoped<IPipelineBehavior<UpdateRuleRequest, UpdateRuleResponse>, ValidationBehavior<UpdateRuleRequest, UpdateRuleResponse>>();
+        services.AddScoped<IPipelineBehavior<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>, ValidationBehavior<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -168,6 +168,12 @@ namespace Anela.Heblo.Application.Features.Photobank
             return await _context.PhotobankTags.FindAsync(new object[] { id }, cancellationToken);
         }
 
+        public async Task DeleteTagAsync(Tag tag, CancellationToken cancellationToken)
+        {
+            _context.PhotobankTags.Remove(tag);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
         // Photo tags
 
         public Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -90,6 +90,16 @@ namespace Anela.Heblo.Application.Features.Photobank
                 .ToListAsync(cancellationToken);
         }
 
+        public async Task<List<int>> GetExistingPhotoIdsMissingTagAsync(
+            IReadOnlyList<int> photoIds, int tagId,
+            CancellationToken cancellationToken)
+        {
+            return await _context.Photos
+                .Where(p => photoIds.Contains(p.Id) && !p.Tags.Any(pt => pt.TagId == tagId))
+                .Select(p => p.Id)
+                .ToListAsync(cancellationToken);
+        }
+
         public async Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken)
         {
             return await _context.Photos

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -100,6 +100,15 @@ namespace Anela.Heblo.Application.Features.Photobank
                 .ToListAsync(cancellationToken);
         }
 
+        public async Task<int> CountExistingPhotosAsync(
+            IReadOnlyList<int> photoIds,
+            CancellationToken cancellationToken)
+        {
+            return await _context.Photos
+                .Where(p => photoIds.Contains(p.Id))
+                .CountAsync(cancellationToken);
+        }
+
         public async Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken)
         {
             return await _context.Photos

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsHandler.cs
@@ -40,6 +40,9 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByI
             var distinctIds = request.PhotoIds.Distinct().ToList();
 
             var normalizedName = request.TagName.Trim().ToLowerInvariant();
+            if (normalizedName.Length == 0)
+                return new BulkAddPhotoTagByIdsResponse(ErrorCodes.BulkTagInvalidRequest);
+
             var tag = await _repository.GetOrCreateTagAsync(normalizedName, cancellationToken);
             if (tag == null)
                 return new BulkAddPhotoTagByIdsResponse(ErrorCodes.PhotoTagCreationFailed);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsHandler.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds
+{
+    public class BulkAddPhotoTagByIdsHandler : IRequestHandler<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>
+    {
+        private const int BulkTagLimit = 5_000;
+
+        private readonly IPhotobankRepository _repository;
+
+        public BulkAddPhotoTagByIdsHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<BulkAddPhotoTagByIdsResponse> Handle(
+            BulkAddPhotoTagByIdsRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (request.PhotoIds == null || request.PhotoIds.Count == 0)
+                return new BulkAddPhotoTagByIdsResponse(ErrorCodes.BulkTagInvalidRequest);
+
+            if (request.PhotoIds.Count > BulkTagLimit)
+                return new BulkAddPhotoTagByIdsResponse(ErrorCodes.BulkTagLimitExceeded)
+                {
+                    Params = new Dictionary<string, string>
+                    {
+                        { "Count", request.PhotoIds.Count.ToString() },
+                        { "Limit", BulkTagLimit.ToString() },
+                    },
+                };
+
+            var normalizedName = request.TagName.Trim().ToLowerInvariant();
+            var tag = await _repository.GetOrCreateTagAsync(normalizedName, cancellationToken);
+            if (tag == null)
+                return new BulkAddPhotoTagByIdsResponse(ErrorCodes.PhotoTagCreationFailed);
+
+            var toAdd = await _repository.GetExistingPhotoIdsMissingTagAsync(
+                request.PhotoIds, tag.Id, cancellationToken);
+
+            var now = DateTime.UtcNow;
+            foreach (var photoId in toAdd)
+            {
+                await _repository.AddPhotoTagAsync(new PhotoTag
+                {
+                    PhotoId = photoId,
+                    TagId = tag.Id,
+                    Source = PhotoTagSource.Manual,
+                    CreatedAt = now,
+                }, cancellationToken);
+            }
+
+            if (toAdd.Count > 0)
+                await _repository.SaveChangesAsync(cancellationToken);
+
+            var distinctCount = request.PhotoIds.Distinct().Count();
+
+            return new BulkAddPhotoTagByIdsResponse
+            {
+                TagId = tag.Id,
+                TagName = tag.Name,
+                AddedCount = toAdd.Count,
+                AlreadyTaggedCount = distinctCount - toAdd.Count,
+            };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsHandler.cs
@@ -37,13 +37,15 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByI
                     },
                 };
 
+            var distinctIds = request.PhotoIds.Distinct().ToList();
+
             var normalizedName = request.TagName.Trim().ToLowerInvariant();
             var tag = await _repository.GetOrCreateTagAsync(normalizedName, cancellationToken);
             if (tag == null)
                 return new BulkAddPhotoTagByIdsResponse(ErrorCodes.PhotoTagCreationFailed);
 
             var toAdd = await _repository.GetExistingPhotoIdsMissingTagAsync(
-                request.PhotoIds, tag.Id, cancellationToken);
+                distinctIds, tag.Id, cancellationToken);
 
             var now = DateTime.UtcNow;
             foreach (var photoId in toAdd)
@@ -60,14 +62,14 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByI
             if (toAdd.Count > 0)
                 await _repository.SaveChangesAsync(cancellationToken);
 
-            var distinctCount = request.PhotoIds.Distinct().Count();
+            var existingCount = await _repository.CountExistingPhotosAsync(distinctIds, cancellationToken);
 
             return new BulkAddPhotoTagByIdsResponse
             {
                 TagId = tag.Id,
                 TagName = tag.Name,
                 AddedCount = toAdd.Count,
-                AlreadyTaggedCount = distinctCount - toAdd.Count,
+                AlreadyTaggedCount = existingCount - toAdd.Count,
             };
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsRequest.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds
+{
+    public class BulkAddPhotoTagByIdsRequest : IRequest<BulkAddPhotoTagByIdsResponse>
+    {
+        public List<int> PhotoIds { get; set; } = null!;
+        public string TagName { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/BulkAddPhotoTagByIds/BulkAddPhotoTagByIdsResponse.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds
+{
+    public class BulkAddPhotoTagByIdsResponse : BaseResponse
+    {
+        public int TagId { get; set; }
+        public string TagName { get; set; } = null!;
+        public int AddedCount { get; set; }
+        public int AlreadyTaggedCount { get; set; }
+
+        public BulkAddPhotoTagByIdsResponse() : base() { }
+        public BulkAddPhotoTagByIdsResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
+{
+    public class DeleteTagHandler : IRequestHandler<DeleteTagRequest, DeleteTagResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public DeleteTagHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<DeleteTagResponse> Handle(DeleteTagRequest request, CancellationToken cancellationToken)
+        {
+            var tag = await _repository.GetTagByIdAsync(request.Id, cancellationToken);
+            if (tag == null)
+                return new DeleteTagResponse(ErrorCodes.PhotobankTagNotFound);
+
+            await _repository.DeleteTagAsync(tag, cancellationToken);
+
+            return new DeleteTagResponse();
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
+{
+    public class DeleteTagRequest : IRequest<DeleteTagResponse>
+    {
+        public int Id { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagResponse.cs
@@ -1,0 +1,11 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
+{
+    public class DeleteTagResponse : BaseResponse
+    {
+        public DeleteTagResponse() : base() { }
+
+        public DeleteTagResponse(ErrorCodes errorCode) : base(errorCode) { }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/BulkAddPhotoTagByIdsRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/BulkAddPhotoTagByIdsRequestValidator.cs
@@ -1,0 +1,22 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Photobank.Validators;
+
+public class BulkAddPhotoTagByIdsRequestValidator : AbstractValidator<BulkAddPhotoTagByIdsRequest>
+{
+    public BulkAddPhotoTagByIdsRequestValidator()
+    {
+        RuleFor(x => x.TagName)
+            .NotEmpty()
+            .WithMessage("TagName is required")
+            .MaximumLength(100)
+            .WithMessage("TagName cannot exceed 100 characters");
+
+        RuleFor(x => x.PhotoIds)
+            .NotNull()
+            .WithMessage("PhotoIds is required")
+            .NotEmpty()
+            .WithMessage("PhotoIds must contain at least one ID");
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -271,6 +271,8 @@ public enum ErrorCodes
     BulkTagLimitExceeded = 2606,
     [HttpStatusCode(HttpStatusCode.BadRequest)]
     BulkTagInvalidRequest = 2607,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotobankTagNotFound = 2608,
 
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -269,6 +269,8 @@ public enum ErrorCodes
     BulkTagFiltersRequired = 2605,
     [HttpStatusCode(HttpStatusCode.BadRequest)]
     BulkTagLimitExceeded = 2606,
+    [HttpStatusCode(HttpStatusCode.BadRequest)]
+    BulkTagInvalidRequest = 2607,
 
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -29,6 +29,7 @@ namespace Anela.Heblo.Domain.Features.Photobank
         Task<List<(Tag Tag, int Count)>> GetTagsWithCountsAsync(CancellationToken cancellationToken);
         Task<Tag?> GetOrCreateTagAsync(string normalizedName, CancellationToken cancellationToken);
         Task<Tag?> GetTagByIdAsync(int id, CancellationToken cancellationToken);
+        Task DeleteTagAsync(Tag tag, CancellationToken cancellationToken);
 
         // Photo tags
         Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -19,6 +19,8 @@ namespace Anela.Heblo.Domain.Features.Photobank
 
         Task<List<int>> GetExistingPhotoIdsMissingTagAsync(IReadOnlyList<int> photoIds, int tagId, CancellationToken cancellationToken);
 
+        Task<int> CountExistingPhotosAsync(IReadOnlyList<int> photoIds, CancellationToken cancellationToken);
+
         Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken);
 
         Task<PhotoLocator?> GetLocatorAsync(int id, CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -17,6 +17,8 @@ namespace Anela.Heblo.Domain.Features.Photobank
 
         Task<List<int>> GetFilteredPhotoIdsMissingTagAsync(List<string>? tags, string? search, string? folderPath, int tagId, CancellationToken cancellationToken);
 
+        Task<List<int>> GetExistingPhotoIdsMissingTagAsync(IReadOnlyList<int> photoIds, int tagId, CancellationToken cancellationToken);
+
         Task<Photo?> GetPhotoByIdAsync(int id, CancellationToken cancellationToken);
 
         Task<PhotoLocator?> GetLocatorAsync(int id, CancellationToken cancellationToken);

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/BulkAddPhotoTagByIdsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/BulkAddPhotoTagByIdsHandlerTests.cs
@@ -162,6 +162,28 @@ public class BulkAddPhotoTagByIdsHandlerTests
             It.IsAny<CancellationToken>()), Times.Exactly(3));
 
         _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync("flowers", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceOnlyTagName_ReturnsInvalidRequestError()
+    {
+        // Arrange
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = new List<int> { 1, 2, 3 },
+            TagName = "   ",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.BulkTagInvalidRequest);
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/BulkAddPhotoTagByIdsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/BulkAddPhotoTagByIdsHandlerTests.cs
@@ -129,6 +129,11 @@ public class BulkAddPhotoTagByIdsHandlerTests
             .ReturnsAsync(missingTagIds);
 
         _repositoryMock
+            .Setup(r => r.CountExistingPhotosAsync(
+                It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(5); // all 5 IDs exist in the database
+
+        _repositoryMock
             .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -150,7 +155,7 @@ public class BulkAddPhotoTagByIdsHandlerTests
         result.TagId.Should().Be(7);
         result.TagName.Should().Be("flowers");
         result.AddedCount.Should().Be(3);
-        result.AlreadyTaggedCount.Should().Be(2);
+        result.AlreadyTaggedCount.Should().Be(2); // 5 existing - 3 added
 
         _repositoryMock.Verify(r => r.AddPhotoTagAsync(
             It.Is<PhotoTag>(pt => pt.TagId == 7 && pt.Source == PhotoTagSource.Manual),
@@ -175,6 +180,11 @@ public class BulkAddPhotoTagByIdsHandlerTests
                 It.IsAny<IReadOnlyList<int>>(), 3, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<int>());
 
+        _repositoryMock
+            .Setup(r => r.CountExistingPhotosAsync(
+                It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3); // all 3 IDs exist in the database
+
         var request = new BulkAddPhotoTagByIdsRequest
         {
             PhotoIds = photoIds,
@@ -187,19 +197,20 @@ public class BulkAddPhotoTagByIdsHandlerTests
         // Assert
         result.Success.Should().BeTrue();
         result.AddedCount.Should().Be(0);
-        result.AlreadyTaggedCount.Should().Be(3);
+        result.AlreadyTaggedCount.Should().Be(3); // 3 existing - 0 added
 
         _repositoryMock.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Never);
         _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task Handle_DuplicatePhotoIdsProvided_AlreadyTaggedCountBasedOnDistinctCount()
+    public async Task Handle_DuplicatePhotoIdsProvided_DeduplicatesBeforeRepositoryCalls()
     {
         // Arrange
         var tag = BuildTag(5, "new");
         var photoIds = new List<int> { 1, 1, 2, 2, 3 }; // 5 items, 3 distinct
         var missingTagIds = new List<int> { 1, 2 };
+        var expectedDistinctIds = new List<int> { 1, 2, 3 };
 
         _repositoryMock
             .Setup(r => r.GetOrCreateTagAsync("new", It.IsAny<CancellationToken>()))
@@ -209,6 +220,11 @@ public class BulkAddPhotoTagByIdsHandlerTests
             .Setup(r => r.GetExistingPhotoIdsMissingTagAsync(
                 It.IsAny<IReadOnlyList<int>>(), 5, It.IsAny<CancellationToken>()))
             .ReturnsAsync(missingTagIds);
+
+        _repositoryMock
+            .Setup(r => r.CountExistingPhotosAsync(
+                It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3); // all 3 distinct IDs exist in the database
 
         _repositoryMock
             .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
@@ -230,6 +246,17 @@ public class BulkAddPhotoTagByIdsHandlerTests
         // Assert
         result.Success.Should().BeTrue();
         result.AddedCount.Should().Be(2);
-        result.AlreadyTaggedCount.Should().Be(1); // 3 distinct - 2 added
+        result.AlreadyTaggedCount.Should().Be(1); // 3 existing - 2 added
+
+        // Verify CountExistingPhotosAsync is called with the deduplicated list
+        _repositoryMock.Verify(r => r.CountExistingPhotosAsync(
+            It.Is<IReadOnlyList<int>>(ids => ids.SequenceEqual(expectedDistinctIds)),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify GetExistingPhotoIdsMissingTagAsync is called with the deduplicated list
+        _repositoryMock.Verify(r => r.GetExistingPhotoIdsMissingTagAsync(
+            It.Is<IReadOnlyList<int>>(ids => ids.SequenceEqual(expectedDistinctIds)),
+            5,
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/BulkAddPhotoTagByIdsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/BulkAddPhotoTagByIdsHandlerTests.cs
@@ -1,0 +1,235 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTagByIds;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class BulkAddPhotoTagByIdsHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly BulkAddPhotoTagByIdsHandler _handler;
+
+    public BulkAddPhotoTagByIdsHandlerTests()
+    {
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _handler = new BulkAddPhotoTagByIdsHandler(_repositoryMock.Object);
+    }
+
+    private static Tag BuildTag(int id, string name) => new() { Id = id, Name = name };
+
+    [Fact]
+    public async Task Handle_EmptyPhotoIds_ReturnsInvalidRequestError()
+    {
+        // Arrange
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = new List<int>(),
+            TagName = "flowers",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.BulkTagInvalidRequest);
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NullPhotoIds_ReturnsInvalidRequestError()
+    {
+        // Arrange
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = null!,
+            TagName = "flowers",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.BulkTagInvalidRequest);
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_PhotoIdsExceedLimit_ReturnsBulkTagLimitExceededError()
+    {
+        // Arrange
+        var photoIds = Enumerable.Range(1, 5_001).ToList();
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = photoIds,
+            TagName = "flowers",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.BulkTagLimitExceeded);
+        result.Params.Should().ContainKey("Count").WhoseValue.Should().Be("5001");
+        result.Params.Should().ContainKey("Limit").WhoseValue.Should().Be("5000");
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_GetOrCreateTagReturnsNull_ReturnsPhotoTagCreationFailedError()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetOrCreateTagAsync("flowers", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = new List<int> { 1, 2, 3 },
+            TagName = "flowers",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.PhotoTagCreationFailed);
+
+        _repositoryMock.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_AddsTagsAndReturnsCounts()
+    {
+        // Arrange
+        var tag = BuildTag(7, "flowers");
+        var photoIds = new List<int> { 1, 2, 3, 4, 5 };
+        var missingTagIds = new List<int> { 1, 2, 3 };
+
+        _repositoryMock
+            .Setup(r => r.GetOrCreateTagAsync("flowers", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.GetExistingPhotoIdsMissingTagAsync(
+                It.IsAny<IReadOnlyList<int>>(), 7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(missingTagIds);
+
+        _repositoryMock
+            .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = photoIds,
+            TagName = "  Flowers  ",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.TagId.Should().Be(7);
+        result.TagName.Should().Be("flowers");
+        result.AddedCount.Should().Be(3);
+        result.AlreadyTaggedCount.Should().Be(2);
+
+        _repositoryMock.Verify(r => r.AddPhotoTagAsync(
+            It.Is<PhotoTag>(pt => pt.TagId == 7 && pt.Source == PhotoTagSource.Manual),
+            It.IsAny<CancellationToken>()), Times.Exactly(3));
+
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AllAlreadyTagged_ReturnsZeroAddedCountAndDoesNotSave()
+    {
+        // Arrange
+        var tag = BuildTag(3, "sale");
+        var photoIds = new List<int> { 10, 11, 12 };
+
+        _repositoryMock
+            .Setup(r => r.GetOrCreateTagAsync("sale", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.GetExistingPhotoIdsMissingTagAsync(
+                It.IsAny<IReadOnlyList<int>>(), 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int>());
+
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = photoIds,
+            TagName = "sale",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.AddedCount.Should().Be(0);
+        result.AlreadyTaggedCount.Should().Be(3);
+
+        _repositoryMock.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicatePhotoIdsProvided_AlreadyTaggedCountBasedOnDistinctCount()
+    {
+        // Arrange
+        var tag = BuildTag(5, "new");
+        var photoIds = new List<int> { 1, 1, 2, 2, 3 }; // 5 items, 3 distinct
+        var missingTagIds = new List<int> { 1, 2 };
+
+        _repositoryMock
+            .Setup(r => r.GetOrCreateTagAsync("new", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.GetExistingPhotoIdsMissingTagAsync(
+                It.IsAny<IReadOnlyList<int>>(), 5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(missingTagIds);
+
+        _repositoryMock
+            .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryMock
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new BulkAddPhotoTagByIdsRequest
+        {
+            PhotoIds = photoIds,
+            TagName = "new",
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.AddedCount.Should().Be(2);
+        result.AlreadyTaggedCount.Should().Be(1); // 3 distinct - 2 added
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
@@ -1,0 +1,93 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class DeleteTagHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock = new();
+
+    private DeleteTagHandler CreateHandler() => new(_repositoryMock.Object);
+
+    private static Tag BuildTag(int id, string name) => new() { Id = id, Name = name };
+
+    [Fact]
+    public async Task Handle_TagNotFound_ReturnsPhotobankTagNotFoundError()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetTagByIdAsync(99, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        var request = new DeleteTagRequest { Id = 99 };
+
+        // Act
+        var result = await CreateHandler().Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.PhotobankTagNotFound);
+
+        _repositoryMock.Verify(r => r.DeleteTagAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_TagExists_PassesEntityToDeleteTagAsync()
+    {
+        // Arrange
+        var tag = BuildTag(5, "promo");
+
+        _repositoryMock
+            .Setup(r => r.GetTagByIdAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new DeleteTagRequest { Id = 5 };
+
+        // Act
+        var result = await CreateHandler().Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+
+        _repositoryMock.Verify(
+            r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TagExists_DoesNotCallDeleteWithWrongEntity()
+    {
+        // Arrange
+        var tag = BuildTag(3, "sale");
+        var otherTag = BuildTag(7, "other");
+
+        _repositoryMock
+            .Setup(r => r.GetTagByIdAsync(3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new DeleteTagRequest { Id = 3 };
+
+        // Act
+        await CreateHandler().Handle(request, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.DeleteTagAsync(otherTag, It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -162,6 +162,29 @@ export interface BulkAddPhotoTagResult {
   alreadyTaggedCount?: number;
 }
 
+// ---- Bulk tag by IDs --------------------------------------------------------
+
+export interface BulkAddPhotoTagByIdsParams {
+  photoIds: number[];
+  tagName: string;
+}
+
+export const useBulkAddPhotoTagByIds = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, BulkAddPhotoTagByIdsParams>({
+    mutationFn: async (params) => {
+      const { apiClient, baseUrl } = getClientAndBaseUrl();
+      await apiPost(apiClient, `${baseUrl}/api/photobank/photos/tag-by-ids`, {
+        photoIds: params.photoIds,
+        tagName: params.tagName,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.photobank });
+    },
+  });
+};
+
 export const useBulkAddPhotoTag = () => {
   const queryClient = useQueryClient();
   return useMutation<BulkAddPhotoTagResult, Error, BulkAddPhotoTagParams>({

--- a/frontend/src/components/marketing/photobank/PhotoGrid.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoGrid.tsx
@@ -66,17 +66,14 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
             const isSelected = photo.id === selectedPhotoId;
             const isChecked = selectedIds.has(photo.id);
             return (
-              <button
+              <div
                 key={photo.id}
-                onClick={() => onPhotoSelect(photo)}
                 className={[
-                  "group relative aspect-square rounded-lg overflow-hidden border-2 transition-all focus:outline-none focus:ring-2 focus:ring-primary-blue focus:ring-offset-2",
+                  "group relative aspect-square rounded-lg overflow-hidden border-2 transition-all",
                   isSelected
                     ? "border-primary-blue ring-2 ring-primary-blue ring-offset-1"
                     : "border-transparent hover:border-gray-300",
                 ].join(" ")}
-                aria-pressed={isSelected}
-                aria-label={photo.name}
               >
                 {canSelect && (
                   <div
@@ -86,7 +83,6 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                         ? "opacity-100"
                         : "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
                     ].join(" ")}
-                    onClick={(e) => e.stopPropagation()}
                   >
                     <input
                       type="checkbox"
@@ -103,17 +99,24 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                     />
                   </div>
                 )}
-                <PhotoThumbnail
-                  photoId={photo.id}
-                  modifiedAt={photo.lastModifiedAt}
-                  alt={photo.name}
-                  className="w-full h-full"
-                  size="medium"
-                />
-                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-0 hover:opacity-100 transition-opacity">
-                  <p className="text-white text-xs truncate">{photo.name}</p>
-                </div>
-              </button>
+                <button
+                  onClick={() => onPhotoSelect(photo)}
+                  className="w-full h-full focus:outline-none focus:ring-2 focus:ring-primary-blue focus:ring-offset-2"
+                  aria-pressed={isSelected}
+                  aria-label={photo.name}
+                >
+                  <PhotoThumbnail
+                    photoId={photo.id}
+                    modifiedAt={photo.lastModifiedAt}
+                    alt={photo.name}
+                    className="w-full h-full"
+                    size="medium"
+                  />
+                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-0 hover:opacity-100 transition-opacity">
+                    <p className="text-white text-xs truncate">{photo.name}</p>
+                  </div>
+                </button>
+              </div>
             );
           })}
         </div>

--- a/frontend/src/components/marketing/photobank/PhotoGrid.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoGrid.tsx
@@ -12,6 +12,9 @@ interface PhotoGridProps {
   isLoading: boolean;
   onPhotoSelect: (photo: PhotoDto) => void;
   onPageChange: (page: number) => void;
+  selectedIds: Set<number>;
+  onTogglePhotoSelection: (photoId: number, withRange: boolean) => void;
+  canSelect: boolean;
 }
 
 const PhotoGrid: React.FC<PhotoGridProps> = ({
@@ -23,6 +26,9 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
   isLoading,
   onPhotoSelect,
   onPageChange,
+  selectedIds,
+  onTogglePhotoSelection,
+  canSelect,
 }) => {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const canGoPrev = page > 1;
@@ -58,12 +64,13 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
         <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3">
           {photos.map((photo) => {
             const isSelected = photo.id === selectedPhotoId;
+            const isChecked = selectedIds.has(photo.id);
             return (
               <button
                 key={photo.id}
                 onClick={() => onPhotoSelect(photo)}
                 className={[
-                  "relative aspect-square rounded-lg overflow-hidden border-2 transition-all focus:outline-none focus:ring-2 focus:ring-primary-blue focus:ring-offset-2",
+                  "group relative aspect-square rounded-lg overflow-hidden border-2 transition-all focus:outline-none focus:ring-2 focus:ring-primary-blue focus:ring-offset-2",
                   isSelected
                     ? "border-primary-blue ring-2 ring-primary-blue ring-offset-1"
                     : "border-transparent hover:border-gray-300",
@@ -71,6 +78,31 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                 aria-pressed={isSelected}
                 aria-label={photo.name}
               >
+                {canSelect && (
+                  <div
+                    className={[
+                      "absolute top-1 left-1 z-10",
+                      isChecked
+                        ? "opacity-100"
+                        : "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+                    ].join(" ")}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isChecked}
+                      aria-label="Vybrat fotku"
+                      data-testid={`photo-select-checkbox-${photo.id}`}
+                      onChange={(e) => {
+                        onTogglePhotoSelection(
+                          photo.id,
+                          e.nativeEvent instanceof MouseEvent && (e.nativeEvent as MouseEvent).shiftKey,
+                        );
+                      }}
+                      className="w-4 h-4 accent-primary-blue cursor-pointer"
+                    />
+                  </div>
+                )}
                 <PhotoThumbnail
                   photoId={photo.id}
                   modifiedAt={photo.lastModifiedAt}

--- a/frontend/src/components/marketing/photobank/PhotoList.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoList.tsx
@@ -45,7 +45,7 @@ function PhotoList({
 
   if (isLoading) {
     return (
-      <div className="flex-1 p-4 space-y-3">
+      <div className="flex-1 p-4 space-y-3" data-testid="loading-skeleton">
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="flex gap-3 animate-pulse">
             <div className="w-20 h-20 bg-gray-200 rounded-lg flex-shrink-0" />

--- a/frontend/src/components/marketing/photobank/PhotoList.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoList.tsx
@@ -21,6 +21,9 @@ interface PhotoListProps {
   isLoading: boolean;
   onPhotoSelect: (photo: PhotoDto) => void;
   onPageChange: (page: number) => void;
+  selectedIds: Set<number>;
+  onTogglePhotoSelection: (photoId: number, withRange: boolean) => void;
+  canSelect: boolean;
 }
 
 function PhotoList({
@@ -32,6 +35,9 @@ function PhotoList({
   isLoading,
   onPhotoSelect,
   onPageChange,
+  selectedIds,
+  onTogglePhotoSelection,
+  canSelect,
 }: PhotoListProps) {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const canGoPrev = page > 1;
@@ -71,18 +77,38 @@ function PhotoList({
           const overflowCount = photo.tags.length - MAX_VISIBLE_TAGS;
 
           return (
-            <button
+            <div
               key={photo.id}
-              onClick={() => onPhotoSelect(photo)}
               className={[
-                "w-full flex items-center gap-3 px-4 py-3 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-blue",
+                "w-full flex items-center gap-3 px-4 py-3",
                 isSelected
                   ? "border-l-2 border-primary-blue bg-secondary-blue-pale"
                   : "hover:bg-gray-50",
               ].join(" ")}
-              aria-pressed={isSelected}
-              aria-label={photo.name}
             >
+              {canSelect && (
+                <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(photo.id)}
+                    aria-label="Vybrat fotku"
+                    data-testid={`photo-select-checkbox-${photo.id}`}
+                    onChange={(e) => {
+                      onTogglePhotoSelection(
+                        photo.id,
+                        e.nativeEvent instanceof MouseEvent && (e.nativeEvent as MouseEvent).shiftKey,
+                      );
+                    }}
+                    className="w-4 h-4 accent-primary-blue cursor-pointer"
+                  />
+                </div>
+              )}
+              <button
+                onClick={() => onPhotoSelect(photo)}
+                className="flex items-center gap-3 flex-1 min-w-0 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-blue"
+                aria-pressed={isSelected}
+                aria-label={photo.name}
+              >
               <PhotoThumbnail
                 photoId={photo.id}
                 modifiedAt={photo.lastModifiedAt}
@@ -132,7 +158,8 @@ function PhotoList({
                   )}
                 </div>
               </div>
-            </button>
+              </button>
+            </div>
           );
         })}
       </div>

--- a/frontend/src/components/marketing/photobank/PhotobankBulkActionBar.tsx
+++ b/frontend/src/components/marketing/photobank/PhotobankBulkActionBar.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import type { TagWithCountDto } from "../../../api/hooks/usePhotobank";
+
+const MAX_SELECTION = 5000;
+
+interface PhotobankBulkActionBarProps {
+  selectedCount: number;
+  existingTags: TagWithCountDto[];
+  isApplying: boolean;
+  onApplyTag: (tagName: string) => Promise<void>;
+  onClear: () => void;
+}
+
+export default function PhotobankBulkActionBar({
+  selectedCount,
+  existingTags,
+  isApplying,
+  onApplyTag,
+  onClear,
+}: PhotobankBulkActionBarProps) {
+  const [tagInput, setTagInput] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isOverLimit = selectedCount > MAX_SELECTION;
+  const isApplyDisabled = tagInput.trim() === "" || isApplying || isOverLimit;
+
+  async function handleApply() {
+    const trimmed = tagInput.trim();
+    if (!trimmed || isApplying || isOverLimit) return;
+
+    setErrorMessage(null);
+    try {
+      await onApplyTag(trimmed);
+      setTagInput("");
+    } catch {
+      setErrorMessage("Operace selhala. Zkuste to prosím znovu.");
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      void handleApply();
+    }
+  }
+
+  return (
+    <div
+      data-testid="bulk-action-bar"
+      className="flex items-center gap-3 px-4 py-2 bg-secondary-blue-pale border-b border-primary-blue/20"
+    >
+      {/* Left: selection count */}
+      <span className="text-sm font-medium text-primary-blue whitespace-nowrap">
+        {selectedCount} fotek vybráno
+      </span>
+
+      {/* Middle: tag input */}
+      <div className="flex-1 flex flex-col gap-0.5">
+        <input
+          data-testid="bulk-tag-input"
+          type="text"
+          list="bulk-tag-datalist"
+          value={tagInput}
+          onChange={(e) => {
+            setTagInput(e.target.value);
+            setErrorMessage(null);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="Název štítku"
+          className="px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-primary-blue w-full max-w-xs"
+          autoComplete="off"
+        />
+        <datalist id="bulk-tag-datalist">
+          {existingTags.map((tag) => (
+            <option key={tag.id} value={tag.name} />
+          ))}
+        </datalist>
+        {errorMessage && (
+          <p className="text-xs text-red-600">{errorMessage}</p>
+        )}
+        {isOverLimit && (
+          <p className="text-xs text-amber-600">
+            Vyberte max. 5 000 fotek
+          </p>
+        )}
+      </div>
+
+      {/* Right: action buttons */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <button
+          data-testid="bulk-apply-btn"
+          type="button"
+          disabled={isApplyDisabled}
+          onClick={() => void handleApply()}
+          className="px-3 py-1.5 text-sm bg-primary-blue text-white rounded-md hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+        >
+          {isApplying && (
+            <span className="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+          )}
+          Přidat štítek
+        </button>
+        <button
+          data-testid="bulk-clear-btn"
+          type="button"
+          onClick={onClear}
+          className="px-3 py-1.5 text-sm border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+        >
+          Zrušit výběr
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
@@ -38,6 +38,9 @@ function renderGrid(overrides: Partial<React.ComponentProps<typeof PhotoGrid>> =
     isLoading: false,
     onPhotoSelect: jest.fn(),
     onPageChange: jest.fn(),
+    selectedIds: new Set<number>(),
+    onTogglePhotoSelection: jest.fn(),
+    canSelect: false,
     ...overrides,
   };
   return { ...render(<PhotoGrid {...defaults} />), props: defaults };
@@ -149,5 +152,47 @@ describe("PhotoGrid", () => {
 
     // Assert
     expect(screen.getByText("Žádné fotografie nenalezeny")).toBeInTheDocument();
+  });
+
+  describe("selection", () => {
+    test("with canSelect=false checkboxes are not rendered", () => {
+      // Arrange & Act
+      renderGrid({ canSelect: false });
+
+      // Assert
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    test("with canSelect=true checkboxes are rendered for each photo", () => {
+      // Arrange & Act
+      renderGrid({ canSelect: true, selectedIds: new Set<number>() });
+
+      // Assert
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(mockPhotos.length);
+    });
+
+    test("checkbox for selected photo is checked", () => {
+      // Arrange & Act
+      renderGrid({ canSelect: true, selectedIds: new Set([1]) });
+
+      // Assert
+      const checkbox1 = screen.getByTestId("photo-select-checkbox-1");
+      const checkbox2 = screen.getByTestId("photo-select-checkbox-2");
+      expect(checkbox1).toBeChecked();
+      expect(checkbox2).not.toBeChecked();
+    });
+
+    test("checkbox onChange calls onTogglePhotoSelection with photoId", () => {
+      // Arrange
+      const onTogglePhotoSelection = jest.fn();
+      renderGrid({ canSelect: true, selectedIds: new Set<number>(), onTogglePhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-select-checkbox-1"));
+
+      // Assert
+      expect(onTogglePhotoSelection).toHaveBeenCalledWith(1, expect.any(Boolean));
+    });
   });
 });

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
@@ -177,7 +177,7 @@ describe("PhotoList", () => {
 
     // Assert — no photos rendered, skeleton present via animate-pulse divs
     expect(screen.queryByRole("button", { name: /photo/ })).not.toBeInTheDocument();
-    expect(document.querySelector(".animate-pulse")).toBeInTheDocument();
+    expect(screen.getByTestId("loading-skeleton")).toBeInTheDocument();
   });
 
   test("shows empty state when photos is empty and not loading", () => {

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
@@ -39,6 +39,9 @@ function renderList(overrides: Partial<React.ComponentProps<typeof PhotoList>> =
     isLoading: false,
     onPhotoSelect: jest.fn(),
     onPageChange: jest.fn(),
+    selectedIds: new Set<number>(),
+    onTogglePhotoSelection: jest.fn(),
+    canSelect: false,
     ...overrides,
   };
   return { ...render(<PhotoList {...defaults} />), props: defaults };
@@ -183,5 +186,47 @@ describe("PhotoList", () => {
 
     // Assert
     expect(screen.getByText("Žádné fotografie nenalezeny")).toBeInTheDocument();
+  });
+
+  describe("selection", () => {
+    test("with canSelect=false checkboxes are not rendered", () => {
+      // Arrange & Act
+      renderList({ canSelect: false });
+
+      // Assert
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    test("with canSelect=true checkboxes are rendered for each photo", () => {
+      // Arrange & Act
+      renderList({ canSelect: true, selectedIds: new Set<number>() });
+
+      // Assert
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(mockPhotos.length);
+    });
+
+    test("checkbox for selected photo is checked", () => {
+      // Arrange & Act
+      renderList({ canSelect: true, selectedIds: new Set([1]) });
+
+      // Assert
+      const checkbox1 = screen.getByTestId("photo-select-checkbox-1");
+      const checkbox2 = screen.getByTestId("photo-select-checkbox-2");
+      expect(checkbox1).toBeChecked();
+      expect(checkbox2).not.toBeChecked();
+    });
+
+    test("checkbox onChange calls onTogglePhotoSelection with photoId", () => {
+      // Arrange
+      const onTogglePhotoSelection = jest.fn();
+      renderList({ canSelect: true, selectedIds: new Set<number>(), onTogglePhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-select-checkbox-1"));
+
+      // Assert
+      expect(onTogglePhotoSelection).toHaveBeenCalledWith(1, expect.any(Boolean));
+    });
   });
 });

--- a/frontend/src/components/marketing/photobank/__tests__/PhotobankBulkActionBar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotobankBulkActionBar.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import PhotobankBulkActionBar from "../PhotobankBulkActionBar";
+import type { TagWithCountDto } from "../../../../api/hooks/usePhotobank";
+
+const EXISTING_TAGS: TagWithCountDto[] = [
+  { id: 1, name: "produkty", count: 5 },
+  { id: 2, name: "promo", count: 3 },
+];
+
+const DEFAULT_PROPS = {
+  selectedCount: 3,
+  existingTags: EXISTING_TAGS,
+  isApplying: false,
+  onApplyTag: jest.fn().mockResolvedValue(undefined),
+  onClear: jest.fn(),
+};
+
+function renderBar(overrides: Partial<typeof DEFAULT_PROPS> = {}) {
+  return render(<PhotobankBulkActionBar {...DEFAULT_PROPS} {...overrides} />);
+}
+
+beforeEach(() => {
+  (DEFAULT_PROPS.onApplyTag as jest.Mock).mockClear().mockResolvedValue(undefined);
+  (DEFAULT_PROPS.onClear as jest.Mock).mockClear();
+});
+
+describe("PhotobankBulkActionBar", () => {
+  test("renders selectedCount as '3 fotek vybráno'", () => {
+    // Arrange & Act
+    renderBar();
+
+    // Assert
+    expect(screen.getByText("3 fotek vybráno")).toBeInTheDocument();
+  });
+
+  test("input is empty initially and apply button is disabled", () => {
+    // Arrange & Act
+    renderBar();
+
+    // Assert
+    expect(screen.getByTestId("bulk-tag-input")).toHaveValue("");
+    expect(screen.getByTestId("bulk-apply-btn")).toBeDisabled();
+  });
+
+  test("apply button enabled after typing a tag name", () => {
+    // Arrange
+    renderBar();
+
+    // Act
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "akce" },
+    });
+
+    // Assert
+    expect(screen.getByTestId("bulk-apply-btn")).not.toBeDisabled();
+  });
+
+  test("clicking apply calls onApplyTag with trimmed value", async () => {
+    // Arrange
+    const onApplyTag = jest.fn().mockResolvedValue(undefined);
+    renderBar({ onApplyTag });
+
+    // Act
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "  akce  " },
+    });
+    fireEvent.click(screen.getByTestId("bulk-apply-btn"));
+
+    // Assert
+    await waitFor(() => {
+      expect(onApplyTag).toHaveBeenCalledWith("akce");
+    });
+  });
+
+  test("pressing Enter in input calls onApplyTag", async () => {
+    // Arrange
+    const onApplyTag = jest.fn().mockResolvedValue(undefined);
+    renderBar({ onApplyTag });
+
+    // Act
+    const input = screen.getByTestId("bulk-tag-input");
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    // Assert
+    await waitFor(() => {
+      expect(onApplyTag).toHaveBeenCalledWith("test");
+    });
+  });
+
+  test("isApplying=true disables apply button", () => {
+    // Arrange
+    renderBar({ isApplying: true });
+
+    // Act
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "akce" },
+    });
+
+    // Assert
+    expect(screen.getByTestId("bulk-apply-btn")).toBeDisabled();
+  });
+
+  test("selectedCount > 5000 disables apply button and shows hint", () => {
+    // Arrange & Act
+    renderBar({ selectedCount: 5001 });
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "akce" },
+    });
+
+    // Assert
+    expect(screen.getByTestId("bulk-apply-btn")).toBeDisabled();
+    expect(screen.getByText(/Vyberte max\. 5 000 fotek/)).toBeInTheDocument();
+  });
+
+  test("selectedCount = 5000 does NOT disable apply button with limit hint", () => {
+    // Arrange & Act
+    renderBar({ selectedCount: 5000 });
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "akce" },
+    });
+
+    // Assert
+    expect(screen.getByTestId("bulk-apply-btn")).not.toBeDisabled();
+    expect(screen.queryByText(/Vyberte max\. 5 000 fotek/)).not.toBeInTheDocument();
+  });
+
+  test("clicking clear calls onClear", () => {
+    // Arrange
+    const onClear = jest.fn();
+    renderBar({ onClear });
+
+    // Act
+    fireEvent.click(screen.getByTestId("bulk-clear-btn"));
+
+    // Assert
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  test("input is cleared after successful apply", async () => {
+    // Arrange
+    renderBar();
+
+    // Act
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "akce" },
+    });
+    fireEvent.click(screen.getByTestId("bulk-apply-btn"));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-tag-input")).toHaveValue("");
+    });
+  });
+
+  test("shows inline error when onApplyTag throws", async () => {
+    // Arrange
+    const onApplyTag = jest.fn().mockRejectedValue(new Error("Network error"));
+    renderBar({ onApplyTag });
+
+    // Act
+    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
+      target: { value: "akce" },
+    });
+    fireEvent.click(screen.getByTestId("bulk-apply-btn"));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText("Operace selhala. Zkuste to prosím znovu.")).toBeInTheDocument();
+    });
+    // Input should NOT be cleared on error
+    expect(screen.getByTestId("bulk-tag-input")).toHaveValue("akce");
+  });
+
+  test("renders data-testid on bulk-action-bar container", () => {
+    // Arrange & Act
+    renderBar();
+
+    // Assert
+    expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/marketing/photobank/__tests__/PhotobankBulkActionBar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotobankBulkActionBar.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import PhotobankBulkActionBar from "../PhotobankBulkActionBar";
 import type { TagWithCountDto } from "../../../../api/hooks/usePhotobank";
 
@@ -59,13 +60,13 @@ describe("PhotobankBulkActionBar", () => {
   test("clicking apply calls onApplyTag with trimmed value", async () => {
     // Arrange
     const onApplyTag = jest.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
     renderBar({ onApplyTag });
 
     // Act
-    fireEvent.change(screen.getByTestId("bulk-tag-input"), {
-      target: { value: "  akce  " },
-    });
-    fireEvent.click(screen.getByTestId("bulk-apply-btn"));
+    await user.clear(screen.getByTestId("bulk-tag-input"));
+    await user.type(screen.getByTestId("bulk-tag-input"), "  akce  ");
+    await user.click(screen.getByTestId("bulk-apply-btn"));
 
     // Assert
     await waitFor(() => {
@@ -76,12 +77,13 @@ describe("PhotobankBulkActionBar", () => {
   test("pressing Enter in input calls onApplyTag", async () => {
     // Arrange
     const onApplyTag = jest.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
     renderBar({ onApplyTag });
 
     // Act
-    const input = screen.getByTestId("bulk-tag-input");
-    fireEvent.change(input, { target: { value: "test" } });
-    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    await user.click(screen.getByTestId("bulk-tag-input"));
+    await user.type(screen.getByTestId("bulk-tag-input"), "test");
+    await user.keyboard("{Enter}");
 
     // Assert
     await waitFor(() => {

--- a/frontend/src/components/marketing/photobank/__tests__/PhotobankPage.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotobankPage.test.tsx
@@ -9,6 +9,10 @@ jest.mock("@azure/msal-react", () => ({
 jest.mock("../../../../api/hooks/usePhotobank", () => ({
   usePhotos: () => ({ data: undefined, isLoading: false }),
   usePhotoTags: () => ({ data: [] }),
+  useBulkAddPhotoTagByIds: () => ({
+    mutateAsync: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+  }),
 }));
 
 jest.mock("react-router-dom", () => ({

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -9,7 +9,8 @@ import PhotoDrawer from "../PhotoDrawer";
 import PhotoViewToggle from "../PhotoViewToggle";
 import BulkTagButton from "../BulkTagButton";
 import BulkTagDialog from "../BulkTagDialog";
-import { usePhotos, usePhotoTags } from "../../../../api/hooks/usePhotobank";
+import PhotobankBulkActionBar from "../PhotobankBulkActionBar";
+import { usePhotos, usePhotoTags, useBulkAddPhotoTagByIds } from "../../../../api/hooks/usePhotobank";
 import type { PhotoDto } from "../../../../api/hooks/usePhotobank";
 
 const ADMIN_ROLE = "super_user";
@@ -48,6 +49,8 @@ function PhotobankPage() {
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoDto | null>(null);
   const [view, setView] = useState<ViewMode>(readViewMode);
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [selectionAnchorId, setSelectionAnchorId] = useState<number | null>(null);
 
   useEffect(() => {
     try {
@@ -85,11 +88,15 @@ function PhotobankPage() {
   const handleSearchChange = useCallback((value: string) => {
     setSearch(value);
     setPage(1);
+    setSelectedIds(new Set());
+    setSelectionAnchorId(null);
   }, []);
 
   const handleFolderPathChange = useCallback((value: string) => {
     setFolderPath(value);
     setPage(1);
+    setSelectedIds(new Set());
+    setSelectionAnchorId(null);
   }, []);
 
   const handleClearFilters = useCallback(() => {
@@ -110,10 +117,66 @@ function PhotobankPage() {
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);
     setSelectedPhoto(null);
+    setSelectedIds(new Set());
+    setSelectionAnchorId(null);
   }, []);
 
   const handleOpenBulkTagDialog = useCallback(() => setBulkTagDialogOpen(true), []);
   const handleCloseBulkTagDialog = useCallback(() => setBulkTagDialogOpen(false), []);
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    setSelectionAnchorId(null);
+  }, []);
+
+  const handleTogglePhotoSelection = useCallback(
+    (photoId: number, withRange: boolean) => {
+      const items = photosData?.items ?? [];
+
+      if (withRange && selectionAnchorId !== null) {
+        const anchorIdx = items.findIndex((p) => p.id === selectionAnchorId);
+        const targetIdx = items.findIndex((p) => p.id === photoId);
+
+        if (anchorIdx !== -1 && targetIdx !== -1) {
+          const lo = Math.min(anchorIdx, targetIdx);
+          const hi = Math.max(anchorIdx, targetIdx);
+          const rangeIds = items.slice(lo, hi + 1).map((p) => p.id);
+          setSelectedIds((prev) => {
+            const next = new Set(prev);
+            rangeIds.forEach((id) => next.add(id));
+            return next;
+          });
+          return;
+        }
+      }
+
+      // Single toggle
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(photoId)) {
+          next.delete(photoId);
+        } else {
+          next.add(photoId);
+        }
+        return next;
+      });
+      setSelectionAnchorId(photoId);
+    },
+    [photosData?.items, selectionAnchorId],
+  );
+
+  const bulkAddByIdsMutation = useBulkAddPhotoTagByIds();
+
+  const handleApplyBulkTag = useCallback(
+    async (tagName: string) => {
+      await bulkAddByIdsMutation.mutateAsync({
+        photoIds: Array.from(selectedIds),
+        tagName,
+      });
+      handleClearSelection();
+    },
+    [selectedIds, bulkAddByIdsMutation, handleClearSelection],
+  );
 
   const sharedPhotoProps = {
     photos: photosData?.items ?? [],
@@ -124,6 +187,9 @@ function PhotobankPage() {
     isLoading: photosLoading,
     onPhotoSelect: handlePhotoSelect,
     onPageChange: handlePageChange,
+    selectedIds,
+    onTogglePhotoSelection: handleTogglePhotoSelection,
+    canSelect: canBulkTag,
   };
 
   return (
@@ -175,6 +241,16 @@ function PhotobankPage() {
               onChange={(v) => setView(v as ViewMode)}
             />
           </div>
+          {/* Bulk selection action bar */}
+          {canBulkTag && selectedIds.size > 0 && (
+            <PhotobankBulkActionBar
+              selectedCount={selectedIds.size}
+              existingTags={tagsData ?? []}
+              isApplying={bulkAddByIdsMutation.isPending}
+              onApplyTag={handleApplyBulkTag}
+              onClear={handleClearSelection}
+            />
+          )}
           {/* Photo grid or list */}
           <div className="flex-1 flex overflow-hidden">
             {view === "tiles" ? (

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -83,6 +83,8 @@ function PhotobankPage() {
       prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId],
     );
     setPage(1);
+    setSelectedIds(new Set());
+    setSelectionAnchorId(null);
   }, []);
 
   const handleSearchChange = useCallback((value: string) => {
@@ -104,6 +106,8 @@ function PhotobankPage() {
     setSearch("");
     setFolderPath("");
     setPage(1);
+    setSelectedIds(new Set());
+    setSelectionAnchorId(null);
   }, []);
 
   const handlePhotoSelect = useCallback((photo: PhotoDto) => {

--- a/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
+++ b/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import PhotobankPage from "../PhotobankPage";
+import type { PhotoDto } from "../../../../../api/hooks/usePhotobank";
+
+// ---- Mocks ------------------------------------------------------------------
+
+const mockBulkAddByIdsMutateAsync = jest.fn().mockResolvedValue(undefined);
+const mockBulkAddByIdsMutation = {
+  mutateAsync: mockBulkAddByIdsMutateAsync,
+  isPending: false,
+};
+
+jest.mock("@azure/msal-react", () => ({
+  useMsal: () => ({ accounts: [{ idTokenClaims: { roles: ["marketing_writer"] } }] }),
+}));
+
+const mockPhotos: PhotoDto[] = [
+  {
+    id: 1,
+    sharePointFileId: "f1",
+    driveId: null,
+    name: "photo-01.jpg",
+    folderPath: "/test",
+    sharePointWebUrl: null,
+    fileSizeBytes: null,
+    lastModifiedAt: "2026-01-01T00:00:00Z",
+    tags: [],
+  },
+  {
+    id: 2,
+    sharePointFileId: "f2",
+    driveId: null,
+    name: "photo-02.jpg",
+    folderPath: "/test",
+    sharePointWebUrl: null,
+    fileSizeBytes: null,
+    lastModifiedAt: "2026-01-01T00:00:00Z",
+    tags: [],
+  },
+];
+
+jest.mock("../../../../../api/hooks/usePhotobank", () => ({
+  usePhotos: () => ({ data: { items: mockPhotos, total: 2, page: 1, pageSize: 48 }, isLoading: false }),
+  usePhotoTags: () => ({ data: [] }),
+  useBulkAddPhotoTagByIds: () => mockBulkAddByIdsMutation,
+}));
+
+jest.mock("react-router-dom", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+jest.mock("../../PhotoThumbnail", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+jest.mock("../../TagSidebar", () => ({
+  __esModule: true,
+  default: () => <div data-testid="tag-sidebar" />,
+}));
+
+jest.mock("../../PhotoDrawer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="photo-drawer" />,
+}));
+
+// ---- Tests ------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorage.clear();
+  mockBulkAddByIdsMutateAsync.mockClear().mockResolvedValue(undefined);
+});
+
+test("initial state: bulk action bar not shown when nothing selected", () => {
+  // Arrange & Act
+  render(<PhotobankPage />);
+
+  // Assert
+  expect(screen.queryByTestId("bulk-action-bar")).not.toBeInTheDocument();
+});
+
+test("bulk action bar not shown when canBulkTag=false (no marketing_writer role)", () => {
+  // Arrange — use no-role account
+  jest.resetModules();
+  // Re-render with explicit no-role mock (test isolation via different module mock)
+  // This test verifies that canBulkTag gate works via absence of action bar when role missing.
+  // The simpler approach: mock useMsal to return no roles
+  render(<PhotobankPage />);
+
+  // Since the default mock includes marketing_writer, the action bar is hidden (no selection),
+  // so we just verify that checkboxes rendered from PhotoGrid pass canSelect properly.
+  // Full role-gate test is covered by the grid/list unit tests.
+  expect(screen.queryByTestId("bulk-action-bar")).not.toBeInTheDocument();
+});
+
+test("checkboxes are rendered in grid view when canBulkTag=true", () => {
+  // Arrange & Act
+  render(<PhotobankPage />);
+
+  // Assert: checkboxes should be present for each photo
+  expect(screen.getByTestId("photo-select-checkbox-1")).toBeInTheDocument();
+  expect(screen.getByTestId("photo-select-checkbox-2")).toBeInTheDocument();
+});
+
+test("selecting a photo shows the bulk action bar", () => {
+  // Arrange
+  render(<PhotobankPage />);
+
+  // Act — click photo-1 checkbox
+  act(() => {
+    screen.getByTestId("photo-select-checkbox-1").click();
+  });
+
+  // Assert
+  expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+  expect(screen.getByText("1 fotek vybráno")).toBeInTheDocument();
+});
+
+test("clicking clear in bulk action bar hides the bar", () => {
+  // Arrange
+  render(<PhotobankPage />);
+  act(() => {
+    screen.getByTestId("photo-select-checkbox-1").click();
+  });
+  expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+
+  // Act
+  act(() => {
+    screen.getByTestId("bulk-clear-btn").click();
+  });
+
+  // Assert
+  expect(screen.queryByTestId("bulk-action-bar")).not.toBeInTheDocument();
+});

--- a/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
+++ b/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
@@ -80,19 +80,9 @@ test("initial state: bulk action bar not shown when nothing selected", () => {
   expect(screen.queryByTestId("bulk-action-bar")).not.toBeInTheDocument();
 });
 
-test("bulk action bar not shown when canBulkTag=false (no marketing_writer role)", () => {
-  // Arrange — use no-role account
-  jest.resetModules();
-  // Re-render with explicit no-role mock (test isolation via different module mock)
-  // This test verifies that canBulkTag gate works via absence of action bar when role missing.
-  // The simpler approach: mock useMsal to return no roles
-  render(<PhotobankPage />);
-
-  // Since the default mock includes marketing_writer, the action bar is hidden (no selection),
-  // so we just verify that checkboxes rendered from PhotoGrid pass canSelect properly.
-  // Full role-gate test is covered by the grid/list unit tests.
-  expect(screen.queryByTestId("bulk-action-bar")).not.toBeInTheDocument();
-});
+// TODO: Add a test for canBulkTag=false (no marketing_writer role) that properly isolates
+// the useMsal mock per describe block. The role gate is exercised implicitly by unit tests
+// on PhotoGrid and PhotoList (canSelect=false hides checkboxes).
 
 test("checkboxes are rendered in grid view when canBulkTag=true", () => {
   // Arrange & Act

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -215,6 +215,8 @@ const resources = {
         PhotoTagCreationFailed: "Vytvoření tagu fotky selhalo.",
         BulkTagFiltersRequired: "Pro hromadné tagování musí být aktivní alespoň jeden filtr.",
         BulkTagLimitExceeded: "Filtr odpovídá příliš mnoha fotkám ({{Count}}). Upřesněte filtry (max {{Limit}}).",
+        BulkTagInvalidRequest: "Neplatný požadavek pro hromadné tagování.",
+        PhotobankTagNotFound: "Tag fotobanka nebyl nalezen.",
         PhotobankInvalidRegexPattern: "Neplatný regulární výraz.",
 
         // Article Generation errors


### PR DESCRIPTION
## Summary

- **Backend:** New `POST /api/photobank/photos/tag-by-ids` endpoint and MediatR use case (`BulkAddPhotoTagByIds`) that tags an explicit list of photo IDs — sibling to the existing filter-based bulk-tag endpoint. Includes FluentValidation validator, idempotency (skips already-tagged), 5 000-ID cap, and `AlreadyTaggedCount` in the response.
- **Frontend:** GitHub-style multi-select in both tile and list views — checkboxes on hover (tiles) or always visible (list), shift-click range selection, selection persists across view-mode switch, clears on any filter/page change. A sticky "N fotek vybráno" action bar appears when photos are selected; type a tag name and apply to all selected photos at once.
- **Tests:** 8 new backend xUnit handler tests (including validator, whitespace guard, idempotency, dedup, non-existent IDs); new frontend tests for `PhotobankBulkActionBar`, selection state in `PhotobankPage`, and checkbox rendering in `PhotoGrid`/`PhotoList`. All 71 BE + 1 186 FE tests pass.

## Changed files

**New:**
- `backend/.../UseCases/BulkAddPhotoTagByIds/` — Request, Response, Handler
- `backend/.../Validators/BulkAddPhotoTagByIdsRequestValidator.cs`
- `backend/test/.../BulkAddPhotoTagByIdsHandlerTests.cs`
- `frontend/src/components/marketing/photobank/PhotobankBulkActionBar.tsx`
- `frontend/src/components/marketing/photobank/__tests__/PhotobankBulkActionBar.test.tsx`
- `frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx`

**Modified:**
- `PhotobankController.cs` — new endpoint + body DTO
- `IPhotobankRepository.cs` + `PhotobankRepository.cs` — two new repo methods (`GetExistingPhotoIdsMissingTagAsync`, `CountExistingPhotosAsync`)
- `PhotobankModule.cs` — DI registration for new validator + pipeline behavior
- `ErrorCodes.cs` — `BulkTagInvalidRequest`
- `PhotobankPage.tsx` — selection state, shift-click range, action bar, clear-on-filter
- `PhotoGrid.tsx` — checkboxes (hover-revealed, top-left of tile)
- `PhotoList.tsx` — checkboxes (always visible, start of row)
- `usePhotobank.ts` — `useBulkAddPhotoTagByIds` hook

## Test plan

- [ ] Log in as `marketing_writer`. Open `/marketing/photobank` in tile view.
- [ ] Hover a tile — checkbox appears top-left. Click it — "1 fotek vybráno" bar appears.
- [ ] Click two more checkboxes — bar updates to "3 fotek vybráno".
- [ ] Shift-click a tile further down — all tiles between are added to selection.
- [ ] Switch to list view — selection persists; checkboxes visible at row start.
- [ ] Type a tag name in the bar input, press Enter — tag is applied; selection clears; tiles/rows show the new badge.
- [ ] Apply again with same tag — `AlreadyTaggedCount` reflects already-tagged photos in the success result.
- [ ] Change page — selection clears.
- [ ] Change tag filter in sidebar — selection clears.
- [ ] Log in as a user **without** `marketing_writer` — no checkboxes, no action bar.
- [ ] Select > 5 000 photos (if seeded data allows) — apply button disabled with hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)