### PR TITLE
feat(photobank): automatic tag application — regex rules + LLM batch job

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -17,6 +17,7 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.GetRules;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetTags;
 using Anela.Heblo.Application.Features.Photobank.UseCases.ReapplyRules;
 using Anela.Heblo.Application.Features.Photobank.UseCases.RemovePhotoTag;
+using Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using Anela.Heblo.Domain.Features.Authorization;
 using Anela.Heblo.Domain.Features.Photobank;
@@ -169,6 +170,23 @@ namespace Anela.Heblo.API.Controllers
             };
             var response = await _mediator.Send(request, cancellationToken);
             return HandleResponse(response);
+        }
+
+        /// <summary>
+        /// Re-tag specific photos via AI. Resets LastAutoTaggedAt and enqueues a Hangfire job.
+        /// Optionally clears existing AI tags before re-processing.
+        /// </summary>
+        [HttpPost("photos/auto-tag")]
+        [Authorize(Roles = AuthorizationConstants.Roles.MarketingWriter)]
+        [ProducesResponseType(typeof(RetagPhotosResponse), StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<ActionResult<RetagPhotosResponse>> RetagPhotos(
+            [FromBody] RetagPhotosRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await _mediator.Send(request, cancellationToken);
+            return result.Success ? Accepted(result) : BadRequest(result);
         }
 
         // --- Settings: Index Roots ---

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -14,6 +14,7 @@ using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
 using Anela.Heblo.API.Extensions;
 using Anela.Heblo.API.MCP;
 using Anela.Heblo.Application;
+using Anela.Heblo.Application.Features.Photobank;
 using Anela.Heblo.Domain.Features.Invoices;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Xcc;
@@ -114,6 +115,13 @@ public partial class Program
         if (app.Environment.IsProduction())
         {
             await app.MigrateDatabaseAsync();
+        }
+
+        // Migrate any remaining legacy glob PathPattern rows to .NET regex (idempotent).
+        using (var scope = app.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            await PhotobankModule.MigrateTagRulePatternsAsync(db);
         }
 
         // Seed default recurring job configurations from discovered IRecurringJob implementations.

--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -162,6 +162,15 @@
   "Anthropic": {
     "ApiKey": ""
   },
+  "Photobank": {
+    "AutoTag": {
+      "Enabled": false,
+      "BatchSize": 50,
+      "MaxPhotosPerRun": 5000,
+      "Model": "claude-haiku-4-5-20251001",
+      "MaxTagsPerPhoto": 5
+    }
+  },
   "WebSearch": {
     "Provider": "Mock",
     "ApiKey": "",

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/AutoTagOptions.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Application.Features.Photobank;
+
+public sealed class AutoTagOptions
+{
+    public const string SectionName = "Photobank:AutoTag";
+
+    public bool Enabled { get; init; } = false;
+    public int BatchSize { get; init; } = 50;
+    public int MaxPhotosPerRun { get; init; } = 5_000;
+    public string Model { get; init; } = "claude-haiku-4-5-20251001";
+    public int MaxTagsPerPhoto { get; init; } = 5;
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
@@ -109,7 +109,7 @@ public class PhotobankAutoTagJob : IRecurringJob
         }
 
         var raw = response.Text ?? string.Empty;
-        var fallback = new AutoTagLlmResponse { Results = [] };
+        var fallback = new AutoTagLlmPayload { Results = [] };
         var parsed = JsonResponseParser.ParseOrFallback(raw, fallback, _logger);
 
         foreach (var result in parsed.Results ?? [])
@@ -168,7 +168,7 @@ public class PhotobankAutoTagJob : IRecurringJob
     }
 }
 
-internal sealed class AutoTagLlmResponse
+internal sealed class AutoTagLlmPayload
 {
     [JsonPropertyName("results")]
     public List<AutoTagResult>? Results { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
@@ -1,0 +1,175 @@
+using System.Text.Json.Serialization;
+using Anela.Heblo.Application.Shared.Json;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Domain.Features.Photobank;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.Photobank.Infrastructure.Jobs;
+
+public class PhotobankAutoTagJob : IRecurringJob
+{
+    private readonly IPhotobankRepository _repo;
+    private readonly IChatClient _chat;
+    private readonly AutoTagOptions _options;
+    private readonly ILogger<PhotobankAutoTagJob> _logger;
+
+    public RecurringJobMetadata Metadata { get; } = new()
+    {
+        JobName = "photobank-auto-tag",
+        DisplayName = "Photobank Auto-Tag",
+        Description = "Sends untagged photos to the LLM and stamps validated tags back",
+        CronExpression = "0 4 * * *",
+        DefaultIsEnabled = false,
+    };
+
+    public PhotobankAutoTagJob(
+        IPhotobankRepository repo,
+        IChatClient chat,
+        IOptions<AutoTagOptions> options,
+        ILogger<PhotobankAutoTagJob> logger)
+    {
+        _repo = repo;
+        _chat = chat;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Job {JobName} is disabled. Skipping.", Metadata.JobName);
+            return;
+        }
+
+        var tagsByName = (await _repo.GetTagsWithCountsAsync(cancellationToken))
+            .ToDictionary(t => t.Tag.Name, t => t.Tag, StringComparer.Ordinal);
+
+        _logger.LogInformation("{JobName} starting — vocabulary size: {VocabSize}", Metadata.JobName, tagsByName.Count);
+
+        var processedCount = 0;
+        var offset = 0;
+
+        while (processedCount < _options.MaxPhotosPerRun)
+        {
+            var remaining = _options.MaxPhotosPerRun - processedCount;
+            var pageSize = Math.Min(_options.BatchSize, remaining);
+
+            var batch = await _repo.GetPhotosPendingAutoTagAsync(pageSize, offset, cancellationToken);
+            if (batch.Count == 0) break;
+
+            await ProcessBatchAsync(batch, tagsByName, cancellationToken);
+
+            processedCount += batch.Count;
+            offset += batch.Count;
+        }
+
+        _logger.LogInformation("{JobName} completed — {ProcessedCount} photos processed", Metadata.JobName, processedCount);
+    }
+
+    public async Task ExecuteForPhotosAsync(IReadOnlyList<PhotoAutoTagCandidate> candidates, CancellationToken ct)
+    {
+        var tagsByName = (await _repo.GetTagsWithCountsAsync(ct))
+            .ToDictionary(t => t.Tag.Name, t => t.Tag, StringComparer.Ordinal);
+
+        for (var offset = 0; offset < candidates.Count; offset += _options.BatchSize)
+        {
+            var batch = candidates.Skip(offset).Take(_options.BatchSize).ToList();
+            await ProcessBatchAsync(batch, tagsByName, ct);
+        }
+    }
+
+    private async Task ProcessBatchAsync(
+        IReadOnlyList<PhotoAutoTagCandidate> batch,
+        Dictionary<string, Tag> tagsByName,
+        CancellationToken ct)
+    {
+        var batchIds = batch.Select(p => p.Id).ToList();
+
+        var systemPrompt = BuildSystemPrompt(tagsByName.Keys);
+        var userPrompt = BuildUserPrompt(batch);
+
+        var response = await _chat.GetResponseAsync(
+            [
+                new ChatMessage(ChatRole.System, systemPrompt),
+                new ChatMessage(ChatRole.User, userPrompt),
+            ],
+            new ChatOptions { ModelId = _options.Model },
+            ct);
+
+        var raw = response.Text ?? string.Empty;
+        var fallback = new AutoTagLlmResponse { Results = [] };
+        var parsed = JsonResponseParser.ParseOrFallback(raw, fallback, _logger);
+
+        foreach (var result in parsed.Results ?? [])
+        {
+            await ApplyTagsForPhotoAsync(result, tagsByName, ct);
+        }
+
+        await _repo.SaveChangesAsync(ct);
+        await _repo.StampAutoTaggedAtAsync(batchIds, DateTime.UtcNow, ct);
+    }
+
+    private async Task ApplyTagsForPhotoAsync(
+        AutoTagResult result,
+        Dictionary<string, Tag> tagsByName,
+        CancellationToken ct)
+    {
+        var validTags = (result.Tags ?? [])
+            .Where(name => tagsByName.ContainsKey(name))
+            .Take(_options.MaxTagsPerPhoto)
+            .ToList();
+
+        foreach (var tagName in validTags)
+        {
+            var tag = tagsByName[tagName];
+
+            if (await _repo.PhotoTagExistsAsync(result.Id, tag.Id, ct)) continue;
+
+            await _repo.AddPhotoTagAsync(
+                new PhotoTag
+                {
+                    PhotoId = result.Id,
+                    TagId = tag.Id,
+                    Source = PhotoTagSource.AI,
+                    CreatedAt = DateTime.UtcNow,
+                },
+                ct);
+        }
+    }
+
+    private static string BuildSystemPrompt(IEnumerable<string> vocabulary)
+    {
+        var vocabList = string.Join(", ", vocabulary);
+        return $"""
+            You are a photo tagging assistant for a cosmetics company.
+            Tag each photo using ONLY tags from the following vocabulary (diacritic-sensitive, exact match required):
+            {vocabList}
+
+            Return JSON in this exact format, no markdown fences:
+            """ + """{"results":[{"id":<photo_id>,"tags":["tag1","tag2"]}]}""";
+    }
+
+    private static string BuildUserPrompt(IReadOnlyList<PhotoAutoTagCandidate> batch)
+    {
+        var entries = batch.Select(p => $"id={p.Id} path={p.FolderPath}/{p.FileName}");
+        return string.Join("\n", entries);
+    }
+}
+
+internal sealed class AutoTagLlmResponse
+{
+    [JsonPropertyName("results")]
+    public List<AutoTagResult>? Results { get; set; }
+}
+
+internal sealed class AutoTagResult
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string>? Tags { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankAutoTagJob.cs
@@ -91,13 +91,22 @@ public class PhotobankAutoTagJob : IRecurringJob
         var systemPrompt = BuildSystemPrompt(tagsByName.Keys);
         var userPrompt = BuildUserPrompt(batch);
 
-        var response = await _chat.GetResponseAsync(
-            [
-                new ChatMessage(ChatRole.System, systemPrompt),
-                new ChatMessage(ChatRole.User, userPrompt),
-            ],
-            new ChatOptions { ModelId = _options.Model },
-            ct);
+        ChatResponse response;
+        try
+        {
+            response = await _chat.GetResponseAsync(
+                [
+                    new ChatMessage(ChatRole.System, systemPrompt),
+                    new ChatMessage(ChatRole.User, userPrompt),
+                ],
+                new ChatOptions { ModelId = _options.Model },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "LLM call failed for batch of {Count} photos; skipping batch", batch.Count);
+            return;
+        }
 
         var raw = response.Text ?? string.Empty;
         var fallback = new AutoTagLlmResponse { Results = [] };

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs
@@ -119,6 +119,9 @@ public class PhotobankIndexJob : IRecurringJob
     {
         var photo = await _db.Photos.FirstOrDefaultAsync(p => p.SharePointFileId == item.ItemId, ct);
 
+        var pathChanged = photo != null &&
+            (photo.FolderPath != item.FolderPath || photo.FileName != item.Name);
+
         if (photo == null)
         {
             photo = new Photo
@@ -135,6 +138,9 @@ public class PhotobankIndexJob : IRecurringJob
         photo.FileSizeBytes = item.FileSizeBytes;
         photo.ModifiedAt = item.LastModifiedAt ?? DateTime.UtcNow;
         photo.DriveId = driveId;
+
+        if (pathChanged)
+            photo!.LastAutoTaggedAt = null;
 
         await _db.SaveChangesAsync(ct);
 

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Infrastructure/Jobs/PhotobankIndexJob.cs
@@ -144,7 +144,7 @@ public class PhotobankIndexJob : IRecurringJob
             .ToListAsync(ct);
         _db.PhotoTags.RemoveRange(existingRuleTags);
 
-        var matchingTagNames = TagRuleMatcher.GetMatchingTags(item.FolderPath, tagRules);
+        var matchingTagNames = TagRuleMatcher.GetMatchingTags(item.FolderPath, item.Name, tagRules);
         foreach (var tagName in matchingTagNames)
         {
             var tag = await _db.PhotobankTags.FirstOrDefaultAsync(t => t.Name == tagName, ct)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.Behaviors;
+using Anela.Heblo.Application.Features.Photobank.Infrastructure.Jobs;
 using Anela.Heblo.Application.Features.Photobank.Services;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRoot;
@@ -25,6 +26,7 @@ public static class PhotobankModule
     public static IServiceCollection AddPhotobankModule(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddScoped<IPhotobankRepository, PhotobankRepository>();
+        services.AddScoped<PhotobankAutoTagJob>();
         services.Configure<AutoTagOptions>(configuration.GetSection(AutoTagOptions.SectionName));
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -11,7 +11,9 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.RemovePhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using Anela.Heblo.Application.Features.Photobank.Validators;
 using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Persistence;
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -64,5 +66,19 @@ public static class PhotobankModule
         services.AddScoped<IPipelineBehavior<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>, ValidationBehavior<BulkAddPhotoTagByIdsRequest, BulkAddPhotoTagByIdsResponse>>();
 
         return services;
+    }
+
+    public static async Task MigrateTagRulePatternsAsync(ApplicationDbContext db, CancellationToken ct = default)
+    {
+        var rules = await db.PhotobankTagRules
+            .Where(r => !r.PathPattern.StartsWith("^"))
+            .ToListAsync(ct);
+
+        if (rules.Count == 0) return;
+
+        foreach (var rule in rules)
+            rule.PathPattern = TagRulePatternTranslator.Translate(rule.PathPattern);
+
+        await db.SaveChangesAsync(ct);
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -25,6 +25,7 @@ public static class PhotobankModule
     public static IServiceCollection AddPhotobankModule(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddScoped<IPhotobankRepository, PhotobankRepository>();
+        services.Configure<AutoTagOptions>(configuration.GetSection(AutoTagOptions.SectionName));
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
         var bypassJwtValidation = configuration.GetValue<bool>("BypassJwtValidation", false);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -285,7 +285,7 @@ namespace Anela.Heblo.Application.Features.Photobank
 
             foreach (var photo in photos)
             {
-                var matchingTagNames = TagRuleMatcher.GetMatchingTags(photo.FolderPath, activeRules);
+                var matchingTagNames = TagRuleMatcher.GetMatchingTags(photo.FolderPath, photo.FileName, activeRules);
                 if (matchingTagNames.Count == 0)
                     continue;
 

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -313,6 +313,56 @@ namespace Anela.Heblo.Application.Features.Photobank
             return photosUpdated;
         }
 
+        // Auto-tagging
+
+        public async Task<List<PhotoAutoTagCandidate>> GetPhotosPendingAutoTagAsync(
+            int pageSize, int offset, CancellationToken cancellationToken)
+        {
+            return await _context.Photos
+                .Where(p => p.LastAutoTaggedAt == null)
+                .OrderBy(p => p.Id)
+                .Skip(offset)
+                .Take(pageSize)
+                .Select(p => new PhotoAutoTagCandidate(p.Id, p.FolderPath, p.FileName))
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task StampAutoTaggedAtAsync(
+            IReadOnlyList<int> photoIds, DateTime timestamp, CancellationToken cancellationToken)
+        {
+            await _context.Photos
+                .Where(p => photoIds.Contains(p.Id))
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(p => p.LastAutoTaggedAt, timestamp),
+                    cancellationToken);
+        }
+
+        public async Task ResetAutoTaggedAtAsync(
+            IReadOnlyList<int> photoIds, CancellationToken cancellationToken)
+        {
+            await _context.Photos
+                .Where(p => photoIds.Contains(p.Id))
+                .ExecuteUpdateAsync(
+                    s => s.SetProperty(p => p.LastAutoTaggedAt, (DateTime?)null),
+                    cancellationToken);
+        }
+
+        public async Task<List<Photo>> GetPhotosByIdsAsync(
+            IReadOnlyList<int> photoIds, CancellationToken cancellationToken)
+        {
+            return await _context.Photos
+                .Where(p => photoIds.Contains(p.Id))
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task RemovePhotoTagsBySourceAsync(
+            IReadOnlyList<int> photoIds, PhotoTagSource source, CancellationToken cancellationToken)
+        {
+            await _context.PhotoTags
+                .Where(pt => photoIds.Contains(pt.PhotoId) && pt.Source == source)
+                .ExecuteDeleteAsync(cancellationToken);
+        }
+
         public async Task SaveChangesAsync(CancellationToken cancellationToken)
         {
             await _context.SaveChangesAsync(cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosHandler.cs
@@ -1,0 +1,38 @@
+using Anela.Heblo.Application.Features.Photobank.Infrastructure.Jobs;
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Xcc.Services;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
+
+public class RetagPhotosHandler : IRequestHandler<RetagPhotosRequest, RetagPhotosResponse>
+{
+    private readonly IPhotobankRepository _repository;
+    private readonly IBackgroundWorker _backgroundWorker;
+
+    public RetagPhotosHandler(IPhotobankRepository repository, IBackgroundWorker backgroundWorker)
+    {
+        _repository = repository;
+        _backgroundWorker = backgroundWorker;
+    }
+
+    public async Task<RetagPhotosResponse> Handle(RetagPhotosRequest request, CancellationToken cancellationToken)
+    {
+        var photos = await _repository.GetPhotosByIdsAsync(request.PhotoIds, cancellationToken);
+        var foundIds = photos.Select(p => p.Id).ToList();
+
+        await _repository.ResetAutoTaggedAtAsync(foundIds, cancellationToken);
+
+        if (request.ClearExistingAiTags)
+            await _repository.RemovePhotoTagsBySourceAsync(foundIds, PhotoTagSource.AI, cancellationToken);
+
+        var candidates = photos
+            .Select(p => new PhotoAutoTagCandidate(p.Id, p.FolderPath, p.FileName))
+            .ToList();
+
+        var jobId = _backgroundWorker.Enqueue<PhotobankAutoTagJob>(
+            j => j.ExecuteForPhotosAsync(candidates, CancellationToken.None));
+
+        return new RetagPhotosResponse { JobId = jobId };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosHandler.cs
@@ -19,6 +19,10 @@ public class RetagPhotosHandler : IRequestHandler<RetagPhotosRequest, RetagPhoto
     public async Task<RetagPhotosResponse> Handle(RetagPhotosRequest request, CancellationToken cancellationToken)
     {
         var photos = await _repository.GetPhotosByIdsAsync(request.PhotoIds, cancellationToken);
+
+        if (photos.Count == 0)
+            return new RetagPhotosResponse { JobId = null };
+
         var foundIds = photos.Select(p => p.Id).ToList();
 
         await _repository.ResetAutoTaggedAtAsync(foundIds, cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
+
+public class RetagPhotosRequest : IRequest<RetagPhotosResponse>
+{
+    public int[] PhotoIds { get; set; } = Array.Empty<int>();
+    public bool ClearExistingAiTags { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
+
+public class RetagPhotosRequestValidator : AbstractValidator<RetagPhotosRequest>
+{
+    private const int MaxPhotoIds = 5_000;
+
+    public RetagPhotosRequestValidator()
+    {
+        RuleFor(x => x.PhotoIds)
+            .NotNull()
+            .Must(ids => ids.Length > 0)
+            .WithMessage("At least one photo ID is required")
+            .Must(ids => ids.Length <= MaxPhotoIds)
+            .WithMessage($"Cannot retag more than {MaxPhotoIds} photos at once");
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosRequestValidator.cs
@@ -10,9 +10,11 @@ public class RetagPhotosRequestValidator : AbstractValidator<RetagPhotosRequest>
     {
         RuleFor(x => x.PhotoIds)
             .NotNull()
-            .Must(ids => ids.Length > 0)
-            .WithMessage("At least one photo ID is required")
+                .WithMessage("PhotoIds is required")
+            .NotEmpty()
+                .WithMessage("At least one photo ID is required")
             .Must(ids => ids.Length <= MaxPhotoIds)
-            .WithMessage($"Cannot retag more than {MaxPhotoIds} photos at once");
+                .WithMessage($"Cannot retag more than {MaxPhotoIds} photos at once")
+                .When(x => x.PhotoIds != null && x.PhotoIds.Length > 0);
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/RetagPhotos/RetagPhotosResponse.cs
@@ -1,0 +1,8 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
+
+public class RetagPhotosResponse : BaseResponse
+{
+    public string? JobId { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/AddRuleRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/AddRuleRequestValidator.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
 using FluentValidation;
 
@@ -13,7 +12,7 @@ public class AddRuleRequestValidator : AbstractValidator<AddRuleRequest>
             .WithMessage("PathPattern is required")
             .MaximumLength(500)
             .WithMessage("PathPattern cannot exceed 500 characters")
-            .Must(BeValidRegex)
+            .Must(PhotobankValidationHelpers.BeValidRegex)
             .WithMessage("Invalid regular expression pattern.");
 
         RuleFor(x => x.TagName)
@@ -21,12 +20,5 @@ public class AddRuleRequestValidator : AbstractValidator<AddRuleRequest>
             .WithMessage("TagName is required")
             .MaximumLength(100)
             .WithMessage("TagName cannot exceed 100 characters");
-    }
-
-    private static bool BeValidRegex(string? pattern)
-    {
-        if (string.IsNullOrWhiteSpace(pattern)) return true;
-        try { _ = new Regex(pattern); return true; }
-        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/AddRuleRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/AddRuleRequestValidator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddRule;
 using FluentValidation;
 
@@ -11,12 +12,21 @@ public class AddRuleRequestValidator : AbstractValidator<AddRuleRequest>
             .NotEmpty()
             .WithMessage("PathPattern is required")
             .MaximumLength(500)
-            .WithMessage("PathPattern cannot exceed 500 characters");
+            .WithMessage("PathPattern cannot exceed 500 characters")
+            .Must(BeValidRegex)
+            .WithMessage("Invalid regular expression pattern.");
 
         RuleFor(x => x.TagName)
             .NotEmpty()
             .WithMessage("TagName is required")
             .MaximumLength(100)
             .WithMessage("TagName cannot exceed 100 characters");
+    }
+
+    private static bool BeValidRegex(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern)) return true;
+        try { _ = new Regex(pattern); return true; }
+        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
 using FluentValidation;
 
@@ -20,8 +21,15 @@ public class GetPhotosRequestValidator : AbstractValidator<GetPhotosRequest>
             .WithMessage($"PageSize cannot exceed {MaxPageSize}");
 
         RuleFor(x => x.Search)
-            .Must(PhotobankValidationHelpers.BeValidRegex)
+            .Must(BeValidRegex)
             .When(x => x.UseRegex && !string.IsNullOrWhiteSpace(x.Search))
             .WithMessage("Invalid regular expression pattern.");
+    }
+
+    private static bool BeValidRegex(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern)) return true;
+        try { _ = new Regex(pattern); return true; }
+        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
 using FluentValidation;
 
@@ -21,15 +20,8 @@ public class GetPhotosRequestValidator : AbstractValidator<GetPhotosRequest>
             .WithMessage($"PageSize cannot exceed {MaxPageSize}");
 
         RuleFor(x => x.Search)
-            .Must(BeValidRegex)
+            .Must(PhotobankValidationHelpers.BeValidRegex)
             .When(x => x.UseRegex && !string.IsNullOrWhiteSpace(x.Search))
             .WithMessage("Invalid regular expression pattern.");
-    }
-
-    private static bool BeValidRegex(string? pattern)
-    {
-        if (string.IsNullOrWhiteSpace(pattern)) return true;
-        try { _ = new Regex(pattern); return true; }
-        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/PhotobankValidationHelpers.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/PhotobankValidationHelpers.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Anela.Heblo.Application.Features.Photobank.Validators;
+
+internal static class PhotobankValidationHelpers
+{
+    public static bool BeValidRegex(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern)) return true;
+        try { _ = new Regex(pattern); return true; }
+        catch (ArgumentException) { return false; }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using FluentValidation;
 
@@ -15,7 +16,9 @@ public class UpdateRuleRequestValidator : AbstractValidator<UpdateRuleRequest>
             .NotEmpty()
             .WithMessage("PathPattern is required")
             .MaximumLength(500)
-            .WithMessage("PathPattern cannot exceed 500 characters");
+            .WithMessage("PathPattern cannot exceed 500 characters")
+            .Must(BeValidRegex)
+            .WithMessage("Invalid regular expression pattern.");
 
         RuleFor(x => x.TagName)
             .NotEmpty()
@@ -25,5 +28,12 @@ public class UpdateRuleRequestValidator : AbstractValidator<UpdateRuleRequest>
 
         RuleFor(x => x.SortOrder)
             .GreaterThanOrEqualTo(0);
+    }
+
+    private static bool BeValidRegex(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern)) return true;
+        try { _ = new Regex(pattern); return true; }
+        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/UpdateRuleRequestValidator.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using FluentValidation;
 
@@ -17,7 +16,7 @@ public class UpdateRuleRequestValidator : AbstractValidator<UpdateRuleRequest>
             .WithMessage("PathPattern is required")
             .MaximumLength(500)
             .WithMessage("PathPattern cannot exceed 500 characters")
-            .Must(BeValidRegex)
+            .Must(PhotobankValidationHelpers.BeValidRegex)
             .WithMessage("Invalid regular expression pattern.");
 
         RuleFor(x => x.TagName)
@@ -28,12 +27,5 @@ public class UpdateRuleRequestValidator : AbstractValidator<UpdateRuleRequest>
 
         RuleFor(x => x.SortOrder)
             .GreaterThanOrEqualTo(0);
-    }
-
-    private static bool BeValidRegex(string? pattern)
-    {
-        if (string.IsNullOrWhiteSpace(pattern)) return true;
-        try { _ = new Regex(pattern); return true; }
-        catch (ArgumentException) { return false; }
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -51,6 +51,13 @@ namespace Anela.Heblo.Domain.Features.Photobank
         // Reapply rules
         Task<int> ReapplyRulesAsync(List<TagRule> activeRules, CancellationToken cancellationToken);
 
+        // Auto-tagging
+        Task<List<PhotoAutoTagCandidate>> GetPhotosPendingAutoTagAsync(int pageSize, int offset, CancellationToken cancellationToken);
+        Task StampAutoTaggedAtAsync(IReadOnlyList<int> photoIds, DateTime timestamp, CancellationToken cancellationToken);
+        Task ResetAutoTaggedAtAsync(IReadOnlyList<int> photoIds, CancellationToken cancellationToken);
+        Task<List<Photo>> GetPhotosByIdsAsync(IReadOnlyList<int> photoIds, CancellationToken cancellationToken);
+        Task RemovePhotoTagsBySourceAsync(IReadOnlyList<int> photoIds, PhotoTagSource source, CancellationToken cancellationToken);
+
         Task SaveChangesAsync(CancellationToken cancellationToken);
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/Photo.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/Photo.cs
@@ -37,6 +37,8 @@ namespace Anela.Heblo.Domain.Features.Photobank
 
         public DateTime ModifiedAt { get; set; }
 
+        public DateTime? LastAutoTaggedAt { get; set; }
+
         public virtual ICollection<PhotoTag> Tags { get; set; } = new List<PhotoTag>();
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotoAutoTagCandidate.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/PhotoAutoTagCandidate.cs
@@ -1,0 +1,3 @@
+namespace Anela.Heblo.Domain.Features.Photobank;
+
+public sealed record PhotoAutoTagCandidate(int Id, string FolderPath, string FileName);

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRuleMatcher.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRuleMatcher.cs
@@ -1,57 +1,42 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
-namespace Anela.Heblo.Domain.Features.Photobank
+namespace Anela.Heblo.Domain.Features.Photobank;
+
+public static class TagRuleMatcher
 {
-    public static class TagRuleMatcher
+    private static readonly ConcurrentDictionary<string, Regex> RegexCache = new();
+
+    public static IReadOnlyList<string> GetMatchingTags(
+        string folderPath,
+        string fileName,
+        IEnumerable<TagRule> rules)
     {
-        /// <summary>
-        /// Returns all tag names whose PathPattern matches the given folderPath.
-        /// Only active rules are considered.
-        /// Pattern matching: case-insensitive prefix, '*' matches exactly one segment.
-        /// All matching rules apply (not first-match-wins).
-        /// </summary>
-        public static IReadOnlyList<string> GetMatchingTags(
-            string folderPath,
-            IEnumerable<TagRule> rules)
-        {
-            if (string.IsNullOrEmpty(folderPath)) return Array.Empty<string>();
+        if (string.IsNullOrEmpty(folderPath) && string.IsNullOrEmpty(fileName))
+            return Array.Empty<string>();
 
-            var pathSegments = folderPath
-                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var virtualPath = string.IsNullOrEmpty(fileName)
+            ? folderPath
+            : folderPath + "/" + fileName;
 
-            return rules
-                .Where(r => r.IsActive)
-                .OrderBy(r => r.SortOrder)
-                .Where(r => Matches(pathSegments, r.PathPattern))
-                .Select(r => r.TagName.ToLowerInvariant())
-                .Distinct()
-                .ToList();
-        }
+        return rules
+            .Where(r => r.IsActive)
+            .OrderBy(r => r.SortOrder)
+            .Where(r => Matches(virtualPath, r.PathPattern))
+            .Select(r => r.TagName.ToLowerInvariant())
+            .Distinct()
+            .ToList();
+    }
 
-        private static bool Matches(string[] pathSegments, string pattern)
-        {
-            var patternSegments = pattern
-                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+    private static bool Matches(string virtualPath, string pattern)
+    {
+        var regex = RegexCache.GetOrAdd(
+            pattern,
+            p => new Regex(p, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled));
 
-            if (patternSegments.Length > pathSegments.Length)
-                return false;
-
-            for (var i = 0; i < patternSegments.Length; i++)
-            {
-                var p = patternSegments[i];
-                if (p == "*")
-                {
-                    // '*' matches exactly one segment — already consuming one via loop
-                    continue;
-                }
-
-                if (!string.Equals(p, pathSegments[i], StringComparison.OrdinalIgnoreCase))
-                    return false;
-            }
-
-            return true;
-        }
+        return regex.IsMatch(virtualPath);
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRulePatternTranslator.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRulePatternTranslator.cs
@@ -1,0 +1,24 @@
+using System.Text.RegularExpressions;
+
+namespace Anela.Heblo.Domain.Features.Photobank;
+
+public static class TagRulePatternTranslator
+{
+    public static string Translate(string pattern)
+    {
+        if (pattern.StartsWith('^'))
+            return pattern;
+
+        var segments = pattern.Split('/');
+        var regexSegments = new string[segments.Length];
+
+        for (var i = 0; i < segments.Length; i++)
+        {
+            regexSegments[i] = segments[i] == "*"
+                ? "[^/]+"
+                : Regex.Escape(segments[i]);
+        }
+
+        return "^" + string.Join("/", regexSegments) + "(/|$)";
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRulePatternTranslator.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/TagRulePatternTranslator.cs
@@ -6,6 +6,8 @@ public static class TagRulePatternTranslator
 {
     public static string Translate(string pattern)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pattern);
+
         if (pattern.StartsWith('^'))
             return pattern;
 

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260507145218_AddPhotobankAutoTagState.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260507145218_AddPhotobankAutoTagState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507145218_AddPhotobankAutoTagState")]
+    partial class AddPhotobankAutoTagState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260507145218_AddPhotobankAutoTagState.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260507145218_AddPhotobankAutoTagState.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhotobankAutoTagState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastAutoTaggedAt",
+                schema: "public",
+                table: "Photos",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastAutoTaggedAt",
+                schema: "public",
+                table: "Photos");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
@@ -130,6 +130,71 @@ public class PhotobankAutoTagJobTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_RespectsMaxTagsPerPhoto_Cap()
+    {
+        // Arrange
+        var photos = new List<PhotoAutoTagCandidate>
+        {
+            new(20, "marketing", "photo.jpg"),
+        };
+
+        var tags = new List<(Tag Tag, int Count)>
+        {
+            (new Tag { Id = 1, Name = "andy" }, 1),
+            (new Tag { Id = 2, Name = "ela" }, 1),
+            (new Tag { Id = 3, Name = "peťa" }, 1),
+        };
+
+        _repo
+            .Setup(r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tags);
+
+        _repo
+            .SetupSequence(r => r.GetPhotosPendingAutoTagAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(photos)
+            .ReturnsAsync(new List<PhotoAutoTagCandidate>());
+
+        // LLM returns all 3 valid tags, but MaxTagsPerPhoto = 2 in the test options
+        _chat
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant,
+                "{\"results\":[{\"id\":20,\"tags\":[\"andy\",\"ela\",\"peťa\"]}]}")));
+
+        _repo.Setup(r => r.PhotoTagExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repo
+            .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repo
+            .Setup(r => r.StampAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Use job with MaxTagsPerPhoto = 2
+        var jobWithCap = new PhotobankAutoTagJob(
+            _repo.Object,
+            _chat.Object,
+            Options.Create(new AutoTagOptions { Enabled = true, BatchSize = 50, MaxPhotosPerRun = 100, Model = "test-model", MaxTagsPerPhoto = 2 }),
+            NullLogger<PhotobankAutoTagJob>.Instance);
+
+        // Act
+        await jobWithCap.ExecuteAsync(CancellationToken.None);
+
+        // Assert — only 2 out of 3 valid tags should be applied
+        _repo.Verify(r => r.AddPhotoTagAsync(
+            It.Is<PhotoTag>(pt => pt.PhotoId == 20 && pt.Source == PhotoTagSource.AI),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task ExecuteAsync_AppliesValidTagsAndDropsHallucinations()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankAutoTagJobTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank;
+using Anela.Heblo.Application.Features.Photobank.Infrastructure.Jobs;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class PhotobankAutoTagJobTests
+{
+    private readonly Mock<IPhotobankRepository> _repo = new();
+    private readonly Mock<IChatClient> _chat = new();
+
+    private PhotobankAutoTagJob CreateJob(AutoTagOptions? options = null)
+    {
+        var opts = options ?? new AutoTagOptions { Enabled = true, BatchSize = 50, MaxPhotosPerRun = 5_000 };
+        return new PhotobankAutoTagJob(
+            _repo.Object,
+            _chat.Object,
+            Options.Create(opts),
+            NullLogger<PhotobankAutoTagJob>.Instance);
+    }
+
+    private void SetupEmptyTags() =>
+        _repo
+            .Setup(r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<(Tag, int)>());
+
+    private void SetupNoPendingPhotos() =>
+        _repo
+            .Setup(r => r.GetPhotosPendingAutoTagAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PhotoAutoTagCandidate>());
+
+    private void SetupChatResponse(string json) =>
+        _chat
+            .Setup(c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse([new ChatMessage(ChatRole.Assistant, json)]));
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDisabled_DoesNotCallLlmOrRepository()
+    {
+        // Arrange
+        var job = CreateJob(new AutoTagOptions { Enabled = false });
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        _chat.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repo.Verify(
+            r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoPendingPhotos_DoesNotCallLlm()
+    {
+        // Arrange
+        SetupEmptyTags();
+        SetupNoPendingPhotos();
+        var job = CreateJob();
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        _chat.Verify(
+            c => c.GetResponseAsync(
+                It.IsAny<IEnumerable<ChatMessage>>(),
+                It.IsAny<ChatOptions?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StampsAllPhotosInBatch_EvenWhenLlmReturnsEmptyTags()
+    {
+        // Arrange
+        var candidates = new List<PhotoAutoTagCandidate>
+        {
+            new(Id: 1, FolderPath: "/photos", FileName: "a.jpg"),
+            new(Id: 2, FolderPath: "/photos", FileName: "b.jpg"),
+        };
+
+        var tags = new List<(Tag, int)>
+        {
+            (new Tag { Id = 10, Name = "kosmetika" }, 5),
+        };
+
+        _repo
+            .Setup(r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tags);
+
+        _repo
+            .SetupSequence(r => r.GetPhotosPendingAutoTagAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(candidates)
+            .ReturnsAsync(new List<PhotoAutoTagCandidate>());
+
+        SetupChatResponse("""{"results":[]}""");
+
+        IReadOnlyList<int>? stampedIds = null;
+        _repo
+            .Setup(r => r.StampAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<int>, DateTime, CancellationToken>((ids, _, _) => stampedIds = ids)
+            .Returns(Task.CompletedTask);
+
+        var job = CreateJob();
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        stampedIds.Should().NotBeNull();
+        stampedIds.Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AppliesValidTagsAndDropsHallucinations()
+    {
+        // Arrange
+        var kandidat = new PhotoAutoTagCandidate(Id: 42, FolderPath: "/photos", FileName: "product.jpg");
+
+        var tags = new List<(Tag, int)>
+        {
+            (new Tag { Id = 1, Name = "kosmetika" }, 3),
+            (new Tag { Id = 2, Name = "pleťová péče" }, 2),
+        };
+
+        _repo
+            .Setup(r => r.GetTagsWithCountsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tags);
+
+        _repo
+            .SetupSequence(r => r.GetPhotosPendingAutoTagAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PhotoAutoTagCandidate> { kandidat })
+            .ReturnsAsync(new List<PhotoAutoTagCandidate>());
+
+        SetupChatResponse("""
+            {
+              "results": [
+                {
+                  "id": 42,
+                  "tags": ["kosmetika", "pleťová péče", "hallucinated-tag"]
+                }
+              ]
+            }
+            """);
+
+        _repo
+            .Setup(r => r.PhotoTagExistsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _repo
+            .Setup(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _repo
+            .Setup(r => r.StampAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var job = CreateJob();
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert — only the two vocabulary tags are added, not the hallucination
+        _repo.Verify(
+            r => r.AddPhotoTagAsync(
+                It.Is<PhotoTag>(pt => pt.PhotoId == 42 && pt.TagId == 1 && pt.Source == PhotoTagSource.AI),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repo.Verify(
+            r => r.AddPhotoTagAsync(
+                It.Is<PhotoTag>(pt => pt.PhotoId == 42 && pt.TagId == 2 && pt.Source == PhotoTagSource.AI),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _repo.Verify(
+            r => r.AddPhotoTagAsync(
+                It.Is<PhotoTag>(pt => pt.PhotoId == 42 && pt.TagId == 99),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repo.Verify(r => r.AddPhotoTagAsync(It.IsAny<PhotoTag>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/RetagPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/RetagPhotosHandlerTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using Anela.Heblo.Application.Features.Photobank.Infrastructure.Jobs;
+using Anela.Heblo.Application.Features.Photobank.UseCases.RetagPhotos;
+using Anela.Heblo.Domain.Features.Photobank;
+using Anela.Heblo.Xcc.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class RetagPhotosHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock;
+    private readonly Mock<IBackgroundWorker> _backgroundWorkerMock;
+    private readonly RetagPhotosHandler _handler;
+
+    public RetagPhotosHandlerTests()
+    {
+        _repositoryMock = new Mock<IPhotobankRepository>();
+        _backgroundWorkerMock = new Mock<IBackgroundWorker>();
+        _handler = new RetagPhotosHandler(_repositoryMock.Object, _backgroundWorkerMock.Object);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_ResetsLastAutoTaggedAt_ForAllPhotoIds()
+    {
+        // Arrange
+        var photoIds = new[] { 1, 2, 3 };
+        var photos = photoIds
+            .Select(id => new Photo { Id = id, FolderPath = "Photos", FileName = $"photo{id}.jpg" })
+            .ToList();
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosByIdsAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(photos);
+
+        _repositoryMock
+            .Setup(r => r.ResetAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        _backgroundWorkerMock
+            .Setup(w => w.Enqueue<PhotobankAutoTagJob>(It.IsAny<Expression<Func<PhotobankAutoTagJob, System.Threading.Tasks.Task>>>()))
+            .Returns("job-123");
+
+        var request = new RetagPhotosRequest { PhotoIds = photoIds, ClearExistingAiTags = false };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _repositoryMock.Verify(
+            r => r.ResetAutoTaggedAtAsync(
+                It.Is<IReadOnlyList<int>>(ids => ids.Count == 3 && ids.Contains(1) && ids.Contains(2) && ids.Contains(3)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_ClearsAiTags_WhenClearExistingAiTagsIsTrue()
+    {
+        // Arrange
+        var photoIds = new[] { 10, 20 };
+        var photos = photoIds
+            .Select(id => new Photo { Id = id, FolderPath = "Photos", FileName = $"photo{id}.jpg" })
+            .ToList();
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosByIdsAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(photos);
+
+        _repositoryMock
+            .Setup(r => r.ResetAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        _repositoryMock
+            .Setup(r => r.RemovePhotoTagsBySourceAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<PhotoTagSource>(), It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        _backgroundWorkerMock
+            .Setup(w => w.Enqueue<PhotobankAutoTagJob>(It.IsAny<Expression<Func<PhotobankAutoTagJob, System.Threading.Tasks.Task>>>()))
+            .Returns("job-456");
+
+        var request = new RetagPhotosRequest { PhotoIds = photoIds, ClearExistingAiTags = true };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _repositoryMock.Verify(
+            r => r.RemovePhotoTagsBySourceAsync(
+                It.IsAny<IReadOnlyList<int>>(),
+                PhotoTagSource.AI,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_DoesNotClearAiTags_WhenClearExistingAiTagsIsFalse()
+    {
+        // Arrange
+        var photoIds = new[] { 5 };
+        var photos = photoIds
+            .Select(id => new Photo { Id = id, FolderPath = "Photos", FileName = $"photo{id}.jpg" })
+            .ToList();
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosByIdsAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(photos);
+
+        _repositoryMock
+            .Setup(r => r.ResetAutoTaggedAtAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .Returns(System.Threading.Tasks.Task.CompletedTask);
+
+        _backgroundWorkerMock
+            .Setup(w => w.Enqueue<PhotobankAutoTagJob>(It.IsAny<Expression<Func<PhotobankAutoTagJob, System.Threading.Tasks.Task>>>()))
+            .Returns("job-789");
+
+        var request = new RetagPhotosRequest { PhotoIds = photoIds, ClearExistingAiTags = false };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _repositoryMock.Verify(
+            r => r.RemovePhotoTagsBySourceAsync(
+                It.IsAny<IReadOnlyList<int>>(),
+                It.IsAny<PhotoTagSource>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/RetagPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/RetagPhotosHandlerTests.cs
@@ -100,6 +100,27 @@ public class RetagPhotosHandlerTests
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task Handle_ReturnsNullJobId_WhenNoPhotosFound()
+    {
+        // Arrange
+        _repositoryMock
+            .Setup(r => r.GetPhotosByIdsAsync(It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Photo>());
+
+        var request = new RetagPhotosRequest { PhotoIds = new[] { 999 } };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.JobId.Should().BeNull();
+
+        _repositoryMock.Verify(r => r.ResetAutoTaggedAtAsync(
+            It.IsAny<IReadOnlyList<int>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async System.Threading.Tasks.Task Handle_DoesNotClearAiTags_WhenClearExistingAiTagsIsFalse()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRuleMatcherTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRuleMatcherTests.cs
@@ -7,72 +7,94 @@ namespace Anela.Heblo.Tests.Features.Photobank;
 
 public class TagRuleMatcherTests
 {
-    private static TagRule Rule(string pattern, string tag, bool active = true, int sort = 0) =>
-        new() { PathPattern = pattern, TagName = tag, IsActive = active, SortOrder = sort };
+    private static TagRule Rule(string pattern, string tagName, bool isActive = true) =>
+        new() { Id = 1, PathPattern = pattern, TagName = tagName, IsActive = isActive, SortOrder = 0 };
 
     [Fact]
-    public void ExactPrefix_Matches()
+    public void GetMatchingTags_FindsTagInsideFolderSegment()
     {
-        var rules = new[] { Rule("Photos/2025/Events", "events") };
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
-        result.Should().ContainSingle("events");
+        var rule = Rule("peťa", "peta");
+        var path = "Grafika_interní/PROFI_FOCENI/_Vánoce + Advent/2024_Háta/garance dodání_Andy, Peťa";
+        var fileName = "dsc-6411.jpg";
+
+        var result = TagRuleMatcher.GetMatchingTags(path, fileName, new[] { rule });
+
+        result.Should().Contain("peta");
     }
 
     [Fact]
-    public void Wildcard_MatchesSingleSegment()
+    public void GetMatchingTags_MatchesFileName_WhenPatternAppearsOnlyInFileName()
     {
-        var rules = new[] { Rule("Photos/*/Events", "events") };
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
-        result.Should().ContainSingle("events");
+        var rule = Rule("andy", "andy");
+        var result = TagRuleMatcher.GetMatchingTags("marketing/2024", "andy_portrait.jpg", new[] { rule });
+        result.Should().Contain("andy");
     }
 
     [Fact]
-    public void Wildcard_DoesNotMatchMultipleSegments()
+    public void GetMatchingTags_TranslatedLegacyWildcard_StillMatches()
     {
-        var rules = new[] { Rule("Photos/*", "any") };
-        // '*' only matches one segment, so "Photos/2025/Events" should NOT match "Photos/*"
-        // because the path has more segments beyond the wildcard position
-        // BUT the pattern "Photos/*" means: prefix must be Photos/{one segment}
-        // path "Photos/2025/Events" has Photos, 2025, Events — 3 segments, pattern has 2
-        // pattern segments <= path segments, wildcard matches "2025" — so it DOES match as prefix
-        // The spec says '*' matches exactly one segment in position, not "rest of path"
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events", rules);
-        result.Should().ContainSingle("any"); // prefix "Photos/*" matches "Photos/2025/..."
+        var rule = Rule(@"^people/[^/]+/2024(/|$)", "team2024");
+        var result = TagRuleMatcher.GetMatchingTags("people/foo/2024", "photo.jpg", new[] { rule });
+        result.Should().Contain("team2024");
     }
 
     [Fact]
-    public void AllMatchingRulesApply_NotFirstMatchWins()
+    public void GetMatchingTags_TranslatedLegacyWildcard_DoesNotMatchMultipleSegments()
     {
-        var rules = new[]
-        {
-            Rule("Photos/2025", "year-2025"),
-            Rule("Photos/2025/Events", "events"),
-        };
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
-        result.Should().BeEquivalentTo(new[] { "year-2025", "events" });
-    }
-
-    [Fact]
-    public void CaseInsensitive_Matches()
-    {
-        var rules = new[] { Rule("photos/2025/events", "events") };
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Events/Party", rules);
-        result.Should().ContainSingle("events");
-    }
-
-    [Fact]
-    public void InactiveRules_AreSkipped()
-    {
-        var rules = new[] { Rule("Photos/2025", "year-2025", active: false) };
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Party", rules);
+        var rule = Rule(@"^people/[^/]+/2024(/|$)", "team2024");
+        var result = TagRuleMatcher.GetMatchingTags("people/foo/bar/2024", "photo.jpg", new[] { rule });
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public void NoMatch_ReturnsEmpty()
+    public void GetMatchingTags_CaseInsensitive()
     {
-        var rules = new[] { Rule("Videos/2025", "videos") };
-        var result = TagRuleMatcher.GetMatchingTags("Photos/2025/Party", rules);
+        var rule = Rule("profi", "profi");
+        var result = TagRuleMatcher.GetMatchingTags("Grafika/PROFI_FOCENI", "img.jpg", new[] { rule });
+        result.Should().Contain("profi");
+    }
+
+    [Fact]
+    public void GetMatchingTags_DiacriticSensitive_PatternWithHacek_DoesNotMatchPlain()
+    {
+        var rule = Rule("peťa", "peta");
+        var result = TagRuleMatcher.GetMatchingTags("marketing/peta_photos", "img.jpg", new[] { rule });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMatchingTags_DiacriticSensitive_PatternPlain_DoesNotMatchHacek()
+    {
+        var rule = Rule("peta", "peta_plain");
+        var result = TagRuleMatcher.GetMatchingTags("marketing/Peťa", "img.jpg", new[] { rule });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMatchingTags_SkipsInactiveRules()
+    {
+        var rule = Rule("photos", "photos", isActive: false);
+        var result = TagRuleMatcher.GetMatchingTags("photos/2024", "img.jpg", new[] { rule });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetMatchingTags_ReturnsDistinctTagNames()
+    {
+        var rules = new[]
+        {
+            Rule("photos", "products"),
+            Rule("2024", "products"),
+        };
+        var result = TagRuleMatcher.GetMatchingTags("photos/2024", "img.jpg", rules);
+        result.Should().ContainSingle(t => t == "products");
+    }
+
+    [Fact]
+    public void GetMatchingTags_EmptyFolderPathAndFileName_ReturnsEmpty()
+    {
+        var rule = Rule("photos", "photos");
+        var result = TagRuleMatcher.GetMatchingTags("", "", new[] { rule });
         result.Should().BeEmpty();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRulePatternTranslatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRulePatternTranslatorTests.cs
@@ -1,0 +1,47 @@
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public class TagRulePatternTranslatorTests
+{
+    [Theory]
+    [InlineData("Photos", @"^Photos(/|$)")]
+    [InlineData("Photos/Products", @"^Photos/Products(/|$)")]
+    [InlineData("Photos/*", @"^Photos/[^/]+(/|$)")]
+    [InlineData("Photos/*/2024", @"^Photos/[^/]+/2024(/|$)")]
+    [InlineData("*", @"^[^/]+(/|$)")]
+    public void Translate_ConvertsLegacyGlobToRegex(string pattern, string expected)
+    {
+        var result = TagRulePatternTranslator.Translate(pattern);
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Photos", "Photos/Products/photo.jpg")]
+    [InlineData("Photos/*", "Photos/Anything/photo.jpg")]
+    [InlineData("Photos/*/2024", "Photos/Team/2024/img.jpg")]
+    public void Translate_ProducesRegexThatMatchesSamePaths(string legacyPattern, string path)
+    {
+        var regex = TagRulePatternTranslator.Translate(legacyPattern);
+        Regex.IsMatch(path, regex, RegexOptions.IgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Translate_EscapesRegexSpecialChars_InLiteralSegments()
+    {
+        var regex = TagRulePatternTranslator.Translate("Anela.Heblo/Photos");
+        Regex.IsMatch("AnelaXHeblo/Photos/img.jpg", regex, RegexOptions.IgnoreCase).Should().BeFalse();
+        Regex.IsMatch("Anela.Heblo/Photos/img.jpg", regex, RegexOptions.IgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Translate_IdempotentCheck_SkipsAlreadyMigratedPatterns()
+    {
+        var alreadyRegex = @"^Photos/[^/]+(/|$)";
+        var result = TagRulePatternTranslator.Translate(alreadyRegex);
+        result.Should().Be(alreadyRegex);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRulePatternTranslatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/TagRulePatternTranslatorTests.cs
@@ -8,6 +8,24 @@ namespace Anela.Heblo.Tests.Features.Photobank;
 public class TagRulePatternTranslatorTests
 {
     [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Translate_ThrowsArgumentException_ForNullOrWhiteSpace(string pattern)
+    {
+        var act = () => TagRulePatternTranslator.Translate(pattern);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData("Photos/*", "OtherFolder/x/photo.jpg")]
+    [InlineData("Photos/*/2024", "Photos/foo/bar/2024/img.jpg")]
+    public void Translate_ProducesRegexThatDoesNotMatchOtherPaths(string legacyPattern, string path)
+    {
+        var regex = TagRulePatternTranslator.Translate(legacyPattern);
+        Regex.IsMatch(path, regex, RegexOptions.IgnoreCase).Should().BeFalse();
+    }
+
+    [Theory]
     [InlineData("Photos", @"^Photos(/|$)")]
     [InlineData("Photos/Products", @"^Photos/Products(/|$)")]
     [InlineData("Photos/*", @"^Photos/[^/]+(/|$)")]

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -189,6 +189,27 @@ export const useBulkAddPhotoTagByIds = () => {
   });
 };
 
+// ---- Auto-tag ---------------------------------------------------------------
+
+export interface RetagPhotosRequest {
+  photoIds: number[];
+  clearExistingAiTags: boolean;
+}
+
+export const useRetagPhotos = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (request: RetagPhotosRequest) => {
+      const { apiClient, baseUrl } = getClientAndBaseUrl();
+      await apiPost(apiClient, `${baseUrl}/api/photobank/photos/auto-tag`, request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.photobank });
+    },
+  });
+};
+
 export const useBulkAddPhotoTag = () => {
   const queryClient = useQueryClient();
   return useMutation<BulkAddPhotoTagResult, Error, BulkAddPhotoTagParams>({

--- a/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoDrawer.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useState } from "react";
 import { useMsal } from "@azure/msal-react";
-import { X, ExternalLink, Copy, Check, Plus, Tag } from "lucide-react";
+import { X, ExternalLink, Copy, Check, Plus, Tag, Sparkles } from "lucide-react";
 import PhotoThumbnail from "./PhotoThumbnail";
 import { TagBadge } from "../../../components/ui/TagBadge";
-import { useAddPhotoTag, useRemovePhotoTag } from "../../../api/hooks/usePhotobank";
+import { useAddPhotoTag, useRemovePhotoTag, useRetagPhotos } from "../../../api/hooks/usePhotobank";
 import type { PhotoDto } from "../../../api/hooks/usePhotobank";
 
 interface PhotoDrawerProps {
@@ -24,6 +24,15 @@ const PhotoDrawer: React.FC<PhotoDrawerProps> = ({ photo, onClose }) => {
 
   const addTagMutation = useAddPhotoTag(photo.id);
   const removeTagMutation = useRemovePhotoTag(photo.id);
+  const retagMutation = useRetagPhotos();
+
+  const [retagSuccess, setRetagSuccess] = useState(false);
+
+  const handleRetag = useCallback(async () => {
+    await retagMutation.mutateAsync({ photoIds: [photo.id], clearExistingAiTags: false });
+    setRetagSuccess(true);
+    setTimeout(() => setRetagSuccess(false), 2000);
+  }, [photo.id, retagMutation]);
 
   const handleCopyLink = useCallback(async () => {
     if (!photo.sharePointWebUrl) return;
@@ -126,6 +135,25 @@ const PhotoDrawer: React.FC<PhotoDrawerProps> = ({ photo, onClose }) => {
               <>
                 <Copy className="w-3.5 h-3.5" />
                 Kopírovat odkaz
+              </>
+            )}
+          </button>
+        )}
+        {isAdmin && (
+          <button
+            onClick={() => void handleRetag()}
+            disabled={retagMutation.isPending}
+            className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {retagSuccess ? (
+              <>
+                <Check className="w-3.5 h-3.5 text-green-500" />
+                <span className="text-green-600">Přetagováno!</span>
+              </>
+            ) : (
+              <>
+                <Sparkles className="w-3.5 h-3.5" />
+                {retagMutation.isPending ? "Přetagování…" : "Re-tag s AI"}
               </>
             )}
           </button>

--- a/frontend/src/components/marketing/photobank/PhotobankBulkActionBar.tsx
+++ b/frontend/src/components/marketing/photobank/PhotobankBulkActionBar.tsx
@@ -7,7 +7,9 @@ interface PhotobankBulkActionBarProps {
   selectedCount: number;
   existingTags: TagWithCountDto[];
   isApplying: boolean;
+  isAutoTagging?: boolean;
   onApplyTag: (tagName: string) => Promise<void>;
+  onAutoTag?: () => void;
   onClear: () => void;
 }
 
@@ -15,7 +17,9 @@ export default function PhotobankBulkActionBar({
   selectedCount,
   existingTags,
   isApplying,
+  isAutoTagging = false,
   onApplyTag,
+  onAutoTag,
   onClear,
 }: PhotobankBulkActionBarProps) {
   const [tagInput, setTagInput] = useState("");
@@ -98,6 +102,20 @@ export default function PhotobankBulkActionBar({
           )}
           Přidat štítek
         </button>
+        {onAutoTag && (
+          <button
+            data-testid="bulk-auto-tag-btn"
+            type="button"
+            disabled={isAutoTagging || isOverLimit}
+            onClick={onAutoTag}
+            className="px-3 py-1.5 text-sm border border-primary-blue text-primary-blue rounded-md hover:bg-secondary-blue-pale disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+          >
+            {isAutoTagging && (
+              <span className="w-3.5 h-3.5 border-2 border-primary-blue border-t-transparent rounded-full animate-spin" />
+            )}
+            {isAutoTagging ? "Tagování…" : "Auto-tag výběru"}
+          </button>
+        )}
         <button
           data-testid="bulk-clear-btn"
           type="button"

--- a/frontend/src/components/marketing/photobank/__tests__/PhotobankPage.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotobankPage.test.tsx
@@ -13,6 +13,10 @@ jest.mock("../../../../api/hooks/usePhotobank", () => ({
     mutateAsync: jest.fn().mockResolvedValue(undefined),
     isPending: false,
   }),
+  useRetagPhotos: () => ({
+    mutate: jest.fn(),
+    isPending: false,
+  }),
 }));
 
 jest.mock("react-router-dom", () => ({

--- a/frontend/src/components/marketing/photobank/__tests__/TagRulesTab.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/TagRulesTab.test.tsx
@@ -114,7 +114,7 @@ describe('TagRulesTab', () => {
     render(<TagRulesTab />, { wrapper: createWrapper() });
 
     // Act
-    fireEvent.change(screen.getByLabelText(/Vzor cesty \*/), {
+    fireEvent.change(screen.getByLabelText(/Pattern \(regex\) \*/), {
       target: { value: '/Fotky/Produkty/*' },
     });
     fireEvent.change(screen.getByLabelText(/Štítek \*/), { target: { value: 'produkty' } });

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -10,7 +10,7 @@ import PhotoViewToggle from "../PhotoViewToggle";
 import BulkTagButton from "../BulkTagButton";
 import BulkTagDialog from "../BulkTagDialog";
 import PhotobankBulkActionBar from "../PhotobankBulkActionBar";
-import { usePhotos, usePhotoTags, useBulkAddPhotoTagByIds } from "../../../../api/hooks/usePhotobank";
+import { usePhotos, usePhotoTags, useBulkAddPhotoTagByIds, useRetagPhotos } from "../../../../api/hooks/usePhotobank";
 import type { PhotoDto } from "../../../../api/hooks/usePhotobank";
 
 const ADMIN_ROLE = "super_user";
@@ -203,6 +203,7 @@ function PhotobankPage() {
   );
 
   const bulkAddByIdsMutation = useBulkAddPhotoTagByIds();
+  const retagMutation = useRetagPhotos();
 
   const handleApplyBulkTag = useCallback(
     async (tagName: string) => {
@@ -214,6 +215,13 @@ function PhotobankPage() {
     },
     [selectedIds, bulkAddByIdsMutation, handleClearSelection],
   );
+
+  const handleAutoTagSelected = useCallback(() => {
+    retagMutation.mutate({
+      photoIds: Array.from(selectedIds),
+      clearExistingAiTags: false,
+    });
+  }, [selectedIds, retagMutation]);
 
   const sharedPhotoProps = {
     photos: photosData?.items ?? [],
@@ -307,7 +315,9 @@ function PhotobankPage() {
               selectedCount={selectedIds.size}
               existingTags={tagsData ?? []}
               isApplying={bulkAddByIdsMutation.isPending}
+              isAutoTagging={retagMutation.isPending}
               onApplyTag={handleApplyBulkTag}
+              onAutoTag={handleAutoTagSelected}
               onClear={handleClearSelection}
             />
           )}

--- a/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
+++ b/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
@@ -44,6 +44,10 @@ jest.mock("../../../../../api/hooks/usePhotobank", () => ({
   usePhotos: () => ({ data: { items: mockPhotos, total: 2, page: 1, pageSize: 48 }, isLoading: false }),
   usePhotoTags: () => ({ data: [] }),
   useBulkAddPhotoTagByIds: () => mockBulkAddByIdsMutation,
+  useRetagPhotos: () => ({
+    mutate: jest.fn(),
+    isPending: false,
+  }),
 }));
 
 jest.mock("react-router-dom", () => ({

--- a/frontend/src/components/marketing/photobank/settings/TagRulesTab.tsx
+++ b/frontend/src/components/marketing/photobank/settings/TagRulesTab.tsx
@@ -137,7 +137,7 @@ const TagRulesTab: React.FC = () => {
         <div className="grid grid-cols-2 gap-3">
           <div>
             <label htmlFor="pathPattern" className="block text-xs text-gray-500 mb-1">
-              Vzor cesty *
+              Pattern (regex) *
             </label>
             <input
               id="pathPattern"


### PR DESCRIPTION
## Summary

- **Regex rule matching**: `TagRuleMatcher` rewritten to use .NET regex (case-insensitive, diacritic-sensitive) against the full virtual path (`FolderPath + "/" + FileName`). Legacy `*`-segment glob patterns are translated automatically at startup via `PhotobankModule.MigrateTagRulePatternsAsync`. Rule validators now reject invalid regex patterns.
- **Nightly LLM batch job**: `PhotobankAutoTagJob` (Hangfire, cron `0 4 * * *`, disabled by default) pages through photos with `LastAutoTaggedAt IS NULL`, sends batches of 50 paths to Anthropic, validates returned tags against the existing tag vocabulary (exact match, diacritic-sensitive), and stamps `LastAutoTaggedAt` on every processed photo — guaranteeing idempotency.
- **On-demand re-tagging**: `POST /api/photobank/photos/auto-tag` resets `LastAutoTaggedAt` for specific photo IDs, optionally clears existing AI tags, and enqueues a targeted job run.
- **Frontend**: "Re-tag s AI" button in PhotoDrawer, "Auto-tag výběru" in bulk toolbar, tag rule form label updated to `Pattern (regex)`.

## Database changes

- Migration `AddPhotobankAutoTagState` adds `Photo.LastAutoTaggedAt` (nullable, all existing photos start as pending).
- No new tables. `PhotoTagSource.AI = 2` was already declared.

## Enabling the LLM job

Set `Photobank:AutoTag:Enabled = true` in `appsettings.Production.json` (or via Azure config) and enable `photobank-auto-tag` from the recurring jobs settings page.

## Test plan

- [ ] `dotnet test` — 2891 pass, 0 fail ✅
- [ ] `dotnet format --verify-no-changes` — clean ✅
- [ ] `npm run build` — Vite build passes ✅
- [ ] Verify rule with pattern `peťa` tags photos with `Peťa` in path but NOT photos with only `peta`
- [ ] Verify rule with pattern `peťa` matches filename `garance dodání_Andy, Peťa/dsc-6411.jpg`
- [ ] Apply DB migration; confirm startup logs show `MigrateTagRulePatternsAsync` ran
- [ ] Enable `PhotobankAutoTagJob` from recurring jobs UI; trigger manually; verify AI tags appear and `LastAutoTaggedAt` is set
- [ ] Trigger job a second time; verify 0 photos processed (idempotency)
- [ ] Call `POST /api/photobank/photos/auto-tag` with `clearExistingAiTags: true`; verify AI tags removed and re-applied
- [ ] Click "Re-tag s AI" in PhotoDrawer; verify toast appears and tags refresh