### PR TITLE
feat(photobank): optional regex filename search

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -47,13 +47,15 @@ namespace Anela.Heblo.API.Controllers
 
         /// <summary>
         /// Get photos with optional tag AND filter, filename search, and pagination.
+        /// Set useRegex=true to use POSIX regex matching on filename instead of substring search.
         /// </summary>
         [HttpGet("photos")]
         [ProducesResponseType(typeof(GetPhotosResponse), StatusCodes.Status200OK)]
         public async Task<ActionResult<GetPhotosResponse>> GetPhotos(
             [FromQuery] List<string>? tags,
             [FromQuery] string? search,
-            [FromQuery] string? folderPath,
+            [FromQuery] bool useRegex = false,
+            [FromQuery] string? folderPath = null,
             [FromQuery] bool withoutTags = false,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 48,
@@ -63,6 +65,7 @@ namespace Anela.Heblo.API.Controllers
             {
                 Tags = tags,
                 Search = search,
+                UseRegex = useRegex,
                 FolderPath = folderPath,
                 WithoutTags = withoutTags,
                 Page = page,

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Anela.Heblo.Domain.Features.Photobank;
@@ -20,14 +21,22 @@ namespace Anela.Heblo.Application.Features.Photobank
 
         // Photos
 
-        private IQueryable<Photo> BuildFilterQuery(List<string>? tags, string? search, string? folderPath)
+        private IQueryable<Photo> BuildFilterQuery(List<string>? tags, string? search, bool useRegex, string? folderPath)
         {
             var query = _context.Photos.AsQueryable();
 
             if (!string.IsNullOrWhiteSpace(search))
             {
-                var term = search.Trim().ToLowerInvariant();
-                query = query.Where(p => p.FileName.ToLower().Contains(term));
+                if (useRegex)
+                {
+                    var pattern = search.Trim();
+                    query = query.Where(p => Regex.IsMatch(p.FileName, pattern, RegexOptions.IgnoreCase));
+                }
+                else
+                {
+                    var term = search.Trim().ToLowerInvariant();
+                    query = query.Where(p => p.FileName.ToLower().Contains(term));
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(folderPath))
@@ -54,10 +63,10 @@ namespace Anela.Heblo.Application.Features.Photobank
         }
 
         public async Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, string? folderPath, bool withoutTags, int page, int pageSize,
+            List<string>? tags, string? search, bool useRegex, string? folderPath, bool withoutTags, int page, int pageSize,
             CancellationToken cancellationToken)
         {
-            IQueryable<Photo> query = BuildFilterQuery(tags, search, folderPath)
+            IQueryable<Photo> query = BuildFilterQuery(tags, search, useRegex, folderPath)
                 .Include(p => p.Tags)
                     .ThenInclude(pt => pt.Tag);
 
@@ -78,7 +87,7 @@ namespace Anela.Heblo.Application.Features.Photobank
             List<string>? tags, string? search, string? folderPath,
             CancellationToken cancellationToken)
         {
-            var query = BuildFilterQuery(tags, search, folderPath);
+            var query = BuildFilterQuery(tags, search, false, folderPath);
             return await query.CountAsync(cancellationToken);
         }
 
@@ -86,7 +95,7 @@ namespace Anela.Heblo.Application.Features.Photobank
             List<string>? tags, string? search, string? folderPath, int tagId,
             CancellationToken cancellationToken)
         {
-            var query = BuildFilterQuery(tags, search, folderPath);
+            var query = BuildFilterQuery(tags, search, false, folderPath);
             return await query
                 .Where(p => !p.Tags.Any(pt => pt.TagId == tagId))
                 .Select(p => p.Id)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -46,7 +46,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
                 return new GetPhotosResponse
                 {
                     Success = false,
-                    ErrorCode = ErrorCodes.InvalidFormat,
+                    ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern,
                     Params = new Dictionary<string, string> { ["pattern"] = request.Search ?? string.Empty },
                 };
             }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Photobank;
 using MediatR;
+using Npgsql;
 
 namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
 {
@@ -18,22 +21,35 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
 
         public async Task<GetPhotosResponse> Handle(GetPhotosRequest request, CancellationToken cancellationToken)
         {
-            var (items, total) = await _repository.GetPhotosAsync(
-                request.Tags,
-                request.Search,
-                request.FolderPath,
-                request.WithoutTags,
-                request.Page,
-                request.PageSize,
-                cancellationToken);
-
-            return new GetPhotosResponse
+            try
             {
-                Items = items.Select(MapToDto).ToList(),
-                Total = total,
-                Page = request.Page,
-                PageSize = request.PageSize,
-            };
+                var (items, total) = await _repository.GetPhotosAsync(
+                    request.Tags,
+                    request.Search,
+                    request.UseRegex,
+                    request.FolderPath,
+                    request.WithoutTags,
+                    request.Page,
+                    request.PageSize,
+                    cancellationToken);
+
+                return new GetPhotosResponse
+                {
+                    Items = items.Select(MapToDto).ToList(),
+                    Total = total,
+                    Page = request.Page,
+                    PageSize = request.PageSize,
+                };
+            }
+            catch (PostgresException ex) when (request.UseRegex && ex.SqlState == "2201B")
+            {
+                return new GetPhotosResponse
+                {
+                    Success = false,
+                    ErrorCode = ErrorCodes.InvalidFormat,
+                    Params = new Dictionary<string, string> { ["pattern"] = request.Search ?? string.Empty },
+                };
+            }
         }
 
         internal static PhotoDto MapToDto(Photo photo) => new()

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
@@ -7,7 +7,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
     {
         public List<string>? Tags { get; set; }
         public string? Search { get; set; }
-        public bool UseRegex { get; set; } = false;
+        public bool UseRegex { get; set; }
         public string? FolderPath { get; set; }
         public bool WithoutTags { get; set; }
         public int Page { get; set; } = 1;

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
@@ -7,6 +7,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
     {
         public List<string>? Tags { get; set; }
         public string? Search { get; set; }
+        public bool UseRegex { get; set; } = false;
         public string? FolderPath { get; set; }
         public bool WithoutTags { get; set; }
         public int Page { get; set; } = 1;

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
 using FluentValidation;
 
@@ -18,5 +19,17 @@ public class GetPhotosRequestValidator : AbstractValidator<GetPhotosRequest>
             .WithMessage("PageSize must be a positive integer")
             .LessThanOrEqualTo(MaxPageSize)
             .WithMessage($"PageSize cannot exceed {MaxPageSize}");
+
+        RuleFor(x => x.Search)
+            .Must(BeValidRegex)
+            .When(x => x.UseRegex && !string.IsNullOrWhiteSpace(x.Search))
+            .WithMessage("Neplatný regulární výraz.");
+    }
+
+    private static bool BeValidRegex(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern)) return true;
+        try { _ = new Regex(pattern); return true; }
+        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
@@ -23,7 +23,7 @@ public class GetPhotosRequestValidator : AbstractValidator<GetPhotosRequest>
         RuleFor(x => x.Search)
             .Must(BeValidRegex)
             .When(x => x.UseRegex && !string.IsNullOrWhiteSpace(x.Search))
-            .WithMessage("Neplatný regulární výraz.");
+            .WithMessage("Invalid regular expression pattern.");
     }
 
     private static bool BeValidRegex(string? pattern)

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -269,6 +269,8 @@ public enum ErrorCodes
     BulkTagFiltersRequired = 2605,
     [HttpStatusCode(HttpStatusCode.BadRequest)]
     BulkTagLimitExceeded = 2606,
+    [HttpStatusCode(HttpStatusCode.BadRequest)]
+    PhotobankInvalidRegexPattern = 2607,
 
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -10,7 +10,7 @@ namespace Anela.Heblo.Domain.Features.Photobank
     {
         // Photos
         Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, string? folderPath, bool withoutTags, int page, int pageSize,
+            List<string>? tags, string? search, bool useRegex, string? folderPath, bool withoutTags, int page, int pageSize,
             CancellationToken cancellationToken);
 
         Task<int> CountFilteredPhotosAsync(List<string>? tags, string? search, string? folderPath, CancellationToken cancellationToken);

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -45,7 +45,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, false, null, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 2));
 
         var request = new GetPhotosRequest();
@@ -76,7 +76,7 @@ public class GetPhotosHandlerTests
         var tagFilter = new List<string> { "products" };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(tagFilter, null, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(tagFilter, null, false, null, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Tags = tagFilter };
@@ -90,7 +90,7 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].Tags.Should().ContainSingle(t => t.Name == "products");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, null, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, false, null, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, "ruze", null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, "ruze", false, null, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Search = "ruze" };
@@ -122,7 +122,7 @@ public class GetPhotosHandlerTests
     {
         // Arrange
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(), 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<bool>(), 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((new List<Photo>(), 0));
 
         var request = new GetPhotosRequest { Tags = new List<string> { "nonexistent" } };
@@ -146,7 +146,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, false, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { FolderPath = "Produkty" };
@@ -159,6 +159,31 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].FolderPath.Should().Be("Marketing/Produkty/Ruze");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, false, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_UseRegexTrue_ForwardsUseRegexToRepository()
+    {
+        // Arrange
+        var photos = new List<Photo>
+        {
+            BuildPhoto(1, "report_2024.pdf", "Reports"),
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((photos, 1));
+
+        var request = new GetPhotosRequest { Search = @"^report_\d+", UseRegex = true };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Items.Should().ContainSingle(p => p.Name == "report_2024.pdf");
+
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs
@@ -29,7 +29,7 @@ public class GetPhotosRequestValidatorTests
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Search)
-            .WithErrorMessage("Neplatný regulární výraz.");
+            .WithErrorMessage("Invalid regular expression pattern.");
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs
@@ -1,0 +1,85 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
+using Anela.Heblo.Application.Features.Photobank.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class GetPhotosRequestValidatorTests
+{
+    private readonly GetPhotosRequestValidator _validator;
+
+    public GetPhotosRequestValidatorTests()
+    {
+        _validator = new GetPhotosRequestValidator();
+    }
+
+    [Fact]
+    public void Search_InvalidRegex_UseRegexTrue_FailsValidation()
+    {
+        // Arrange
+        var request = new GetPhotosRequest
+        {
+            Search = "[unclosed",
+            UseRegex = true,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Search)
+            .WithErrorMessage("Neplatný regulární výraz.");
+    }
+
+    [Fact]
+    public void Search_ValidRegex_UseRegexTrue_PassesValidation()
+    {
+        // Arrange
+        var request = new GetPhotosRequest
+        {
+            Search = @"^foo.*\.png$",
+            UseRegex = true,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Search);
+    }
+
+    [Fact]
+    public void Search_InvalidRegex_UseRegexFalse_PassesValidation()
+    {
+        // Arrange — flag off, regex pattern syntax is not checked
+        var request = new GetPhotosRequest
+        {
+            Search = "[unclosed",
+            UseRegex = false,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Search_Null_UseRegexTrue_PassesValidation()
+    {
+        // Arrange — no pattern provided, nothing to validate
+        var request = new GetPhotosRequest
+        {
+            Search = null,
+            UseRegex = true,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
@@ -137,6 +137,11 @@ public class PhotobankRepositoryFilterTests : IDisposable
     }
 }
 
+// NOTE: These tests run against the EF Core InMemory provider, which evaluates
+// Regex.IsMatch via the .NET regex engine. In production, Npgsql translates
+// this to Postgres POSIX ~* syntax. The two engines differ on some constructs
+// (e.g., .NET lookahead, \b). Postgres-specific failures are caught by the
+// PostgresException handler in GetPhotosHandler.
 public class PhotobankRepositoryRegexFilterTests : IDisposable
 {
     private readonly ApplicationDbContext _context;

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Persistence;
 using Anela.Heblo.Application.Features.Photobank;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Photobank;
 
@@ -53,7 +54,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, folderPath, false, 1, 48, CancellationToken.None);
+            null, null, false, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(2);
@@ -70,7 +71,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, folderPath, false, 1, 48, CancellationToken.None);
+            null, null, false, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -86,7 +87,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, search, folderPath, false, 1, 48, CancellationToken.None);
+            null, search, false, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -113,7 +114,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act — folderPath "Produkty" matches photos 1 & 2; tag "featured" is only on photo 1
         var (items, total) = await _repository.GetPhotosAsync(
-            new List<string> { "featured" }, null, "Produkty", false, 1, 48, CancellationToken.None);
+            new List<string> { "featured" }, null, false, "Produkty", false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -128,10 +129,80 @@ public class PhotobankRepositoryFilterTests : IDisposable
     {
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, folderPath, false, 1, 48, CancellationToken.None);
+            null, null, false, folderPath, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(4);
         items.Should().HaveCount(4);
+    }
+}
+
+public class PhotobankRepositoryRegexFilterTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly PhotobankRepository _repository;
+
+    public PhotobankRepositoryRegexFilterTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new PhotobankRepository(_context);
+
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        var photos = new List<Photo>
+        {
+            new() { Id = 1, SharePointFileId = "sp-1", FileName = "report_2024.pdf",  FolderPath = "Reports", ModifiedAt = DateTime.UtcNow },
+            new() { Id = 2, SharePointFileId = "sp-2", FileName = "IMG_001.png",      FolderPath = "Photos",  ModifiedAt = DateTime.UtcNow },
+            new() { Id = 3, SharePointFileId = "sp-3", FileName = "report_final.pdf", FolderPath = "Reports", ModifiedAt = DateTime.UtcNow },
+        };
+
+        _context.Photos.AddRange(photos);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_regexSearch_matchesOnlyNumericReport()
+    {
+        // Arrange — pattern matches "report_" followed by digits
+        var pattern = @"^report_\d+";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, pattern, true, null, false, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(1);
+        items.Should().ContainSingle(p => p.FileName == "report_2024.pdf");
+        items.Should().NotContain(p => p.FileName == "report_final.pdf");
+        items.Should().NotContain(p => p.FileName == "IMG_001.png");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_substringSearch_matchesBothReportFiles()
+    {
+        // Arrange — plain substring search returns all files containing "report"
+        var search = "report";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, search, false, null, false, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(2);
+        items.Should().Contain(p => p.FileName == "report_2024.pdf");
+        items.Should().Contain(p => p.FileName == "report_final.pdf");
+        items.Should().NotContain(p => p.FileName == "IMG_001.png");
     }
 }

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -37,6 +37,7 @@ export interface GetPhotosResponse {
 export interface GetPhotosParams {
   tags?: string[];
   search?: string;
+  useRegex?: boolean;
   folderPath?: string;
   withoutTags?: boolean;
   page?: number;
@@ -82,6 +83,7 @@ async function apiDelete(apiClient: ReturnType<typeof getAuthenticatedApiClient>
 function buildPhotosUrl(baseUrl: string, params: GetPhotosParams): string {
   const qs = new URLSearchParams();
   if (params.search) qs.set("search", params.search);
+  if (params.useRegex) qs.set("useRegex", "true");
   if (params.folderPath) qs.set("folderPath", params.folderPath);
   if (params.withoutTags) qs.set("withoutTags", "true");
   if (params.page != null) qs.set("page", String(params.page));

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -9,11 +9,13 @@ interface TagSidebarProps {
   search: string;
   folderPath: string;
   withoutTags: boolean;
+  useRegex: boolean;
   onTagToggle: (tagId: number) => void;
   onSearchChange: (value: string) => void;
   onFolderPathChange: (value: string) => void;
   onWithoutTagsToggle: () => void;
   onClearFilters: () => void;
+  onRegexChange: (value: boolean) => void;
 }
 
 const DEBOUNCE_MS = 300;
@@ -24,31 +26,48 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
   search,
   folderPath,
   withoutTags,
+  useRegex,
   onTagToggle,
   onSearchChange,
   onFolderPathChange,
   onWithoutTagsToggle,
   onClearFilters,
+  onRegexChange,
 }) => {
   const [inputValue, setInputValue] = useState(search);
   const [folderPathValue, setFolderPathValue] = useState(folderPath);
   const [tagFilter, setTagFilter] = useState("");
+  const [regexError, setRegexError] = useState<string | null>(null);
 
   // Sync external search value to local input
   useEffect(() => {
     setInputValue(search);
   }, [search]);
 
+  // Validate regex pattern when regex mode is active
+  useEffect(() => {
+    if (!useRegex || !inputValue) {
+      setRegexError(null);
+      return;
+    }
+    try {
+      new RegExp(inputValue);
+      setRegexError(null);
+    } catch {
+      setRegexError("Neplatný regulární výraz");
+    }
+  }, [inputValue, useRegex]);
+
   // Debounce search input changes
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (inputValue !== search) {
+      if (inputValue !== search && regexError === null) {
         onSearchChange(inputValue);
       }
     }, DEBOUNCE_MS);
 
     return () => clearTimeout(timer);
-  }, [inputValue, search, onSearchChange]);
+  }, [inputValue, search, onSearchChange, regexError]);
 
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -122,8 +141,10 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
             type="text"
             value={inputValue}
             onChange={handleInputChange}
-            placeholder="Hledat soubory..."
-            className="w-full pl-8 pr-7 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-transparent"
+            placeholder={useRegex ? "Regex (POSIX, case-insensitive)..." : "Hledat soubory..."}
+            className={`w-full pl-8 pr-7 py-1.5 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-transparent ${
+              regexError ? "border-red-400" : "border-gray-300"
+            }`}
             aria-label="Hledat soubory"
           />
           {inputValue && (
@@ -136,6 +157,20 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
             </button>
           )}
         </div>
+
+        {/* Regex toggle */}
+        <label className="flex items-center gap-1.5 mt-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={useRegex}
+            onChange={(e) => onRegexChange(e.target.checked)}
+            className="w-3.5 h-3.5 accent-primary-blue"
+          />
+          <span className="text-xs text-gray-600">Regex</span>
+        </label>
+        {regexError && (
+          <p className="mt-1 text-xs text-red-600">{regexError}</p>
+        )}
 
         {/* Folder path input */}
         <div className="relative mt-2">

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -16,6 +16,7 @@ interface TagSidebarProps {
   onWithoutTagsToggle: () => void;
   onClearFilters: () => void;
   onRegexChange: (value: boolean) => void;
+  errorMessage?: string | null;
 }
 
 const DEBOUNCE_MS = 300;
@@ -33,6 +34,7 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
   onWithoutTagsToggle,
   onClearFilters,
   onRegexChange,
+  errorMessage,
 }) => {
   const [inputValue, setInputValue] = useState(search);
   const [folderPathValue, setFolderPathValue] = useState(folderPath);
@@ -170,6 +172,9 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
         </label>
         {regexError && (
           <p className="mt-1 text-xs text-red-600">{regexError}</p>
+        )}
+        {!regexError && errorMessage && (
+          <p className="mt-1 text-xs text-red-600">{errorMessage}</p>
         )}
 
         {/* Folder path input */}

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -113,7 +113,7 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     ? tags.filter((t) => t.name.toLowerCase().includes(tagFilter.trim().toLowerCase()))
     : tags;
 
-  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0 || withoutTags;
+  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0 || withoutTags || useRegex;
 
   return (
     <aside className="flex flex-col h-full bg-white border-r border-gray-200 overflow-hidden">

--- a/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
@@ -15,10 +15,14 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof TagSidebar
     selectedTagIds: [],
     search: "",
     folderPath: "",
+    withoutTags: false,
+    useRegex: false,
     onTagToggle: jest.fn(),
     onSearchChange: jest.fn(),
     onFolderPathChange: jest.fn(),
+    onWithoutTagsToggle: jest.fn(),
     onClearFilters: jest.fn(),
+    onRegexChange: jest.fn(),
     ...overrides,
   };
   return { ...render(<TagSidebar {...defaults} />), props: defaults };
@@ -199,5 +203,71 @@ describe("TagSidebar", () => {
     renderSidebar({ folderPath: "Marketing", onFolderPathChange });
     fireEvent.click(screen.getByRole("button", { name: "Vymazat složku" }));
     expect(onFolderPathChange).toHaveBeenCalledWith("");
+  });
+
+  test("regex mode with invalid pattern shows error and does not call onSearchChange after debounce", () => {
+    // Arrange
+    const onSearchChange = jest.fn();
+    renderSidebar({ useRegex: true, onSearchChange });
+
+    const input = screen.getByPlaceholderText("Regex (POSIX, case-insensitive)...");
+
+    // Act — type an invalid regex
+    fireEvent.change(input, { target: { value: "[bad" } });
+
+    // Assert: error message appears
+    expect(screen.getByText("Neplatný regulární výraz")).toBeInTheDocument();
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Assert: onSearchChange is NOT called when pattern is invalid
+    expect(onSearchChange).not.toHaveBeenCalled();
+  });
+
+  test("regex mode with valid pattern calls onSearchChange after debounce", () => {
+    // Arrange
+    const onSearchChange = jest.fn();
+    renderSidebar({ useRegex: true, onSearchChange });
+
+    const input = screen.getByPlaceholderText("Regex (POSIX, case-insensitive)...");
+
+    // Act — type a valid regex
+    fireEvent.change(input, { target: { value: "^ok$" } });
+
+    // Assert: no error shown
+    expect(screen.queryByText("Neplatný regulární výraz")).not.toBeInTheDocument();
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Assert: onSearchChange is called with the valid pattern
+    expect(onSearchChange).toHaveBeenCalledWith("^ok$");
+  });
+
+  test("regex mode off with invalid regex-like input calls onSearchChange and shows no error", () => {
+    // Arrange
+    const onSearchChange = jest.fn();
+    renderSidebar({ useRegex: false, onSearchChange });
+
+    const input = screen.getByPlaceholderText("Hledat soubory...");
+
+    // Act — type something that would be invalid regex but regex mode is off
+    fireEvent.change(input, { target: { value: "[bad" } });
+
+    // Assert: no error shown
+    expect(screen.queryByText("Neplatný regulární výraz")).not.toBeInTheDocument();
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Assert: onSearchChange is called as normal
+    expect(onSearchChange).toHaveBeenCalledWith("[bad");
   });
 });

--- a/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
@@ -270,4 +270,38 @@ describe("TagSidebar", () => {
     // Assert: onSearchChange is called as normal
     expect(onSearchChange).toHaveBeenCalledWith("[bad");
   });
+
+  test("toggling regex off clears the error", () => {
+    // Arrange — render with regex enabled and type invalid pattern
+    const { rerender } = renderSidebar({ useRegex: true });
+
+    const input = screen.getByPlaceholderText("Regex (POSIX, case-insensitive)...");
+
+    // Act — type an invalid regex
+    fireEvent.change(input, { target: { value: "[bad" } });
+
+    // Assert: error message appears
+    expect(screen.getByText("Neplatný regulární výraz")).toBeInTheDocument();
+
+    // Act — re-render the component with useRegex={false} (simulating parent passing new props)
+    rerender(
+      <TagSidebar
+        tags={mockTags}
+        selectedTagIds={[]}
+        search="[bad"
+        folderPath=""
+        withoutTags={false}
+        useRegex={false}
+        onTagToggle={jest.fn()}
+        onSearchChange={jest.fn()}
+        onFolderPathChange={jest.fn()}
+        onWithoutTagsToggle={jest.fn()}
+        onClearFilters={jest.fn()}
+        onRegexChange={jest.fn()}
+      />
+    );
+
+    // Assert: error message is gone
+    expect(screen.queryByText("Neplatný regulární výraz")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -87,7 +87,7 @@ function PhotobankPage() {
     [selectedTagIds, tagsData],
   );
 
-  const { data: photosData, isLoading: photosLoading } = usePhotos({
+  const { data: photosData, isLoading: photosLoading, isError: photosError } = usePhotos({
     tags: selectedTagNames.length > 0 ? selectedTagNames : undefined,
     search: search || undefined,
     useRegex: useRegex || undefined,
@@ -96,6 +96,10 @@ function PhotobankPage() {
     page,
     pageSize: DEFAULT_PAGE_SIZE,
   });
+
+  const searchErrorMessage = photosError && useRegex
+    ? "Neplatný regulární výraz"
+    : null;
 
   const handleTagToggle = useCallback((tagId: number) => {
     setSelectedTagIds((prev) =>
@@ -184,6 +188,7 @@ function PhotobankPage() {
             onWithoutTagsToggle={() => { setWithoutTags((v) => !v); setPage(1); }}
             onClearFilters={handleClearFilters}
             onRegexChange={handleRegexChange}
+            errorMessage={searchErrorMessage}
           />
         </div>
 

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -90,7 +90,7 @@ function PhotobankPage() {
   const { data: photosData, isLoading: photosLoading } = usePhotos({
     tags: selectedTagNames.length > 0 ? selectedTagNames : undefined,
     search: search || undefined,
-    useRegex,
+    useRegex: useRegex || undefined,
     folderPath: folderPath || undefined,
     withoutTags: withoutTags || undefined,
     page,

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -54,6 +54,7 @@ function PhotobankPage() {
   const [search, setSearch] = useState("");
   const [folderPath, setFolderPath] = useState("");
   const [withoutTags, setWithoutTags] = useState(false);
+  const [useRegex, setUseRegex] = useState(false);
   const [page, setPage] = useState(1);
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoDto | null>(null);
   const [view, setView] = useState<ViewMode>(readViewMode);
@@ -89,6 +90,7 @@ function PhotobankPage() {
   const { data: photosData, isLoading: photosLoading } = usePhotos({
     tags: selectedTagNames.length > 0 ? selectedTagNames : undefined,
     search: search || undefined,
+    useRegex,
     folderPath: folderPath || undefined,
     withoutTags: withoutTags || undefined,
     page,
@@ -112,11 +114,17 @@ function PhotobankPage() {
     setPage(1);
   }, []);
 
+  const handleRegexChange = useCallback((value: boolean) => {
+    setUseRegex(value);
+    setPage(1);
+  }, []);
+
   const handleClearFilters = useCallback(() => {
     setSelectedTagIds([]);
     setSearch("");
     setFolderPath("");
     setWithoutTags(false);
+    setUseRegex(false);
     setPage(1);
   }, []);
 
@@ -169,11 +177,13 @@ function PhotobankPage() {
             search={search}
             folderPath={folderPath}
             withoutTags={withoutTags}
+            useRegex={useRegex}
             onTagToggle={handleTagToggle}
             onSearchChange={handleSearchChange}
             onFolderPathChange={handleFolderPathChange}
             onWithoutTagsToggle={() => { setWithoutTags((v) => !v); setPage(1); }}
             onClearFilters={handleClearFilters}
+            onRegexChange={handleRegexChange}
           />
         </div>
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -215,6 +215,7 @@ const resources = {
         PhotoTagCreationFailed: "Vytvoření tagu fotky selhalo.",
         BulkTagFiltersRequired: "Pro hromadné tagování musí být aktivní alespoň jeden filtr.",
         BulkTagLimitExceeded: "Filtr odpovídá příliš mnoha fotkám ({{Count}}). Upřesněte filtry (max {{Limit}}).",
+        PhotobankInvalidRegexPattern: "Neplatný regulární výraz.",
 
         // Article Generation errors
         ArticleNotFound: "Článek nebyl nalezen (ID: {{id}})",


### PR DESCRIPTION
## Summary

- Adds a **Regex** checkbox to the photobank search sidebar that switches filename matching from substring to POSIX case-insensitive regex (`~*` in Postgres)
- Default is unchanged — substring search works exactly as before; regex is opt-in
- Defense-in-depth validation: client-side `RegExp` syntax check (blocks API call on invalid pattern), FluentValidation server-side pre-check (returns 400), and `PostgresException` handler for Postgres-specific failures

## Changes

**Backend:**
- `GetPhotosRequest` / `IPhotobankRepository` / `PhotobankRepository` — new `useRegex` flag; when true, `Regex.IsMatch(fileName, pattern, IgnoreCase)` is used (Npgsql 8.0.4 translates to `~*`)
- `GetPhotosRequestValidator` — rejects invalid patterns via `Must(BeValidRegex).When(UseRegex)`
- `GetPhotosHandler` — forwards flag, catches `PostgresException` sqlstate `2201B` → `PhotobankInvalidRegexPattern` (2607) error code
- `PhotobankController` — new `[FromQuery] bool useRegex = false` parameter

**Frontend:**
- `TagSidebar` — "Regex" checkbox, dynamic placeholder, red border + inline error on invalid pattern, debounce blocked while pattern is invalid
- `PhotobankPage` — `useRegex` state, reset on "Vymazat", `hasActiveFilters` updated, server-side error surfaced via `errorMessage` prop
- `usePhotobank` hook — `useRegex?: boolean` in `GetPhotosParams`, emits `?useRegex=true` when set

## Test Plan

- [ ] `dotnet test` — 2,848 passing (validator × 4 cases, repository regex vs substring, handler wiring)
- [ ] `npm test` — 19 TagSidebar tests passing (invalid pattern blocked, valid fires, toggle-off clears error)
- [ ] Smoke: type `IMG` with checkbox off → substring results unchanged
- [ ] Smoke: check Regex box, type `^IMG_\d+\.png$` → only matching filenames; pagination correct
- [ ] Smoke: type `[unclosed` → red border, error label, no network request
- [ ] Smoke: uncheck Regex → same value re-runs as substring, error clears
- [ ] Smoke: click "Vymazat" → all filters including regex flag reset