### PR TITLE
feat(expedition-print): bold order notes on PDF

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
@@ -105,10 +105,10 @@ public class ExpeditionProtocolDocument : IDocument
                 {
                     if (hasCustomerRemark)
                         notesCol.Item().Text($"Poznámka zákazníka: {order.CustomerRemark}")
-                            .FontSize(8).Italic();
+                            .FontSize(8).Italic().Bold();
                     if (hasEshopRemark)
                         notesCol.Item().Text($"Interní poznámka: {order.EshopRemark}")
-                            .FontSize(8).Italic();
+                            .FontSize(8).Italic().Bold();
                 });
             }
 


### PR DESCRIPTION
## Summary
- Customer (`Poznámka zákazníka`) and internal (`Interní poznámka`) lines on the QuestPDF expedition list are now **bold** in addition to italic, making per-order notes pop for warehouse staff during packing.
- Only the two note lines in `ComposeOrderBlock` change — items table, summary page, and set-row italics are untouched.

## Files changed
- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs` — appended `.Bold()` to both `.FontSize(8).Italic()` chains in the notes block.

## Test plan
- [x] `dotnet build` of `Anela.Heblo.Adapters.ShoptetApi.csproj` — 0 errors.
- [x] `dotnet test --filter "FullyQualifiedName~ExpeditionProtocolDocumentTests"` — 12/12 passed.
- [ ] Open generated visual-inspection PDF (`<temp>/ExpeditionList_126000038_WithNotes.pdf` from the `Generate_Order126000038_WithNotes_SavesToDiskForVisualInspection` test) and confirm both note lines render bold + italic.
- [ ] End-to-end: from `Expedice → Archiv`, download a PDF for a date with carrier batches that have remarks; verify on the per-order block.