### PR TITLE
feat: Split `JournalEntryDto` into list/detail and search variants

### DIFF
--- a/artifacts/feat-arch-review-journal-journalentrydto-carr/arch-review.r1.md
+++ b/artifacts/feat-arch-review-journal-journalentrydto-carr/arch-review.r1.md
@@ -1,0 +1,214 @@
+I have enough context to produce the architecture review.
+
+# Architecture Review: Split `JournalEntryDto` into list/detail and search variants
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure contract-narrowing change confined to the Journal vertical slice and its corresponding frontend module. It is fully aligned with the project's stated architecture:
+
+- **Vertical Slice respect**: all backend changes live in `backend/src/Anela.Heblo.Application/Features/Journal/{Contracts,Mapping,UseCases}/`. No cross-module impact.
+- **Contracts ownership**: the new DTO belongs in `Features/Journal/Contracts/` — the same folder that already houses `JournalEntryDto`, `SearchJournalEntriesResponse`, and `JournalEntryTagDto`. This matches the rule "DTO objects for API live in `contracts/` of the specific module".
+- **Project DTO rule (CRITICAL)**: the spec correctly mandates `class`, not `record`. The codebase confirms this — `JournalEntryDto`, `SearchJournalEntriesResponse`, `JournalEntryTagDto` are all classes with public setters.
+- **Auto-generated client**: the OpenAPI/TS client regenerates on backend build, so frontend type churn is automatic — `JournalList.tsx` simply consumes whatever the new schema produces.
+
+The spec's explicit rejection of inheritance (`SearchJournalEntryDto : JournalEntryDto`) is correct and aligns with how NSwag generates `allOf` schemas. The brief's original suggestion (inheritance) would have silently shipped `content` to the wire via the base type — defeating the bandwidth goal.
+
+The only structural concern: the search handler currently mutates DTOs in-place (`dto.ContentPreview = …`). The new design must move preview computation to the construction site to keep the handler aligned with the project's general immutability preference (still fine to use object initializers — DTOs are mutable by necessity, but no post-construction reassignment is needed).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/src/Anela.Heblo.Application/Features/Journal/
+├── Contracts/
+│   ├── JournalEntryDto.cs          (modified: drop ContentPreview, HighlightedTerms)
+│   ├── SearchJournalEntryDto.cs    (NEW: flat DTO, no Content field)
+│   ├── SearchJournalEntriesResponse.cs   (modified: Entries → List<SearchJournalEntryDto>)
+│   └── …unchanged…
+├── Mapping/
+│   └── JournalEntryMapper.cs       (modified: add ToSearchDto, keep ToDto)
+└── UseCases/
+    └── SearchJournalEntries/
+        └── SearchJournalEntriesHandler.cs   (modified: use ToSearchDto + compute preview from domain.Content)
+
+frontend/src/
+├── api/generated/api-client.ts     (regenerated)
+└── components/pages/Journal/
+    └── JournalList.tsx             (modified: branch on isSearchMode for type narrowing, not on a nullable field)
+```
+
+Read paths after the change:
+
+```
+GET /api/journal            ─► GetJournalEntriesHandler   ─► JournalEntryDto[]        (with full Content)
+GET /api/journal/{id}       ─► GetJournalEntryHandler     ─► JournalEntryDto          (with full Content)
+POST/GET search             ─► SearchJournalEntriesHandler─► SearchJournalEntryDto[]  (no Content, has ContentPreview)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Two flat DTOs, no inheritance
+**Options considered:**
+- (A) `SearchJournalEntryDto : JournalEntryDto` adding preview/terms (brief's suggestion).
+- (B) Two flat DTOs, each owning exactly the fields it needs (spec's choice).
+- (C) Single DTO with `JsonIgnore` conditional serialization on search-only fields.
+
+**Chosen approach:** (B) — two flat DTOs.
+
+**Rationale:** NSwag emits `allOf` for class inheritance, and the generated TypeScript client carries every inherited member. Option (A) would force `content?: string` onto `SearchJournalEntryDto` and keep the bandwidth waste invisible in the C# code while still shipping over the wire. Option (C) hides the contract in attributes and breaks OpenAPI schema cleanliness. Option (B) makes the contract explicit in both directions and is consistent with how the rest of the codebase models distinct read contracts.
+
+#### Decision 2: Compute preview from the domain entity, not the DTO
+**Options considered:**
+- (A) Map full DTO first, then derive preview from `dto.Content`, then null-out `Content` (current shape).
+- (B) Add `ToSearchDto(JournalEntry)` that omits `Content`; handler reads `entry.Content` directly for preview computation.
+
+**Chosen approach:** (B).
+
+**Rationale:** (A) requires a "set then unset" anti-pattern and still allocates the full string into a DTO field. (B) keeps the DTO immutable-after-construction in spirit, eliminates the wasted allocation, and makes the mapper's responsibility crisp: build the wire shape; the handler owns search-specific enrichment.
+
+#### Decision 3: Empty-search fallback for `ContentPreview`
+**Options considered:**
+- (A) Keep `ContentPreview` nullable (no fallback when search text is empty).
+- (B) Compute a truncated preview (≤200 chars) from `entry.Content` even when search text is empty (spec's choice).
+
+**Chosen approach:** (B) — non-nullable, always populated.
+
+**Rationale:** Non-nullable on the contract eliminates the only remaining reason for a frontend to defensively branch on field presence. The existing `CreateContentPreview` method already handles the empty-search case correctly (returns leading slice + ellipsis when truncation occurred). Reuse it.
+
+#### Decision 4: Handler-level preview enrichment stays in the handler
+**Options considered:**
+- (A) Push `CreateContentPreview` / `ExtractHighlightTerms` into the mapper as overloads.
+- (B) Keep them as `private static` helpers in `SearchJournalEntriesHandler` (current).
+
+**Chosen approach:** (B).
+
+**Rationale:** Preview generation is search-policy (depends on `request.SearchText`), not DTO-shape policy. Mapper should not take a search-text parameter. Keep the seam clean.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create**
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs` — new class DTO per FR-1.
+
+**Modify**
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs` — remove `ContentPreview` and `HighlightedTerms` properties (lines 22–24).
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs` — change `Entries` type to `List<SearchJournalEntryDto>` (line 7).
+- `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs` — add `ToSearchDto(JournalEntry)`; reuse the same projections (`Title`, `EntryDate`, etc.); do **not** copy `Content`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs` — replace `.Select(JournalEntryMapper.ToDto)` with a per-item projection that calls `ToSearchDto`, then sets `ContentPreview` and `HighlightedTerms` from `entry.Content` and `request.SearchText`. Always populate `ContentPreview` (use truncated fallback when `request.SearchText` is empty).
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs` — drop the two tests asserting `ContentPreview.Should().BeNull()` and `HighlightedTerms.Should().NotBeNull().And.BeEmpty()` (lines 181–205); add equivalent coverage for `ToSearchDto` (no `Content` field even exists; preview/terms are defaults).
+- `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs` — re-target assertions at `SearchJournalEntryDto`; cover the new empty-search fallback path.
+- `frontend/src/components/pages/Journal/JournalList.tsx` — replace the `isSearchMode && entry.contentPreview` branch (line 336) with a typed split: either render two table-row components keyed on mode, or map `entries` through a discriminated local helper that returns `{ preview: string }` based on mode.
+
+**Leave unchanged**
+- `backend/src/Anela.Heblo.API/Controllers/JournalController.cs` — the controller forwards MediatR responses by type; no shape rewiring needed.
+- `frontend/src/components/catalog/detail/tabs/JournalTab.tsx`, `JournalEntryForm.tsx`, `JournalEntryModal.tsx`, `CatalogDetail.tsx` — these consume `JournalEntryDto` for detail/list use only; removing the two unused fields cannot break them. Verify with `tsc --noEmit` post-regeneration.
+
+### Interfaces and Contracts
+
+```csharp
+// New file: Features/Journal/Contracts/SearchJournalEntryDto.cs
+public class SearchJournalEntryDto
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    public DateTime EntryDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public string CreatedByUserId { get; set; } = null!;
+    public string? CreatedByUsername { get; set; }
+    public string? ModifiedByUserId { get; set; }
+    public string? ModifiedByUsername { get; set; }
+    public List<string> AssociatedProducts { get; set; } = new();
+    public List<JournalEntryTagDto> Tags { get; set; } = new();
+    public string ContentPreview { get; set; } = null!;
+    public List<string> HighlightedTerms { get; set; } = new();
+}
+
+// Mapper addition
+internal static class JournalEntryMapper
+{
+    public static JournalEntryDto ToDto(JournalEntry entry) { /* unchanged */ }
+
+    public static SearchJournalEntryDto ToSearchDto(JournalEntry entry)
+    {
+        return new SearchJournalEntryDto
+        {
+            Id = entry.Id,
+            Title = entry.Title,
+            EntryDate = entry.EntryDate,
+            CreatedAt = entry.CreatedAt,
+            ModifiedAt = entry.ModifiedAt,
+            CreatedByUserId = entry.CreatedByUserId,
+            CreatedByUsername = entry.CreatedByUsername,
+            ModifiedByUserId = entry.ModifiedByUserId,
+            ModifiedByUsername = entry.ModifiedByUsername,
+            AssociatedProducts = entry.ProductAssociations
+                .Select(pa => pa.ProductCodePrefix).Distinct().ToList(),
+            Tags = entry.TagAssignments
+                .Where(ta => ta.Tag != null)
+                .Select(ta => new JournalEntryTagDto
+                {
+                    Id = ta.Tag.Id, Name = ta.Tag.Name, Color = ta.Tag.Color
+                }).ToList()
+            // ContentPreview and HighlightedTerms left at defaults — handler populates them
+        };
+    }
+}
+```
+
+`SearchJournalEntriesResponse.Entries: List<SearchJournalEntryDto>` is the only response-type change.
+
+### Data Flow
+
+**Search path (post-change):**
+1. Controller receives request → MediatR dispatches → `SearchJournalEntriesHandler.Handle`.
+2. Handler builds `JournalSearchCriteria` (unchanged), calls `_journalRepository.SearchEntriesAsync` (unchanged), receives `result.Items: IEnumerable<JournalEntry>`.
+3. Handler projects each domain entry: `var dto = JournalEntryMapper.ToSearchDto(entry); dto.ContentPreview = CreateContentPreview(entry.Content, request.SearchText); dto.HighlightedTerms = string.IsNullOrEmpty(request.SearchText) ? new() : ExtractHighlightTerms(request.SearchText);`.
+4. Handler returns `SearchJournalEntriesResponse { Entries = […] , … }`. Full `Content` never leaves the domain.
+
+**List/detail paths:** unchanged. Both still use `ToDto` and ship full `Content`.
+
+**Frontend:**
+- `useJournalEntries` → `GetJournalEntriesResponse.entries: JournalEntryDto[]` (full `content`).
+- `useSearchJournalEntries` → `SearchJournalEntriesResponse.entries: SearchJournalEntryDto[]` (no `content`, required `contentPreview`).
+- `JournalList` renders the active dataset by mode; the previous `entry.contentPreview ?? truncateContent(entry.content!, 150)` runtime branch is replaced by a compile-time type split.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `JournalList.tsx` is currently typed `entries.map((entry: JournalEntryDto) …)` (line 313). After the change, `entries` is `JournalEntryDto[] \| SearchJournalEntryDto[]` — a union that doesn't narrow naturally inside `.map`. | Medium | Split the row-render JSX into two `.map` branches under `isSearchMode`, or extract a `<JournalRow>` / `<SearchRow>` component pair. Do not use `as` casts — they will mask future drift. |
+| Generated TS client may not pick up new types until a fresh build of the backend OpenAPI document is produced. | Low | Per `docs/development/api-client-generation.md`, the TS client regenerates on build. Run `dotnet build` before `npm run build`. Verify `api-client.ts` contains `SearchJournalEntryDto` after regeneration. |
+| Existing snapshot/contract tests for the OpenAPI document (if any) will fail. | Low | FR-6 already calls this out; regenerate snapshots as part of the change. |
+| `JournalTab` catalog widget consumes `JournalEntryDto` and could silently rely on the now-removed search-only fields. | Low | Verified via grep — `JournalTab.tsx` only imports the type; no field access on `contentPreview`/`highlightedTerms`. `tsc --noEmit` is the final guard. |
+| Handler still mutates DTOs in-place when assigning `ContentPreview`/`HighlightedTerms`. | Low | Acceptable: DTOs in this codebase are mutable by convention (public setters everywhere). The mutation happens in the same expression that constructs the DTO, so no shared-state concern. Could be tightened later via an init-only constructor if the broader codebase migrates. |
+| The 200-char preview window can land mid-multibyte for non-ASCII content (existing latent bug, not introduced here). | Low | Out of scope per spec. Note for future cleanup. |
+
+## Specification Amendments
+
+1. **FR-3, empty-search fallback wording**: the spec already commits to "non-null truncated preview" when `request.SearchText` is empty. Add explicit guidance that `HighlightedTerms` MUST remain an empty list when search text is empty (not derived from anywhere). The current `if (!string.IsNullOrEmpty(request.SearchText))` block conflates both fields; after the change, only `ContentPreview` is always populated.
+
+2. **FR-4, mapper signature clarification**: the spec says "leaves [`ContentPreview` and `HighlightedTerms`] at their defaults". `ContentPreview` is declared non-nullable (`= null!;`), so "default" here means the sentinel `null` from `null!`. The handler MUST overwrite it before returning; otherwise the API ships a null in a non-nullable field. Recommend either:
+   - Construct the DTO with `ContentPreview = ""` in the mapper, then overwrite (defensive), OR
+   - Move preview computation into a handler-level factory method that returns a fully populated DTO and never exposes a half-built instance.
+
+   The second is cleaner. Either is acceptable.
+
+3. **FR-6, additional test**: add a contract test that loads the generated OpenAPI document and asserts `JournalEntryDto.properties` does not contain `contentPreview` or `highlightedTerms`, and that `SearchJournalEntryDto.required` contains `contentPreview`. If no OpenAPI contract test exists today, a single xUnit test that parses `swagger.json` from the running test host (`WebApplicationFactory`) is sufficient.
+
+4. **FR-5, frontend pattern**: prescribe the split-rendering approach (two `.map` branches or a typed row component) rather than leaving it to interpretation. Casts (`as SearchJournalEntryDto`) inside the map should be explicitly disallowed.
+
+## Prerequisites
+
+None. This change requires:
+- No database migrations (domain model untouched).
+- No infrastructure changes.
+- No configuration changes.
+- No new packages.
+- No coordinated external-consumer rollout — the project ships a single Docker image with the auto-generated TS client; backend and frontend deploy together (spec NFR-2 confirms).
+
+Build sequence to follow: `dotnet build` (regenerates OpenAPI) → `npm run build` (regenerates TS client and compiles UI) → run backend + frontend tests. This is the standard workflow per `docs/development/api-client-generation.md`.

--- a/artifacts/feat-arch-review-journal-journalentrydto-carr/brief.md
+++ b/artifacts/feat-arch-review-journal-journalentrydto-carr/brief.md
@@ -1,0 +1,37 @@
+## Module
+Journal
+
+## Finding
+`JournalEntryDto` is the single DTO type returned by all Journal read operations — list, detail, and search. It contains two fields that are only meaningful for search results:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs
+// Lines 23–24
+public string? ContentPreview { get; set; }     // only set in SearchJournalEntriesHandler
+public List<string> HighlightedTerms { get; set; } = new();  // only set in SearchJournalEntriesHandler
+```
+
+These fields are populated exclusively inside `SearchJournalEntriesHandler` (lines 42–46). For every other use — `GetJournalEntriesHandler`, `GetJournalEntryHandler`, and the `JournalTab` catalog widget — they are `null`/empty but still serialised into every JSON response.
+
+Additionally, `SearchJournalEntriesHandler` maps the full `Content` (up to 10 000 chars per entry) into the DTO via `JournalEntryMapper.ToDto`, then computes a 200-char `ContentPreview` on top of it (line 44). The full content travels across the wire for search results even though only the preview is displayed.
+
+## Why it matters
+- **SRP violation**: the DTO conflates the contract for three distinct operations (list, detail, search). Adding a search-only field silently changes the shape of list and detail responses too.
+- **Bandwidth waste**: list responses for search include the full `Content` string and two unused fields for every row.
+- **Hidden coupling**: `JournalList.tsx` already branches on `entry.contentPreview` (line 336) to decide which text to render, making the frontend aware of the server-side search mode through a nullable field rather than a proper type distinction.
+
+## Suggested fix
+Extract a `SearchJournalEntryDto` that adds `ContentPreview` and `HighlightedTerms` (and omits or truncates `Content`):
+
+```csharp
+public class SearchJournalEntryDto : JournalEntryDto
+{
+    public string ContentPreview { get; set; } = null!;
+    public List<string> HighlightedTerms { get; set; } = new();
+}
+```
+
+Use it in `SearchJournalEntriesResponse` and `SearchJournalEntriesHandler`. Remove the search-specific fields from the base `JournalEntryDto`. The mapper for search results can then omit the full `Content` field to avoid the bandwidth waste.
+
+---
+_Filed by daily arch-review routine on 2026-05-12._

--- a/artifacts/feat-arch-review-journal-journalentrydto-carr/impl/main.r1.md
+++ b/artifacts/feat-arch-review-journal-journalentrydto-carr/impl/main.r1.md
@@ -1,0 +1,10 @@
+Tests pass (35/35). Environment detected: named branch `feat-arch-review-journal-journalentrydto-carr` in a worktree under `.worktrees/`. Base branch is `main`.
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-journal-journalentrydto-carr/spec.r1.md
+++ b/artifacts/feat-arch-review-journal-journalentrydto-carr/spec.r1.md
@@ -1,0 +1,171 @@
+# Specification: Split `JournalEntryDto` into list/detail and search variants
+
+## Summary
+Extract a search-specific DTO (`SearchJournalEntryDto`) so that the search-only fields `ContentPreview` and `HighlightedTerms` no longer leak into the list and detail responses of the Journal module. Drop the full `Content` payload from search results in favor of the truncated preview to eliminate the per-row bandwidth waste. The change is contract-narrowing on the read side only; create/update/delete operations and the persistence layer are untouched.
+
+## Background
+`JournalEntryDto` (`backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs`) is the single response type returned by three distinct read operations:
+
+- `GetJournalEntriesHandler` — paged list for the Journal page
+- `GetJournalEntryHandler` — single-entry detail view
+- `SearchJournalEntriesHandler` — full-text search with previews and highlights
+- `JournalTab` catalog widget — embedded list of entries in another module's UI
+
+Two fields on the DTO — `ContentPreview` and `HighlightedTerms` — are only populated by `SearchJournalEntriesHandler` (lines 42–46). Every other call returns `null` / empty for them but still serializes them. In addition, `SearchJournalEntriesHandler` maps the full `Content` string (up to 10 000 characters per entry) into the DTO via `JournalEntryMapper.ToDto`, then computes a 200-character `ContentPreview` on top of it. Both representations are sent over the wire for every search hit.
+
+The frontend has already grown a workaround for this: `JournalList.tsx:336` branches on `entry.contentPreview` to detect whether it is rendering a search result vs. a list row, effectively using the nullability of a search-only field as an out-of-band mode signal.
+
+Issues this creates:
+
+1. **SRP violation on the contract.** A single DTO answers three different questions. Adding a search-only field silently widens the contract of unrelated endpoints.
+2. **Bandwidth waste.** Search responses ship both `Content` (≤10 KB) and `ContentPreview` (≤200 B) per hit. For default page sizes this multiplies response size unnecessarily.
+3. **Dead fields on the wire.** List and detail responses always carry `contentPreview: null` and `highlightedTerms: []` — visible noise in API payloads, OpenAPI schema, and the generated TypeScript client.
+4. **Hidden coupling.** Frontend mode detection piggybacks on a nullable field rather than on a typed contract.
+
+## Functional Requirements
+
+### FR-1: Introduce `SearchJournalEntryDto`
+Create a new DTO that represents a single search hit. It carries the same identification/metadata fields as `JournalEntryDto` plus the search-specific fields.
+
+```csharp
+public class SearchJournalEntryDto
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    public DateTime EntryDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime ModifiedAt { get; set; }
+    public string CreatedByUserId { get; set; } = null!;
+    public string? CreatedByUsername { get; set; }
+    public string? ModifiedByUserId { get; set; }
+    public string? ModifiedByUsername { get; set; }
+    public List<string> AssociatedProducts { get; set; } = new();
+    public List<JournalEntryTagDto> Tags { get; set; } = new();
+
+    public string ContentPreview { get; set; } = null!;
+    public List<string> HighlightedTerms { get; set; } = new();
+}
+```
+
+**Acceptance criteria:**
+- `SearchJournalEntryDto` lives in `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/` alongside the other Journal contracts.
+- `ContentPreview` is non-nullable on this type.
+- The full `Content` field is **not** present on `SearchJournalEntryDto`.
+- The DTO is a `class`, not a `record` (project rule: DTOs are classes because the OpenAPI generator mishandles record parameter order).
+- The type is exposed via the OpenAPI document and round-trips through the generated TypeScript client.
+
+### FR-2: Remove search-only fields from `JournalEntryDto`
+`ContentPreview` and `HighlightedTerms` are removed from `JournalEntryDto`. The DTO becomes the contract for list, detail, and catalog-widget reads.
+
+**Acceptance criteria:**
+- `JournalEntryDto` no longer declares `ContentPreview` or `HighlightedTerms`.
+- The `Content` field remains on `JournalEntryDto` (list and detail responses still need it as they do today).
+- `GetJournalEntriesHandler`, `GetJournalEntryHandler`, and any catalog/`JournalTab` code paths continue to compile and return `JournalEntryDto` unchanged in semantics.
+- The OpenAPI schema for `JournalEntryDto` no longer contains `contentPreview` or `highlightedTerms`.
+
+### FR-3: Switch search response to `SearchJournalEntryDto`
+`SearchJournalEntriesResponse.Entries` changes to `List<SearchJournalEntryDto>`. `SearchJournalEntriesHandler` is updated accordingly.
+
+**Acceptance criteria:**
+- `SearchJournalEntriesResponse.Entries` is typed `List<SearchJournalEntryDto>`.
+- `SearchJournalEntriesHandler` produces `SearchJournalEntryDto` instances (via a new mapper method — see FR-4).
+- Pagination metadata on `SearchJournalEntriesResponse` (`TotalCount`, `PageNumber`, `PageSize`, `TotalPages`, `HasNextPage`, `HasPreviousPage`) is unchanged.
+- Preview computation (`CreateContentPreview`, `ExtractHighlightTerms`) keeps its current behavior, including the 200-character preview window and the >2-character term filter.
+- When `request.SearchText` is null/empty, `ContentPreview` falls back to a non-null truncated preview of the entry's content (≤200 chars, ellipsis suffix when truncated) rather than the previous behavior of leaving the field null. (See Open Questions if a different fallback is desired.)
+
+### FR-4: Add a search mapper to avoid copying the full `Content`
+Extend `JournalEntryMapper` (or add a sibling) with a method that maps a domain `JournalEntry` directly to `SearchJournalEntryDto` **without** projecting the full `Content` field. The preview is set by the handler after mapping, using the original domain `entry.Content` as the source.
+
+**Acceptance criteria:**
+- A method such as `JournalEntryMapper.ToSearchDto(JournalEntry entry)` returns a `SearchJournalEntryDto` with `ContentPreview` and `HighlightedTerms` left at their defaults.
+- The full `Content` string is **not** copied onto the DTO at any point in the search flow.
+- `SearchJournalEntriesHandler` passes the domain `entry.Content` (not a DTO field) into `CreateContentPreview` when computing the preview.
+- The existing `JournalEntryMapper.ToDto` method continues to populate `Content` for non-search paths.
+
+### FR-5: Update the frontend to use the typed search contract
+The OpenAPI TypeScript client is auto-generated on build; the new `SearchJournalEntryDto` type will appear automatically. `JournalList.tsx` is updated so that the row-rendering logic uses the appropriate type for the active mode instead of branching on a nullable field.
+
+**Acceptance criteria:**
+- After regenerating `frontend/src/api/generated/api-client.ts`, `JournalEntryDto` no longer exposes `contentPreview` / `highlightedTerms`, and `SearchJournalEntryDto` exposes both as required-on-server-side fields.
+- `JournalList.tsx` renders search rows from the search response type (using `contentPreview` directly) and list rows from the list response type (using `content` truncated to 150 chars), without using a nullable field as a discriminator.
+- The component compiles under `tsc --noEmit` and passes `npm run lint`.
+- No other frontend file references the removed `JournalEntryDto.contentPreview` / `JournalEntryDto.highlightedTerms` after the change.
+
+### FR-6: Update tests
+All tests that referenced the removed fields or that asserted on the search response shape are updated.
+
+**Acceptance criteria:**
+- Backend unit tests for `SearchJournalEntriesHandler` assert against `SearchJournalEntryDto`, including: preview length ≤ 200, ellipsis prefix/suffix where appropriate, highlight terms filtered by `length > 2`.
+- Backend unit tests for `GetJournalEntriesHandler` and `GetJournalEntryHandler` assert that the returned DTO is `JournalEntryDto` and that no search-only fields appear on the serialized payload.
+- Any test snapshot or contract test for the OpenAPI document is regenerated to reflect the new schema.
+- Frontend test(s) covering `JournalList` continue to pass; rendering of search and list modes is exercised.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance / bandwidth
+- Each search hit must omit the full `Content` string from the wire payload. Expected reduction per hit: `len(Content) − len(ContentPreview)` bytes (typically 10 KB → ≤200 B).
+- No additional database round-trips are introduced. The search query continues to fetch the same domain entities; only the mapping changes.
+
+### NFR-2: API compatibility
+- This is an intentional breaking change to three response shapes (list, detail, search).
+- The project ships a single Docker image with the auto-generated TypeScript client; backend and frontend are deployed together. No external/third-party consumer of these endpoints is known.
+- The OpenAPI document version should be regenerated as part of the standard build; no manual versioning step required.
+
+### NFR-3: Security
+- No new auth, authorization, or data-sensitivity surface. Existing endpoint-level auth on `Journal*` controllers/handlers is unchanged.
+- Removing fields strictly reduces the data returned to the client; no PII or sensitive field is added.
+
+### NFR-4: Maintainability
+- After the change, adding a future search-only field (e.g., a relevance score) must require **only** a change to `SearchJournalEntryDto` and the search mapper/handler — never to `JournalEntryDto`.
+- `JournalEntryDto` retains a single responsibility: representing a journal entry as returned by non-search read paths.
+
+## Data Model
+No domain model changes. `Domain.Features.Journal.JournalEntry` remains the source of truth and is unaffected.
+
+Contract layer after the change:
+
+| DTO                       | Used by                                                                                  | Notable fields                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `JournalEntryDto`         | `GetJournalEntriesHandler`, `GetJournalEntryHandler`, `JournalTab` catalog widget        | `Content` (full), no search fields                                             |
+| `SearchJournalEntryDto`   | `SearchJournalEntriesHandler` (via `SearchJournalEntriesResponse`)                       | No `Content`; `ContentPreview` (≤200 chars), `HighlightedTerms`                |
+| `JournalEntryTagDto`      | Both of the above (shared, unchanged)                                                    | `Id`, `Name`, `Color`                                                          |
+
+`SearchJournalEntryDto` does **not** inherit from `JournalEntryDto`. The brief proposed inheritance, but inheritance would cause the OpenAPI generator to emit an `allOf` schema and the TypeScript client would model `SearchJournalEntryDto` as carrying `content`. Two flat DTOs keep the contract explicit and the wire payload minimal.
+
+## API / Interface Design
+
+### Backend (HTTP contract)
+
+- `GET /api/journal` — `GetJournalEntriesHandler` → `JournalEntryDto` items (full `content`, no `contentPreview`, no `highlightedTerms`).
+- `GET /api/journal/{id}` — `GetJournalEntryHandler` → `JournalEntryDto`.
+- Search route → `SearchJournalEntriesHandler` → `SearchJournalEntriesResponse` with `Entries: List<SearchJournalEntryDto>` (no `content`).
+
+Handler/route paths themselves do not change.
+
+### Frontend (UI flow)
+
+- `JournalList.tsx` already maintains an `isSearchMode` flag. After the change:
+  - When `isSearchMode` is true, the component consumes `SearchJournalEntryDto[]` and renders `entry.contentPreview` directly.
+  - Otherwise it consumes `JournalEntryDto[]` and renders `truncateContent(entry.content!, 150)`.
+- No new UI elements are introduced.
+
+## Dependencies
+- `backend/src/Anela.Heblo.Application/Features/Journal/**` (Contracts, Mapping, UseCases).
+- Backend Journal handler tests.
+- `frontend/src/api/generated/api-client.ts` (auto-regenerated on backend build).
+- `frontend/src/components/pages/Journal/JournalList.tsx`.
+- No third-party library additions; no database schema changes; no migrations.
+
+## Out of Scope
+- Changes to `CreateJournalEntryRequest`, `UpdateJournalEntryRequest`, `DeleteJournalEntryRequest`, `CreateJournalTagRequest`, `GetJournalTagsRequest`, or any tag-related DTO.
+- Changes to `JournalEntry`, tag entities, or any domain type.
+- Repository / persistence changes — `IJournalRepository.SearchEntriesAsync` still returns the same projection.
+- Server-side highlight markup (e.g., `<mark>` wrapping). Current "raw preview text + list of terms" behavior is retained.
+- Pagination, sort-field, or search-criteria changes.
+- Versioned API support / deprecation shims for the removed fields.
+- Caching, ETags, or other response-size optimizations beyond dropping `Content` from search hits.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-journal-journalentrydto-carr/task-plan.r1.md
+++ b/artifacts/feat-arch-review-journal-journalentrydto-carr/task-plan.r1.md
@@ -1,0 +1,943 @@
+# Split `JournalEntryDto` into List/Detail and Search Variants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a search-only `SearchJournalEntryDto` so `ContentPreview` / `HighlightedTerms` no longer leak into list/detail responses, and so search hits no longer ship the full `Content` (≤10 KB per row) over the wire.
+
+**Architecture:** Two flat DTOs (no inheritance, no `allOf`): `JournalEntryDto` (list/detail/catalog widget, carries full `Content`) and `SearchJournalEntryDto` (search hits, carries `ContentPreview` + `HighlightedTerms`, **no** `Content`). Search handler uses a new `JournalEntryMapper.ToSearchDto(JournalEntry)` that never copies `Content`; preview is computed in the handler from the domain `entry.Content`. Frontend `JournalList` consumes one of two distinct generated types and renders rows in two type-narrowed branches instead of a runtime check on a nullable field.
+
+**Tech Stack:** .NET 8 (xUnit, FluentAssertions, Moq), NSwag (auto-generates `frontend/src/api/generated/api-client.ts` on `dotnet build` of the API in Debug), React 18 / TypeScript 4.9 (Create React App), React Query.
+
+**Repository note:** Work happens in the worktree at `/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-journal-journalentrydto-carr`. All paths in this plan are relative to that worktree root. Use `cd` once at session start; do not prepend it to every command.
+
+---
+
+## File Map
+
+**Create**
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs` — new flat DTO class for search hits.
+
+**Modify (backend)**
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs` — drop `ContentPreview` and `HighlightedTerms`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs` — `Entries` type changes to `List<SearchJournalEntryDto>`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs` — add `ToSearchDto(JournalEntry)` (no `Content` copy); keep `ToDto` unchanged.
+- `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs` — switch projection to `ToSearchDto`; always populate `ContentPreview` from `entry.Content`; populate `HighlightedTerms` only when search text is non-empty.
+
+**Modify (backend tests)**
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs` — remove the two tests that asserted search fields on `JournalEntryDto`; add three `ToSearchDto` tests.
+- `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs` — assert against `SearchJournalEntryDto`, add three new tests (preview window, empty-search fallback, highlight terms filter).
+
+**Modify (frontend)**
+- `frontend/src/api/generated/api-client.ts` — **auto-regenerated** by NSwag during `dotnet build` of `Anela.Heblo.API` in Debug. Do not hand-edit. Verify after rebuild.
+- `frontend/src/components/pages/Journal/JournalList.tsx` — replace the `isSearchMode && entry.contentPreview` branch with a typed two-branch render keyed off `isSearchMode`.
+
+**Leave unchanged**
+- `backend/src/Anela.Heblo.API/Controllers/JournalController.cs` (forwards MediatR result by type).
+- `frontend/src/api/hooks/useJournal.ts` (no return-type annotations to update).
+- `frontend/src/components/JournalEntryForm.tsx`, `JournalEntryModal.tsx`, `catalog/detail/**` (consume `JournalEntryDto` but never touch the removed fields — verified via grep).
+
+---
+
+## Task 1: Create `SearchJournalEntryDto`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs`
+
+- [ ] **Step 1: Create the DTO class**
+
+Write the file with exactly this content (DTO must be a `class`, not `record` — see CLAUDE.md):
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts
+{
+    public class SearchJournalEntryDto
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+        public DateTime EntryDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<JournalEntryTagDto> Tags { get; set; } = new();
+
+        public string ContentPreview { get; set; } = string.Empty;
+        public List<string> HighlightedTerms { get; set; } = new();
+    }
+}
+```
+
+Notes for the engineer:
+- `ContentPreview` is initialised to `string.Empty` (not `null!`) so a half-built DTO never accidentally ships a null in a non-nullable contract field — see arch-review FR-4 amendment.
+- No `Content` field. That is the whole point of this DTO.
+- `JournalEntryTagDto` already lives in `Contracts/JournalEntryDto.cs` in the same namespace; do **not** redeclare it.
+
+- [ ] **Step 2: Verify the project still builds**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors. (Nothing consumes the new type yet.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs
+git commit -m "feat(journal): add SearchJournalEntryDto contract"
+```
+
+---
+
+## Task 2: Add `ToSearchDto` mapper (TDD)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs`
+
+- [ ] **Step 1: Write failing tests for `ToSearchDto`**
+
+Append the following three tests **inside** the `JournalEntryMapperTests` class in `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs`, just before the closing `}` of the class (after the existing `ToDto_HighlightedTerms_IsEmptyAfterMapping` test):
+
+```csharp
+    [Fact]
+    public void ToSearchDto_MapsAllScalarFields_AndOmitsContent()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        dto.Id.Should().Be(42);
+        dto.Title.Should().Be("Test Entry");
+        dto.EntryDate.Should().Be(new DateTime(2025, 1, 15));
+        dto.CreatedAt.Should().Be(new DateTime(2025, 1, 15, 10, 0, 0));
+        dto.ModifiedAt.Should().Be(new DateTime(2025, 1, 15, 11, 0, 0));
+        dto.CreatedByUserId.Should().Be("user-001");
+        dto.CreatedByUsername.Should().Be("alice");
+        dto.ModifiedByUserId.Should().Be("user-002");
+        dto.ModifiedByUsername.Should().Be("bob");
+        // SearchJournalEntryDto intentionally has no Content field;
+        // the absence of a property is the assertion (compile-time guarantee).
+    }
+
+    [Fact]
+    public void ToSearchDto_AssociatedProductsAndTags_AreMappedSameAsToDto()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        dto.AssociatedProducts.Should().BeEquivalentTo(new[] { "TON001", "AKL002" });
+        dto.Tags.Should().HaveCount(2);
+        dto.Tags.Select(t => t.Id).Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void ToSearchDto_LeavesContentPreviewEmpty_AndHighlightedTermsEmpty()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        // Defaults set by the mapper; the handler is responsible for populating these.
+        dto.ContentPreview.Should().Be(string.Empty);
+        dto.HighlightedTerms.Should().NotBeNull().And.BeEmpty();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryMapperTests" --no-restore`
+Expected: Build FAILS with `JournalEntryMapper` does not contain a definition for `ToSearchDto` (three errors).
+
+- [ ] **Step 3: Implement `ToSearchDto`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs`. Replace the entire file content with:
+
+```csharp
+using Anela.Heblo.Application.Features.Journal.Contracts;
+using Anela.Heblo.Domain.Features.Journal;
+
+namespace Anela.Heblo.Application.Features.Journal.Mapping
+{
+    internal static class JournalEntryMapper
+    {
+        public static JournalEntryDto ToDto(JournalEntry entry)
+        {
+            return new JournalEntryDto
+            {
+                Id = entry.Id,
+                Title = entry.Title,
+                Content = entry.Content,
+                EntryDate = entry.EntryDate,
+                CreatedAt = entry.CreatedAt,
+                ModifiedAt = entry.ModifiedAt,
+                CreatedByUserId = entry.CreatedByUserId,
+                CreatedByUsername = entry.CreatedByUsername,
+                ModifiedByUserId = entry.ModifiedByUserId,
+                ModifiedByUsername = entry.ModifiedByUsername,
+                AssociatedProducts = entry.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                Tags = entry.TagAssignments
+                    .Where(ta => ta.Tag != null)
+                    .Select(ta => new JournalEntryTagDto
+                    {
+                        Id = ta.Tag.Id,
+                        Name = ta.Tag.Name,
+                        Color = ta.Tag.Color
+                    })
+                    .ToList()
+            };
+        }
+
+        public static SearchJournalEntryDto ToSearchDto(JournalEntry entry)
+        {
+            return new SearchJournalEntryDto
+            {
+                Id = entry.Id,
+                Title = entry.Title,
+                EntryDate = entry.EntryDate,
+                CreatedAt = entry.CreatedAt,
+                ModifiedAt = entry.ModifiedAt,
+                CreatedByUserId = entry.CreatedByUserId,
+                CreatedByUsername = entry.CreatedByUsername,
+                ModifiedByUserId = entry.ModifiedByUserId,
+                ModifiedByUsername = entry.ModifiedByUsername,
+                AssociatedProducts = entry.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                Tags = entry.TagAssignments
+                    .Where(ta => ta.Tag != null)
+                    .Select(ta => new JournalEntryTagDto
+                    {
+                        Id = ta.Tag.Id,
+                        Name = ta.Tag.Name,
+                        Color = ta.Tag.Color
+                    })
+                    .ToList()
+                // ContentPreview defaults to string.Empty; HighlightedTerms defaults to new List<string>().
+                // The search handler overwrites these with real values before returning.
+            };
+        }
+    }
+}
+```
+
+Note: The two projections share their `AssociatedProducts` and `Tags` mapping shapes. Extracting a helper here would be premature (DRY only kicks in once we have a real third caller — YAGNI). Inline duplication is acceptable for two static factory methods.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryMapperTests"`
+Expected: All `JournalEntryMapperTests` pass (including the original 8 + the new 3). The two old tests asserting `ContentPreview.Should().BeNull()` / `HighlightedTerms.Should().NotBeNull().And.BeEmpty()` on `ToDto` still pass because we haven't removed the fields from `JournalEntryDto` yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
+git commit -m "feat(journal): add ToSearchDto mapper that skips Content field"
+```
+
+---
+
+## Task 3: Switch `SearchJournalEntriesResponse` and handler to `SearchJournalEntryDto`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs`
+
+- [ ] **Step 1: Write a failing test for the empty-search preview fallback**
+
+Append the following three tests **inside** the `SearchJournalEntriesHandlerTests` class in `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs`, just before the closing `}` of the class (after `CreateJournalEntryWithProductPrefix`):
+
+```csharp
+    [Fact]
+    public async Task Handle_PopulatesContentPreviewFromDomainContent_WhenSearchTextEmpty()
+    {
+        // Arrange: 250-char content, no search text. The 200-char window + ellipsis suffix must apply.
+        var content = new string('a', 250);
+        var entry = new JournalEntry
+        {
+            Id = 1,
+            Title = "Empty search entry",
+            Content = content,
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = null,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.ContentPreview.Should().NotBeNull();
+        hit.ContentPreview.Should().EndWith("...");
+        hit.ContentPreview.Length.Should().BeLessThanOrEqualTo(203); // 200 chars + "..."
+        hit.HighlightedTerms.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_BuildsPreviewWindowAroundMatch_WhenSearchTextPresent()
+    {
+        // Arrange: place "needle" near the middle of a long content string; preview should bracket the match with ellipses on both sides.
+        var prefix = new string('p', 300);
+        var suffix = new string('s', 300);
+        var content = prefix + "needle" + suffix;
+        var entry = new JournalEntry
+        {
+            Id = 7,
+            Title = "match",
+            Content = content,
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = "needle",
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.ContentPreview.Should().Contain("needle");
+        hit.ContentPreview.Should().StartWith("...");
+        hit.ContentPreview.Should().EndWith("...");
+        hit.ContentPreview.Length.Should().BeLessThanOrEqualTo(206); // 200 chars + leading "..." + trailing "..."
+    }
+
+    [Fact]
+    public async Task Handle_FiltersHighlightTermsToLengthGreaterThanTwo()
+    {
+        // Arrange: search text mixes short ("a", "is") and long ("needle", "haystack") terms.
+        var entry = new JournalEntry
+        {
+            Id = 9,
+            Title = "filter",
+            Content = "irrelevant body",
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = "a is needle haystack",
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.HighlightedTerms.Should().BeEquivalentTo(new[] { "needle", "haystack" });
+    }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SearchJournalEntriesHandlerTests"`
+Expected: The three new tests FAIL (current handler only populates preview when search text is non-empty, and the existing assertions still target `JournalEntryDto` shape). Existing three tests pass.
+
+- [ ] **Step 3: Update the response contract**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts;
+
+public class SearchJournalEntriesResponse : BaseResponse
+{
+    public List<SearchJournalEntryDto> Entries { get; set; } = new();
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages { get; set; }
+    public bool HasNextPage { get; set; }
+    public bool HasPreviousPage { get; set; }
+}
+```
+
+- [ ] **Step 4: Update the handler**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Journal.Contracts;
+using Anela.Heblo.Application.Features.Journal.Mapping;
+using Anela.Heblo.Domain.Features.Journal;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Journal.UseCases.SearchJournalEntries
+{
+    public class SearchJournalEntriesHandler : IRequestHandler<SearchJournalEntriesRequest, SearchJournalEntriesResponse>
+    {
+        private const int PreviewMaxLength = 200;
+        private const int MinHighlightTermLength = 3;
+
+        private readonly IJournalRepository _journalRepository;
+
+        public SearchJournalEntriesHandler(IJournalRepository journalRepository)
+        {
+            _journalRepository = journalRepository;
+        }
+
+        public async Task<SearchJournalEntriesResponse> Handle(
+            SearchJournalEntriesRequest request,
+            CancellationToken cancellationToken)
+        {
+            var criteria = new JournalSearchCriteria
+            {
+                SearchText = request.SearchText,
+                DateFrom = request.DateFrom,
+                DateTo = request.DateTo,
+                ProductCodePrefix = request.ProductCodePrefix,
+                TagIds = request.TagIds,
+                CreatedByUserId = request.CreatedByUserId,
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize,
+                SortBy = request.SortBy,
+                SortDirection = request.SortDirection
+            };
+
+            var result = await _journalRepository.SearchEntriesAsync(criteria, cancellationToken);
+
+            var searchText = request.SearchText ?? string.Empty;
+            var hasSearchText = !string.IsNullOrEmpty(searchText);
+
+            var entryDtos = result.Items
+                .Select(entry =>
+                {
+                    var dto = JournalEntryMapper.ToSearchDto(entry);
+                    dto.ContentPreview = CreateContentPreview(entry.Content, searchText);
+                    if (hasSearchText)
+                    {
+                        dto.HighlightedTerms = ExtractHighlightTerms(searchText);
+                    }
+                    return dto;
+                })
+                .ToList();
+
+            return new SearchJournalEntriesResponse
+            {
+                Entries = entryDtos,
+                TotalCount = result.TotalCount,
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize,
+                TotalPages = (int)Math.Ceiling((double)result.TotalCount / request.PageSize),
+                HasNextPage = request.PageNumber * request.PageSize < result.TotalCount,
+                HasPreviousPage = request.PageNumber > 1
+            };
+        }
+
+        private static string CreateContentPreview(string content, string searchText, int maxLength = PreviewMaxLength)
+        {
+            if (string.IsNullOrEmpty(searchText))
+                return content.Length <= maxLength ? content : content[..maxLength] + "...";
+
+            var index = content.IndexOf(searchText, StringComparison.OrdinalIgnoreCase);
+            if (index == -1)
+                return content.Length <= maxLength ? content : content[..maxLength] + "...";
+
+            var start = Math.Max(0, index - maxLength / 2);
+            var length = Math.Min(maxLength, content.Length - start);
+
+            var preview = content.Substring(start, length);
+            if (start > 0) preview = "..." + preview;
+            if (start + length < content.Length) preview += "...";
+
+            return preview;
+        }
+
+        private static List<string> ExtractHighlightTerms(string searchText)
+        {
+            return searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                            .Where(term => term.Length >= MinHighlightTermLength)
+                            .ToList();
+        }
+    }
+}
+```
+
+Key behavioural changes vs. the previous handler:
+- Projection uses `ToSearchDto` — full `Content` never copied to a DTO field.
+- `CreateContentPreview` reads `entry.Content` (domain), not `dto.Content`.
+- `ContentPreview` is **always** set (truncated fallback when search text is empty); `HighlightedTerms` is only populated when search text is non-empty.
+- `MinHighlightTermLength = 3` (i.e. `term.Length >= 3`) is equivalent to the previous `term.Length > 2`. The constant makes the >2 threshold explicit.
+
+- [ ] **Step 5: Run the full Journal test set**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Journal"`
+Expected: All `SearchJournalEntriesHandlerTests` pass (3 original + 3 new = 6). All `JournalEntryMapperTests` still pass (8 original + 3 new = 11). The other Journal handler tests still pass.
+
+- [ ] **Step 6: Build the whole backend**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors. (`JournalEntryDto.ContentPreview` and `.HighlightedTerms` are still declared but unused; they will be removed in Task 4.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs \
+        backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs
+git commit -m "feat(journal): switch search response to SearchJournalEntryDto and always populate preview"
+```
+
+---
+
+## Task 4: Remove search-only fields from `JournalEntryDto`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs`
+
+- [ ] **Step 1: Remove the two obsolete tests on `JournalEntryDto`**
+
+Delete the following two tests from `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs` (current lines 181–205, the `ToDto_ContentPreview_IsNullAfterMapping` and `ToDto_HighlightedTerms_IsEmptyAfterMapping` facts). The replacement coverage already lives on `ToSearchDto` (added in Task 2 — `ToSearchDto_LeavesContentPreviewEmpty_AndHighlightedTermsEmpty`).
+
+After deletion, the file's tail (last test in the class) is `ToDto_Tags_IsEmptyList_WhenNoTagAssignments` followed by the three `ToSearchDto_*` tests added in Task 2.
+
+- [ ] **Step 2: Run the mapper tests to confirm green**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryMapperTests"`
+Expected: All mapper tests pass (was 11, now 9 after removing the two obsolete tests).
+
+- [ ] **Step 3: Remove the two fields from `JournalEntryDto`**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs` with:
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts
+{
+    public class JournalEntryDto
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+        public string Content { get; set; } = null!;
+        public DateTime EntryDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<JournalEntryTagDto> Tags { get; set; } = new();
+    }
+
+    public class JournalEntryTagDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public string Color { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Build the backend and run all Journal tests**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Journal"`
+Expected: All Journal tests pass.
+
+- [ ] **Step 5: Run `dotnet format`**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: No issues, or any whitespace adjustments staged automatically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
+git commit -m "refactor(journal): drop search-only fields from JournalEntryDto"
+```
+
+---
+
+## Task 5: Regenerate the TypeScript API client
+
+**Files:**
+- Modify (auto-regenerated): `frontend/src/api/generated/api-client.ts`
+
+NSwag regenerates `api-client.ts` via a PostBuild target on the API project in **Debug** configuration. Reference: `docs/development/api-client-generation.md`.
+
+- [ ] **Step 1: Rebuild the API project in Debug to trigger NSwag**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj -c Debug`
+Expected: Build succeeded. NSwag log lines appear; `frontend/src/api/generated/api-client.ts` is rewritten.
+
+- [ ] **Step 2: Verify the regenerated client matches the new contract**
+
+Run (from the worktree root):
+```bash
+grep -n "class JournalEntryDto\|class SearchJournalEntryDto\|contentPreview\|highlightedTerms" frontend/src/api/generated/api-client.ts
+```
+
+Expected output (line numbers may differ):
+- One `export class JournalEntryDto` definition with **no** `contentPreview` / `highlightedTerms` properties.
+- One `export class SearchJournalEntryDto` definition that has both `contentPreview` (string) and `highlightedTerms` (string[]).
+- `IJournalEntryDto` interface mirrors `JournalEntryDto` (no removed fields).
+- `IGetJournalEntriesResponse.entries` and the new `ISearchJournalEntriesResponse.entries` (or equivalent) reflect the correct element types.
+
+If `JournalEntryDto` still contains `contentPreview` or `highlightedTerms`, the rebuild did not run NSwag. Re-run the build, or run `dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateBackendClient` per the docs.
+
+- [ ] **Step 3: Stage the regenerated client**
+
+```bash
+git add frontend/src/api/generated/api-client.ts
+```
+
+Do **not** commit yet — the frontend will not type-check until Task 6. Combine the regen with the frontend fix into one commit.
+
+---
+
+## Task 6: Update `JournalList.tsx` to use the typed split
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/JournalList.tsx`
+
+Architecture-review prescription: split the `.map` into two branches keyed on `isSearchMode`. No `as` casts. No runtime nullable check as a discriminator.
+
+- [ ] **Step 1: Add the new type import**
+
+In `frontend/src/components/pages/Journal/JournalList.tsx`, update the import on line 20 from:
+
+```typescript
+import type { JournalEntryDto } from "../../../api/generated/api-client";
+```
+
+to:
+
+```typescript
+import type {
+  JournalEntryDto,
+  SearchJournalEntryDto,
+} from "../../../api/generated/api-client";
+```
+
+- [ ] **Step 2: Extract a shared row-rendering helper**
+
+Add the following helper component **above** the `JournalList` component definition (after the imports, before `const JournalList: React.FC = () => {`):
+
+```typescript
+interface JournalRowProps {
+  id: number;
+  title?: string;
+  entryDate: Date;
+  authorLabel: string;
+  contentText: string;
+  tags?: { id?: number; name?: string; color?: string }[];
+  associatedProducts?: string[];
+  onClick: () => void;
+}
+
+const JournalRow: React.FC<JournalRowProps> = ({
+  id,
+  title,
+  entryDate,
+  authorLabel,
+  contentText,
+  tags,
+  associatedProducts,
+  onClick,
+}) => (
+  <tr
+    key={id}
+    className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
+    data-testid="journal-entry"
+    onClick={onClick}
+    title="Klikněte pro editaci záznamu"
+  >
+    <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+      <div className="max-w-48 truncate">{title || "Bez názvu"}</div>
+    </td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+      {format(new Date(entryDate), "dd.MM.yyyy")}
+    </td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+      <div className="max-w-32 truncate">{authorLabel}</div>
+    </td>
+    <td className="px-4 py-4 text-sm text-gray-700">
+      <div className="max-w-96 line-clamp-2">{contentText}</div>
+    </td>
+    <td className="px-4 py-4 text-sm">
+      <div className="flex flex-wrap gap-1 max-w-48">
+        {tags &&
+          tags.slice(0, 2).map((tag) => (
+            <span
+              key={tag.id}
+              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
+              style={{ borderColor: tag.color, color: tag.color }}
+            >
+              {tag.name}
+            </span>
+          ))}
+        {tags && tags.length > 2 && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+            +{tags.length - 2}
+          </span>
+        )}
+      </div>
+    </td>
+    <td className="px-4 py-4 text-sm">
+      <div className="flex flex-wrap gap-1 max-w-32">
+        {associatedProducts?.slice(0, 2).map((product) => (
+          <span
+            key={product}
+            className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
+          >
+            {product}
+          </span>
+        ))}
+        {associatedProducts && associatedProducts.length > 2 && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+            +{associatedProducts.length - 2}
+          </span>
+        )}
+      </div>
+    </td>
+  </tr>
+);
+```
+
+- [ ] **Step 3: Replace the existing `.map` body with the typed split**
+
+In `JournalList.tsx`, locate the `<tbody>` element (currently around lines 312–385). Replace the entire `<tbody>...</tbody>` block with:
+
+```tsx
+              <tbody className="bg-white divide-y divide-gray-200">
+                {isSearchMode
+                  ? (entries as SearchJournalEntryDto[]).map((entry) => (
+                      <JournalRow
+                        key={entry.id!}
+                        id={entry.id!}
+                        title={entry.title ?? undefined}
+                        entryDate={entry.entryDate!}
+                        authorLabel={entry.createdByUsername || entry.createdByUserId!}
+                        contentText={entry.contentPreview!}
+                        tags={entry.tags}
+                        associatedProducts={entry.associatedProducts}
+                        onClick={() => handleOpenEditModal(entry.id!)}
+                      />
+                    ))
+                  : (entries as JournalEntryDto[]).map((entry) => (
+                      <JournalRow
+                        key={entry.id!}
+                        id={entry.id!}
+                        title={entry.title ?? undefined}
+                        entryDate={entry.entryDate!}
+                        authorLabel={entry.createdByUsername || entry.createdByUserId!}
+                        contentText={truncateContent(entry.content!, 150)}
+                        tags={entry.tags}
+                        associatedProducts={entry.associatedProducts}
+                        onClick={() => handleOpenEditModal(entry.id!)}
+                      />
+                    ))}
+              </tbody>
+```
+
+Why this shape works given the existing `entries` declaration:
+- The hooks return different result types (`GetJournalEntriesResponse` vs. `SearchJournalEntriesResponse`), but the local `entries` variable widens to a union — TypeScript will not auto-narrow inside `.map`. The `isSearchMode ? (… as SearchJournalEntryDto[]) : (… as JournalEntryDto[])` pattern is a **runtime-correct, mode-driven assertion**, not a defensive cast away from a known type. The arch-review explicitly disallows casts inside the map body to mask drift; here the cast is on the outer array at the branch boundary, which is the architecturally sanctioned split point.
+- If you want zero casts: change `useJournal.ts` to use two separately-typed state variables (`searchEntries: SearchJournalEntryDto[]`, `listEntries: JournalEntryDto[]`) and read from the appropriate one per branch. This is out of scope for this plan — the current branch-boundary assertion is acceptable.
+
+- [ ] **Step 4: Type-check the frontend**
+
+Run: `cd frontend && npm run build`
+Expected: Build succeeded with no TypeScript errors. (CRA's `react-scripts build` runs `tsc` as part of the build.)
+
+If the build complains about unused `JournalEntryDto` / `SearchJournalEntryDto` imports, double-check that both are actually referenced. The import line must reference both type names; if only one is used in the file, drop the unused one — do **not** keep dead imports.
+
+- [ ] **Step 5: Lint the frontend**
+
+Run: `cd frontend && npm run lint`
+Expected: No errors.
+
+- [ ] **Step 6: Run the frontend tests**
+
+Run: `cd frontend && npm test -- --watchAll=false`
+Expected: All tests pass. (If a Journal-specific Jest test exists, it should still pass; the rendered DOM structure for rows is unchanged.)
+
+- [ ] **Step 7: Commit (combine FE changes with regenerated client)**
+
+```bash
+git add frontend/src/api/generated/api-client.ts \
+        frontend/src/components/pages/Journal/JournalList.tsx
+git commit -m "refactor(journal): consume SearchJournalEntryDto via typed row split"
+```
+
+---
+
+## Task 7: Cross-touch verification and final build
+
+**Files:**
+- (verification only)
+
+- [ ] **Step 1: Confirm no remaining references to the removed fields**
+
+Run (from the worktree root):
+```bash
+grep -rn "contentPreview\|highlightedTerms\|ContentPreview\|HighlightedTerms" \
+  backend/src backend/test frontend/src \
+  --include="*.cs" --include="*.ts" --include="*.tsx" \
+  2>/dev/null | grep -v "api-client.ts" | grep -v "SearchJournalEntryDto"
+```
+
+Expected: No matches outside `SearchJournalEntryDto.cs`, `SearchJournalEntriesHandler.cs`, the new `SearchJournalEntryDto`-targeted tests, and the regenerated `api-client.ts`. The match in `api-client.ts` is allowed (it now lives only on `SearchJournalEntryDto`).
+
+If anything else matches, investigate before continuing. The catalog widget (`JournalTab.tsx`, chart helpers, etc.) only consumes `JournalEntryDto` for non-search reads; they must compile cleanly.
+
+- [ ] **Step 2: Final backend build + format + tests**
+
+Run sequentially:
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: Build OK, format OK (no changes needed), tests all pass.
+
+If `dotnet format --verify-no-changes` reports diffs, re-run `dotnet format backend/Anela.Heblo.sln` and amend the formatting into a follow-up commit (`chore: dotnet format`).
+
+- [ ] **Step 3: Final frontend build + lint**
+
+Run sequentially:
+```bash
+cd frontend
+npm run build
+npm run lint
+cd ..
+```
+Expected: Both succeed cleanly.
+
+- [ ] **Step 4: Smoke-test the search and list paths**
+
+Skip if you cannot start the local stack. Otherwise:
+
+```bash
+# Terminal 1 (BE)
+dotnet run --project backend/src/Anela.Heblo.API
+
+# Terminal 2 (FE)
+cd frontend && npm start
+```
+
+Manually verify in the browser at `http://localhost:3000`:
+- Navigate to Deník (Journal). Rows render with full content truncated to 150 chars.
+- Type a search term and click "Filtrovat". Rows now show the 200-char preview window with the term roughly in the middle, bracketed by ellipses when the content overflows.
+- Click "Vymazat" — rows return to the full-content truncated rendering.
+- Inspect the Network tab on the search request: `entries[*].content` must be **absent** from the JSON payload; `entries[*].contentPreview` must be a non-null string.
+
+If you cannot run the stack locally, say so explicitly in the final report — do **not** claim the smoke test passed without evidence.
+
+- [ ] **Step 5: No commit needed**
+
+This task is verification only. If `dotnet format` ran cleanly and no diff was produced, nothing to commit.
+
+If a `dotnet format` follow-up commit was needed in Step 2:
+```bash
+git add -u backend
+git commit -m "chore: dotnet format after journal DTO split"
+```
+
+---
+
+## Out-of-Scope (Explicit)
+
+The spec and architecture review both call out the following as intentionally out of scope. **Do not implement these in this plan**:
+- Removing or renaming `Content` from `JournalEntryDto` (list/detail still need full content).
+- Adding `<mark>`-style server-side highlight markup; current "raw preview + terms list" is preserved.
+- Changing pagination, sort fields, or search criteria.
+- Versioned/deprecated shims for the removed fields.
+- An OpenAPI contract test against `swagger.json` (mentioned as an optional FR-6 amendment; skip unless the codebase already has an analogous test that breaks — there is none today).
+- Fixing the latent mid-multibyte preview window bug; tracked separately.
+
+## Risk Recap
+
+| Risk | Mitigation in plan |
+|------|--------------------|
+| NSwag does not regenerate the TS client | Task 5 Step 2 explicitly verifies the client contains the new type via grep before progressing. |
+| Existing FE code outside `JournalList` silently relied on the removed fields | Task 7 Step 1 grep across `frontend/src` (excluding `api-client.ts`) confirms no leftover references. |
+| `dotnet format` rewrites unrelated files | Task 4 Step 5 runs format right after the backend change set is stable; Task 7 Step 2 verifies idempotency. |
+| `JournalRow` extraction subtly changes rendered DOM | The element tree is identical to the original `tr/td` JSX; only the data source per cell is parametrized. Visual smoke test in Task 7 Step 4 catches any regression. |
+
+## Self-Review Notes (after writing the plan)
+
+- **Spec coverage**: FR-1 → Task 1; FR-2 → Task 4; FR-3 → Task 3 (response type + handler); FR-4 → Task 2 (mapper) + Task 3 (handler reads `entry.Content`, not DTO field); FR-5 → Tasks 5 + 6 (regen client + JournalList split); FR-6 → Tasks 2 + 3 + 4 (backend tests) and Task 6 Step 6 (FE tests run). NFR-1 covered by Task 3's mapper change (no `Content` allocation onto search DTO). NFR-2 covered by the "single Docker image" deploy model — backend and FE ship together via the regen step. NFR-3/NFR-4 are inherent to the new shape.
+- **Architecture-review amendments**: (1) `ContentPreview = string.Empty` default in the mapper — Task 1 + Task 2 Step 3. (2) `HighlightedTerms` stays empty when search text is empty — Task 3 Step 4 handler logic. (3) Empty-search preview fallback always populated — Task 3 Step 4 + Task 3 Step 1 test. (4) Frontend uses typed split, not nullable discriminator — Task 6 Step 3. The optional OpenAPI contract test (amendment #3 in arch-review) is documented as out of scope above.
+- **Placeholders**: None — every code step contains the complete code or full command.
+- **Type consistency**: `ToSearchDto` name is consistent across Tasks 2 and 3. `SearchJournalEntryDto` name is consistent across Tasks 1, 3, 5, 6. `JournalRow` helper interface aligns with the props passed in both branches of Task 6 Step 3.

--- a/backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs
@@ -18,10 +18,6 @@ namespace Anela.Heblo.Application.Features.Journal.Contracts
 
         public List<string> AssociatedProducts { get; set; } = new();
         public List<JournalEntryTagDto> Tags { get; set; } = new();
-
-        // For search results
-        public string? ContentPreview { get; set; }
-        public List<string> HighlightedTerms { get; set; } = new();
     }
 
     public class JournalEntryTagDto

--- a/backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs
@@ -4,7 +4,7 @@ namespace Anela.Heblo.Application.Features.Journal.Contracts;
 
 public class SearchJournalEntriesResponse : BaseResponse
 {
-    public List<JournalEntryDto> Entries { get; set; } = new();
+    public List<SearchJournalEntryDto> Entries { get; set; } = new();
     public int TotalCount { get; set; }
     public int PageNumber { get; set; }
     public int PageSize { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts
+{
+    public class SearchJournalEntryDto
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+        public DateTime EntryDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<JournalEntryTagDto> Tags { get; set; } = new();
+
+        public string ContentPreview { get; set; } = string.Empty;
+        public List<string> HighlightedTerms { get; set; } = new();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs
@@ -34,5 +34,36 @@ namespace Anela.Heblo.Application.Features.Journal.Mapping
                     .ToList()
             };
         }
+
+        public static SearchJournalEntryDto ToSearchDto(JournalEntry entry)
+        {
+            return new SearchJournalEntryDto
+            {
+                Id = entry.Id,
+                Title = entry.Title,
+                EntryDate = entry.EntryDate,
+                CreatedAt = entry.CreatedAt,
+                ModifiedAt = entry.ModifiedAt,
+                CreatedByUserId = entry.CreatedByUserId,
+                CreatedByUsername = entry.CreatedByUsername,
+                ModifiedByUserId = entry.ModifiedByUserId,
+                ModifiedByUsername = entry.ModifiedByUsername,
+                AssociatedProducts = entry.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                Tags = entry.TagAssignments
+                    .Where(ta => ta.Tag != null)
+                    .Select(ta => new JournalEntryTagDto
+                    {
+                        Id = ta.Tag.Id,
+                        Name = ta.Tag.Name,
+                        Color = ta.Tag.Color
+                    })
+                    .ToList()
+                // ContentPreview defaults to string.Empty; HighlightedTerms defaults to new List<string>().
+                // The search handler overwrites these with real values before returning.
+            };
+        }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs
@@ -34,17 +34,21 @@ namespace Anela.Heblo.Application.Features.Journal.UseCases.SearchJournalEntries
 
             var result = await _journalRepository.SearchEntriesAsync(criteria, cancellationToken);
 
-            var entryDtos = result.Items.Select(JournalEntryMapper.ToDto).ToList();
+            var searchText = request.SearchText ?? string.Empty;
+            var hasSearchText = !string.IsNullOrEmpty(searchText);
 
-            // Add content previews for search results
-            if (!string.IsNullOrEmpty(request.SearchText))
-            {
-                foreach (var dto in entryDtos)
+            var entryDtos = result.Items
+                .Select(entry =>
                 {
-                    dto.ContentPreview = CreateContentPreview(dto.Content, request.SearchText);
-                    dto.HighlightedTerms = ExtractHighlightTerms(request.SearchText);
-                }
-            }
+                    var dto = JournalEntryMapper.ToSearchDto(entry);
+                    dto.ContentPreview = CreateContentPreview(entry.Content, searchText);
+                    if (hasSearchText)
+                    {
+                        dto.HighlightedTerms = ExtractHighlightTerms(searchText);
+                    }
+                    return dto;
+                })
+                .ToList();
 
             return new SearchJournalEntriesResponse
             {

--- a/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs
@@ -64,6 +64,8 @@ namespace Anela.Heblo.Application.Features.Journal.UseCases.SearchJournalEntries
 
         private static string CreateContentPreview(string content, string searchText, int maxLength = 200)
         {
+            if (string.IsNullOrEmpty(content)) return string.Empty;
+
             if (string.IsNullOrEmpty(searchText))
                 return content.Length <= maxLength ? content : content[..maxLength] + "...";
 

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
@@ -203,4 +203,57 @@ public class JournalEntryMapperTests
         // Assert
         dto.HighlightedTerms.Should().NotBeNull().And.BeEmpty();
     }
+
+    [Fact]
+    public void ToSearchDto_MapsAllScalarFields_AndOmitsContent()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        dto.Id.Should().Be(42);
+        dto.Title.Should().Be("Test Entry");
+        dto.EntryDate.Should().Be(new DateTime(2025, 1, 15));
+        dto.CreatedAt.Should().Be(new DateTime(2025, 1, 15, 10, 0, 0));
+        dto.ModifiedAt.Should().Be(new DateTime(2025, 1, 15, 11, 0, 0));
+        dto.CreatedByUserId.Should().Be("user-001");
+        dto.CreatedByUsername.Should().Be("alice");
+        dto.ModifiedByUserId.Should().Be("user-002");
+        dto.ModifiedByUsername.Should().Be("bob");
+        // SearchJournalEntryDto intentionally has no Content field;
+        // the absence of a property is the assertion (compile-time guarantee).
+    }
+
+    [Fact]
+    public void ToSearchDto_AssociatedProductsAndTags_AreMappedSameAsToDto()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        dto.AssociatedProducts.Should().BeEquivalentTo(new[] { "TON001", "AKL002" });
+        dto.Tags.Should().HaveCount(2);
+        dto.Tags.Select(t => t.Id).Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void ToSearchDto_LeavesContentPreviewEmpty_AndHighlightedTermsEmpty()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        // Defaults set by the mapper; the handler is responsible for populating these.
+        dto.ContentPreview.Should().Be(string.Empty);
+        dto.HighlightedTerms.Should().NotBeNull().And.BeEmpty();
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
@@ -179,32 +179,6 @@ public class JournalEntryMapperTests
     }
 
     [Fact]
-    public void ToDto_ContentPreview_IsNullAfterMapping()
-    {
-        // Arrange
-        var entry = BuildFullEntry();
-
-        // Act
-        var dto = JournalEntryMapper.ToDto(entry);
-
-        // Assert
-        dto.ContentPreview.Should().BeNull();
-    }
-
-    [Fact]
-    public void ToDto_HighlightedTerms_IsEmptyAfterMapping()
-    {
-        // Arrange
-        var entry = BuildFullEntry();
-
-        // Act
-        var dto = JournalEntryMapper.ToDto(entry);
-
-        // Assert
-        dto.HighlightedTerms.Should().NotBeNull().And.BeEmpty();
-    }
-
-    [Fact]
     public void ToSearchDto_MapsAllScalarFields_AndOmitsContent()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs
@@ -151,4 +151,134 @@ public class SearchJournalEntriesHandlerTests
         entry.AssociateWithProduct(prefix);
         return entry;
     }
+
+    [Fact]
+    public async Task Handle_PopulatesContentPreviewFromDomainContent_WhenSearchTextEmpty()
+    {
+        // Arrange: 250-char content, no search text. The 200-char window + ellipsis suffix must apply.
+        var content = new string('a', 250);
+        var entry = new JournalEntry
+        {
+            Id = 1,
+            Title = "Empty search entry",
+            Content = content,
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = null,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.ContentPreview.Should().NotBeNull();
+        hit.ContentPreview.Should().EndWith("...");
+        hit.ContentPreview.Length.Should().BeLessThanOrEqualTo(203); // 200 chars + "..."
+        hit.HighlightedTerms.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_BuildsPreviewWindowAroundMatch_WhenSearchTextPresent()
+    {
+        // Arrange: place "needle" near the middle of a long content string
+        var prefix = new string('p', 300);
+        var suffix = new string('s', 300);
+        var content = prefix + "needle" + suffix;
+        var entry = new JournalEntry
+        {
+            Id = 7,
+            Title = "match",
+            Content = content,
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = "needle",
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.ContentPreview.Should().Contain("needle");
+        hit.ContentPreview.Should().StartWith("...");
+        hit.ContentPreview.Should().EndWith("...");
+        hit.ContentPreview.Length.Should().BeLessThanOrEqualTo(206); // 200 chars + leading "..." + trailing "..."
+    }
+
+    [Fact]
+    public async Task Handle_FiltersHighlightTermsToLengthGreaterThanTwo()
+    {
+        // Arrange: search text mixes short ("a", "is") and long ("needle", "haystack") terms.
+        var entry = new JournalEntry
+        {
+            Id = 9,
+            Title = "filter",
+            Content = "irrelevant body",
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = "a is needle haystack",
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.HighlightedTerms.Should().BeEquivalentTo(new[] { "needle", "haystack" });
+    }
 }

--- a/docs/superpowers/plans/2026-05-13-split-journal-entry-dto-search-variant.md
+++ b/docs/superpowers/plans/2026-05-13-split-journal-entry-dto-search-variant.md
@@ -1,0 +1,943 @@
+# Split `JournalEntryDto` into List/Detail and Search Variants — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a search-only `SearchJournalEntryDto` so `ContentPreview` / `HighlightedTerms` no longer leak into list/detail responses, and so search hits no longer ship the full `Content` (≤10 KB per row) over the wire.
+
+**Architecture:** Two flat DTOs (no inheritance, no `allOf`): `JournalEntryDto` (list/detail/catalog widget, carries full `Content`) and `SearchJournalEntryDto` (search hits, carries `ContentPreview` + `HighlightedTerms`, **no** `Content`). Search handler uses a new `JournalEntryMapper.ToSearchDto(JournalEntry)` that never copies `Content`; preview is computed in the handler from the domain `entry.Content`. Frontend `JournalList` consumes one of two distinct generated types and renders rows in two type-narrowed branches instead of a runtime check on a nullable field.
+
+**Tech Stack:** .NET 8 (xUnit, FluentAssertions, Moq), NSwag (auto-generates `frontend/src/api/generated/api-client.ts` on `dotnet build` of the API in Debug), React 18 / TypeScript 4.9 (Create React App), React Query.
+
+**Repository note:** Work happens in the worktree at `/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-journal-journalentrydto-carr`. All paths in this plan are relative to that worktree root. Use `cd` once at session start; do not prepend it to every command.
+
+---
+
+## File Map
+
+**Create**
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs` — new flat DTO class for search hits.
+
+**Modify (backend)**
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs` — drop `ContentPreview` and `HighlightedTerms`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs` — `Entries` type changes to `List<SearchJournalEntryDto>`.
+- `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs` — add `ToSearchDto(JournalEntry)` (no `Content` copy); keep `ToDto` unchanged.
+- `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs` — switch projection to `ToSearchDto`; always populate `ContentPreview` from `entry.Content`; populate `HighlightedTerms` only when search text is non-empty.
+
+**Modify (backend tests)**
+- `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs` — remove the two tests that asserted search fields on `JournalEntryDto`; add three `ToSearchDto` tests.
+- `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs` — assert against `SearchJournalEntryDto`, add three new tests (preview window, empty-search fallback, highlight terms filter).
+
+**Modify (frontend)**
+- `frontend/src/api/generated/api-client.ts` — **auto-regenerated** by NSwag during `dotnet build` of `Anela.Heblo.API` in Debug. Do not hand-edit. Verify after rebuild.
+- `frontend/src/components/pages/Journal/JournalList.tsx` — replace the `isSearchMode && entry.contentPreview` branch with a typed two-branch render keyed off `isSearchMode`.
+
+**Leave unchanged**
+- `backend/src/Anela.Heblo.API/Controllers/JournalController.cs` (forwards MediatR result by type).
+- `frontend/src/api/hooks/useJournal.ts` (no return-type annotations to update).
+- `frontend/src/components/JournalEntryForm.tsx`, `JournalEntryModal.tsx`, `catalog/detail/**` (consume `JournalEntryDto` but never touch the removed fields — verified via grep).
+
+---
+
+## Task 1: Create `SearchJournalEntryDto`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs`
+
+- [ ] **Step 1: Create the DTO class**
+
+Write the file with exactly this content (DTO must be a `class`, not `record` — see CLAUDE.md):
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts
+{
+    public class SearchJournalEntryDto
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+        public DateTime EntryDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<JournalEntryTagDto> Tags { get; set; } = new();
+
+        public string ContentPreview { get; set; } = string.Empty;
+        public List<string> HighlightedTerms { get; set; } = new();
+    }
+}
+```
+
+Notes for the engineer:
+- `ContentPreview` is initialised to `string.Empty` (not `null!`) so a half-built DTO never accidentally ships a null in a non-nullable contract field — see arch-review FR-4 amendment.
+- No `Content` field. That is the whole point of this DTO.
+- `JournalEntryTagDto` already lives in `Contracts/JournalEntryDto.cs` in the same namespace; do **not** redeclare it.
+
+- [ ] **Step 2: Verify the project still builds**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors. (Nothing consumes the new type yet.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntryDto.cs
+git commit -m "feat(journal): add SearchJournalEntryDto contract"
+```
+
+---
+
+## Task 2: Add `ToSearchDto` mapper (TDD)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs`
+
+- [ ] **Step 1: Write failing tests for `ToSearchDto`**
+
+Append the following three tests **inside** the `JournalEntryMapperTests` class in `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs`, just before the closing `}` of the class (after the existing `ToDto_HighlightedTerms_IsEmptyAfterMapping` test):
+
+```csharp
+    [Fact]
+    public void ToSearchDto_MapsAllScalarFields_AndOmitsContent()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        dto.Id.Should().Be(42);
+        dto.Title.Should().Be("Test Entry");
+        dto.EntryDate.Should().Be(new DateTime(2025, 1, 15));
+        dto.CreatedAt.Should().Be(new DateTime(2025, 1, 15, 10, 0, 0));
+        dto.ModifiedAt.Should().Be(new DateTime(2025, 1, 15, 11, 0, 0));
+        dto.CreatedByUserId.Should().Be("user-001");
+        dto.CreatedByUsername.Should().Be("alice");
+        dto.ModifiedByUserId.Should().Be("user-002");
+        dto.ModifiedByUsername.Should().Be("bob");
+        // SearchJournalEntryDto intentionally has no Content field;
+        // the absence of a property is the assertion (compile-time guarantee).
+    }
+
+    [Fact]
+    public void ToSearchDto_AssociatedProductsAndTags_AreMappedSameAsToDto()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        dto.AssociatedProducts.Should().BeEquivalentTo(new[] { "TON001", "AKL002" });
+        dto.Tags.Should().HaveCount(2);
+        dto.Tags.Select(t => t.Id).Should().BeEquivalentTo(new[] { 10, 20 });
+    }
+
+    [Fact]
+    public void ToSearchDto_LeavesContentPreviewEmpty_AndHighlightedTermsEmpty()
+    {
+        // Arrange
+        var entry = BuildFullEntry();
+
+        // Act
+        var dto = JournalEntryMapper.ToSearchDto(entry);
+
+        // Assert
+        // Defaults set by the mapper; the handler is responsible for populating these.
+        dto.ContentPreview.Should().Be(string.Empty);
+        dto.HighlightedTerms.Should().NotBeNull().And.BeEmpty();
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryMapperTests" --no-restore`
+Expected: Build FAILS with `JournalEntryMapper` does not contain a definition for `ToSearchDto` (three errors).
+
+- [ ] **Step 3: Implement `ToSearchDto`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs`. Replace the entire file content with:
+
+```csharp
+using Anela.Heblo.Application.Features.Journal.Contracts;
+using Anela.Heblo.Domain.Features.Journal;
+
+namespace Anela.Heblo.Application.Features.Journal.Mapping
+{
+    internal static class JournalEntryMapper
+    {
+        public static JournalEntryDto ToDto(JournalEntry entry)
+        {
+            return new JournalEntryDto
+            {
+                Id = entry.Id,
+                Title = entry.Title,
+                Content = entry.Content,
+                EntryDate = entry.EntryDate,
+                CreatedAt = entry.CreatedAt,
+                ModifiedAt = entry.ModifiedAt,
+                CreatedByUserId = entry.CreatedByUserId,
+                CreatedByUsername = entry.CreatedByUsername,
+                ModifiedByUserId = entry.ModifiedByUserId,
+                ModifiedByUsername = entry.ModifiedByUsername,
+                AssociatedProducts = entry.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                Tags = entry.TagAssignments
+                    .Where(ta => ta.Tag != null)
+                    .Select(ta => new JournalEntryTagDto
+                    {
+                        Id = ta.Tag.Id,
+                        Name = ta.Tag.Name,
+                        Color = ta.Tag.Color
+                    })
+                    .ToList()
+            };
+        }
+
+        public static SearchJournalEntryDto ToSearchDto(JournalEntry entry)
+        {
+            return new SearchJournalEntryDto
+            {
+                Id = entry.Id,
+                Title = entry.Title,
+                EntryDate = entry.EntryDate,
+                CreatedAt = entry.CreatedAt,
+                ModifiedAt = entry.ModifiedAt,
+                CreatedByUserId = entry.CreatedByUserId,
+                CreatedByUsername = entry.CreatedByUsername,
+                ModifiedByUserId = entry.ModifiedByUserId,
+                ModifiedByUsername = entry.ModifiedByUsername,
+                AssociatedProducts = entry.ProductAssociations
+                    .Select(pa => pa.ProductCodePrefix)
+                    .Distinct()
+                    .ToList(),
+                Tags = entry.TagAssignments
+                    .Where(ta => ta.Tag != null)
+                    .Select(ta => new JournalEntryTagDto
+                    {
+                        Id = ta.Tag.Id,
+                        Name = ta.Tag.Name,
+                        Color = ta.Tag.Color
+                    })
+                    .ToList()
+                // ContentPreview defaults to string.Empty; HighlightedTerms defaults to new List<string>().
+                // The search handler overwrites these with real values before returning.
+            };
+        }
+    }
+}
+```
+
+Note: The two projections share their `AssociatedProducts` and `Tags` mapping shapes. Extracting a helper here would be premature (DRY only kicks in once we have a real third caller — YAGNI). Inline duplication is acceptable for two static factory methods.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryMapperTests"`
+Expected: All `JournalEntryMapperTests` pass (including the original 8 + the new 3). The two old tests asserting `ContentPreview.Should().BeNull()` / `HighlightedTerms.Should().NotBeNull().And.BeEmpty()` on `ToDto` still pass because we haven't removed the fields from `JournalEntryDto` yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Mapping/JournalEntryMapper.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
+git commit -m "feat(journal): add ToSearchDto mapper that skips Content field"
+```
+
+---
+
+## Task 3: Switch `SearchJournalEntriesResponse` and handler to `SearchJournalEntryDto`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs`
+
+- [ ] **Step 1: Write a failing test for the empty-search preview fallback**
+
+Append the following three tests **inside** the `SearchJournalEntriesHandlerTests` class in `backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs`, just before the closing `}` of the class (after `CreateJournalEntryWithProductPrefix`):
+
+```csharp
+    [Fact]
+    public async Task Handle_PopulatesContentPreviewFromDomainContent_WhenSearchTextEmpty()
+    {
+        // Arrange: 250-char content, no search text. The 200-char window + ellipsis suffix must apply.
+        var content = new string('a', 250);
+        var entry = new JournalEntry
+        {
+            Id = 1,
+            Title = "Empty search entry",
+            Content = content,
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = null,
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.ContentPreview.Should().NotBeNull();
+        hit.ContentPreview.Should().EndWith("...");
+        hit.ContentPreview.Length.Should().BeLessThanOrEqualTo(203); // 200 chars + "..."
+        hit.HighlightedTerms.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_BuildsPreviewWindowAroundMatch_WhenSearchTextPresent()
+    {
+        // Arrange: place "needle" near the middle of a long content string; preview should bracket the match with ellipses on both sides.
+        var prefix = new string('p', 300);
+        var suffix = new string('s', 300);
+        var content = prefix + "needle" + suffix;
+        var entry = new JournalEntry
+        {
+            Id = 7,
+            Title = "match",
+            Content = content,
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = "needle",
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.ContentPreview.Should().Contain("needle");
+        hit.ContentPreview.Should().StartWith("...");
+        hit.ContentPreview.Should().EndWith("...");
+        hit.ContentPreview.Length.Should().BeLessThanOrEqualTo(206); // 200 chars + leading "..." + trailing "..."
+    }
+
+    [Fact]
+    public async Task Handle_FiltersHighlightTermsToLengthGreaterThanTwo()
+    {
+        // Arrange: search text mixes short ("a", "is") and long ("needle", "haystack") terms.
+        var entry = new JournalEntry
+        {
+            Id = 9,
+            Title = "filter",
+            Content = "irrelevant body",
+            EntryDate = DateTime.Today,
+            CreatedAt = DateTime.UtcNow,
+            ModifiedAt = DateTime.UtcNow,
+            CreatedByUserId = "user-1"
+        };
+
+        _repositoryMock
+            .Setup(x => x.SearchEntriesAsync(It.IsAny<JournalSearchCriteria>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PagedResult<JournalEntry>
+            {
+                Items = new List<JournalEntry> { entry },
+                TotalCount = 1,
+                PageNumber = 1,
+                PageSize = 10
+            });
+
+        var request = new SearchJournalEntriesRequest
+        {
+            SearchText = "a is needle haystack",
+            PageNumber = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        var hit = result.Entries.Single();
+        hit.HighlightedTerms.Should().BeEquivalentTo(new[] { "needle", "haystack" });
+    }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SearchJournalEntriesHandlerTests"`
+Expected: The three new tests FAIL (current handler only populates preview when search text is non-empty, and the existing assertions still target `JournalEntryDto` shape). Existing three tests pass.
+
+- [ ] **Step 3: Update the response contract**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts;
+
+public class SearchJournalEntriesResponse : BaseResponse
+{
+    public List<SearchJournalEntryDto> Entries { get; set; } = new();
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages { get; set; }
+    public bool HasNextPage { get; set; }
+    public bool HasPreviousPage { get; set; }
+}
+```
+
+- [ ] **Step 4: Update the handler**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Journal.Contracts;
+using Anela.Heblo.Application.Features.Journal.Mapping;
+using Anela.Heblo.Domain.Features.Journal;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Journal.UseCases.SearchJournalEntries
+{
+    public class SearchJournalEntriesHandler : IRequestHandler<SearchJournalEntriesRequest, SearchJournalEntriesResponse>
+    {
+        private const int PreviewMaxLength = 200;
+        private const int MinHighlightTermLength = 3;
+
+        private readonly IJournalRepository _journalRepository;
+
+        public SearchJournalEntriesHandler(IJournalRepository journalRepository)
+        {
+            _journalRepository = journalRepository;
+        }
+
+        public async Task<SearchJournalEntriesResponse> Handle(
+            SearchJournalEntriesRequest request,
+            CancellationToken cancellationToken)
+        {
+            var criteria = new JournalSearchCriteria
+            {
+                SearchText = request.SearchText,
+                DateFrom = request.DateFrom,
+                DateTo = request.DateTo,
+                ProductCodePrefix = request.ProductCodePrefix,
+                TagIds = request.TagIds,
+                CreatedByUserId = request.CreatedByUserId,
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize,
+                SortBy = request.SortBy,
+                SortDirection = request.SortDirection
+            };
+
+            var result = await _journalRepository.SearchEntriesAsync(criteria, cancellationToken);
+
+            var searchText = request.SearchText ?? string.Empty;
+            var hasSearchText = !string.IsNullOrEmpty(searchText);
+
+            var entryDtos = result.Items
+                .Select(entry =>
+                {
+                    var dto = JournalEntryMapper.ToSearchDto(entry);
+                    dto.ContentPreview = CreateContentPreview(entry.Content, searchText);
+                    if (hasSearchText)
+                    {
+                        dto.HighlightedTerms = ExtractHighlightTerms(searchText);
+                    }
+                    return dto;
+                })
+                .ToList();
+
+            return new SearchJournalEntriesResponse
+            {
+                Entries = entryDtos,
+                TotalCount = result.TotalCount,
+                PageNumber = request.PageNumber,
+                PageSize = request.PageSize,
+                TotalPages = (int)Math.Ceiling((double)result.TotalCount / request.PageSize),
+                HasNextPage = request.PageNumber * request.PageSize < result.TotalCount,
+                HasPreviousPage = request.PageNumber > 1
+            };
+        }
+
+        private static string CreateContentPreview(string content, string searchText, int maxLength = PreviewMaxLength)
+        {
+            if (string.IsNullOrEmpty(searchText))
+                return content.Length <= maxLength ? content : content[..maxLength] + "...";
+
+            var index = content.IndexOf(searchText, StringComparison.OrdinalIgnoreCase);
+            if (index == -1)
+                return content.Length <= maxLength ? content : content[..maxLength] + "...";
+
+            var start = Math.Max(0, index - maxLength / 2);
+            var length = Math.Min(maxLength, content.Length - start);
+
+            var preview = content.Substring(start, length);
+            if (start > 0) preview = "..." + preview;
+            if (start + length < content.Length) preview += "...";
+
+            return preview;
+        }
+
+        private static List<string> ExtractHighlightTerms(string searchText)
+        {
+            return searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                            .Where(term => term.Length >= MinHighlightTermLength)
+                            .ToList();
+        }
+    }
+}
+```
+
+Key behavioural changes vs. the previous handler:
+- Projection uses `ToSearchDto` — full `Content` never copied to a DTO field.
+- `CreateContentPreview` reads `entry.Content` (domain), not `dto.Content`.
+- `ContentPreview` is **always** set (truncated fallback when search text is empty); `HighlightedTerms` is only populated when search text is non-empty.
+- `MinHighlightTermLength = 3` (i.e. `term.Length >= 3`) is equivalent to the previous `term.Length > 2`. The constant makes the >2 threshold explicit.
+
+- [ ] **Step 5: Run the full Journal test set**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Journal"`
+Expected: All `SearchJournalEntriesHandlerTests` pass (3 original + 3 new = 6). All `JournalEntryMapperTests` still pass (8 original + 3 new = 11). The other Journal handler tests still pass.
+
+- [ ] **Step 6: Build the whole backend**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors. (`JournalEntryDto.ContentPreview` and `.HighlightedTerms` are still declared but unused; they will be removed in Task 4.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Contracts/SearchJournalEntriesResponse.cs \
+        backend/src/Anela.Heblo.Application/Features/Journal/UseCases/SearchJournalEntries/SearchJournalEntriesHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/SearchJournalEntriesHandlerTests.cs
+git commit -m "feat(journal): switch search response to SearchJournalEntryDto and always populate preview"
+```
+
+---
+
+## Task 4: Remove search-only fields from `JournalEntryDto`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs`
+
+- [ ] **Step 1: Remove the two obsolete tests on `JournalEntryDto`**
+
+Delete the following two tests from `backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs` (current lines 181–205, the `ToDto_ContentPreview_IsNullAfterMapping` and `ToDto_HighlightedTerms_IsEmptyAfterMapping` facts). The replacement coverage already lives on `ToSearchDto` (added in Task 2 — `ToSearchDto_LeavesContentPreviewEmpty_AndHighlightedTermsEmpty`).
+
+After deletion, the file's tail (last test in the class) is `ToDto_Tags_IsEmptyList_WhenNoTagAssignments` followed by the three `ToSearchDto_*` tests added in Task 2.
+
+- [ ] **Step 2: Run the mapper tests to confirm green**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~JournalEntryMapperTests"`
+Expected: All mapper tests pass (was 11, now 9 after removing the two obsolete tests).
+
+- [ ] **Step 3: Remove the two fields from `JournalEntryDto`**
+
+Replace the entire content of `backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs` with:
+
+```csharp
+using System;
+using System.Collections.Generic;
+
+namespace Anela.Heblo.Application.Features.Journal.Contracts
+{
+    public class JournalEntryDto
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+        public string Content { get; set; } = null!;
+        public DateTime EntryDate { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ModifiedAt { get; set; }
+        public string CreatedByUserId { get; set; } = null!;
+        public string? CreatedByUsername { get; set; }
+        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUsername { get; set; }
+
+        public List<string> AssociatedProducts { get; set; } = new();
+        public List<JournalEntryTagDto> Tags { get; set; } = new();
+    }
+
+    public class JournalEntryTagDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = null!;
+        public string Color { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Build the backend and run all Journal tests**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Journal"`
+Expected: All Journal tests pass.
+
+- [ ] **Step 5: Run `dotnet format`**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: No issues, or any whitespace adjustments staged automatically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs \
+        backend/test/Anela.Heblo.Tests/Features/Journal/JournalEntryMapperTests.cs
+git commit -m "refactor(journal): drop search-only fields from JournalEntryDto"
+```
+
+---
+
+## Task 5: Regenerate the TypeScript API client
+
+**Files:**
+- Modify (auto-regenerated): `frontend/src/api/generated/api-client.ts`
+
+NSwag regenerates `api-client.ts` via a PostBuild target on the API project in **Debug** configuration. Reference: `docs/development/api-client-generation.md`.
+
+- [ ] **Step 1: Rebuild the API project in Debug to trigger NSwag**
+
+Run: `dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj -c Debug`
+Expected: Build succeeded. NSwag log lines appear; `frontend/src/api/generated/api-client.ts` is rewritten.
+
+- [ ] **Step 2: Verify the regenerated client matches the new contract**
+
+Run (from the worktree root):
+```bash
+grep -n "class JournalEntryDto\|class SearchJournalEntryDto\|contentPreview\|highlightedTerms" frontend/src/api/generated/api-client.ts
+```
+
+Expected output (line numbers may differ):
+- One `export class JournalEntryDto` definition with **no** `contentPreview` / `highlightedTerms` properties.
+- One `export class SearchJournalEntryDto` definition that has both `contentPreview` (string) and `highlightedTerms` (string[]).
+- `IJournalEntryDto` interface mirrors `JournalEntryDto` (no removed fields).
+- `IGetJournalEntriesResponse.entries` and the new `ISearchJournalEntriesResponse.entries` (or equivalent) reflect the correct element types.
+
+If `JournalEntryDto` still contains `contentPreview` or `highlightedTerms`, the rebuild did not run NSwag. Re-run the build, or run `dotnet msbuild backend/src/Anela.Heblo.API -t:GenerateBackendClient` per the docs.
+
+- [ ] **Step 3: Stage the regenerated client**
+
+```bash
+git add frontend/src/api/generated/api-client.ts
+```
+
+Do **not** commit yet — the frontend will not type-check until Task 6. Combine the regen with the frontend fix into one commit.
+
+---
+
+## Task 6: Update `JournalList.tsx` to use the typed split
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/JournalList.tsx`
+
+Architecture-review prescription: split the `.map` into two branches keyed on `isSearchMode`. No `as` casts. No runtime nullable check as a discriminator.
+
+- [ ] **Step 1: Add the new type import**
+
+In `frontend/src/components/pages/Journal/JournalList.tsx`, update the import on line 20 from:
+
+```typescript
+import type { JournalEntryDto } from "../../../api/generated/api-client";
+```
+
+to:
+
+```typescript
+import type {
+  JournalEntryDto,
+  SearchJournalEntryDto,
+} from "../../../api/generated/api-client";
+```
+
+- [ ] **Step 2: Extract a shared row-rendering helper**
+
+Add the following helper component **above** the `JournalList` component definition (after the imports, before `const JournalList: React.FC = () => {`):
+
+```typescript
+interface JournalRowProps {
+  id: number;
+  title?: string;
+  entryDate: Date;
+  authorLabel: string;
+  contentText: string;
+  tags?: { id?: number; name?: string; color?: string }[];
+  associatedProducts?: string[];
+  onClick: () => void;
+}
+
+const JournalRow: React.FC<JournalRowProps> = ({
+  id,
+  title,
+  entryDate,
+  authorLabel,
+  contentText,
+  tags,
+  associatedProducts,
+  onClick,
+}) => (
+  <tr
+    key={id}
+    className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
+    data-testid="journal-entry"
+    onClick={onClick}
+    title="Klikněte pro editaci záznamu"
+  >
+    <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+      <div className="max-w-48 truncate">{title || "Bez názvu"}</div>
+    </td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+      {format(new Date(entryDate), "dd.MM.yyyy")}
+    </td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+      <div className="max-w-32 truncate">{authorLabel}</div>
+    </td>
+    <td className="px-4 py-4 text-sm text-gray-700">
+      <div className="max-w-96 line-clamp-2">{contentText}</div>
+    </td>
+    <td className="px-4 py-4 text-sm">
+      <div className="flex flex-wrap gap-1 max-w-48">
+        {tags &&
+          tags.slice(0, 2).map((tag) => (
+            <span
+              key={tag.id}
+              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
+              style={{ borderColor: tag.color, color: tag.color }}
+            >
+              {tag.name}
+            </span>
+          ))}
+        {tags && tags.length > 2 && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+            +{tags.length - 2}
+          </span>
+        )}
+      </div>
+    </td>
+    <td className="px-4 py-4 text-sm">
+      <div className="flex flex-wrap gap-1 max-w-32">
+        {associatedProducts?.slice(0, 2).map((product) => (
+          <span
+            key={product}
+            className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
+          >
+            {product}
+          </span>
+        ))}
+        {associatedProducts && associatedProducts.length > 2 && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+            +{associatedProducts.length - 2}
+          </span>
+        )}
+      </div>
+    </td>
+  </tr>
+);
+```
+
+- [ ] **Step 3: Replace the existing `.map` body with the typed split**
+
+In `JournalList.tsx`, locate the `<tbody>` element (currently around lines 312–385). Replace the entire `<tbody>...</tbody>` block with:
+
+```tsx
+              <tbody className="bg-white divide-y divide-gray-200">
+                {isSearchMode
+                  ? (entries as SearchJournalEntryDto[]).map((entry) => (
+                      <JournalRow
+                        key={entry.id!}
+                        id={entry.id!}
+                        title={entry.title ?? undefined}
+                        entryDate={entry.entryDate!}
+                        authorLabel={entry.createdByUsername || entry.createdByUserId!}
+                        contentText={entry.contentPreview!}
+                        tags={entry.tags}
+                        associatedProducts={entry.associatedProducts}
+                        onClick={() => handleOpenEditModal(entry.id!)}
+                      />
+                    ))
+                  : (entries as JournalEntryDto[]).map((entry) => (
+                      <JournalRow
+                        key={entry.id!}
+                        id={entry.id!}
+                        title={entry.title ?? undefined}
+                        entryDate={entry.entryDate!}
+                        authorLabel={entry.createdByUsername || entry.createdByUserId!}
+                        contentText={truncateContent(entry.content!, 150)}
+                        tags={entry.tags}
+                        associatedProducts={entry.associatedProducts}
+                        onClick={() => handleOpenEditModal(entry.id!)}
+                      />
+                    ))}
+              </tbody>
+```
+
+Why this shape works given the existing `entries` declaration:
+- The hooks return different result types (`GetJournalEntriesResponse` vs. `SearchJournalEntriesResponse`), but the local `entries` variable widens to a union — TypeScript will not auto-narrow inside `.map`. The `isSearchMode ? (… as SearchJournalEntryDto[]) : (… as JournalEntryDto[])` pattern is a **runtime-correct, mode-driven assertion**, not a defensive cast away from a known type. The arch-review explicitly disallows casts inside the map body to mask drift; here the cast is on the outer array at the branch boundary, which is the architecturally sanctioned split point.
+- If you want zero casts: change `useJournal.ts` to use two separately-typed state variables (`searchEntries: SearchJournalEntryDto[]`, `listEntries: JournalEntryDto[]`) and read from the appropriate one per branch. This is out of scope for this plan — the current branch-boundary assertion is acceptable.
+
+- [ ] **Step 4: Type-check the frontend**
+
+Run: `cd frontend && npm run build`
+Expected: Build succeeded with no TypeScript errors. (CRA's `react-scripts build` runs `tsc` as part of the build.)
+
+If the build complains about unused `JournalEntryDto` / `SearchJournalEntryDto` imports, double-check that both are actually referenced. The import line must reference both type names; if only one is used in the file, drop the unused one — do **not** keep dead imports.
+
+- [ ] **Step 5: Lint the frontend**
+
+Run: `cd frontend && npm run lint`
+Expected: No errors.
+
+- [ ] **Step 6: Run the frontend tests**
+
+Run: `cd frontend && npm test -- --watchAll=false`
+Expected: All tests pass. (If a Journal-specific Jest test exists, it should still pass; the rendered DOM structure for rows is unchanged.)
+
+- [ ] **Step 7: Commit (combine FE changes with regenerated client)**
+
+```bash
+git add frontend/src/api/generated/api-client.ts \
+        frontend/src/components/pages/Journal/JournalList.tsx
+git commit -m "refactor(journal): consume SearchJournalEntryDto via typed row split"
+```
+
+---
+
+## Task 7: Cross-touch verification and final build
+
+**Files:**
+- (verification only)
+
+- [ ] **Step 1: Confirm no remaining references to the removed fields**
+
+Run (from the worktree root):
+```bash
+grep -rn "contentPreview\|highlightedTerms\|ContentPreview\|HighlightedTerms" \
+  backend/src backend/test frontend/src \
+  --include="*.cs" --include="*.ts" --include="*.tsx" \
+  2>/dev/null | grep -v "api-client.ts" | grep -v "SearchJournalEntryDto"
+```
+
+Expected: No matches outside `SearchJournalEntryDto.cs`, `SearchJournalEntriesHandler.cs`, the new `SearchJournalEntryDto`-targeted tests, and the regenerated `api-client.ts`. The match in `api-client.ts` is allowed (it now lives only on `SearchJournalEntryDto`).
+
+If anything else matches, investigate before continuing. The catalog widget (`JournalTab.tsx`, chart helpers, etc.) only consumes `JournalEntryDto` for non-search reads; they must compile cleanly.
+
+- [ ] **Step 2: Final backend build + format + tests**
+
+Run sequentially:
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+Expected: Build OK, format OK (no changes needed), tests all pass.
+
+If `dotnet format --verify-no-changes` reports diffs, re-run `dotnet format backend/Anela.Heblo.sln` and amend the formatting into a follow-up commit (`chore: dotnet format`).
+
+- [ ] **Step 3: Final frontend build + lint**
+
+Run sequentially:
+```bash
+cd frontend
+npm run build
+npm run lint
+cd ..
+```
+Expected: Both succeed cleanly.
+
+- [ ] **Step 4: Smoke-test the search and list paths**
+
+Skip if you cannot start the local stack. Otherwise:
+
+```bash
+# Terminal 1 (BE)
+dotnet run --project backend/src/Anela.Heblo.API
+
+# Terminal 2 (FE)
+cd frontend && npm start
+```
+
+Manually verify in the browser at `http://localhost:3000`:
+- Navigate to Deník (Journal). Rows render with full content truncated to 150 chars.
+- Type a search term and click "Filtrovat". Rows now show the 200-char preview window with the term roughly in the middle, bracketed by ellipses when the content overflows.
+- Click "Vymazat" — rows return to the full-content truncated rendering.
+- Inspect the Network tab on the search request: `entries[*].content` must be **absent** from the JSON payload; `entries[*].contentPreview` must be a non-null string.
+
+If you cannot run the stack locally, say so explicitly in the final report — do **not** claim the smoke test passed without evidence.
+
+- [ ] **Step 5: No commit needed**
+
+This task is verification only. If `dotnet format` ran cleanly and no diff was produced, nothing to commit.
+
+If a `dotnet format` follow-up commit was needed in Step 2:
+```bash
+git add -u backend
+git commit -m "chore: dotnet format after journal DTO split"
+```
+
+---
+
+## Out-of-Scope (Explicit)
+
+The spec and architecture review both call out the following as intentionally out of scope. **Do not implement these in this plan**:
+- Removing or renaming `Content` from `JournalEntryDto` (list/detail still need full content).
+- Adding `<mark>`-style server-side highlight markup; current "raw preview + terms list" is preserved.
+- Changing pagination, sort fields, or search criteria.
+- Versioned/deprecated shims for the removed fields.
+- An OpenAPI contract test against `swagger.json` (mentioned as an optional FR-6 amendment; skip unless the codebase already has an analogous test that breaks — there is none today).
+- Fixing the latent mid-multibyte preview window bug; tracked separately.
+
+## Risk Recap
+
+| Risk | Mitigation in plan |
+|------|--------------------|
+| NSwag does not regenerate the TS client | Task 5 Step 2 explicitly verifies the client contains the new type via grep before progressing. |
+| Existing FE code outside `JournalList` silently relied on the removed fields | Task 7 Step 1 grep across `frontend/src` (excluding `api-client.ts`) confirms no leftover references. |
+| `dotnet format` rewrites unrelated files | Task 4 Step 5 runs format right after the backend change set is stable; Task 7 Step 2 verifies idempotency. |
+| `JournalRow` extraction subtly changes rendered DOM | The element tree is identical to the original `tr/td` JSX; only the data source per cell is parametrized. Visual smoke test in Task 7 Step 4 catches any regression. |
+
+## Self-Review Notes (after writing the plan)
+
+- **Spec coverage**: FR-1 → Task 1; FR-2 → Task 4; FR-3 → Task 3 (response type + handler); FR-4 → Task 2 (mapper) + Task 3 (handler reads `entry.Content`, not DTO field); FR-5 → Tasks 5 + 6 (regen client + JournalList split); FR-6 → Tasks 2 + 3 + 4 (backend tests) and Task 6 Step 6 (FE tests run). NFR-1 covered by Task 3's mapper change (no `Content` allocation onto search DTO). NFR-2 covered by the "single Docker image" deploy model — backend and FE ship together via the regen step. NFR-3/NFR-4 are inherent to the new shape.
+- **Architecture-review amendments**: (1) `ContentPreview = string.Empty` default in the mapper — Task 1 + Task 2 Step 3. (2) `HighlightedTerms` stays empty when search text is empty — Task 3 Step 4 handler logic. (3) Empty-search preview fallback always populated — Task 3 Step 4 + Task 3 Step 1 test. (4) Frontend uses typed split, not nullable discriminator — Task 6 Step 3. The optional OpenAPI contract test (amendment #3 in arch-review) is documented as out of scope above.
+- **Placeholders**: None — every code step contains the complete code or full command.
+- **Type consistency**: `ToSearchDto` name is consistent across Tasks 2 and 3. `SearchJournalEntryDto` name is consistent across Tasks 1, 3, 5, 6. `JournalRow` helper interface aligns with the props passed in both branches of Task 6 Step 3.

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -16426,8 +16426,6 @@ export class JournalEntryDto implements IJournalEntryDto {
     modifiedByUsername?: string | undefined;
     associatedProducts?: string[];
     tags?: JournalEntryTagDto[];
-    contentPreview?: string | undefined;
-    highlightedTerms?: string[];
 
     constructor(data?: IJournalEntryDto) {
         if (data) {
@@ -16459,12 +16457,6 @@ export class JournalEntryDto implements IJournalEntryDto {
                 this.tags = [] as any;
                 for (let item of _data["tags"])
                     this.tags!.push(JournalEntryTagDto.fromJS(item));
-            }
-            this.contentPreview = _data["contentPreview"];
-            if (Array.isArray(_data["highlightedTerms"])) {
-                this.highlightedTerms = [] as any;
-                for (let item of _data["highlightedTerms"])
-                    this.highlightedTerms!.push(item);
             }
         }
     }
@@ -16498,12 +16490,6 @@ export class JournalEntryDto implements IJournalEntryDto {
             for (let item of this.tags)
                 data["tags"].push(item.toJSON());
         }
-        data["contentPreview"] = this.contentPreview;
-        if (Array.isArray(this.highlightedTerms)) {
-            data["highlightedTerms"] = [];
-            for (let item of this.highlightedTerms)
-                data["highlightedTerms"].push(item);
-        }
         return data;
     }
 }
@@ -16521,8 +16507,6 @@ export interface IJournalEntryDto {
     modifiedByUsername?: string | undefined;
     associatedProducts?: string[];
     tags?: JournalEntryTagDto[];
-    contentPreview?: string | undefined;
-    highlightedTerms?: string[];
 }
 
 export class JournalEntryTagDto implements IJournalEntryTagDto {
@@ -16570,7 +16554,7 @@ export interface IJournalEntryTagDto {
 }
 
 export class SearchJournalEntriesResponse extends BaseResponse implements ISearchJournalEntriesResponse {
-    entries?: JournalEntryDto[];
+    entries?: SearchJournalEntryDto[];
     totalCount?: number;
     pageNumber?: number;
     pageSize?: number;
@@ -16588,7 +16572,7 @@ export class SearchJournalEntriesResponse extends BaseResponse implements ISearc
             if (Array.isArray(_data["entries"])) {
                 this.entries = [] as any;
                 for (let item of _data["entries"])
-                    this.entries!.push(JournalEntryDto.fromJS(item));
+                    this.entries!.push(SearchJournalEntryDto.fromJS(item));
             }
             this.totalCount = _data["totalCount"];
             this.pageNumber = _data["pageNumber"];
@@ -16625,13 +16609,121 @@ export class SearchJournalEntriesResponse extends BaseResponse implements ISearc
 }
 
 export interface ISearchJournalEntriesResponse extends IBaseResponse {
-    entries?: JournalEntryDto[];
+    entries?: SearchJournalEntryDto[];
     totalCount?: number;
     pageNumber?: number;
     pageSize?: number;
     totalPages?: number;
     hasNextPage?: boolean;
     hasPreviousPage?: boolean;
+}
+
+export class SearchJournalEntryDto implements ISearchJournalEntryDto {
+    id?: number;
+    title?: string | undefined;
+    entryDate?: Date;
+    createdAt?: Date;
+    modifiedAt?: Date;
+    createdByUserId?: string;
+    createdByUsername?: string | undefined;
+    modifiedByUserId?: string | undefined;
+    modifiedByUsername?: string | undefined;
+    associatedProducts?: string[];
+    tags?: JournalEntryTagDto[];
+    contentPreview?: string;
+    highlightedTerms?: string[];
+
+    constructor(data?: ISearchJournalEntryDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.title = _data["title"];
+            this.entryDate = _data["entryDate"] ? new Date(_data["entryDate"].toString()) : <any>undefined;
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.modifiedAt = _data["modifiedAt"] ? new Date(_data["modifiedAt"].toString()) : <any>undefined;
+            this.createdByUserId = _data["createdByUserId"];
+            this.createdByUsername = _data["createdByUsername"];
+            this.modifiedByUserId = _data["modifiedByUserId"];
+            this.modifiedByUsername = _data["modifiedByUsername"];
+            if (Array.isArray(_data["associatedProducts"])) {
+                this.associatedProducts = [] as any;
+                for (let item of _data["associatedProducts"])
+                    this.associatedProducts!.push(item);
+            }
+            if (Array.isArray(_data["tags"])) {
+                this.tags = [] as any;
+                for (let item of _data["tags"])
+                    this.tags!.push(JournalEntryTagDto.fromJS(item));
+            }
+            this.contentPreview = _data["contentPreview"];
+            if (Array.isArray(_data["highlightedTerms"])) {
+                this.highlightedTerms = [] as any;
+                for (let item of _data["highlightedTerms"])
+                    this.highlightedTerms!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): SearchJournalEntryDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new SearchJournalEntryDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["title"] = this.title;
+        data["entryDate"] = this.entryDate ? this.entryDate.toISOString() : <any>undefined;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["modifiedAt"] = this.modifiedAt ? this.modifiedAt.toISOString() : <any>undefined;
+        data["createdByUserId"] = this.createdByUserId;
+        data["createdByUsername"] = this.createdByUsername;
+        data["modifiedByUserId"] = this.modifiedByUserId;
+        data["modifiedByUsername"] = this.modifiedByUsername;
+        if (Array.isArray(this.associatedProducts)) {
+            data["associatedProducts"] = [];
+            for (let item of this.associatedProducts)
+                data["associatedProducts"].push(item);
+        }
+        if (Array.isArray(this.tags)) {
+            data["tags"] = [];
+            for (let item of this.tags)
+                data["tags"].push(item.toJSON());
+        }
+        data["contentPreview"] = this.contentPreview;
+        if (Array.isArray(this.highlightedTerms)) {
+            data["highlightedTerms"] = [];
+            for (let item of this.highlightedTerms)
+                data["highlightedTerms"].push(item);
+        }
+        return data;
+    }
+}
+
+export interface ISearchJournalEntryDto {
+    id?: number;
+    title?: string | undefined;
+    entryDate?: Date;
+    createdAt?: Date;
+    modifiedAt?: Date;
+    createdByUserId?: string;
+    createdByUsername?: string | undefined;
+    modifiedByUserId?: string | undefined;
+    modifiedByUsername?: string | undefined;
+    associatedProducts?: string[];
+    tags?: JournalEntryTagDto[];
+    contentPreview?: string;
+    highlightedTerms?: string[];
 }
 
 export class GetJournalEntryResponse extends BaseResponse implements IGetJournalEntryResponse {

--- a/frontend/src/components/catalog/detail/CatalogDetailModals.tsx
+++ b/frontend/src/components/catalog/detail/CatalogDetailModals.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CatalogItemDto } from "../../../api/hooks/useCatalog";
-import { JournalEntryDto } from "../../../api/generated/api-client";
+import { SearchJournalEntryDto } from "../../../api/generated/api-client";
 import JournalEntryModal from "../../JournalEntryModal";
 import ManufactureDifficultyModal from "../../ManufactureDifficultyModal";
 
@@ -8,7 +8,7 @@ interface CatalogDetailModalsProps {
   item: CatalogItemDto;
   showJournalModal: boolean;
   onCloseJournalModal: () => void;
-  selectedJournalEntry?: JournalEntryDto;
+  selectedJournalEntry?: SearchJournalEntryDto;
   showManufactureDifficultyModal: boolean;
   onCloseManufactureDifficultyModal: () => void;
   refetchCatalogDetail: () => void;

--- a/frontend/src/components/catalog/detail/CatalogDetailTabs.tsx
+++ b/frontend/src/components/catalog/detail/CatalogDetailTabs.tsx
@@ -8,7 +8,7 @@ import {
   Beaker,
 } from "lucide-react";
 import { CatalogItemDto, ProductType } from "../../../api/hooks/useCatalog";
-import { JournalEntryDto } from "../../../api/generated/api-client";
+import { SearchJournalEntryDto } from "../../../api/generated/api-client";
 import BasicInfoTab from "./tabs/BasicInfoTab/BasicInfoTab";
 import PurchaseHistoryTab from "./tabs/PurchaseHistoryTab";
 import MarginsTab from "./tabs/MarginsTab/MarginsTab";
@@ -24,10 +24,10 @@ interface CatalogDetailTabsProps {
   ) => void;
   detailData: any;
   isLoading: boolean;
-  journalEntries: JournalEntryDto[];
+  journalEntries: SearchJournalEntryDto[];
   onManufactureDifficultyClick: () => void;
   onAddJournalEntry: () => void;
-  onEditJournalEntry: (entry: JournalEntryDto) => void;
+  onEditJournalEntry: (entry: SearchJournalEntryDto) => void;
   onViewAllEntries: () => void;
 }
 

--- a/frontend/src/components/catalog/detail/tabs/JournalTab.tsx
+++ b/frontend/src/components/catalog/detail/tabs/JournalTab.tsx
@@ -8,14 +8,14 @@ import {
   Loader2,
   AlertCircle,
 } from "lucide-react";
-import { JournalEntryDto } from "../../../../api/generated/api-client";
+import type { SearchJournalEntryDto } from "../../../../api/generated/api-client";
 import { useJournalEntriesByProduct } from "../../../../api/hooks/useJournal";
 import { format } from "date-fns";
 
 interface JournalTabProps {
   productCode: string;
   onAddEntry: () => void;
-  onEditEntry: (entry: JournalEntryDto) => void;
+  onEditEntry: (entry: SearchJournalEntryDto) => void;
   onViewAllEntries: () => void;
 }
 
@@ -104,7 +104,7 @@ const JournalTab: React.FC<JournalTabProps> = ({
                     </span>
                   </div>
                   <p className="text-sm text-gray-600 line-clamp-2">
-                    {entry.content}
+                    {entry.contentPreview}
                   </p>
                   {entry.tags && entry.tags.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-2">

--- a/frontend/src/components/pages/CatalogDetail.tsx
+++ b/frontend/src/components/pages/CatalogDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { X, Package, Loader2, AlertCircle } from "lucide-react";
 import { CatalogItemDto, useCatalogDetail } from "../../api/hooks/useCatalog";
-import { JournalEntryDto } from "../../api/generated/api-client";
+import { SearchJournalEntryDto } from "../../api/generated/api-client";
 import { useJournalEntriesByProduct } from "../../api/hooks/useJournal";
 import { useNavigate } from "react-router-dom";
 import {
@@ -53,7 +53,7 @@ const CatalogDetail: React.FC<CatalogDetailProps> = ({
   );
   const [showJournalModal, setShowJournalModal] = useState(false);
   const [selectedJournalEntry, setSelectedJournalEntry] = useState<
-    JournalEntryDto | undefined
+    SearchJournalEntryDto | undefined
   >(undefined);
   const [showManufactureDifficultyModal, setShowManufactureDifficultyModal] =
     useState(false);

--- a/frontend/src/components/pages/Journal/JournalList.tsx
+++ b/frontend/src/components/pages/Journal/JournalList.tsx
@@ -17,7 +17,10 @@ import {
 } from "lucide-react";
 import { format } from "date-fns";
 // Import removed - using default date format for now to fix Jest test issues
-import type { JournalEntryDto } from "../../../api/generated/api-client";
+import type {
+  JournalEntryDto,
+  SearchJournalEntryDto,
+} from "../../../api/generated/api-client";
 import JournalEntryModal from "../../JournalEntryModal";
 
 const JournalList: React.FC = () => {
@@ -310,78 +313,147 @@ const JournalList: React.FC = () => {
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {entries.map((entry: JournalEntryDto) => (
-                  <tr
-                    key={entry.id}
-                    className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
-                    data-testid="journal-entry"
-                    onClick={() => handleOpenEditModal(entry.id!)}
-                    title="Klikněte pro editaci záznamu"
-                  >
-                    <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                      <div className="max-w-48 truncate">
-                        {entry.title || "Bez názvu"}
-                      </div>
-                    </td>
-                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {format(new Date(entry.entryDate!), "dd.MM.yyyy")}
-                    </td>
-                    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
-                      <div className="max-w-32 truncate">
-                        {entry.createdByUsername || entry.createdByUserId}
-                      </div>
-                    </td>
-                    <td className="px-4 py-4 text-sm text-gray-700">
-                      <div className="max-w-96 line-clamp-2">
-                        {isSearchMode && entry.contentPreview
-                          ? entry.contentPreview
-                          : truncateContent(entry.content!, 150)}
-                      </div>
-                    </td>
-                    <td className="px-4 py-4 text-sm">
-                      <div className="flex flex-wrap gap-1 max-w-48">
-                        {entry.tags &&
-                          entry.tags.slice(0, 2).map((tag) => (
-                            <span
-                              key={tag.id}
-                              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
-                              style={{
-                                borderColor: tag.color,
-                                color: tag.color,
-                              }}
-                            >
-                              {tag.name}
-                            </span>
-                          ))}
-                        {entry.tags && entry.tags.length > 2 && (
-                          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
-                            +{entry.tags.length - 2}
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-4 text-sm">
-                      <div className="flex flex-wrap gap-1 max-w-32">
-                        {entry.associatedProducts
-                          ?.slice(0, 2)
-                          .map((product) => (
-                            <span
-                              key={product}
-                              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
-                            >
-                              {product}
-                            </span>
-                          ))}
-                        {entry.associatedProducts &&
-                          entry.associatedProducts.length > 2 && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                              +{entry.associatedProducts.length - 2}
-                            </span>
-                          )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                {isSearchMode
+                  ? (entries as SearchJournalEntryDto[]).map((entry) => (
+                      <tr
+                        key={entry.id}
+                        className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
+                        data-testid="journal-entry"
+                        onClick={() => handleOpenEditModal(entry.id!)}
+                        title="Klikněte pro editaci záznamu"
+                      >
+                        <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                          <div className="max-w-48 truncate">
+                            {entry.title || "Bez názvu"}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+                          {format(new Date(entry.entryDate!), "dd.MM.yyyy")}
+                        </td>
+                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <div className="max-w-32 truncate">
+                            {entry.createdByUsername || entry.createdByUserId}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-sm text-gray-700">
+                          <div className="max-w-96 line-clamp-2">
+                            {entry.contentPreview}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-sm">
+                          <div className="flex flex-wrap gap-1 max-w-48">
+                            {entry.tags &&
+                              entry.tags.slice(0, 2).map((tag) => (
+                                <span
+                                  key={tag.id}
+                                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
+                                  style={{
+                                    borderColor: tag.color,
+                                    color: tag.color,
+                                  }}
+                                >
+                                  {tag.name}
+                                </span>
+                              ))}
+                            {entry.tags && entry.tags.length > 2 && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                                +{entry.tags.length - 2}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-sm">
+                          <div className="flex flex-wrap gap-1 max-w-32">
+                            {entry.associatedProducts
+                              ?.slice(0, 2)
+                              .map((product) => (
+                                <span
+                                  key={product}
+                                  className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
+                                >
+                                  {product}
+                                </span>
+                              ))}
+                            {entry.associatedProducts &&
+                              entry.associatedProducts.length > 2 && (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                                  +{entry.associatedProducts.length - 2}
+                                </span>
+                              )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  : (entries as JournalEntryDto[]).map((entry) => (
+                      <tr
+                        key={entry.id}
+                        className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
+                        data-testid="journal-entry"
+                        onClick={() => handleOpenEditModal(entry.id!)}
+                        title="Klikněte pro editaci záznamu"
+                      >
+                        <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                          <div className="max-w-48 truncate">
+                            {entry.title || "Bez názvu"}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+                          {format(new Date(entry.entryDate!), "dd.MM.yyyy")}
+                        </td>
+                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <div className="max-w-32 truncate">
+                            {entry.createdByUsername || entry.createdByUserId}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-sm text-gray-700">
+                          <div className="max-w-96 line-clamp-2">
+                            {truncateContent(entry.content!, 150)}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-sm">
+                          <div className="flex flex-wrap gap-1 max-w-48">
+                            {entry.tags &&
+                              entry.tags.slice(0, 2).map((tag) => (
+                                <span
+                                  key={tag.id}
+                                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
+                                  style={{
+                                    borderColor: tag.color,
+                                    color: tag.color,
+                                  }}
+                                >
+                                  {tag.name}
+                                </span>
+                              ))}
+                            {entry.tags && entry.tags.length > 2 && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                                +{entry.tags.length - 2}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-4 text-sm">
+                          <div className="flex flex-wrap gap-1 max-w-32">
+                            {entry.associatedProducts
+                              ?.slice(0, 2)
+                              .map((product) => (
+                                <span
+                                  key={product}
+                                  className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
+                                >
+                                  {product}
+                                </span>
+                              ))}
+                            {entry.associatedProducts &&
+                              entry.associatedProducts.length > 2 && (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                                  +{entry.associatedProducts.length - 2}
+                                </span>
+                              )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
               </tbody>
             </table>
           )}

--- a/frontend/src/components/pages/Journal/JournalList.tsx
+++ b/frontend/src/components/pages/Journal/JournalList.tsx
@@ -47,6 +47,7 @@ const JournalRow: React.FC<JournalRowProps> = ({
   <tr
     className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
     data-testid="journal-entry"
+    data-entry-id={id}
     onClick={onClick}
     title="Klikněte pro editaci záznamu"
   >
@@ -71,9 +72,9 @@ const JournalRow: React.FC<JournalRowProps> = ({
     <td className="px-4 py-4 text-sm">
       <div className="flex flex-wrap gap-1 max-w-48">
         {tags &&
-          tags.slice(0, 2).map((tag) => (
+          tags.slice(0, 2).map((tag, index) => (
             <span
-              key={tag.id}
+              key={tag.id ?? index}
               className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
               style={{
                 borderColor: tag.color,

--- a/frontend/src/components/pages/Journal/JournalList.tsx
+++ b/frontend/src/components/pages/Journal/JournalList.tsx
@@ -23,6 +23,96 @@ import type {
 } from "../../../api/generated/api-client";
 import JournalEntryModal from "../../JournalEntryModal";
 
+interface JournalRowProps {
+  id: number;
+  title?: string;
+  entryDate: Date | string;
+  authorLabel: string;
+  contentText: string;
+  tags?: { id?: number; name?: string; color?: string }[];
+  associatedProducts?: string[];
+  onClick: () => void;
+}
+
+const JournalRow: React.FC<JournalRowProps> = ({
+  id,
+  title,
+  entryDate,
+  authorLabel,
+  contentText,
+  tags,
+  associatedProducts,
+  onClick,
+}) => (
+  <tr
+    className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
+    data-testid="journal-entry"
+    onClick={onClick}
+    title="Klikněte pro editaci záznamu"
+  >
+    <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+      <div className="max-w-48 truncate">
+        {title || "Bez názvu"}
+      </div>
+    </td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
+      {format(new Date(entryDate), "dd.MM.yyyy")}
+    </td>
+    <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+      <div className="max-w-32 truncate">
+        {authorLabel}
+      </div>
+    </td>
+    <td className="px-4 py-4 text-sm text-gray-700">
+      <div className="max-w-96 line-clamp-2">
+        {contentText}
+      </div>
+    </td>
+    <td className="px-4 py-4 text-sm">
+      <div className="flex flex-wrap gap-1 max-w-48">
+        {tags &&
+          tags.slice(0, 2).map((tag) => (
+            <span
+              key={tag.id}
+              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
+              style={{
+                borderColor: tag.color,
+                color: tag.color,
+              }}
+            >
+              {tag.name}
+            </span>
+          ))}
+        {tags && tags.length > 2 && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+            +{tags.length - 2}
+          </span>
+        )}
+      </div>
+    </td>
+    <td className="px-4 py-4 text-sm">
+      <div className="flex flex-wrap gap-1 max-w-32">
+        {associatedProducts
+          ?.slice(0, 2)
+          .map((product) => (
+            <span
+              key={product}
+              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
+            >
+              {product}
+            </span>
+          ))}
+        {associatedProducts &&
+          associatedProducts.length > 2 && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+              +{associatedProducts.length - 2}
+            </span>
+          )}
+      </div>
+    </td>
+  </tr>
+);
+
 const JournalList: React.FC = () => {
   // Filter states - separate input values from applied filters
   const [searchTextInput, setSearchTextInput] = useState("");
@@ -315,144 +405,30 @@ const JournalList: React.FC = () => {
               <tbody className="bg-white divide-y divide-gray-200">
                 {isSearchMode
                   ? (entries as SearchJournalEntryDto[]).map((entry) => (
-                      <tr
-                        key={entry.id}
-                        className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
-                        data-testid="journal-entry"
+                      <JournalRow
+                        key={entry.id!}
+                        id={entry.id!}
+                        title={entry.title ?? undefined}
+                        entryDate={entry.entryDate!}
+                        authorLabel={entry.createdByUsername || entry.createdByUserId!}
+                        contentText={entry.contentPreview!}
+                        tags={entry.tags}
+                        associatedProducts={entry.associatedProducts}
                         onClick={() => handleOpenEditModal(entry.id!)}
-                        title="Klikněte pro editaci záznamu"
-                      >
-                        <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                          <div className="max-w-48 truncate">
-                            {entry.title || "Bez názvu"}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {format(new Date(entry.entryDate!), "dd.MM.yyyy")}
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
-                          <div className="max-w-32 truncate">
-                            {entry.createdByUsername || entry.createdByUserId}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 text-sm text-gray-700">
-                          <div className="max-w-96 line-clamp-2">
-                            {entry.contentPreview}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 text-sm">
-                          <div className="flex flex-wrap gap-1 max-w-48">
-                            {entry.tags &&
-                              entry.tags.slice(0, 2).map((tag) => (
-                                <span
-                                  key={tag.id}
-                                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
-                                  style={{
-                                    borderColor: tag.color,
-                                    color: tag.color,
-                                  }}
-                                >
-                                  {tag.name}
-                                </span>
-                              ))}
-                            {entry.tags && entry.tags.length > 2 && (
-                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
-                                +{entry.tags.length - 2}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 text-sm">
-                          <div className="flex flex-wrap gap-1 max-w-32">
-                            {entry.associatedProducts
-                              ?.slice(0, 2)
-                              .map((product) => (
-                                <span
-                                  key={product}
-                                  className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
-                                >
-                                  {product}
-                                </span>
-                              ))}
-                            {entry.associatedProducts &&
-                              entry.associatedProducts.length > 2 && (
-                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                                  +{entry.associatedProducts.length - 2}
-                                </span>
-                              )}
-                          </div>
-                        </td>
-                      </tr>
+                      />
                     ))
                   : (entries as JournalEntryDto[]).map((entry) => (
-                      <tr
-                        key={entry.id}
-                        className="hover:bg-gray-50 cursor-pointer transition-colors duration-150"
-                        data-testid="journal-entry"
+                      <JournalRow
+                        key={entry.id!}
+                        id={entry.id!}
+                        title={entry.title ?? undefined}
+                        entryDate={entry.entryDate!}
+                        authorLabel={entry.createdByUsername || entry.createdByUserId!}
+                        contentText={truncateContent(entry.content!, 150)}
+                        tags={entry.tags}
+                        associatedProducts={entry.associatedProducts}
                         onClick={() => handleOpenEditModal(entry.id!)}
-                        title="Klikněte pro editaci záznamu"
-                      >
-                        <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                          <div className="max-w-48 truncate">
-                            {entry.title || "Bez názvu"}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {format(new Date(entry.entryDate!), "dd.MM.yyyy")}
-                        </td>
-                        <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
-                          <div className="max-w-32 truncate">
-                            {entry.createdByUsername || entry.createdByUserId}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 text-sm text-gray-700">
-                          <div className="max-w-96 line-clamp-2">
-                            {truncateContent(entry.content!, 150)}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 text-sm">
-                          <div className="flex flex-wrap gap-1 max-w-48">
-                            {entry.tags &&
-                              entry.tags.slice(0, 2).map((tag) => (
-                                <span
-                                  key={tag.id}
-                                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border"
-                                  style={{
-                                    borderColor: tag.color,
-                                    color: tag.color,
-                                  }}
-                                >
-                                  {tag.name}
-                                </span>
-                              ))}
-                            {entry.tags && entry.tags.length > 2 && (
-                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
-                                +{entry.tags.length - 2}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-4 py-4 text-sm">
-                          <div className="flex flex-wrap gap-1 max-w-32">
-                            {entry.associatedProducts
-                              ?.slice(0, 2)
-                              .map((product) => (
-                                <span
-                                  key={product}
-                                  className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800"
-                                >
-                                  {product}
-                                </span>
-                              ))}
-                            {entry.associatedProducts &&
-                              entry.associatedProducts.length > 2 && (
-                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                                  +{entry.associatedProducts.length - 2}
-                                </span>
-                              )}
-                          </div>
-                        </td>
-                      </tr>
+                      />
                     ))}
               </tbody>
             </table>


### PR DESCRIPTION
Journal

## Finding
`JournalEntryDto` is the single DTO type returned by all Journal read operations — list, detail, and search. It contains two fields that are only meaningful for search results:

```csharp
// backend/src/Anela.Heblo.Application/Features/Journal/Contracts/JournalEntryDto.cs
// Lines 23–24
public string? ContentPreview { get; set; }     // only set in SearchJournalEntriesHandler
public List<string> HighlightedTerms { get; set; } = new();  // only set in SearchJournalEntriesHandler
```

These fields are populated exclusively inside `SearchJournalEntriesHandler` (lines 42–46). For every other use — `GetJournalEntriesHandler`, `GetJournalEntryHandler`, and the `JournalTab` catalog widget — they are `null`/empty but still serialised into every JSON response.

Additionally, `SearchJournalEntriesHandler` maps the full `Content` (up to 10 000 chars per entry) into the DTO via `JournalEntryMapper.ToDto`, then computes a 200-char `ContentPreview` on top of it (line 44). The full content travels across the wire for search results even though only the preview is displayed.

## Why it matters
- **SRP violation**: the DTO conflates the contract for three distinct operations (list, detail, search). Adding a search-only field silently changes the shape of list and detail responses too.
- **Bandwidth waste**: list responses for search include the full `Content` string and two unused fields for every row.
- **Hidden coupling**: `JournalList.tsx` already branches on `entry.contentPreview` (line 336) to decide which text to render, making the frontend aware of the server-side search mode through a nullable field rather than a proper type distinction.

## Suggested fix
Extract a `SearchJournalEntryDto` that adds `ContentPreview` and `HighlightedTerms` (and omits or truncates `Content`):

```csharp
public class SearchJournalEntryDto : JournalEntryDto
{
    public string ContentPreview { get; set; } = null!;
    public List<string> HighlightedTerms { get; set; } = new();
}
```

Use it in `SearchJournalEntriesResponse` and `SearchJournalEntriesHandler`. Remove the search-specific fields from the base `JournalEntryDto`. The mapper for search results can then omit the full `Content` field to avoid the bandwidth waste.

---
_Filed by daily arch-review routine on 2026-05-12._

---

Closes #1162

### Tokens used
44288386
