### PR TITLE
feat: Encapsulate Replace Semantics for JournalEntry Collections

### DIFF
--- a/artifacts/feat-arch-review-journal-updatejournalentryha/arch-review.r1.md
+++ b/artifacts/feat-arch-review-journal-updatejournalentryha/arch-review.r1.md
@@ -1,0 +1,206 @@
+I have enough context. Now I will write the architecture review.
+
+# Architecture Review: Encapsulate Replace Semantics for JournalEntry Collections
+
+## Skip Design: true
+
+(Pure backend refactor — no UI, no API contract change, no schema change.)
+
+## Architectural Fit Assessment
+
+The change is **strongly aligned with existing patterns** and is in fact a correction of a localized drift away from them:
+
+- The codebase follows **Clean Architecture + Vertical Slice** (`Domain → Application → Persistence → API`) with MediatR handlers in `UseCases/*`. Domain entities under `Anela.Heblo.Domain/Features/Journal/` are rich models that own their invariants.
+- `JournalEntry` already exposes intent-revealing methods (`AssociateWithProduct`, `AssignTag`, `SoftDelete`, `IsAssociatedWithProduct`). Adding `ReplaceProductAssociations` / `ReplaceTagAssignments` mirrors that style exactly.
+- `CreateJournalEntryHandler` already routes 100% of mutations through domain methods; `UpdateJournalEntryHandler` is the lone deviation. This change restores symmetry.
+- No new abstractions, DI registrations, NuGet packages, migrations, or contract changes are required. Integration points are: (a) `JournalEntry` entity, (b) `UpdateJournalEntryHandler`, (c) a new test file in `Anela.Heblo.Tests/Features/Journal/`.
+
+**Verified against codebase reality:**
+- `JournalEntryProduct` PK is composite `{JournalEntryId, ProductCodePrefix}` — DB-level uniqueness is enforced, so the in-memory dedupe is defense-in-depth, not the sole guard.
+- `JournalEntryTagAssignment` PK is composite `{JournalEntryId, TagId}` — same.
+- Both child entity configurations declare `CreatedAt` as `IsRequired()`. The existing `AssociateWithProduct` / `AssignTag` methods do **not** set `CreatedAt`, relying on EF/DB defaulting. The new methods must follow the same pattern (don't set it) to preserve behavioral parity — this is what the spec already prescribes.
+- `IJournalRepository.GetByIdAsync` eagerly `Include`s both child collections, so `entry.ProductAssociations`/`TagAssignments` are fully materialized in the handler — no lazy-loading hazard when diffing.
+- Soft delete query filter (`!x.IsDeleted`) operates only on `JournalEntries`; child collections are not filtered. The diff operates on the in-memory tracked set, which is correct.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+                   ┌──────────────────────────────────────────┐
+                   │ UpdateJournalEntryHandler (Application)  │
+                   │ ──────────────────────────────────────── │
+                   │  GetByIdAsync (incl. children)           │
+                   │  entry.Title/Content/EntryDate = …       │
+                   │  entry.ReplaceProductAssociations(req…)  │◄── two domain calls
+                   │  entry.ReplaceTagAssignments(req…)       │     replace lines 62–80
+                   │  UpdateAsync + SaveChangesAsync          │
+                   └──────────────────────────────────────────┘
+                                      │
+                                      ▼
+                   ┌──────────────────────────────────────────┐
+                   │ JournalEntry (Domain)                    │
+                   │ ──────────────────────────────────────── │
+                   │  AssociateWithProduct(code)   [existing] │
+                   │  AssignTag(tagId)             [existing] │
+                   │  ReplaceProductAssociations(codes) [NEW] │── set-diff:
+                   │  ReplaceTagAssignments(tagIds)     [NEW] │   keep, add, remove
+                   │  ProductAssociations  (ICollection)      │
+                   │  TagAssignments       (ICollection)      │
+                   └──────────────────────────────────────────┘
+                                      │
+                                      ▼
+                   ┌──────────────────────────────────────────┐
+                   │ EF Core Change Tracker                   │
+                   │ ──────────────────────────────────────── │
+                   │  Removed children → DELETE (cascade)     │
+                   │  Added children   → INSERT               │
+                   │  Kept children    → unchanged            │
+                   └──────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Set-diff vs. clear-and-re-add
+
+**Options considered:**
+1. **Clear-and-re-add inside the domain method** — preserves the encapsulation goal but keeps EF tracking churn and discards original `CreatedAt` for unchanged children.
+2. **Set-diff (compute add/remove against existing items)** — only removes children that are truly gone and only adds children that are truly new; unchanged items keep their identity and `CreatedAt`.
+
+**Chosen approach:** Set-diff using `HashSet<T>` for both keys (normalized `ProductCodePrefix` and `TagId`).
+
+**Rationale:**
+- Preserves the historical `CreatedAt` on unchanged children (the spec calls this out explicitly).
+- Generates a minimal change set for EF — only the children that actually moved produce SQL. With current sizes (single-digit / low-double-digit), the algorithmic cost (O(n+m)) is identical in practice, but the SQL footprint is strictly smaller.
+- Plays nicely with the composite PK: EF cannot have two tracked entities with the same key, so clear-and-re-add in the same `SaveChanges` cycle can trigger tracking conflicts on overlapping items unless the cleared list is detached first. Set-diff sidesteps that class of bug entirely.
+
+#### Decision 2: Where the input-normalization rules live
+
+**Options considered:**
+1. Duplicate the `Trim().ToUpperInvariant()` + whitespace guard logic inside `ReplaceProductAssociations`.
+2. Extract a private static helper (e.g. `NormalizeProductCode`) and use it from both `AssociateWithProduct` and `ReplaceProductAssociations`.
+
+**Chosen approach:** Extract one private static helper inside `JournalEntry` (e.g. `private static string NormalizeProductCode(string raw)`), used by both the existing `AssociateWithProduct` and the new `ReplaceProductAssociations`. Same guard semantics, same normalization, **one source of truth**.
+
+**Rationale:**
+- The spec's acceptance criteria require behavioral parity with `AssociateWithProduct` for trim/upper/whitespace. Two independent copies of the rule will drift. The spec lists "Refactoring `AssociateWithProduct`" as out of scope, but extracting a private helper used by both is a non-behavioral, internal refactor — it leaves the public API of `AssociateWithProduct` unchanged. This is the minimum required change to keep the rule DRY.
+- If the user intends "do not touch `AssociateWithProduct` at all", fall back to duplicating the four-line normalization inline. **Recommend the helper; flag as an explicit choice for the user.**
+
+#### Decision 3: Whitespace-guard placement
+
+**Options considered:**
+1. Pre-filter (silently drop) blanks before diffing.
+2. Throw `ArgumentException` on the first whitespace-only entry, before any mutation.
+
+**Chosen approach:** Throw `ArgumentException` **before** mutating the collection. Validate the entire incoming set in a single pass first, then apply the diff. This matches the spec's acceptance criterion ("Calling with `[" "]` throws `ArgumentException`") and preserves entity state on invalid input — no partial replacement.
+
+**Rationale:** Domain methods that throw mid-mutation leave aggregates in inconsistent states; the handler currently has no try/catch and would propagate to MediatR's pipeline. Fail fast, atomically. This also matches the guard-first ordering used by `AssociateWithProduct`.
+
+#### Decision 4: Tag validation (existence)
+
+**Options considered:**
+1. Validate `tagId` exists in `JournalEntryTag` before assigning.
+2. Skip existence validation (current `AssignTag` behavior).
+
+**Chosen approach:** Skip — behavioral parity with existing `AssignTag`.
+
+**Rationale:** The spec is explicit on this. FK constraint at the DB level will reject an invalid `TagId` at `SaveChangesAsync` time; the resulting `DbUpdateException` is the existing handling path. Introducing pre-validation would expand scope and require injecting `IJournalTagRepository` into the domain entity — a Clean-Architecture violation.
+
+#### Decision 5: Method signatures accept `IEnumerable<T>?`
+
+**Chosen approach:** `IEnumerable<string>?` and `IEnumerable<int>?` (nullable). Null and empty are treated identically (clear all).
+
+**Rationale:** Matches the nullable `UpdateJournalEntryRequest.AssociatedProducts` / `TagIds` shape and removes the null-check from the handler — the whole point of the refactor is to let the handler stop reasoning about the input shape.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files except the test file. Modifications only:
+
+```
+backend/src/Anela.Heblo.Domain/Features/Journal/
+  JournalEntry.cs                                   [MODIFY: +2 public methods, +1 private helper]
+
+backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/
+  UpdateJournalEntryHandler.cs                      [MODIFY: replace lines 61–80 with 2 calls]
+
+backend/test/Anela.Heblo.Tests/Features/Journal/
+  JournalEntryDomainTests.cs                        [NEW: xUnit + FluentAssertions]
+```
+
+This matches `docs/architecture/filesystem.md` exactly: domain entities live under `Domain/Features/{Feature}/`, handlers under `Application/Features/{Feature}/UseCases/{UseCase}/`, tests mirror at `test/Anela.Heblo.Tests/Features/{Feature}/`.
+
+### Interfaces and Contracts
+
+**Public surface added to `JournalEntry`:**
+
+```csharp
+public void ReplaceProductAssociations(IEnumerable<string>? productCodes);
+public void ReplaceTagAssignments(IEnumerable<int>? tagIds);
+```
+
+**Internal helpers (private to `JournalEntry`):**
+
+```csharp
+private static string NormalizeProductCode(string raw); // Trim().ToUpperInvariant(), throws on whitespace-only
+```
+
+**Unchanged:**
+- `IJournalRepository`, `UpdateJournalEntryRequest`, `UpdateJournalEntryResponse`, `JournalController` PUT route, all EF configurations and migrations.
+
+### Data Flow
+
+**Update flow (golden path):**
+
+1. `JournalController` → MediatR → `UpdateJournalEntryHandler.Handle`.
+2. `_journalRepository.GetByIdAsync(id, ct)` loads entry **with** `ProductAssociations` + `TagAssignments` + `Tag` (already configured with `Include` chains).
+3. Handler updates scalar fields (`Title`, `Content`, `EntryDate`, `ModifiedAt`, `ModifiedByUserId`, `ModifiedByUsername`).
+4. Handler calls `entry.ReplaceProductAssociations(request.AssociatedProducts)`:
+   - **Validate pass**: normalize every non-null code via `NormalizeProductCode` (throws `ArgumentException` if any is whitespace).
+   - **Build target set**: `HashSet<string>` of normalized codes (deduplicated, case-insensitive via the `ToUpperInvariant` normalization step).
+   - **Remove**: iterate `ProductAssociations` snapshot, remove any whose `ProductCodePrefix` is not in target set.
+   - **Add**: iterate target set, add a new `JournalEntryProduct { JournalEntryId = Id, ProductCodePrefix = normalized }` for any not already present.
+5. Handler calls `entry.ReplaceTagAssignments(request.TagIds)` with the same algorithm keyed on `TagId`.
+6. `UpdateAsync` + `SaveChangesAsync` flush diffs. EF's change tracker emits `DELETE` for removed children and `INSERT` for new ones. Unchanged children produce no SQL.
+7. Return `UpdateJournalEntryResponse { Id, ModifiedAt }`.
+
+**Failure flow — invalid product code:**
+
+`ReplaceProductAssociations` throws `ArgumentException` before any mutation. The handler does not catch it; MediatR pipeline / ASP.NET middleware returns 500 — same behavior as the existing `AssociateWithProduct` invocation when a blank prefix is sent. No partial state.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Iterating and mutating `ProductAssociations` in the same loop throws `InvalidOperationException` | Medium | Snapshot to `var toRemove = existing.Where(...).ToList()` before calling `Remove`. Standard C# pattern; the test "disjoint set removes the old codes" will catch a violation. |
+| EF change tracker conflict if two children with the same composite PK ever coexist in the tracked graph | Medium | The set-diff approach never adds a duplicate to the in-memory collection — the "already present" branch returns the existing instance untouched. Tests for the "overlap preserves instance reference" case validate this. |
+| `CreatedAt` on `JournalEntryProduct`/`JournalEntryTagAssignment` is `IsRequired()` but neither old nor new construction paths set it | Low (pre-existing) | Out of scope for this refactor; spec explicitly requires parity with `AssociateWithProduct`. If `CreatedAt` is currently being populated by a value generator, `AsUtcTimestamp()`, or DB default, the new method inherits the same behavior. Flag for a follow-up issue. |
+| Behavioral drift between `AssociateWithProduct` and `ReplaceProductAssociations` normalization rules | Medium | Single private `NormalizeProductCode` helper used by both. If the user vetoes touching `AssociateWithProduct`, duplicate the four lines verbatim and add a comment cross-referencing the two. |
+| Future audit/validation requirements on remove operations | Low | The whole point of the refactor — the domain method becomes the single seam where future remove invariants land. |
+| Test file name collision | Low | Verified no `JournalEntryDomainTests.cs` or `UpdateJournalEntryHandlerTests.cs` exists in `backend/test/Anela.Heblo.Tests/Features/Journal/`. |
+
+## Specification Amendments
+
+1. **Extract a private `NormalizeProductCode` helper on `JournalEntry`** (Decision 2). The spec says "Refactoring `AssociateWithProduct` itself is out of scope" — clarify that **swapping its inline normalization for a private helper call is permitted and recommended**, because it is a non-behavioral internal cleanup that prevents the DRY violation the spec otherwise creates. If the user prefers strict no-touch on `AssociateWithProduct`, duplicate the normalization inside the new method and add an explicit `// keep in sync with AssociateWithProduct` comment.
+
+2. **Validate-then-mutate ordering** (Decision 3). The spec lists the whitespace-throws acceptance criterion but does not say at which point in the algorithm the throw happens. Specify: **all incoming items are normalized/validated in a first pass; mutation only begins if validation succeeds.** Add an acceptance criterion: "Calling with `["A", " ", "B"]` throws `ArgumentException` and leaves `ProductAssociations` unchanged" (state preservation on failure).
+
+3. **`ReplaceTagAssignments` null-input contract**. The spec lists `null` → clear for products and tags but does not list "calling with `null` empties existing tag assignments" in the FR-2 acceptance bullets (line says it under "Behavior" but missing from the bullets). Add the explicit acceptance bullet for symmetry with FR-1.
+
+4. **Test naming convention.** Spec proposes `JournalEntryDomainTests.cs`. Looking at the existing test layout (`GetJournalEntryHandlerTests.cs`, `JournalEntryMapperTests.cs`, `SearchJournalEntriesHandlerTests.cs`), a more idiomatic name is `JournalEntryTests.cs` (entity tests are named after the entity, not after "Domain"). Minor; either is fine.
+
+5. **Add one new test case**: "calling `ReplaceProductAssociations` on an entry with `["X", "Y"]` and an input of `["x"]` (different case) preserves the existing `X` instance reference and removes `Y`." Pins the case-insensitive matching against the existing-instance preservation contract.
+
+## Prerequisites
+
+None. The refactor is self-contained:
+
+- No DB migration (schema unchanged).
+- No configuration / appsettings change.
+- No infrastructure change.
+- No new NuGet packages, no DI registration changes.
+- No frontend change.
+- No prior PR or feature must land first.
+
+Implementation can start immediately. Validation gates per project rules: `dotnet build`, `dotnet format`, `dotnet test --filter FullyQualifiedName~Journal` must all pass; existing handler-level tests (if any are added later) must continue to pass.

--- a/artifacts/feat-arch-review-journal-updatejournalentryha/brief.md
+++ b/artifacts/feat-arch-review-journal-updatejournalentryha/brief.md
@@ -1,0 +1,37 @@
+## Module
+Journal
+
+## Finding
+`UpdateJournalEntryHandler` directly mutates navigation-property collections on the `JournalEntry` aggregate instead of going through domain methods:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs
+// Lines 62–78
+entry.ProductAssociations.Clear();   // ← raw collection mutation
+if (request.AssociatedProducts?.Any() == true)
+{
+    foreach (var productIdentifier in request.AssociatedProducts.Distinct())
+        entry.AssociateWithProduct(productIdentifier);   // ← then domain method
+}
+
+entry.TagAssignments.Clear();         // ← raw collection mutation
+if (request.TagIds?.Any() == true)
+{
+    foreach (var tagId in request.TagIds.Distinct())
+        entry.AssignTag(tagId);                          // ← then domain method
+}
+```
+
+The entity already provides `AssociateWithProduct` and `AssignTag` for the *add* path (used consistently in `CreateJournalEntryHandler`), but the *replace* path skips domain encapsulation entirely by calling `.Clear()` directly on the collections.
+
+## Why it matters
+- **Inconsistency between create and update paths**: create routes all mutations through domain methods; update partially bypasses them.
+- **Domain invariants not enforced for removal**: `.Clear()` does not go through any domain logic; future invariants on removal (e.g. audit trail, validation) would need to be added in two places — the handler and the domain method.
+- **EF change-tracking fragility**: clearing owned collections directly can cause unexpected behaviour under EF tracking if the collection is lazy-loaded or if the cascade delete behaviour changes.
+- **Violates tell-don't-ask**: the handler asks for the collection and mutates it rather than telling the entity what its new state should be.
+
+## Suggested fix
+Add `ReplaceProductAssociations(IEnumerable<string> productIdentifiers)` and `ReplaceTagAssignments(IEnumerable<int> tagIds)` domain methods to `JournalEntry` (mirroring the existing guard logic in `AssociateWithProduct`/`AssignTag`), then call those from the handler instead of the raw `.Clear()` + loop pattern.
+
+---
+_Filed by daily arch-review routine on 2026-05-12._

--- a/artifacts/feat-arch-review-journal-updatejournalentryha/impl/main.r1.md
+++ b/artifacts/feat-arch-review-journal-updatejournalentryha/impl/main.r1.md
@@ -1,0 +1,8 @@
+Base branch is `main`. Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-journal-updatejournalentryha/spec.r1.md
+++ b/artifacts/feat-arch-review-journal-updatejournalentryha/spec.r1.md
@@ -1,0 +1,169 @@
+# Specification: Encapsulate Replace Semantics for JournalEntry Collections
+
+## Summary
+Replace the raw `.Clear()` + per-item add pattern in `UpdateJournalEntryHandler` with two new domain methods on `JournalEntry`: `ReplaceProductAssociations(IEnumerable<string>)` and `ReplaceTagAssignments(IEnumerable<int>)`. This restores tell-don't-ask encapsulation, eliminates the inconsistency between the create and update paths, and centralizes invariant enforcement for both add and remove flows.
+
+## Background
+`UpdateJournalEntryHandler.Handle` (lines 62–80) directly mutates the `ProductAssociations` and `TagAssignments` navigation collections by calling `.Clear()` on them before re-adding items through the existing `AssociateWithProduct`/`AssignTag` domain methods. `CreateJournalEntryHandler` routes 100% of mutations through domain methods. The asymmetry means:
+
+- Any future removal invariant (audit, validation, side effect) would need to be applied in both the handler and the entity.
+- The handler violates tell-don't-ask by reaching into the aggregate's internal collections.
+- EF Core change-tracking for owned/related collections is brittle when cleared directly — future cascade or tracking changes could surface as silent data bugs.
+
+The fix is small, surgical, and confined to the Journal aggregate and one handler. The domain entity already has the templates (`AssociateWithProduct`, `AssignTag`) that the new methods mirror.
+
+## Functional Requirements
+
+### FR-1: Add `ReplaceProductAssociations` domain method to `JournalEntry`
+A new public instance method on `Anela.Heblo.Domain.Features.Journal.JournalEntry` that accepts a collection of product identifiers and atomically updates `ProductAssociations` to exactly match that collection.
+
+**Signature:**
+```csharp
+public void ReplaceProductAssociations(IEnumerable<string>? productCodes)
+```
+
+**Behavior:**
+- A `null` or empty input clears all existing associations.
+- Input is de-duplicated (case-insensitive, after trim/upper) before comparison.
+- Each non-null, non-whitespace product code is normalized with `Trim().ToUpperInvariant()`, matching the existing rule in `AssociateWithProduct`.
+- Whitespace-only or empty codes trigger `ArgumentException`, matching the per-item guard in `AssociateWithProduct`.
+- Associations not present in the new set are removed.
+- Associations already present (matched by `ProductCodePrefix` after normalization) are left in place — no churn on unchanged items, so `CreatedAt` is preserved and EF tracking is not unnecessarily disturbed.
+- New associations are added via the same construction path used by `AssociateWithProduct` (sets `JournalEntryId` and normalized `ProductCodePrefix`).
+
+**Acceptance criteria:**
+- Calling with `null` empties `ProductAssociations`.
+- Calling with `[]` empties `ProductAssociations`.
+- Calling with `["AB-1", "ab-1", " AB-1 "]` results in exactly one association with `ProductCodePrefix = "AB-1"`.
+- Calling with `["X"]` on an entry that already has `["X", "Y"]` removes `Y`, retains the existing `X` instance (object reference preserved), and adds no duplicate.
+- Calling with `[" "]` throws `ArgumentException`.
+
+### FR-2: Add `ReplaceTagAssignments` domain method to `JournalEntry`
+A new public instance method that accepts a collection of tag IDs and atomically updates `TagAssignments` to exactly match that collection.
+
+**Signature:**
+```csharp
+public void ReplaceTagAssignments(IEnumerable<int>? tagIds)
+```
+
+**Behavior:**
+- A `null` or empty input clears all existing tag assignments.
+- Input is de-duplicated.
+- Assignments not present in the new set are removed.
+- Assignments already present (matched by `TagId`) are retained (instance preserved).
+- New assignments are constructed via the same path as `AssignTag` (sets `JournalEntryId` and `TagId`).
+
+**Acceptance criteria:**
+- Calling with `null` empties `TagAssignments`.
+- Calling with `[1, 1, 2]` leaves assignments for exactly `{1, 2}`.
+- Calling with `[1]` on an entry with `{1, 2}` removes the assignment for `2` and retains the existing `TagId == 1` instance.
+- No validation on tag-existence is performed in the domain method (consistent with the existing `AssignTag`, which also does not verify the tag row exists).
+
+### FR-3: Update `UpdateJournalEntryHandler` to use the new domain methods
+Replace lines 61–80 of `UpdateJournalEntryHandler.cs` with two calls:
+
+```csharp
+entry.ReplaceProductAssociations(request.AssociatedProducts);
+entry.ReplaceTagAssignments(request.TagIds);
+```
+
+The handler no longer touches `ProductAssociations` or `TagAssignments` directly.
+
+**Acceptance criteria:**
+- The handler file no longer references `.Clear()` on `ProductAssociations` or `TagAssignments`.
+- The handler file no longer iterates `request.AssociatedProducts` or `request.TagIds` directly.
+- Behavior observed via the existing PUT endpoint (`PUT /api/journal/{id}` or equivalent) is unchanged for typical inputs: passing a list replaces the set; passing `null` clears it.
+
+### FR-4: Unit-test coverage for the new domain methods
+Add xUnit tests in `backend/test/Anela.Heblo.Tests/Features/Journal/` (new file, e.g. `JournalEntryDomainTests.cs`) covering both methods.
+
+**Acceptance criteria — `ReplaceProductAssociations`:**
+- Replacing with `null` clears existing associations.
+- Replacing with empty collection clears existing associations.
+- Replacing with a superset adds the new codes.
+- Replacing with a disjoint set removes the old codes.
+- Replacing with overlapping codes preserves the existing instance reference for unchanged items.
+- De-duplication is case-insensitive and whitespace-insensitive.
+- Whitespace-only entries throw `ArgumentException`.
+
+**Acceptance criteria — `ReplaceTagAssignments`:**
+- Replacing with `null` clears existing assignments.
+- Replacing with empty collection clears existing assignments.
+- Replacing with a superset adds the new IDs.
+- Replacing with a disjoint set removes the old IDs.
+- Replacing with overlapping IDs preserves the existing instance reference.
+- Duplicate IDs in input are collapsed.
+
+### FR-5: Handler test coverage
+If unit tests for `UpdateJournalEntryHandler` exist, update them to verify behavior via the new domain methods (i.e. set up an entry with prior associations and assert replacement semantics through the handler). If none exist, do not introduce a new test project — handler behavior is exercised indirectly by the domain tests.
+
+**Acceptance criteria:**
+- Existing tests still pass.
+- No new test infrastructure is introduced.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Replace operations are O(n + m) where n = existing count, m = incoming count. Journal entries have a small number of associations and tags in practice (single-digit to low-double-digit), so set-difference using `HashSet<T>` is acceptable and preferred over nested loops.
+- No additional database round-trips are introduced. EF change tracking should detect removal of the unwanted child rows and insertion of new ones via the existing `UpdateAsync`/`SaveChangesAsync` flow.
+
+### NFR-2: Security
+- No change to the authentication/authorization model. The existing `currentUser.IsAuthenticated` check in the handler remains.
+- No new user input is accepted; the contract of `UpdateJournalEntryRequest` is unchanged.
+
+### NFR-3: Backwards compatibility
+- Public API contract (`UpdateJournalEntryRequest`/`UpdateJournalEntryResponse`) is unchanged.
+- Database schema is unchanged.
+- Observable behavior of `PUT` is unchanged for all valid inputs already accepted today.
+
+### NFR-4: Code quality
+- Domain methods must follow the same coding style as existing `AssociateWithProduct`/`AssignTag`: `[`guard clauses → existence check → mutation`]`.
+- `dotnet build` and `dotnet format` must pass.
+- All journal-related tests must pass.
+
+## Data Model
+
+No schema changes. Affected entities:
+
+- `JournalEntry` (1) — gains two methods, no property/field changes.
+- `JournalEntryProduct` (n) — owned child; lifecycle continues to be managed via parent's navigation collection.
+- `JournalEntryTagAssignment` (n) — owned child; same.
+
+Relationships and EF mappings are unchanged.
+
+## API / Interface Design
+
+### Domain (new public methods on `JournalEntry`)
+```csharp
+public void ReplaceProductAssociations(IEnumerable<string>? productCodes);
+public void ReplaceTagAssignments(IEnumerable<int>? tagIds);
+```
+
+### Application handler (changed body, unchanged signature)
+`UpdateJournalEntryHandler.Handle` retains its signature; the replace blocks become two method calls.
+
+### HTTP API
+Unchanged. `PUT /api/journal/{id}` (or whichever route maps to `UpdateJournalEntryRequest`) continues to accept the same payload.
+
+## Dependencies
+
+- `Anela.Heblo.Domain.Features.Journal.JournalEntry`
+- `Anela.Heblo.Application.Features.Journal.UseCases.UpdateJournalEntry.UpdateJournalEntryHandler`
+- `Anela.Heblo.Tests` project for new unit tests
+- No new NuGet packages, no new abstractions, no new DI registrations.
+
+## Out of Scope
+
+- Refactoring `AssociateWithProduct` or `AssignTag` themselves.
+- Validating that supplied `tagId` values exist in the `JournalEntryTag` table (current `AssignTag` does not validate either; behavioral parity is intentional).
+- Adding audit-trail entries for removed associations/assignments (no existing audit mechanism on these child entities).
+- Introducing a domain event for replace operations.
+- Changing the `CreateJournalEntryHandler` (already correctly delegates to domain methods).
+- Restricting edit permissions to the original author (explicitly left as a future concern in the handler comment).
+- Front-end changes.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-journal-updatejournalentryha/task-plan.r1.md
+++ b/artifacts/feat-arch-review-journal-updatejournalentryha/task-plan.r1.md
@@ -1,0 +1,603 @@
+# JournalEntry Replace Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw `.Clear()` + per-item add pattern in `UpdateJournalEntryHandler` with two new tell-don't-ask domain methods on `JournalEntry` — `ReplaceProductAssociations` and `ReplaceTagAssignments` — that perform set-diff replacement, preserve unchanged child rows, and validate input atomically.
+
+**Architecture:** Adds two `public void` methods to the rich `JournalEntry` aggregate using a set-diff algorithm (`HashSet<T>` keyed on `ProductCodePrefix` / `TagId`). Extracts a single private `NormalizeProductCode` helper used by both `AssociateWithProduct` and the new replace method to keep normalization rules DRY. The handler shrinks from ~20 lines of mutation logic to two intent-revealing calls. No schema, contract, or DI changes.
+
+**Tech Stack:** .NET 8, EF Core (change tracker handles child add/remove via composite PKs), xUnit + FluentAssertions for tests.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — add `NormalizeProductCode` private helper, refactor `AssociateWithProduct` to use it, add `ReplaceProductAssociations` and `ReplaceTagAssignments`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs` — replace lines 61–80 with two domain method calls.
+
+**Create:**
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs` — xUnit tests for both new domain methods plus `NormalizeProductCode` behavior surfaced via `AssociateWithProduct` to confirm no regression.
+
+**Validation commands (from worktree root):**
+- `dotnet build backend/Anela.Heblo.sln`
+- `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+- `dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Journal"`
+
+---
+
+## Task 1: Extract `NormalizeProductCode` helper and refactor `AssociateWithProduct`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs:55-68`
+
+This task is a pure non-behavioral refactor. It introduces the helper that Task 2 depends on and verifies the existing `AssociateWithProduct` contract is unchanged.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.Journal;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Journal;
+
+public class JournalEntryTests
+{
+    private static JournalEntry NewEntry() => new JournalEntry
+    {
+        Id = 1,
+        Content = "test",
+        EntryDate = DateTime.UtcNow.Date,
+        CreatedAt = DateTime.UtcNow,
+        ModifiedAt = DateTime.UtcNow,
+        CreatedByUserId = "user-1"
+    };
+
+    // ----- AssociateWithProduct: existing-behavior regression coverage -----
+
+    [Fact]
+    public void AssociateWithProduct_NormalizesCodeToTrimmedUpper()
+    {
+        var entry = NewEntry();
+
+        entry.AssociateWithProduct("  ab-1  ");
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.ProductCodePrefix.Should().Be("AB-1");
+    }
+
+    [Fact]
+    public void AssociateWithProduct_ThrowsOnWhitespaceCode()
+    {
+        var entry = NewEntry();
+
+        var act = () => entry.AssociateWithProduct("   ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify the regression test passes against the current code**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryTests"`
+
+Expected: Both tests **PASS** (`AssociateWithProduct` already trims/uppers and throws on whitespace).
+
+Note: The current `AssociateWithProduct` compares the raw input against existing `ProductCodePrefix` values before normalizing. The "NormalizesCodeToTrimmedUpper" test passes today only because nothing matches on first add; we will fix the order-of-operations bug as part of the helper extraction in step 3.
+
+- [ ] **Step 3: Extract `NormalizeProductCode` and refactor `AssociateWithProduct`**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — replace the existing `AssociateWithProduct` (lines 55–68) with:
+
+```csharp
+        // Domain methods
+        public void AssociateWithProduct(string productCode)
+        {
+            var normalized = NormalizeProductCode(productCode);
+
+            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
+                return; // Already associated
+
+            ProductAssociations.Add(new JournalEntryProduct
+            {
+                JournalEntryId = Id,
+                ProductCodePrefix = normalized
+            });
+        }
+
+        private static string NormalizeProductCode(string? productCode)
+        {
+            if (string.IsNullOrWhiteSpace(productCode))
+                throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+            return productCode.Trim().ToUpperInvariant();
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they still pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryTests"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full journal test suite to catch any regression in handler-level tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All existing journal tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+git commit -m "refactor: extract NormalizeProductCode helper on JournalEntry"
+```
+
+---
+
+## Task 2: Add `ReplaceProductAssociations` to `JournalEntry`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs`
+
+Adds the first replace method. Validates the whole input set before mutating (so invalid input leaves the entity untouched). Set-diffs against existing associations keyed on `ProductCodePrefix` so unchanged rows keep their identity and `CreatedAt`.
+
+- [ ] **Step 1: Append failing tests for `ReplaceProductAssociations` to `JournalEntryTests.cs`**
+
+Append inside the `JournalEntryTests` class (after the existing tests):
+
+```csharp
+    // ----- ReplaceProductAssociations -----
+
+    [Fact]
+    public void ReplaceProductAssociations_WithNull_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        entry.AssociateWithProduct("B");
+
+        entry.ReplaceProductAssociations(null);
+
+        entry.ProductAssociations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithEmpty_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+
+        entry.ReplaceProductAssociations(Array.Empty<string>());
+
+        entry.ProductAssociations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithSuperset_AddsMissingCodes()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+
+        entry.ReplaceProductAssociations(new[] { "A", "B", "C" });
+
+        entry.ProductAssociations.Select(p => p.ProductCodePrefix)
+            .Should().BeEquivalentTo(new[] { "A", "B", "C" });
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithDisjointSet_RemovesOldAndAddsNew()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        entry.AssociateWithProduct("B");
+
+        entry.ReplaceProductAssociations(new[] { "C", "D" });
+
+        entry.ProductAssociations.Select(p => p.ProductCodePrefix)
+            .Should().BeEquivalentTo(new[] { "C", "D" });
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("X");
+        entry.AssociateWithProduct("Y");
+        var originalX = entry.ProductAssociations.Single(p => p.ProductCodePrefix == "X");
+
+        entry.ReplaceProductAssociations(new[] { "X" });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalX);
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithDifferentCaseOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("X");
+        entry.AssociateWithProduct("Y");
+        var originalX = entry.ProductAssociations.Single(p => p.ProductCodePrefix == "X");
+
+        entry.ReplaceProductAssociations(new[] { "x" });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalX);
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_DedupesCaseAndWhitespaceInsensitively()
+    {
+        var entry = NewEntry();
+
+        entry.ReplaceProductAssociations(new[] { "AB-1", "ab-1", "  AB-1  " });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.ProductCodePrefix.Should().Be("AB-1");
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithWhitespaceItem_ThrowsAndLeavesStateUnchanged()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        var snapshot = entry.ProductAssociations.ToList();
+
+        var act = () => entry.ReplaceProductAssociations(new[] { "B", "   ", "C" });
+
+        act.Should().Throw<ArgumentException>();
+        entry.ProductAssociations.Should().BeEquivalentTo(snapshot);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceProductAssociations"`
+
+Expected: Compilation FAIL — `ReplaceProductAssociations` does not exist on `JournalEntry`.
+
+- [ ] **Step 3: Implement `ReplaceProductAssociations` on `JournalEntry`**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — add after `AssociateWithProduct` and before `AssignTag`:
+
+```csharp
+        public void ReplaceProductAssociations(IEnumerable<string>? productCodes)
+        {
+            // Validate-then-mutate: normalize the entire incoming set first.
+            // Any whitespace-only entry throws before any mutation occurs.
+            var targetCodes = new HashSet<string>(StringComparer.Ordinal);
+            if (productCodes != null)
+            {
+                foreach (var raw in productCodes)
+                {
+                    targetCodes.Add(NormalizeProductCode(raw));
+                }
+            }
+
+            var toRemove = ProductAssociations
+                .Where(pa => !targetCodes.Contains(pa.ProductCodePrefix))
+                .ToList();
+            foreach (var association in toRemove)
+            {
+                ProductAssociations.Remove(association);
+            }
+
+            var existingCodes = new HashSet<string>(
+                ProductAssociations.Select(pa => pa.ProductCodePrefix),
+                StringComparer.Ordinal);
+            foreach (var code in targetCodes)
+            {
+                if (existingCodes.Contains(code))
+                    continue;
+
+                ProductAssociations.Add(new JournalEntryProduct
+                {
+                    JournalEntryId = Id,
+                    ProductCodePrefix = code
+                });
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceProductAssociations"`
+
+Expected: All 8 `ReplaceProductAssociations_*` tests PASS.
+
+- [ ] **Step 5: Re-run the broader journal suite to check for regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All journal tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+git commit -m "feat(journal): add ReplaceProductAssociations domain method"
+```
+
+---
+
+## Task 3: Add `ReplaceTagAssignments` to `JournalEntry`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs`
+
+Same algorithm as Task 2, keyed on `TagId`. No validation beyond deduplication (parity with existing `AssignTag`).
+
+- [ ] **Step 1: Append failing tests for `ReplaceTagAssignments`**
+
+Append inside `JournalEntryTests`:
+
+```csharp
+    // ----- ReplaceTagAssignments -----
+
+    [Fact]
+    public void ReplaceTagAssignments_WithNull_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+
+        entry.ReplaceTagAssignments(null);
+
+        entry.TagAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithEmpty_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+
+        entry.ReplaceTagAssignments(Array.Empty<int>());
+
+        entry.TagAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithSuperset_AddsMissingIds()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+
+        entry.ReplaceTagAssignments(new[] { 1, 2, 3 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithDisjointSet_RemovesOldAndAddsNew()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+
+        entry.ReplaceTagAssignments(new[] { 3, 4 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 3, 4 });
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+        var originalOne = entry.TagAssignments.Single(t => t.TagId == 1);
+
+        entry.ReplaceTagAssignments(new[] { 1 });
+
+        entry.TagAssignments.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalOne);
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_DedupesDuplicateIds()
+    {
+        var entry = NewEntry();
+
+        entry.ReplaceTagAssignments(new[] { 1, 1, 2 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceTagAssignments"`
+
+Expected: Compilation FAIL — `ReplaceTagAssignments` does not exist on `JournalEntry`.
+
+- [ ] **Step 3: Implement `ReplaceTagAssignments` on `JournalEntry`**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — add after `AssignTag`:
+
+```csharp
+        public void ReplaceTagAssignments(IEnumerable<int>? tagIds)
+        {
+            var targetIds = tagIds != null
+                ? new HashSet<int>(tagIds)
+                : new HashSet<int>();
+
+            var toRemove = TagAssignments
+                .Where(ta => !targetIds.Contains(ta.TagId))
+                .ToList();
+            foreach (var assignment in toRemove)
+            {
+                TagAssignments.Remove(assignment);
+            }
+
+            var existingIds = new HashSet<int>(TagAssignments.Select(ta => ta.TagId));
+            foreach (var tagId in targetIds)
+            {
+                if (existingIds.Contains(tagId))
+                    continue;
+
+                TagAssignments.Add(new JournalEntryTagAssignment
+                {
+                    JournalEntryId = Id,
+                    TagId = tagId
+                });
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceTagAssignments"`
+
+Expected: All 6 `ReplaceTagAssignments_*` tests PASS.
+
+- [ ] **Step 5: Re-run full journal suite**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All journal tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+git commit -m "feat(journal): add ReplaceTagAssignments domain method"
+```
+
+---
+
+## Task 4: Wire the new domain methods into `UpdateJournalEntryHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs:61-80`
+
+Replaces the `.Clear()` + foreach blocks with two domain-method calls.
+
+- [ ] **Step 1: Replace lines 61–80 with two domain calls**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs`.
+
+Find this block (lines 61–80):
+
+```csharp
+            // Update product associations (both products and families)
+            entry.ProductAssociations.Clear();
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var productIdentifier in request.AssociatedProducts.Distinct())
+                {
+                    // Try as full product code first, then as prefix
+                    entry.AssociateWithProduct(productIdentifier);
+                }
+            }
+
+            // Update tag assignments
+            entry.TagAssignments.Clear();
+            if (request.TagIds?.Any() == true)
+            {
+                foreach (var tagId in request.TagIds.Distinct())
+                {
+                    entry.AssignTag(tagId);
+                }
+            }
+```
+
+Replace with:
+
+```csharp
+            entry.ReplaceProductAssociations(request.AssociatedProducts);
+            entry.ReplaceTagAssignments(request.TagIds);
+```
+
+- [ ] **Step 2: Verify the handler builds**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Verify no `.Clear()` reference remains on these collections in the handler**
+
+Run via Grep tool on `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs` for the pattern `(ProductAssociations|TagAssignments)\.Clear`.
+
+Expected: No matches.
+
+- [ ] **Step 4: Run the full journal test suite to confirm handler behavior is preserved**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All journal tests PASS (including `JournalRepositoryIntegrationTests` and any existing `UpdateJournalEntryHandler` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs
+git commit -m "refactor(journal): use Replace* domain methods in UpdateJournalEntryHandler"
+```
+
+---
+
+## Task 5: Final validation gates
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run full solution build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: Build succeeds with no errors or new warnings.
+
+- [ ] **Step 2: Run `dotnet format` verification**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+
+Expected: Exit code 0, no formatting violations.
+
+If violations are reported, run `dotnet format backend/Anela.Heblo.sln` to fix them, then re-run with `--verify-no-changes` and commit the formatting fixes:
+
+```bash
+git add -A
+git commit -m "style: dotnet format"
+```
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Confirm no unexpected files changed**
+
+Run: `git status` and `git diff --stat main...HEAD`
+
+Expected: Only the three files in scope (`JournalEntry.cs`, `UpdateJournalEntryHandler.cs`, `JournalEntryTests.cs`) appear in the diff. No migrations, no contract changes, no DI changes.
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Implemented in |
+|---|---|
+| FR-1 `ReplaceProductAssociations` signature + behavior (null/empty clears, dedupe, normalize, whitespace throws, instance preservation) | Task 2 |
+| FR-2 `ReplaceTagAssignments` signature + behavior (null/empty clears, dedupe, instance preservation, no tag-existence validation) | Task 3 |
+| FR-3 Handler uses the new methods, no `.Clear()` references remain | Task 4 |
+| FR-4 Unit-test coverage for both domain methods (all acceptance bullets) | Tasks 2 and 3 |
+| FR-5 Existing tests still pass; no new test infrastructure | Tasks 1–5 (existing tests are run at each stage) |
+| NFR-1 O(n+m) set-diff via `HashSet<T>` | Tasks 2 and 3 |
+| NFR-2 No auth/security change | (no edits to handler auth path) |
+| NFR-3 No public API/schema/contract change | (no edits to contracts, EF configurations, migrations) |
+| NFR-4 `dotnet build` and `dotnet format` clean | Task 5 |
+| Arch-review Decision 2 — single `NormalizeProductCode` helper | Task 1 |
+| Arch-review Decision 3 — validate-then-mutate (state unchanged on invalid input) | Task 2, test `ReplaceProductAssociations_WithWhitespaceItem_ThrowsAndLeavesStateUnchanged` |
+| Arch-review amendment 5 — case-insensitive overlap preserves instance | Task 2, test `ReplaceProductAssociations_WithDifferentCaseOverlap_PreservesExistingInstance` |

--- a/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs
@@ -58,26 +58,8 @@ namespace Anela.Heblo.Application.Features.Journal.UseCases.UpdateJournalEntry
             entry.ModifiedByUserId = currentUser.Id;
             entry.ModifiedByUsername = currentUser.Name ?? "Unknown User";
 
-            // Update product associations (both products and families)
-            entry.ProductAssociations.Clear();
-            if (request.AssociatedProducts?.Any() == true)
-            {
-                foreach (var productIdentifier in request.AssociatedProducts.Distinct())
-                {
-                    // Try as full product code first, then as prefix
-                    entry.AssociateWithProduct(productIdentifier);
-                }
-            }
-
-            // Update tag assignments
-            entry.TagAssignments.Clear();
-            if (request.TagIds?.Any() == true)
-            {
-                foreach (var tagId in request.TagIds.Distinct())
-                {
-                    entry.AssignTag(tagId);
-                }
-            }
+            entry.ReplaceProductAssociations(request.AssociatedProducts);
+            entry.ReplaceTagAssignments(request.TagIds);
 
             await _journalRepository.UpdateAsync(entry, cancellationToken);
             await _journalRepository.SaveChangesAsync(cancellationToken);

--- a/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
@@ -54,17 +54,24 @@ namespace Anela.Heblo.Domain.Features.Journal
         // Domain methods
         public void AssociateWithProduct(string productCode)
         {
-            if (string.IsNullOrWhiteSpace(productCode))
-                throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+            var normalized = NormalizeProductCode(productCode);
 
-            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))
+            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
                 return; // Already associated
 
             ProductAssociations.Add(new JournalEntryProduct
             {
                 JournalEntryId = Id,
-                ProductCodePrefix = productCode.Trim().ToUpperInvariant()
+                ProductCodePrefix = normalized
             });
+        }
+
+        private static string NormalizeProductCode(string? productCode)
+        {
+            if (string.IsNullOrWhiteSpace(productCode))
+                throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+            return productCode.Trim().ToUpperInvariant();
         }
 
         public void AssignTag(int tagId)

--- a/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
@@ -122,6 +122,34 @@ namespace Anela.Heblo.Domain.Features.Journal
             });
         }
 
+        public void ReplaceTagAssignments(IEnumerable<int>? tagIds)
+        {
+            var targetIds = tagIds != null
+                ? new HashSet<int>(tagIds)
+                : new HashSet<int>();
+
+            var toRemove = TagAssignments
+                .Where(ta => !targetIds.Contains(ta.TagId))
+                .ToList();
+            foreach (var assignment in toRemove)
+            {
+                TagAssignments.Remove(assignment);
+            }
+
+            var existingIds = new HashSet<int>(TagAssignments.Select(ta => ta.TagId));
+            foreach (var tagId in targetIds)
+            {
+                if (existingIds.Contains(tagId))
+                    continue;
+
+                TagAssignments.Add(new JournalEntryTagAssignment
+                {
+                    JournalEntryId = Id,
+                    TagId = tagId
+                });
+            }
+        }
+
         public void SoftDelete(string userId, string username)
         {
             IsDeleted = true;

--- a/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
@@ -66,6 +66,42 @@ namespace Anela.Heblo.Domain.Features.Journal
             });
         }
 
+        public void ReplaceProductAssociations(IEnumerable<string>? productCodes)
+        {
+            // Validate entire input set before any mutation (state preserved on invalid input).
+            var targetCodes = new HashSet<string>(StringComparer.Ordinal);
+            if (productCodes != null)
+            {
+                foreach (var raw in productCodes)
+                {
+                    targetCodes.Add(NormalizeProductCode(raw));
+                }
+            }
+
+            var toRemove = ProductAssociations
+                .Where(pa => !targetCodes.Contains(pa.ProductCodePrefix))
+                .ToList();
+            foreach (var association in toRemove)
+            {
+                ProductAssociations.Remove(association);
+            }
+
+            var existingCodes = new HashSet<string>(
+                ProductAssociations.Select(pa => pa.ProductCodePrefix),
+                StringComparer.Ordinal);
+            foreach (var code in targetCodes)
+            {
+                if (existingCodes.Contains(code))
+                    continue;
+
+                ProductAssociations.Add(new JournalEntryProduct
+                {
+                    JournalEntryId = Id,
+                    ProductCodePrefix = code
+                });
+            }
+        }
+
         private static string NormalizeProductCode(string? productCode)
         {
             if (string.IsNullOrWhiteSpace(productCode))

--- a/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs
@@ -69,7 +69,7 @@ namespace Anela.Heblo.Domain.Features.Journal
         public void ReplaceProductAssociations(IEnumerable<string>? productCodes)
         {
             // Validate entire input set before any mutation (state preserved on invalid input).
-            var targetCodes = new HashSet<string>(StringComparer.Ordinal);
+            var targetCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (productCodes != null)
             {
                 foreach (var raw in productCodes)
@@ -88,7 +88,7 @@ namespace Anela.Heblo.Domain.Features.Journal
 
             var existingCodes = new HashSet<string>(
                 ProductAssociations.Select(pa => pa.ProductCodePrefix),
-                StringComparer.Ordinal);
+                StringComparer.OrdinalIgnoreCase);
             foreach (var code in targetCodes)
             {
                 if (existingCodes.Contains(code))

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
@@ -38,4 +38,106 @@ public class JournalEntryTests
 
         act.Should().Throw<ArgumentException>();
     }
+
+    // ----- ReplaceProductAssociations -----
+
+    [Fact]
+    public void ReplaceProductAssociations_WithNull_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        entry.AssociateWithProduct("B");
+
+        entry.ReplaceProductAssociations(null);
+
+        entry.ProductAssociations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithEmpty_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+
+        entry.ReplaceProductAssociations(Array.Empty<string>());
+
+        entry.ProductAssociations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithSuperset_AddsMissingCodes()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+
+        entry.ReplaceProductAssociations(new[] { "A", "B", "C" });
+
+        entry.ProductAssociations.Select(p => p.ProductCodePrefix)
+            .Should().BeEquivalentTo(new[] { "A", "B", "C" });
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithDisjointSet_RemovesOldAndAddsNew()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        entry.AssociateWithProduct("B");
+
+        entry.ReplaceProductAssociations(new[] { "C", "D" });
+
+        entry.ProductAssociations.Select(p => p.ProductCodePrefix)
+            .Should().BeEquivalentTo(new[] { "C", "D" });
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("X");
+        entry.AssociateWithProduct("Y");
+        var originalX = entry.ProductAssociations.Single(p => p.ProductCodePrefix == "X");
+
+        entry.ReplaceProductAssociations(new[] { "X" });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalX);
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithDifferentCaseOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("X");
+        entry.AssociateWithProduct("Y");
+        var originalX = entry.ProductAssociations.Single(p => p.ProductCodePrefix == "X");
+
+        entry.ReplaceProductAssociations(new[] { "x" });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalX);
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_DedupesCaseAndWhitespaceInsensitively()
+    {
+        var entry = NewEntry();
+
+        entry.ReplaceProductAssociations(new[] { "AB-1", "ab-1", "  AB-1  " });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.ProductCodePrefix.Should().Be("AB-1");
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithWhitespaceItem_ThrowsAndLeavesStateUnchanged()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        var snapshot = entry.ProductAssociations.ToList();
+
+        var act = () => entry.ReplaceProductAssociations(new[] { "B", "   ", "C" });
+
+        act.Should().Throw<ArgumentException>();
+        entry.ProductAssociations.Should().BeEquivalentTo(snapshot);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
@@ -1,0 +1,41 @@
+using Anela.Heblo.Domain.Features.Journal;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Journal;
+
+public class JournalEntryTests
+{
+    private static JournalEntry NewEntry() => new JournalEntry
+    {
+        Id = 1,
+        Content = "test",
+        EntryDate = DateTime.UtcNow.Date,
+        CreatedAt = DateTime.UtcNow,
+        ModifiedAt = DateTime.UtcNow,
+        CreatedByUserId = "user-1"
+    };
+
+    // ----- AssociateWithProduct: existing-behavior regression coverage -----
+
+    [Fact]
+    public void AssociateWithProduct_NormalizesCodeToTrimmedUpper()
+    {
+        var entry = NewEntry();
+
+        entry.AssociateWithProduct("  ab-1  ");
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.ProductCodePrefix.Should().Be("AB-1");
+    }
+
+    [Fact]
+    public void AssociateWithProduct_ThrowsOnWhitespaceCode()
+    {
+        var entry = NewEntry();
+
+        var act = () => entry.AssociateWithProduct("   ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
@@ -140,4 +140,79 @@ public class JournalEntryTests
         act.Should().Throw<ArgumentException>();
         entry.ProductAssociations.Should().BeEquivalentTo(snapshot);
     }
+
+    // ----- ReplaceTagAssignments -----
+
+    [Fact]
+    public void ReplaceTagAssignments_WithNull_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+
+        entry.ReplaceTagAssignments(null);
+
+        entry.TagAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithEmpty_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+
+        entry.ReplaceTagAssignments(Array.Empty<int>());
+
+        entry.TagAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithSuperset_AddsMissingIds()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+
+        entry.ReplaceTagAssignments(new[] { 1, 2, 3 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithDisjointSet_RemovesOldAndAddsNew()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+
+        entry.ReplaceTagAssignments(new[] { 3, 4 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 3, 4 });
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+        var originalOne = entry.TagAssignments.Single(t => t.TagId == 1);
+
+        entry.ReplaceTagAssignments(new[] { 1 });
+
+        entry.TagAssignments.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalOne);
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_DedupesDuplicateIds()
+    {
+        var entry = NewEntry();
+
+        entry.ReplaceTagAssignments(new[] { 1, 1, 2 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 1, 2 });
+    }
 }

--- a/docs/superpowers/plans/2026-05-13-journal-entry-replace-semantics.md
+++ b/docs/superpowers/plans/2026-05-13-journal-entry-replace-semantics.md
@@ -1,0 +1,603 @@
+# JournalEntry Replace Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw `.Clear()` + per-item add pattern in `UpdateJournalEntryHandler` with two new tell-don't-ask domain methods on `JournalEntry` — `ReplaceProductAssociations` and `ReplaceTagAssignments` — that perform set-diff replacement, preserve unchanged child rows, and validate input atomically.
+
+**Architecture:** Adds two `public void` methods to the rich `JournalEntry` aggregate using a set-diff algorithm (`HashSet<T>` keyed on `ProductCodePrefix` / `TagId`). Extracts a single private `NormalizeProductCode` helper used by both `AssociateWithProduct` and the new replace method to keep normalization rules DRY. The handler shrinks from ~20 lines of mutation logic to two intent-revealing calls. No schema, contract, or DI changes.
+
+**Tech Stack:** .NET 8, EF Core (change tracker handles child add/remove via composite PKs), xUnit + FluentAssertions for tests.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — add `NormalizeProductCode` private helper, refactor `AssociateWithProduct` to use it, add `ReplaceProductAssociations` and `ReplaceTagAssignments`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs` — replace lines 61–80 with two domain method calls.
+
+**Create:**
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs` — xUnit tests for both new domain methods plus `NormalizeProductCode` behavior surfaced via `AssociateWithProduct` to confirm no regression.
+
+**Validation commands (from worktree root):**
+- `dotnet build backend/Anela.Heblo.sln`
+- `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+- `dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Journal"`
+
+---
+
+## Task 1: Extract `NormalizeProductCode` helper and refactor `AssociateWithProduct`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs:55-68`
+
+This task is a pure non-behavioral refactor. It introduces the helper that Task 2 depends on and verifies the existing `AssociateWithProduct` contract is unchanged.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.Journal;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Journal;
+
+public class JournalEntryTests
+{
+    private static JournalEntry NewEntry() => new JournalEntry
+    {
+        Id = 1,
+        Content = "test",
+        EntryDate = DateTime.UtcNow.Date,
+        CreatedAt = DateTime.UtcNow,
+        ModifiedAt = DateTime.UtcNow,
+        CreatedByUserId = "user-1"
+    };
+
+    // ----- AssociateWithProduct: existing-behavior regression coverage -----
+
+    [Fact]
+    public void AssociateWithProduct_NormalizesCodeToTrimmedUpper()
+    {
+        var entry = NewEntry();
+
+        entry.AssociateWithProduct("  ab-1  ");
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.ProductCodePrefix.Should().Be("AB-1");
+    }
+
+    [Fact]
+    public void AssociateWithProduct_ThrowsOnWhitespaceCode()
+    {
+        var entry = NewEntry();
+
+        var act = () => entry.AssociateWithProduct("   ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify the regression test passes against the current code**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryTests"`
+
+Expected: Both tests **PASS** (`AssociateWithProduct` already trims/uppers and throws on whitespace).
+
+Note: The current `AssociateWithProduct` compares the raw input against existing `ProductCodePrefix` values before normalizing. The "NormalizesCodeToTrimmedUpper" test passes today only because nothing matches on first add; we will fix the order-of-operations bug as part of the helper extraction in step 3.
+
+- [ ] **Step 3: Extract `NormalizeProductCode` and refactor `AssociateWithProduct`**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — replace the existing `AssociateWithProduct` (lines 55–68) with:
+
+```csharp
+        // Domain methods
+        public void AssociateWithProduct(string productCode)
+        {
+            var normalized = NormalizeProductCode(productCode);
+
+            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
+                return; // Already associated
+
+            ProductAssociations.Add(new JournalEntryProduct
+            {
+                JournalEntryId = Id,
+                ProductCodePrefix = normalized
+            });
+        }
+
+        private static string NormalizeProductCode(string? productCode)
+        {
+            if (string.IsNullOrWhiteSpace(productCode))
+                throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+            return productCode.Trim().ToUpperInvariant();
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they still pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryTests"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full journal test suite to catch any regression in handler-level tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All existing journal tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+git commit -m "refactor: extract NormalizeProductCode helper on JournalEntry"
+```
+
+---
+
+## Task 2: Add `ReplaceProductAssociations` to `JournalEntry`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs`
+
+Adds the first replace method. Validates the whole input set before mutating (so invalid input leaves the entity untouched). Set-diffs against existing associations keyed on `ProductCodePrefix` so unchanged rows keep their identity and `CreatedAt`.
+
+- [ ] **Step 1: Append failing tests for `ReplaceProductAssociations` to `JournalEntryTests.cs`**
+
+Append inside the `JournalEntryTests` class (after the existing tests):
+
+```csharp
+    // ----- ReplaceProductAssociations -----
+
+    [Fact]
+    public void ReplaceProductAssociations_WithNull_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        entry.AssociateWithProduct("B");
+
+        entry.ReplaceProductAssociations(null);
+
+        entry.ProductAssociations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithEmpty_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+
+        entry.ReplaceProductAssociations(Array.Empty<string>());
+
+        entry.ProductAssociations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithSuperset_AddsMissingCodes()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+
+        entry.ReplaceProductAssociations(new[] { "A", "B", "C" });
+
+        entry.ProductAssociations.Select(p => p.ProductCodePrefix)
+            .Should().BeEquivalentTo(new[] { "A", "B", "C" });
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithDisjointSet_RemovesOldAndAddsNew()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        entry.AssociateWithProduct("B");
+
+        entry.ReplaceProductAssociations(new[] { "C", "D" });
+
+        entry.ProductAssociations.Select(p => p.ProductCodePrefix)
+            .Should().BeEquivalentTo(new[] { "C", "D" });
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("X");
+        entry.AssociateWithProduct("Y");
+        var originalX = entry.ProductAssociations.Single(p => p.ProductCodePrefix == "X");
+
+        entry.ReplaceProductAssociations(new[] { "X" });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalX);
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithDifferentCaseOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("X");
+        entry.AssociateWithProduct("Y");
+        var originalX = entry.ProductAssociations.Single(p => p.ProductCodePrefix == "X");
+
+        entry.ReplaceProductAssociations(new[] { "x" });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalX);
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_DedupesCaseAndWhitespaceInsensitively()
+    {
+        var entry = NewEntry();
+
+        entry.ReplaceProductAssociations(new[] { "AB-1", "ab-1", "  AB-1  " });
+
+        entry.ProductAssociations.Should().ContainSingle()
+            .Which.ProductCodePrefix.Should().Be("AB-1");
+    }
+
+    [Fact]
+    public void ReplaceProductAssociations_WithWhitespaceItem_ThrowsAndLeavesStateUnchanged()
+    {
+        var entry = NewEntry();
+        entry.AssociateWithProduct("A");
+        var snapshot = entry.ProductAssociations.ToList();
+
+        var act = () => entry.ReplaceProductAssociations(new[] { "B", "   ", "C" });
+
+        act.Should().Throw<ArgumentException>();
+        entry.ProductAssociations.Should().BeEquivalentTo(snapshot);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceProductAssociations"`
+
+Expected: Compilation FAIL — `ReplaceProductAssociations` does not exist on `JournalEntry`.
+
+- [ ] **Step 3: Implement `ReplaceProductAssociations` on `JournalEntry`**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — add after `AssociateWithProduct` and before `AssignTag`:
+
+```csharp
+        public void ReplaceProductAssociations(IEnumerable<string>? productCodes)
+        {
+            // Validate-then-mutate: normalize the entire incoming set first.
+            // Any whitespace-only entry throws before any mutation occurs.
+            var targetCodes = new HashSet<string>(StringComparer.Ordinal);
+            if (productCodes != null)
+            {
+                foreach (var raw in productCodes)
+                {
+                    targetCodes.Add(NormalizeProductCode(raw));
+                }
+            }
+
+            var toRemove = ProductAssociations
+                .Where(pa => !targetCodes.Contains(pa.ProductCodePrefix))
+                .ToList();
+            foreach (var association in toRemove)
+            {
+                ProductAssociations.Remove(association);
+            }
+
+            var existingCodes = new HashSet<string>(
+                ProductAssociations.Select(pa => pa.ProductCodePrefix),
+                StringComparer.Ordinal);
+            foreach (var code in targetCodes)
+            {
+                if (existingCodes.Contains(code))
+                    continue;
+
+                ProductAssociations.Add(new JournalEntryProduct
+                {
+                    JournalEntryId = Id,
+                    ProductCodePrefix = code
+                });
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceProductAssociations"`
+
+Expected: All 8 `ReplaceProductAssociations_*` tests PASS.
+
+- [ ] **Step 5: Re-run the broader journal suite to check for regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All journal tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+git commit -m "feat(journal): add ReplaceProductAssociations domain method"
+```
+
+---
+
+## Task 3: Add `ReplaceTagAssignments` to `JournalEntry`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs`
+
+Same algorithm as Task 2, keyed on `TagId`. No validation beyond deduplication (parity with existing `AssignTag`).
+
+- [ ] **Step 1: Append failing tests for `ReplaceTagAssignments`**
+
+Append inside `JournalEntryTests`:
+
+```csharp
+    // ----- ReplaceTagAssignments -----
+
+    [Fact]
+    public void ReplaceTagAssignments_WithNull_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+
+        entry.ReplaceTagAssignments(null);
+
+        entry.TagAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithEmpty_ClearsAll()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+
+        entry.ReplaceTagAssignments(Array.Empty<int>());
+
+        entry.TagAssignments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithSuperset_AddsMissingIds()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+
+        entry.ReplaceTagAssignments(new[] { 1, 2, 3 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithDisjointSet_RemovesOldAndAddsNew()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+
+        entry.ReplaceTagAssignments(new[] { 3, 4 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 3, 4 });
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_WithOverlap_PreservesExistingInstance()
+    {
+        var entry = NewEntry();
+        entry.AssignTag(1);
+        entry.AssignTag(2);
+        var originalOne = entry.TagAssignments.Single(t => t.TagId == 1);
+
+        entry.ReplaceTagAssignments(new[] { 1 });
+
+        entry.TagAssignments.Should().ContainSingle()
+            .Which.Should().BeSameAs(originalOne);
+    }
+
+    [Fact]
+    public void ReplaceTagAssignments_DedupesDuplicateIds()
+    {
+        var entry = NewEntry();
+
+        entry.ReplaceTagAssignments(new[] { 1, 1, 2 });
+
+        entry.TagAssignments.Select(t => t.TagId)
+            .Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceTagAssignments"`
+
+Expected: Compilation FAIL — `ReplaceTagAssignments` does not exist on `JournalEntry`.
+
+- [ ] **Step 3: Implement `ReplaceTagAssignments` on `JournalEntry`**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs` — add after `AssignTag`:
+
+```csharp
+        public void ReplaceTagAssignments(IEnumerable<int>? tagIds)
+        {
+            var targetIds = tagIds != null
+                ? new HashSet<int>(tagIds)
+                : new HashSet<int>();
+
+            var toRemove = TagAssignments
+                .Where(ta => !targetIds.Contains(ta.TagId))
+                .ToList();
+            foreach (var assignment in toRemove)
+            {
+                TagAssignments.Remove(assignment);
+            }
+
+            var existingIds = new HashSet<int>(TagAssignments.Select(ta => ta.TagId));
+            foreach (var tagId in targetIds)
+            {
+                if (existingIds.Contains(tagId))
+                    continue;
+
+                TagAssignments.Add(new JournalEntryTagAssignment
+                {
+                    JournalEntryId = Id,
+                    TagId = tagId
+                });
+            }
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ReplaceTagAssignments"`
+
+Expected: All 6 `ReplaceTagAssignments_*` tests PASS.
+
+- [ ] **Step 5: Re-run full journal suite**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All journal tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Journal/JournalEntry.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryTests.cs
+git commit -m "feat(journal): add ReplaceTagAssignments domain method"
+```
+
+---
+
+## Task 4: Wire the new domain methods into `UpdateJournalEntryHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs:61-80`
+
+Replaces the `.Clear()` + foreach blocks with two domain-method calls.
+
+- [ ] **Step 1: Replace lines 61–80 with two domain calls**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs`.
+
+Find this block (lines 61–80):
+
+```csharp
+            // Update product associations (both products and families)
+            entry.ProductAssociations.Clear();
+            if (request.AssociatedProducts?.Any() == true)
+            {
+                foreach (var productIdentifier in request.AssociatedProducts.Distinct())
+                {
+                    // Try as full product code first, then as prefix
+                    entry.AssociateWithProduct(productIdentifier);
+                }
+            }
+
+            // Update tag assignments
+            entry.TagAssignments.Clear();
+            if (request.TagIds?.Any() == true)
+            {
+                foreach (var tagId in request.TagIds.Distinct())
+                {
+                    entry.AssignTag(tagId);
+                }
+            }
+```
+
+Replace with:
+
+```csharp
+            entry.ReplaceProductAssociations(request.AssociatedProducts);
+            entry.ReplaceTagAssignments(request.TagIds);
+```
+
+- [ ] **Step 2: Verify the handler builds**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Verify no `.Clear()` reference remains on these collections in the handler**
+
+Run via Grep tool on `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs` for the pattern `(ProductAssociations|TagAssignments)\.Clear`.
+
+Expected: No matches.
+
+- [ ] **Step 4: Run the full journal test suite to confirm handler behavior is preserved**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Journal"`
+
+Expected: All journal tests PASS (including `JournalRepositoryIntegrationTests` and any existing `UpdateJournalEntryHandler` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs
+git commit -m "refactor(journal): use Replace* domain methods in UpdateJournalEntryHandler"
+```
+
+---
+
+## Task 5: Final validation gates
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run full solution build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: Build succeeds with no errors or new warnings.
+
+- [ ] **Step 2: Run `dotnet format` verification**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes`
+
+Expected: Exit code 0, no formatting violations.
+
+If violations are reported, run `dotnet format backend/Anela.Heblo.sln` to fix them, then re-run with `--verify-no-changes` and commit the formatting fixes:
+
+```bash
+git add -A
+git commit -m "style: dotnet format"
+```
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Confirm no unexpected files changed**
+
+Run: `git status` and `git diff --stat main...HEAD`
+
+Expected: Only the three files in scope (`JournalEntry.cs`, `UpdateJournalEntryHandler.cs`, `JournalEntryTests.cs`) appear in the diff. No migrations, no contract changes, no DI changes.
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Implemented in |
+|---|---|
+| FR-1 `ReplaceProductAssociations` signature + behavior (null/empty clears, dedupe, normalize, whitespace throws, instance preservation) | Task 2 |
+| FR-2 `ReplaceTagAssignments` signature + behavior (null/empty clears, dedupe, instance preservation, no tag-existence validation) | Task 3 |
+| FR-3 Handler uses the new methods, no `.Clear()` references remain | Task 4 |
+| FR-4 Unit-test coverage for both domain methods (all acceptance bullets) | Tasks 2 and 3 |
+| FR-5 Existing tests still pass; no new test infrastructure | Tasks 1–5 (existing tests are run at each stage) |
+| NFR-1 O(n+m) set-diff via `HashSet<T>` | Tasks 2 and 3 |
+| NFR-2 No auth/security change | (no edits to handler auth path) |
+| NFR-3 No public API/schema/contract change | (no edits to contracts, EF configurations, migrations) |
+| NFR-4 `dotnet build` and `dotnet format` clean | Task 5 |
+| Arch-review Decision 2 — single `NormalizeProductCode` helper | Task 1 |
+| Arch-review Decision 3 — validate-then-mutate (state unchanged on invalid input) | Task 2, test `ReplaceProductAssociations_WithWhitespaceItem_ThrowsAndLeavesStateUnchanged` |
+| Arch-review amendment 5 — case-insensitive overlap preserves instance | Task 2, test `ReplaceProductAssociations_WithDifferentCaseOverlap_PreservesExistingInstance` |


### PR DESCRIPTION
Journal

## Finding
`UpdateJournalEntryHandler` directly mutates navigation-property collections on the `JournalEntry` aggregate instead of going through domain methods:

```csharp
// backend/src/Anela.Heblo.Application/Features/Journal/UseCases/UpdateJournalEntry/UpdateJournalEntryHandler.cs
// Lines 62–78
entry.ProductAssociations.Clear();   // ← raw collection mutation
if (request.AssociatedProducts?.Any() == true)
{
    foreach (var productIdentifier in request.AssociatedProducts.Distinct())
        entry.AssociateWithProduct(productIdentifier);   // ← then domain method
}

entry.TagAssignments.Clear();         // ← raw collection mutation
if (request.TagIds?.Any() == true)
{
    foreach (var tagId in request.TagIds.Distinct())
        entry.AssignTag(tagId);                          // ← then domain method
}
```

The entity already provides `AssociateWithProduct` and `AssignTag` for the *add* path (used consistently in `CreateJournalEntryHandler`), but the *replace* path skips domain encapsulation entirely by calling `.Clear()` directly on the collections.

## Why it matters
- **Inconsistency between create and update paths**: create routes all mutations through domain methods; update partially bypasses them.
- **Domain invariants not enforced for removal**: `.Clear()` does not go through any domain logic; future invariants on removal (e.g. audit trail, validation) would need to be added in two places — the handler and the domain method.
- **EF change-tracking fragility**: clearing owned collections directly can cause unexpected behaviour under EF tracking if the collection is lazy-loaded or if the cascade delete behaviour changes.
- **Violates tell-don't-ask**: the handler asks for the collection and mutates it rather than telling the entity what its new state should be.

## Suggested fix
Add `ReplaceProductAssociations(IEnumerable<string> productIdentifiers)` and `ReplaceTagAssignments(IEnumerable<int> tagIds)` domain methods to `JournalEntry` (mirroring the existing guard logic in `AssociateWithProduct`/`AssignTag`), then call those from the handler instead of the raw `.Clear()` + loop pattern.

---
_Filed by daily arch-review routine on 2026-05-12._

---

Closes #1161

### Tokens used
15217270
