### PR TITLE
fix: stop raw JSON wrappers leaking into generated articles

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs
@@ -9,8 +9,8 @@ public sealed class ArticleOptions
     [Required, MinLength(1)]
     public string DefaultModel { get; set; } = "claude-sonnet-4-6";
 
-    [Range(1, 8192)]
-    public int WriteMaxTokens { get; set; } = 4096;
+    [Range(1, 16384)]
+    public int WriteMaxTokens { get; set; } = 8192;
 
     [Range(1, 4096)]
     public int AggregateMaxTokens { get; set; } = 1024;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
@@ -1,5 +1,8 @@
+using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Shared.Http;
 using Anela.Heblo.Application.Shared.Json;
 using Anela.Heblo.Domain.Features.Article;
@@ -50,12 +53,20 @@ public class WriteArticleStep : IArticlePipelineStep
 
         var raw = response.Text ?? string.Empty;
 
-        var fallback = new WriteArticleOutput(article.Topic, $"<p>{raw}</p>", null);
-        var parsed = JsonResponseParser.ParseOrFallback<WriteArticleOutput>(raw, fallback, _logger);
+        if (JsonResponseParser.TryParse<WriteArticleOutput>(raw, out var parsed, _logger))
+        {
+            context.GeneratedTitle = parsed.ArticleTitle ?? article.Topic;
+            context.GeneratedHtml = parsed.ArticleHtml ?? FallbackHtml(raw);
+            context.SourceRefs = MapSources(parsed.SourcesUsed, context.ContextSnippets, context.Facts);
+            return;
+        }
 
-        context.GeneratedTitle = parsed.ArticleTitle ?? article.Topic;
-        context.GeneratedHtml = parsed.ArticleHtml ?? $"<p>{raw}</p>";
-        context.SourceRefs = MapSources(parsed.SourcesUsed, context.ContextSnippets, context.Facts);
+        _logger.LogWarning("WriteArticle: strict JSON parse failed, attempting rescue. Raw head: {Head}",
+            raw[..Math.Min(raw.Length, 500)]);
+
+        context.GeneratedTitle = RescueArticleTitle(raw) ?? article.Topic;
+        context.GeneratedHtml = RescueArticleHtml(raw) ?? FallbackHtml(raw);
+        context.SourceRefs = [];
     }
 
     private const string SystemInstruction =
@@ -113,6 +124,53 @@ public class WriteArticleStep : IArticlePipelineStep
 
         return sb.ToString();
     }
+
+    // Rescue helpers — extract fields from partially-valid or truncated JSON
+
+    private static readonly Regex RescueHtmlComplete = new(
+        "\"article_html\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex RescueHtmlPartial = new(
+        "\"article_html\"\\s*:\\s*\"(.+)$",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex RescueTitleComplete = new(
+        "\"article_title\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static string? RescueArticleHtml(string raw)
+    {
+        var complete = RescueHtmlComplete.Match(raw);
+        if (complete.Success)
+        {
+            try { return JsonSerializer.Deserialize<string>($"\"{complete.Groups[1].Value}\""); }
+            catch (JsonException) { return UnescapeJsonString(complete.Groups[1].Value); }
+        }
+
+        var partial = RescueHtmlPartial.Match(raw);
+        return partial.Success ? UnescapeJsonString(partial.Groups[1].Value) : null;
+    }
+
+    private static string? RescueArticleTitle(string raw)
+    {
+        var match = RescueTitleComplete.Match(raw);
+        if (!match.Success) return null;
+        try { return JsonSerializer.Deserialize<string>($"\"{match.Groups[1].Value}\""); }
+        catch (JsonException) { return UnescapeJsonString(match.Groups[1].Value); }
+    }
+
+    private static string UnescapeJsonString(string s) =>
+        s.Replace("\\\\", "\\")
+         .Replace("\\\"", "\"")
+         .Replace("\\n", "\n")
+         .Replace("\\r", "\r")
+         .Replace("\\t", "\t");
+
+    private static string FallbackHtml(string raw) =>
+        $"<p>{WebUtility.HtmlEncode(raw)}</p>";
+
+    // Source mapping
 
     private static List<ArticleSourceRef> MapSources(
         List<SourceUsedDto>? sourcesUsed,

--- a/backend/src/Anela.Heblo.Application/Shared/Json/JsonResponseParser.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/Json/JsonResponseParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -7,9 +8,13 @@ namespace Anela.Heblo.Application.Shared.Json;
 
 public static class JsonResponseParser
 {
-    private static readonly Regex FencePattern = new(
-        @"```(?:json)?\s*\r?\n(.*?)\r?\n?```",
-        RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex LeadingFence = new(
+        @"^\s*```(?:json)?[ \t]*\r?\n?",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex TrailingFence = new(
+        @"\r?\n```\s*$",
+        RegexOptions.Compiled);
 
     public static T ParseOrFallback<T>(
         string raw,
@@ -32,15 +37,46 @@ public static class JsonResponseParser
         }
         catch (JsonException ex)
         {
-            logger.LogWarning(ex, "{HandlerName}: failed to parse JSON response, using fallback. Cleaned input: {Cleaned}", handlerName, cleaned[..Math.Min(cleaned.Length, 500)]);
+            logger.LogWarning(ex, "{HandlerName}: failed to parse JSON response, using fallback. Cleaned input: {CleanedHead}",
+                handlerName, cleaned[..Math.Min(cleaned.Length, 500)]);
             return fallback;
+        }
+    }
+
+    public static bool TryParse<T>(
+        string raw,
+        [NotNullWhen(true)] out T? result,
+        ILogger logger,
+        [CallerMemberName] string handlerName = "")
+    {
+        result = default;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            logger.LogWarning("{HandlerName}: received null or empty JSON response", handlerName);
+            return false;
+        }
+
+        var cleaned = StripJsonFences(raw);
+
+        try
+        {
+            result = JsonSerializer.Deserialize<T>(cleaned);
+            return result is not null;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "{HandlerName}: failed to parse JSON. Cleaned head: {CleanedHead}",
+                handlerName, cleaned[..Math.Min(cleaned.Length, 500)]);
+            return false;
         }
     }
 
     private static string StripJsonFences(string raw)
     {
         var trimmed = raw.Trim();
-        var match = FencePattern.Match(trimmed);
-        return match.Success ? match.Groups[1].Value.Trim() : trimmed;
+        trimmed = LeadingFence.Replace(trimmed, string.Empty, 1);
+        trimmed = TrailingFence.Replace(trimmed, string.Empty, 1);
+        return trimmed.Trim();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs
@@ -163,4 +163,52 @@ public class WriteArticleStepTests
 
         context.SourceRefs.Single().Excerpt!.Length.Should().Be(200);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_FencedJsonNoClosingFence_ValidBody_ParsesSuccessfully()
+    {
+        // Opening fence, no closing fence, but the JSON body is complete
+        SetupChatResponse("```json\n{\"article_title\":\"Fenced Title\",\"article_html\":\"<p>content</p>\",\"sources_used\":[]}");
+
+        var context = CreateContext("Fenced Topic");
+        await CreateStep().ExecuteAsync(context, default);
+
+        context.GeneratedTitle.Should().Be("Fenced Title");
+        context.GeneratedHtml.Should().Be("<p>content</p>");
+        context.SourceRefs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FencedTruncatedJson_RescuesPartialArticleHtml()
+    {
+        // Simulates max-token truncation: response starts with fence + JSON but
+        // is cut off in the middle of article_html, before any closing quote/brace/fence
+        const string truncated = "```json\n{\"article_title\":\"Bisabolol\",\"article_html\":\"<article><p>Partial";
+
+        SetupChatResponse(truncated);
+
+        var context = CreateContext("Bisabolol");
+        await CreateStep().ExecuteAsync(context, default);
+
+        context.GeneratedTitle.Should().Be("Bisabolol");
+        context.GeneratedHtml.Should().NotStartWith("```json");
+        context.GeneratedHtml.Should().Contain("<article><p>Partial");
+        // The rescue must extract just the HTML — the JSON field names must NOT appear in the output
+        context.GeneratedHtml.Should().NotContain("\"article_html\"");
+        context.SourceRefs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GarbageResponse_FallbackIsHtmlEncoded()
+    {
+        // Raw garbage that contains < and > must not be injected as HTML
+        SetupChatResponse("<script>alert('xss')</script>");
+
+        var context = CreateContext("Topic");
+        await CreateStep().ExecuteAsync(context, default);
+
+        context.GeneratedTitle.Should().Be("Topic");
+        context.GeneratedHtml.Should().NotContain("<script>");
+        context.GeneratedHtml.Should().Contain("&lt;script&gt;");
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Shared/Json/JsonResponseParserTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Shared/Json/JsonResponseParserTests.cs
@@ -1,0 +1,100 @@
+using Anela.Heblo.Application.Shared.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Anela.Heblo.Tests.Shared.Json;
+
+public class JsonResponseParserTests
+{
+    private sealed record TestOutput(string? Value);
+
+    private static TestOutput? Run(string raw)
+        => JsonResponseParser.ParseOrFallback<TestOutput>(raw, null!, NullLogger.Instance);
+
+    [Fact]
+    public void ParseOrFallback_NoFences_ValidJson_Returns_Deserialized()
+    {
+        var result = Run("""{"Value":"hello"}""");
+        result!.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ParseOrFallback_WellFormedFenceBlock_Returns_Deserialized()
+    {
+        var result = Run("```json\n{\"Value\":\"hello\"}\n```");
+        result!.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ParseOrFallback_MissingClosingFence_ValidJsonBody_Returns_Deserialized()
+    {
+        // Opening fence present, closing fence absent — truncated response simulation
+        var result = Run("```json\n{\"Value\":\"hello\"}");
+        result!.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ParseOrFallback_InlineFenceNoNewline_Returns_Deserialized()
+    {
+        // ```json immediately followed by JSON with no newline separator
+        var result = Run("```json{\"Value\":\"hello\"}");
+        result!.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ParseOrFallback_UntypedFence_Returns_Deserialized()
+    {
+        var result = Run("```\n{\"Value\":\"hello\"}\n```");
+        result!.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ParseOrFallback_TruncatedJsonWithFence_Returns_Fallback_NotRawFencedText()
+    {
+        // Truncated mid-JSON — parse must fail cleanly, returning the fallback
+        var fallback = new TestOutput("FALLBACK");
+        var raw = "```json\n{\"Value\":\"trun";   // truncated — no closing quote, brace or fence
+        var result = JsonResponseParser.ParseOrFallback(raw, fallback, NullLogger.Instance);
+
+        result.Should().BeSameAs(fallback);   // fallback returned, not the raw blob
+    }
+
+    [Fact]
+    public void ParseOrFallback_EmptyString_Returns_Fallback()
+    {
+        var fallback = new TestOutput("FALLBACK");
+        var result = JsonResponseParser.ParseOrFallback("", fallback, NullLogger.Instance);
+        result.Should().BeSameAs(fallback);
+    }
+
+    [Fact]
+    public void TryParse_ValidJson_ReturnsTrue_AndPopulatesResult()
+    {
+        var success = JsonResponseParser.TryParse<TestOutput>(
+            """{"Value":"parsed"}""", out var result, NullLogger.Instance);
+
+        success.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Value.Should().Be("parsed");
+    }
+
+    [Fact]
+    public void TryParse_EmptyString_ReturnsFalse_AndResultIsNull()
+    {
+        var success = JsonResponseParser.TryParse<TestOutput>(
+            "", out var result, NullLogger.Instance);
+
+        success.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParse_MalformedJson_ReturnsFalse_AndResultIsNull()
+    {
+        var success = JsonResponseParser.TryParse<TestOutput>(
+            "not json at all", out var result, NullLogger.Instance);
+
+        success.Should().BeFalse();
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix `JsonResponseParser.StripJsonFences`** — replace single all-or-nothing regex (required both newline after opening fence AND closing fence) with two independent passes (`LeadingFence` + `TrailingFence`). Missing closing fence (truncated response) and inline fence (no newline after `` ```json ``) are now handled correctly. All 5 existing callers benefit automatically.
- **Add `JsonResponseParser.TryParse<T>`** — new method that returns `bool` success/failure instead of a pre-baked fallback, enabling callers that need to branch on parse result.
- **Rescue path in `WriteArticleStep`** — replaces the `ParseOrFallback` fallback that dumped `<p>{raw JSON blob}</p>` into the article body. On parse failure, two regex-based rescue helpers (`RescueArticleHtml`, `RescueArticleTitle`) extract whatever partial HTML the model produced before truncation. Ultimate fallback uses `WebUtility.HtmlEncode(raw)` to prevent XSS.
- **Raise `WriteMaxTokens` default 4096 → 8192** (ceiling 8192 → 16384) to reduce truncation frequency on longer articles.

## Test Plan

- [x] `JsonResponseParserTests` (10 tests) — covers no-fence, well-formed fence, missing closing fence, inline fence, untyped fence, truncated JSON, empty string; plus 3 `TryParse<T>` cases
- [x] `WriteArticleStepTests` (8 tests) — covers valid JSON, fenced JSON with no closing fence, truncated JSON rescue (assert `"article_html"` key not in output), XSS-encoded garbage fallback, KB source enrichment, long excerpt truncation
- [x] Full suite: 2919 passed, 3 skipped, 0 failed