### PR TITLE
feat: Decouple ProductEnrichmentCache from Catalog Domain via Module Contract

### DIFF
--- a/artifacts/feat-arch-review-knowledgebase-productenrichm/arch-review.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-productenrichm/arch-review.r1.md
@@ -1,0 +1,193 @@
+# Architecture Review: Decouple ProductEnrichmentCache from Catalog Domain via Module Contract
+
+## Skip Design: true
+
+Backend-only refactor. No UI/UX surface change, no new screens, no visual components.
+
+## Architectural Fit Assessment
+
+**Excellent fit.** The proposal directly implements the documented inter-module communication pattern from `docs/architecture/development_guidelines.md`:
+
+> *"Communication between modules **exclusively through `contracts/`** (e.g., `IProductQueryService`)"*
+> *"**No direct access to another module's entities**"*
+
+The current code violates both rules: `ProductEnrichmentCache` imports `Anela.Heblo.Domain.Features.Catalog`, resolves `ICatalogRepository`, builds a predicate over `CatalogAggregate`, and reads three fields from the domain entity. The refactor introduces precisely the `IProductQueryService`-style contract the guidelines mandate.
+
+**Integration points (all preserved unchanged):**
+- `IProductEnrichmentCache` consumer surface (used by `PostAnswerEnrichmentMiddleware`, `AskQuestionHandler`).
+- `KnowledgeBaseOptions.ProductEnrichmentCacheTtlMinutes` config.
+- Singleton lifetime of `IProductEnrichmentCache` resolving a transient via `IServiceScopeFactory`.
+
+**One convention deviation to fix (see Amendments §1).** Spec calls for `internal sealed` implementation, but all four sibling files in `Features/Catalog/Services/` (`MarginCalculationService`, `StockUpProcessingService`, `ProductWeightRecalculationService`, `EshopStockDomainService`) are `public class`. Consistency matters more than the marginal encapsulation win.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Application/Features/KnowledgeBase                                │
+│                                                                   │
+│   ProductEnrichmentCache (singleton)                              │
+│     │                                                             │
+│     │ uses (via IServiceScopeFactory.CreateScope())               │
+│     ▼                                                             │
+│   IProductCatalogQueryService  ◄────── contract boundary ────┐    │
+│                                                              │    │
+└──────────────────────────────────────────────────────────────┼────┘
+                                                               │
+┌──────────────────────────────────────────────────────────────┼────┐
+│ Application/Features/Catalog                                 │    │
+│                                                              │    │
+│   Contracts/                                                 │    │
+│     IProductCatalogQueryService  ────────────────────────────┘    │
+│     ProductCatalogEntry          (class, three string fields)     │
+│                                                                   │
+│   Services/                                                       │
+│     ProductCatalogQueryService                                    │
+│       │ depends on                                                │
+│       ▼                                                           │
+│   ICatalogRepository  ──►  CatalogAggregate (domain entity)       │
+│                            ProductType (domain enum)              │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+The dotted boundary above is the only line KnowledgeBase may cross to read product data. `CatalogAggregate`, `ProductType`, and `ICatalogRepository` stay private to the Catalog module.
+
+### Key Design Decisions
+
+#### Decision 1: DTO as `class`, not `record`
+**Options considered:** `record` (C# default for immutable DTOs per global rules), `class` (project convention).
+**Chosen approach:** `public class` with mutable get/set properties.
+**Rationale:** Project rule (`CLAUDE.md`): *"DTOs are classes, never C# records."* Every existing file in `Features/Catalog/Contracts/` (e.g., `CatalogItemDto.cs`, `PriceDto.cs`) follows this. Driven by OpenAPI client generator handling of record constructor parameter order. Even though this DTO isn't exposed via HTTP today, future reuse over the wire stays safe.
+
+#### Decision 2: Filter and projection live in Catalog, not in the contract
+**Options considered:** (a) Expose `FindAsync(predicate)` to KnowledgeBase via the contract; (b) Catalog owns the predicate and returns a pre-filtered, pre-projected list.
+**Chosen approach:** (b). Method = `GetActiveProductsAsync()`. Predicate (`Type == Product || Type == Goods`) and mapping live inside `ProductCatalogQueryService`.
+**Rationale:** A contract that takes a predicate would leak `CatalogAggregate` through the expression tree, defeating the whole refactor. Catalog owns what "active product" means; KnowledgeBase consumes the result.
+
+#### Decision 3: Implementation is `public class` (deviation from spec)
+**Options considered:** `internal sealed` (spec); `public class` (sibling convention).
+**Chosen approach:** `public class ProductCatalogQueryService : IProductCatalogQueryService`.
+**Rationale:** All four sibling implementations in `Features/Catalog/Services/` are `public class`. The whole `Anela.Heblo.Application` assembly ships as one unit today, so `internal` adds no real isolation but breaks pattern consistency and complicates any future direct-construction usage in tests. Mark `sealed` if desired — that part is cheap and harmless.
+
+#### Decision 4: Keep `IServiceScopeFactory` indirection in the cache
+**Options considered:** Inject `IProductCatalogQueryService` directly into the singleton cache; keep the scope-factory indirection.
+**Chosen approach:** Keep `IServiceScopeFactory`.
+**Rationale:** `IProductEnrichmentCache` is registered **singleton** (`KnowledgeBaseModule.cs:55`). The contract implementation depends on `ICatalogRepository`, registered **transient** (`CatalogModule.cs:39`). Capturing a transient in a singleton constructor is a captive-dependency bug. Spec correctly preserves this.
+
+#### Decision 5: Lifetime of `IProductCatalogQueryService` = Transient
+**Options considered:** Transient, Scoped, Singleton.
+**Chosen approach:** Transient — matches `ICatalogRepository` (its only dependency) at `CatalogModule.cs:39`.
+**Rationale:** Stateless wrapper; transient is the simplest correct choice and matches the dependency's lifetime so no captive-dependency warnings.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New files:
+```
+backend/src/Anela.Heblo.Application/Features/Catalog/
+├── Contracts/
+│   ├── IProductCatalogQueryService.cs    ← new
+│   └── ProductCatalogEntry.cs            ← new
+└── Services/
+    └── ProductCatalogQueryService.cs     ← new
+
+backend/test/Anela.Heblo.Tests/Features/Catalog/
+└── Services/
+    └── ProductCatalogQueryServiceTests.cs  ← new
+```
+
+Modified files:
+```
+backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs
+backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs
+```
+
+Note: the spec's suggested test path `backend/test/Anela.Heblo.Tests/Catalog/Services/` does not exist. The actual catalog test root is `backend/test/Anela.Heblo.Tests/Features/Catalog/` (verified). Use that.
+
+### Interfaces and Contracts
+
+```csharp
+// Features/Catalog/Contracts/IProductCatalogQueryService.cs
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public interface IProductCatalogQueryService
+{
+    Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(
+        CancellationToken ct = default);
+}
+```
+
+```csharp
+// Features/Catalog/Contracts/ProductCatalogEntry.cs
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public class ProductCatalogEntry
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public string? Url { get; set; }
+}
+```
+
+**Hard constraints:**
+- Neither file may `using Anela.Heblo.Domain.*`. Enforce via review; consider adding a one-line grep gate in CI later (out of scope here).
+- `ProductCatalogEntry` is a `class`, not a `record` (project rule).
+- `IReadOnlyList<>` return type — keeps the contract immutable from the consumer's POV without forcing a copy on the caller.
+
+### Data Flow
+
+**Cache miss (after TTL expiry):**
+```
+PostAnswerEnrichmentMiddleware / AskQuestionHandler
+  └─► IProductEnrichmentCache.GetProductLookupAsync(ct)              [singleton]
+        ├─ TTL expired → acquire SemaphoreSlim, re-check
+        ├─ scope = _scopeFactory.CreateScope()
+        ├─ svc = scope.ServiceProvider.GetRequiredService<IProductCatalogQueryService>()  [transient]
+        │     └─ ctor injects ICatalogRepository (transient)
+        ├─ entries = await svc.GetActiveProductsAsync(ct)
+        │     └─ repo.FindAsync(p => p.Type == Product || p.Type == Goods, ct)
+        │     └─ .Select(p => new ProductCatalogEntry { ProductCode, ProductName, Url })
+        │     └─ .ToList()  // → IReadOnlyList<ProductCatalogEntry>
+        ├─ _cache = entries.ToDictionary(e => e.ProductCode, e => new ProductEnrichmentEntry {...})
+        └─ release lock, return _cache
+```
+
+**Cache hit:** identical to today — direct dictionary read, no scope creation, no allocations.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Singleton captures transient (captive-dependency) | High | Spec already mandates keeping `IServiceScopeFactory` — verify in PR review that constructor of `ProductEnrichmentCache` still takes `IServiceScopeFactory` and not the new contract directly. |
+| Duplicate product codes cause `ToDictionary` to throw | Low | Pre-existing risk, not new — current code does the same. Out of scope. If observed, switch to `GroupBy(x).First()` in a follow-up. |
+| Contract used by other modules later with different "active" definition | Low | Method name `GetActiveProductsAsync` is generic enough; if a divergent need appears, add a second method rather than parameterizing. |
+| Test predicate-capture pattern (Moq `Callback`) lost when test moves | Low | Predicate test moves to `ProductCatalogQueryServiceTests`. Use the same capture-and-compile pattern shown in the existing test (lines 43–70) to assert `Product`/`Goods` allowed, others rejected. |
+| Convention drift — spec says `internal sealed`, siblings are `public class` | Low | Implement as `public class` per Decision 3. If `sealed` is desired, add it; do not make the type `internal`. |
+| Stale test path in spec (`Tests/Catalog/Services/`) | Low | Use `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs` instead. |
+
+## Specification Amendments
+
+1. **§FR-2 acceptance criterion 1:** Change *"`ProductCatalogQueryService` is `internal sealed`"* to *"`ProductCatalogQueryService` is `public class` (or `public sealed class`), matching sibling services in `Features/Catalog/Services/`."* Rationale: consistency with `MarginCalculationService`, `StockUpProcessingService`, `ProductWeightRecalculationService`, `EshopStockDomainService`, all of which are `public class`.
+
+2. **§FR-5 acceptance criterion (new test location):** Replace *"under `backend/test/Anela.Heblo.Tests/Catalog/Services/`"* with *"under `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/`"*. The path `Tests/Catalog/` does not exist; the existing pattern is `Tests/Features/Catalog/`.
+
+3. **§FR-3 placement:** Spec says *"after line ~62, before feature-flags block."* Line 62 is currently `services.AddScoped<IEshopStockDomainService, EshopStockDomainService>();` (end of the "Register catalog-specific services" block). Place the new registration on a new line immediately after that one — same block, same lifetime style, transient alongside `IMarginCalculationService` at line 56.
+
+4. **§FR-5 (clarify predicate-test method):** When porting the `PredicateFiltersToProductAndGoodsOnly` test to `ProductCatalogQueryServiceTests`, reuse Moq's `Callback` to capture the `Expression<Func<CatalogAggregate, bool>>`, compile it, and assert it accepts `Product`/`Goods` and rejects `Material`/`SemiProduct`/`Set`/`UNDEFINED` — same shape as the existing test at lines 43–70 of `ProductEnrichmentCacheTests.cs`. The new file is the only place still allowed to reference `CatalogAggregate` and `ProductType` for this assertion (it lives in the Catalog test tree).
+
+5. **§FR-5 (KnowledgeBase test mocking):** When rewriting `ProductEnrichmentCacheTests.cs`, follow the same `IServiceScopeFactory` → `IServiceScope` → `IServiceProvider` mock chain already in place (lines 13–25); only the resolved service changes from `ICatalogRepository` to `IProductCatalogQueryService`, and `SetupRepository` is replaced by a setup on `service.GetActiveProductsAsync(...)` returning `ProductCatalogEntry[]`.
+
+## Prerequisites
+
+None. The refactor is self-contained:
+
+- No DB migrations.
+- No new configuration keys (`KnowledgeBaseOptions.ProductEnrichmentCacheTtlMinutes` already exists).
+- No new NuGet packages.
+- No new infrastructure.
+- DI ordering in `Program.cs` is unchanged — `AddCatalogModule()` is already called before `AddKnowledgeBaseModule()` (and even if it weren't, registration order doesn't matter for resolution).
+- Build gate: `dotnet build` after the change must compile with zero references to `Anela.Heblo.Domain.Features.Catalog` from anywhere under `Features/KnowledgeBase/` (verifiable by grep).

--- a/artifacts/feat-arch-review-knowledgebase-productenrichm/brief.md
+++ b/artifacts/feat-arch-review-knowledgebase-productenrichm/brief.md
@@ -1,0 +1,46 @@
+## Module
+KnowledgeBase
+
+## Finding
+`ProductEnrichmentCache` in the KnowledgeBase module directly resolves and calls `ICatalogRepository` — a domain-layer interface owned by the Catalog module:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs:1
+using Anela.Heblo.Domain.Features.Catalog;
+
+// line 40
+var repository = scope.ServiceProvider.GetRequiredService<ICatalogRepository>();
+var products = await repository.FindAsync(
+    p => p.Type == ProductType.Product || p.Type == ProductType.Goods, ct);
+```
+
+It then reads `p.ProductCode`, `p.ProductName`, and `p.Url` from `CatalogAggregate` domain entities.
+
+## Why it matters
+`development_guidelines.md` states: _"Communication between modules exclusively through `contracts/`"_ and _"No direct access to another module's entities."_ This coupling means:
+- KnowledgeBase has a compile-time (and runtime) dependency on Catalog's domain and persistence layers.
+- Any change to `CatalogAggregate` or `ICatalogRepository` can silently break the KnowledgeBase pipeline.
+- It becomes impossible to test `ProductEnrichmentCache` in isolation from the Catalog module.
+
+## Suggested fix
+Define a narrow read-only contract in the Catalog module:
+
+```csharp
+// Catalog/Contracts/IProductCatalogQueryService.cs
+public interface IProductCatalogQueryService
+{
+    Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default);
+}
+
+public class ProductCatalogEntry
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public string? Url { get; set; }
+}
+```
+
+Implement it inside the Catalog module (wrapping `ICatalogRepository`), register it in `CatalogModule.cs`, then inject `IProductCatalogQueryService` into `ProductEnrichmentCache` instead of `ICatalogRepository`. This removes the cross-module entity access while keeping the cache logic identical.
+
+---
+_Filed by daily arch-review routine on 2026-05-13._

--- a/artifacts/feat-arch-review-knowledgebase-productenrichm/impl/main.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-productenrichm/impl/main.r1.md
@@ -1,0 +1,12 @@
+Named branch in what appears to be a standalone repo (GIT_DIR == GIT_COMMON), at path under `.worktrees/`. Branch: `feat-arch-review-knowledgebase-productenrichm`.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-knowledgebase-productenrichm/spec.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-productenrichm/spec.r1.md
@@ -1,0 +1,182 @@
+Now I have enough context to produce the spec.
+
+# Specification: Decouple ProductEnrichmentCache from Catalog Domain via Module Contract
+
+## Summary
+Remove the cross-module coupling where `ProductEnrichmentCache` (KnowledgeBase) directly consumes `ICatalogRepository` and `CatalogAggregate` (Catalog domain). Introduce a narrow read-only query contract (`IProductCatalogQueryService`) owned by the Catalog module and inject it into the cache, eliminating the domain-layer dependency from KnowledgeBase while preserving identical behavior.
+
+## Background
+`backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` reaches across module boundaries: it resolves `ICatalogRepository` from the DI container, calls `FindAsync` with a predicate over `CatalogAggregate`, and reads `ProductCode`, `ProductName`, and `Url` from those domain entities.
+
+This violates two rules from `docs/architecture/development_guidelines.md`:
+- "Communication between modules **exclusively through `contracts/`**"
+- "**No direct access to another module's entities**"
+
+Concrete consequences observed today:
+1. Changes to `CatalogAggregate` or `ICatalogRepository` can silently break the KnowledgeBase ingestion pipeline.
+2. KnowledgeBase tests must mock the full `ICatalogRepository` surface (see `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs`) and depend on `Anela.Heblo.Domain.Features.Catalog` types just to set up the test.
+3. The two modules can never be split into independently deployable services, which is the stated long-term architectural goal.
+
+The fix is surgical and low risk: introduce a narrow contract that returns a Catalog-owned DTO, replace the dependency, and update tests.
+
+## Functional Requirements
+
+### FR-1: Introduce Catalog-owned query contract for product enrichment
+Create a new public read-only interface in the Catalog module that returns the minimal product projection needed by KnowledgeBase.
+
+- Interface location: `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs`
+- DTO location: `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs`
+- Per project rule, the DTO is a **class** (not a `record`), matching all other files in `Features/Catalog/Contracts/`.
+- The DTO exposes only `ProductCode`, `ProductName`, `Url`.
+- The interface exposes one async method that returns the filtered, active product set (currently `Type == Product || Type == Goods`).
+
+**Acceptance criteria:**
+- New file `IProductCatalogQueryService.cs` exists in `Features/Catalog/Contracts/`.
+- New file `ProductCatalogEntry.cs` exists in `Features/Catalog/Contracts/`.
+- `ProductCatalogEntry` is a class with `ProductCode` (string, non-null), `ProductName` (string, non-null), `Url` (string?).
+- Interface signature: `Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default);`.
+- Neither file references any `Anela.Heblo.Domain.*` namespace.
+
+### FR-2: Implement contract inside Catalog module
+Implement `IProductCatalogQueryService` inside Catalog so the filter and mapping logic remain owned by the module that owns `CatalogAggregate`.
+
+- Implementation location: `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs`.
+- The implementation wraps `ICatalogRepository`, applies the existing predicate (`p.Type == ProductType.Product || p.Type == ProductType.Goods`), and maps to `ProductCatalogEntry`.
+- No behavior change: same predicate, same field projection, same null handling for `Url`.
+
+**Acceptance criteria:**
+- `ProductCatalogQueryService` is `internal sealed` and lives in `Features/Catalog/Services/`.
+- Constructor takes `ICatalogRepository` only.
+- `GetActiveProductsAsync` calls `repository.FindAsync(p => p.Type == ProductType.Product || p.Type == ProductType.Goods, ct)` and maps each `CatalogAggregate` to `ProductCatalogEntry { ProductCode, ProductName, Url }`.
+- Returns `IReadOnlyList<ProductCatalogEntry>` (e.g., via `.Select(...).ToList()` cast to `IReadOnlyList<>`).
+- Propagates the `CancellationToken`.
+
+### FR-3: Register contract in CatalogModule
+The new service must be registered in `CatalogModule.AddCatalogModule` so the KnowledgeBase module can resolve it without referencing Catalog internals.
+
+- Registration lifetime: **Transient**, consistent with `ICatalogRepository` (line 39 of `CatalogModule.cs`).
+- Placement: alongside other catalog-specific service registrations (after line ~62, before feature-flags block).
+
+**Acceptance criteria:**
+- `services.AddTransient<IProductCatalogQueryService, ProductCatalogQueryService>();` is present in `CatalogModule.cs`.
+- The registration uses the contract interface, not the concrete type.
+
+### FR-4: Refactor ProductEnrichmentCache to depend on the contract
+Replace direct `ICatalogRepository` usage in `ProductEnrichmentCache` with `IProductCatalogQueryService`.
+
+- File: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs`.
+- Remove `using Anela.Heblo.Domain.Features.Catalog;`.
+- Add `using Anela.Heblo.Application.Features.Catalog.Contracts;`.
+- Replace `scope.ServiceProvider.GetRequiredService<ICatalogRepository>()` with `GetRequiredService<IProductCatalogQueryService>()`.
+- Replace the predicate call with `await service.GetActiveProductsAsync(ct)`.
+- Map directly from `ProductCatalogEntry` (no `CatalogAggregate` reference).
+- Keep the `IServiceScopeFactory` indirection — `IProductEnrichmentCache` is a **singleton** (see `KnowledgeBaseModule.cs:55`) and must not capture a scoped/transient service in its constructor.
+
+**Acceptance criteria:**
+- `ProductEnrichmentCache.cs` contains no reference to `Anela.Heblo.Domain.Features.Catalog`, `ICatalogRepository`, `CatalogAggregate`, or `ProductType`.
+- The TTL/double-check-locking flow and `_cache` dictionary semantics are unchanged.
+- Build succeeds with `dotnet build`.
+
+### FR-5: Update unit tests to consume the new contract
+Existing tests in `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` mock `ICatalogRepository` and `CatalogAggregate`. They must be rewritten to mock `IProductCatalogQueryService` and assert on `ProductCatalogEntry`.
+
+The original test "PredicateFiltersToProductAndGoodsOnly" verified the predicate composition; that responsibility now belongs to the new `ProductCatalogQueryService`. A corresponding test must move with the responsibility.
+
+**Acceptance criteria:**
+- `ProductEnrichmentCacheTests.cs` no longer references `Anela.Heblo.Domain.Features.Catalog`, `CatalogAggregate`, or `ProductType`.
+- Tests mock `IProductCatalogQueryService.GetActiveProductsAsync` and verify:
+  - The lookup correctly maps `ProductCatalogEntry` → `ProductEnrichmentEntry`.
+  - TTL caching: repository is called once within TTL.
+  - TTL expiry: repository is called again after TTL.
+- A **new** test class `ProductCatalogQueryServiceTests` is added under `backend/test/Anela.Heblo.Tests/Catalog/Services/` (or equivalent existing Catalog test folder) covering:
+  - Predicate filters to `Product` and `Goods` only (excludes `Material`, `SemiProduct`, `Set`, `UNDEFINED`).
+  - Projection maps `ProductCode`, `ProductName`, `Url` correctly, preserving `null` for `Url`.
+  - `CancellationToken` is passed through to the repository.
+- All existing other tests that depend on `ProductEnrichmentCache` (e.g., `AskQuestionHandlerTests`, `PostAnswerEnrichmentMiddlewareTests`) continue to pass without changes (the cache's public contract `IProductEnrichmentCache` is unchanged).
+
+### FR-6: No behavioral change to downstream consumers
+`IProductEnrichmentCache` and `ProductEnrichmentEntry` are not modified. `PostAnswerEnrichmentMiddleware` and `AskQuestionHandler` continue to consume the same dictionary shape.
+
+**Acceptance criteria:**
+- `IProductEnrichmentCache.cs` and `ProductEnrichmentEntry.cs` are unchanged.
+- Grepping the codebase for `IProductEnrichmentCache` shows no signature changes at any call site.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance regression is acceptable. The refactor adds one allocation per cache reload (the `ProductCatalogEntry` list inside Catalog) but cache reloads happen at most once per `ProductEnrichmentCacheTtlMinutes` (default operational TTL). The hot path (cache hit) is untouched.
+
+- Cache hit path executes zero additional allocations vs. baseline.
+- Cache reload path: one additional projection pass over the filtered product set (O(n) where n is the number of products and goods).
+
+### NFR-2: Security
+No new authorization surface, no new external calls, no PII handling change. The new contract returns the same product metadata that KnowledgeBase already reads.
+
+### NFR-3: Maintainability
+- KnowledgeBase must no longer reference `Anela.Heblo.Domain.Features.Catalog` from production code (verified via grep).
+- New types follow project conventions: classes for contract DTOs, `IXxx` interfaces, `internal sealed` for implementations.
+- Nullable reference types remain enabled; `ProductCatalogEntry.Url` is the only nullable field.
+
+### NFR-4: Testability
+After the refactor:
+- `ProductEnrichmentCache` can be unit tested with a single mock (`IProductCatalogQueryService`) and zero Catalog-domain types.
+- `ProductCatalogQueryService` carries the predicate test responsibility and can be tested with `ICatalogRepository` mocked, owned by Catalog tests.
+
+## Data Model
+
+No persistence or schema changes. Two new in-memory types only:
+
+```
+ProductCatalogEntry (class, Catalog/Contracts)
+├── ProductCode : string (non-null, "")
+├── ProductName : string (non-null, "")
+└── Url         : string?
+
+IProductCatalogQueryService (interface, Catalog/Contracts)
+└── GetActiveProductsAsync(CancellationToken ct = default)
+        : Task<IReadOnlyList<ProductCatalogEntry>>
+```
+
+Mapping from existing `CatalogAggregate`:
+- `ProductCode` ← `CatalogAggregate.ProductCode`
+- `ProductName` ← `CatalogAggregate.ProductName`
+- `Url`         ← `CatalogAggregate.Url`
+
+Filter: `Type == ProductType.Product || Type == ProductType.Goods` (unchanged from current behavior).
+
+## API / Interface Design
+
+No HTTP endpoint, controller, or MediatR request changes. This is purely a backend internal-contract refactor.
+
+DI wiring (added in `CatalogModule.cs`):
+```
+services.AddTransient<IProductCatalogQueryService, ProductCatalogQueryService>();
+```
+
+DI consumption (refactored in `ProductEnrichmentCache.cs`):
+```
+var service = scope.ServiceProvider.GetRequiredService<IProductCatalogQueryService>();
+var products = await service.GetActiveProductsAsync(ct);
+```
+
+## Dependencies
+
+- `Anela.Heblo.Application.Features.Catalog.Contracts` (new namespace usage from KnowledgeBase). This is permitted; it is the documented inter-module communication surface.
+- No new NuGet packages.
+- No configuration changes; `KnowledgeBaseOptions.ProductEnrichmentCacheTtlMinutes` continues to govern cache TTL.
+
+## Out of Scope
+
+- Refactoring other Catalog → outside-module integrations (e.g., dashboard tiles, margin services). This spec is limited to the KnowledgeBase pipeline.
+- Splitting `Anela.Heblo.Application.Features.Catalog.Contracts` into a separate project/assembly.
+- Removing the `IServiceScopeFactory` indirection. The singleton-resolves-transient pattern is the existing design; changing it is out of scope.
+- Adding caching, batching, or pagination inside `IProductCatalogQueryService`. The cache layer already handles freshness via TTL.
+- Renaming `ProductEnrichmentEntry` or changing its shape.
+- Updating `AskQuestionHandlerTests` or `PostAnswerEnrichmentMiddlewareTests` beyond what is strictly necessary to keep them green.
+- Migration of any other `ICatalogRepository` consumer outside KnowledgeBase.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-knowledgebase-productenrichm/task-plan.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-productenrichm/task-plan.r1.md
@@ -1,0 +1,615 @@
+# Decouple ProductEnrichmentCache from Catalog Domain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the cross-module dependency where `ProductEnrichmentCache` (KnowledgeBase) imports `Anela.Heblo.Domain.Features.Catalog` types and consumes `ICatalogRepository` directly — by introducing a narrow Catalog-owned read contract (`IProductCatalogQueryService`) and refactoring the cache to depend on it. Behavior, lifetimes, TTL, and downstream consumer signatures stay identical.
+
+**Architecture:** A new contract pair (`IProductCatalogQueryService` + `ProductCatalogEntry` DTO) is added to `Anela.Heblo.Application/Features/Catalog/Contracts/`. The implementation `ProductCatalogQueryService` lives in `Anela.Heblo.Application/Features/Catalog/Services/`, wraps `ICatalogRepository`, owns the `Type == Product || Type == Goods` predicate, and projects each `CatalogAggregate` into the DTO. `ProductEnrichmentCache` is rewritten to resolve `IProductCatalogQueryService` (transient) via `IServiceScopeFactory` — the singleton-resolving-transient indirection is preserved because the cache itself is singleton. The predicate test that was previously in `ProductEnrichmentCacheTests` moves into a new `ProductCatalogQueryServiceTests` class — that file becomes the only place outside the Catalog module that still references `CatalogAggregate` and `ProductType`.
+
+**Tech Stack:** .NET 8, C#, xUnit, Moq, Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options. No new NuGet packages.
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs` — DTO (class, three string properties).
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs` — Catalog-owned read contract.
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs` — Implementation; wraps `ICatalogRepository`, owns the predicate and projection.
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs` — Predicate-filter, projection, and cancellation-token tests; lives in Catalog test tree (the only allowed `CatalogAggregate` / `ProductType` reference site for this refactor).
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — One-line DI registration.
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` — Replace `ICatalogRepository` with `IProductCatalogQueryService`; drop all Catalog-domain `using`s.
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` — Mock `IProductCatalogQueryService` instead of `ICatalogRepository`; drop `CatalogAggregate`/`ProductType` usage; remove the predicate test (moved to Catalog tests); keep TTL tests.
+
+**Unchanged (but verified by grep):**
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/IProductEnrichmentCache.cs`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentEntry.cs`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`
+- Consumers: `PostAnswerEnrichmentMiddleware`, `AskQuestionHandler`, and their tests.
+
+---
+
+### Task 1: Add `ProductCatalogEntry` DTO
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs`
+
+- [ ] **Step 1: Create the DTO file**
+
+Per the project rule in `CLAUDE.md` (*"DTOs are classes, never C# records"*) and consistent with every other file under `Features/Catalog/Contracts/` (e.g., `CatalogItemDto.cs`), declare a `public class` with mutable get/set properties.
+
+Write the following content to `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs`:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public class ProductCatalogEntry
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public string? Url { get; set; }
+}
+```
+
+- [ ] **Step 2: Verify no `Anela.Heblo.Domain.*` reference**
+
+Run: `grep -n "Anela.Heblo.Domain" backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs || echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Build to confirm the file compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs
+git commit -m "feat(catalog): add ProductCatalogEntry contract DTO"
+```
+
+---
+
+### Task 2: Add `IProductCatalogQueryService` contract
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs`
+
+- [ ] **Step 1: Create the interface**
+
+Method returns `IReadOnlyList<>` so consumers cannot mutate the producer's list. Optional `CancellationToken ct = default` matches the calling convention used by `ICatalogRepository.FindAsync`.
+
+Write the following to `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs`:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public interface IProductCatalogQueryService
+{
+    Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Verify no `Anela.Heblo.Domain.*` reference**
+
+Run: `grep -n "Anela.Heblo.Domain" backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs || echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Build to confirm the file compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs
+git commit -m "feat(catalog): add IProductCatalogQueryService contract"
+```
+
+---
+
+### Task 3: Write failing tests for `ProductCatalogQueryService`
+
+This task is TDD-Red. We write the full test class before any implementation. The test file is the only place outside the Catalog module that still references `CatalogAggregate` and `ProductType`, and that is intentional — it lives in the Catalog test tree.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs`
+
+- [ ] **Step 1: Write the test file**
+
+The tests cover three behaviors:
+1. Predicate filters to `Product` and `Goods` only (capture the `Expression`, compile it, assert per `ProductType`).
+2. Projection maps `ProductCode`, `ProductName`, `Url` correctly and preserves `null` for `Url`.
+3. The provided `CancellationToken` is propagated to the repository.
+
+Note: `ICatalogRepository.FindAsync` returns `Task<IEnumerable<CatalogAggregate>>` (see `BaseRepository.FindAsync` and `MockCatalogRepository.FindAsync`), not `Task<IReadOnlyList<...>>`. The implementation will materialize to a list before returning.
+
+Write the following to `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs`:
+
+```csharp
+using System.Linq.Expressions;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Domain.Features.Catalog;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Services;
+
+public class ProductCatalogQueryServiceTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private ProductCatalogQueryService Create() => new(_repository.Object);
+
+    [Fact]
+    public async Task GetActiveProductsAsync_PredicateFiltersToProductAndGoodsOnly()
+    {
+        Expression<Func<CatalogAggregate, bool>>? capturedPredicate = null;
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<CatalogAggregate, bool>>, CancellationToken>((pred, _) => capturedPredicate = pred)
+            .ReturnsAsync(Array.Empty<CatalogAggregate>());
+
+        var service = Create();
+        await service.GetActiveProductsAsync();
+
+        Assert.NotNull(capturedPredicate);
+        var compiled = capturedPredicate!.Compile();
+        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Product }));
+        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Goods }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Material }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.SemiProduct }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Set }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.UNDEFINED }));
+    }
+
+    [Fact]
+    public async Task GetActiveProductsAsync_MapsProductCodeNameAndUrl()
+    {
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new CatalogAggregate { ProductCode = "PRD001", ProductName = "Sérum ABC", Type = ProductType.Product, Url = "https://example.com/prd001" },
+                new CatalogAggregate { ProductCode = "GDS001", ProductName = "Krém XYZ", Type = ProductType.Goods, Url = null }
+            });
+
+        var service = Create();
+        var result = await service.GetActiveProductsAsync();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("PRD001", result[0].ProductCode);
+        Assert.Equal("Sérum ABC", result[0].ProductName);
+        Assert.Equal("https://example.com/prd001", result[0].Url);
+        Assert.Equal("GDS001", result[1].ProductCode);
+        Assert.Equal("Krém XYZ", result[1].ProductName);
+        Assert.Null(result[1].Url);
+    }
+
+    [Fact]
+    public async Task GetActiveProductsAsync_PropagatesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var capturedToken = CancellationToken.None;
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<CatalogAggregate, bool>>, CancellationToken>((_, t) => capturedToken = t)
+            .ReturnsAsync(Array.Empty<CatalogAggregate>());
+
+        var service = Create();
+        await service.GetActiveProductsAsync(cts.Token);
+
+        Assert.Equal(cts.Token, capturedToken);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductCatalogQueryServiceTests"`
+Expected: Build fails with "The type or namespace name 'ProductCatalogQueryService' could not be found" (the implementation doesn't exist yet). This is the correct TDD-Red state.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs
+git commit -m "test(catalog): add failing tests for ProductCatalogQueryService"
+```
+
+---
+
+### Task 4: Implement `ProductCatalogQueryService`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs`
+
+- [ ] **Step 1: Write the implementation**
+
+Per the architecture review (Decision 3), this is `public class` matching sibling implementations in `Features/Catalog/Services/` (`MarginCalculationService`, `StockUpProcessingService`, `ProductWeightRecalculationService`, `EshopStockDomainService`). The architecture review's Amendment §1 overrides the spec's `internal sealed` wording. We mark `sealed` because the class is not designed for inheritance.
+
+Write the following to `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Services;
+
+public sealed class ProductCatalogQueryService : IProductCatalogQueryService
+{
+    private readonly ICatalogRepository _repository;
+
+    public ProductCatalogQueryService(ICatalogRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default)
+    {
+        var products = await _repository.FindAsync(
+            p => p.Type == ProductType.Product || p.Type == ProductType.Goods,
+            ct);
+
+        return products
+            .Select(p => new ProductCatalogEntry
+            {
+                ProductCode = p.ProductCode,
+                ProductName = p.ProductName,
+                Url = p.Url
+            })
+            .ToList();
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests — they should now pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductCatalogQueryServiceTests"`
+Expected: 3 tests passed, 0 failed.
+
+- [ ] **Step 3: Run `dotnet format` on the touched files**
+
+Run: `dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs`
+Expected: No errors, formatting applied.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs
+git commit -m "feat(catalog): implement ProductCatalogQueryService"
+```
+
+---
+
+### Task 5: Register `IProductCatalogQueryService` in `CatalogModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` (insert after line 62)
+
+- [ ] **Step 1: Add the DI registration**
+
+The architecture review's Amendment §3 specifies the exact placement: after the `IEshopStockDomainService` registration on line 62, at the end of the "Register catalog-specific services" block. Lifetime is `Transient` to match `ICatalogRepository` (line 39) and avoid captive-dependency warnings.
+
+Apply this edit to `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`:
+
+Replace:
+```csharp
+        services.AddScoped<IEshopStockDomainService, EshopStockDomainService>();
+
+        // Configure feature flags from configuration
+```
+
+With:
+```csharp
+        services.AddScoped<IEshopStockDomainService, EshopStockDomainService>();
+        services.AddTransient<IProductCatalogQueryService, ProductCatalogQueryService>();
+
+        // Configure feature flags from configuration
+```
+
+- [ ] **Step 2: Add the `using` directive**
+
+The `Anela.Heblo.Application.Features.Catalog.Services` namespace is already imported (line 8) — `ProductCatalogQueryService` is reachable. The `Anela.Heblo.Application.Features.Catalog.Contracts` namespace is **not** in the file's existing usings. Add it.
+
+Apply this edit to `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`:
+
+Replace:
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Cache;
+```
+
+With:
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Cache;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+```
+
+- [ ] **Step 3: Build to confirm registration compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Run the full Catalog test slice to confirm no regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Catalog"`
+Expected: All tests pass (existing Catalog tests + the three new `ProductCatalogQueryServiceTests`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "feat(catalog): register IProductCatalogQueryService in CatalogModule"
+```
+
+---
+
+### Task 6: Rewrite `ProductEnrichmentCacheTests` to consume the contract (TDD-Red)
+
+We rewrite the KB tests first — they will fail to compile because the cache still references `ICatalogRepository`. Then Task 7 makes them pass.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` (full rewrite)
+
+- [ ] **Step 1: Replace the test file content**
+
+Drop `using Anela.Heblo.Domain.Features.Catalog;` and the predicate test (it now lives in `ProductCatalogQueryServiceTests`). Replace `ICatalogRepository` setup with `IProductCatalogQueryService`. Keep the existing `IServiceScopeFactory` → `IServiceScope` → `IServiceProvider` chain (lines 13–25 of the original) — that's still the pattern under singleton-resolves-transient.
+
+Overwrite `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase;
+using Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.KnowledgeBase.Pipeline;
+
+public class ProductEnrichmentCacheTests
+{
+    private readonly Mock<IServiceScopeFactory> _scopeFactory = new();
+    private readonly Mock<IServiceScope> _scope = new();
+    private readonly Mock<IServiceProvider> _serviceProvider = new();
+    private readonly Mock<IProductCatalogQueryService> _queryService = new();
+
+    public ProductEnrichmentCacheTests()
+    {
+        _scopeFactory.Setup(f => f.CreateScope()).Returns(_scope.Object);
+        _scope.Setup(s => s.ServiceProvider).Returns(_serviceProvider.Object);
+        _serviceProvider
+            .Setup(sp => sp.GetService(typeof(IProductCatalogQueryService)))
+            .Returns(_queryService.Object);
+    }
+
+    private ProductEnrichmentCache Create(int ttlMinutes = 60) =>
+        new(_scopeFactory.Object, Options.Create(new KnowledgeBaseOptions
+        {
+            ProductEnrichmentCacheTtlMinutes = ttlMinutes
+        }));
+
+    private void SetupQueryService(params ProductCatalogEntry[] entries)
+    {
+        _queryService
+            .Setup(s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+    }
+
+    [Fact]
+    public async Task GetProductLookupAsync_MapsEntriesIntoLookup()
+    {
+        SetupQueryService(
+            new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC", Url = null },
+            new ProductCatalogEntry { ProductCode = "GDS001", ProductName = "Krém XYZ", Url = "https://example.com/gds001" });
+
+        var cache = Create();
+        var lookup = await cache.GetProductLookupAsync();
+
+        Assert.Equal(2, lookup.Count);
+        Assert.True(lookup.ContainsKey("PRD001"));
+        Assert.Equal("Sérum ABC", lookup["PRD001"].ProductName);
+        Assert.Null(lookup["PRD001"].Url);
+        Assert.Equal("https://example.com/gds001", lookup["GDS001"].Url);
+    }
+
+    [Fact]
+    public async Task GetProductLookupAsync_WithinTtl_ReturnsCachedResult_QueryServiceCalledOnce()
+    {
+        SetupQueryService(new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC" });
+        var cache = Create(ttlMinutes: 60);
+
+        await cache.GetProductLookupAsync();
+        await cache.GetProductLookupAsync();
+
+        _queryService.Verify(
+            s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProductLookupAsync_AfterTtlExpiry_RefreshesFromQueryService()
+    {
+        SetupQueryService(new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC" });
+        var cache = Create(ttlMinutes: 0); // TTL = 0 → always expired
+
+        await cache.GetProductLookupAsync();
+        await cache.GetProductLookupAsync();
+
+        _queryService.Verify(
+            s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail to compile**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductEnrichmentCacheTests"`
+Expected: Build fails because `ProductEnrichmentCache` still uses `ICatalogRepository` internally, so the production code still compiles, but the test mock chain returns the new service. Concretely, the cache's runtime call `GetRequiredService<ICatalogRepository>()` will throw `InvalidOperationException` (the mock `_serviceProvider` no longer responds to `typeof(ICatalogRepository)`). Tests will execute (compile passes) but the three behavior tests will throw at runtime. That is the correct TDD-Red state for this task.
+
+Note: If the compiler did fail (it shouldn't because the test file only uses Contracts types now), Task 7 below restores green by changing the production code.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs
+git commit -m "test(knowledge-base): switch ProductEnrichmentCacheTests to IProductCatalogQueryService"
+```
+
+---
+
+### Task 7: Refactor `ProductEnrichmentCache` to depend on the contract (TDD-Green)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` (full rewrite)
+
+- [ ] **Step 1: Rewrite the cache to use `IProductCatalogQueryService`**
+
+Drop `using Anela.Heblo.Domain.Features.Catalog;`. Add `using Anela.Heblo.Application.Features.Catalog.Contracts;`. Replace the repository resolution and predicate call. Keep the singleton-safe `IServiceScopeFactory` indirection, the double-check locking, the `SemaphoreSlim`, and the `_cache` / `_lastLoaded` fields exactly as they are. The `_cache` dictionary semantics (`ProductCode` → `ProductEnrichmentEntry`) and its shape are unchanged so downstream consumers don't notice.
+
+Overwrite `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
+
+public class ProductEnrichmentCache : IProductEnrichmentCache
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<KnowledgeBaseOptions> _options;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    private IReadOnlyDictionary<string, ProductEnrichmentEntry> _cache =
+        new Dictionary<string, ProductEnrichmentEntry>();
+    private DateTime _lastLoaded = DateTime.MinValue;
+
+    public ProductEnrichmentCache(
+        IServiceScopeFactory scopeFactory,
+        IOptions<KnowledgeBaseOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+    }
+
+    public async Task<IReadOnlyDictionary<string, ProductEnrichmentEntry>> GetProductLookupAsync(
+        CancellationToken ct = default)
+    {
+        var ttl = TimeSpan.FromMinutes(_options.Value.ProductEnrichmentCacheTtlMinutes);
+
+        if (DateTime.UtcNow - _lastLoaded < ttl)
+            return _cache;
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            if (DateTime.UtcNow - _lastLoaded < ttl)
+                return _cache;
+
+            using var scope = _scopeFactory.CreateScope();
+            var service = scope.ServiceProvider.GetRequiredService<IProductCatalogQueryService>();
+
+            var products = await service.GetActiveProductsAsync(ct);
+
+            _cache = products.ToDictionary(
+                p => p.ProductCode,
+                p => new ProductEnrichmentEntry
+                {
+                    ProductCode = p.ProductCode,
+                    ProductName = p.ProductName,
+                    Url = p.Url
+                });
+
+            _lastLoaded = DateTime.UtcNow;
+            return _cache;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the cache tests — they should now pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductEnrichmentCacheTests"`
+Expected: 3 tests passed, 0 failed.
+
+- [ ] **Step 3: Verify zero Catalog-domain references remain under `Features/KnowledgeBase/`**
+
+Run: `grep -rn "Anela.Heblo.Domain.Features.Catalog\|ICatalogRepository\|CatalogAggregate\|ProductType" backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ || echo OK`
+Expected: `OK` (no matches).
+
+- [ ] **Step 4: Run `dotnet format` on touched files**
+
+Run: `dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs`
+Expected: No errors, formatting applied.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs
+git commit -m "refactor(knowledge-base): consume IProductCatalogQueryService instead of ICatalogRepository"
+```
+
+---
+
+### Task 8: Final verification — full build, full test suite, downstream consumers green
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Full backend build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors, 0 warnings (or only pre-existing warnings unrelated to this change).
+
+- [ ] **Step 2: Full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: All tests pass. The downstream consumers of `IProductEnrichmentCache` (`AskQuestionHandlerTests`, `PostAnswerEnrichmentMiddlewareTests`) must remain green without changes — their contract surface (`IProductEnrichmentCache.GetProductLookupAsync`) was not modified.
+
+- [ ] **Step 3: Verify downstream consumer signatures untouched**
+
+Run: `git diff main -- backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/IProductEnrichmentCache.cs backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentEntry.cs`
+Expected: empty output (no changes to either file).
+
+- [ ] **Step 4: Verify the architectural invariant**
+
+Run: `grep -rn "Anela.Heblo.Domain.Features.Catalog" backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ || echo OK`
+Expected: `OK`.
+
+Run: `grep -rn "Anela.Heblo.Domain.Features.Catalog\|CatalogAggregate\|ProductType" backend/test/Anela.Heblo.Tests/KnowledgeBase/ || echo OK`
+Expected: `OK`.
+
+- [ ] **Step 5: Final `dotnet format` over the whole solution**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: No diagnostics that block the build.
+
+- [ ] **Step 6: Final commit if formatter touched anything**
+
+```bash
+git status
+# If there are remaining changes from `dotnet format`:
+git add -u backend/
+git commit -m "chore: dotnet format"
+```
+
+If `git status` reports a clean tree, skip the commit.
+
+---
+
+## Self-Review Checklist (already applied)
+
+- **Spec coverage:** FR-1 → Tasks 1, 2. FR-2 → Tasks 3, 4. FR-3 → Task 5. FR-4 → Task 7. FR-5 → Tasks 3 (new Catalog tests), 6 (KB tests rewrite). FR-6 → Task 8 step 3 (verify untouched files). NFR-1/2/3/4 → preserved by design; verified by step 3/4 of Task 8.
+- **Arch-review amendments applied:** §1 (`public sealed class` not `internal sealed`) → Task 4 step 1. §2 (test path under `Features/Catalog/Services/`) → Task 3 file path. §3 (registration placement after line 62) → Task 5 step 1. §4 (predicate-capture pattern) → Task 3 test 1. §5 (KB test mocking chain preserved) → Task 6 test class constructor.
+- **Placeholders:** none. Every code step shows exact code; every command shows the exact invocation.
+- **Type consistency:** `ProductCatalogEntry` properties (`ProductCode`, `ProductName`, `Url`) are spelled identically in Tasks 1, 3, 4, 6, 7. `GetActiveProductsAsync` signature is identical across Tasks 2, 3, 4, 6, 7. `IProductEnrichmentCache.GetProductLookupAsync` is unchanged (verified Task 8 step 3).

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Common;
 using Anela.Heblo.Application.Common.Behaviors;
 using Anela.Heblo.Application.Features.Catalog.Cache;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
 using Anela.Heblo.Application.Features.Catalog.CostProviders;
 using Anela.Heblo.Application.Features.Catalog.DashboardTiles;
 using Anela.Heblo.Xcc.Services.BackgroundRefresh;
@@ -60,6 +61,7 @@ public static class CatalogModule
         services.AddTransient<IProductWeightRecalculationService, ProductWeightRecalculationService>();
         services.AddTransient<IStockUpProcessingService, StockUpProcessingService>();
         services.AddScoped<IEshopStockDomainService, EshopStockDomainService>();
+        services.AddTransient<IProductCatalogQueryService, ProductCatalogQueryService>();
 
         // Configure feature flags from configuration
         services.Configure<CatalogFeatureFlags>(options =>

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public interface IProductCatalogQueryService
+{
+    Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public class ProductCatalogEntry
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public string? Url { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs
@@ -1,0 +1,30 @@
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Services;
+
+public sealed class ProductCatalogQueryService : IProductCatalogQueryService
+{
+    private readonly ICatalogRepository _repository;
+
+    public ProductCatalogQueryService(ICatalogRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default)
+    {
+        var products = await _repository.FindAsync(
+            p => p.Type == ProductType.Product || p.Type == ProductType.Goods,
+            ct);
+
+        return products
+            .Select(p => new ProductCatalogEntry
+            {
+                ProductCode = p.ProductCode,
+                ProductName = p.ProductName,
+                Url = p.Url
+            })
+            .ToList();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -37,11 +37,9 @@ public class ProductEnrichmentCache : IProductEnrichmentCache
                 return _cache;
 
             using var scope = _scopeFactory.CreateScope();
-            var repository = scope.ServiceProvider.GetRequiredService<ICatalogRepository>();
+            var service = scope.ServiceProvider.GetRequiredService<IProductCatalogQueryService>();
 
-            var products = await repository.FindAsync(
-                p => p.Type == ProductType.Product || p.Type == ProductType.Goods,
-                ct);
+            var products = await service.GetActiveProductsAsync(ct);
 
             _cache = products.ToDictionary(
                 p => p.ProductCode,

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs
@@ -1,0 +1,76 @@
+using System.Linq.Expressions;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Domain.Features.Catalog;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Services;
+
+public class ProductCatalogQueryServiceTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private ProductCatalogQueryService Create() => new(_repository.Object);
+
+    [Fact]
+    public async Task GetActiveProductsAsync_PredicateFiltersToProductAndGoodsOnly()
+    {
+        Expression<Func<CatalogAggregate, bool>>? capturedPredicate = null;
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<CatalogAggregate, bool>>, CancellationToken>((pred, _) => capturedPredicate = pred)
+            .ReturnsAsync(Array.Empty<CatalogAggregate>());
+
+        var service = Create();
+        await service.GetActiveProductsAsync();
+
+        Assert.NotNull(capturedPredicate);
+        var compiled = capturedPredicate!.Compile();
+        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Product }));
+        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Goods }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Material }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.SemiProduct }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Set }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.UNDEFINED }));
+    }
+
+    [Fact]
+    public async Task GetActiveProductsAsync_MapsProductCodeNameAndUrl()
+    {
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new CatalogAggregate { ProductCode = "PRD001", ProductName = "Sérum ABC", Type = ProductType.Product, Url = "https://example.com/prd001" },
+                new CatalogAggregate { ProductCode = "GDS001", ProductName = "Krém XYZ", Type = ProductType.Goods, Url = null }
+            });
+
+        var service = Create();
+        var result = await service.GetActiveProductsAsync();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("PRD001", result[0].ProductCode);
+        Assert.Equal("Sérum ABC", result[0].ProductName);
+        Assert.Equal("https://example.com/prd001", result[0].Url);
+        Assert.Equal("GDS001", result[1].ProductCode);
+        Assert.Equal("Krém XYZ", result[1].ProductName);
+        Assert.Null(result[1].Url);
+    }
+
+    [Fact]
+    public async Task GetActiveProductsAsync_PropagatesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var capturedToken = CancellationToken.None;
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<CatalogAggregate, bool>>, CancellationToken>((_, t) => capturedToken = t)
+            .ReturnsAsync(Array.Empty<CatalogAggregate>());
+
+        var service = Create();
+        await service.GetActiveProductsAsync(cts.Token);
+
+        Assert.Equal(cts.Token, capturedToken);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs
@@ -1,6 +1,6 @@
+using Anela.Heblo.Application.Features.Catalog.Contracts;
 using Anela.Heblo.Application.Features.KnowledgeBase;
 using Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
-using Anela.Heblo.Domain.Features.Catalog;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -13,15 +13,15 @@ public class ProductEnrichmentCacheTests
     private readonly Mock<IServiceScopeFactory> _scopeFactory = new();
     private readonly Mock<IServiceScope> _scope = new();
     private readonly Mock<IServiceProvider> _serviceProvider = new();
-    private readonly Mock<ICatalogRepository> _repository = new();
+    private readonly Mock<IProductCatalogQueryService> _queryService = new();
 
     public ProductEnrichmentCacheTests()
     {
         _scopeFactory.Setup(f => f.CreateScope()).Returns(_scope.Object);
         _scope.Setup(s => s.ServiceProvider).Returns(_serviceProvider.Object);
         _serviceProvider
-            .Setup(sp => sp.GetService(typeof(ICatalogRepository)))
-            .Returns(_repository.Object);
+            .Setup(sp => sp.GetService(typeof(IProductCatalogQueryService)))
+            .Returns(_queryService.Object);
     }
 
     private ProductEnrichmentCache Create(int ttlMinutes = 60) =>
@@ -30,71 +30,55 @@ public class ProductEnrichmentCacheTests
             ProductEnrichmentCacheTtlMinutes = ttlMinutes
         }));
 
-    private void SetupRepository(params CatalogAggregate[] products)
+    private void SetupQueryService(params ProductCatalogEntry[] entries)
     {
-        _repository
-            .Setup(r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(products);
+        _queryService
+            .Setup(s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
     }
 
     [Fact]
-    public async Task GetProductLookupAsync_PredicateFiltersToProductAndGoodsOnly()
+    public async Task GetProductLookupAsync_MapsEntriesIntoLookup()
     {
-        System.Linq.Expressions.Expression<Func<CatalogAggregate, bool>>? capturedPredicate = null;
-        _repository
-            .Setup(r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
-            .Callback<System.Linq.Expressions.Expression<Func<CatalogAggregate, bool>>, CancellationToken>(
-                (pred, _) => capturedPredicate = pred)
-            .ReturnsAsync(new[]
-            {
-                new CatalogAggregate { ProductCode = "PRD001", ProductName = "Sérum ABC", Type = ProductType.Product },
-                new CatalogAggregate { ProductCode = "GDS001", ProductName = "Krém XYZ", Type = ProductType.Goods }
-            });
+        SetupQueryService(
+            new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC", Url = null },
+            new ProductCatalogEntry { ProductCode = "GDS001", ProductName = "Krém XYZ", Url = "https://example.com/gds001" });
 
         var cache = Create();
         var lookup = await cache.GetProductLookupAsync();
 
-        // Verify data mapping
         Assert.Equal(2, lookup.Count);
         Assert.True(lookup.ContainsKey("PRD001"));
         Assert.Equal("Sérum ABC", lookup["PRD001"].ProductName);
         Assert.Null(lookup["PRD001"].Url);
-
-        // Verify the predicate actually filters correctly
-        var compiled = capturedPredicate!.Compile();
-        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Product }));
-        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Goods }));
-        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Material }));
-        Assert.False(compiled(new CatalogAggregate { Type = ProductType.SemiProduct }));
-        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Set }));
-        Assert.False(compiled(new CatalogAggregate { Type = ProductType.UNDEFINED }));
+        Assert.Equal("https://example.com/gds001", lookup["GDS001"].Url);
     }
 
     [Fact]
-    public async Task GetProductLookupAsync_WithinTtl_ReturnsCachedResult_RepositoryCalledOnce()
+    public async Task GetProductLookupAsync_WithinTtl_ReturnsCachedResult_QueryServiceCalledOnce()
     {
-        SetupRepository(new CatalogAggregate { ProductCode = "PRD001", ProductName = "Sérum ABC", Type = ProductType.Product });
+        SetupQueryService(new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC" });
         var cache = Create(ttlMinutes: 60);
 
         await cache.GetProductLookupAsync();
         await cache.GetProductLookupAsync();
 
-        _repository.Verify(
-            r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()),
+        _queryService.Verify(
+            s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task GetProductLookupAsync_AfterTtlExpiry_RefreshesFromRepository()
+    public async Task GetProductLookupAsync_AfterTtlExpiry_RefreshesFromQueryService()
     {
-        SetupRepository(new CatalogAggregate { ProductCode = "PRD001", ProductName = "Sérum ABC", Type = ProductType.Product });
+        SetupQueryService(new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC" });
         var cache = Create(ttlMinutes: 0); // TTL = 0 → always expired
 
         await cache.GetProductLookupAsync();
         await cache.GetProductLookupAsync();
 
-        _repository.Verify(
-            r => r.FindAsync(It.IsAny<System.Linq.Expressions.Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()),
+        _queryService.Verify(
+            s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
 }

--- a/docs/superpowers/plans/2026-05-13-decouple-productenrichmentcache.md
+++ b/docs/superpowers/plans/2026-05-13-decouple-productenrichmentcache.md
@@ -1,0 +1,615 @@
+# Decouple ProductEnrichmentCache from Catalog Domain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the cross-module dependency where `ProductEnrichmentCache` (KnowledgeBase) imports `Anela.Heblo.Domain.Features.Catalog` types and consumes `ICatalogRepository` directly — by introducing a narrow Catalog-owned read contract (`IProductCatalogQueryService`) and refactoring the cache to depend on it. Behavior, lifetimes, TTL, and downstream consumer signatures stay identical.
+
+**Architecture:** A new contract pair (`IProductCatalogQueryService` + `ProductCatalogEntry` DTO) is added to `Anela.Heblo.Application/Features/Catalog/Contracts/`. The implementation `ProductCatalogQueryService` lives in `Anela.Heblo.Application/Features/Catalog/Services/`, wraps `ICatalogRepository`, owns the `Type == Product || Type == Goods` predicate, and projects each `CatalogAggregate` into the DTO. `ProductEnrichmentCache` is rewritten to resolve `IProductCatalogQueryService` (transient) via `IServiceScopeFactory` — the singleton-resolving-transient indirection is preserved because the cache itself is singleton. The predicate test that was previously in `ProductEnrichmentCacheTests` moves into a new `ProductCatalogQueryServiceTests` class — that file becomes the only place outside the Catalog module that still references `CatalogAggregate` and `ProductType`.
+
+**Tech Stack:** .NET 8, C#, xUnit, Moq, Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Options. No new NuGet packages.
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs` — DTO (class, three string properties).
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs` — Catalog-owned read contract.
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs` — Implementation; wraps `ICatalogRepository`, owns the predicate and projection.
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs` — Predicate-filter, projection, and cancellation-token tests; lives in Catalog test tree (the only allowed `CatalogAggregate` / `ProductType` reference site for this refactor).
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — One-line DI registration.
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` — Replace `ICatalogRepository` with `IProductCatalogQueryService`; drop all Catalog-domain `using`s.
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` — Mock `IProductCatalogQueryService` instead of `ICatalogRepository`; drop `CatalogAggregate`/`ProductType` usage; remove the predicate test (moved to Catalog tests); keep TTL tests.
+
+**Unchanged (but verified by grep):**
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/IProductEnrichmentCache.cs`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentEntry.cs`
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`
+- Consumers: `PostAnswerEnrichmentMiddleware`, `AskQuestionHandler`, and their tests.
+
+---
+
+### Task 1: Add `ProductCatalogEntry` DTO
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs`
+
+- [ ] **Step 1: Create the DTO file**
+
+Per the project rule in `CLAUDE.md` (*"DTOs are classes, never C# records"*) and consistent with every other file under `Features/Catalog/Contracts/` (e.g., `CatalogItemDto.cs`), declare a `public class` with mutable get/set properties.
+
+Write the following content to `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs`:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public class ProductCatalogEntry
+{
+    public string ProductCode { get; set; } = string.Empty;
+    public string ProductName { get; set; } = string.Empty;
+    public string? Url { get; set; }
+}
+```
+
+- [ ] **Step 2: Verify no `Anela.Heblo.Domain.*` reference**
+
+Run: `grep -n "Anela.Heblo.Domain" backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs || echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Build to confirm the file compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ProductCatalogEntry.cs
+git commit -m "feat(catalog): add ProductCatalogEntry contract DTO"
+```
+
+---
+
+### Task 2: Add `IProductCatalogQueryService` contract
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs`
+
+- [ ] **Step 1: Create the interface**
+
+Method returns `IReadOnlyList<>` so consumers cannot mutate the producer's list. Optional `CancellationToken ct = default` matches the calling convention used by `ICatalogRepository.FindAsync`.
+
+Write the following to `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs`:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Contracts;
+
+public interface IProductCatalogQueryService
+{
+    Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Verify no `Anela.Heblo.Domain.*` reference**
+
+Run: `grep -n "Anela.Heblo.Domain" backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs || echo OK`
+Expected: `OK`
+
+- [ ] **Step 3: Build to confirm the file compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/IProductCatalogQueryService.cs
+git commit -m "feat(catalog): add IProductCatalogQueryService contract"
+```
+
+---
+
+### Task 3: Write failing tests for `ProductCatalogQueryService`
+
+This task is TDD-Red. We write the full test class before any implementation. The test file is the only place outside the Catalog module that still references `CatalogAggregate` and `ProductType`, and that is intentional — it lives in the Catalog test tree.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs`
+
+- [ ] **Step 1: Write the test file**
+
+The tests cover three behaviors:
+1. Predicate filters to `Product` and `Goods` only (capture the `Expression`, compile it, assert per `ProductType`).
+2. Projection maps `ProductCode`, `ProductName`, `Url` correctly and preserves `null` for `Url`.
+3. The provided `CancellationToken` is propagated to the repository.
+
+Note: `ICatalogRepository.FindAsync` returns `Task<IEnumerable<CatalogAggregate>>` (see `BaseRepository.FindAsync` and `MockCatalogRepository.FindAsync`), not `Task<IReadOnlyList<...>>`. The implementation will materialize to a list before returning.
+
+Write the following to `backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs`:
+
+```csharp
+using System.Linq.Expressions;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Domain.Features.Catalog;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Services;
+
+public class ProductCatalogQueryServiceTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private ProductCatalogQueryService Create() => new(_repository.Object);
+
+    [Fact]
+    public async Task GetActiveProductsAsync_PredicateFiltersToProductAndGoodsOnly()
+    {
+        Expression<Func<CatalogAggregate, bool>>? capturedPredicate = null;
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<CatalogAggregate, bool>>, CancellationToken>((pred, _) => capturedPredicate = pred)
+            .ReturnsAsync(Array.Empty<CatalogAggregate>());
+
+        var service = Create();
+        await service.GetActiveProductsAsync();
+
+        Assert.NotNull(capturedPredicate);
+        var compiled = capturedPredicate!.Compile();
+        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Product }));
+        Assert.True(compiled(new CatalogAggregate { Type = ProductType.Goods }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Material }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.SemiProduct }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.Set }));
+        Assert.False(compiled(new CatalogAggregate { Type = ProductType.UNDEFINED }));
+    }
+
+    [Fact]
+    public async Task GetActiveProductsAsync_MapsProductCodeNameAndUrl()
+    {
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new CatalogAggregate { ProductCode = "PRD001", ProductName = "Sérum ABC", Type = ProductType.Product, Url = "https://example.com/prd001" },
+                new CatalogAggregate { ProductCode = "GDS001", ProductName = "Krém XYZ", Type = ProductType.Goods, Url = null }
+            });
+
+        var service = Create();
+        var result = await service.GetActiveProductsAsync();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("PRD001", result[0].ProductCode);
+        Assert.Equal("Sérum ABC", result[0].ProductName);
+        Assert.Equal("https://example.com/prd001", result[0].Url);
+        Assert.Equal("GDS001", result[1].ProductCode);
+        Assert.Equal("Krém XYZ", result[1].ProductName);
+        Assert.Null(result[1].Url);
+    }
+
+    [Fact]
+    public async Task GetActiveProductsAsync_PropagatesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var capturedToken = CancellationToken.None;
+        _repository
+            .Setup(r => r.FindAsync(It.IsAny<Expression<Func<CatalogAggregate, bool>>>(), It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<CatalogAggregate, bool>>, CancellationToken>((_, t) => capturedToken = t)
+            .ReturnsAsync(Array.Empty<CatalogAggregate>());
+
+        var service = Create();
+        await service.GetActiveProductsAsync(cts.Token);
+
+        Assert.Equal(cts.Token, capturedToken);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductCatalogQueryServiceTests"`
+Expected: Build fails with "The type or namespace name 'ProductCatalogQueryService' could not be found" (the implementation doesn't exist yet). This is the correct TDD-Red state.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs
+git commit -m "test(catalog): add failing tests for ProductCatalogQueryService"
+```
+
+---
+
+### Task 4: Implement `ProductCatalogQueryService`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs`
+
+- [ ] **Step 1: Write the implementation**
+
+Per the architecture review (Decision 3), this is `public class` matching sibling implementations in `Features/Catalog/Services/` (`MarginCalculationService`, `StockUpProcessingService`, `ProductWeightRecalculationService`, `EshopStockDomainService`). The architecture review's Amendment §1 overrides the spec's `internal sealed` wording. We mark `sealed` because the class is not designed for inheritance.
+
+Write the following to `backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Services;
+
+public sealed class ProductCatalogQueryService : IProductCatalogQueryService
+{
+    private readonly ICatalogRepository _repository;
+
+    public ProductCatalogQueryService(ICatalogRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default)
+    {
+        var products = await _repository.FindAsync(
+            p => p.Type == ProductType.Product || p.Type == ProductType.Goods,
+            ct);
+
+        return products
+            .Select(p => new ProductCatalogEntry
+            {
+                ProductCode = p.ProductCode,
+                ProductName = p.ProductName,
+                Url = p.Url
+            })
+            .ToList();
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests — they should now pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductCatalogQueryServiceTests"`
+Expected: 3 tests passed, 0 failed.
+
+- [ ] **Step 3: Run `dotnet format` on the touched files**
+
+Run: `dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs backend/test/Anela.Heblo.Tests/Features/Catalog/Services/ProductCatalogQueryServiceTests.cs`
+Expected: No errors, formatting applied.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Services/ProductCatalogQueryService.cs
+git commit -m "feat(catalog): implement ProductCatalogQueryService"
+```
+
+---
+
+### Task 5: Register `IProductCatalogQueryService` in `CatalogModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` (insert after line 62)
+
+- [ ] **Step 1: Add the DI registration**
+
+The architecture review's Amendment §3 specifies the exact placement: after the `IEshopStockDomainService` registration on line 62, at the end of the "Register catalog-specific services" block. Lifetime is `Transient` to match `ICatalogRepository` (line 39) and avoid captive-dependency warnings.
+
+Apply this edit to `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`:
+
+Replace:
+```csharp
+        services.AddScoped<IEshopStockDomainService, EshopStockDomainService>();
+
+        // Configure feature flags from configuration
+```
+
+With:
+```csharp
+        services.AddScoped<IEshopStockDomainService, EshopStockDomainService>();
+        services.AddTransient<IProductCatalogQueryService, ProductCatalogQueryService>();
+
+        // Configure feature flags from configuration
+```
+
+- [ ] **Step 2: Add the `using` directive**
+
+The `Anela.Heblo.Application.Features.Catalog.Services` namespace is already imported (line 8) — `ProductCatalogQueryService` is reachable. The `Anela.Heblo.Application.Features.Catalog.Contracts` namespace is **not** in the file's existing usings. Add it.
+
+Apply this edit to `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`:
+
+Replace:
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Cache;
+```
+
+With:
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Cache;
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+```
+
+- [ ] **Step 3: Build to confirm registration compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Run the full Catalog test slice to confirm no regressions**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.Catalog"`
+Expected: All tests pass (existing Catalog tests + the three new `ProductCatalogQueryServiceTests`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "feat(catalog): register IProductCatalogQueryService in CatalogModule"
+```
+
+---
+
+### Task 6: Rewrite `ProductEnrichmentCacheTests` to consume the contract (TDD-Red)
+
+We rewrite the KB tests first — they will fail to compile because the cache still references `ICatalogRepository`. Then Task 7 makes them pass.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` (full rewrite)
+
+- [ ] **Step 1: Replace the test file content**
+
+Drop `using Anela.Heblo.Domain.Features.Catalog;` and the predicate test (it now lives in `ProductCatalogQueryServiceTests`). Replace `ICatalogRepository` setup with `IProductCatalogQueryService`. Keep the existing `IServiceScopeFactory` → `IServiceScope` → `IServiceProvider` chain (lines 13–25 of the original) — that's still the pattern under singleton-resolves-transient.
+
+Overwrite `backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase;
+using Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.KnowledgeBase.Pipeline;
+
+public class ProductEnrichmentCacheTests
+{
+    private readonly Mock<IServiceScopeFactory> _scopeFactory = new();
+    private readonly Mock<IServiceScope> _scope = new();
+    private readonly Mock<IServiceProvider> _serviceProvider = new();
+    private readonly Mock<IProductCatalogQueryService> _queryService = new();
+
+    public ProductEnrichmentCacheTests()
+    {
+        _scopeFactory.Setup(f => f.CreateScope()).Returns(_scope.Object);
+        _scope.Setup(s => s.ServiceProvider).Returns(_serviceProvider.Object);
+        _serviceProvider
+            .Setup(sp => sp.GetService(typeof(IProductCatalogQueryService)))
+            .Returns(_queryService.Object);
+    }
+
+    private ProductEnrichmentCache Create(int ttlMinutes = 60) =>
+        new(_scopeFactory.Object, Options.Create(new KnowledgeBaseOptions
+        {
+            ProductEnrichmentCacheTtlMinutes = ttlMinutes
+        }));
+
+    private void SetupQueryService(params ProductCatalogEntry[] entries)
+    {
+        _queryService
+            .Setup(s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+    }
+
+    [Fact]
+    public async Task GetProductLookupAsync_MapsEntriesIntoLookup()
+    {
+        SetupQueryService(
+            new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC", Url = null },
+            new ProductCatalogEntry { ProductCode = "GDS001", ProductName = "Krém XYZ", Url = "https://example.com/gds001" });
+
+        var cache = Create();
+        var lookup = await cache.GetProductLookupAsync();
+
+        Assert.Equal(2, lookup.Count);
+        Assert.True(lookup.ContainsKey("PRD001"));
+        Assert.Equal("Sérum ABC", lookup["PRD001"].ProductName);
+        Assert.Null(lookup["PRD001"].Url);
+        Assert.Equal("https://example.com/gds001", lookup["GDS001"].Url);
+    }
+
+    [Fact]
+    public async Task GetProductLookupAsync_WithinTtl_ReturnsCachedResult_QueryServiceCalledOnce()
+    {
+        SetupQueryService(new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC" });
+        var cache = Create(ttlMinutes: 60);
+
+        await cache.GetProductLookupAsync();
+        await cache.GetProductLookupAsync();
+
+        _queryService.Verify(
+            s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProductLookupAsync_AfterTtlExpiry_RefreshesFromQueryService()
+    {
+        SetupQueryService(new ProductCatalogEntry { ProductCode = "PRD001", ProductName = "Sérum ABC" });
+        var cache = Create(ttlMinutes: 0); // TTL = 0 → always expired
+
+        await cache.GetProductLookupAsync();
+        await cache.GetProductLookupAsync();
+
+        _queryService.Verify(
+            s => s.GetActiveProductsAsync(It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail to compile**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductEnrichmentCacheTests"`
+Expected: Build fails because `ProductEnrichmentCache` still uses `ICatalogRepository` internally, so the production code still compiles, but the test mock chain returns the new service. Concretely, the cache's runtime call `GetRequiredService<ICatalogRepository>()` will throw `InvalidOperationException` (the mock `_serviceProvider` no longer responds to `typeof(ICatalogRepository)`). Tests will execute (compile passes) but the three behavior tests will throw at runtime. That is the correct TDD-Red state for this task.
+
+Note: If the compiler did fail (it shouldn't because the test file only uses Contracts types now), Task 7 below restores green by changing the production code.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs
+git commit -m "test(knowledge-base): switch ProductEnrichmentCacheTests to IProductCatalogQueryService"
+```
+
+---
+
+### Task 7: Refactor `ProductEnrichmentCache` to depend on the contract (TDD-Green)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` (full rewrite)
+
+- [ ] **Step 1: Rewrite the cache to use `IProductCatalogQueryService`**
+
+Drop `using Anela.Heblo.Domain.Features.Catalog;`. Add `using Anela.Heblo.Application.Features.Catalog.Contracts;`. Replace the repository resolution and predicate call. Keep the singleton-safe `IServiceScopeFactory` indirection, the double-check locking, the `SemaphoreSlim`, and the `_cache` / `_lastLoaded` fields exactly as they are. The `_cache` dictionary semantics (`ProductCode` → `ProductEnrichmentEntry`) and its shape are unchanged so downstream consumers don't notice.
+
+Overwrite `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
+
+public class ProductEnrichmentCache : IProductEnrichmentCache
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<KnowledgeBaseOptions> _options;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    private IReadOnlyDictionary<string, ProductEnrichmentEntry> _cache =
+        new Dictionary<string, ProductEnrichmentEntry>();
+    private DateTime _lastLoaded = DateTime.MinValue;
+
+    public ProductEnrichmentCache(
+        IServiceScopeFactory scopeFactory,
+        IOptions<KnowledgeBaseOptions> options)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+    }
+
+    public async Task<IReadOnlyDictionary<string, ProductEnrichmentEntry>> GetProductLookupAsync(
+        CancellationToken ct = default)
+    {
+        var ttl = TimeSpan.FromMinutes(_options.Value.ProductEnrichmentCacheTtlMinutes);
+
+        if (DateTime.UtcNow - _lastLoaded < ttl)
+            return _cache;
+
+        await _lock.WaitAsync(ct);
+        try
+        {
+            if (DateTime.UtcNow - _lastLoaded < ttl)
+                return _cache;
+
+            using var scope = _scopeFactory.CreateScope();
+            var service = scope.ServiceProvider.GetRequiredService<IProductCatalogQueryService>();
+
+            var products = await service.GetActiveProductsAsync(ct);
+
+            _cache = products.ToDictionary(
+                p => p.ProductCode,
+                p => new ProductEnrichmentEntry
+                {
+                    ProductCode = p.ProductCode,
+                    ProductName = p.ProductName,
+                    Url = p.Url
+                });
+
+            _lastLoaded = DateTime.UtcNow;
+            return _cache;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the cache tests — they should now pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ProductEnrichmentCacheTests"`
+Expected: 3 tests passed, 0 failed.
+
+- [ ] **Step 3: Verify zero Catalog-domain references remain under `Features/KnowledgeBase/`**
+
+Run: `grep -rn "Anela.Heblo.Domain.Features.Catalog\|ICatalogRepository\|CatalogAggregate\|ProductType" backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ || echo OK`
+Expected: `OK` (no matches).
+
+- [ ] **Step 4: Run `dotnet format` on touched files**
+
+Run: `dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs backend/test/Anela.Heblo.Tests/KnowledgeBase/Pipeline/ProductEnrichmentCacheTests.cs`
+Expected: No errors, formatting applied.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs
+git commit -m "refactor(knowledge-base): consume IProductCatalogQueryService instead of ICatalogRepository"
+```
+
+---
+
+### Task 8: Final verification — full build, full test suite, downstream consumers green
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Full backend build**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors, 0 warnings (or only pre-existing warnings unrelated to this change).
+
+- [ ] **Step 2: Full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: All tests pass. The downstream consumers of `IProductEnrichmentCache` (`AskQuestionHandlerTests`, `PostAnswerEnrichmentMiddlewareTests`) must remain green without changes — their contract surface (`IProductEnrichmentCache.GetProductLookupAsync`) was not modified.
+
+- [ ] **Step 3: Verify downstream consumer signatures untouched**
+
+Run: `git diff main -- backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/IProductEnrichmentCache.cs backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentEntry.cs`
+Expected: empty output (no changes to either file).
+
+- [ ] **Step 4: Verify the architectural invariant**
+
+Run: `grep -rn "Anela.Heblo.Domain.Features.Catalog" backend/src/Anela.Heblo.Application/Features/KnowledgeBase/ || echo OK`
+Expected: `OK`.
+
+Run: `grep -rn "Anela.Heblo.Domain.Features.Catalog\|CatalogAggregate\|ProductType" backend/test/Anela.Heblo.Tests/KnowledgeBase/ || echo OK`
+Expected: `OK`.
+
+- [ ] **Step 5: Final `dotnet format` over the whole solution**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: No diagnostics that block the build.
+
+- [ ] **Step 6: Final commit if formatter touched anything**
+
+```bash
+git status
+# If there are remaining changes from `dotnet format`:
+git add -u backend/
+git commit -m "chore: dotnet format"
+```
+
+If `git status` reports a clean tree, skip the commit.
+
+---
+
+## Self-Review Checklist (already applied)
+
+- **Spec coverage:** FR-1 → Tasks 1, 2. FR-2 → Tasks 3, 4. FR-3 → Task 5. FR-4 → Task 7. FR-5 → Tasks 3 (new Catalog tests), 6 (KB tests rewrite). FR-6 → Task 8 step 3 (verify untouched files). NFR-1/2/3/4 → preserved by design; verified by step 3/4 of Task 8.
+- **Arch-review amendments applied:** §1 (`public sealed class` not `internal sealed`) → Task 4 step 1. §2 (test path under `Features/Catalog/Services/`) → Task 3 file path. §3 (registration placement after line 62) → Task 5 step 1. §4 (predicate-capture pattern) → Task 3 test 1. §5 (KB test mocking chain preserved) → Task 6 test class constructor.
+- **Placeholders:** none. Every code step shows exact code; every command shows the exact invocation.
+- **Type consistency:** `ProductCatalogEntry` properties (`ProductCode`, `ProductName`, `Url`) are spelled identically in Tasks 1, 3, 4, 6, 7. `GetActiveProductsAsync` signature is identical across Tasks 2, 3, 4, 6, 7. `IProductEnrichmentCache.GetProductLookupAsync` is unchanged (verified Task 8 step 3).


### PR DESCRIPTION
KnowledgeBase

## Finding
`ProductEnrichmentCache` in the KnowledgeBase module directly resolves and calls `ICatalogRepository` — a domain-layer interface owned by the Catalog module:

```csharp
// backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/ProductEnrichmentCache.cs:1
using Anela.Heblo.Domain.Features.Catalog;

// line 40
var repository = scope.ServiceProvider.GetRequiredService<ICatalogRepository>();
var products = await repository.FindAsync(
    p => p.Type == ProductType.Product || p.Type == ProductType.Goods, ct);
```

It then reads `p.ProductCode`, `p.ProductName`, and `p.Url` from `CatalogAggregate` domain entities.

## Why it matters
`development_guidelines.md` states: _"Communication between modules exclusively through `contracts/`"_ and _"No direct access to another module's entities."_ This coupling means:
- KnowledgeBase has a compile-time (and runtime) dependency on Catalog's domain and persistence layers.
- Any change to `CatalogAggregate` or `ICatalogRepository` can silently break the KnowledgeBase pipeline.
- It becomes impossible to test `ProductEnrichmentCache` in isolation from the Catalog module.

## Suggested fix
Define a narrow read-only contract in the Catalog module:

```csharp
// Catalog/Contracts/IProductCatalogQueryService.cs
public interface IProductCatalogQueryService
{
    Task<IReadOnlyList<ProductCatalogEntry>> GetActiveProductsAsync(CancellationToken ct = default);
}

public class ProductCatalogEntry
{
    public string ProductCode { get; set; } = string.Empty;
    public string ProductName { get; set; } = string.Empty;
    public string? Url { get; set; }
}
```

Implement it inside the Catalog module (wrapping `ICatalogRepository`), register it in `CatalogModule.cs`, then inject `IProductCatalogQueryService` into `ProductEnrichmentCache` instead of `ICatalogRepository`. This removes the cross-module entity access while keeping the cache logic identical.

---
_Filed by daily arch-review routine on 2026-05-13._

---

Closes #1177

### Tokens used
15381549
