### PR TITLE
feat(photobank): add regex toggle for folder path filter

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -51,6 +51,7 @@ namespace Anela.Heblo.API.Controllers
         /// <summary>
         /// Get photos with optional tag AND filter, filename search, and pagination.
         /// Set useRegex=true to use POSIX regex matching on filename instead of substring search.
+        /// Set useFolderRegex=true to use POSIX regex matching on folder path instead of substring search.
         /// </summary>
         [HttpGet("photos")]
         [ProducesResponseType(typeof(GetPhotosResponse), StatusCodes.Status200OK)]
@@ -59,6 +60,7 @@ namespace Anela.Heblo.API.Controllers
             [FromQuery] string? search,
             [FromQuery] bool useRegex = false,
             [FromQuery] string? folderPath = null,
+            [FromQuery] bool useFolderRegex = false,
             [FromQuery] bool withoutTags = false,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 48,
@@ -70,6 +72,7 @@ namespace Anela.Heblo.API.Controllers
                 Search = search,
                 UseRegex = useRegex,
                 FolderPath = folderPath,
+                UseFolderRegex = useFolderRegex,
                 WithoutTags = withoutTags,
                 Page = page,
                 PageSize = pageSize,

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -21,7 +21,7 @@ namespace Anela.Heblo.Application.Features.Photobank
 
         // Photos
 
-        private IQueryable<Photo> BuildFilterQuery(List<string>? tags, string? search, bool useRegex, string? folderPath)
+        private IQueryable<Photo> BuildFilterQuery(List<string>? tags, string? search, bool useRegex, string? folderPath, bool useFolderRegex)
         {
             var query = _context.Photos.AsQueryable();
 
@@ -41,8 +41,16 @@ namespace Anela.Heblo.Application.Features.Photobank
 
             if (!string.IsNullOrWhiteSpace(folderPath))
             {
-                var pathTerm = folderPath.Trim().ToLowerInvariant();
-                query = query.Where(p => p.FolderPath.ToLower().Contains(pathTerm));
+                if (useFolderRegex)
+                {
+                    var pattern = folderPath.Trim();
+                    query = query.Where(p => Regex.IsMatch(p.FolderPath, pattern, RegexOptions.IgnoreCase));
+                }
+                else
+                {
+                    var pathTerm = folderPath.Trim().ToLowerInvariant();
+                    query = query.Where(p => p.FolderPath.ToLower().Contains(pathTerm));
+                }
             }
 
             if (tags != null && tags.Count > 0)
@@ -63,10 +71,10 @@ namespace Anela.Heblo.Application.Features.Photobank
         }
 
         public async Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, bool useRegex, string? folderPath, bool withoutTags, int page, int pageSize,
+            List<string>? tags, string? search, bool useRegex, string? folderPath, bool useFolderRegex, bool withoutTags, int page, int pageSize,
             CancellationToken cancellationToken)
         {
-            IQueryable<Photo> query = BuildFilterQuery(tags, search, useRegex, folderPath)
+            IQueryable<Photo> query = BuildFilterQuery(tags, search, useRegex, folderPath, useFolderRegex)
                 .Include(p => p.Tags)
                     .ThenInclude(pt => pt.Tag);
 
@@ -87,7 +95,7 @@ namespace Anela.Heblo.Application.Features.Photobank
             List<string>? tags, string? search, string? folderPath,
             CancellationToken cancellationToken)
         {
-            var query = BuildFilterQuery(tags, search, false, folderPath);
+            var query = BuildFilterQuery(tags, search, false, folderPath, false);
             return await query.CountAsync(cancellationToken);
         }
 
@@ -95,7 +103,7 @@ namespace Anela.Heblo.Application.Features.Photobank
             List<string>? tags, string? search, string? folderPath, int tagId,
             CancellationToken cancellationToken)
         {
-            var query = BuildFilterQuery(tags, search, false, folderPath);
+            var query = BuildFilterQuery(tags, search, false, folderPath, false);
             return await query
                 .Where(p => !p.Tags.Any(pt => pt.TagId == tagId))
                 .Select(p => p.Id)

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -42,13 +42,17 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
                     PageSize = request.PageSize,
                 };
             }
-            catch (PostgresException ex) when (request.UseRegex && ex.SqlState == "2201B")
+            catch (PostgresException ex) when ((request.UseRegex || request.UseFolderRegex) && ex.SqlState == "2201B")
             {
+                var pattern = request.UseFolderRegex
+                    ? (request.FolderPath ?? string.Empty)
+                    : (request.Search ?? string.Empty);
+
                 return new GetPhotosResponse
                 {
                     Success = false,
                     ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern,
-                    Params = new Dictionary<string, string> { ["pattern"] = request.Search ?? string.Empty },
+                    Params = new Dictionary<string, string> { ["pattern"] = pattern },
                 };
             }
         }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -28,6 +28,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
                     request.Search,
                     request.UseRegex,
                     request.FolderPath,
+                    request.UseFolderRegex,
                     request.WithoutTags,
                     request.Page,
                     request.PageSize,

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosRequest.cs
@@ -9,6 +9,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
         public string? Search { get; set; }
         public bool UseRegex { get; set; }
         public string? FolderPath { get; set; }
+        public bool UseFolderRegex { get; set; }
         public bool WithoutTags { get; set; }
         public int Page { get; set; } = 1;
         public int PageSize { get; set; } = 48;

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Validators/GetPhotosRequestValidator.cs
@@ -24,6 +24,11 @@ public class GetPhotosRequestValidator : AbstractValidator<GetPhotosRequest>
             .Must(BeValidRegex)
             .When(x => x.UseRegex && !string.IsNullOrWhiteSpace(x.Search))
             .WithMessage("Invalid regular expression pattern.");
+
+        RuleFor(x => x.FolderPath)
+            .Must(BeValidRegex)
+            .When(x => x.UseFolderRegex && !string.IsNullOrWhiteSpace(x.FolderPath))
+            .WithMessage("Invalid regular expression pattern.");
     }
 
     private static bool BeValidRegex(string? pattern)

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/IPhotobankRepository.cs
@@ -10,7 +10,7 @@ namespace Anela.Heblo.Domain.Features.Photobank
     {
         // Photos
         Task<(List<Photo> Items, int Total)> GetPhotosAsync(
-            List<string>? tags, string? search, bool useRegex, string? folderPath, bool withoutTags, int page, int pageSize,
+            List<string>? tags, string? search, bool useRegex, string? folderPath, bool useFolderRegex, bool withoutTags, int page, int pageSize,
             CancellationToken cancellationToken);
 
         Task<int> CountFilteredPhotosAsync(List<string>? tags, string? search, string? folderPath, CancellationToken cancellationToken);

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Photobank;
 using FluentAssertions;
 using Moq;
@@ -185,5 +186,59 @@ public class GetPhotosHandlerTests
         result.Items.Should().ContainSingle(p => p.Name == "report_2024.pdf");
 
         _repositoryMock.Verify(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_UseFolderRegexTrue_ForwardsUseFolderRegexToRepository()
+    {
+        // Arrange
+        var photos = new List<Photo>
+        {
+            BuildPhoto(1, "a.jpg", "Marketing/2025/Q1"),
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, null, false, @"^Marketing/", true, false, 1, 48, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((photos, 1));
+
+        var request = new GetPhotosRequest { FolderPath = @"^Marketing/", UseFolderRegex = true };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Items.Should().ContainSingle(p => p.FolderPath == "Marketing/2025/Q1");
+
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, false, @"^Marketing/", true, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_UseFolderRegexTrue_PostgresException2201B_ReturnsFolderPathAsPattern()
+    {
+        // Arrange — simulate Postgres rejecting a POSIX-invalid pattern
+        var postgresEx = new Npgsql.PostgresException(
+            messageText: "ERROR: invalid regular expression: quantifier operand invalid",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: "2201B");
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, null, false, "(?<x>foo)", true, false, 1, 48, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(postgresEx);
+
+        var request = new GetPhotosRequest
+        {
+            FolderPath = "(?<x>foo)",
+            UseFolderRegex = true,
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.PhotobankInvalidRegexPattern);
+        result.Params.Should().ContainKey("pattern").WhoseValue.Should().Be("(?<x>foo)");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -45,7 +45,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, false, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, false, null, false, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 2));
 
         var request = new GetPhotosRequest();
@@ -76,7 +76,7 @@ public class GetPhotosHandlerTests
         var tagFilter = new List<string> { "products" };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(tagFilter, null, false, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(tagFilter, null, false, null, false, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Tags = tagFilter };
@@ -90,7 +90,7 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].Tags.Should().ContainSingle(t => t.Name == "products");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, false, null, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(tagFilter, null, false, null, false, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -103,7 +103,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, "ruze", false, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, "ruze", false, null, false, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Search = "ruze" };
@@ -122,7 +122,7 @@ public class GetPhotosHandlerTests
     {
         // Arrange
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<bool>(), 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(It.IsAny<List<string>?>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<bool>(), 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((new List<Photo>(), 0));
 
         var request = new GetPhotosRequest { Tags = new List<string> { "nonexistent" } };
@@ -146,7 +146,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, null, false, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, null, false, "Produkty", false, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { FolderPath = "Produkty" };
@@ -159,7 +159,7 @@ public class GetPhotosHandlerTests
         result.Items.Should().HaveCount(1);
         result.Items[0].FolderPath.Should().Be("Marketing/Produkty/Ruze");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, false, "Produkty", false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, null, false, "Produkty", false, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -172,7 +172,7 @@ public class GetPhotosHandlerTests
         };
 
         _repositoryMock
-            .Setup(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, 1, 48, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, false, 1, 48, It.IsAny<CancellationToken>()))
             .ReturnsAsync((photos, 1));
 
         var request = new GetPhotosRequest { Search = @"^report_\d+", UseRegex = true };
@@ -184,6 +184,6 @@ public class GetPhotosHandlerTests
         result.Success.Should().BeTrue();
         result.Items.Should().ContainSingle(p => p.Name == "report_2024.pdf");
 
-        _repositoryMock.Verify(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPhotosAsync(null, @"^report_\d+", true, null, false, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosRequestValidatorTests.cs
@@ -82,4 +82,73 @@ public class GetPhotosRequestValidatorTests
         // Assert
         result.ShouldNotHaveAnyValidationErrors();
     }
+
+    [Fact]
+    public void FolderPath_InvalidRegex_UseFolderRegexTrue_FailsValidation()
+    {
+        // Arrange
+        var request = new GetPhotosRequest
+        {
+            FolderPath = "[unclosed",
+            UseFolderRegex = true,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.FolderPath)
+            .WithErrorMessage("Invalid regular expression pattern.");
+    }
+
+    [Fact]
+    public void FolderPath_ValidRegex_UseFolderRegexTrue_PassesValidation()
+    {
+        // Arrange
+        var request = new GetPhotosRequest
+        {
+            FolderPath = @"^Marketing/.*",
+            UseFolderRegex = true,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.FolderPath);
+    }
+
+    [Fact]
+    public void FolderPath_InvalidRegex_UseFolderRegexFalse_PassesValidation()
+    {
+        // Arrange — flag off, regex pattern syntax is not checked
+        var request = new GetPhotosRequest
+        {
+            FolderPath = "[unclosed",
+            UseFolderRegex = false,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void FolderPath_Null_UseFolderRegexTrue_PassesValidation()
+    {
+        // Arrange — no pattern provided, nothing to validate
+        var request = new GetPhotosRequest
+        {
+            FolderPath = null,
+            UseFolderRegex = true,
+        };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryFilterTests.cs
@@ -54,7 +54,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, false, folderPath, false, 1, 48, CancellationToken.None);
+            null, null, false, folderPath, false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(2);
@@ -71,7 +71,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, false, folderPath, false, 1, 48, CancellationToken.None);
+            null, null, false, folderPath, false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -87,7 +87,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, search, false, folderPath, false, 1, 48, CancellationToken.None);
+            null, search, false, folderPath, false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -114,7 +114,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
 
         // Act — folderPath "Produkty" matches photos 1 & 2; tag "featured" is only on photo 1
         var (items, total) = await _repository.GetPhotosAsync(
-            new List<string> { "featured" }, null, false, "Produkty", false, 1, 48, CancellationToken.None);
+            new List<string> { "featured" }, null, false, "Produkty", false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -129,7 +129,7 @@ public class PhotobankRepositoryFilterTests : IDisposable
     {
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, null, false, folderPath, false, 1, 48, CancellationToken.None);
+            null, null, false, folderPath, false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(4);
@@ -185,7 +185,7 @@ public class PhotobankRepositoryRegexFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, pattern, true, null, false, 1, 48, CancellationToken.None);
+            null, pattern, true, null, false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(1);
@@ -202,12 +202,78 @@ public class PhotobankRepositoryRegexFilterTests : IDisposable
 
         // Act
         var (items, total) = await _repository.GetPhotosAsync(
-            null, search, false, null, false, 1, 48, CancellationToken.None);
+            null, search, false, null, false, false, 1, 48, CancellationToken.None);
 
         // Assert
         total.Should().Be(2);
         items.Should().Contain(p => p.FileName == "report_2024.pdf");
         items.Should().Contain(p => p.FileName == "report_final.pdf");
         items.Should().NotContain(p => p.FileName == "IMG_001.png");
+    }
+}
+
+public class PhotobankRepositoryFolderRegexFilterTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly PhotobankRepository _repository;
+
+    public PhotobankRepositoryFolderRegexFilterTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new PhotobankRepository(_context);
+
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        var photos = new List<Photo>
+        {
+            new() { Id = 1, SharePointFileId = "sp-1", FileName = "a.jpg", FolderPath = "Marketing/2025/Q1", ModifiedAt = DateTime.UtcNow },
+            new() { Id = 2, SharePointFileId = "sp-2", FileName = "b.jpg", FolderPath = "Marketing/2025/Q2", ModifiedAt = DateTime.UtcNow },
+            new() { Id = 3, SharePointFileId = "sp-3", FileName = "c.jpg", FolderPath = "Vyrobky/2025",      ModifiedAt = DateTime.UtcNow },
+        };
+
+        _context.Photos.AddRange(photos);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_folderRegex_matchesOnlyMarketingFolders()
+    {
+        // Arrange
+        var pattern = @"^Marketing/";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, null, false, pattern, true, false, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(2);
+        items.Should().OnlyContain(p => p.FolderPath.StartsWith("Marketing/"));
+        items.Should().NotContain(p => p.FileName == "c.jpg");
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task GetPhotosAsync_folderRegexFalse_usesFolderSubstringFallback()
+    {
+        // Arrange
+        var term = "2025";
+
+        // Act
+        var (items, total) = await _repository.GetPhotosAsync(
+            null, null, false, term, false, false, 1, 48, CancellationToken.None);
+
+        // Assert
+        total.Should().Be(3);
     }
 }

--- a/frontend/src/api/hooks/usePhotobank.ts
+++ b/frontend/src/api/hooks/usePhotobank.ts
@@ -38,6 +38,7 @@ export interface GetPhotosParams {
   tags?: string[];
   search?: string;
   useRegex?: boolean;
+  useFolderRegex?: boolean;
   folderPath?: string;
   withoutTags?: boolean;
   page?: number;
@@ -84,6 +85,7 @@ function buildPhotosUrl(baseUrl: string, params: GetPhotosParams): string {
   const qs = new URLSearchParams();
   if (params.search) qs.set("search", params.search);
   if (params.useRegex) qs.set("useRegex", "true");
+  if (params.useFolderRegex) qs.set("useFolderRegex", "true");
   if (params.folderPath) qs.set("folderPath", params.folderPath);
   if (params.withoutTags) qs.set("withoutTags", "true");
   if (params.page != null) qs.set("page", String(params.page));

--- a/frontend/src/components/marketing/photobank/TagSidebar.tsx
+++ b/frontend/src/components/marketing/photobank/TagSidebar.tsx
@@ -10,12 +10,14 @@ interface TagSidebarProps {
   folderPath: string;
   withoutTags: boolean;
   useRegex: boolean;
+  useFolderRegex: boolean;
   onTagToggle: (tagId: number) => void;
   onSearchChange: (value: string) => void;
   onFolderPathChange: (value: string) => void;
   onWithoutTagsToggle: () => void;
   onClearFilters: () => void;
   onRegexChange: (value: boolean) => void;
+  onFolderRegexChange: (value: boolean) => void;
   errorMessage?: string | null;
 }
 
@@ -28,25 +30,26 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
   folderPath,
   withoutTags,
   useRegex,
+  useFolderRegex,
   onTagToggle,
   onSearchChange,
   onFolderPathChange,
   onWithoutTagsToggle,
   onClearFilters,
   onRegexChange,
+  onFolderRegexChange,
   errorMessage,
 }) => {
   const [inputValue, setInputValue] = useState(search);
   const [folderPathValue, setFolderPathValue] = useState(folderPath);
   const [tagFilter, setTagFilter] = useState("");
   const [regexError, setRegexError] = useState<string | null>(null);
+  const [folderRegexError, setFolderRegexError] = useState<string | null>(null);
 
-  // Sync external search value to local input
   useEffect(() => {
     setInputValue(search);
   }, [search]);
 
-  // Validate regex pattern when regex mode is active
   useEffect(() => {
     if (!useRegex || !inputValue) {
       setRegexError(null);
@@ -60,7 +63,6 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     }
   }, [inputValue, useRegex]);
 
-  // Debounce search input changes
   useEffect(() => {
     const timer = setTimeout(() => {
       if (inputValue !== search && regexError === null) {
@@ -83,21 +85,32 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     onSearchChange("");
   }, [onSearchChange]);
 
-  // Sync external folderPath value to local input
   useEffect(() => {
     setFolderPathValue(folderPath);
   }, [folderPath]);
 
-  // Debounce folder path input changes
+  useEffect(() => {
+    if (!useFolderRegex || !folderPathValue) {
+      setFolderRegexError(null);
+      return;
+    }
+    try {
+      new RegExp(folderPathValue);
+      setFolderRegexError(null);
+    } catch {
+      setFolderRegexError("Neplatný regulární výraz");
+    }
+  }, [folderPathValue, useFolderRegex]);
+
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (folderPathValue !== folderPath) {
+      if (folderPathValue !== folderPath && folderRegexError === null) {
         onFolderPathChange(folderPathValue);
       }
     }, DEBOUNCE_MS);
 
     return () => clearTimeout(timer);
-  }, [folderPathValue, folderPath, onFolderPathChange]);
+  }, [folderPathValue, folderPath, onFolderPathChange, folderRegexError]);
 
   const handleFolderPathInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,7 +128,7 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
     ? tags.filter((t) => t.name.toLowerCase().includes(tagFilter.trim().toLowerCase()))
     : tags;
 
-  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0 || withoutTags || useRegex;
+  const hasActiveFilters = search.length > 0 || folderPath.length > 0 || selectedTagIds.length > 0 || withoutTags || useRegex || useFolderRegex;
 
   return (
     <aside className="flex flex-col h-full bg-white border-r border-gray-200 overflow-hidden">
@@ -160,7 +173,7 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
           )}
         </div>
 
-        {/* Regex toggle */}
+        {/* Filename regex toggle */}
         <label className="flex items-center gap-1.5 mt-2 cursor-pointer select-none">
           <input
             type="checkbox"
@@ -184,8 +197,10 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
             type="text"
             value={folderPathValue}
             onChange={handleFolderPathInputChange}
-            placeholder="Hledat ve složkách..."
-            className="w-full pl-8 pr-7 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-transparent"
+            placeholder={useFolderRegex ? "Regex (POSIX, case-insensitive)..." : "Hledat ve složkách..."}
+            className={`w-full pl-8 pr-7 py-1.5 text-sm border rounded-md focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-transparent ${
+              folderRegexError ? "border-red-400" : "border-gray-300"
+            }`}
             aria-label="Hledat ve složkách"
           />
           {folderPathValue && (
@@ -198,6 +213,21 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
             </button>
           )}
         </div>
+
+        {/* Folder regex toggle */}
+        <label className="flex items-center gap-1.5 mt-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={useFolderRegex}
+            onChange={(e) => onFolderRegexChange(e.target.checked)}
+            className="w-3.5 h-3.5 accent-primary-blue"
+            aria-label="Regex složky"
+          />
+          <span className="text-xs text-gray-600">Regex</span>
+        </label>
+        {folderRegexError && (
+          <p className="mt-1 text-xs text-red-600">{folderRegexError}</p>
+        )}
       </div>
 
       {/* Tag list */}
@@ -238,7 +268,6 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
           <p className="text-sm text-gray-400 mt-2">Žádné štítky</p>
         ) : (
           <ul className="space-y-0.5">
-            {/* "Without tags" special option */}
             <li>
               <button
                 type="button"
@@ -256,7 +285,6 @@ const TagSidebar: React.FC<TagSidebarProps> = ({
               </button>
             </li>
 
-            {/* Filtered tag list */}
             {filteredTags.map((tag) => {
               const isSelected = selectedTagIds.includes(tag.id);
               return (

--- a/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/TagSidebar.test.tsx
@@ -17,12 +17,14 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof TagSidebar
     folderPath: "",
     withoutTags: false,
     useRegex: false,
+    useFolderRegex: false,
     onTagToggle: jest.fn(),
     onSearchChange: jest.fn(),
     onFolderPathChange: jest.fn(),
     onWithoutTagsToggle: jest.fn(),
     onClearFilters: jest.fn(),
     onRegexChange: jest.fn(),
+    onFolderRegexChange: jest.fn(),
     ...overrides,
   };
   return { ...render(<TagSidebar {...defaults} />), props: defaults };
@@ -292,16 +294,95 @@ describe("TagSidebar", () => {
         folderPath=""
         withoutTags={false}
         useRegex={false}
+        useFolderRegex={false}
         onTagToggle={jest.fn()}
         onSearchChange={jest.fn()}
         onFolderPathChange={jest.fn()}
         onWithoutTagsToggle={jest.fn()}
         onClearFilters={jest.fn()}
         onRegexChange={jest.fn()}
+        onFolderRegexChange={jest.fn()}
       />
     );
 
     // Assert: error message is gone
     expect(screen.queryByText("Neplatný regulární výraz")).not.toBeInTheDocument();
+  });
+
+  test("folder regex toggle calls onFolderRegexChange", () => {
+    // Arrange
+    const onFolderRegexChange = jest.fn();
+    renderSidebar({ onFolderRegexChange });
+
+    // Act
+    const checkbox = screen.getByRole("checkbox", { name: /Regex složky/i });
+    fireEvent.click(checkbox);
+
+    // Assert
+    expect(onFolderRegexChange).toHaveBeenCalledWith(true);
+  });
+
+  test("folder regex mode with valid pattern calls onFolderPathChange after debounce", () => {
+    // Arrange
+    const onFolderPathChange = jest.fn();
+    renderSidebar({ useFolderRegex: true, onFolderPathChange });
+
+    // Act — target folder input by its stable aria-label
+    const folderInput = screen.getByLabelText("Hledat ve složkách");
+    fireEvent.change(folderInput, { target: { value: "^Marketing/" } });
+
+    // Assert: not called immediately
+    expect(onFolderPathChange).not.toHaveBeenCalled();
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(onFolderPathChange).toHaveBeenCalledWith("^Marketing/");
+  });
+
+  test("folder regex mode with invalid pattern shows error and does not call onFolderPathChange after debounce", () => {
+    // Arrange
+    const onFolderPathChange = jest.fn();
+    renderSidebar({ useFolderRegex: true, onFolderPathChange });
+
+    const folderInput = screen.getByLabelText("Hledat ve složkách");
+
+    // Act — type an invalid regex
+    fireEvent.change(folderInput, { target: { value: "[bad" } });
+
+    // Assert: error message appears
+    expect(screen.getAllByText("Neplatný regulární výraz")).toHaveLength(1);
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Assert: onFolderPathChange is NOT called
+    expect(onFolderPathChange).not.toHaveBeenCalled();
+  });
+
+  test("folder regex mode off with invalid regex-like folder input calls onFolderPathChange", () => {
+    // Arrange
+    const onFolderPathChange = jest.fn();
+    renderSidebar({ useFolderRegex: false, onFolderPathChange });
+
+    const folderInput = screen.getByLabelText("Hledat ve složkách");
+
+    // Act
+    fireEvent.change(folderInput, { target: { value: "[bad" } });
+
+    // Assert: no error shown
+    expect(screen.queryByText("Neplatný regulární výraz")).not.toBeInTheDocument();
+
+    // Fast-forward debounce timer
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Assert: onFolderPathChange is called as normal
+    expect(onFolderPathChange).toHaveBeenCalledWith("[bad");
   });
 });

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -56,6 +56,7 @@ function PhotobankPage() {
   const [folderPath, setFolderPath] = useState("");
   const [withoutTags, setWithoutTags] = useState(false);
   const [useRegex, setUseRegex] = useState(false);
+  const [useFolderRegex, setUseFolderRegex] = useState(false);
   const [page, setPage] = useState(1);
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoDto | null>(null);
   const [view, setView] = useState<ViewMode>(readViewMode);
@@ -94,6 +95,7 @@ function PhotobankPage() {
     tags: selectedTagNames.length > 0 ? selectedTagNames : undefined,
     search: search || undefined,
     useRegex: useRegex || undefined,
+    useFolderRegex: useFolderRegex || undefined,
     folderPath: folderPath || undefined,
     withoutTags: withoutTags || undefined,
     page,
@@ -132,12 +134,18 @@ function PhotobankPage() {
     setPage(1);
   }, []);
 
+  const handleFolderRegexChange = useCallback((value: boolean) => {
+    setUseFolderRegex(value);
+    setPage(1);
+  }, []);
+
   const handleClearFilters = useCallback(() => {
     setSelectedTagIds([]);
     setSearch("");
     setFolderPath("");
     setWithoutTags(false);
     setUseRegex(false);
+    setUseFolderRegex(false);
     setPage(1);
     setSelectedIds(new Set());
     setSelectionAnchorId(null);
@@ -252,12 +260,14 @@ function PhotobankPage() {
             folderPath={folderPath}
             withoutTags={withoutTags}
             useRegex={useRegex}
+            useFolderRegex={useFolderRegex}
             onTagToggle={handleTagToggle}
             onSearchChange={handleSearchChange}
             onFolderPathChange={handleFolderPathChange}
             onWithoutTagsToggle={() => { setWithoutTags((v) => !v); setPage(1); }}
             onClearFilters={handleClearFilters}
             onRegexChange={handleRegexChange}
+            onFolderRegexChange={handleFolderRegexChange}
             errorMessage={searchErrorMessage}
           />
         </div>


### PR DESCRIPTION
## Summary

- Adds optional `UseFolderRegex` / `useFolderRegex` boolean flag that enables POSIX regex matching on `FolderPath`, mirroring the existing `UseRegex` feature for filenames
- Flag is plumbed end-to-end: DTO → FluentValidation validator → repository `BuildFilterQuery` → MediatR handler → controller query param → TypeScript hook → React UI (new checkbox in `TagSidebar`)
- Postgres exception catch in `GetPhotosHandler` extended to cover both flags; surfaces the correct offending pattern (`FolderPath` when folder regex, `Search` when filename regex)
- Bulk-tagging flows (`CountFilteredPhotosAsync`, `GetFilteredPhotoIdsMissingTagAsync`) keep `useFolderRegex: false` — same as they do for `useRegex`

## Test plan

- [ ] Backend: `dotnet test backend/test/Anela.Heblo.Tests --filter "FullyQualifiedName~Photobank"` — 100/100 pass
- [ ] Frontend: `npm test -- --watchAll=false` — 1248/1253 pass (5 skipped, pre-existing)
- [ ] Manual: open photobank, type literal folder substring → results filter correctly (substring mode)
- [ ] Manual: check the new "Regex" checkbox below the folder input, type `^Marketing/` → only photos with paths starting `Marketing/` appear
- [ ] Manual: type `[unclosed` in folder regex mode → red border + inline error `"Neplatný regulární výraz"`, no network call
- [ ] Manual: type Postgres-invalid pattern (e.g. `(?<name>foo)`) → expect `PhotobankInvalidRegexPattern` error response; `Params["pattern"]` matches the folder input value
- [ ] Manual: "Vymazat" resets the folder regex toggle

@claude