### PR TITLE
feat(photobank): tag catalog management — create and delete tags

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -8,6 +8,8 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
 using Anela.Heblo.Application.Features.Photobank.UseCases.BulkAddPhotoTag;
+using Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag;
+using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRule;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
@@ -81,6 +83,36 @@ namespace Anela.Heblo.API.Controllers
         {
             var response = await _mediator.Send(new GetTagsRequest(), cancellationToken);
             return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Create a new tag. Requires marketing writer role.
+        /// </summary>
+        [HttpPost("tags")]
+        [Authorize(Roles = AuthorizationConstants.Roles.MarketingWriter)]
+        [ProducesResponseType(typeof(CreateTagResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> CreateTag([FromBody] CreateTagBody body, CancellationToken ct)
+        {
+            var response = await _mediator.Send(new CreateTagRequest { Name = body.Name }, ct);
+            return Ok(response);
+        }
+
+        /// <summary>
+        /// Delete a tag by ID. Requires marketing writer role.
+        /// </summary>
+        [HttpDelete("tags/{id:int}")]
+        [Authorize(Roles = AuthorizationConstants.Roles.MarketingWriter)]
+        [ProducesResponseType(typeof(DeleteTagResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteTag(int id, CancellationToken ct)
+        {
+            var response = await _mediator.Send(new DeleteTagRequest { Id = id }, ct);
+            if (!response.Deleted)
+                return NotFound();
+            return Ok(response);
         }
 
         /// <summary>
@@ -338,6 +370,11 @@ namespace Anela.Heblo.API.Controllers
     public class AddPhotoTagBody
     {
         public string TagName { get; set; } = null!;
+    }
+
+    public class CreateTagBody
+    {
+        public string Name { get; set; } = string.Empty;
     }
 
     public class BulkAddPhotoTagBody

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -93,10 +93,10 @@ namespace Anela.Heblo.API.Controllers
         [ProducesResponseType(typeof(CreateTagResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> CreateTag([FromBody] CreateTagBody body, CancellationToken ct)
+        public async Task<ActionResult<CreateTagResponse>> CreateTag([FromBody] CreateTagBody body, CancellationToken ct)
         {
             var response = await _mediator.Send(new CreateTagRequest { Name = body.Name }, ct);
-            return Ok(response);
+            return HandleResponse(response);
         }
 
         /// <summary>
@@ -107,12 +107,10 @@ namespace Anela.Heblo.API.Controllers
         [ProducesResponseType(typeof(DeleteTagResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> DeleteTag(int id, CancellationToken ct)
+        public async Task<ActionResult<DeleteTagResponse>> DeleteTag(int id, CancellationToken ct)
         {
             var response = await _mediator.Send(new DeleteTagRequest { Id = id }, ct);
-            if (!response.Deleted)
-                return NotFound();
-            return Ok(response);
+            return HandleResponse(response);
         }
 
         /// <summary>

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -86,10 +86,10 @@ namespace Anela.Heblo.API.Controllers
         }
 
         /// <summary>
-        /// Create a new tag. Requires marketing writer role.
+        /// Create a new tag. Requires super user role.
         /// </summary>
         [HttpPost("tags")]
-        [Authorize(Roles = AuthorizationConstants.Roles.MarketingWriter)]
+        [Authorize(Roles = AuthorizationConstants.Roles.SuperUser)]
         [ProducesResponseType(typeof(CreateTagResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -100,10 +100,10 @@ namespace Anela.Heblo.API.Controllers
         }
 
         /// <summary>
-        /// Delete a tag by ID. Requires marketing writer role.
+        /// Delete a tag by ID. Requires super user role.
         /// </summary>
         [HttpDelete("tags/{id:int}")]
-        [Authorize(Roles = AuthorizationConstants.Roles.MarketingWriter)]
+        [Authorize(Roles = AuthorizationConstants.Roles.SuperUser)]
         [ProducesResponseType(typeof(DeleteTagResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -3,8 +3,10 @@ using Anela.Heblo.Application.Features.Photobank.Services;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
+using Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRoot;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteRule;
+using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
 using Anela.Heblo.Application.Features.Photobank.UseCases.RemovePhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
@@ -49,6 +51,8 @@ public static class PhotobankModule
         services.AddScoped<IValidator<RemovePhotoTagRequest>, RemovePhotoTagRequestValidator>();
         services.AddScoped<IValidator<GetPhotosRequest>, GetPhotosRequestValidator>();
         services.AddScoped<IValidator<UpdateRuleRequest>, UpdateRuleRequestValidator>();
+        services.AddScoped<IValidator<CreateTagRequest>, CreateTagRequestValidator>();
+        services.AddScoped<IValidator<DeleteTagRequest>, DeleteTagRequestValidator>();
 
         // Register MediatR validation behavior for photobank requests
         services.AddScoped<IPipelineBehavior<AddPhotoTagRequest, AddPhotoTagResponse>, ValidationBehavior<AddPhotoTagRequest, AddPhotoTagResponse>>();
@@ -59,6 +63,8 @@ public static class PhotobankModule
         services.AddScoped<IPipelineBehavior<RemovePhotoTagRequest, RemovePhotoTagResponse>, ValidationBehavior<RemovePhotoTagRequest, RemovePhotoTagResponse>>();
         services.AddScoped<IPipelineBehavior<GetPhotosRequest, GetPhotosResponse>, ValidationBehavior<GetPhotosRequest, GetPhotosResponse>>();
         services.AddScoped<IPipelineBehavior<UpdateRuleRequest, UpdateRuleResponse>, ValidationBehavior<UpdateRuleRequest, UpdateRuleResponse>>();
+        services.AddScoped<IPipelineBehavior<CreateTagRequest, CreateTagResponse>, ValidationBehavior<CreateTagRequest, CreateTagResponse>>();
+        services.AddScoped<IPipelineBehavior<DeleteTagRequest, DeleteTagResponse>, ValidationBehavior<DeleteTagRequest, DeleteTagResponse>>();
 
         return services;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -161,10 +161,10 @@ namespace Anela.Heblo.Application.Features.Photobank
             return FindTagByNameAsync(normalizedName, cancellationToken);
         }
 
-        public async Task DeleteTagAsync(Tag tag, CancellationToken cancellationToken)
+        public Task DeleteTagAsync(Tag tag, CancellationToken cancellationToken)
         {
             _context.PhotobankTags.Remove(tag);
-            await _context.SaveChangesAsync(cancellationToken);
+            return Task.CompletedTask;
         }
 
         // Photo tags

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -161,14 +161,10 @@ namespace Anela.Heblo.Application.Features.Photobank
             return FindTagByNameAsync(normalizedName, cancellationToken);
         }
 
-        public async Task<bool> DeleteTagAsync(int tagId, CancellationToken cancellationToken)
+        public async Task DeleteTagAsync(Tag tag, CancellationToken cancellationToken)
         {
-            var tag = await _context.PhotobankTags.FindAsync(new object[] { tagId }, cancellationToken);
-            if (tag == null)
-                return false;
             _context.PhotobankTags.Remove(tag);
             await _context.SaveChangesAsync(cancellationToken);
-            return true;
         }
 
         // Photo tags

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -151,7 +151,9 @@ namespace Anela.Heblo.Application.Features.Photobank
 
         public async Task<Tag?> GetTagByIdAsync(int id, CancellationToken cancellationToken)
         {
-            return await _context.PhotobankTags.FindAsync(new object[] { id }, cancellationToken);
+            return await _context.PhotobankTags
+                .Include(t => t.PhotoTags)
+                .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
         }
 
         public Task<Tag?> GetTagByNameAsync(string normalizedName, CancellationToken cancellationToken)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -130,10 +130,15 @@ namespace Anela.Heblo.Application.Features.Photobank
             return results.Select(x => (x.Tag, x.Count)).ToList();
         }
 
+        private Task<Tag?> FindTagByNameAsync(string normalizedName, CancellationToken ct)
+        {
+            return _context.PhotobankTags
+                .FirstOrDefaultAsync(t => t.Name == normalizedName, ct);
+        }
+
         public async Task<Tag?> GetOrCreateTagAsync(string normalizedName, CancellationToken cancellationToken)
         {
-            var existing = await _context.PhotobankTags
-                .FirstOrDefaultAsync(t => t.Name == normalizedName, cancellationToken);
+            var existing = await FindTagByNameAsync(normalizedName, cancellationToken);
 
             if (existing != null)
                 return existing;
@@ -149,10 +154,9 @@ namespace Anela.Heblo.Application.Features.Photobank
             return await _context.PhotobankTags.FindAsync(new object[] { id }, cancellationToken);
         }
 
-        public async Task<Tag?> GetTagByNameAsync(string normalizedName, CancellationToken cancellationToken)
+        public Task<Tag?> GetTagByNameAsync(string normalizedName, CancellationToken cancellationToken)
         {
-            return await _context.PhotobankTags
-                .FirstOrDefaultAsync(t => t.Name == normalizedName, cancellationToken);
+            return FindTagByNameAsync(normalizedName, cancellationToken);
         }
 
         public async Task<bool> DeleteTagAsync(int tagId, CancellationToken cancellationToken)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -149,6 +149,22 @@ namespace Anela.Heblo.Application.Features.Photobank
             return await _context.PhotobankTags.FindAsync(new object[] { id }, cancellationToken);
         }
 
+        public async Task<Tag?> GetTagByNameAsync(string normalizedName, CancellationToken cancellationToken)
+        {
+            return await _context.PhotobankTags
+                .FirstOrDefaultAsync(t => t.Name == normalizedName, cancellationToken);
+        }
+
+        public async Task<bool> DeleteTagAsync(int tagId, CancellationToken cancellationToken)
+        {
+            var tag = await _context.PhotobankTags.FindAsync(new object[] { tagId }, cancellationToken);
+            if (tag == null)
+                return false;
+            _context.PhotobankTags.Remove(tag);
+            await _context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+
         // Photo tags
 
         public Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag
+{
+    public class CreateTagHandler : IRequestHandler<CreateTagRequest, CreateTagResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public CreateTagHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<CreateTagResponse> Handle(CreateTagRequest request, CancellationToken cancellationToken)
+        {
+            var normalizedName = request.Name.Trim().ToLowerInvariant();
+
+            var existing = await _repository.GetTagByNameAsync(normalizedName, cancellationToken);
+            if (existing != null)
+                return new CreateTagResponse { Id = existing.Id, Name = existing.Name, AlreadyExisted = true };
+
+            var tag = await _repository.GetOrCreateTagAsync(normalizedName, cancellationToken);
+            return new CreateTagResponse { Id = tag!.Id, Name = tag.Name, AlreadyExisted = false };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagHandler.cs
@@ -18,12 +18,16 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag
         {
             var normalizedName = request.Name.Trim().ToLowerInvariant();
 
+            // Two-step check-then-create is intentional; the TOCTOU race window is acceptable
+            // for a single-user marketing tool. GetOrCreateTagAsync handles concurrent inserts atomically.
             var existing = await _repository.GetTagByNameAsync(normalizedName, cancellationToken);
             if (existing != null)
                 return new CreateTagResponse { Id = existing.Id, Name = existing.Name, AlreadyExisted = true };
 
             var tag = await _repository.GetOrCreateTagAsync(normalizedName, cancellationToken);
-            return new CreateTagResponse { Id = tag!.Id, Name = tag.Name, AlreadyExisted = false };
+            if (tag is null)
+                throw new InvalidOperationException($"GetOrCreateTagAsync returned null for '{normalizedName}'.");
+            return new CreateTagResponse { Id = tag.Id, Name = tag.Name, AlreadyExisted = false };
         }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag
+{
+    public class CreateTagRequest : IRequest<CreateTagResponse>
+    {
+        public string Name { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagResponse.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag
+{
+    public class CreateTagResponse
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public bool AlreadyExisted { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/CreateTag/CreateTagResponse.cs
@@ -1,9 +1,15 @@
+using Anela.Heblo.Application.Shared;
+
 namespace Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag
 {
-    public class CreateTagResponse
+    public class CreateTagResponse : BaseResponse
     {
         public int Id { get; set; }
         public string Name { get; set; } = null!;
         public bool AlreadyExisted { get; set; }
+
+        public CreateTagResponse() : base() { }
+
+        public CreateTagResponse(ErrorCodes errorCode) : base(errorCode) { }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
+{
+    public class DeleteTagHandler : IRequestHandler<DeleteTagRequest, DeleteTagResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+
+        public DeleteTagHandler(IPhotobankRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<DeleteTagResponse> Handle(DeleteTagRequest request, CancellationToken cancellationToken)
+        {
+            var tag = await _repository.GetTagByIdAsync(request.Id, cancellationToken);
+            if (tag is null)
+                return new DeleteTagResponse { Deleted = false, RemovedAssignmentCount = 0 };
+
+            var assignmentCount = tag.PhotoTags.Count;
+            await _repository.DeleteTagAsync(request.Id, cancellationToken);
+
+            return new DeleteTagResponse { Deleted = true, RemovedAssignmentCount = assignmentCount };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
@@ -21,7 +21,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
                 return new DeleteTagResponse { Deleted = false, RemovedAssignmentCount = 0 };
 
             var assignmentCount = tag.PhotoTags.Count;
-            await _repository.DeleteTagAsync(request.Id, cancellationToken);
+            await _repository.DeleteTagAsync(tag, cancellationToken);
 
             return new DeleteTagResponse { Deleted = true, RemovedAssignmentCount = assignmentCount };
         }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
@@ -23,6 +23,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
 
             var assignmentCount = tag.PhotoTags.Count;
             await _repository.DeleteTagAsync(tag, cancellationToken);
+            await _repository.SaveChangesAsync(cancellationToken);
 
             return new DeleteTagResponse { RemovedAssignmentCount = assignmentCount };
         }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagHandler.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Photobank;
 using MediatR;
 
@@ -18,12 +19,12 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
         {
             var tag = await _repository.GetTagByIdAsync(request.Id, cancellationToken);
             if (tag is null)
-                return new DeleteTagResponse { Deleted = false, RemovedAssignmentCount = 0 };
+                return new DeleteTagResponse(ErrorCodes.PhotobankTagNotFound);
 
             var assignmentCount = tag.PhotoTags.Count;
             await _repository.DeleteTagAsync(tag, cancellationToken);
 
-            return new DeleteTagResponse { Deleted = true, RemovedAssignmentCount = assignmentCount };
+            return new DeleteTagResponse { RemovedAssignmentCount = assignmentCount };
         }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
+{
+    public class DeleteTagRequest : IRequest<DeleteTagResponse>
+    {
+        public int Id { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagResponse.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
+{
+    public class DeleteTagResponse
+    {
+        public bool Deleted { get; set; }
+        public int RemovedAssignmentCount { get; set; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/DeleteTag/DeleteTagResponse.cs
@@ -1,8 +1,13 @@
+using Anela.Heblo.Application.Shared;
+
 namespace Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag
 {
-    public class DeleteTagResponse
+    public class DeleteTagResponse : BaseResponse
     {
-        public bool Deleted { get; set; }
         public int RemovedAssignmentCount { get; set; }
+
+        public DeleteTagResponse() : base() { }
+
+        public DeleteTagResponse(ErrorCodes errorCode) : base(errorCode) { }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/CreateTagRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/CreateTagRequestValidator.cs
@@ -1,0 +1,18 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Photobank.Validators;
+
+public class CreateTagRequestValidator : AbstractValidator<CreateTagRequest>
+{
+    public CreateTagRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage("Name is required")
+            .Must(name => !string.IsNullOrWhiteSpace(name))
+            .WithMessage("Name cannot be whitespace only")
+            .MaximumLength(100)
+            .WithMessage("Name cannot exceed 100 characters");
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/CreateTagRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/CreateTagRequestValidator.cs
@@ -10,8 +10,6 @@ public class CreateTagRequestValidator : AbstractValidator<CreateTagRequest>
         RuleFor(x => x.Name)
             .NotEmpty()
             .WithMessage("Name is required")
-            .Must(name => !string.IsNullOrWhiteSpace(name))
-            .WithMessage("Name cannot be whitespace only")
             .MaximumLength(100)
             .WithMessage("Name cannot exceed 100 characters");
     }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/DeleteTagRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/DeleteTagRequestValidator.cs
@@ -1,0 +1,14 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Photobank.Validators;
+
+public class DeleteTagRequestValidator : AbstractValidator<DeleteTagRequest>
+{
+    public DeleteTagRequestValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0)
+            .WithMessage("Id must be greater than 0");
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -269,6 +269,8 @@ public enum ErrorCodes
     BulkTagFiltersRequired = 2605,
     [HttpStatusCode(HttpStatusCode.BadRequest)]
     BulkTagLimitExceeded = 2606,
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotobankTagNotFound = 2607,
 
     // External Service errors (90XX)
     [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -25,6 +25,8 @@ namespace Anela.Heblo.Domain.Features.Photobank
         Task<List<(Tag Tag, int Count)>> GetTagsWithCountsAsync(CancellationToken cancellationToken);
         Task<Tag?> GetOrCreateTagAsync(string normalizedName, CancellationToken cancellationToken);
         Task<Tag?> GetTagByIdAsync(int id, CancellationToken cancellationToken);
+        Task<Tag?> GetTagByNameAsync(string normalizedName, CancellationToken cancellationToken);
+        Task<bool> DeleteTagAsync(int tagId, CancellationToken cancellationToken);
 
         // Photo tags
         Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken);

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -26,7 +26,7 @@ namespace Anela.Heblo.Domain.Features.Photobank
         Task<Tag?> GetOrCreateTagAsync(string normalizedName, CancellationToken cancellationToken);
         Task<Tag?> GetTagByIdAsync(int id, CancellationToken cancellationToken);
         Task<Tag?> GetTagByNameAsync(string normalizedName, CancellationToken cancellationToken);
-        Task<bool> DeleteTagAsync(int tagId, CancellationToken cancellationToken);
+        Task DeleteTagAsync(Tag tag, CancellationToken cancellationToken);
 
         // Photo tags
         Task AddPhotoTagAsync(PhotoTag photoTag, CancellationToken cancellationToken);

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/CreateTagHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/CreateTagHandlerTests.cs
@@ -1,0 +1,100 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class CreateTagHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly CreateTagHandler _handler;
+
+    public CreateTagHandlerTests()
+    {
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _handler = new CreateTagHandler(_repositoryMock.Object);
+    }
+
+    private static Tag BuildTag(int id, string name) => new() { Id = id, Name = name };
+
+    [Fact]
+    public async Task Handle_NewTag_CallsGetOrCreateAndReturnsAlreadyExistedFalse()
+    {
+        // Arrange
+        var createdTag = BuildTag(42, "summer");
+
+        _repositoryMock
+            .Setup(r => r.GetTagByNameAsync("summer", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        _repositoryMock
+            .Setup(r => r.GetOrCreateTagAsync("summer", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdTag);
+
+        var request = new CreateTagRequest { Name = "summer" };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Id.Should().Be(42);
+        result.Name.Should().Be("summer");
+        result.AlreadyExisted.Should().BeFalse();
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync("summer", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingTag_ReturnsAlreadyExistedTrueWithoutCallingGetOrCreate()
+    {
+        // Arrange
+        var existingTag = BuildTag(7, "sale");
+
+        _repositoryMock
+            .Setup(r => r.GetTagByNameAsync("sale", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingTag);
+
+        var request = new CreateTagRequest { Name = "sale" };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Id.Should().Be(7);
+        result.Name.Should().Be("sale");
+        result.AlreadyExisted.Should().BeTrue();
+
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MixedCaseInput_PassesNormalizedNameToRepositoryCalls()
+    {
+        // Arrange
+        var createdTag = BuildTag(10, "hello world");
+
+        _repositoryMock
+            .Setup(r => r.GetTagByNameAsync("hello world", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        _repositoryMock
+            .Setup(r => r.GetOrCreateTagAsync("hello world", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdTag);
+
+        var request = new CreateTagRequest { Name = "HELLO World" };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Name.Should().Be("hello world");
+        result.AlreadyExisted.Should().BeFalse();
+
+        _repositoryMock.Verify(r => r.GetTagByNameAsync("hello world", It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync("hello world", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/CreateTagHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/CreateTagHandlerTests.cs
@@ -71,30 +71,32 @@ public class CreateTagHandlerTests
         _repositoryMock.Verify(r => r.GetOrCreateTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    [Fact]
-    public async Task Handle_MixedCaseInput_PassesNormalizedNameToRepositoryCalls()
+    [Theory]
+    [InlineData("HELLO World", "hello world")]
+    [InlineData("  Summer  ", "summer")]
+    public async Task Handle_NormalizableInput_PassesNormalizedNameToRepositoryCalls(string input, string expectedNormalized)
     {
         // Arrange
-        var createdTag = BuildTag(10, "hello world");
+        var createdTag = BuildTag(10, expectedNormalized);
 
         _repositoryMock
-            .Setup(r => r.GetTagByNameAsync("hello world", It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetTagByNameAsync(expectedNormalized, It.IsAny<CancellationToken>()))
             .ReturnsAsync((Tag?)null);
 
         _repositoryMock
-            .Setup(r => r.GetOrCreateTagAsync("hello world", It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetOrCreateTagAsync(expectedNormalized, It.IsAny<CancellationToken>()))
             .ReturnsAsync(createdTag);
 
-        var request = new CreateTagRequest { Name = "HELLO World" };
+        var request = new CreateTagRequest { Name = input };
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
-        result.Name.Should().Be("hello world");
+        result.Name.Should().Be(expectedNormalized);
         result.AlreadyExisted.Should().BeFalse();
 
-        _repositoryMock.Verify(r => r.GetTagByNameAsync("hello world", It.IsAny<CancellationToken>()), Times.Once);
-        _repositoryMock.Verify(r => r.GetOrCreateTagAsync("hello world", It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetTagByNameAsync(expectedNormalized, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetOrCreateTagAsync(expectedNormalized, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/CreateTagRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/CreateTagRequestValidatorTests.cs
@@ -1,0 +1,69 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.CreateTag;
+using Anela.Heblo.Application.Features.Photobank.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class CreateTagRequestValidatorTests
+{
+    private readonly CreateTagRequestValidator _validator;
+
+    public CreateTagRequestValidatorTests()
+    {
+        _validator = new CreateTagRequestValidator();
+    }
+
+    [Fact]
+    public void EmptyName_FailsValidation()
+    {
+        // Arrange
+        var request = new CreateTagRequest { Name = "" };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void WhitespaceOnlyName_FailsValidation()
+    {
+        // Arrange
+        var request = new CreateTagRequest { Name = "   " };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void NameExceedsMaxLength_FailsValidation()
+    {
+        // Arrange
+        var request = new CreateTagRequest { Name = new string('a', 101) };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorMessage("Name cannot exceed 100 characters");
+    }
+
+    [Fact]
+    public void ValidName_PassesValidation()
+    {
+        // Arrange
+        var request = new CreateTagRequest { Name = "summer" };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
@@ -39,8 +38,8 @@ public class DeleteTagHandlerTests
             .ReturnsAsync(tag);
 
         _repositoryMock
-            .Setup(r => r.DeleteTagAsync(5, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         var request = new DeleteTagRequest { Id = 5 };
 
@@ -51,7 +50,7 @@ public class DeleteTagHandlerTests
         result.Deleted.Should().BeTrue();
         result.RemovedAssignmentCount.Should().Be(3);
 
-        _repositoryMock.Verify(r => r.DeleteTagAsync(5, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -65,8 +64,8 @@ public class DeleteTagHandlerTests
             .ReturnsAsync(tag);
 
         _repositoryMock
-            .Setup(r => r.DeleteTagAsync(7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         var request = new DeleteTagRequest { Id = 7 };
 
@@ -77,7 +76,7 @@ public class DeleteTagHandlerTests
         result.Deleted.Should().BeTrue();
         result.RemovedAssignmentCount.Should().Be(0);
 
-        _repositoryMock.Verify(r => r.DeleteTagAsync(7, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -97,6 +96,6 @@ public class DeleteTagHandlerTests
         result.Deleted.Should().BeFalse();
         result.RemovedAssignmentCount.Should().Be(0);
 
-        _repositoryMock.Verify(r => r.DeleteTagAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repositoryMock.Verify(r => r.DeleteTagAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Photobank;
 using FluentAssertions;
 using Moq;
@@ -10,14 +11,9 @@ namespace Anela.Heblo.Tests.Features.Photobank;
 
 public class DeleteTagHandlerTests
 {
-    private readonly Mock<IPhotobankRepository> _repositoryMock;
-    private readonly DeleteTagHandler _handler;
+    private readonly Mock<IPhotobankRepository> _repositoryMock = new();
 
-    public DeleteTagHandlerTests()
-    {
-        _repositoryMock = new Mock<IPhotobankRepository>();
-        _handler = new DeleteTagHandler(_repositoryMock.Object);
-    }
+    private DeleteTagHandler CreateHandler() => new(_repositoryMock.Object);
 
     private static Tag BuildTag(int id, string name, int photoTagCount = 0)
     {
@@ -28,7 +24,7 @@ public class DeleteTagHandlerTests
     }
 
     [Fact]
-    public async Task Handle_TagExistsWithAssignments_DeletesAndReturnsCorrectCount()
+    public async Task Handle_TagExistsWithAssignments_ReturnsSuccessWithCorrectCount()
     {
         // Arrange
         var tag = BuildTag(5, "summer", photoTagCount: 3);
@@ -44,17 +40,17 @@ public class DeleteTagHandlerTests
         var request = new DeleteTagRequest { Id = 5 };
 
         // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
+        var result = await CreateHandler().Handle(request, CancellationToken.None);
 
         // Assert
-        result.Deleted.Should().BeTrue();
+        result.Success.Should().BeTrue();
         result.RemovedAssignmentCount.Should().Be(3);
 
         _repositoryMock.Verify(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task Handle_TagExistsWithNoAssignments_DeletesAndReturnsZeroCount()
+    public async Task Handle_TagExistsWithNoAssignments_ReturnsSuccessWithZeroCount()
     {
         // Arrange
         var tag = BuildTag(7, "sale", photoTagCount: 0);
@@ -70,17 +66,17 @@ public class DeleteTagHandlerTests
         var request = new DeleteTagRequest { Id = 7 };
 
         // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
+        var result = await CreateHandler().Handle(request, CancellationToken.None);
 
         // Assert
-        result.Deleted.Should().BeTrue();
+        result.Success.Should().BeTrue();
         result.RemovedAssignmentCount.Should().Be(0);
 
         _repositoryMock.Verify(r => r.DeleteTagAsync(tag, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task Handle_TagNotFound_ReturnsFalseWithoutCallingDelete()
+    public async Task Handle_TagNotFound_ReturnsNotFoundErrorWithoutCallingDelete()
     {
         // Arrange
         _repositoryMock
@@ -90,11 +86,11 @@ public class DeleteTagHandlerTests
         var request = new DeleteTagRequest { Id = 99 };
 
         // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
+        var result = await CreateHandler().Handle(request, CancellationToken.None);
 
         // Assert
-        result.Deleted.Should().BeFalse();
-        result.RemovedAssignmentCount.Should().Be(0);
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.PhotobankTagNotFound);
 
         _repositoryMock.Verify(r => r.DeleteTagAsync(It.IsAny<Tag>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagHandlerTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class DeleteTagHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly DeleteTagHandler _handler;
+
+    public DeleteTagHandlerTests()
+    {
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _handler = new DeleteTagHandler(_repositoryMock.Object);
+    }
+
+    private static Tag BuildTag(int id, string name, int photoTagCount = 0)
+    {
+        var tag = new Tag { Id = id, Name = name };
+        for (var i = 0; i < photoTagCount; i++)
+            tag.PhotoTags.Add(new PhotoTag { PhotoId = i + 1, TagId = id });
+        return tag;
+    }
+
+    [Fact]
+    public async Task Handle_TagExistsWithAssignments_DeletesAndReturnsCorrectCount()
+    {
+        // Arrange
+        var tag = BuildTag(5, "summer", photoTagCount: 3);
+
+        _repositoryMock
+            .Setup(r => r.GetTagByIdAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.DeleteTagAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var request = new DeleteTagRequest { Id = 5 };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Deleted.Should().BeTrue();
+        result.RemovedAssignmentCount.Should().Be(3);
+
+        _repositoryMock.Verify(r => r.DeleteTagAsync(5, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TagExistsWithNoAssignments_DeletesAndReturnsZeroCount()
+    {
+        // Arrange
+        var tag = BuildTag(7, "sale", photoTagCount: 0);
+
+        _repositoryMock
+            .Setup(r => r.GetTagByIdAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tag);
+
+        _repositoryMock
+            .Setup(r => r.DeleteTagAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var request = new DeleteTagRequest { Id = 7 };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Deleted.Should().BeTrue();
+        result.RemovedAssignmentCount.Should().Be(0);
+
+        _repositoryMock.Verify(r => r.DeleteTagAsync(7, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TagNotFound_ReturnsFalseWithoutCallingDelete()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetTagByIdAsync(99, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Tag?)null);
+
+        var request = new DeleteTagRequest { Id = 99 };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Deleted.Should().BeFalse();
+        result.RemovedAssignmentCount.Should().Be(0);
+
+        _repositoryMock.Verify(r => r.DeleteTagAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/DeleteTagRequestValidatorTests.cs
@@ -1,0 +1,55 @@
+using Anela.Heblo.Application.Features.Photobank.UseCases.DeleteTag;
+using Anela.Heblo.Application.Features.Photobank.Validators;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class DeleteTagRequestValidatorTests
+{
+    private readonly DeleteTagRequestValidator _validator;
+
+    public DeleteTagRequestValidatorTests()
+    {
+        _validator = new DeleteTagRequestValidator();
+    }
+
+    [Fact]
+    public void IdIsZero_FailsValidation()
+    {
+        // Arrange
+        var request = new DeleteTagRequest { Id = 0 };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Fact]
+    public void IdIsNegative_FailsValidation()
+    {
+        // Arrange
+        var request = new DeleteTagRequest { Id = -1 };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Id);
+    }
+
+    [Fact]
+    public void IdIsPositive_PassesValidation()
+    {
+        // Arrange
+        var request = new DeleteTagRequest { Id = 1 };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/frontend/src/api/hooks/__tests__/usePhotobank.test.ts
+++ b/frontend/src/api/hooks/__tests__/usePhotobank.test.ts
@@ -5,6 +5,8 @@ import {
   usePhotos,
   usePhotoTags,
   useAddPhotoTag,
+  useCreateTag,
+  useDeleteTag,
 } from "../usePhotobank";
 import { getAuthenticatedApiClient } from "../../client";
 
@@ -258,6 +260,126 @@ describe("useAddPhotoTag", () => {
     });
 
     result.current.mutate("bad-tag");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Assert
+    expect(result.current.error).toBeTruthy();
+  });
+});
+
+describe("useCreateTag", () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue(
+      createMockClient(mockFetch) as any,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("calls POST to /api/photobank/tags with tag name in body", async () => {
+    // Arrange
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 99, name: "nový tag", source: "Manual" }),
+    });
+
+    // Act
+    const { result } = renderHook(() => useCreateTag(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("nový tag");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Assert
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/photobank/tags"),
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ name: "nový tag" });
+  });
+
+  test("sets error state on API failure", async () => {
+    // Arrange
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+    });
+
+    // Act
+    const { result } = renderHook(() => useCreateTag(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate("duplicate");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Assert
+    expect(result.current.error).toBeTruthy();
+  });
+});
+
+describe("useDeleteTag", () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue(
+      createMockClient(mockFetch) as any,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("calls DELETE to /api/photobank/tags/:id", async () => {
+    // Arrange
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    // Act
+    const { result } = renderHook(() => useDeleteTag(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(55);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Assert
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/photobank/tags/55"),
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  test("sets error state on API failure", async () => {
+    // Arrange
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    // Act
+    const { result } = renderHook(() => useDeleteTag(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate(999);
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -145,6 +145,36 @@ export const useRemovePhotoTag = (photoId: number) => {
   });
 };
 
+// ---- Tag CRUD ---------------------------------------------------------------
+
+export const useCreateTag = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (name: string) => {
+      const { apiClient, baseUrl } = getClientAndBaseUrl();
+      const response = await apiPost(apiClient, `${baseUrl}/api/photobank/tags`, { name });
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.photobank });
+    },
+  });
+};
+
+export const useDeleteTag = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (tagId: number) => {
+      const { apiClient, baseUrl } = getClientAndBaseUrl();
+      const response = await apiDelete(apiClient, `${baseUrl}/api/photobank/tags/${tagId}`);
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.photobank });
+    },
+  });
+};
+
 // ---- Bulk tag ---------------------------------------------------------------
 
 export interface BulkAddPhotoTagParams {

--- a/frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useMsal } from '@azure/msal-react';
 import IndexRootsTab from '../settings/IndexRootsTab';
 import TagRulesTab from '../settings/TagRulesTab';
+import TagsTab from '../settings/TagsTab';
 
 const ADMIN_ROLE = 'super_user';
 
@@ -11,7 +12,7 @@ const PhotobankSettingsPage = () => {
   const isAdmin =
     (accounts[0]?.idTokenClaims as any)?.roles?.includes(ADMIN_ROLE) ?? false;
 
-  const [activeTab, setActiveTab] = useState<'roots' | 'rules'>('roots');
+  const [activeTab, setActiveTab] = useState<'roots' | 'rules' | 'tags'>('roots');
 
   if (!isAdmin) {
     return (
@@ -53,10 +54,22 @@ const PhotobankSettingsPage = () => {
         >
           Tag Rules
         </button>
+        <button
+          onClick={() => setActiveTab('tags')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
+            activeTab === 'tags'
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          Štítky
+        </button>
       </div>
 
       {/* Tab content */}
-      {activeTab === 'roots' ? <IndexRootsTab /> : <TagRulesTab />}
+      {activeTab === 'roots' && <IndexRootsTab />}
+      {activeTab === 'rules' && <TagRulesTab />}
+      {activeTab === 'tags' && <TagsTab />}
     </div>
   );
 };

--- a/frontend/src/components/marketing/photobank/settings/ConfirmDeleteTagDialog.tsx
+++ b/frontend/src/components/marketing/photobank/settings/ConfirmDeleteTagDialog.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface Props {
+  isOpen: boolean;
+  tagName: string;
+  assignmentCount: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmDeleteTagDialog: React.FC<Props> = ({
+  isOpen,
+  tagName,
+  assignmentCount,
+  onConfirm,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        onClick={onCancel}
+      />
+
+      {/* Dialog */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+          {/* Close button */}
+          <button
+            onClick={onCancel}
+            className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+            aria-label="Zavřít"
+          >
+            <X className="h-5 w-5" />
+          </button>
+
+          {/* Icon */}
+          <div className="flex items-center justify-center w-12 h-12 mx-auto bg-yellow-100 rounded-full mb-4">
+            <AlertTriangle className="h-6 w-6 text-yellow-600" />
+          </div>
+
+          {/* Title */}
+          <h3 className="text-lg font-semibold text-gray-900 text-center mb-2">
+            Smazat štítek?
+          </h3>
+
+          {/* Message */}
+          <p className="text-sm text-gray-600 text-center mb-6">
+            {`Štítek „${tagName}" je přiřazen k ${assignmentCount} fotografiím. Smazáním ho odstraníte ze všech fotografií. Pokračovat?`}
+          </p>
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              onClick={onCancel}
+              className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              Zrušit
+            </button>
+            <button
+              onClick={onConfirm}
+              className="flex-1 px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors"
+            >
+              Smazat
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDeleteTagDialog;

--- a/frontend/src/components/marketing/photobank/settings/TagsTab.tsx
+++ b/frontend/src/components/marketing/photobank/settings/TagsTab.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import {
+  usePhotoTags,
+  useCreateTag,
+  useDeleteTag,
+} from '../../../../api/hooks/usePhotobank';
+import ConfirmDeleteTagDialog from './ConfirmDeleteTagDialog';
+
+interface TagToDelete {
+  id: number;
+  name: string;
+  count: number;
+}
+
+const TagsTab: React.FC = () => {
+  const { data: tags = [], isLoading } = usePhotoTags();
+  const createTag = useCreateTag();
+  const deleteTag = useDeleteTag();
+
+  const [tagName, setTagName] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [alreadyExisted, setAlreadyExisted] = useState(false);
+  const [tagToDelete, setTagToDelete] = useState<TagToDelete | null>(null);
+
+  const isFormValid = tagName.trim() !== '';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isFormValid) return;
+    setSubmitError(null);
+    setAlreadyExisted(false);
+    try {
+      const result = await createTag.mutateAsync(tagName.trim());
+      if (result?.alreadyExisted) {
+        setAlreadyExisted(true);
+      }
+      setTagName('');
+    } catch {
+      setSubmitError('Nepodařilo se přidat štítek. Zkuste to znovu.');
+    }
+  };
+
+  const handleDeleteClick = (tag: TagToDelete) => {
+    if (tag.count === 0) {
+      deleteTag.mutate(tag.id);
+    } else {
+      setTagToDelete(tag);
+    }
+  };
+
+  const handleConfirmDelete = () => {
+    if (tagToDelete) {
+      deleteTag.mutate(tagToDelete.id);
+      setTagToDelete(null);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setTagToDelete(null);
+  };
+
+  const sortedTags = [...tags].sort((a, b) => a.name.localeCompare(b.name));
+
+  if (isLoading) {
+    return <div className="text-sm text-gray-500">Načítání...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <h3 className="text-sm font-semibold text-gray-700">Přidat štítek</h3>
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={tagName}
+            onChange={(e) => setTagName(e.target.value)}
+            placeholder="Název štítku"
+            className="flex-1 px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-transparent"
+          />
+          <button
+            type="submit"
+            disabled={createTag.isPending || !isFormValid}
+            className="px-3 py-1.5 text-sm bg-primary-blue text-white rounded-md hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Přidat štítek
+          </button>
+        </div>
+        {submitError && (
+          <p className="text-red-600 text-sm mt-2">{submitError}</p>
+        )}
+        {alreadyExisted && (
+          <p className="text-sm text-gray-500 mt-2">Štítek již existuje</p>
+        )}
+      </form>
+
+      <div className="border-t border-gray-200 pt-4">
+        {sortedTags.length === 0 ? (
+          <p className="text-sm text-gray-500">Žádné štítky nejsou vytvořeny.</p>
+        ) : (
+          <ul className="divide-y divide-gray-100">
+            {sortedTags.map((tag) => (
+              <li key={tag.id} className="flex items-center justify-between py-2">
+                <span className="text-sm text-gray-800">{tag.name}</span>
+                <div className="flex items-center gap-3">
+                  <span className="px-1.5 py-0.5 rounded text-xs bg-gray-100 text-gray-600">
+                    {tag.count} fotek
+                  </span>
+                  <button
+                    onClick={() => handleDeleteClick(tag)}
+                    disabled={deleteTag.isPending}
+                    className="p-1 text-gray-400 hover:text-red-500 rounded disabled:opacity-50"
+                    aria-label={`Smazat štítek ${tag.name}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmDeleteTagDialog
+        isOpen={tagToDelete !== null}
+        tagName={tagToDelete?.name ?? ''}
+        assignmentCount={tagToDelete?.count ?? 0}
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+      />
+    </div>
+  );
+};
+
+export default TagsTab;

--- a/frontend/src/components/marketing/photobank/settings/TagsTab.tsx
+++ b/frontend/src/components/marketing/photobank/settings/TagsTab.tsx
@@ -1,17 +1,12 @@
 import { useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import {
+  TagWithCountDto,
   usePhotoTags,
   useCreateTag,
   useDeleteTag,
 } from '../../../../api/hooks/usePhotobank';
 import ConfirmDeleteTagDialog from './ConfirmDeleteTagDialog';
-
-interface TagToDelete {
-  id: number;
-  name: string;
-  count: number;
-}
 
 const TagsTab: React.FC = () => {
   const { data: tags = [], isLoading } = usePhotoTags();
@@ -21,7 +16,8 @@ const TagsTab: React.FC = () => {
   const [tagName, setTagName] = useState('');
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [alreadyExisted, setAlreadyExisted] = useState(false);
-  const [tagToDelete, setTagToDelete] = useState<TagToDelete | null>(null);
+  const [tagToDelete, setTagToDelete] = useState<TagWithCountDto | null>(null);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   const isFormValid = tagName.trim() !== '';
 
@@ -41,9 +37,10 @@ const TagsTab: React.FC = () => {
     }
   };
 
-  const handleDeleteClick = (tag: TagToDelete) => {
+  const handleDeleteClick = (tag: TagWithCountDto) => {
     if (tag.count === 0) {
-      deleteTag.mutate(tag.id);
+      setDeletingId(tag.id);
+      deleteTag.mutate(tag.id, { onSettled: () => setDeletingId(null) });
     } else {
       setTagToDelete(tag);
     }
@@ -51,7 +48,8 @@ const TagsTab: React.FC = () => {
 
   const handleConfirmDelete = () => {
     if (tagToDelete) {
-      deleteTag.mutate(tagToDelete.id);
+      setDeletingId(tagToDelete.id);
+      deleteTag.mutate(tagToDelete.id, { onSettled: () => setDeletingId(null) });
       setTagToDelete(null);
     }
   };
@@ -69,9 +67,12 @@ const TagsTab: React.FC = () => {
   return (
     <div className="space-y-6">
       <form onSubmit={handleSubmit} className="space-y-3">
-        <h3 className="text-sm font-semibold text-gray-700">Přidat štítek</h3>
+        <label htmlFor="tag-name" className="block text-sm font-semibold text-gray-700">
+          Přidat štítek
+        </label>
         <div className="flex gap-3">
           <input
+            id="tag-name"
             type="text"
             value={tagName}
             onChange={(e) => setTagName(e.target.value)}
@@ -108,7 +109,7 @@ const TagsTab: React.FC = () => {
                   </span>
                   <button
                     onClick={() => handleDeleteClick(tag)}
-                    disabled={deleteTag.isPending}
+                    disabled={deletingId === tag.id}
                     className="p-1 text-gray-400 hover:text-red-500 rounded disabled:opacity-50"
                     aria-label={`Smazat štítek ${tag.name}`}
                   >

--- a/frontend/src/components/marketing/photobank/settings/__tests__/ConfirmDeleteTagDialog.test.tsx
+++ b/frontend/src/components/marketing/photobank/settings/__tests__/ConfirmDeleteTagDialog.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConfirmDeleteTagDialog from '../ConfirmDeleteTagDialog';
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  tagName: 'produkty',
+  assignmentCount: 5,
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+beforeEach(() => {
+  (DEFAULT_PROPS.onConfirm as jest.Mock).mockClear();
+  (DEFAULT_PROPS.onCancel as jest.Mock).mockClear();
+});
+
+test('renders dialog when isOpen is true with correct tag name and count', () => {
+  render(<ConfirmDeleteTagDialog {...DEFAULT_PROPS} />);
+
+  expect(screen.getByText(/Smazat štítek/i)).toBeInTheDocument();
+  expect(screen.getByText(/produkty/)).toBeInTheDocument();
+  expect(screen.getByText(/5 fotografiím/)).toBeInTheDocument();
+});
+
+test('does not render when isOpen is false', () => {
+  render(<ConfirmDeleteTagDialog {...DEFAULT_PROPS} isOpen={false} />);
+
+  expect(screen.queryByText(/Smazat štítek/i)).not.toBeInTheDocument();
+});
+
+test('calls onConfirm when confirm button is clicked', () => {
+  render(<ConfirmDeleteTagDialog {...DEFAULT_PROPS} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /Smazat/i }));
+
+  expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledTimes(1);
+  expect(DEFAULT_PROPS.onCancel).not.toHaveBeenCalled();
+});
+
+test('calls onCancel when cancel button is clicked', () => {
+  render(<ConfirmDeleteTagDialog {...DEFAULT_PROPS} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /Zrušit/i }));
+
+  expect(DEFAULT_PROPS.onCancel).toHaveBeenCalledTimes(1);
+  expect(DEFAULT_PROPS.onConfirm).not.toHaveBeenCalled();
+});

--- a/frontend/src/components/marketing/photobank/settings/__tests__/TagsTab.test.tsx
+++ b/frontend/src/components/marketing/photobank/settings/__tests__/TagsTab.test.tsx
@@ -97,7 +97,7 @@ test('calls useDeleteTag mutate immediately when trash clicked on tag with count
   // 'akce' has count=0
   fireEvent.click(screen.getByRole('button', { name: 'Smazat štítek akce' }));
 
-  expect(mutate).toHaveBeenCalledWith(2);
+  expect(mutate).toHaveBeenCalledWith(2, expect.objectContaining({ onSettled: expect.any(Function) }));
 });
 
 test('opens confirm dialog when trash clicked on tag with count > 0', () => {
@@ -119,12 +119,26 @@ test('calls useDeleteTag mutate when confirm dialog is confirmed', () => {
 
   // Open dialog for 'produkty' (count=10)
   fireEvent.click(screen.getByRole('button', { name: 'Smazat štítek produkty' }));
-  // Click confirm (the red "Smazat" button inside the dialog)
-  const smazatButtons = screen.getAllByRole('button', { name: /Smazat/i });
-  // The dialog's confirm button is the last one
-  fireEvent.click(smazatButtons[smazatButtons.length - 1]);
+  // Click the dialog's confirm button (exact text "Smazat", distinct from trash aria-labels)
+  fireEvent.click(screen.getByRole('button', { name: 'Smazat' }));
 
-  expect(mutate).toHaveBeenCalledWith(1);
+  expect(mutate).toHaveBeenCalledWith(1, expect.objectContaining({ onSettled: expect.any(Function) }));
+});
+
+test('shows "Štítek již existuje" when response has alreadyExisted=true', async () => {
+  const mutateAsync = jest.fn().mockResolvedValue({ alreadyExisted: true });
+  useCreateTag.mockReturnValue(buildMockMutation({ mutateAsync }));
+
+  render(<TagsTab />);
+
+  fireEvent.change(screen.getByPlaceholderText('Název štítku'), {
+    target: { value: 'produkty' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Přidat štítek/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText('Štítek již existuje')).toBeInTheDocument();
+  });
 });
 
 test('does NOT call useDeleteTag mutate when confirm dialog is cancelled', () => {

--- a/frontend/src/components/marketing/photobank/settings/__tests__/TagsTab.test.tsx
+++ b/frontend/src/components/marketing/photobank/settings/__tests__/TagsTab.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TagsTab from '../TagsTab';
+
+// ---- Mocks ------------------------------------------------------------------
+
+jest.mock('../../../../../api/hooks/usePhotobank', () => ({
+  usePhotoTags: jest.fn(),
+  useCreateTag: jest.fn(),
+  useDeleteTag: jest.fn(),
+}));
+
+const { usePhotoTags, useCreateTag, useDeleteTag } = jest.requireMock(
+  '../../../../../api/hooks/usePhotobank',
+) as {
+  usePhotoTags: jest.Mock;
+  useCreateTag: jest.Mock;
+  useDeleteTag: jest.Mock;
+};
+
+// ---- Helpers ----------------------------------------------------------------
+
+const TAGS = [
+  { id: 1, name: 'produkty', count: 10 },
+  { id: 2, name: 'akce', count: 0 },
+  { id: 3, name: 'promo', count: 3 },
+];
+
+function buildMockMutation(
+  overrides: Partial<{ mutate: jest.Mock; mutateAsync: jest.Mock; isPending: boolean }> = {},
+) {
+  return {
+    mutate: jest.fn(),
+    mutateAsync: jest.fn().mockResolvedValue({}),
+    isPending: false,
+    ...overrides,
+  };
+}
+
+function buildDefaultMocks() {
+  usePhotoTags.mockReturnValue({ data: TAGS, isLoading: false });
+  useCreateTag.mockReturnValue(buildMockMutation());
+  useDeleteTag.mockReturnValue(buildMockMutation());
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+beforeEach(() => {
+  buildDefaultMocks();
+});
+
+test('renders the tag list from mocked usePhotoTags', () => {
+  render(<TagsTab />);
+
+  expect(screen.getByText('produkty')).toBeInTheDocument();
+  expect(screen.getByText('akce')).toBeInTheDocument();
+  expect(screen.getByText('promo')).toBeInTheDocument();
+  expect(screen.getByText('10 fotek')).toBeInTheDocument();
+  expect(screen.getByText('0 fotek')).toBeInTheDocument();
+  expect(screen.getByText('3 fotek')).toBeInTheDocument();
+});
+
+test('submit button is disabled when input is empty', () => {
+  render(<TagsTab />);
+
+  const submitBtn = screen.getByRole('button', { name: /Přidat štítek/i });
+  expect(submitBtn).toBeDisabled();
+});
+
+test('calls useCreateTag mutateAsync when form is submitted', async () => {
+  const mutateAsync = jest.fn().mockResolvedValue({});
+  useCreateTag.mockReturnValue(buildMockMutation({ mutateAsync }));
+
+  render(<TagsTab />);
+
+  fireEvent.change(screen.getByPlaceholderText('Název štítku'), {
+    target: { value: 'nový štítek' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Přidat štítek/i }));
+
+  await waitFor(() => {
+    expect(mutateAsync).toHaveBeenCalledWith('nový štítek');
+  });
+
+  // Input cleared on success
+  await waitFor(() => {
+    expect(screen.getByPlaceholderText('Název štítku')).toHaveValue('');
+  });
+});
+
+test('calls useDeleteTag mutate immediately when trash clicked on tag with count=0', () => {
+  const mutate = jest.fn();
+  useDeleteTag.mockReturnValue(buildMockMutation({ mutate }));
+
+  render(<TagsTab />);
+
+  // 'akce' has count=0
+  fireEvent.click(screen.getByRole('button', { name: 'Smazat štítek akce' }));
+
+  expect(mutate).toHaveBeenCalledWith(2);
+});
+
+test('opens confirm dialog when trash clicked on tag with count > 0', () => {
+  render(<TagsTab />);
+
+  // 'produkty' has count=10 — should open confirm dialog
+  fireEvent.click(screen.getByRole('button', { name: 'Smazat štítek produkty' }));
+
+  expect(screen.getByText(/Smazat štítek\?/i)).toBeInTheDocument();
+  // Dialog body contains tag name in the confirmation message
+  expect(screen.getByText(/přiřazen k 10 fotografiím/)).toBeInTheDocument();
+});
+
+test('calls useDeleteTag mutate when confirm dialog is confirmed', () => {
+  const mutate = jest.fn();
+  useDeleteTag.mockReturnValue(buildMockMutation({ mutate }));
+
+  render(<TagsTab />);
+
+  // Open dialog for 'produkty' (count=10)
+  fireEvent.click(screen.getByRole('button', { name: 'Smazat štítek produkty' }));
+  // Click confirm (the red "Smazat" button inside the dialog)
+  const smazatButtons = screen.getAllByRole('button', { name: /Smazat/i });
+  // The dialog's confirm button is the last one
+  fireEvent.click(smazatButtons[smazatButtons.length - 1]);
+
+  expect(mutate).toHaveBeenCalledWith(1);
+});
+
+test('does NOT call useDeleteTag mutate when confirm dialog is cancelled', () => {
+  const mutate = jest.fn();
+  useDeleteTag.mockReturnValue(buildMockMutation({ mutate }));
+
+  render(<TagsTab />);
+
+  // Open dialog for 'promo' (count=3)
+  fireEvent.click(screen.getByRole('button', { name: 'Smazat štítek promo' }));
+  // Click cancel
+  fireEvent.click(screen.getByRole('button', { name: /Zrušit/i }));
+
+  expect(mutate).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

- **Backend**: Added `CreateTag` and `DeleteTag` use cases (MediatR handlers + FluentValidation validators) with `POST /api/photobank/tags` and `DELETE /api/photobank/tags/{id}` controller endpoints, both gated by `SuperUser` role to match the rest of the settings page
- **Backend**: Idempotent tag creation — if a tag with the same normalized name already exists, returns it with `AlreadyExisted=true` (200 OK, no duplicate)
- **Backend**: `DeleteTag` loads the tag with its `PhotoTag` join rows, records the assignment count, then removes the tag (EF Core cascade deletes the join rows; photos are never affected)
- **Frontend**: New `TagsTab` component in `PhotobankSettingsPage` with create form and sortable tag list; instant delete when `count=0`, confirmation dialog when `count>0`
- **Frontend**: `useCreateTag` and `useDeleteTag` hooks wired to broad React Query invalidation so tag counts stay in sync across the UI

## Test Plan

- [ ] Backend: `dotnet test --filter "FullyQualifiedName~Photobank"` — 14 new tests pass (handler + validator tests for both use cases)
- [ ] Frontend: `npm test -- --watchAll=false src/components/marketing/photobank/settings src/api/hooks/__tests__/usePhotobank.test.ts` — 24 new tests pass
- [ ] Navigate to `/marketing/photobank/settings` → open **Štítky** tab → confirm existing tags list with counts appears
- [ ] Create a new tag → row appears with count 0
- [ ] Create the same tag again → no duplicate row, "Štítek již existuje" notice shown
- [ ] Delete a tag with count=0 (trash button) → no dialog, row disappears immediately
- [ ] Delete a tag with count>0 → confirm dialog shows tag name and count → confirm → row disappears, photo tag chips updated
- [ ] Delete a tag with count>0 → cancel dialog → tag remains
- [ ] Auth check: non-`SuperUser` hitting `POST /api/photobank/tags` or `DELETE /api/photobank/tags/{id}` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)