### PR TITLE
feat: replace photobank checkboxes with modifier-click multi-select

### DIFF
--- a/frontend/src/components/marketing/photobank/PhotoGrid.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoGrid.tsx
@@ -17,7 +17,7 @@ interface PhotoGridProps {
   onPhotoSelect: (photo: PhotoDto) => void;
   onPageChange: (page: number) => void;
   selectedIds: Set<number>;
-  onTogglePhotoSelection: (photoId: number, withRange: boolean) => void;
+  onPhotoSelection: (photoId: number, mode: "toggle" | "range") => void;
   canSelect: boolean;
 }
 
@@ -32,7 +32,7 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
   onPhotoSelect,
   onPageChange,
   selectedIds,
-  onTogglePhotoSelection,
+  onPhotoSelection,
   canSelect,
 }) => {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -66,7 +66,7 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Photo grid */}
       <div className="flex-1 overflow-y-auto p-4">
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-3 select-none">
           {photos.map((photo) => {
             const isSelected = photo.id === selectedPhotoId;
             const isChecked = selectedIds.has(photo.id);
@@ -75,39 +75,34 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                 key={photo.id}
                 className={[
                   "group relative aspect-square rounded-lg overflow-hidden border-2 transition-all",
-                  isSelected
+                  isChecked
                     ? "border-primary-blue ring-2 ring-primary-blue ring-offset-1"
-                    : "border-transparent hover:border-gray-300",
+                    : isSelected
+                      ? "border-primary-blue/60"
+                      : "border-transparent hover:border-gray-300",
                 ].join(" ")}
               >
-                {canSelect && (
-                  <div
-                    className={[
-                      "absolute top-1 left-1 z-10",
-                      isChecked
-                        ? "opacity-100"
-                        : "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
-                    ].join(" ")}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={isChecked}
-                      aria-label="Vybrat fotku"
-                      data-testid={`photo-select-checkbox-${photo.id}`}
-                      onChange={(e) => {
-                        onTogglePhotoSelection(
-                          photo.id,
-                          e.nativeEvent instanceof MouseEvent && (e.nativeEvent as MouseEvent).shiftKey,
-                        );
-                      }}
-                      className="w-4 h-4 accent-primary-blue cursor-pointer"
-                    />
-                  </div>
-                )}
                 <button
-                  onClick={() => onPhotoSelect(photo)}
+                  data-testid={`photo-tile-${photo.id}`}
+                  onClick={(e) => {
+                    if (!canSelect) {
+                      onPhotoSelect(photo);
+                      return;
+                    }
+                    if (e.shiftKey) {
+                      e.preventDefault();
+                      onPhotoSelection(photo.id, "range");
+                      return;
+                    }
+                    if (e.metaKey || e.ctrlKey) {
+                      e.preventDefault();
+                      onPhotoSelection(photo.id, "toggle");
+                      return;
+                    }
+                    onPhotoSelect(photo);
+                  }}
                   className="w-full h-full focus:outline-none focus:ring-2 focus:ring-primary-blue focus:ring-offset-2"
-                  aria-pressed={isSelected}
+                  aria-pressed={isChecked}
                   aria-label={photo.name}
                 >
                   <PhotoThumbnail

--- a/frontend/src/components/marketing/photobank/PhotoGrid.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoGrid.tsx
@@ -103,6 +103,7 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({
                   }}
                   className="w-full h-full focus:outline-none focus:ring-2 focus:ring-primary-blue focus:ring-offset-2"
                   aria-pressed={isChecked}
+                  aria-expanded={isSelected}
                   aria-label={photo.name}
                 >
                   <PhotoThumbnail

--- a/frontend/src/components/marketing/photobank/PhotoList.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoList.tsx
@@ -111,6 +111,7 @@ function PhotoList({
                 }}
                 className="flex items-center gap-3 flex-1 min-w-0 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-blue"
                 aria-pressed={isChecked}
+                aria-expanded={isSelected}
                 aria-label={photo.name}
               >
                 <PhotoThumbnail

--- a/frontend/src/components/marketing/photobank/PhotoList.tsx
+++ b/frontend/src/components/marketing/photobank/PhotoList.tsx
@@ -23,7 +23,7 @@ interface PhotoListProps {
   onPhotoSelect: (photo: PhotoDto) => void;
   onPageChange: (page: number) => void;
   selectedIds: Set<number>;
-  onTogglePhotoSelection: (photoId: number, withRange: boolean) => void;
+  onPhotoSelection: (photoId: number, mode: "toggle" | "range") => void;
   canSelect: boolean;
 }
 
@@ -37,7 +37,7 @@ function PhotoList({
   onPhotoSelect,
   onPageChange,
   selectedIds,
-  onTogglePhotoSelection,
+  onPhotoSelection,
   canSelect,
 }: PhotoListProps) {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -74,6 +74,7 @@ function PhotoList({
       <div className="flex-1 overflow-y-auto divide-y divide-gray-200">
         {photos.map((photo) => {
           const isSelected = photo.id === selectedPhotoId;
+          const isChecked = selectedIds.has(photo.id);
           const visibleTags = photo.tags.slice(0, MAX_VISIBLE_TAGS);
           const overflowCount = photo.tags.length - MAX_VISIBLE_TAGS;
 
@@ -81,79 +82,81 @@ function PhotoList({
             <div
               key={photo.id}
               className={[
-                "w-full flex items-center gap-3 px-4 py-3",
-                isSelected
-                  ? "border-l-2 border-primary-blue bg-secondary-blue-pale"
-                  : "hover:bg-gray-50",
+                "w-full flex items-center gap-3 px-4 py-3 select-none",
+                isChecked
+                  ? "border-l-4 border-primary-blue bg-secondary-blue-pale ring-1 ring-inset ring-primary-blue/30"
+                  : isSelected
+                    ? "border-l-2 border-primary-blue bg-secondary-blue-pale"
+                    : "hover:bg-gray-50",
               ].join(" ")}
             >
-              {canSelect && (
-                <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
-                  <input
-                    type="checkbox"
-                    checked={selectedIds.has(photo.id)}
-                    aria-label="Vybrat fotku"
-                    data-testid={`photo-select-checkbox-${photo.id}`}
-                    onChange={(e) => {
-                      onTogglePhotoSelection(
-                        photo.id,
-                        e.nativeEvent instanceof MouseEvent && (e.nativeEvent as MouseEvent).shiftKey,
-                      );
-                    }}
-                    className="w-4 h-4 accent-primary-blue cursor-pointer"
-                  />
-                </div>
-              )}
               <button
-                onClick={() => onPhotoSelect(photo)}
+                data-testid={`photo-row-${photo.id}`}
+                onClick={(e) => {
+                  if (!canSelect) {
+                    onPhotoSelect(photo);
+                    return;
+                  }
+                  if (e.shiftKey) {
+                    e.preventDefault();
+                    onPhotoSelection(photo.id, "range");
+                    return;
+                  }
+                  if (e.metaKey || e.ctrlKey) {
+                    e.preventDefault();
+                    onPhotoSelection(photo.id, "toggle");
+                    return;
+                  }
+                  onPhotoSelect(photo);
+                }}
                 className="flex items-center gap-3 flex-1 min-w-0 text-left focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-blue"
-                aria-pressed={isSelected}
+                aria-pressed={isChecked}
                 aria-label={photo.name}
               >
-              <PhotoThumbnail
-                photoId={photo.id}
-                modifiedAt={photo.lastModifiedAt}
-                alt={photo.name}
-                className="w-20 h-20 rounded-lg object-cover flex-shrink-0"
-                size="medium"
-              />
-              <div className="flex flex-col gap-0.5 flex-1 min-w-0">
-                <span className="text-base font-medium text-gray-900 truncate">
-                  {photo.name}
-                </span>
-                <span className="text-sm text-gray-500 truncate">
-                  {photo.folderPath}
-                </span>
-                {photo.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1">
-                    {visibleTags.map((tag) => (
-                      <TagBadge key={tag.id} name={tag.name} />
-                    ))}
-                    {overflowCount > 0 && (
-                      <span className="inline-flex items-center px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
-                        +{overflowCount}
-                      </span>
+                <PhotoThumbnail
+                  photoId={photo.id}
+                  modifiedAt={photo.lastModifiedAt}
+                  alt={photo.name}
+                  className="w-20 h-20 rounded-lg object-cover flex-shrink-0"
+                  size="medium"
+                />
+                <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+                  <span className="text-base font-medium text-gray-900 truncate">
+                    {photo.name}
+                  </span>
+                  <span className="text-sm text-gray-500 truncate">
+                    {photo.folderPath}
+                  </span>
+                  {photo.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {visibleTags.map((tag) => (
+                        <TagBadge key={tag.id} name={tag.name} />
+                      ))}
+                      {overflowCount > 0 && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+                          +{overflowCount}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  <div className="flex items-center gap-3 text-xs text-gray-500">
+                    <span>{formatFileSize(photo.fileSizeBytes)}</span>
+                    <span>
+                      {new Date(photo.lastModifiedAt).toLocaleDateString("cs-CZ")}
+                    </span>
+                    {photo.sharePointWebUrl && (
+                      <a
+                        href={photo.sharePointWebUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-primary-blue flex items-center gap-1"
+                      >
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
                     )}
                   </div>
-                )}
-                <div className="flex items-center gap-3 text-xs text-gray-500">
-                  <span>{formatFileSize(photo.fileSizeBytes)}</span>
-                  <span>
-                    {new Date(photo.lastModifiedAt).toLocaleDateString("cs-CZ")}
-                  </span>
-                  {photo.sharePointWebUrl && (
-                    <a
-                      href={photo.sharePointWebUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      className="text-primary-blue flex items-center gap-1"
-                    >
-                      <ExternalLink className="w-3 h-3" />
-                    </a>
-                  )}
                 </div>
-              </div>
               </button>
             </div>
           );

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
@@ -92,6 +92,15 @@ describe("PhotoGrid", () => {
     expect(btn).toHaveAttribute("aria-pressed", "false");
   });
 
+  test("drawer-open photo has aria-expanded true", () => {
+    // Arrange — selectedPhotoId=2 means the drawer is open for photo 2
+    renderGrid({ selectedPhotoId: 2 });
+
+    // Assert
+    expect(screen.getByLabelText("photo-02.jpg")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByLabelText("photo-01.jpg")).toHaveAttribute("aria-expanded", "false");
+  });
+
   test("pagination shows correct page info", () => {
     // Arrange
     renderGrid({ total: 100, page: 2, pageSize: 48 });

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoGrid.test.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import PhotoGrid from "../PhotoGrid";
-import type { PhotoDto } from "../../../../api/hooks/usePhotobank";
 
-// Stub PhotoThumbnail to avoid MSAL/fetch dependencies in unit tests
-jest.mock("../PhotoThumbnail", () => ({
-  __esModule: true,
-  default: ({ alt }: { alt: string }) => <div data-testid="thumbnail">{alt}</div>,
-}));
+jest.mock("../PhotoThumbnail", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ alt }) => React.createElement("div", { "data-testid": "thumbnail" }, alt),
+  };
+});
 
-const makePhoto = (overrides: Partial<PhotoDto> = {}): PhotoDto => ({
+const makePhoto = (overrides = {}) => ({
   id: 1,
   sharePointFileId: "file-001",
   driveId: "drive-xyz",
@@ -22,14 +24,14 @@ const makePhoto = (overrides: Partial<PhotoDto> = {}): PhotoDto => ({
   ...overrides,
 });
 
-const mockPhotos: PhotoDto[] = [
+const mockPhotos = [
   makePhoto({ id: 1, name: "photo-01.jpg" }),
   makePhoto({ id: 2, name: "photo-02.jpg", sharePointFileId: "file-002" }),
   makePhoto({ id: 3, name: "photo-03.jpg", sharePointFileId: "file-003" }),
 ];
 
-function renderGrid(overrides: Partial<React.ComponentProps<typeof PhotoGrid>> = {}) {
-  const defaults: React.ComponentProps<typeof PhotoGrid> = {
+function renderGrid(overrides = {}) {
+  const defaults = {
     photos: mockPhotos,
     selectedPhotoId: null,
     total: 3,
@@ -38,12 +40,12 @@ function renderGrid(overrides: Partial<React.ComponentProps<typeof PhotoGrid>> =
     isLoading: false,
     onPhotoSelect: jest.fn(),
     onPageChange: jest.fn(),
-    selectedIds: new Set<number>(),
-    onTogglePhotoSelection: jest.fn(),
+    selectedIds: new Set(),
+    onPhotoSelection: jest.fn(),
     canSelect: false,
     ...overrides,
   };
-  return { ...render(<PhotoGrid {...defaults} />), props: defaults };
+  return { ...render(React.createElement(PhotoGrid, defaults)), props: defaults };
 }
 
 describe("PhotoGrid", () => {
@@ -72,9 +74,9 @@ describe("PhotoGrid", () => {
     expect(onPhotoSelect).toHaveBeenCalledWith(mockPhotos[0]);
   });
 
-  test("selected photo has aria-pressed true", () => {
+  test("multi-selected photo has aria-pressed true", () => {
     // Arrange
-    renderGrid({ selectedPhotoId: 2 });
+    renderGrid({ selectedIds: new Set([2]) });
 
     // Assert
     const btn = screen.getByLabelText("photo-02.jpg");
@@ -83,7 +85,7 @@ describe("PhotoGrid", () => {
 
   test("non-selected photo has aria-pressed false", () => {
     // Arrange
-    renderGrid({ selectedPhotoId: 2 });
+    renderGrid({ selectedIds: new Set([2]) });
 
     // Assert
     const btn = screen.getByLabelText("photo-01.jpg");
@@ -155,44 +157,91 @@ describe("PhotoGrid", () => {
   });
 
   describe("selection", () => {
-    test("with canSelect=false checkboxes are not rendered", () => {
+    test("no checkboxes are rendered regardless of canSelect", () => {
       // Arrange & Act
-      renderGrid({ canSelect: false });
+      renderGrid({ canSelect: true, selectedIds: new Set() });
 
-      // Assert
+      // Assert — checkboxes are gone; selection is frame-only
       expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     });
 
-    test("with canSelect=true checkboxes are rendered for each photo", () => {
-      // Arrange & Act
-      renderGrid({ canSelect: true, selectedIds: new Set<number>() });
-
-      // Assert
-      const checkboxes = screen.getAllByRole("checkbox");
-      expect(checkboxes).toHaveLength(mockPhotos.length);
-    });
-
-    test("checkbox for selected photo is checked", () => {
+    test("selected tile gets ring class when canSelect=true", () => {
       // Arrange & Act
       renderGrid({ canSelect: true, selectedIds: new Set([1]) });
 
-      // Assert
-      const checkbox1 = screen.getByTestId("photo-select-checkbox-1");
-      const checkbox2 = screen.getByTestId("photo-select-checkbox-2");
-      expect(checkbox1).toBeChecked();
-      expect(checkbox2).not.toBeChecked();
+      // Assert — the tile wrapper for photo 1 has the ring class
+      const tile = screen.getByTestId("photo-tile-1").parentElement;
+      expect(tile?.className).toContain("ring-2");
     });
 
-    test("checkbox onChange calls onTogglePhotoSelection with photoId", () => {
+    test("plain click calls onPhotoSelect and does NOT call onPhotoSelection", () => {
       // Arrange
-      const onTogglePhotoSelection = jest.fn();
-      renderGrid({ canSelect: true, selectedIds: new Set<number>(), onTogglePhotoSelection });
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderGrid({ canSelect: true, onPhotoSelect, onPhotoSelection });
 
       // Act
-      fireEvent.click(screen.getByTestId("photo-select-checkbox-1"));
+      fireEvent.click(screen.getByTestId("photo-tile-1"));
 
       // Assert
-      expect(onTogglePhotoSelection).toHaveBeenCalledWith(1, expect.any(Boolean));
+      expect(onPhotoSelect).toHaveBeenCalledWith(mockPhotos[0]);
+      expect(onPhotoSelection).not.toHaveBeenCalled();
+    });
+
+    test("Cmd+click calls onPhotoSelection(id, toggle) and does NOT open drawer", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderGrid({ canSelect: true, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-tile-1"), { metaKey: true });
+
+      // Assert
+      expect(onPhotoSelection).toHaveBeenCalledWith(1, "toggle");
+      expect(onPhotoSelect).not.toHaveBeenCalled();
+    });
+
+    test("Ctrl+click calls onPhotoSelection(id, toggle) and does NOT open drawer", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderGrid({ canSelect: true, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-tile-1"), { ctrlKey: true });
+
+      // Assert
+      expect(onPhotoSelection).toHaveBeenCalledWith(1, "toggle");
+      expect(onPhotoSelect).not.toHaveBeenCalled();
+    });
+
+    test("Shift+click calls onPhotoSelection(id, range) and does NOT open drawer", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderGrid({ canSelect: true, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-tile-2"), { shiftKey: true });
+
+      // Assert
+      expect(onPhotoSelection).toHaveBeenCalledWith(2, "range");
+      expect(onPhotoSelect).not.toHaveBeenCalled();
+    });
+
+    test("when canSelect=false, Cmd+click falls through to onPhotoSelect", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderGrid({ canSelect: false, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-tile-1"), { metaKey: true });
+
+      // Assert — read-only users always open drawer regardless of modifier
+      expect(onPhotoSelect).toHaveBeenCalledWith(mockPhotos[0]);
+      expect(onPhotoSelection).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
@@ -40,7 +40,7 @@ function renderList(overrides: Partial<React.ComponentProps<typeof PhotoList>> =
     onPhotoSelect: jest.fn(),
     onPageChange: jest.fn(),
     selectedIds: new Set<number>(),
-    onTogglePhotoSelection: jest.fn(),
+    onPhotoSelection: jest.fn(),
     canSelect: false,
     ...overrides,
   };
@@ -139,9 +139,9 @@ describe("PhotoList", () => {
     expect(onPhotoSelect).toHaveBeenCalledWith(mockPhotos[0]);
   });
 
-  test("selected row has aria-pressed true", () => {
+  test("multi-selected row has aria-pressed true", () => {
     // Arrange
-    renderList({ selectedPhotoId: 2 });
+    renderList({ selectedIds: new Set([2]) });
 
     // Assert
     expect(screen.getByLabelText("photo-02.jpg")).toHaveAttribute("aria-pressed", "true");
@@ -149,7 +149,7 @@ describe("PhotoList", () => {
 
   test("non-selected row has aria-pressed false", () => {
     // Arrange
-    renderList({ selectedPhotoId: 2 });
+    renderList({ selectedIds: new Set([2]) });
 
     // Assert
     expect(screen.getByLabelText("photo-01.jpg")).toHaveAttribute("aria-pressed", "false");
@@ -189,44 +189,82 @@ describe("PhotoList", () => {
   });
 
   describe("selection", () => {
-    test("with canSelect=false checkboxes are not rendered", () => {
-      // Arrange & Act
-      renderList({ canSelect: false });
-
-      // Assert
-      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
-    });
-
-    test("with canSelect=true checkboxes are rendered for each photo", () => {
+    test("no checkboxes are rendered regardless of canSelect", () => {
       // Arrange & Act
       renderList({ canSelect: true, selectedIds: new Set<number>() });
 
-      // Assert
-      const checkboxes = screen.getAllByRole("checkbox");
-      expect(checkboxes).toHaveLength(mockPhotos.length);
+      // Assert — checkboxes gone
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     });
 
-    test("checkbox for selected photo is checked", () => {
-      // Arrange & Act
-      renderList({ canSelect: true, selectedIds: new Set([1]) });
-
-      // Assert
-      const checkbox1 = screen.getByTestId("photo-select-checkbox-1");
-      const checkbox2 = screen.getByTestId("photo-select-checkbox-2");
-      expect(checkbox1).toBeChecked();
-      expect(checkbox2).not.toBeChecked();
-    });
-
-    test("checkbox onChange calls onTogglePhotoSelection with photoId", () => {
+    test("plain click calls onPhotoSelect and does NOT call onPhotoSelection", () => {
       // Arrange
-      const onTogglePhotoSelection = jest.fn();
-      renderList({ canSelect: true, selectedIds: new Set<number>(), onTogglePhotoSelection });
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderList({ canSelect: true, onPhotoSelect, onPhotoSelection });
 
       // Act
-      fireEvent.click(screen.getByTestId("photo-select-checkbox-1"));
+      fireEvent.click(screen.getByTestId("photo-row-1"));
 
       // Assert
-      expect(onTogglePhotoSelection).toHaveBeenCalledWith(1, expect.any(Boolean));
+      expect(onPhotoSelect).toHaveBeenCalledWith(mockPhotos[0]);
+      expect(onPhotoSelection).not.toHaveBeenCalled();
+    });
+
+    test("Cmd+click calls onPhotoSelection(id, toggle) and does NOT open drawer", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderList({ canSelect: true, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-row-1"), { metaKey: true });
+
+      // Assert
+      expect(onPhotoSelection).toHaveBeenCalledWith(1, "toggle");
+      expect(onPhotoSelect).not.toHaveBeenCalled();
+    });
+
+    test("Ctrl+click calls onPhotoSelection(id, toggle) and does NOT open drawer", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderList({ canSelect: true, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-row-1"), { ctrlKey: true });
+
+      // Assert
+      expect(onPhotoSelection).toHaveBeenCalledWith(1, "toggle");
+      expect(onPhotoSelect).not.toHaveBeenCalled();
+    });
+
+    test("Shift+click calls onPhotoSelection(id, range) and does NOT open drawer", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderList({ canSelect: true, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-row-2"), { shiftKey: true });
+
+      // Assert
+      expect(onPhotoSelection).toHaveBeenCalledWith(2, "range");
+      expect(onPhotoSelect).not.toHaveBeenCalled();
+    });
+
+    test("when canSelect=false, Cmd+click falls through to onPhotoSelect", () => {
+      // Arrange
+      const onPhotoSelect = jest.fn();
+      const onPhotoSelection = jest.fn();
+      renderList({ canSelect: false, onPhotoSelect, onPhotoSelection });
+
+      // Act
+      fireEvent.click(screen.getByTestId("photo-row-1"), { metaKey: true });
+
+      // Assert
+      expect(onPhotoSelect).toHaveBeenCalledWith(mockPhotos[0]);
+      expect(onPhotoSelection).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotoList.test.tsx
@@ -155,6 +155,15 @@ describe("PhotoList", () => {
     expect(screen.getByLabelText("photo-01.jpg")).toHaveAttribute("aria-pressed", "false");
   });
 
+  test("drawer-open row has aria-expanded true", () => {
+    // Arrange — selectedPhotoId=2 means the drawer is open for photo 2
+    renderList({ selectedPhotoId: 2 });
+
+    // Assert
+    expect(screen.getByLabelText("photo-02.jpg")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByLabelText("photo-01.jpg")).toHaveAttribute("aria-expanded", "false");
+  });
+
   test("clicking SharePoint link does NOT fire onPhotoSelect", () => {
     // Arrange
     const onPhotoSelect = jest.fn();

--- a/frontend/src/components/marketing/photobank/__tests__/PhotobankPage.test.tsx
+++ b/frontend/src/components/marketing/photobank/__tests__/PhotobankPage.test.tsx
@@ -1,13 +1,26 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import PhotobankPage from "../pages/PhotobankPage";
 
 jest.mock("@azure/msal-react", () => ({
-  useMsal: () => ({ accounts: [] }),
+  useMsal: () => ({
+    accounts: [{ idTokenClaims: { roles: ["marketing_writer"] } }],
+  }),
 }));
 
 jest.mock("../../../../api/hooks/usePhotobank", () => ({
-  usePhotos: () => ({ data: undefined, isLoading: false }),
+  usePhotos: () => ({
+    data: {
+      items: [
+        { id: 1, name: "p1.jpg", sharePointFileId: "f1", driveId: "d", folderPath: "/", sharePointWebUrl: null, fileSizeBytes: null, lastModifiedAt: "2026-01-01T00:00:00Z", tags: [] },
+        { id: 2, name: "p2.jpg", sharePointFileId: "f2", driveId: "d", folderPath: "/", sharePointWebUrl: null, fileSizeBytes: null, lastModifiedAt: "2026-01-01T00:00:00Z", tags: [] },
+        { id: 3, name: "p3.jpg", sharePointFileId: "f3", driveId: "d", folderPath: "/", sharePointWebUrl: null, fileSizeBytes: null, lastModifiedAt: "2026-01-01T00:00:00Z", tags: [] },
+      ],
+      total: 3,
+      page: 1,
+    },
+    isLoading: false,
+  }),
   usePhotoTags: () => ({ data: [] }),
   useBulkAddPhotoTagByIds: () => ({
     mutateAsync: jest.fn().mockResolvedValue(undefined),
@@ -28,9 +41,13 @@ jest.mock("../PhotoThumbnail", () => ({
   default: ({ alt }: { alt: string }) => <img alt={alt} />,
 }));
 
+let capturedGridProps: any;
 jest.mock("../PhotoGrid", () => ({
   __esModule: true,
-  default: () => <div data-testid="photo-grid" />,
+  default: (props: any) => {
+    capturedGridProps = props;
+    return <div data-testid="photo-grid" />;
+  },
 }));
 
 jest.mock("../PhotoList", () => ({
@@ -93,4 +110,35 @@ test("reads initial view from localStorage", () => {
 
   expect(screen.getByTestId("photo-list")).toBeInTheDocument();
   expect(screen.queryByTestId("photo-grid")).not.toBeInTheDocument();
+});
+
+test("Shift+click (range mode) with no prior anchor treats click as single toggle", () => {
+  // Arrange — render with no prior anchor (fresh page)
+  render(<PhotobankPage />);
+
+  // Act — simulate Shift+click on photo 2 (mode=range, no anchor set)
+  act(() => {
+    capturedGridProps.onPhotoSelection(2, "range");
+  });
+
+  // Assert — no anchor means range falls through to single toggle:
+  // photo 2 is selected and the bulk action bar appears
+  expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+});
+
+test("Cmd+click then Shift+click replaces selection with range (not additive)", () => {
+  // Arrange
+  render(<PhotobankPage />);
+
+  // Act — Cmd+click photo 1 (anchor=1, selected={1})
+  act(() => {
+    capturedGridProps.onPhotoSelection(1, "toggle");
+  });
+  // Shift+click photo 3 (range from anchor=1 to 3, REPLACE)
+  act(() => {
+    capturedGridProps.onPhotoSelection(3, "range");
+  });
+
+  // Assert — bulk action bar shows 3 selected (photos 1, 2, 3)
+  expect(screen.getByText(/^3 fotek/)).toBeInTheDocument();
 });

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -161,28 +161,22 @@ function PhotobankPage() {
     setSelectionAnchorId(null);
   }, []);
 
-  const handleTogglePhotoSelection = useCallback(
-    (photoId: number, withRange: boolean) => {
+  const handlePhotoSelection = useCallback(
+    (photoId: number, mode: "toggle" | "range") => {
       const items = photosData?.items ?? [];
 
-      if (withRange && selectionAnchorId !== null) {
+      if (mode === "range" && selectionAnchorId !== null) {
         const anchorIdx = items.findIndex((p) => p.id === selectionAnchorId);
         const targetIdx = items.findIndex((p) => p.id === photoId);
 
         if (anchorIdx !== -1 && targetIdx !== -1) {
           const lo = Math.min(anchorIdx, targetIdx);
           const hi = Math.max(anchorIdx, targetIdx);
-          const rangeIds = items.slice(lo, hi + 1).map((p) => p.id);
-          setSelectedIds((prev) => {
-            const next = new Set(prev);
-            rangeIds.forEach((id) => next.add(id));
-            return next;
-          });
+          setSelectedIds(new Set(items.slice(lo, hi + 1).map((p) => p.id)));
           return;
         }
       }
 
-      // Single toggle
       setSelectedIds((prev) => {
         const next = new Set(prev);
         if (next.has(photoId)) {
@@ -228,7 +222,7 @@ function PhotobankPage() {
     onPhotoSelect: handlePhotoSelect,
     onPageChange: handlePageChange,
     selectedIds,
-    onTogglePhotoSelection: handleTogglePhotoSelection,
+    onPhotoSelection: handlePhotoSelection,
     canSelect: canBulkTag,
   };
 

--- a/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
+++ b/frontend/src/components/marketing/photobank/pages/__tests__/PhotobankPage.selection.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import PhotobankPage from "../PhotobankPage";
 import type { PhotoDto } from "../../../../../api/hooks/usePhotobank";
 
@@ -88,22 +88,23 @@ test("initial state: bulk action bar not shown when nothing selected", () => {
 // the useMsal mock per describe block. The role gate is exercised implicitly by unit tests
 // on PhotoGrid and PhotoList (canSelect=false hides checkboxes).
 
-test("checkboxes are rendered in grid view when canBulkTag=true", () => {
+test("photo tiles are rendered in grid view and no checkboxes shown", () => {
   // Arrange & Act
   render(<PhotobankPage />);
 
-  // Assert: checkboxes should be present for each photo
-  expect(screen.getByTestId("photo-select-checkbox-1")).toBeInTheDocument();
-  expect(screen.getByTestId("photo-select-checkbox-2")).toBeInTheDocument();
+  // Assert: tiles present, checkboxes gone (selection is frame-only now)
+  expect(screen.getByTestId("photo-tile-1")).toBeInTheDocument();
+  expect(screen.getByTestId("photo-tile-2")).toBeInTheDocument();
+  expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
 });
 
 test("selecting a photo shows the bulk action bar", () => {
   // Arrange
   render(<PhotobankPage />);
 
-  // Act — click photo-1 checkbox
+  // Act — Cmd+click photo-1 tile to toggle selection
   act(() => {
-    screen.getByTestId("photo-select-checkbox-1").click();
+    fireEvent.click(screen.getByTestId("photo-tile-1"), { metaKey: true });
   });
 
   // Assert
@@ -115,7 +116,7 @@ test("clicking clear in bulk action bar hides the bar", () => {
   // Arrange
   render(<PhotobankPage />);
   act(() => {
-    screen.getByTestId("photo-select-checkbox-1").click();
+    fireEvent.click(screen.getByTestId("photo-tile-1"), { metaKey: true });
   });
   expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary

- Drop per-photo checkboxes from grid and list views; selection is now shown via a frame/ring around selected tiles and rows
- Cmd/Ctrl+click toggles individual photo selection; Shift+click replaces the current selection with the range from the anchor to the clicked photo (replace semantics, not additive)
- Plain click still opens the detail drawer; \`aria-expanded\` added to communicate drawer-open state to screen readers

## Test Plan

- [ ] Plain click on a tile → drawer opens, no selection frame appears
- [ ] Cmd/Ctrl+click a tile → ring frame appears, drawer does NOT open, bulk action bar shows count
- [ ] Cmd+click photo A, Shift+click photo B → only the A→B range is selected (not additive)
- [ ] Shift+click with no prior selection → treats as single toggle (sets that photo as anchor)
- [ ] Switch to list view → same modifier behaviors on rows
- [ ] Change search/tag filter or switch page → selection clears
- [ ] Read-only user (no `marketing_writer` role) → modifier+click behaves like plain click, no frame shown
- [ ] All 114 frontend unit tests pass