### PR TITLE
feat: Meeting Task Write Handlers — Edit, Approve/Reject, Add Task

### DIFF
--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/arch-review.r1.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/arch-review.r1.md
@@ -1,0 +1,259 @@
+I have enough context. Writing the architecture review now.
+
+# Architecture Review: Meeting Task Write Handlers — Edit, Approve/Reject, Add Task
+
+## Skip Design: true
+
+Backend-only MediatR handlers with no UI components, screens, or visual changes. UI work is explicitly out of scope (handled in a later subtask).
+
+## Architectural Fit Assessment
+
+The feature is a clean addition to the existing Vertical Slice in `Features/MeetingTasks/UseCases/`. Three sibling write/read handlers already exist (`IngestPlaudRecording`, `GetTranscriptList`, `GetTranscriptDetail`) and define the conventions to follow: one folder per UseCase, request/response/handler split into three files, `IRequestHandler<TRequest, TResponse>` with constructor-injected `IMeetingTranscriptRepository` and `ILogger<THandler>`, `BaseResponse`-derived responses with an `ErrorCodes` constructor overload.
+
+**Two material mismatches between the spec and the existing codebase must be resolved before implementation:**
+
+1. **`ErrorCodes.NotFound` does not exist.** The enum member is `ResourceNotFound` (`backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:25`), and that is what `GetTranscriptDetailHandler` uses. The spec's `ErrorCodes.NotFound` references will fail to compile.
+2. **`MeetingTranscript.SourceEmail` does not exist.** The actual entity (`backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs` on `origin/feat/meeting-task-validation-epic`) has `PlaudRecordingId`, `PlaudCreatedAt`, `Subject`, `Summary`, `RawTranscript`, `Status`, `ReceivedAt`, `ReviewedAt`, `ReviewedByUser`, `Tasks`. The spec's test helper sets `SourceEmail` — this won't compile and is missing two required scalars (`PlaudRecordingId`, `RawTranscript`) needed to mirror the sibling test's instantiation pattern.
+
+A third prerequisite is also unmet: **this branch was not created from `feat/meeting-task-validation-epic`.** It was branched from `main`, so the entire domain model (`MeetingTranscript`, `ProposedTask`, `ProposedTaskStatus`, `IMeetingTranscriptRepository`) and contract (`ProposedTaskDto`) do not exist on disk in this worktree. The brief is explicit that the epic branch is the required base.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Features/MeetingTasks/UseCases/                                     │
+│                                                                      │
+│   UpdateProposedTask/                  UpdateProposedTaskStatus/     │
+│   ├─ Request   ──┐                     ├─ Request    ──┐             │
+│   ├─ Response    ├─► Handler           ├─ Response     ├─► Handler   │
+│   └─ Handler  ───┘     │               └─ Handler   ───┘     │       │
+│                        ▼                                     ▼       │
+│   AddProposedTask/    [IMeetingTranscriptRepository]                 │
+│   ├─ Request   ──┐     ▲                                     ▲       │
+│   ├─ Response    ├─► Handler ────────────────────────────────┘       │
+│   └─ Handler  ───┘                                                   │
+│                                                                      │
+│   Contracts/ProposedTaskDto  ◄─── AddProposedTaskResponse.Task       │
+└──────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+              Domain.Features.MeetingTasks (aggregate + enum + repo iface)
+                                  │
+                                  ▼
+              Persistence.MeetingTasks.MeetingTranscriptRepository
+                                  │
+                                  ▼
+                       ApplicationDbContext (EF Core)
+```
+
+All three handlers are auto-registered by MediatR assembly scan via the existing `AddMeetingTasksModule` registration; no DI changes are needed.
+
+### Key Design Decisions
+
+#### Decision 1: Response file granularity
+**Options considered:** (a) Define response class in the same file as the handler (spec's approach); (b) Three files per UseCase folder — `*Request.cs`, `*Response.cs`, `*Handler.cs` (sibling convention).
+
+**Chosen approach:** Three files per UseCase. Each response gets its own file.
+
+**Rationale:** Every existing UseCase under `MeetingTasks/` (and across the codebase based on the sibling pattern) keeps the response in a dedicated file. The spec embedding `UpdateProposedTaskResponse` inside `UpdateProposedTaskHandler.cs` is the only deviation — keeping it consistent costs nothing and avoids the "find the response type" friction. This also matches the constructor-overload pattern (`public Foo() {} public Foo(ErrorCodes e) : base(e) {}`) the siblings use.
+
+#### Decision 2: How to signal not-found / validation failures
+**Options considered:** (a) Property setter (`new Response { Success = false, ErrorCode = ErrorCodes.ResourceNotFound }`); (b) Constructor overload (`new Response(ErrorCodes.ResourceNotFound)`) matching `GetTranscriptDetailResponse`.
+
+**Chosen approach:** Constructor overload. Mirror `GetTranscriptDetailResponse`:
+```csharp
+public class UpdateProposedTaskResponse : BaseResponse
+{
+    public UpdateProposedTaskResponse() { }
+    public UpdateProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+**Rationale:** `BaseResponse` ships a protected error-code constructor specifically for this. Using it is the documented intent and keeps call sites terse. The setter form works but drifts from the immediate sibling.
+
+#### Decision 3: Whether handlers should log
+**Options considered:** (a) No logger (spec); (b) Inject `ILogger<THandler>` and log at the same level as siblings.
+
+**Chosen approach:** Inject `ILogger<THandler>` and emit one `LogInformation` on success and one `LogWarning` on not-found, matching `GetTranscriptDetailHandler` and `IngestPlaudRecordingHandler`.
+
+**Rationale:** Both sibling handlers log; observability for write operations is more valuable than for reads. Cost is one extra ctor parameter and two log lines per handler.
+
+#### Decision 4: Error code value (`NotFound` vs `ResourceNotFound`)
+**Options considered:** (a) Use `ErrorCodes.NotFound` as the spec says; (b) Use `ErrorCodes.ResourceNotFound` as actually defined.
+
+**Chosen approach:** `ErrorCodes.ResourceNotFound`. Treat this as a spec correction.
+
+**Rationale:** `NotFound` is not a member of the `ErrorCodes` enum. The sibling `GetTranscriptDetailHandler` already uses `ResourceNotFound` (HTTP 404). This is the only correct choice that compiles and matches existing handler semantics for the same condition.
+
+#### Decision 5: Test framework idioms
+**Options considered:** (a) xUnit + `Assert.*` (spec); (b) xUnit + FluentAssertions + `NullLogger<T>` (sibling test convention).
+
+**Chosen approach:** Match the sibling test (`GetTranscriptDetailHandlerTests`): FluentAssertions for assertions, `NullLogger<THandler>.Instance` for the logger, and `_repositoryMock.Verify(r => r.SaveChangesAsync(...))` to assert persistence was actually called.
+
+**Rationale:** Consistency with the existing test file ten lines away in the same folder. FluentAssertions is already a referenced package and idiomatic across the project.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Files (paths exactly as the spec lists) plus the three new `*Response.cs` files:
+
+```
+backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/
+├── UpdateProposedTask/
+│   ├── UpdateProposedTaskRequest.cs
+│   ├── UpdateProposedTaskResponse.cs   ← add (not in spec)
+│   └── UpdateProposedTaskHandler.cs
+├── UpdateProposedTaskStatus/
+│   ├── UpdateProposedTaskStatusRequest.cs
+│   ├── UpdateProposedTaskStatusResponse.cs   ← add
+│   └── UpdateProposedTaskStatusHandler.cs
+└── AddProposedTask/
+    ├── AddProposedTaskRequest.cs
+    ├── AddProposedTaskResponse.cs   ← add (currently embedded with Request in spec)
+    └── AddProposedTaskHandler.cs
+
+backend/test/Anela.Heblo.Tests/Features/MeetingTasks/
+└── UpdateProposedTaskHandlerTests.cs
+```
+
+No changes to `MeetingTasksModule.cs` (MediatR scans the assembly). No changes to `IMeetingTranscriptRepository` (existing `GetByIdAsync` + `SaveChangesAsync` suffice; `EF Core change tracking` handles edits and the collection append).
+
+### Interfaces and Contracts
+
+**Requests** (MVC binding will validate `[Required]`):
+```csharp
+public class UpdateProposedTaskRequest : IRequest<UpdateProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+    [Required] public string Title { get; set; } = null!;
+    public string Description { get; set; } = string.Empty;
+    [Required] public string Assignee { get; set; } = null!;
+    public DateTime? DueDate { get; set; }
+}
+
+public class UpdateProposedTaskStatusRequest : IRequest<UpdateProposedTaskStatusResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+    [Required] public string Status { get; set; } = null!;
+}
+
+public class AddProposedTaskRequest : IRequest<AddProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+    [Required] public string Title { get; set; } = null!;
+    public string Description { get; set; } = string.Empty;
+    [Required] public string Assignee { get; set; } = null!;
+    public DateTime? DueDate { get; set; }
+}
+```
+
+> Note: `IRequest<BaseResponse>` (per spec) works at runtime but is weaker than `IRequest<UpdateProposedTaskResponse>`. Type the request generic over the concrete response class so callers and the OpenAPI surface (future) see the concrete shape. This still satisfies the spec's "Response type" requirement.
+
+**Responses:**
+```csharp
+public class UpdateProposedTaskResponse : BaseResponse
+{
+    public UpdateProposedTaskResponse() { }
+    public UpdateProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+// Same shape for UpdateProposedTaskStatusResponse.
+
+public class AddProposedTaskResponse : BaseResponse
+{
+    public AddProposedTaskResponse() { }
+    public AddProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+    public ProposedTaskDto Task { get; set; } = null!;
+}
+```
+
+`ProposedTaskDto` (already exists) has eight fields — when populating in `AddProposedTaskHandler`, also set `ExternalTaskId = null` explicitly or rely on default. (Spec lists only seven fields for the response DTO; ExternalTaskId on a brand-new manual task is `null` — assign `task.ExternalTaskId` for symmetry with the read handler's mapping.)
+
+### Data Flow
+
+```
+UpdateProposedTask:
+  client → controller (later subtask) → MediatR
+    → Handler.GetByIdAsync(TranscriptId)
+      missing → Response(ResourceNotFound)
+    → transcript.Tasks.FirstOrDefault(t => t.Id == TaskId)
+      missing → Response(ResourceNotFound)
+    → mutate Title, Description, Assignee, DueDate on the tracked entity
+    → SaveChangesAsync(ct)   // EF Core emits an UPDATE on ProposedTask row
+    → Response()              // Success = true
+
+UpdateProposedTaskStatus:
+  ... same load/locate guard ...
+    → Enum.TryParse<ProposedTaskStatus>(Status, ignoreCase: true, out var s)
+      false → Response(ValidationError)
+    → task.Status = s
+    → SaveChangesAsync(ct)
+    → Response()
+
+AddProposedTask:
+  ... transcript load guard ...
+    → construct ProposedTask { Id=NewGuid, MeetingTranscriptId=transcript.Id,
+                                Status=Pending, IsManuallyAdded=true, ... }
+    → transcript.Tasks.Add(task)   // EF tracks add via aggregate
+    → SaveChangesAsync(ct)         // INSERT on ProposedTask
+    → Response { Task = ProposedTaskDto.From(task) }
+```
+
+EF Core change tracking persists in-place edits because `GetByIdAsync` returns a tracked entity (verified via the existing `MeetingTranscriptRepository` + `GetTranscriptDetailHandler` pattern). No explicit `Update` call is needed.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Branch is rooted on `main` and the entire prerequisite chain (domain entities, repository, DTO) is absent. Implementation cannot start. | Critical | Rebase or reset this branch on top of `origin/feat/meeting-task-validation-epic` before any file is written. PR target must be `feat/meeting-task-validation-epic`. |
+| Spec uses non-existent `ErrorCodes.NotFound`. Copying the brief code verbatim will not compile. | High | Use `ErrorCodes.ResourceNotFound` (HTTP 404) for both transcript-missing and task-missing cases — matches the sibling handler. |
+| Spec uses non-existent `MeetingTranscript.SourceEmail` in the test helper and omits required `PlaudRecordingId` / `RawTranscript` fields. Test class will not compile. | High | Drop `SourceEmail`; populate `PlaudRecordingId = "rec-xyz"` and `RawTranscript = ""` to mirror the sibling test (`GetTranscriptDetailHandlerTests`). |
+| `IRequest<BaseResponse>` (spec) weakens caller typing — controllers and any future client see only the base. | Low | Type each request with its concrete response class. |
+| `Enum.TryParse<ProposedTaskStatus>` will accept integer strings (`"1"`, `"2"`) because of `Enum.TryParse` semantics. Spec only contemplates name strings. | Low | Either accept this as harmless (still maps to a valid enum value) or follow with `Enum.IsDefined(typeof(ProposedTaskStatus), newStatus)`. Recommend accepting — current behavior parses "1" as `Pending`, which is no worse than the controller doing the same. |
+| No optimistic concurrency. Two concurrent edits on the same task last-write-wins. | Low (out of scope) | Documented as out of scope. Revisit when controller + audit are added. |
+| Spec says nothing about updating `transcript.Status` or `ReviewedAt`/`ReviewedByUser` when all tasks are approved/rejected. | Medium | Confirmed out of scope by spec ("Status transition rules" and "audit logging" are excluded). Note this for the controller/UI subtask. |
+| `transcript.Tasks.Add(task)` while a referenced navigation property `MeetingTranscript` is `null!`. EF Core sets the FK from `MeetingTranscriptId` so this is fine, but tests reading `task.MeetingTranscript` would NRE. | Low | Set `MeetingTranscriptId = transcript.Id` (as spec does) and do not touch `task.MeetingTranscript` in tests. |
+| Logger added but not asserted in tests. | Low | Use `NullLogger<THandler>.Instance` and skip assertions; verifying log output is not required by the spec. |
+
+## Specification Amendments
+
+1. **Replace every `ErrorCodes.NotFound` reference with `ErrorCodes.ResourceNotFound`** in FR-1, FR-2, FR-3, the response code samples in the brief, and the acceptance criteria. This is the only existing 404-mapped code in `ErrorCodes`.
+
+2. **Remove `SourceEmail` from the test helper** in FR-4. The field does not exist on `MeetingTranscript`. Replace with the actual required scalars: `PlaudRecordingId = "rec-test"`, `PlaudCreatedAt = DateTime.UtcNow`, `RawTranscript = ""`. `Subject`, `Summary`, `Status`, `ReceivedAt` stay.
+
+3. **Type request generics over concrete response classes** (FR-1 and FR-2): `IRequest<UpdateProposedTaskResponse>` and `IRequest<UpdateProposedTaskStatusResponse>` instead of `IRequest<BaseResponse>`. FR-3 already does this.
+
+4. **Add `ILogger<THandler>` constructor dependency** to each handler and emit `LogInformation` on success / `LogWarning` on not-found / `LogWarning` on invalid status (FR-2). Matches sibling convention. NFR-1 unaffected.
+
+5. **Split each response into its own `*Response.cs` file** under the UseCase folder (FR-5). Update file layout list:
+   - Add `UpdateProposedTaskResponse.cs`
+   - Add `UpdateProposedTaskStatusResponse.cs`
+   - Move `AddProposedTaskResponse` out of `AddProposedTaskRequest.cs` into `AddProposedTaskResponse.cs`
+
+6. **Use constructor-overload error responses** (`new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound)`) instead of object-initializer (`new UpdateProposedTaskResponse { Success = false, ErrorCode = ... }`). Matches `GetTranscriptDetailResponse`.
+
+7. **Test conventions:** use FluentAssertions, `NullLogger<THandler>.Instance`, and `Mock.Verify` to assert `SaveChangesAsync` is invoked exactly once on the success paths. Matches `GetTranscriptDetailHandlerTests`.
+
+8. **`AddProposedTaskHandler` should populate `ExternalTaskId = null` on the returned `ProposedTaskDto`** for symmetry with `GetTranscriptDetailHandler.Tasks.Select(...)`. The DTO field is nullable so this is purely about completeness.
+
+## Prerequisites
+
+Before any handler code is written:
+
+1. **Rebase or recreate this branch from `origin/feat/meeting-task-validation-epic`.** Current branch base is `main`, which is missing:
+   - `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/*` (4 files: entities, enums, repository interface)
+   - `backend/src/Anela.Heblo.Application/Features/MeetingTasks/*` (module, contracts, services, existing UseCases — `IngestPlaudRecording`, `GetTranscriptList`, `GetTranscriptDetail`)
+   - `backend/src/Anela.Heblo.Persistence/MeetingTasks/*` (EF configurations, repository implementation)
+   - EF migration `20260512191541_AddMeetingTasksTables`
+
+   Without these, the implementation references compile errors on every type.
+
+2. **PR target must be `feat/meeting-task-validation-epic`**, not `main`. The brief is explicit; the epic is still in-flight on its own branch.
+
+3. **Confirm `MeetingTranscriptRepository.GetByIdAsync` eagerly loads `Tasks`** (Include). This is already validated by `GetTranscriptDetailHandler`, which iterates `transcript.Tasks` immediately after `GetByIdAsync`, so the eager-load path is exercised — no change required, but verify before declaring done.
+
+No database migrations, no new DI registrations, no infrastructure changes are needed.

--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/brief.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/brief.md
@@ -338,4 +338,3 @@ git commit -m "feat(meeting-tasks): add UpdateProposedTask, UpdateProposedTaskSt
 ---
 
 > **Integration:** Create your feature branch from `feat/meeting-task-validation-epic`. When done, open a PR targeting `feat/meeting-task-validation-epic` (not `main`).
-

--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/brief.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/brief.md
@@ -1,0 +1,341 @@
+# Subtask 4: Write Handlers — Edit, Approve/Reject, Add Task
+
+**Parent Epic:** Meeting Task Validation Checkpoint
+
+CRITICAL - This is part of epic, you **MUST** use epic branch - feat/meeting-task-validation-epic as a source for this feature branch and create a PR back to this branch instead of main
+
+
+## Task 6: UpdateProposedTask, UpdateProposedTaskStatus, AddProposedTask Handlers
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs`
+- Test: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`
+
+- [ ] **Step 1: Create UpdateProposedTask request and handler**
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs
+using Anela.Heblo.Application.Shared;
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskRequest : IRequest<BaseResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}
+```
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskHandler : IRequestHandler<UpdateProposedTaskRequest, BaseResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+
+    public UpdateProposedTaskHandler(IMeetingTranscriptRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<BaseResponse> Handle(UpdateProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript == null)
+            return new UpdateProposedTaskResponse { Success = false, ErrorCode = ErrorCodes.NotFound };
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task == null)
+            return new UpdateProposedTaskResponse { Success = false, ErrorCode = ErrorCodes.NotFound };
+
+        task.Title = request.Title;
+        task.Description = request.Description;
+        task.Assignee = request.Assignee;
+        task.DueDate = request.DueDate;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskResponse();
+    }
+}
+
+public class UpdateProposedTaskResponse : BaseResponse { }
+```
+
+- [ ] **Step 2: Create UpdateProposedTaskStatus request and handler**
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs
+using Anela.Heblo.Application.Shared;
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusRequest : IRequest<BaseResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Status { get; set; } = null!;
+}
+```
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusHandler : IRequestHandler<UpdateProposedTaskStatusRequest, BaseResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+
+    public UpdateProposedTaskStatusHandler(IMeetingTranscriptRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<BaseResponse> Handle(UpdateProposedTaskStatusRequest request, CancellationToken cancellationToken)
+    {
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript == null)
+            return new UpdateProposedTaskStatusResponse { Success = false, ErrorCode = ErrorCodes.NotFound };
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task == null)
+            return new UpdateProposedTaskStatusResponse { Success = false, ErrorCode = ErrorCodes.NotFound };
+
+        if (!Enum.TryParse<ProposedTaskStatus>(request.Status, true, out var newStatus))
+            return new UpdateProposedTaskStatusResponse { Success = false, ErrorCode = ErrorCodes.ValidationError };
+
+        task.Status = newStatus;
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskStatusResponse();
+    }
+}
+
+public class UpdateProposedTaskStatusResponse : BaseResponse { }
+```
+
+- [ ] **Step 3: Create AddProposedTask request and handler**
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskRequest : IRequest<AddProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}
+
+public class AddProposedTaskResponse : BaseResponse
+{
+    public ProposedTaskDto Task { get; set; } = null!;
+}
+```
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskHandler : IRequestHandler<AddProposedTaskRequest, AddProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+
+    public AddProposedTaskHandler(IMeetingTranscriptRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<AddProposedTaskResponse> Handle(AddProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript == null)
+            return new AddProposedTaskResponse { Success = false, ErrorCode = Application.Shared.ErrorCodes.NotFound };
+
+        var task = new ProposedTask
+        {
+            Id = Guid.NewGuid(),
+            MeetingTranscriptId = transcript.Id,
+            Title = request.Title,
+            Description = request.Description,
+            Assignee = request.Assignee,
+            DueDate = request.DueDate,
+            Status = ProposedTaskStatus.Pending,
+            IsManuallyAdded = true
+        };
+
+        transcript.Tasks.Add(task);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return new AddProposedTaskResponse
+        {
+            Task = new ProposedTaskDto
+            {
+                Id = task.Id,
+                Title = task.Title,
+                Description = task.Description,
+                Assignee = task.Assignee,
+                DueDate = task.DueDate,
+                Status = task.Status.ToString(),
+                IsManuallyAdded = true
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Write tests**
+
+```csharp
+// backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.MeetingTasks;
+
+public class UpdateProposedTaskHandlerTests
+{
+    private readonly Mock<IMeetingTranscriptRepository> _repoMock = new();
+
+    private MeetingTranscript CreateTranscriptWithTask(out Guid transcriptId, out Guid taskId)
+    {
+        transcriptId = Guid.NewGuid();
+        taskId = Guid.NewGuid();
+        return new MeetingTranscript
+        {
+            Id = transcriptId,
+            Subject = "Test",
+            Summary = "Summary",
+            SourceEmail = "test@example.com",
+            Status = MeetingTranscriptStatus.PendingReview,
+            ReceivedAt = DateTime.UtcNow,
+            Tasks = new List<ProposedTask>
+            {
+                new() { Id = taskId, Title = "Original", Description = "Desc", Assignee = "Alice", Status = ProposedTaskStatus.Pending }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task UpdateTask_ModifiesFields()
+    {
+        var transcript = CreateTranscriptWithTask(out var tId, out var taskId);
+        _repoMock.Setup(r => r.GetByIdAsync(tId, It.IsAny<CancellationToken>())).ReturnsAsync(transcript);
+
+        var handler = new UpdateProposedTaskHandler(_repoMock.Object);
+        var result = await handler.Handle(new UpdateProposedTaskRequest
+        {
+            TranscriptId = tId, TaskId = taskId, Title = "Updated", Description = "New desc", Assignee = "Bob"
+        }, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("Updated", transcript.Tasks[0].Title);
+        Assert.Equal("Bob", transcript.Tasks[0].Assignee);
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatus_ApprovesTask()
+    {
+        var transcript = CreateTranscriptWithTask(out var tId, out var taskId);
+        _repoMock.Setup(r => r.GetByIdAsync(tId, It.IsAny<CancellationToken>())).ReturnsAsync(transcript);
+
+        var handler = new UpdateProposedTaskStatusHandler(_repoMock.Object);
+        var result = await handler.Handle(new UpdateProposedTaskStatusRequest
+        {
+            TranscriptId = tId, TaskId = taskId, Status = "Approved"
+        }, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal(ProposedTaskStatus.Approved, transcript.Tasks[0].Status);
+    }
+
+    [Fact]
+    public async Task AddTask_CreatesManualTask()
+    {
+        var transcript = CreateTranscriptWithTask(out var tId, out _);
+        _repoMock.Setup(r => r.GetByIdAsync(tId, It.IsAny<CancellationToken>())).ReturnsAsync(transcript);
+
+        var handler = new AddProposedTaskHandler(_repoMock.Object);
+        var result = await handler.Handle(new AddProposedTaskRequest
+        {
+            TranscriptId = tId, Title = "New Task", Assignee = "Charlie", Description = "Manual"
+        }, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.True(result.Task.IsManuallyAdded);
+        Assert.Equal(2, transcript.Tasks.Count);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/ --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"`
+Expected: All 3 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/
+git add backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat(meeting-tasks): add UpdateProposedTask, UpdateProposedTaskStatus, AddProposedTask handlers with tests"
+```
+
+---
+
+
+---
+
+> **Integration:** Create your feature branch from `feat/meeting-task-validation-epic`. When done, open a PR targeting `feat/meeting-task-validation-epic` (not `main`).
+

--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/impl/main.r1.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/impl/main.r1.md
@@ -1,0 +1,12 @@
+This is a standalone git clone (not a worktree — `GIT_DIR == GIT_COMMON`). The PR target is `feat/meeting-task-validation-epic` as specified in the task plan.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `feat/meeting-task-validation-epic` locally
+2. Push and create a Pull Request targeting `feat/meeting-task-validation-epic`
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/impl/main.r1.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/impl/main.r1.md
@@ -1,12 +1,64 @@
-This is a standalone git clone (not a worktree — `GIT_DIR == GIT_COMMON`). The PR target is `feat/meeting-task-validation-epic` as specified in the task plan.
+0 errors. The warnings are pre-existing (162 of them, none in MeetingTasks code).
 
 ---
 
-Implementation complete. What would you like to do?
+# Implementation: Meeting Task Write Handlers — Edit, Approve/Reject, Add Task
 
-1. Merge back to `feat/meeting-task-validation-epic` locally
-2. Push and create a Pull Request targeting `feat/meeting-task-validation-epic`
-3. Keep the branch as-is (I'll handle it later)
-4. Discard this work
+## What was implemented
 
-Which option?
+Three MediatR write-side handlers for the Meeting Task Validation Checkpoint feature, plus unit tests covering all three happy paths and edge cases (not-found, invalid status).
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs` — request DTO with `[Required]` on Title/Assignee
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs` — BaseResponse-derived marker class with error-code constructor
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs` — handler: loads transcript, locates task, mutates 4 fields, saves
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs` — request DTO with `[Required]` on Status
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs` — BaseResponse-derived marker class
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs` — handler: validates enum parse, transitions status
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs` — request DTO
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs` — carries `ProposedTaskDto Task`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs` — handler: constructs `ProposedTask` with `IsManuallyAdded=true`, appends, returns DTO
+- `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` — 9 tests covering happy paths + error cases for all three handlers
+
+## Tests
+
+`backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` — 9 tests passing:
+- `UpdateTask_ModifiesFields` — confirms all 4 fields are mutated and `SaveChangesAsync` called once
+- `UpdateTaskStatus_ApprovesTask` — confirms `Approved` status is set
+- `AddTask_CreatesManualTask` — confirms task appended with `IsManuallyAdded=true`, DTO populated correctly
+- Additional edge-case tests for not-found transcript, not-found task, invalid status string
+
+## How to verify
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"
+# Expected: 9 passed, 0 failed
+
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MeetingTasks"
+# Expected: 24 passed, 0 failed
+```
+
+## Notes
+
+- Used `ErrorCodes.ResourceNotFound` (not `ErrorCodes.NotFound` from spec) — the actual enum member, matching sibling `GetTranscriptDetailHandler`
+- Each handler injects `ILogger<THandler>` and logs on entry/warning on failure — matching sibling convention
+- Each response type lives in its own `*Response.cs` file per Vertical Slice convention
+- Error responses use constructor-overload form (`new Response(ErrorCodes.ResourceNotFound)`) matching `GetTranscriptDetailResponse`
+- Test helper uses real `MeetingTranscript` fields (`PlaudRecordingId`, `RawTranscript`) — spec's `SourceEmail` field does not exist on the entity
+- `AddProposedTaskHandler` explicitly sets `ExternalTaskId = null` on the DTO for symmetry with read handler
+
+## PR Summary
+
+Adds three MediatR write-side handlers for the meeting task validation checkpoint: `UpdateProposedTask` (edits Title/Description/Assignee/DueDate), `UpdateProposedTaskStatus` (transitions Pending→Approved/Rejected via case-insensitive enum parse), and `AddProposedTask` (creates a manually-authored task with `IsManuallyAdded=true`). All handlers follow the established Vertical Slice convention: one UseCase folder with three files (request/response/handler), constructor-injected `IMeetingTranscriptRepository` + `ILogger<T>`, `ErrorCodes.ResourceNotFound` for not-found cases, and `BaseResponse`-derived responses with constructor-overload error signaling.
+
+### Changes
+- `UseCases/UpdateProposedTask/` — request, response, handler (edit task fields)
+- `UseCases/UpdateProposedTaskStatus/` — request, response, handler (status lifecycle)
+- `UseCases/AddProposedTask/` — request, response, handler (manual task creation)
+- `Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` — 9 unit tests with FluentAssertions + NullLogger + Mock.Verify
+
+## Status
+DONE

--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/spec.r1.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/spec.r1.md
@@ -1,0 +1,193 @@
+# Specification: Meeting Task Write Handlers — Edit, Approve/Reject, Add Task
+
+## Summary
+Implement three MediatR write-side handlers for the Meeting Task Validation Checkpoint feature: `UpdateProposedTask` (edit task fields), `UpdateProposedTaskStatus` (approve/reject lifecycle), and `AddProposedTask` (manually create a task on an existing transcript). Each handler mutates a `MeetingTranscript` aggregate via `IMeetingTranscriptRepository`, persists via `SaveChangesAsync`, and returns a `BaseResponse`-shaped result with standardized error codes.
+
+## Background
+The parent epic (`feat/meeting-task-validation-epic`) introduces a human-in-the-loop validation step for AI-extracted meeting tasks. Earlier subtasks delivered the domain model (`MeetingTranscript`, `ProposedTask`, `ProposedTaskStatus`), repository contract (`IMeetingTranscriptRepository`), read-side queries, and the `ProposedTaskDto` contract. This subtask adds the write-side: handlers that let users edit a proposed task's fields, transition its status (Approved/Rejected), or insert an additional manually-authored task into the transcript's task list. These handlers will later be exposed via MVC controller endpoints and consumed by the frontend validation UI.
+
+## Functional Requirements
+
+### FR-1: UpdateProposedTask handler
+Allow editing the editable fields of an existing proposed task on a transcript.
+
+**Request shape (`UpdateProposedTaskRequest : IRequest<BaseResponse>`):**
+- `TranscriptId: Guid`
+- `TaskId: Guid`
+- `Title: string` (required, `[Required]`)
+- `Description: string` (defaults to empty string)
+- `Assignee: string` (required, `[Required]`)
+- `DueDate: DateTime?` (optional)
+
+**Behavior:**
+1. Load the `MeetingTranscript` by `TranscriptId` via `IMeetingTranscriptRepository.GetByIdAsync`.
+2. If the transcript is not found, return `Success = false`, `ErrorCode = ErrorCodes.NotFound`.
+3. Locate the `ProposedTask` with `Id == TaskId` inside `transcript.Tasks`.
+4. If the task is not found, return `Success = false`, `ErrorCode = ErrorCodes.NotFound`.
+5. Overwrite `Title`, `Description`, `Assignee`, `DueDate` on the task entity (in-place — EF tracks the loaded aggregate).
+6. Call `SaveChangesAsync(cancellationToken)` on the repository.
+7. Return `new UpdateProposedTaskResponse()` (defaults to `Success = true`).
+
+**Response type:** `UpdateProposedTaskResponse : BaseResponse` (empty marker class — preserves a strongly typed handler return for future fields).
+
+**Acceptance criteria:**
+- Updating an existing task on an existing transcript mutates the four target fields and persists.
+- Missing transcript → response carries `Success = false` and `ErrorCode = ErrorCodes.NotFound`.
+- Missing task on an existing transcript → response carries `Success = false` and `ErrorCode = ErrorCodes.NotFound`.
+- `Title` and `Assignee` enforce `[Required]` validation at the MVC binding layer.
+- Unit test `UpdateTask_ModifiesFields` passes.
+
+### FR-2: UpdateProposedTaskStatus handler
+Transition a proposed task's lifecycle status (e.g., Pending → Approved/Rejected).
+
+**Request shape (`UpdateProposedTaskStatusRequest : IRequest<BaseResponse>`):**
+- `TranscriptId: Guid`
+- `TaskId: Guid`
+- `Status: string` (required, `[Required]`) — string form of `ProposedTaskStatus` enum, case-insensitive
+
+**Behavior:**
+1. Load transcript by id. Missing → `Success = false`, `ErrorCode = ErrorCodes.NotFound`.
+2. Locate task by id. Missing → `Success = false`, `ErrorCode = ErrorCodes.NotFound`.
+3. Parse `request.Status` with `Enum.TryParse<ProposedTaskStatus>(value, ignoreCase: true, out var newStatus)`. Failure → `Success = false`, `ErrorCode = ErrorCodes.ValidationError`.
+4. Assign `task.Status = newStatus`.
+5. Call `SaveChangesAsync(cancellationToken)`.
+6. Return `new UpdateProposedTaskStatusResponse()` on success.
+
+**Response type:** `UpdateProposedTaskStatusResponse : BaseResponse` (empty marker class).
+
+**Acceptance criteria:**
+- A valid status string (e.g., `"Approved"`, `"approved"`, `"REJECTED"`) parses and is applied to the task.
+- An unrecognized status string returns `ErrorCode = ErrorCodes.ValidationError` and the task is unchanged.
+- Missing transcript or task returns `ErrorCode = ErrorCodes.NotFound`.
+- Unit test `UpdateTaskStatus_ApprovesTask` passes.
+
+### FR-3: AddProposedTask handler
+Create a new manually-authored task and append it to an existing transcript's task list.
+
+**Request shape (`AddProposedTaskRequest : IRequest<AddProposedTaskResponse>`):**
+- `TranscriptId: Guid`
+- `Title: string` (required, `[Required]`)
+- `Description: string` (defaults to empty)
+- `Assignee: string` (required, `[Required]`)
+- `DueDate: DateTime?` (optional)
+
+**Behavior:**
+1. Load transcript by id. Missing → `Success = false`, `ErrorCode = ErrorCodes.NotFound`, `Task = null`.
+2. Construct a new `ProposedTask`:
+   - `Id = Guid.NewGuid()`
+   - `MeetingTranscriptId = transcript.Id`
+   - `Title`, `Description`, `Assignee`, `DueDate` from the request
+   - `Status = ProposedTaskStatus.Pending`
+   - `IsManuallyAdded = true`
+3. Append to `transcript.Tasks`.
+4. Call `SaveChangesAsync(cancellationToken)`.
+5. Return `AddProposedTaskResponse` with a populated `ProposedTaskDto`:
+   - `Id, Title, Description, Assignee, DueDate` mirror the created entity
+   - `Status = task.Status.ToString()` (string form for transport)
+   - `IsManuallyAdded = true`
+
+**Response type:** `AddProposedTaskResponse : BaseResponse { public ProposedTaskDto Task { get; set; } }`.
+
+**Acceptance criteria:**
+- On a valid transcript, a new task is appended with `IsManuallyAdded = true` and `Status = Pending`.
+- The response `Task` DTO reflects the persisted entity.
+- Missing transcript returns `Success = false`, `ErrorCode = ErrorCodes.NotFound`.
+- Unit test `AddTask_CreatesManualTask` passes.
+
+### FR-4: Unit tests
+A single test class `UpdateProposedTaskHandlerTests` covers happy paths for all three handlers using a Moq `IMeetingTranscriptRepository`.
+
+**Acceptance criteria:**
+- Test file location: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`.
+- Tests included: `UpdateTask_ModifiesFields`, `UpdateTaskStatus_ApprovesTask`, `AddTask_CreatesManualTask`.
+- Helper `CreateTranscriptWithTask(out Guid transcriptId, out Guid taskId)` constructs a transcript with `Status = MeetingTranscriptStatus.PendingReview`, one seeded `ProposedTask` (`Status = Pending`), and required scalar fields (`Subject`, `Summary`, `SourceEmail`, `ReceivedAt`).
+- `dotnet test --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"` reports 3 passing tests.
+
+### FR-5: File layout
+Each handler lives in its own UseCase folder following Vertical Slice conventions.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs`
+- Namespaces match folder structure (`Anela.Heblo.Application.Features.MeetingTasks.UseCases.{UseCase}`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Each handler performs a single aggregate load + single `SaveChangesAsync`. No batched, looped, or N+1 access. Repository calls accept the request's `CancellationToken`. Targeted single-handler call should complete in <200ms against a warm database for typical transcripts (≤50 proposed tasks).
+
+### NFR-2: Security
+- Handlers themselves do not enforce authorization — that responsibility belongs to the controller layer (out of scope for this subtask). However, handlers must not return data beyond what the caller is authorized to mutate; since input is keyed by `TranscriptId`/`TaskId` and only mutates fields on the located task, no data leakage occurs.
+- `[Required]` validation on `Title`, `Assignee`, and `Status` runs at MVC model binding.
+- No raw SQL — repository abstracts EF Core access, eliminating injection risk.
+
+### NFR-3: Reliability
+- All three handlers must return a `BaseResponse`-shaped result instead of throwing for known business failures (not found, validation). Unexpected exceptions propagate.
+- `CancellationToken` from MediatR is honored on every repository call.
+
+### NFR-4: Consistency
+- Error codes follow the existing `ErrorCodes` static class (`NotFound`, `ValidationError`) already used by sibling MeetingTasks handlers.
+- Response DTOs inherit `BaseResponse`; success defaults to `true`, failure paths set `Success = false` and `ErrorCode`.
+
+### NFR-5: Testability
+- All collaborators are injected via constructor (`IMeetingTranscriptRepository`).
+- Tests use Moq with no real EF or database.
+- Tests assert both the handler's return value and the mutation on the in-memory aggregate.
+
+## Data Model
+
+No schema changes. Handlers operate on existing entities introduced by earlier subtasks of the epic:
+
+- **`MeetingTranscript`** (aggregate root): `Id`, `Subject`, `Summary`, `SourceEmail`, `Status: MeetingTranscriptStatus`, `ReceivedAt`, `Tasks: ICollection<ProposedTask>`.
+- **`ProposedTask`** (child entity): `Id`, `MeetingTranscriptId`, `Title`, `Description`, `Assignee`, `DueDate: DateTime?`, `Status: ProposedTaskStatus`, `IsManuallyAdded: bool`.
+- **`ProposedTaskStatus`** (enum): `Pending`, `Approved`, `Rejected` (exact members defined by prior subtask).
+- **`MeetingTranscriptStatus`** (enum): includes at least `PendingReview`.
+- **`ProposedTaskDto`** (contract): `Id`, `Title`, `Description`, `Assignee`, `DueDate`, `Status: string`, `IsManuallyAdded: bool`.
+
+`AddProposedTask` mutates the `Tasks` collection (insert). `UpdateProposedTask` mutates four scalar fields. `UpdateProposedTaskStatus` mutates `Status`. All changes persist through EF Core change tracking via `SaveChangesAsync`.
+
+## API / Interface Design
+
+MediatR request/response contracts (no controller wiring in this subtask):
+
+| Request | Response | Mutation |
+|---|---|---|
+| `UpdateProposedTaskRequest` | `UpdateProposedTaskResponse : BaseResponse` | Updates `Title`, `Description`, `Assignee`, `DueDate` on a task |
+| `UpdateProposedTaskStatusRequest` | `UpdateProposedTaskStatusResponse : BaseResponse` | Updates `Status` on a task (string-parsed to enum) |
+| `AddProposedTaskRequest` | `AddProposedTaskResponse : BaseResponse { ProposedTaskDto Task }` | Appends a new task with `IsManuallyAdded = true`, `Status = Pending` |
+
+Dispatched via `IMediator.Send(request, cancellationToken)`. Error signaling: never throw for known failures; populate `Success = false` and `ErrorCode` on the response. Successful response defaults to `Success = true`.
+
+## Dependencies
+
+- **MediatR** — `IRequest<TResponse>`, `IRequestHandler<TRequest, TResponse>`.
+- **`IMeetingTranscriptRepository`** (`Anela.Heblo.Domain.Features.MeetingTasks`) — `GetByIdAsync(Guid, CancellationToken)` and `SaveChangesAsync(CancellationToken)`. Must already expose these signatures from a prior epic subtask.
+- **`MeetingTranscript`, `ProposedTask`, `ProposedTaskStatus`** domain types (`Anela.Heblo.Domain.Features.MeetingTasks`).
+- **`ProposedTaskDto`** (`Anela.Heblo.Application.Features.MeetingTasks.Contracts`).
+- **`BaseResponse`, `ErrorCodes`** (`Anela.Heblo.Application.Shared`).
+- **`System.ComponentModel.DataAnnotations`** for `[Required]`.
+- **Test packages:** `xUnit`, `Moq`.
+- **Branching:** feature branch must be created from `feat/meeting-task-validation-epic`; PR targets `feat/meeting-task-validation-epic` (not `main`).
+
+## Out of Scope
+
+- MVC controller endpoints exposing these handlers (separate subtask).
+- Authorization/authentication checks (handled at controller layer).
+- Frontend UI for editing/approving/adding tasks.
+- Status transition rules (e.g., disallowing Approved→Pending) — current handler accepts any valid enum value.
+- Domain events, audit logging, or notifications on status change.
+- Validation that the transcript is in `PendingReview` state before edits — not specified in brief.
+- Bulk approve/reject across multiple tasks.
+- Optimistic concurrency / `RowVersion` handling.
+- E2E tests for these handlers; only unit tests are required here.
+- OpenAPI/Swagger DTO surface — there is no controller in this subtask.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-meeting-tasks-write-handlers-edit-approv/task-plan.r1.md
+++ b/artifacts/feat-meeting-tasks-write-handlers-edit-approv/task-plan.r1.md
@@ -1,0 +1,1049 @@
+# Meeting Task Write Handlers — Edit, Approve/Reject, Add Task — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three MediatR write-side handlers — `UpdateProposedTask`, `UpdateProposedTaskStatus`, `AddProposedTask` — to the Meeting Tasks vertical slice so users can edit, approve/reject, and manually add tasks on a `MeetingTranscript` aggregate.
+
+**Architecture:** Three independent UseCase folders under `Application/Features/MeetingTasks/UseCases/`, each containing a request/response/handler triple following the sibling `GetTranscriptDetail` convention. Handlers load the aggregate via `IMeetingTranscriptRepository.GetByIdAsync`, mutate via EF Core change tracking, persist via `SaveChangesAsync`, and return a `BaseResponse`-derived response carrying `ErrorCodes.ResourceNotFound` / `ErrorCodes.ValidationError` for known failures. No DI changes (MediatR scan picks up handlers), no schema changes, no controller wiring (out of scope).
+
+**Tech Stack:** .NET 8, C#, MediatR, EF Core (via existing repository), xUnit + Moq + FluentAssertions + `NullLogger<T>` for tests.
+
+---
+
+## Prerequisites
+
+This worktree branch (`feat-meeting-tasks-write-handlers-edit-approv`) was created from `main`. The epic branch `feat/meeting-task-validation-epic` contains the entire prerequisite chain (domain entities, enum, repository interface + implementation, `ProposedTaskDto`, sibling handlers, EF migration). **None of those files exist on disk in this worktree.** Task 0 below rebases this branch onto the epic so that all referenced types resolve. Do not skip it — every subsequent task will fail to compile otherwise.
+
+The PR target for this work is `feat/meeting-task-validation-epic`, not `main`.
+
+---
+
+## File Structure
+
+### Files to create
+
+```
+backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/
+├── UpdateProposedTask/
+│   ├── UpdateProposedTaskRequest.cs    (request DTO, IRequest<UpdateProposedTaskResponse>)
+│   ├── UpdateProposedTaskResponse.cs   (response, BaseResponse-derived)
+│   └── UpdateProposedTaskHandler.cs    (handler with logger + repo)
+├── UpdateProposedTaskStatus/
+│   ├── UpdateProposedTaskStatusRequest.cs
+│   ├── UpdateProposedTaskStatusResponse.cs
+│   └── UpdateProposedTaskStatusHandler.cs
+└── AddProposedTask/
+    ├── AddProposedTaskRequest.cs
+    ├── AddProposedTaskResponse.cs       (carries ProposedTaskDto Task)
+    └── AddProposedTaskHandler.cs
+
+backend/test/Anela.Heblo.Tests/Features/MeetingTasks/
+└── UpdateProposedTaskHandlerTests.cs    (all 3 happy-path tests + helper)
+```
+
+### Files to modify
+
+None. MediatR assembly scan in the existing `AddMeetingTasksModule` registration auto-picks the new handlers; no DI changes are needed.
+
+### Files referenced (must already exist on epic branch after Task 0)
+
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/ProposedTask.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/ProposedTaskStatus.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscriptStatus.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/IMeetingTranscriptRepository.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/Contracts/ProposedTaskDto.cs`
+- `backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs`
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`
+
+---
+
+## Working Tree Reference
+
+For convenience, here are the exact shapes of the types this plan depends on (taken verbatim from `origin/feat/meeting-task-validation-epic`):
+
+```csharp
+// Domain.Features.MeetingTasks.MeetingTranscript
+public class MeetingTranscript
+{
+    public Guid Id { get; set; }
+    public string PlaudRecordingId { get; set; } = null!;
+    public DateTime PlaudCreatedAt { get; set; }
+    public string Subject { get; set; } = null!;
+    public string Summary { get; set; } = null!;
+    public string RawTranscript { get; set; } = null!;
+    public MeetingTranscriptStatus Status { get; set; }
+    public DateTime ReceivedAt { get; set; }
+    public DateTime? ReviewedAt { get; set; }
+    public string? ReviewedByUser { get; set; }
+    public List<ProposedTask> Tasks { get; set; } = new();
+}
+
+// Domain.Features.MeetingTasks.ProposedTask
+public class ProposedTask
+{
+    public Guid Id { get; set; }
+    public Guid MeetingTranscriptId { get; set; }
+    public MeetingTranscript MeetingTranscript { get; set; } = null!;
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public string Assignee { get; set; } = null!;
+    public DateTime? DueDate { get; set; }
+    public ProposedTaskStatus Status { get; set; }
+    public string? ExternalTaskId { get; set; }
+    public bool IsManuallyAdded { get; set; }
+}
+
+// Domain.Features.MeetingTasks.ProposedTaskStatus
+public enum ProposedTaskStatus { Pending = 1, Approved = 2, Rejected = 3 }
+
+// Domain.Features.MeetingTasks.MeetingTranscriptStatus
+public enum MeetingTranscriptStatus { PendingReview = 1, Approved = 2, PartiallyApproved = 3 }
+
+// Domain.Features.MeetingTasks.IMeetingTranscriptRepository
+public interface IMeetingTranscriptRepository
+{
+    Task<MeetingTranscript?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(List<MeetingTranscript> Items, int TotalCount)> GetListAsync(
+        MeetingTranscriptStatus? statusFilter, int page, int pageSize, CancellationToken ct = default);
+    Task<bool> ExistsByPlaudIdAsync(string plaudRecordingId, CancellationToken ct = default);
+    Task AddAsync(MeetingTranscript transcript, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}
+
+// Application.Features.MeetingTasks.Contracts.ProposedTaskDto
+public class ProposedTaskDto
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public string Assignee { get; set; } = null!;
+    public DateTime? DueDate { get; set; }
+    public string Status { get; set; } = null!;
+    public string? ExternalTaskId { get; set; }
+    public bool IsManuallyAdded { get; set; }
+}
+
+// Application.Shared.ErrorCodes (relevant members only)
+public enum ErrorCodes
+{
+    ValidationError = 0001,    // [HttpStatusCode(HttpStatusCode.BadRequest)]
+    ResourceNotFound = 0006,   // [HttpStatusCode(HttpStatusCode.NotFound)]
+    // ...
+}
+
+// Application.Shared.BaseResponse (relevant members only)
+public abstract class BaseResponse
+{
+    public bool Success { get; set; } = true;
+    public ErrorCodes? ErrorCode { get; set; }
+    public Dictionary<string, string>? Params { get; set; }
+    protected BaseResponse() { Success = true; }
+    protected BaseResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+    {
+        Success = false;
+        ErrorCode = errorCode;
+        Params = parameters;
+    }
+}
+```
+
+---
+
+## Task 0: Rebase branch onto epic
+
+**Files:**
+- No source files. This task only changes the branch's git history.
+
+- [ ] **Step 1: Fetch the epic branch from origin**
+
+Run:
+
+```bash
+git fetch origin feat/meeting-task-validation-epic
+```
+
+Expected: command exits 0; `origin/feat/meeting-task-validation-epic` is now a known ref locally.
+
+- [ ] **Step 2: Confirm the current branch is not already based on the epic**
+
+Run:
+
+```bash
+git merge-base --is-ancestor origin/feat/meeting-task-validation-epic HEAD && echo OK || echo NEEDS_REBASE
+```
+
+Expected: `NEEDS_REBASE`. If `OK`, this task is already done — skip to Task 1.
+
+- [ ] **Step 3: Confirm the current branch has no commits beyond pipeline artifacts**
+
+Run:
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output: only artifact-upload commits (e.g., `agent: upload artifacts/...spec.r1.md`, `agent: upload artifacts/...arch-review.r1.md`, `agent: upload artifacts/...brief.md`). No source-code commits. If there are any source-code commits, STOP and ask before continuing — rebase strategy depends on what they contain.
+
+- [ ] **Step 4: Reset the branch onto the epic**
+
+Run:
+
+```bash
+git reset --hard origin/feat/meeting-task-validation-epic
+```
+
+Expected: working tree now reflects the epic branch tip. The pipeline-uploaded artifacts under `artifacts/feat-meeting-tasks-write-handlers-edit-approv/` will be gone from the working tree, but they remain available in `origin/feat-meeting-tasks-write-handlers-edit-approv` (unmodified upstream) and the brief is still accessible in the agent's context — no further action needed.
+
+- [ ] **Step 5: Verify the prerequisite files now exist**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs \
+   backend/src/Anela.Heblo.Domain/Features/MeetingTasks/ProposedTask.cs \
+   backend/src/Anela.Heblo.Domain/Features/MeetingTasks/IMeetingTranscriptRepository.cs \
+   backend/src/Anela.Heblo.Application/Features/MeetingTasks/Contracts/ProposedTaskDto.cs \
+   backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/GetTranscriptDetail/GetTranscriptDetailHandler.cs
+```
+
+Expected: all five files listed without errors.
+
+- [ ] **Step 6: Build to confirm the baseline compiles**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 7: Run existing MeetingTasks tests as a sanity check**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.MeetingTasks"
+```
+
+Expected: existing tests (`GetTranscriptDetailHandlerTests`, `GetTranscriptListHandlerTests`, `IngestPlaudRecordingHandlerTests`, etc.) all pass.
+
+- [ ] **Step 8: No commit for this task**
+
+The rebase itself is the commit boundary. Do not create a new commit. The next task's first commit will sit on top of the epic.
+
+---
+
+## Task 1: UpdateProposedTask — request, response, handler, test
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test (creates the test file and helper)**
+
+Create `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` with this content:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.MeetingTasks;
+
+public class UpdateProposedTaskHandlerTests
+{
+    private readonly Mock<IMeetingTranscriptRepository> _repositoryMock = new();
+
+    private MeetingTranscript CreateTranscriptWithTask(out Guid transcriptId, out Guid taskId)
+    {
+        transcriptId = Guid.NewGuid();
+        taskId = Guid.NewGuid();
+        var transcript = new MeetingTranscript
+        {
+            Id = transcriptId,
+            PlaudRecordingId = "rec-test",
+            PlaudCreatedAt = new DateTime(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc),
+            Subject = "Sprint Planning",
+            Summary = "Plan the sprint",
+            RawTranscript = "",
+            Status = MeetingTranscriptStatus.PendingReview,
+            ReceivedAt = new DateTime(2026, 5, 1, 9, 30, 0, DateTimeKind.Utc),
+            Tasks = new List<ProposedTask>
+            {
+                new ProposedTask
+                {
+                    Id = taskId,
+                    MeetingTranscriptId = transcriptId,
+                    Title = "Original title",
+                    Description = "Original description",
+                    Assignee = "alice",
+                    DueDate = null,
+                    Status = ProposedTaskStatus.Pending,
+                    IsManuallyAdded = false
+                }
+            }
+        };
+        return transcript;
+    }
+
+    [Fact]
+    public async Task UpdateTask_ModifiesFields()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskHandler>.Instance);
+        var request = new UpdateProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = taskId,
+            Title = "New title",
+            Description = "New description",
+            Assignee = "bob",
+            DueDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        var task = transcript.Tasks.Single();
+        task.Title.Should().Be("New title");
+        task.Description.Should().Be("New description");
+        task.Assignee.Should().Be("bob");
+        task.DueDate.Should().Be(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+> Note: This file references `AddProposedTask*` and `UpdateProposedTaskStatus*` types in its `using` block, which won't compile until Tasks 2 and 3 land. That is intentional — those two tests will be added in their respective tasks. For Task 1, comment out the two extra `using` lines that don't resolve yet **only if needed to compile the test for this task in isolation**. They will be re-added when Tasks 2 and 3 add their tests.
+
+Decision: leave both extra `using` lines commented out for now to keep the test file compiling between tasks. Use:
+
+```csharp
+// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+```
+
+The commented lines will be uncommented in Tasks 2 and 3.
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"
+```
+
+Expected: build failure. Errors should reference unresolved `UpdateProposedTaskHandler`, `UpdateProposedTaskRequest`. That's the RED state.
+
+- [ ] **Step 3: Create `UpdateProposedTaskRequest.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskRequest : IRequest<UpdateProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `UpdateProposedTaskResponse.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskResponse : BaseResponse
+{
+    public UpdateProposedTaskResponse() { }
+    public UpdateProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 5: Create `UpdateProposedTaskHandler.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskHandler : IRequestHandler<UpdateProposedTaskRequest, UpdateProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<UpdateProposedTaskHandler> _logger;
+
+    public UpdateProposedTaskHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<UpdateProposedTaskHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateProposedTaskResponse> Handle(UpdateProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating proposed task — TranscriptId: {TranscriptId}, TaskId: {TaskId}",
+            request.TranscriptId, request.TaskId);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task is null)
+        {
+            _logger.LogWarning(
+                "Proposed task {TaskId} not found on transcript {TranscriptId}",
+                request.TaskId, request.TranscriptId);
+            return new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        task.Title = request.Title;
+        task.Description = request.Description;
+        task.Assignee = request.Assignee;
+        task.DueDate = request.DueDate;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskResponse();
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.UpdateTask_ModifiesFields"
+```
+
+Expected: 1 test passed, 0 failed.
+
+- [ ] **Step 7: Build the application project for full type-check**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 8: Run `dotnet format` on changed files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+```
+
+Expected: command exits 0; no changes required (or whitespace cleanups applied).
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask \
+        backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat: add UpdateProposedTask handler for editing meeting task fields"
+```
+
+---
+
+## Task 2: UpdateProposedTaskStatus — request, response, handler, test
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` (uncomment `using` line, add second test)
+
+- [ ] **Step 1: Add the failing test**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`:
+
+a) Uncomment the previously commented `using` line:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+```
+
+b) Append this test method inside the class, after `UpdateTask_ModifiesFields`:
+
+```csharp
+[Fact]
+public async Task UpdateTaskStatus_ApprovesTask()
+{
+    // Arrange
+    var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+    _repositoryMock
+        .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transcript);
+    var handler = new UpdateProposedTaskStatusHandler(
+        _repositoryMock.Object,
+        NullLogger<UpdateProposedTaskStatusHandler>.Instance);
+    var request = new UpdateProposedTaskStatusRequest
+    {
+        TranscriptId = transcriptId,
+        TaskId = taskId,
+        Status = "Approved"
+    };
+
+    // Act
+    var result = await handler.Handle(request, CancellationToken.None);
+
+    // Assert
+    result.Success.Should().BeTrue();
+    result.ErrorCode.Should().BeNull();
+    transcript.Tasks.Single().Status.Should().Be(ProposedTaskStatus.Approved);
+    _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.UpdateTaskStatus_ApprovesTask"
+```
+
+Expected: build failure; errors reference `UpdateProposedTaskStatusHandler` and `UpdateProposedTaskStatusRequest`.
+
+- [ ] **Step 3: Create `UpdateProposedTaskStatusRequest.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusRequest : IRequest<UpdateProposedTaskStatusResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Status { get; set; } = null!;
+}
+```
+
+- [ ] **Step 4: Create `UpdateProposedTaskStatusResponse.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusResponse : BaseResponse
+{
+    public UpdateProposedTaskStatusResponse() { }
+    public UpdateProposedTaskStatusResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 5: Create `UpdateProposedTaskStatusHandler.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusHandler : IRequestHandler<UpdateProposedTaskStatusRequest, UpdateProposedTaskStatusResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<UpdateProposedTaskStatusHandler> _logger;
+
+    public UpdateProposedTaskStatusHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<UpdateProposedTaskStatusHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateProposedTaskStatusResponse> Handle(UpdateProposedTaskStatusRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating proposed task status — TranscriptId: {TranscriptId}, TaskId: {TaskId}, Status: {Status}",
+            request.TranscriptId, request.TaskId, request.Status);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task is null)
+        {
+            _logger.LogWarning(
+                "Proposed task {TaskId} not found on transcript {TranscriptId}",
+                request.TaskId, request.TranscriptId);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        if (!Enum.TryParse<ProposedTaskStatus>(request.Status, ignoreCase: true, out var newStatus))
+        {
+            _logger.LogWarning("Invalid proposed task status value: {Status}", request.Status);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ValidationError);
+        }
+
+        task.Status = newStatus;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskStatusResponse();
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.UpdateTaskStatus_ApprovesTask"
+```
+
+Expected: 1 test passed, 0 failed.
+
+- [ ] **Step 7: Build the application project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 8: Run `dotnet format` on changed files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+```
+
+Expected: exits 0.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus \
+        backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat: add UpdateProposedTaskStatus handler for task lifecycle transitions"
+```
+
+---
+
+## Task 3: AddProposedTask — request, response, handler, test
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` (uncomment `using` line, add third test)
+
+- [ ] **Step 1: Add the failing test**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`:
+
+a) Uncomment the previously commented `using` line:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+```
+
+b) Append this test method inside the class:
+
+```csharp
+[Fact]
+public async Task AddTask_CreatesManualTask()
+{
+    // Arrange
+    var transcript = CreateTranscriptWithTask(out var transcriptId, out _);
+    _repositoryMock
+        .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transcript);
+    var handler = new AddProposedTaskHandler(
+        _repositoryMock.Object,
+        NullLogger<AddProposedTaskHandler>.Instance);
+    var dueDate = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+    var request = new AddProposedTaskRequest
+    {
+        TranscriptId = transcriptId,
+        Title = "Manually added task",
+        Description = "Added by reviewer",
+        Assignee = "carol",
+        DueDate = dueDate
+    };
+
+    // Act
+    var result = await handler.Handle(request, CancellationToken.None);
+
+    // Assert
+    result.Success.Should().BeTrue();
+    result.ErrorCode.Should().BeNull();
+    result.Task.Should().NotBeNull();
+    result.Task.Title.Should().Be("Manually added task");
+    result.Task.Description.Should().Be("Added by reviewer");
+    result.Task.Assignee.Should().Be("carol");
+    result.Task.DueDate.Should().Be(dueDate);
+    result.Task.Status.Should().Be("Pending");
+    result.Task.IsManuallyAdded.Should().BeTrue();
+    result.Task.ExternalTaskId.Should().BeNull();
+
+    transcript.Tasks.Should().HaveCount(2);
+    var addedEntity = transcript.Tasks.Last();
+    addedEntity.Title.Should().Be("Manually added task");
+    addedEntity.IsManuallyAdded.Should().BeTrue();
+    addedEntity.Status.Should().Be(ProposedTaskStatus.Pending);
+    addedEntity.MeetingTranscriptId.Should().Be(transcriptId);
+    result.Task.Id.Should().Be(addedEntity.Id);
+    _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.AddTask_CreatesManualTask"
+```
+
+Expected: build failure; errors reference `AddProposedTaskHandler`, `AddProposedTaskRequest`.
+
+- [ ] **Step 3: Create `AddProposedTaskRequest.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskRequest : IRequest<AddProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `AddProposedTaskResponse.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskResponse : BaseResponse
+{
+    public AddProposedTaskResponse() { }
+    public AddProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+
+    public ProposedTaskDto Task { get; set; } = null!;
+}
+```
+
+- [ ] **Step 5: Create `AddProposedTaskHandler.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskHandler : IRequestHandler<AddProposedTaskRequest, AddProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<AddProposedTaskHandler> _logger;
+
+    public AddProposedTaskHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<AddProposedTaskHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<AddProposedTaskResponse> Handle(AddProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Adding manual proposed task — TranscriptId: {TranscriptId}, Title: {Title}",
+            request.TranscriptId, request.Title);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new AddProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = new ProposedTask
+        {
+            Id = Guid.NewGuid(),
+            MeetingTranscriptId = transcript.Id,
+            Title = request.Title,
+            Description = request.Description,
+            Assignee = request.Assignee,
+            DueDate = request.DueDate,
+            Status = ProposedTaskStatus.Pending,
+            ExternalTaskId = null,
+            IsManuallyAdded = true
+        };
+
+        transcript.Tasks.Add(task);
+
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return new AddProposedTaskResponse
+        {
+            Task = new ProposedTaskDto
+            {
+                Id = task.Id,
+                Title = task.Title,
+                Description = task.Description,
+                Assignee = task.Assignee,
+                DueDate = task.DueDate,
+                Status = task.Status.ToString(),
+                ExternalTaskId = task.ExternalTaskId,
+                IsManuallyAdded = task.IsManuallyAdded
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.AddTask_CreatesManualTask"
+```
+
+Expected: 1 test passed, 0 failed.
+
+- [ ] **Step 7: Run all three tests together**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"
+```
+
+Expected: 3 tests passed (`UpdateTask_ModifiesFields`, `UpdateTaskStatus_ApprovesTask`, `AddTask_CreatesManualTask`).
+
+- [ ] **Step 8: Build the application project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 9: Run `dotnet format` on changed files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+```
+
+Expected: exits 0.
+
+- [ ] **Step 10: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask \
+        backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat: add AddProposedTask handler for manually appending tasks"
+```
+
+---
+
+## Task 4: Final validation
+
+**Files:** No file changes — verification only.
+
+- [ ] **Step 1: Build the full backend solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` across all projects.
+
+- [ ] **Step 2: Run all MeetingTasks tests (new + existing siblings) together**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.MeetingTasks"
+```
+
+Expected: all tests pass, including the three new ones and the prior `GetTranscriptDetailHandlerTests`, `GetTranscriptListHandlerTests`, `IngestPlaudRecordingHandlerTests`. No regressions.
+
+- [ ] **Step 3: Run the full backend test suite as a regression net**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: all tests pass. If any unrelated test fails, investigate before reporting completion — it likely indicates the rebase pulled in flaky tests from the epic, not an issue introduced by this work.
+
+- [ ] **Step 4: Run `dotnet format` over the whole solution**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exits 0. If it reports unformatted files among the new files, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`), commit the formatting fix as a follow-up `chore:` commit, then re-run with `--verify-no-changes`.
+
+- [ ] **Step 5: Verify PR target — confirm the branch is up to date with the epic**
+
+Run:
+
+```bash
+git fetch origin feat/meeting-task-validation-epic
+git merge-base --is-ancestor origin/feat/meeting-task-validation-epic HEAD && echo OK || echo STALE
+```
+
+Expected: `OK`. If `STALE`, rebase onto the latest epic tip before opening the PR.
+
+- [ ] **Step 6: No commit for this task**
+
+This task is verification-only.
+
+---
+
+## Specification Amendments Incorporated
+
+The architecture review identified amendments to the original spec. They are baked into this plan:
+
+1. `ErrorCodes.NotFound` → `ErrorCodes.ResourceNotFound` everywhere (the actual enum member, used by sibling `GetTranscriptDetailHandler`).
+2. Test helper `CreateTranscriptWithTask` uses real `MeetingTranscript` fields: `PlaudRecordingId`, `PlaudCreatedAt`, `Subject`, `Summary`, `RawTranscript`, `Status`, `ReceivedAt`. The spec's `SourceEmail` field does not exist on the entity.
+3. Requests are typed `IRequest<TConcreteResponse>` (e.g., `IRequest<UpdateProposedTaskResponse>`), not `IRequest<BaseResponse>`, so callers see the concrete shape.
+4. Handlers inject `ILogger<THandler>` and emit `LogInformation` on entry / `LogWarning` on not-found / invalid status. Matches `GetTranscriptDetailHandler` and `IngestPlaudRecordingHandler`.
+5. Each response lives in its own `*Response.cs` file under the UseCase folder.
+6. Error responses use the constructor-overload form: `new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound)`.
+7. Tests use FluentAssertions + `NullLogger<THandler>.Instance` + `Mock.Verify(r => r.SaveChangesAsync(...), Times.Once)` — matches `GetTranscriptDetailHandlerTests`.
+8. `AddProposedTaskHandler` explicitly sets `ExternalTaskId = null` on the response DTO for symmetry with the read handler.
+
+## Out-of-Scope Items (Documented in Spec)
+
+These are not implemented by this plan:
+
+- MVC controller endpoints
+- Authorization checks (handled at the controller layer)
+- Frontend UI
+- Status transition rules (e.g., disallowing Approved→Pending) — handler accepts any valid `ProposedTaskStatus`
+- Domain events, audit logging, notifications
+- Validation that the transcript is in `PendingReview` before edits
+- Bulk approve/reject
+- Optimistic concurrency / `RowVersion`
+- E2E tests
+- OpenAPI/Swagger DTO surface
+- Updating `transcript.Status` / `ReviewedAt` / `ReviewedByUser` when all tasks are reviewed

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs
@@ -1,0 +1,70 @@
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskHandler : IRequestHandler<AddProposedTaskRequest, AddProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<AddProposedTaskHandler> _logger;
+
+    public AddProposedTaskHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<AddProposedTaskHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<AddProposedTaskResponse> Handle(
+        AddProposedTaskRequest request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Adding manual proposed task — TranscriptId: {TranscriptId}, Title: {Title}",
+            request.TranscriptId,
+            request.Title);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new AddProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = new ProposedTask
+        {
+            Id = Guid.NewGuid(),
+            MeetingTranscriptId = transcript.Id,
+            Title = request.Title,
+            Description = request.Description,
+            Assignee = request.Assignee,
+            DueDate = request.DueDate,
+            Status = ProposedTaskStatus.Pending,
+            ExternalTaskId = null,
+            IsManuallyAdded = true
+        };
+
+        transcript.Tasks.Add(task);
+
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return new AddProposedTaskResponse
+        {
+            Task = new ProposedTaskDto
+            {
+                Id = task.Id,
+                Title = task.Title,
+                Description = task.Description,
+                Assignee = task.Assignee,
+                DueDate = task.DueDate,
+                Status = task.Status.ToString(),
+                ExternalTaskId = task.ExternalTaskId,
+                IsManuallyAdded = task.IsManuallyAdded
+            }
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskRequest : IRequest<AddProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs
@@ -1,0 +1,13 @@
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskResponse : BaseResponse
+{
+    public AddProposedTaskResponse() { }
+
+    public AddProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+
+    public ProposedTaskDto? Task { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/IngestPlaudRecording/IngestPlaudRecordingResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/IngestPlaudRecording/IngestPlaudRecordingResponse.cs
@@ -1,8 +1,9 @@
+using Anela.Heblo.Application.Shared;
+
 namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.IngestPlaudRecording;
 
-public class IngestPlaudRecordingResponse
+public class IngestPlaudRecordingResponse : BaseResponse
 {
-    public bool Success { get; set; } = true;
     public bool Skipped { get; set; }
     public Guid? TranscriptId { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs
@@ -1,0 +1,51 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskHandler : IRequestHandler<UpdateProposedTaskRequest, UpdateProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<UpdateProposedTaskHandler> _logger;
+
+    public UpdateProposedTaskHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<UpdateProposedTaskHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateProposedTaskResponse> Handle(UpdateProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating proposed task — TranscriptId: {TranscriptId}, TaskId: {TaskId}",
+            request.TranscriptId, request.TaskId);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task is null)
+        {
+            _logger.LogWarning(
+                "Proposed task {TaskId} not found on transcript {TranscriptId}",
+                request.TaskId, request.TranscriptId);
+            return new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        task.Title = request.Title;
+        task.Description = request.Description;
+        task.Assignee = request.Assignee;
+        task.DueDate = request.DueDate;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskResponse();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskRequest : IRequest<UpdateProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs
@@ -1,0 +1,9 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskResponse : BaseResponse
+{
+    public UpdateProposedTaskResponse() { }
+    public UpdateProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs
@@ -1,0 +1,54 @@
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusHandler : IRequestHandler<UpdateProposedTaskStatusRequest, UpdateProposedTaskStatusResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<UpdateProposedTaskStatusHandler> _logger;
+
+    public UpdateProposedTaskStatusHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<UpdateProposedTaskStatusHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateProposedTaskStatusResponse> Handle(UpdateProposedTaskStatusRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating proposed task status — TranscriptId: {TranscriptId}, TaskId: {TaskId}, Status: {Status}",
+            request.TranscriptId, request.TaskId, request.Status);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task is null)
+        {
+            _logger.LogWarning(
+                "Proposed task {TaskId} not found on transcript {TranscriptId}",
+                request.TaskId, request.TranscriptId);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        if (!Enum.TryParse<ProposedTaskStatus>(request.Status, ignoreCase: true, out var newStatus))
+        {
+            _logger.LogWarning("Invalid proposed task status value: {Status}", request.Status);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ValidationError);
+        }
+
+        task.Status = newStatus;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskStatusResponse();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusRequest : IRequest<UpdateProposedTaskStatusResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Status { get; set; } = null!;
+}

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs
@@ -1,0 +1,9 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusResponse : BaseResponse
+{
+    public UpdateProposedTaskStatusResponse() { }
+    public UpdateProposedTaskStatusResponse(ErrorCodes errorCode) : base(errorCode) { }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
@@ -80,4 +80,64 @@ public class UpdateProposedTaskHandlerTests
         task.DueDate.Should().Be(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
         _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task UpdateTask_ReturnsNotFound_WhenTranscriptMissing()
+    {
+        // Arrange
+        var transcriptId = Guid.NewGuid();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MeetingTranscript?)null);
+        var handler = new UpdateProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskHandler>.Instance);
+        var request = new UpdateProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = Guid.NewGuid(),
+            Title = "Some title",
+            Description = "Some description",
+            Assignee = "alice",
+            DueDate = null
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTask_ReturnsNotFound_WhenTaskMissing()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out _);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskHandler>.Instance);
+        var request = new UpdateProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = Guid.NewGuid(), // non-existent task ID
+            Title = "Some title",
+            Description = "Some description",
+            Assignee = "alice",
+            DueDate = null
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
@@ -1,0 +1,83 @@
+// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.MeetingTasks;
+
+public class UpdateProposedTaskHandlerTests
+{
+    private readonly Mock<IMeetingTranscriptRepository> _repositoryMock = new();
+
+    private MeetingTranscript CreateTranscriptWithTask(out Guid transcriptId, out Guid taskId)
+    {
+        transcriptId = Guid.NewGuid();
+        taskId = Guid.NewGuid();
+        var transcript = new MeetingTranscript
+        {
+            Id = transcriptId,
+            PlaudRecordingId = "rec-test",
+            PlaudCreatedAt = new DateTime(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc),
+            Subject = "Sprint Planning",
+            Summary = "Plan the sprint",
+            RawTranscript = "",
+            Status = MeetingTranscriptStatus.PendingReview,
+            ReceivedAt = new DateTime(2026, 5, 1, 9, 30, 0, DateTimeKind.Utc),
+            Tasks = new List<ProposedTask>
+            {
+                new ProposedTask
+                {
+                    Id = taskId,
+                    MeetingTranscriptId = transcriptId,
+                    Title = "Original title",
+                    Description = "Original description",
+                    Assignee = "alice",
+                    DueDate = null,
+                    Status = ProposedTaskStatus.Pending,
+                    IsManuallyAdded = false
+                }
+            }
+        };
+        return transcript;
+    }
+
+    [Fact]
+    public async Task UpdateTask_ModifiesFields()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskHandler>.Instance);
+        var request = new UpdateProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = taskId,
+            Title = "New title",
+            Description = "New description",
+            Assignee = "bob",
+            DueDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        var task = transcript.Tasks.Single();
+        task.Title.Should().Be("New title");
+        task.Description.Should().Be("New description");
+        task.Assignee.Should().Be("bob");
+        task.DueDate.Should().Be(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
@@ -1,5 +1,5 @@
 // using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
-// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
 using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.MeetingTasks;
@@ -138,6 +138,115 @@ public class UpdateProposedTaskHandlerTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatus_ApprovesTask()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskStatusHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskStatusHandler>.Instance);
+        var request = new UpdateProposedTaskStatusRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = taskId,
+            Status = "Approved"
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        transcript.Tasks.Single().Status.Should().Be(ProposedTaskStatus.Approved);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatus_ReturnsNotFound_WhenTranscriptMissing()
+    {
+        // Arrange
+        var transcriptId = Guid.NewGuid();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MeetingTranscript?)null);
+        var handler = new UpdateProposedTaskStatusHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskStatusHandler>.Instance);
+        var request = new UpdateProposedTaskStatusRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = Guid.NewGuid(),
+            Status = "Approved"
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatus_ReturnsNotFound_WhenTaskMissing()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out _);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskStatusHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskStatusHandler>.Instance);
+        var request = new UpdateProposedTaskStatusRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = Guid.NewGuid(), // non-existent task ID
+            Status = "Approved"
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateTaskStatus_ReturnsValidationError_WhenStatusInvalid()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskStatusHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskStatusHandler>.Instance);
+        var request = new UpdateProposedTaskStatusRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = taskId,
+            Status = "InvalidStatusXYZ"
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
         _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
@@ -1,4 +1,4 @@
-// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
 using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
 using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
 using Anela.Heblo.Application.Shared;
@@ -247,6 +247,82 @@ public class UpdateProposedTaskHandlerTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AddTask_CreatesManualTask()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out _);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new AddProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<AddProposedTaskHandler>.Instance);
+        var dueDate = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        var request = new AddProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            Title = "Manually added task",
+            Description = "Added by reviewer",
+            Assignee = "carol",
+            DueDate = dueDate
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        result.Task.Should().NotBeNull();
+        result.Task.Title.Should().Be("Manually added task");
+        result.Task.Description.Should().Be("Added by reviewer");
+        result.Task.Assignee.Should().Be("carol");
+        result.Task.DueDate.Should().Be(dueDate);
+        result.Task.Status.Should().Be("Pending");
+        result.Task.IsManuallyAdded.Should().BeTrue();
+        result.Task.ExternalTaskId.Should().BeNull();
+
+        transcript.Tasks.Should().HaveCount(2);
+        var addedEntity = transcript.Tasks.Last();
+        addedEntity.Title.Should().Be("Manually added task");
+        addedEntity.IsManuallyAdded.Should().BeTrue();
+        addedEntity.Status.Should().Be(ProposedTaskStatus.Pending);
+        addedEntity.MeetingTranscriptId.Should().Be(transcriptId);
+        result.Task.Id.Should().Be(addedEntity.Id);
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddTask_ReturnsNotFound_WhenTranscriptMissing()
+    {
+        // Arrange
+        var transcriptId = Guid.NewGuid();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MeetingTranscript?)null);
+        var handler = new AddProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<AddProposedTaskHandler>.Instance);
+        var request = new AddProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            Title = "Some task",
+            Description = "Some description",
+            Assignee = "alice",
+            DueDate = null
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ResourceNotFound);
+        result.Task.Should().BeNull();
         _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/docs/superpowers/plans/2026-05-13-meeting-task-write-handlers.md
+++ b/docs/superpowers/plans/2026-05-13-meeting-task-write-handlers.md
@@ -1,0 +1,1049 @@
+# Meeting Task Write Handlers — Edit, Approve/Reject, Add Task — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three MediatR write-side handlers — `UpdateProposedTask`, `UpdateProposedTaskStatus`, `AddProposedTask` — to the Meeting Tasks vertical slice so users can edit, approve/reject, and manually add tasks on a `MeetingTranscript` aggregate.
+
+**Architecture:** Three independent UseCase folders under `Application/Features/MeetingTasks/UseCases/`, each containing a request/response/handler triple following the sibling `GetTranscriptDetail` convention. Handlers load the aggregate via `IMeetingTranscriptRepository.GetByIdAsync`, mutate via EF Core change tracking, persist via `SaveChangesAsync`, and return a `BaseResponse`-derived response carrying `ErrorCodes.ResourceNotFound` / `ErrorCodes.ValidationError` for known failures. No DI changes (MediatR scan picks up handlers), no schema changes, no controller wiring (out of scope).
+
+**Tech Stack:** .NET 8, C#, MediatR, EF Core (via existing repository), xUnit + Moq + FluentAssertions + `NullLogger<T>` for tests.
+
+---
+
+## Prerequisites
+
+This worktree branch (`feat-meeting-tasks-write-handlers-edit-approv`) was created from `main`. The epic branch `feat/meeting-task-validation-epic` contains the entire prerequisite chain (domain entities, enum, repository interface + implementation, `ProposedTaskDto`, sibling handlers, EF migration). **None of those files exist on disk in this worktree.** Task 0 below rebases this branch onto the epic so that all referenced types resolve. Do not skip it — every subsequent task will fail to compile otherwise.
+
+The PR target for this work is `feat/meeting-task-validation-epic`, not `main`.
+
+---
+
+## File Structure
+
+### Files to create
+
+```
+backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/
+├── UpdateProposedTask/
+│   ├── UpdateProposedTaskRequest.cs    (request DTO, IRequest<UpdateProposedTaskResponse>)
+│   ├── UpdateProposedTaskResponse.cs   (response, BaseResponse-derived)
+│   └── UpdateProposedTaskHandler.cs    (handler with logger + repo)
+├── UpdateProposedTaskStatus/
+│   ├── UpdateProposedTaskStatusRequest.cs
+│   ├── UpdateProposedTaskStatusResponse.cs
+│   └── UpdateProposedTaskStatusHandler.cs
+└── AddProposedTask/
+    ├── AddProposedTaskRequest.cs
+    ├── AddProposedTaskResponse.cs       (carries ProposedTaskDto Task)
+    └── AddProposedTaskHandler.cs
+
+backend/test/Anela.Heblo.Tests/Features/MeetingTasks/
+└── UpdateProposedTaskHandlerTests.cs    (all 3 happy-path tests + helper)
+```
+
+### Files to modify
+
+None. MediatR assembly scan in the existing `AddMeetingTasksModule` registration auto-picks the new handlers; no DI changes are needed.
+
+### Files referenced (must already exist on epic branch after Task 0)
+
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/ProposedTask.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/ProposedTaskStatus.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscriptStatus.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MeetingTasks/IMeetingTranscriptRepository.cs`
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/Contracts/ProposedTaskDto.cs`
+- `backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs`
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`
+
+---
+
+## Working Tree Reference
+
+For convenience, here are the exact shapes of the types this plan depends on (taken verbatim from `origin/feat/meeting-task-validation-epic`):
+
+```csharp
+// Domain.Features.MeetingTasks.MeetingTranscript
+public class MeetingTranscript
+{
+    public Guid Id { get; set; }
+    public string PlaudRecordingId { get; set; } = null!;
+    public DateTime PlaudCreatedAt { get; set; }
+    public string Subject { get; set; } = null!;
+    public string Summary { get; set; } = null!;
+    public string RawTranscript { get; set; } = null!;
+    public MeetingTranscriptStatus Status { get; set; }
+    public DateTime ReceivedAt { get; set; }
+    public DateTime? ReviewedAt { get; set; }
+    public string? ReviewedByUser { get; set; }
+    public List<ProposedTask> Tasks { get; set; } = new();
+}
+
+// Domain.Features.MeetingTasks.ProposedTask
+public class ProposedTask
+{
+    public Guid Id { get; set; }
+    public Guid MeetingTranscriptId { get; set; }
+    public MeetingTranscript MeetingTranscript { get; set; } = null!;
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public string Assignee { get; set; } = null!;
+    public DateTime? DueDate { get; set; }
+    public ProposedTaskStatus Status { get; set; }
+    public string? ExternalTaskId { get; set; }
+    public bool IsManuallyAdded { get; set; }
+}
+
+// Domain.Features.MeetingTasks.ProposedTaskStatus
+public enum ProposedTaskStatus { Pending = 1, Approved = 2, Rejected = 3 }
+
+// Domain.Features.MeetingTasks.MeetingTranscriptStatus
+public enum MeetingTranscriptStatus { PendingReview = 1, Approved = 2, PartiallyApproved = 3 }
+
+// Domain.Features.MeetingTasks.IMeetingTranscriptRepository
+public interface IMeetingTranscriptRepository
+{
+    Task<MeetingTranscript?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(List<MeetingTranscript> Items, int TotalCount)> GetListAsync(
+        MeetingTranscriptStatus? statusFilter, int page, int pageSize, CancellationToken ct = default);
+    Task<bool> ExistsByPlaudIdAsync(string plaudRecordingId, CancellationToken ct = default);
+    Task AddAsync(MeetingTranscript transcript, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}
+
+// Application.Features.MeetingTasks.Contracts.ProposedTaskDto
+public class ProposedTaskDto
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public string Assignee { get; set; } = null!;
+    public DateTime? DueDate { get; set; }
+    public string Status { get; set; } = null!;
+    public string? ExternalTaskId { get; set; }
+    public bool IsManuallyAdded { get; set; }
+}
+
+// Application.Shared.ErrorCodes (relevant members only)
+public enum ErrorCodes
+{
+    ValidationError = 0001,    // [HttpStatusCode(HttpStatusCode.BadRequest)]
+    ResourceNotFound = 0006,   // [HttpStatusCode(HttpStatusCode.NotFound)]
+    // ...
+}
+
+// Application.Shared.BaseResponse (relevant members only)
+public abstract class BaseResponse
+{
+    public bool Success { get; set; } = true;
+    public ErrorCodes? ErrorCode { get; set; }
+    public Dictionary<string, string>? Params { get; set; }
+    protected BaseResponse() { Success = true; }
+    protected BaseResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+    {
+        Success = false;
+        ErrorCode = errorCode;
+        Params = parameters;
+    }
+}
+```
+
+---
+
+## Task 0: Rebase branch onto epic
+
+**Files:**
+- No source files. This task only changes the branch's git history.
+
+- [ ] **Step 1: Fetch the epic branch from origin**
+
+Run:
+
+```bash
+git fetch origin feat/meeting-task-validation-epic
+```
+
+Expected: command exits 0; `origin/feat/meeting-task-validation-epic` is now a known ref locally.
+
+- [ ] **Step 2: Confirm the current branch is not already based on the epic**
+
+Run:
+
+```bash
+git merge-base --is-ancestor origin/feat/meeting-task-validation-epic HEAD && echo OK || echo NEEDS_REBASE
+```
+
+Expected: `NEEDS_REBASE`. If `OK`, this task is already done — skip to Task 1.
+
+- [ ] **Step 3: Confirm the current branch has no commits beyond pipeline artifacts**
+
+Run:
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected output: only artifact-upload commits (e.g., `agent: upload artifacts/...spec.r1.md`, `agent: upload artifacts/...arch-review.r1.md`, `agent: upload artifacts/...brief.md`). No source-code commits. If there are any source-code commits, STOP and ask before continuing — rebase strategy depends on what they contain.
+
+- [ ] **Step 4: Reset the branch onto the epic**
+
+Run:
+
+```bash
+git reset --hard origin/feat/meeting-task-validation-epic
+```
+
+Expected: working tree now reflects the epic branch tip. The pipeline-uploaded artifacts under `artifacts/feat-meeting-tasks-write-handlers-edit-approv/` will be gone from the working tree, but they remain available in `origin/feat-meeting-tasks-write-handlers-edit-approv` (unmodified upstream) and the brief is still accessible in the agent's context — no further action needed.
+
+- [ ] **Step 5: Verify the prerequisite files now exist**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Domain/Features/MeetingTasks/MeetingTranscript.cs \
+   backend/src/Anela.Heblo.Domain/Features/MeetingTasks/ProposedTask.cs \
+   backend/src/Anela.Heblo.Domain/Features/MeetingTasks/IMeetingTranscriptRepository.cs \
+   backend/src/Anela.Heblo.Application/Features/MeetingTasks/Contracts/ProposedTaskDto.cs \
+   backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/GetTranscriptDetail/GetTranscriptDetailHandler.cs
+```
+
+Expected: all five files listed without errors.
+
+- [ ] **Step 6: Build to confirm the baseline compiles**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 7: Run existing MeetingTasks tests as a sanity check**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.MeetingTasks"
+```
+
+Expected: existing tests (`GetTranscriptDetailHandlerTests`, `GetTranscriptListHandlerTests`, `IngestPlaudRecordingHandlerTests`, etc.) all pass.
+
+- [ ] **Step 8: No commit for this task**
+
+The rebase itself is the commit boundary. Do not create a new commit. The next task's first commit will sit on top of the epic.
+
+---
+
+## Task 1: UpdateProposedTask — request, response, handler, test
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`
+
+- [ ] **Step 1: Write the failing test (creates the test file and helper)**
+
+Create `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` with this content:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.MeetingTasks;
+
+public class UpdateProposedTaskHandlerTests
+{
+    private readonly Mock<IMeetingTranscriptRepository> _repositoryMock = new();
+
+    private MeetingTranscript CreateTranscriptWithTask(out Guid transcriptId, out Guid taskId)
+    {
+        transcriptId = Guid.NewGuid();
+        taskId = Guid.NewGuid();
+        var transcript = new MeetingTranscript
+        {
+            Id = transcriptId,
+            PlaudRecordingId = "rec-test",
+            PlaudCreatedAt = new DateTime(2026, 5, 1, 9, 0, 0, DateTimeKind.Utc),
+            Subject = "Sprint Planning",
+            Summary = "Plan the sprint",
+            RawTranscript = "",
+            Status = MeetingTranscriptStatus.PendingReview,
+            ReceivedAt = new DateTime(2026, 5, 1, 9, 30, 0, DateTimeKind.Utc),
+            Tasks = new List<ProposedTask>
+            {
+                new ProposedTask
+                {
+                    Id = taskId,
+                    MeetingTranscriptId = transcriptId,
+                    Title = "Original title",
+                    Description = "Original description",
+                    Assignee = "alice",
+                    DueDate = null,
+                    Status = ProposedTaskStatus.Pending,
+                    IsManuallyAdded = false
+                }
+            }
+        };
+        return transcript;
+    }
+
+    [Fact]
+    public async Task UpdateTask_ModifiesFields()
+    {
+        // Arrange
+        var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transcript);
+        var handler = new UpdateProposedTaskHandler(
+            _repositoryMock.Object,
+            NullLogger<UpdateProposedTaskHandler>.Instance);
+        var request = new UpdateProposedTaskRequest
+        {
+            TranscriptId = transcriptId,
+            TaskId = taskId,
+            Title = "New title",
+            Description = "New description",
+            Assignee = "bob",
+            DueDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+        var task = transcript.Tasks.Single();
+        task.Title.Should().Be("New title");
+        task.Description.Should().Be("New description");
+        task.Assignee.Should().Be("bob");
+        task.DueDate.Should().Be(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+> Note: This file references `AddProposedTask*` and `UpdateProposedTaskStatus*` types in its `using` block, which won't compile until Tasks 2 and 3 land. That is intentional — those two tests will be added in their respective tasks. For Task 1, comment out the two extra `using` lines that don't resolve yet **only if needed to compile the test for this task in isolation**. They will be re-added when Tasks 2 and 3 add their tests.
+
+Decision: leave both extra `using` lines commented out for now to keep the test file compiling between tasks. Use:
+
+```csharp
+// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+// using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+```
+
+The commented lines will be uncommented in Tasks 2 and 3.
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"
+```
+
+Expected: build failure. Errors should reference unresolved `UpdateProposedTaskHandler`, `UpdateProposedTaskRequest`. That's the RED state.
+
+- [ ] **Step 3: Create `UpdateProposedTaskRequest.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskRequest : IRequest<UpdateProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `UpdateProposedTaskResponse.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskResponse : BaseResponse
+{
+    public UpdateProposedTaskResponse() { }
+    public UpdateProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 5: Create `UpdateProposedTaskHandler.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTask;
+
+public class UpdateProposedTaskHandler : IRequestHandler<UpdateProposedTaskRequest, UpdateProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<UpdateProposedTaskHandler> _logger;
+
+    public UpdateProposedTaskHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<UpdateProposedTaskHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateProposedTaskResponse> Handle(UpdateProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating proposed task — TranscriptId: {TranscriptId}, TaskId: {TaskId}",
+            request.TranscriptId, request.TaskId);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task is null)
+        {
+            _logger.LogWarning(
+                "Proposed task {TaskId} not found on transcript {TranscriptId}",
+                request.TaskId, request.TranscriptId);
+            return new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        task.Title = request.Title;
+        task.Description = request.Description;
+        task.Assignee = request.Assignee;
+        task.DueDate = request.DueDate;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskResponse();
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.UpdateTask_ModifiesFields"
+```
+
+Expected: 1 test passed, 0 failed.
+
+- [ ] **Step 7: Build the application project for full type-check**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 8: Run `dotnet format` on changed files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask/UpdateProposedTaskHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+```
+
+Expected: command exits 0; no changes required (or whitespace cleanups applied).
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTask \
+        backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat: add UpdateProposedTask handler for editing meeting task fields"
+```
+
+---
+
+## Task 2: UpdateProposedTaskStatus — request, response, handler, test
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` (uncomment `using` line, add second test)
+
+- [ ] **Step 1: Add the failing test**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`:
+
+a) Uncomment the previously commented `using` line:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+```
+
+b) Append this test method inside the class, after `UpdateTask_ModifiesFields`:
+
+```csharp
+[Fact]
+public async Task UpdateTaskStatus_ApprovesTask()
+{
+    // Arrange
+    var transcript = CreateTranscriptWithTask(out var transcriptId, out var taskId);
+    _repositoryMock
+        .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transcript);
+    var handler = new UpdateProposedTaskStatusHandler(
+        _repositoryMock.Object,
+        NullLogger<UpdateProposedTaskStatusHandler>.Instance);
+    var request = new UpdateProposedTaskStatusRequest
+    {
+        TranscriptId = transcriptId,
+        TaskId = taskId,
+        Status = "Approved"
+    };
+
+    // Act
+    var result = await handler.Handle(request, CancellationToken.None);
+
+    // Assert
+    result.Success.Should().BeTrue();
+    result.ErrorCode.Should().BeNull();
+    transcript.Tasks.Single().Status.Should().Be(ProposedTaskStatus.Approved);
+    _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.UpdateTaskStatus_ApprovesTask"
+```
+
+Expected: build failure; errors reference `UpdateProposedTaskStatusHandler` and `UpdateProposedTaskStatusRequest`.
+
+- [ ] **Step 3: Create `UpdateProposedTaskStatusRequest.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusRequest : IRequest<UpdateProposedTaskStatusResponse>
+{
+    public Guid TranscriptId { get; set; }
+    public Guid TaskId { get; set; }
+
+    [Required]
+    public string Status { get; set; } = null!;
+}
+```
+
+- [ ] **Step 4: Create `UpdateProposedTaskStatusResponse.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusResponse : BaseResponse
+{
+    public UpdateProposedTaskStatusResponse() { }
+    public UpdateProposedTaskStatusResponse(ErrorCodes errorCode) : base(errorCode) { }
+}
+```
+
+- [ ] **Step 5: Create `UpdateProposedTaskStatusHandler.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.UpdateProposedTaskStatus;
+
+public class UpdateProposedTaskStatusHandler : IRequestHandler<UpdateProposedTaskStatusRequest, UpdateProposedTaskStatusResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<UpdateProposedTaskStatusHandler> _logger;
+
+    public UpdateProposedTaskStatusHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<UpdateProposedTaskStatusHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<UpdateProposedTaskStatusResponse> Handle(UpdateProposedTaskStatusRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Updating proposed task status — TranscriptId: {TranscriptId}, TaskId: {TaskId}, Status: {Status}",
+            request.TranscriptId, request.TaskId, request.Status);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = transcript.Tasks.FirstOrDefault(t => t.Id == request.TaskId);
+        if (task is null)
+        {
+            _logger.LogWarning(
+                "Proposed task {TaskId} not found on transcript {TranscriptId}",
+                request.TaskId, request.TranscriptId);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        if (!Enum.TryParse<ProposedTaskStatus>(request.Status, ignoreCase: true, out var newStatus))
+        {
+            _logger.LogWarning("Invalid proposed task status value: {Status}", request.Status);
+            return new UpdateProposedTaskStatusResponse(ErrorCodes.ValidationError);
+        }
+
+        task.Status = newStatus;
+
+        await _repository.SaveChangesAsync(cancellationToken);
+        return new UpdateProposedTaskStatusResponse();
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.UpdateTaskStatus_ApprovesTask"
+```
+
+Expected: 1 test passed, 0 failed.
+
+- [ ] **Step 7: Build the application project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 8: Run `dotnet format` on changed files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus/UpdateProposedTaskStatusHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+```
+
+Expected: exits 0.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/UpdateProposedTaskStatus \
+        backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat: add UpdateProposedTaskStatus handler for task lifecycle transitions"
+```
+
+---
+
+## Task 3: AddProposedTask — request, response, handler, test
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` (uncomment `using` line, add third test)
+
+- [ ] **Step 1: Add the failing test**
+
+Edit `backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs`:
+
+a) Uncomment the previously commented `using` line:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+```
+
+b) Append this test method inside the class:
+
+```csharp
+[Fact]
+public async Task AddTask_CreatesManualTask()
+{
+    // Arrange
+    var transcript = CreateTranscriptWithTask(out var transcriptId, out _);
+    _repositoryMock
+        .Setup(r => r.GetByIdAsync(transcriptId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transcript);
+    var handler = new AddProposedTaskHandler(
+        _repositoryMock.Object,
+        NullLogger<AddProposedTaskHandler>.Instance);
+    var dueDate = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+    var request = new AddProposedTaskRequest
+    {
+        TranscriptId = transcriptId,
+        Title = "Manually added task",
+        Description = "Added by reviewer",
+        Assignee = "carol",
+        DueDate = dueDate
+    };
+
+    // Act
+    var result = await handler.Handle(request, CancellationToken.None);
+
+    // Assert
+    result.Success.Should().BeTrue();
+    result.ErrorCode.Should().BeNull();
+    result.Task.Should().NotBeNull();
+    result.Task.Title.Should().Be("Manually added task");
+    result.Task.Description.Should().Be("Added by reviewer");
+    result.Task.Assignee.Should().Be("carol");
+    result.Task.DueDate.Should().Be(dueDate);
+    result.Task.Status.Should().Be("Pending");
+    result.Task.IsManuallyAdded.Should().BeTrue();
+    result.Task.ExternalTaskId.Should().BeNull();
+
+    transcript.Tasks.Should().HaveCount(2);
+    var addedEntity = transcript.Tasks.Last();
+    addedEntity.Title.Should().Be("Manually added task");
+    addedEntity.IsManuallyAdded.Should().BeTrue();
+    addedEntity.Status.Should().Be(ProposedTaskStatus.Pending);
+    addedEntity.MeetingTranscriptId.Should().Be(transcriptId);
+    result.Task.Id.Should().Be(addedEntity.Id);
+    _repositoryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.AddTask_CreatesManualTask"
+```
+
+Expected: build failure; errors reference `AddProposedTaskHandler`, `AddProposedTaskRequest`.
+
+- [ ] **Step 3: Create `AddProposedTaskRequest.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskRequest : IRequest<AddProposedTaskResponse>
+{
+    public Guid TranscriptId { get; set; }
+
+    [Required]
+    public string Title { get; set; } = null!;
+
+    public string Description { get; set; } = string.Empty;
+
+    [Required]
+    public string Assignee { get; set; } = null!;
+
+    public DateTime? DueDate { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `AddProposedTaskResponse.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskResponse : BaseResponse
+{
+    public AddProposedTaskResponse() { }
+    public AddProposedTaskResponse(ErrorCodes errorCode) : base(errorCode) { }
+
+    public ProposedTaskDto Task { get; set; } = null!;
+}
+```
+
+- [ ] **Step 5: Create `AddProposedTaskHandler.cs`**
+
+Create `backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.MeetingTasks.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.MeetingTasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.MeetingTasks.UseCases.AddProposedTask;
+
+public class AddProposedTaskHandler : IRequestHandler<AddProposedTaskRequest, AddProposedTaskResponse>
+{
+    private readonly IMeetingTranscriptRepository _repository;
+    private readonly ILogger<AddProposedTaskHandler> _logger;
+
+    public AddProposedTaskHandler(
+        IMeetingTranscriptRepository repository,
+        ILogger<AddProposedTaskHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<AddProposedTaskResponse> Handle(AddProposedTaskRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Adding manual proposed task — TranscriptId: {TranscriptId}, Title: {Title}",
+            request.TranscriptId, request.Title);
+
+        var transcript = await _repository.GetByIdAsync(request.TranscriptId, cancellationToken);
+        if (transcript is null)
+        {
+            _logger.LogWarning("Meeting transcript {TranscriptId} not found", request.TranscriptId);
+            return new AddProposedTaskResponse(ErrorCodes.ResourceNotFound);
+        }
+
+        var task = new ProposedTask
+        {
+            Id = Guid.NewGuid(),
+            MeetingTranscriptId = transcript.Id,
+            Title = request.Title,
+            Description = request.Description,
+            Assignee = request.Assignee,
+            DueDate = request.DueDate,
+            Status = ProposedTaskStatus.Pending,
+            ExternalTaskId = null,
+            IsManuallyAdded = true
+        };
+
+        transcript.Tasks.Add(task);
+
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return new AddProposedTaskResponse
+        {
+            Task = new ProposedTaskDto
+            {
+                Id = task.Id,
+                Title = task.Title,
+                Description = task.Description,
+                Assignee = task.Assignee,
+                DueDate = task.DueDate,
+                Status = task.Status.ToString(),
+                ExternalTaskId = task.ExternalTaskId,
+                IsManuallyAdded = task.IsManuallyAdded
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests.AddTask_CreatesManualTask"
+```
+
+Expected: 1 test passed, 0 failed.
+
+- [ ] **Step 7: Run all three tests together**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~UpdateProposedTaskHandlerTests"
+```
+
+Expected: 3 tests passed (`UpdateTask_ModifiesFields`, `UpdateTaskStatus_ApprovesTask`, `AddTask_CreatesManualTask`).
+
+- [ ] **Step 8: Build the application project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+- [ ] **Step 9: Run `dotnet format` on changed files**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask/AddProposedTaskHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+```
+
+Expected: exits 0.
+
+- [ ] **Step 10: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/AddProposedTask \
+        backend/test/Anela.Heblo.Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs
+git commit -m "feat: add AddProposedTask handler for manually appending tasks"
+```
+
+---
+
+## Task 4: Final validation
+
+**Files:** No file changes — verification only.
+
+- [ ] **Step 1: Build the full backend solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` across all projects.
+
+- [ ] **Step 2: Run all MeetingTasks tests (new + existing siblings) together**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.MeetingTasks"
+```
+
+Expected: all tests pass, including the three new ones and the prior `GetTranscriptDetailHandlerTests`, `GetTranscriptListHandlerTests`, `IngestPlaudRecordingHandlerTests`. No regressions.
+
+- [ ] **Step 3: Run the full backend test suite as a regression net**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: all tests pass. If any unrelated test fails, investigate before reporting completion — it likely indicates the rebase pulled in flaky tests from the epic, not an issue introduced by this work.
+
+- [ ] **Step 4: Run `dotnet format` over the whole solution**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exits 0. If it reports unformatted files among the new files, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`), commit the formatting fix as a follow-up `chore:` commit, then re-run with `--verify-no-changes`.
+
+- [ ] **Step 5: Verify PR target — confirm the branch is up to date with the epic**
+
+Run:
+
+```bash
+git fetch origin feat/meeting-task-validation-epic
+git merge-base --is-ancestor origin/feat/meeting-task-validation-epic HEAD && echo OK || echo STALE
+```
+
+Expected: `OK`. If `STALE`, rebase onto the latest epic tip before opening the PR.
+
+- [ ] **Step 6: No commit for this task**
+
+This task is verification-only.
+
+---
+
+## Specification Amendments Incorporated
+
+The architecture review identified amendments to the original spec. They are baked into this plan:
+
+1. `ErrorCodes.NotFound` → `ErrorCodes.ResourceNotFound` everywhere (the actual enum member, used by sibling `GetTranscriptDetailHandler`).
+2. Test helper `CreateTranscriptWithTask` uses real `MeetingTranscript` fields: `PlaudRecordingId`, `PlaudCreatedAt`, `Subject`, `Summary`, `RawTranscript`, `Status`, `ReceivedAt`. The spec's `SourceEmail` field does not exist on the entity.
+3. Requests are typed `IRequest<TConcreteResponse>` (e.g., `IRequest<UpdateProposedTaskResponse>`), not `IRequest<BaseResponse>`, so callers see the concrete shape.
+4. Handlers inject `ILogger<THandler>` and emit `LogInformation` on entry / `LogWarning` on not-found / invalid status. Matches `GetTranscriptDetailHandler` and `IngestPlaudRecordingHandler`.
+5. Each response lives in its own `*Response.cs` file under the UseCase folder.
+6. Error responses use the constructor-overload form: `new UpdateProposedTaskResponse(ErrorCodes.ResourceNotFound)`.
+7. Tests use FluentAssertions + `NullLogger<THandler>.Instance` + `Mock.Verify(r => r.SaveChangesAsync(...), Times.Once)` — matches `GetTranscriptDetailHandlerTests`.
+8. `AddProposedTaskHandler` explicitly sets `ExternalTaskId = null` on the response DTO for symmetry with the read handler.
+
+## Out-of-Scope Items (Documented in Spec)
+
+These are not implemented by this plan:
+
+- MVC controller endpoints
+- Authorization checks (handled at the controller layer)
+- Frontend UI
+- Status transition rules (e.g., disallowing Approved→Pending) — handler accepts any valid `ProposedTaskStatus`
+- Domain events, audit logging, notifications
+- Validation that the transcript is in `PendingReview` before edits
+- Bulk approve/reject
+- Optimistic concurrency / `RowVersion`
+- E2E tests
+- OpenAPI/Swagger DTO surface
+- Updating `transcript.Status` / `ReviewedAt` / `ReviewedByUser` when all tasks are reviewed


### PR DESCRIPTION

Adds three MediatR write-side handlers for the meeting task validation checkpoint: `UpdateProposedTask` (edits Title/Description/Assignee/DueDate), `UpdateProposedTaskStatus` (transitions Pending→Approved/Rejected via case-insensitive enum parse), and `AddProposedTask` (creates a manually-authored task with `IsManuallyAdded=true`). All handlers follow the established Vertical Slice convention: one UseCase folder with three files (request/response/handler), constructor-injected `IMeetingTranscriptRepository` + `ILogger<T>`, `ErrorCodes.ResourceNotFound` for not-found cases, and `BaseResponse`-derived responses with constructor-overload error signaling.

### Changes
- `UseCases/UpdateProposedTask/` — request, response, handler (edit task fields)
- `UseCases/UpdateProposedTaskStatus/` — request, response, handler (status lifecycle)
- `UseCases/AddProposedTask/` — request, response, handler (manual task creation)
- `Tests/Features/MeetingTasks/UpdateProposedTaskHandlerTests.cs` — 9 unit tests with FluentAssertions + NullLogger + Mock.Verify

---

Closes #649

### Tokens used
4476926
