### PR TITLE
feat(manufacture): move podmínky výroby to separate tab in order detail

### DIFF
--- a/frontend/src/components/manufacture/detail/ConditionsReadingsSection.tsx
+++ b/frontend/src/components/manufacture/detail/ConditionsReadingsSection.tsx
@@ -47,7 +47,7 @@ const ConditionsReadingsSection: React.FC<Props> = ({ readings }) => {
   const byStage = new Map(readings.map((r) => [r.stage, r]));
 
   return (
-    <div className="bg-gray-50 rounded-lg p-3 mt-4">
+    <div className="bg-gray-50 rounded-lg p-3">
       <h3 className="text-base font-semibold text-gray-800 mb-3">
         Podmínky výroby
       </h3>

--- a/frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx
@@ -7,6 +7,7 @@ import {
   Edit,
   Info,
   StickyNote,
+  Thermometer,
   Factory,
   ArrowLeft,
   X,
@@ -68,7 +69,7 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
   const orderId = isModalMode ? propOrderId : urlOrderId;
   
   // Tab state
-  const [activeTab, setActiveTab] = useState<"info" | "notes" | "log">("info");
+  const [activeTab, setActiveTab] = useState<"info" | "notes" | "log" | "conditions">("info");
   
   // Note input state
   const [newNote, setNewNote] = useState("");
@@ -612,6 +613,17 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
                   <StickyNote className="h-4 w-4 mr-2" />
                   Poznámky ({order.notes?.length || 0})
                 </button>
+                <button
+                  onClick={() => setActiveTab("conditions")}
+                  className={`${
+                    activeTab === "conditions"
+                      ? "border-indigo-500 text-indigo-600"
+                      : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                  } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm flex items-center`}
+                >
+                  <Thermometer className="h-4 w-4 mr-2" />
+                  Podmínky výroby
+                </button>
               </nav>
             </div>
 
@@ -663,7 +675,6 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
                     </div>
                   </div>
 
-                  <ConditionsReadingsSection readings={order?.conditionsReadings ?? []} />
                 </>
               )}
 
@@ -674,6 +685,10 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
                   onNewNoteChange={setNewNote}
                   formatDateTime={formatDateTime}
                 />
+              )}
+
+              {activeTab === "conditions" && (
+                <ConditionsReadingsSection readings={order?.conditionsReadings ?? []} />
               )}
 
             </div>


### PR DESCRIPTION
## Summary
- Adds a new third tab "Podmínky výroby" to the manufacture order detail modal
- Moves `ConditionsReadingsSection` out of "Základní informace" and into the new dedicated tab
- Removes the now-redundant `mt-4` top margin from the section's wrapper div

## Test plan
- [ ] Open any manufacture order detail modal
- [ ] Confirm three tabs render: Základní informace | Poznámky (n) | Podmínky výroby
- [ ] Confirm default active tab is still Základní informace
- [ ] Confirm conditions table no longer appears under Základní informace
- [ ] Click "Podmínky výroby" — confirm table renders with Polotovar and Dokončeno rows and correct source badges
- [ ] Open an order with no readings — confirm both rows show `—` placeholders
- [ ] Confirm switching tabs does not lose in-flight edits on the info tab