### PR TITLE
fix: article generation job silently dropped all EF changes (AsNoTracking bug)

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs
@@ -37,7 +37,7 @@ public sealed class GenerateArticleJob
 
     public async Task RunAsync(Guid articleId, CancellationToken ct = default)
     {
-        var article = await _repository.GetByIdAsync(articleId, ct);
+        var article = await _repository.GetForUpdateAsync(articleId, ct);
         if (article == null)
         {
             _logger.LogWarning("GenerateArticleJob: article {Id} not found, skipping", articleId);

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Article;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services;
-using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using Anela.Heblo.Application.Shared.WebSearch;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
@@ -72,7 +71,7 @@ public class GenerateArticleJobTests
         article.UsedKnowledgeBase = false;
         article.UsedWebSearch = false;
         _repository
-            .Setup(r => r.GetByIdAsync(article.Id, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
         SetupChatResponses(
@@ -101,6 +100,9 @@ public class GenerateArticleJobTests
         _repository.Verify(
             r => r.SaveChangesAsync(It.IsAny<CancellationToken>()),
             Times.AtLeast(3));
+        // Regression guard: must use the tracked variant, never the read-only one
+        _repository.Verify(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()), Times.Once);
+        _repository.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -108,7 +110,7 @@ public class GenerateArticleJobTests
     {
         var id = Guid.NewGuid();
         _repository
-            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetForUpdateAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync((DomainArticle?)null);
 
         await CreateJob().RunAsync(id, default);
@@ -125,7 +127,7 @@ public class GenerateArticleJobTests
         article.UsedKnowledgeBase = false;
         article.UsedWebSearch = false;
         _repository
-            .Setup(r => r.GetByIdAsync(article.Id, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
         var callCount = 0;
@@ -159,7 +161,7 @@ public class GenerateArticleJobTests
         article.UsedKnowledgeBase = false;
         article.UsedWebSearch = false;
         _repository
-            .Setup(r => r.GetByIdAsync(article.Id, It.IsAny<CancellationToken>()))
+            .Setup(r => r.GetForUpdateAsync(article.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
         _chat

--- a/backend/test/Anela.Heblo.Tests/Article/UseCases/SourceEnrichmentIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/UseCases/SourceEnrichmentIntegrationTests.cs
@@ -36,7 +36,7 @@ public class SourceEnrichmentIntegrationTests
             UsedKnowledgeBase = true,
         };
 
-        _repository.Setup(r => r.GetByIdAsync(articleId, It.IsAny<CancellationToken>()))
+        _repository.Setup(r => r.GetForUpdateAsync(articleId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(article);
 
         var chunkId = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- `GenerateArticleJob.RunAsync` called `GetByIdAsync` which returns a detached (`AsNoTracking`) entity — EF ignored all mutations so `SaveChangesAsync` was a silent no-op
- Articles stayed in `Queued` status forever despite Hangfire reporting job success and the full LLM pipeline executing (~1 min)
- Fix: call `GetForUpdateAsync` (already existed on the repository) which returns a tracked entity

## Test plan
- [ ] 4/4 `GenerateArticleJobTests` pass (GREEN after TDD red phase)
- [ ] 39/39 Article tests pass including `SourceEnrichmentIntegrationTests`
- [ ] Regression guard added: `Verify(GetForUpdateAsync, Times.Once)` + `Verify(GetByIdAsync, Times.Never)` in happy-path test
- [ ] In production: requeue the stuck article via Hangfire dashboard and confirm status progresses to `Generated`