### PR TITLE
fix(feedback): remove 120-char truncation from KB and leaflet answer in feedback adapters

### DIFF
--- a/frontend/src/components/feedback/adapters/useKbFeedbackAdapter.ts
+++ b/frontend/src/components/feedback/adapters/useKbFeedbackAdapter.ts
@@ -14,7 +14,7 @@ export function useKbFeedbackAdapter(params: GenericFeedbackParams) {
   const rows: FeedbackDetail[] = (query.data?.logs ?? []).map((log) => ({
     id: log.id,
     primaryText: log.question,
-    secondaryText: (log.answer ?? '').slice(0, 120),
+    secondaryText: log.answer ?? '',
     createdAt: log.createdAt,
     userId: log.userId ?? undefined,
     precisionScore: log.precisionScore,

--- a/frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts
+++ b/frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts
@@ -14,7 +14,7 @@ export function useLeafletFeedbackAdapter(params: GenericFeedbackParams) {
   const rows: FeedbackDetail[] = (query.data?.items ?? []).map((item) => ({
     id: item.id,
     primaryText: item.topic,
-    secondaryText: (item.finalMarkdown ?? '').slice(0, 120),
+    secondaryText: item.finalMarkdown ?? '',
     createdAt: item.createdAt,
     userId: item.userId ?? undefined,
     precisionScore: item.precisionScore,


### PR DESCRIPTION
## Summary

- Removes `.slice(0, 120)` from `secondaryText` mapping in `useKbFeedbackAdapter.ts` and `useLeafletFeedbackAdapter.ts`
- The truncation was leaking into the "Detail záznamu" modal because the modal reuses list-row objects — no separate detail fetch
- The table list never renders `secondaryText`, so removing the cap has no visual impact on the list
- Articles adapter was already correct (no slice); this aligns KB and Leaflet to the same pattern

## Root cause

`secondaryText: (log.answer ?? '').slice(0, 120)` — defensive guard added unnecessarily. Full text is already available on the wire from the API.

## Test plan

- [x] All 1244 frontend tests pass
- [x] All 3173 backend tests pass
- [x] `npm run build` — clean
- [ ] Manual: open a KB record with answer > 120 chars, confirm ODPOVĚĎ shows full text
- [ ] Manual: open a Letáky record, confirm Výstup shows full markdown
- [ ] Manual: Články tab — no regression (control; was never affected)
- [ ] Confirm list table is visually unchanged on all three tabs