### PR TITLE
feat: Replace In-Memory Aggregation in `GetFeedbackStatsAsync` with SQL-Side Aggregation

### DIFF
--- a/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/arch-review.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/arch-review.r1.md
@@ -1,0 +1,170 @@
+# Architecture Review: SQL-Side Aggregation for `GetFeedbackStatsAsync`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The change lives entirely inside one method of one repository (`KnowledgeBaseRepository.GetFeedbackStatsAsync`) and is a textbook fit for the project's existing Clean Architecture layering:
+
+- **Domain layer** (`Anela.Heblo.Domain/Features/KnowledgeBase`): no change — `IKnowledgeBaseRepository` contract and `FeedbackAggregateStats` DTO are stable.
+- **Persistence layer** (`Anela.Heblo.Persistence/KnowledgeBase`): only the body of `GetFeedbackStatsAsync` is rewritten.
+- **Application layer** (`GetFeedbackListHandler`): completely unaffected.
+- **Frontend / OpenAPI client**: no contract surface change, so no client regeneration.
+
+Integration points consist of two EF Core entity sets that already exist (`KnowledgeBaseQuestionLogs`) and the configured Npgsql provider, which translates `CountAsync` and `AverageAsync(l => (double?)x, ct)` to native `COUNT(*)` and `AVG(x)` SQL. The pattern is already used by other repository methods in the same file (`CountAsync` at lines 91 and 290), so there is no novel infrastructure.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Application layer                                           │
+│   GetFeedbackListHandler — unchanged                        │
+│     └── calls IKnowledgeBaseRepository.GetFeedbackStatsAsync│
+└─────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Domain layer (contracts only)                               │
+│   IKnowledgeBaseRepository    — unchanged signature         │
+│   FeedbackAggregateStats DTO  — unchanged shape             │
+└─────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Persistence layer                                           │
+│   KnowledgeBaseRepository.GetFeedbackStatsAsync             │
+│     │ 1. CountAsync(all)            → SELECT COUNT(*)       │
+│     │ 2. CountAsync(predicate)      → SELECT COUNT(*) WHERE │
+│     │ 3. AverageAsync(double?)      → SELECT AVG(col)::dbl  │
+│     │ 4. AverageAsync(double?)      → SELECT AVG(col)::dbl  │
+│     └ rounding/null handling done in C# from 4 scalars      │
+└─────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+                       PostgreSQL (Npgsql)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Four sequential aggregate queries vs. a single `GroupBy(_ => 1)` projection
+**Options considered:**
+- A) Four sequential `CountAsync` / `AverageAsync` calls.
+- B) A single `_context.KnowledgeBaseQuestionLogs.GroupBy(_ => 1).Select(g => new { ... })` projection that pulls all four scalars in one round-trip.
+
+**Chosen approach:** A — four sequential calls.
+
+**Rationale:** Both translate to constant-size aggregate scans, so the dominant cost is fixed-overhead round-trips; against the project's PostgreSQL database four short round-trips are negligible and well within the < 100 ms p95 budget. Option B is harder to read, harder to test (one composite query is more brittle to EF Core translation changes), and provides no measurable benefit at this table size and call frequency. KISS wins — pick the readable form. If profiling later shows the round-trips dominate, consolidating into a `GroupBy(_=>1)` projection is a one-method refactor with no contract impact.
+
+#### Decision 2: Nullable `AverageAsync(l => (double?)l.PrecisionScore, ct)` vs. guarded `AverageAsync(double)`
+**Options considered:**
+- A) `AverageAsync(l => (double?)l.PrecisionScore, ct)` over a filtered set — returns `null` for empty filter.
+- B) `AnyAsync` guard followed by `AverageAsync(l => (double)l.PrecisionScore.Value, ct)`.
+
+**Chosen approach:** A.
+
+**Rationale:** Matches the existing in-memory code's null-on-empty semantics exactly, requires one round-trip instead of two, and avoids `InvalidOperationException` from `AverageAsync` on an empty sequence (a known EF Core gotcha). The nullable-double cast is the canonical EF Core idiom for this case.
+
+#### Decision 3: Keep the four DB calls outside a transaction
+**Options considered:**
+- A) Read each scalar without a transaction (current style for this repository).
+- B) Wrap the four reads in an explicit serializable transaction for a consistent snapshot.
+
+**Chosen approach:** A.
+
+**Rationale:** This is a stats header — a row inserted between calls produces at most one off-by-one in `TotalQuestions` vs. `TotalWithFeedback`, which is acceptable for an informational summary that is recomputed every page load. A transaction adds locking cost and complexity for no user-visible benefit.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Modify in place:
+
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs` — replace lines 299–322 (`GetFeedbackStatsAsync` body).
+
+Add or extend tests:
+
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — extend `SetupSchemaAsync` to also create the `KnowledgeBaseQuestionLogs` table (the existing schema-setup script only creates `KnowledgeBaseDocuments` and `KnowledgeBaseChunks` — this is a real gap that blocks adding the spec's required tests). Then add a `Feedback` region with the four scenarios listed in FR-4.
+
+No new files in `Anela.Heblo.Tests/KnowledgeBase/Repository/`. Co-locating with the existing integration test class keeps the Testcontainers Postgres fixture shared, which dominates runtime — splitting would double container boot time for ~four new tests.
+
+### Interfaces and Contracts
+
+Unchanged:
+
+```csharp
+// Anela.Heblo.Domain/Features/KnowledgeBase/IKnowledgeBaseRepository.cs
+Task<FeedbackAggregateStats> GetFeedbackStatsAsync(CancellationToken ct = default);
+
+// Anela.Heblo.Domain/Features/KnowledgeBase/FeedbackAggregateStats.cs — unchanged class shape
+public class FeedbackAggregateStats
+{
+    public int TotalQuestions { get; set; }
+    public int TotalWithFeedback { get; set; }
+    public double? AvgPrecisionScore { get; set; }
+    public double? AvgStyleScore { get; set; }
+}
+```
+
+Implementation contract for `GetFeedbackStatsAsync` body:
+
+1. Must call exactly four async EF Core aggregation methods.
+2. Each call must pass the `CancellationToken` parameter.
+3. No `ToListAsync`, `ToArrayAsync`, `AsEnumerable`, or row materialisation.
+4. Average calls must use the nullable double cast pattern: `AverageAsync(l => (double?)l.PrecisionScore, ct)`.
+5. Round the average using `Math.Round(value, 1)` (default `MidpointRounding.ToEven`) — do not change to `AwayFromZero`, as the spec requires exact UI parity.
+
+### Data Flow
+
+For the Feedback page stats header:
+
+```
+HTTP GET /knowledge-base/feedback?...
+  ▼
+GetFeedbackListHandler.Handle()
+  ├─ await _repository.GetFeedbackLogsPagedAsync(...)   ← unchanged
+  └─ await _repository.GetFeedbackStatsAsync(ct)        ← rewritten body
+        │
+        ├─ Round-trip 1: SELECT COUNT(*) FROM "KnowledgeBaseQuestionLogs"
+        ├─ Round-trip 2: SELECT COUNT(*) FROM ... WHERE "PrecisionScore" IS NOT NULL OR "StyleScore" IS NOT NULL
+        ├─ Round-trip 3: SELECT AVG(CAST("PrecisionScore" AS double precision)) FROM ... WHERE "PrecisionScore" IS NOT NULL
+        └─ Round-trip 4: SELECT AVG(CAST("StyleScore" AS double precision)) FROM ... WHERE "StyleScore" IS NOT NULL
+        │
+        └─ build FeedbackAggregateStats with Math.Round(_, 1) on the two averages
+  ▼
+maps stats into FeedbackStatsDto (unchanged shape)
+  ▼
+JSON response to frontend
+```
+
+Bytes over the wire: four scalar results, regardless of table size.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| EF Core / Npgsql translation of `AverageAsync(l => (double?)l.PrecisionScore, ct)` returns `numeric` boxed differently across providers and produces a runtime cast error. | Low | Already used by EF Core community as a standard pattern with Npgsql; the integration test added per FR-4 against the real PostgreSQL Testcontainer catches any provider translation regression at build-time. |
+| Test gap is hidden because the existing `KnowledgeBaseRepositoryIntegrationTests.SetupSchemaAsync` does not create the `KnowledgeBaseQuestionLogs` table. Writing the new tests against an in-memory or mocked context would not exercise the actual SQL translation. | High | Extend `SetupSchemaAsync` to also create `KnowledgeBaseQuestionLogs` (id PK, Question text, Answer text, PrecisionScore int null, StyleScore int null, and other columns needed by the entity mapping). Tests for FR-4 must run inside `KnowledgeBaseRepositoryIntegrationTests` against the real Postgres container, not against `UseInMemoryDatabase`, since InMemory does not enforce server-side aggregation semantics. |
+| Rounding behaviour change if the implementer reaches for `MidpointRounding.AwayFromZero` "to be safe", silently changing user-facing numbers (e.g. an average of 3.55 currently rounds to 3.6 with banker's rounding when the prior tail is exactly .55 — but to 3.6 also with AwayFromZero; the divergence shows up at values like 2.5 → 2 vs 3). | Medium | Acceptance test in FR-4 includes a known-input rounding assertion comparing against the prior implementation's exact behaviour (`Math.Round(x, 1)` with default `ToEven`). Reviewer must reject any explicit `MidpointRounding` argument. |
+| Future schema or column-rename change breaks a column-name-dependent test without an obvious failure signal. | Low | Test asserts on the public DTO values, not on captured SQL strings — schema renames trigger compile errors in the LINQ expressions, not silent test passes. |
+| Race window between the four round-trips inflates one count over the other (e.g., row inserted between read 1 and read 2 makes `TotalWithFeedback > TotalQuestions` impossible but skews other comparisons). | Negligible | Accepted by Decision 3. Stats are advisory, recomputed on every page load. |
+
+## Specification Amendments
+
+The spec is implementable as written, with one addition:
+
+1. **Integration test schema setup is a prerequisite, not an afterthought.** The spec's FR-4 silently assumes a test harness exists for `KnowledgeBaseQuestionLogs`. It does not. Add an explicit sub-task to FR-4: *"Extend `KnowledgeBaseRepositoryIntegrationTests.SetupSchemaAsync` to create the `KnowledgeBaseQuestionLogs` table with the columns needed by the `KnowledgeBaseQuestionLog` entity mapping (`Id`, `Question`, `Answer`, `TopK`, `SourceCount`, `DurationMs`, `CreatedAt`, `UserId`, `PrecisionScore`, `StyleScore`, `FeedbackComment`). Without this, the new tests cannot run against PostgreSQL and FR-1's 'no `SELECT *`' assertion is unverifiable."*
+
+2. **Pin the test harness explicitly.** Update FR-4 to state that the tests live in `KnowledgeBaseRepositoryIntegrationTests` (Testcontainers PostgreSQL), not in a Moq-only unit test against the repository. EF Core InMemory provider does not translate `AverageAsync` to SQL the same way Npgsql does and would defeat the purpose of FR-1's SQL-translation acceptance criterion.
+
+3. **No need for the `GroupBy(_=>1)` alternative.** Decision 1 above resolves this. Strike the "Implementer may consolidate into a single round-trip via a `GroupBy(_ => 1).Select(...)` projection" sentence from the spec to avoid implementer ambiguity.
+
+No other amendments. No new properties, no caching, no index changes.
+
+## Prerequisites
+
+- No database migration. The `KnowledgeBaseQuestionLogs` table already exists with the required columns (`PrecisionScore int?`, `StyleScore int?`).
+- No configuration or DI changes.
+- No frontend OpenAPI client regeneration (`FeedbackAggregateStats` shape is unchanged).
+- **Test infrastructure prerequisite:** `KnowledgeBaseRepositoryIntegrationTests.SetupSchemaAsync` must be extended to create the `KnowledgeBaseQuestionLogs` table before any FR-4 tests are written. This is the single non-trivial groundwork item in the change.

--- a/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/brief.md
+++ b/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/brief.md
@@ -1,0 +1,45 @@
+## Module
+KnowledgeBase
+
+## Finding
+`KnowledgeBaseRepository.GetFeedbackStatsAsync` fetches every feedback row that has any score into a `List<>` in application memory and then averages them in C#:
+
+```csharp
+// backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs:303-321
+var withFeedback = await _context.KnowledgeBaseQuestionLogs
+    .Where(l => l.PrecisionScore != null || l.StyleScore != null)
+    .ToListAsync(ct);                          // ← entire result set materialised
+
+double? avgPrecision = withFeedback.Count > 0
+    ? withFeedback.Where(l => l.PrecisionScore != null)
+                  .Average(l => (double?)l.PrecisionScore)
+    : null;
+```
+
+`KnowledgeBaseQuestionLogs` grows with every `/ask` call. As usage increases, this method will transfer an unbounded number of full log rows (including `Question` and `Answer` text fields) over the wire just to compute two scalar averages.
+
+## Why it matters
+SQL aggregation (`AVG`, `COUNT`) is far more efficient than client-side LINQ. This is a concrete performance regression path: the method is called every time the Feedback page loads its stats header. Loading full text columns (`Question`, `Answer`) into memory for averaging violates KISS — the DB can compute this in a single pass over an index.
+
+## Suggested fix
+Replace the in-memory aggregation with a single SQL-side query using EF Core:
+
+```csharp
+var totalQuestions = await _context.KnowledgeBaseQuestionLogs.CountAsync(ct);
+
+var totalWithFeedback = await _context.KnowledgeBaseQuestionLogs
+    .CountAsync(l => l.PrecisionScore != null || l.StyleScore != null, ct);
+
+var avgPrecision = await _context.KnowledgeBaseQuestionLogs
+    .Where(l => l.PrecisionScore != null)
+    .AverageAsync(l => (double?)l.PrecisionScore, ct);
+
+var avgStyle = await _context.KnowledgeBaseQuestionLogs
+    .Where(l => l.StyleScore != null)
+    .AverageAsync(l => (double?)l.StyleScore, ct);
+```
+
+That's 4 lightweight aggregation queries (or collapse into one via `GroupBy(_ => 1)` + `.Select`) instead of a full table scan materialised in memory.
+
+---
+_Filed by daily arch-review routine on 2026-05-13._

--- a/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/impl/main.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/impl/main.r1.md
@@ -1,0 +1,12 @@
+This is a standalone git repository under `.worktrees/` (not a registered `git worktree add` worktree — it's not in the main repo's worktree list). Base branch is `main`.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/spec.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/spec.r1.md
@@ -1,0 +1,151 @@
+# Specification: Replace In-Memory Aggregation in `GetFeedbackStatsAsync` with SQL-Side Aggregation
+
+## Summary
+`KnowledgeBaseRepository.GetFeedbackStatsAsync` currently materialises every feedback-bearing row into application memory before averaging two scalar values in C#. This spec replaces the in-memory aggregation with EF Core SQL-side `Count`/`Average` queries to eliminate an unbounded data transfer that grows with every `/ask` call and is invoked each time the Feedback page loads its stats header.
+
+## Background
+The KnowledgeBase module logs every question/answer pair to `KnowledgeBaseQuestionLogs`, including full `Question` and `Answer` text columns. Users can score responses with `PrecisionScore` and `StyleScore` (1–5). The Feedback page displays a stats header summarising:
+
+- Total number of questions asked
+- Total number of questions with any user feedback
+- Average precision score
+- Average style score
+
+Current implementation at `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs:299-322`:
+
+```csharp
+var withFeedback = await _context.KnowledgeBaseQuestionLogs
+    .Where(l => l.PrecisionScore != null || l.StyleScore != null)
+    .ToListAsync(ct);
+
+double? avgPrecision = withFeedback.Count > 0
+    ? withFeedback.Where(l => l.PrecisionScore != null).Average(l => (double?)l.PrecisionScore)
+    : null;
+```
+
+The `.ToListAsync(ct)` materialises full rows — including large `Question` and `Answer` text columns — for the sole purpose of computing two scalar averages. As `KnowledgeBaseQuestionLogs` grows monotonically with usage, the cost of every Feedback page load grows linearly with the entire history of feedback rows. The SQL engine can compute these aggregates in a single index scan; the cost should be effectively constant relative to result size.
+
+This is a concrete performance regression path identified by the arch-review routine on 2026-05-13.
+
+## Functional Requirements
+
+### FR-1: Replace in-memory aggregation with SQL-side aggregation
+`GetFeedbackStatsAsync` MUST compute all four scalar values (`TotalQuestions`, `TotalWithFeedback`, `AvgPrecisionScore`, `AvgStyleScore`) via EF Core aggregation methods (`CountAsync`, `AverageAsync`) that translate to SQL `COUNT`/`AVG`. No code path may materialise log rows for the purpose of computing these statistics.
+
+**Acceptance criteria:**
+- No call to `.ToListAsync(...)`, `.ToArrayAsync(...)`, `.AsEnumerable()`, or equivalent appears in `GetFeedbackStatsAsync`.
+- EF Core query log (verified at debug level with a SQL provider, or via an integration test capturing executed SQL) shows only aggregate queries — no `SELECT *` or column projection that includes `Question`/`Answer` columns from `KnowledgeBaseQuestionLogs`.
+- Each query passes the `CancellationToken` provided to the method.
+
+### FR-2: Preserve existing return contract
+The returned `FeedbackAggregateStats` MUST be functionally identical to the current implementation for every input state.
+
+**Acceptance criteria:**
+- `TotalQuestions` = total row count of `KnowledgeBaseQuestionLogs`.
+- `TotalWithFeedback` = count of rows where `PrecisionScore IS NOT NULL OR StyleScore IS NOT NULL`.
+- `AvgPrecisionScore` = average of non-null `PrecisionScore`, rounded to 1 decimal place; `null` when no precision scores exist.
+- `AvgStyleScore` = average of non-null `StyleScore`, rounded to 1 decimal place; `null` when no style scores exist.
+- Rounding uses `Math.Round(value, 1)` (default banker's rounding — same as today) to preserve existing UI numbers exactly.
+- The DTO shape `FeedbackAggregateStats` is unchanged. No new properties added, none removed.
+
+### FR-3: Empty-table behaviour
+When the table is empty, or when no rows have scores, the method MUST NOT throw.
+
+**Acceptance criteria:**
+- Empty table → returns `{ TotalQuestions: 0, TotalWithFeedback: 0, AvgPrecisionScore: null, AvgStyleScore: null }`.
+- No precision scores anywhere → `AvgPrecisionScore: null` (other fields computed normally).
+- No style scores anywhere → `AvgStyleScore: null` (other fields computed normally).
+- This requires using the nullable overload of `AverageAsync` (`Average(l => (double?)l.PrecisionScore)`) so an empty filter set returns `null` rather than throwing `InvalidOperationException`.
+
+### FR-4: Test coverage
+Add or update tests proving the new behaviour.
+
+**Acceptance criteria:**
+- Unit/integration test for empty table → all-zero/null result, no exception.
+- Test for table with rows but zero feedback → `TotalQuestions > 0`, `TotalWithFeedback = 0`, both averages `null`.
+- Test for table with mixed feedback (some precision-only, some style-only, some both, some none) → correct counts and averages, both rounded to 1 decimal.
+- Test asserts rounding behaviour matches the prior implementation for a known input.
+- Existing tests touching `GetFeedbackStatsAsync` continue to pass without semantic changes.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Time complexity for the stats endpoint MUST be O(log n) or better given an index on the relevant columns, and MUST NOT scale linearly with row count in materialised bytes transferred.
+- Bytes transferred from database to application per call MUST be constant (four scalar results), independent of `KnowledgeBaseQuestionLogs` size.
+- Acceptable latency target for the stats endpoint: < 100 ms p95 on the production dataset.
+
+### NFR-2: Security
+- No change to authorization model — the method is already only reachable through the existing Feedback page handler. No new endpoints introduced.
+- Cancellation token propagation MUST be preserved on every async DB call to allow request cancellation.
+- No raw user input is composed into SQL; all queries are parameterised through EF Core's expression translation.
+
+### NFR-3: Backward compatibility
+- Public method signature `Task<FeedbackAggregateStats> GetFeedbackStatsAsync(CancellationToken ct = default)` is unchanged.
+- `FeedbackAggregateStats` DTO shape is unchanged.
+- No database schema migration is required.
+- No API contract change visible to the frontend client.
+
+## Data Model
+No schema changes. The implementation reads existing columns on `KnowledgeBaseQuestionLogs`:
+
+| Column           | Type     | Used for                                           |
+|------------------|----------|----------------------------------------------------|
+| `Id`             | PK       | (Implicit row count.)                              |
+| `PrecisionScore` | int?     | Filter, average.                                   |
+| `StyleScore`     | int?     | Filter, average.                                   |
+
+A composite or filtered index on `(PrecisionScore, StyleScore)` would further improve aggregation performance, but is **out of scope** for this change (see Out of Scope). If profiling after this change shows the aggregation queries are still slow on production volume, an index can be added in a follow-up.
+
+## API / Interface Design
+No public API changes. Internal repository method body is rewritten.
+
+Proposed implementation (illustrative — final shape may use a single `GroupBy(_ => 1)` projection or four separate calls; either is acceptable provided FR-1 through FR-3 are met):
+
+```csharp
+public async Task<FeedbackAggregateStats> GetFeedbackStatsAsync(CancellationToken ct = default)
+{
+    var totalQuestions = await _context.KnowledgeBaseQuestionLogs
+        .CountAsync(ct);
+
+    var totalWithFeedback = await _context.KnowledgeBaseQuestionLogs
+        .CountAsync(l => l.PrecisionScore != null || l.StyleScore != null, ct);
+
+    var avgPrecision = await _context.KnowledgeBaseQuestionLogs
+        .Where(l => l.PrecisionScore != null)
+        .AverageAsync(l => (double?)l.PrecisionScore, ct);
+
+    var avgStyle = await _context.KnowledgeBaseQuestionLogs
+        .Where(l => l.StyleScore != null)
+        .AverageAsync(l => (double?)l.StyleScore, ct);
+
+    return new FeedbackAggregateStats
+    {
+        TotalQuestions = totalQuestions,
+        TotalWithFeedback = totalWithFeedback,
+        AvgPrecisionScore = avgPrecision.HasValue ? Math.Round(avgPrecision.Value, 1) : null,
+        AvgStyleScore = avgStyle.HasValue ? Math.Round(avgStyle.Value, 1) : null,
+    };
+}
+```
+
+Implementer may consolidate into a single round-trip via a `GroupBy(_ => 1).Select(...)` projection if EF Core translates it cleanly for the configured provider; otherwise the four-call form above is acceptable since each call is a constant-size aggregate and the round-trip cost is dominated by the network, not query cost.
+
+## Dependencies
+- EF Core (already in use by the repository) — relies on its translation of `CountAsync` and `AverageAsync` with predicate lambdas.
+- Existing `KnowledgeBaseQuestionLogs` `DbSet<>` registration in `AppDbContext` — no change.
+- Existing test harness for repository tests (xUnit + the project's standard EF Core test setup).
+
+No new packages, services, or configuration entries are introduced.
+
+## Out of Scope
+- Adding new database indexes on `PrecisionScore` / `StyleScore`. This is a follow-up optimisation if performance is still insufficient after this change.
+- Changes to the Feedback page UI, the MediatR handler, or the API controller surface.
+- Caching the stats result (e.g. in-memory or distributed cache). The point of this fix is that the underlying DB query becomes cheap enough not to need caching.
+- Schema changes or DTO additions (e.g. p50/p95 score, score distribution histogram).
+- Other unrelated performance issues elsewhere in `KnowledgeBaseRepository` or the module.
+- Migrating other repositories away from in-memory aggregation patterns. Only the method named in the brief is changed.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/task-plan.r1.md
+++ b/artifacts/feat-arch-review-knowledgebase-getfeedbacksta/task-plan.r1.md
@@ -1,0 +1,549 @@
+# KnowledgeBase Feedback Stats SQL-Side Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the in-memory row materialisation in `KnowledgeBaseRepository.GetFeedbackStatsAsync` with EF Core SQL-side `COUNT`/`AVG` aggregates so the Feedback page stats query stops scaling with table size.
+
+**Architecture:** Rewrite the body of a single repository method to issue four constant-size aggregate queries (`CountAsync` all, `CountAsync` with predicate, two `AverageAsync` with nullable-double cast over filtered sets) and assemble the existing `FeedbackAggregateStats` DTO from the four scalars. No contract or schema changes. Tests are added to an existing Testcontainers PostgreSQL integration class, whose schema setup is first extended to include the `KnowledgeBaseQuestionLogs` table (currently absent from the test schema, which is why no test currently covers this method).
+
+**Tech Stack:** .NET 8, EF Core (Npgsql provider), xUnit, Testcontainers PostgreSQL (`pgvector/pgvector:pg16` image), `KnowledgeBaseRepositoryIntegrationTests`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs` — replace the body of `GetFeedbackStatsAsync` (lines 299–322). Public method signature is unchanged.
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — extend `SetupSchemaAsync` to create the `KnowledgeBaseQuestionLogs` table; add four new `[Fact]` tests covering FR-4 scenarios; add a private helper for inserting feedback-log rows.
+
+**No new files.** No new namespaces or interfaces. No schema migrations. No frontend/OpenAPI client regeneration.
+
+**Domain shapes (read-only references — do NOT modify):**
+- `backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/KnowledgeBaseQuestionLog.cs` — entity with `PrecisionScore int?`, `StyleScore int?` and other columns.
+- `backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/FeedbackAggregateStats.cs` — DTO with `TotalQuestions`, `TotalWithFeedback`, `AvgPrecisionScore`, `AvgStyleScore`.
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseQuestionLogConfiguration.cs` — EF Core mapping; the entity lives in the `public` schema.
+
+---
+
+## Task 1: Extend integration test schema to include `KnowledgeBaseQuestionLogs`
+
+**Why first:** Without this, no FR-4 test can run against the real Postgres container. The existing schema setup only creates `KnowledgeBaseDocuments` and `KnowledgeBaseChunks`. Inserting `KnowledgeBaseQuestionLog` rows via EF Core would fail at runtime with a missing-relation error.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs:52-91` — extend `SetupSchemaAsync`.
+
+- [ ] **Step 1: Write a failing schema-presence test**
+
+Add this `[Fact]` at the bottom of the class (just above the closing brace at line 331), so it runs against the post-setup schema. The intent is purely to assert the table exists; we will delete this scaffolding test in Task 2 once real feedback tests cover the same surface.
+
+```csharp
+    [Fact]
+    public async Task SetupSchema_CreatesKnowledgeBaseQuestionLogsTable()
+    {
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = 'KnowledgeBaseQuestionLogs'
+            );
+            """;
+
+        var exists = (bool)(await cmd.ExecuteScalarAsync())!;
+        Assert.True(exists, "KnowledgeBaseQuestionLogs table must be created by SetupSchemaAsync");
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SetupSchema_CreatesKnowledgeBaseQuestionLogsTable" --logger "console;verbosity=normal"`
+
+Expected: FAIL. Assertion fails with `KnowledgeBaseQuestionLogs table must be created by SetupSchemaAsync` because `SetupSchemaAsync` does not create it.
+
+- [ ] **Step 3: Extend `SetupSchemaAsync` to create the table**
+
+In `KnowledgeBaseRepositoryIntegrationTests.cs`, modify `SetupSchemaAsync` (currently lines 52–91). Append the `KnowledgeBaseQuestionLogs` table creation to the existing `cmd.CommandText` triple-quoted string. The column types and nullability must match the EF Core entity mapping in `KnowledgeBaseQuestionLogConfiguration` and the entity property types in `KnowledgeBaseQuestionLog.cs`. Note `CreatedAt` is `DateTimeOffset` so it maps to `timestamp with time zone` (`timestamptz`).
+
+Replace the existing `SetupSchemaAsync` method body with:
+
+```csharp
+    private async Task SetupSchemaAsync()
+    {
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE EXTENSION IF NOT EXISTS vector;
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseDocuments" (
+                "Id"           uuid NOT NULL PRIMARY KEY,
+                "Filename"     varchar(500) NOT NULL,
+                "SourcePath"   varchar(1000) NOT NULL,
+                "ContentType"  varchar(100) NOT NULL,
+                "ContentHash"  varchar(64) NOT NULL UNIQUE,
+                "Status"       varchar(50) NOT NULL,
+                "DocumentType" integer NOT NULL DEFAULT 0,
+                "CreatedAt"    timestamp NOT NULL,
+                "IndexedAt"    timestamp NULL,
+                "DriveId"      text NULL,
+                "GraphItemId"  text NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseChunks" (
+                "Id"           uuid NOT NULL PRIMARY KEY,
+                "DocumentId"   uuid NOT NULL REFERENCES public."KnowledgeBaseDocuments"("Id") ON DELETE CASCADE,
+                "ChunkIndex"   integer NOT NULL,
+                "Content"      text NOT NULL DEFAULT '',
+                "Summary"      text NOT NULL DEFAULT '',
+                "DocumentType" integer NOT NULL DEFAULT 0,
+                "Embedding"    vector(3)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_kb_chunks_embedding
+                ON public."KnowledgeBaseChunks"
+                USING hnsw ("Embedding" vector_cosine_ops)
+                WITH (m = 16, ef_construction = 64);
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseQuestionLogs" (
+                "Id"              uuid NOT NULL PRIMARY KEY,
+                "Question"        text NOT NULL,
+                "Answer"          text NOT NULL,
+                "TopK"            integer NOT NULL,
+                "SourceCount"     integer NOT NULL,
+                "DurationMs"      bigint NOT NULL,
+                "CreatedAt"       timestamp with time zone NOT NULL,
+                "UserId"          text NULL,
+                "PrecisionScore"  integer NULL,
+                "StyleScore"      integer NULL,
+                "FeedbackComment" text NULL
+            );
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SetupSchema_CreatesKnowledgeBaseQuestionLogsTable" --logger "console;verbosity=normal"`
+
+Expected: PASS — the table now exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+git commit -m "test(knowledge-base): create KnowledgeBaseQuestionLogs table in integration test schema"
+```
+
+---
+
+## Task 2: Write failing feedback-stats integration tests (TDD red phase)
+
+**Why:** Before changing `GetFeedbackStatsAsync`, lock in the four FR-4 scenarios against the real Postgres container so any regression in SQL translation or rounding is caught.
+
+The existing implementation already returns correct values for these scenarios (the bug is performance, not correctness). The tests below should therefore PASS against the current implementation — we use them to (a) prove the schema setup from Task 1 is usable and (b) provide a regression guard for the rewrite in Task 3. The "TDD red phase" here is on the schema-setup change, not on the production code; the existing scaffold test from Task 1 is replaced by these realistic tests.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — delete the scaffold `SetupSchema_CreatesKnowledgeBaseQuestionLogsTable` test from Task 1, add a private builder helper, and add four feedback-stats `[Fact]` tests.
+
+- [ ] **Step 1: Delete the scaffold test from Task 1**
+
+Remove the `SetupSchema_CreatesKnowledgeBaseQuestionLogsTable` method added in Task 1. The four new tests below cover the same schema indirectly by inserting and querying rows.
+
+- [ ] **Step 2: Add a private helper for building question-log rows**
+
+Insert this private static method directly below the existing `MakeDocument` helper (around line 110 in the current file, just before the first `[Fact]` test):
+
+```csharp
+    private static KnowledgeBaseQuestionLog MakeQuestionLog(
+        int? precisionScore = null,
+        int? styleScore = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Question = "q",
+            Answer = "a",
+            TopK = 5,
+            SourceCount = 1,
+            DurationMs = 100,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UserId = null,
+            PrecisionScore = precisionScore,
+            StyleScore = styleScore,
+            FeedbackComment = null,
+        };
+```
+
+- [ ] **Step 3: Add the empty-table test**
+
+Add this `[Fact]` at the bottom of the class (just above the closing brace):
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_EmptyTable_ReturnsZeroCountsAndNullAverages()
+    {
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(0, stats.TotalQuestions);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+```
+
+- [ ] **Step 4: Add the rows-but-no-feedback test**
+
+Add this `[Fact]` immediately after the previous one:
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_RowsWithoutScores_ReturnsTotalsAndNullAverages()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(),
+            MakeQuestionLog(),
+            MakeQuestionLog());
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(3, stats.TotalQuestions);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+```
+
+- [ ] **Step 5: Add the mixed-feedback test**
+
+Add this `[Fact]` immediately after the previous one. The dataset contains:
+- 1 row with neither score
+- 1 row with precision only (`PrecisionScore = 5`)
+- 1 row with style only (`StyleScore = 3`)
+- 1 row with both (`PrecisionScore = 4`, `StyleScore = 5`)
+
+So `TotalQuestions = 4`, `TotalWithFeedback = 3`, `AvgPrecisionScore = (5 + 4) / 2 = 4.5`, `AvgStyleScore = (3 + 5) / 2 = 4.0`.
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_MixedFeedback_ReturnsCorrectCountsAndAverages()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(),
+            MakeQuestionLog(precisionScore: 5),
+            MakeQuestionLog(styleScore: 3),
+            MakeQuestionLog(precisionScore: 4, styleScore: 5));
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(4, stats.TotalQuestions);
+        Assert.Equal(3, stats.TotalWithFeedback);
+        Assert.Equal(4.5, stats.AvgPrecisionScore);
+        Assert.Equal(4.0, stats.AvgStyleScore);
+    }
+```
+
+- [ ] **Step 6: Add the rounding test**
+
+Add this `[Fact]` immediately after the previous one. Three precision scores `5, 5, 4` average to `4.6666...`, which `Math.Round(_, 1)` (banker's rounding, default `MidpointRounding.ToEven`) rounds to `4.7`. Two style scores `2, 3` average to exactly `2.5`, which banker's rounding rounds to `2.5` (no rounding needed at 1 decimal — already exact). To exercise the banker's-rounding midpoint, also pick `3, 2` style scores so the average is `2.5` (already exact at 1 dp). Use precision `1, 2` → average `1.5` (exact at 1 dp). The point of this test is: rounding does not throw and matches `Math.Round(value, 1)` for a known computed value.
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_RoundsAveragesToOneDecimalUsingBankersRounding()
+    {
+        // PrecisionScore raw average = (5 + 5 + 4) / 3 = 4.6666... -> 4.7
+        // StyleScore raw average     = (1 + 2) / 2     = 1.5       -> 1.5
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(precisionScore: 5, styleScore: 1),
+            MakeQuestionLog(precisionScore: 5, styleScore: 2),
+            MakeQuestionLog(precisionScore: 4));
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(3, stats.TotalQuestions);
+        Assert.Equal(3, stats.TotalWithFeedback);
+        Assert.NotNull(stats.AvgPrecisionScore);
+        Assert.NotNull(stats.AvgStyleScore);
+        Assert.Equal(Math.Round((5d + 5d + 4d) / 3d, 1), stats.AvgPrecisionScore!.Value);
+        Assert.Equal(Math.Round((1d + 2d) / 2d, 1), stats.AvgStyleScore!.Value);
+    }
+```
+
+- [ ] **Step 7: Run all four feedback tests to verify they pass against the current implementation**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetFeedbackStatsAsync" --logger "console;verbosity=normal"`
+
+Expected: 4 tests PASS. The current implementation already returns correct values; we are establishing a regression baseline before changing the implementation. Each test runs against a fresh Testcontainer instance because the class implements `IAsyncLifetime` and re-creates the schema per test class lifetime (each `[Fact]` shares the same container but the table is empty at start of class; tests inside the class share data. **Important:** rerun the tests one at a time if cross-test pollution becomes visible — current container lifecycle gives each test class one container, not one per test.)
+
+Actually, looking at the class, `_container` is per-instance (xUnit creates one instance per test by default), so each `[Fact]` gets a fresh container — good. No clean-up needed between tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+git commit -m "test(knowledge-base): cover GetFeedbackStatsAsync FR-4 scenarios"
+```
+
+---
+
+## Task 3: Rewrite `GetFeedbackStatsAsync` to use SQL-side aggregation
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs:299-322` — replace method body. Public signature, namespace, and return type are unchanged.
+
+- [ ] **Step 1: Replace the method body**
+
+Locate `GetFeedbackStatsAsync` (currently lines 299–322). Replace the entire method with the version below. All four DB calls forward the `CancellationToken`; no row materialisation occurs; the nullable-double cast in `AverageAsync` makes empty filter sets return `null` without throwing.
+
+```csharp
+    public async Task<FeedbackAggregateStats> GetFeedbackStatsAsync(CancellationToken ct = default)
+    {
+        var totalQuestions = await _context.KnowledgeBaseQuestionLogs
+            .CountAsync(ct);
+
+        var totalWithFeedback = await _context.KnowledgeBaseQuestionLogs
+            .CountAsync(l => l.PrecisionScore != null || l.StyleScore != null, ct);
+
+        var avgPrecision = await _context.KnowledgeBaseQuestionLogs
+            .Where(l => l.PrecisionScore != null)
+            .AverageAsync(l => (double?)l.PrecisionScore, ct);
+
+        var avgStyle = await _context.KnowledgeBaseQuestionLogs
+            .Where(l => l.StyleScore != null)
+            .AverageAsync(l => (double?)l.StyleScore, ct);
+
+        return new FeedbackAggregateStats
+        {
+            TotalQuestions = totalQuestions,
+            TotalWithFeedback = totalWithFeedback,
+            AvgPrecisionScore = avgPrecision.HasValue ? Math.Round(avgPrecision.Value, 1) : null,
+            AvgStyleScore = avgStyle.HasValue ? Math.Round(avgStyle.Value, 1) : null,
+        };
+    }
+```
+
+Notes:
+- `Math.Round(value, 1)` uses default `MidpointRounding.ToEven` — do **not** pass `MidpointRounding.AwayFromZero`. The spec requires exact UI parity with the prior implementation, which used the default.
+- Do not consolidate the four calls into a `GroupBy(_ => 1).Select(...)` projection. Arch-review Decision 1 explicitly rejects it.
+- Do not wrap in a transaction (arch-review Decision 3).
+
+- [ ] **Step 2: Build to confirm compilation**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 3: Run the four feedback-stats tests to confirm they still pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetFeedbackStatsAsync" --logger "console;verbosity=normal"`
+
+Expected: 4 tests PASS — same outputs as in Task 2 step 7, now produced by SQL-side aggregation.
+
+- [ ] **Step 4: Run the full integration test class to confirm no collateral damage**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseRepositoryIntegrationTests" --logger "console;verbosity=normal"`
+
+Expected: all tests in `KnowledgeBaseRepositoryIntegrationTests` PASS (existing tests for `AddChunksAsync`, `SearchSimilarAsync`, `GetChunkByIdAsync`, etc. plus the four new feedback tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
+git commit -m "perf(knowledge-base): aggregate feedback stats in SQL instead of materialising rows"
+```
+
+---
+
+## Task 4: Verify SQL translation does not materialise rows (FR-1 acceptance)
+
+**Why:** FR-1's acceptance criterion includes verifying that the EF Core query log shows aggregate-only SQL — no `SELECT *` and no `Question`/`Answer` column projection. We add a one-off test that captures executed SQL via `DbContext` logging and asserts the patterns.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — add one `[Fact]` and a small private `LogCapturingLoggerProvider` class scoped to the test file.
+
+- [ ] **Step 1: Add a SQL-capture helper class inside the test file**
+
+At the end of the file (after the closing brace of `KnowledgeBaseRepositoryIntegrationTests`), append the following helper. It captures EF Core's `Microsoft.EntityFrameworkCore.Database.Command` log messages into a list for assertion.
+
+```csharp
+internal sealed class CapturingLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
+{
+    public List<string> Messages { get; } = new();
+
+    public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) =>
+        new CapturingLogger(Messages);
+
+    public void Dispose() { }
+
+    private sealed class CapturingLogger : Microsoft.Extensions.Logging.ILogger
+    {
+        private readonly List<string> _messages;
+
+        public CapturingLogger(List<string> messages) => _messages = messages;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}
+```
+
+Add the required using directive at the top of the file if not already present:
+
+```csharp
+using Microsoft.Extensions.Logging;
+```
+
+- [ ] **Step 2: Add the SQL-shape test**
+
+Add this `[Fact]` to `KnowledgeBaseRepositoryIntegrationTests`, just below the rounding test from Task 2. It builds a *separate* `ApplicationDbContext` wired up with the capturing logger, invokes the repository, and asserts the executed SQL contains the expected aggregate forms and does **not** project the `Question` or `Answer` columns.
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(precisionScore: 5, styleScore: 4),
+            MakeQuestionLog());
+        await _context.SaveChangesAsync();
+
+        var loggerProvider = new CapturingLoggerProvider();
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(loggerProvider);
+            builder.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Information);
+        });
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(_container.GetConnectionString());
+        dataSourceBuilder.UseVector();
+        await using var dataSource = dataSourceBuilder.Build();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(dataSource)
+            .UseLoggerFactory(loggerFactory)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        await using var ctx = new ApplicationDbContext(options);
+        var repo = new KnowledgeBaseRepository(ctx);
+
+        var stats = await repo.GetFeedbackStatsAsync();
+
+        Assert.Equal(2, stats.TotalQuestions);
+
+        var sql = string.Join("\n", loggerProvider.Messages);
+        Assert.Contains("COUNT(*)", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AVG(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"Question\"", sql);
+        Assert.DoesNotContain("\"Answer\"", sql);
+    }
+```
+
+- [ ] **Step 3: Run the new test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows" --logger "console;verbosity=normal"`
+
+Expected: PASS. The captured SQL log contains `COUNT(*)` and `AVG(` substrings, and contains no `"Question"` or `"Answer"` identifiers.
+
+If FAIL with "did not contain COUNT(*)": EF Core may log the aggregate as `COUNT(*)::int` or wrap inside a subquery — adjust the substring search to `COUNT(` and re-run. The intent is to confirm aggregation, not match exact whitespace.
+
+If FAIL with "contains \"Question\"" — that is a real regression in the repository implementation and must be fixed in Task 3 before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+git commit -m "test(knowledge-base): assert GetFeedbackStatsAsync emits aggregate SQL without row materialisation"
+```
+
+---
+
+## Task 5: Final validation
+
+**Why:** Confirm the full backend solution builds, formats cleanly, and the integration test class passes end-to-end.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run `dotnet build` on the full backend solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+If the warning count is non-zero, check whether any new warning was introduced by Tasks 1–4. The repository policy is to keep warnings flat; address only warnings you introduced. Pre-existing warnings stay as-is.
+
+- [ ] **Step 2: Run `dotnet format` on the modified files**
+
+Run: `dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs`
+
+Expected: command exits 0 with no formatting changes printed. If it makes edits, review them and amend the most recent commit:
+
+```bash
+git add -u
+git commit --amend --no-edit
+```
+
+- [ ] **Step 3: Run the full `KnowledgeBaseRepositoryIntegrationTests` class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseRepositoryIntegrationTests" --logger "console;verbosity=normal"`
+
+Expected: all tests PASS, including:
+- Existing tests for `AddChunksAsync`, `SearchSimilarAsync`, `GetChunkByIdAsync`, `AddDocumentAsync`, `DeleteDocumentAsync`, `GetDocumentByGraphItemIdAsync`.
+- `GetFeedbackStatsAsync_EmptyTable_ReturnsZeroCountsAndNullAverages`
+- `GetFeedbackStatsAsync_RowsWithoutScores_ReturnsTotalsAndNullAverages`
+- `GetFeedbackStatsAsync_MixedFeedback_ReturnsCorrectCountsAndAverages`
+- `GetFeedbackStatsAsync_RoundsAveragesToOneDecimalUsingBankersRounding`
+- `GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows`
+
+- [ ] **Step 4: Run the full backend test project (smoke check for cross-test regressions)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --logger "console;verbosity=minimal"`
+
+Expected: all tests PASS, including the unrelated unit/integration tests. If something unrelated fails, check whether it was already failing on the branch tip before the plan was executed; if so, it is out of scope.
+
+- [ ] **Step 5: No further commit needed**
+
+If Steps 1–4 produced no edits, there is nothing to commit. The change is complete.
+
+---
+
+## Spec Coverage Check
+
+| Spec / Arch-Review item | Covered by |
+|---|---|
+| FR-1: SQL-side aggregation, no `ToListAsync`, cancellation token propagation | Task 3 step 1; Task 4 step 2 (SQL-shape assertion) |
+| FR-2: Identical `FeedbackAggregateStats` shape and rounding (banker's rounding) | Task 3 step 1 (no DTO changes; `Math.Round(_, 1)` default); Task 2 step 6 (rounding test) |
+| FR-3: Empty / no-score behaviour does not throw | Task 2 step 3 (empty table); Task 2 step 4 (no scores anywhere); Task 3 step 1 (nullable-double cast) |
+| FR-4: Test coverage for empty / no-feedback / mixed / rounding cases | Task 2 steps 3, 4, 5, 6 |
+| FR-4 prerequisite (arch-review amendment 1): schema setup for `KnowledgeBaseQuestionLogs` | Task 1 step 3 |
+| FR-4 pinning (arch-review amendment 2): Testcontainers PostgreSQL, not InMemory | All tests live in `KnowledgeBaseRepositoryIntegrationTests`, which uses `PostgreSqlContainer` |
+| Arch-review amendment 3: do not use `GroupBy(_=>1)` projection | Task 3 step 1 explicit guidance + code |
+| Arch-review Decision 2: nullable-double cast in `AverageAsync` | Task 3 step 1 code |
+| Arch-review Decision 3: no explicit transaction | Task 3 step 1 (none added) |
+| NFR-1: bytes transferred constant; latency target — implicitly satisfied by FR-1 (four scalar aggregates) | Task 4 SQL-shape test confirms no row projection |
+| NFR-2: cancellation propagation | Task 3 step 1 — every `*Async` call receives `ct` |
+| NFR-3: backward compatibility — signature unchanged, DTO unchanged, no migration, no client regen | Task 3 step 1 (method signature unchanged); no migration file added; no contract file changed |
+| Out-of-scope items (caching, new indexes, UI changes, other repos) | Not touched in any task |
+
+No spec requirements are missing from the plan.

--- a/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
@@ -298,24 +298,24 @@ public class KnowledgeBaseRepository : IKnowledgeBaseRepository
 
     public async Task<FeedbackAggregateStats> GetFeedbackStatsAsync(CancellationToken ct = default)
     {
-        var totalQuestions = await _context.KnowledgeBaseQuestionLogs.CountAsync(ct);
+        var totalQuestions = await _context.KnowledgeBaseQuestionLogs
+            .CountAsync(ct);
 
-        var withFeedback = await _context.KnowledgeBaseQuestionLogs
-            .Where(l => l.PrecisionScore != null || l.StyleScore != null)
-            .ToListAsync(ct);
+        var totalWithFeedback = await _context.KnowledgeBaseQuestionLogs
+            .CountAsync(l => l.PrecisionScore != null || l.StyleScore != null, ct);
 
-        double? avgPrecision = withFeedback.Count > 0
-            ? withFeedback.Where(l => l.PrecisionScore != null).Average(l => (double?)l.PrecisionScore)
-            : null;
+        var avgPrecision = await _context.KnowledgeBaseQuestionLogs
+            .Where(l => l.PrecisionScore != null)
+            .AverageAsync(l => (double?)l.PrecisionScore, ct);
 
-        double? avgStyle = withFeedback.Count > 0
-            ? withFeedback.Where(l => l.StyleScore != null).Average(l => (double?)l.StyleScore)
-            : null;
+        var avgStyle = await _context.KnowledgeBaseQuestionLogs
+            .Where(l => l.StyleScore != null)
+            .AverageAsync(l => (double?)l.StyleScore, ct);
 
         return new FeedbackAggregateStats
         {
             TotalQuestions = totalQuestions,
-            TotalWithFeedback = withFeedback.Count,
+            TotalWithFeedback = totalWithFeedback,
             AvgPrecisionScore = avgPrecision.HasValue ? Math.Round(avgPrecision.Value, 1) : null,
             AvgStyleScore = avgStyle.HasValue ? Math.Round(avgStyle.Value, 1) : null,
         };

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.KnowledgeBase;
 using DotNet.Testcontainers.Configurations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using Testcontainers.PostgreSql;
 using Xunit;
@@ -426,5 +427,81 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
         Assert.NotNull(stats.AvgStyleScore);
         Assert.Equal(Math.Round((5d + 5d + 4d) / 3d, 1), stats.AvgPrecisionScore!.Value);
         Assert.Equal(Math.Round((1d + 2d) / 2d, 1), stats.AvgStyleScore!.Value);
+    }
+
+    [Fact]
+    public async Task GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(precisionScore: 5, styleScore: 4),
+            MakeQuestionLog());
+        await _context.SaveChangesAsync();
+
+        var loggerProvider = new CapturingLoggerProvider();
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(loggerProvider);
+            builder.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Information);
+        });
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(_container.GetConnectionString());
+        dataSourceBuilder.UseVector();
+        await using var dataSource = dataSourceBuilder.Build();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(dataSource)
+            .UseLoggerFactory(loggerFactory)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        await using var ctx = new ApplicationDbContext(options);
+        var repo = new KnowledgeBaseRepository(ctx);
+
+        var stats = await repo.GetFeedbackStatsAsync();
+
+        Assert.Equal(2, stats.TotalQuestions);
+
+        var sql = string.Join("\n", loggerProvider.Messages);
+        Assert.Contains("COUNT(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AVG(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"Question\"", sql);
+        Assert.DoesNotContain("\"Answer\"", sql);
+    }
+}
+
+internal sealed class CapturingLoggerProvider : ILoggerProvider
+{
+    public List<string> Messages { get; } = new();
+
+    public ILogger CreateLogger(string categoryName) =>
+        new CapturingLogger(Messages);
+
+    public void Dispose() { }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly List<string> _messages;
+
+        public CapturingLogger(List<string> messages) => _messages = messages;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
@@ -86,6 +86,20 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
                 ON public."KnowledgeBaseChunks"
                 USING hnsw ("Embedding" vector_cosine_ops)
                 WITH (m = 16, ef_construction = 64);
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseQuestionLogs" (
+                "Id"              uuid NOT NULL PRIMARY KEY,
+                "Question"        text NOT NULL,
+                "Answer"          text NOT NULL,
+                "TopK"            integer NOT NULL,
+                "SourceCount"     integer NOT NULL,
+                "DurationMs"      bigint NOT NULL,
+                "CreatedAt"       timestamp with time zone NOT NULL,
+                "UserId"          text NULL,
+                "PrecisionScore"  integer NULL,
+                "StyleScore"      integer NULL,
+                "FeedbackComment" text NULL
+            );
             """;
         await cmd.ExecuteNonQueryAsync();
     }
@@ -327,5 +341,23 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
 
         Assert.Empty(afterDelete);
         Assert.Empty(chunksAfterDelete);
+    }
+
+    [Fact]
+    public async Task SetupSchema_CreatesKnowledgeBaseQuestionLogsTable()
+    {
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = 'KnowledgeBaseQuestionLogs'
+            );
+            """;
+
+        var exists = (bool)(await cmd.ExecuteScalarAsync())!;
+        Assert.True(exists, "KnowledgeBaseQuestionLogs table must be created by SetupSchemaAsync");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
@@ -123,6 +123,24 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
             GraphItemId = graphItemId
         };
 
+    private static KnowledgeBaseQuestionLog MakeQuestionLog(
+        int? precisionScore = null,
+        int? styleScore = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Question = "q",
+            Answer = "a",
+            TopK = 5,
+            SourceCount = 1,
+            DurationMs = 100,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UserId = null,
+            PrecisionScore = precisionScore,
+            StyleScore = styleScore,
+            FeedbackComment = null,
+        };
+
     [Fact]
     public async Task AddChunksAsync_PersistsSummaryAndDocumentType()
     {
@@ -344,20 +362,69 @@ public class KnowledgeBaseRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task SetupSchema_CreatesKnowledgeBaseQuestionLogsTable()
+    public async Task GetFeedbackStatsAsync_EmptyTable_ReturnsZeroCountsAndNullAverages()
     {
-        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
-        await conn.OpenAsync();
+        var stats = await _repository.GetFeedbackStatsAsync();
 
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandText = """
-            SELECT EXISTS (
-                SELECT 1 FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = 'KnowledgeBaseQuestionLogs'
-            );
-            """;
+        Assert.Equal(0, stats.TotalQuestions);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
 
-        var exists = (bool)(await cmd.ExecuteScalarAsync())!;
-        Assert.True(exists, "KnowledgeBaseQuestionLogs table must be created by SetupSchemaAsync");
+    [Fact]
+    public async Task GetFeedbackStatsAsync_RowsWithoutScores_ReturnsTotalsAndNullAverages()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(),
+            MakeQuestionLog(),
+            MakeQuestionLog());
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(3, stats.TotalQuestions);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+
+    [Fact]
+    public async Task GetFeedbackStatsAsync_MixedFeedback_ReturnsCorrectCountsAndAverages()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(),
+            MakeQuestionLog(precisionScore: 5),
+            MakeQuestionLog(styleScore: 3),
+            MakeQuestionLog(precisionScore: 4, styleScore: 5));
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(4, stats.TotalQuestions);
+        Assert.Equal(3, stats.TotalWithFeedback);
+        Assert.Equal(4.5, stats.AvgPrecisionScore);
+        Assert.Equal(4.0, stats.AvgStyleScore);
+    }
+
+    [Fact]
+    public async Task GetFeedbackStatsAsync_RoundsAveragesToOneDecimalUsingBankersRounding()
+    {
+        // PrecisionScore raw average = (5 + 5 + 4) / 3 = 4.6666... -> 4.7
+        // StyleScore raw average     = (1 + 2) / 2     = 1.5       -> 1.5
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(precisionScore: 5, styleScore: 1),
+            MakeQuestionLog(precisionScore: 5, styleScore: 2),
+            MakeQuestionLog(precisionScore: 4));
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(3, stats.TotalQuestions);
+        Assert.Equal(3, stats.TotalWithFeedback);
+        Assert.NotNull(stats.AvgPrecisionScore);
+        Assert.NotNull(stats.AvgStyleScore);
+        Assert.Equal(Math.Round((5d + 5d + 4d) / 3d, 1), stats.AvgPrecisionScore!.Value);
+        Assert.Equal(Math.Round((1d + 2d) / 2d, 1), stats.AvgStyleScore!.Value);
     }
 }

--- a/docs/superpowers/plans/2026-05-13-kb-feedback-stats-sql-aggregation.md
+++ b/docs/superpowers/plans/2026-05-13-kb-feedback-stats-sql-aggregation.md
@@ -1,0 +1,549 @@
+# KnowledgeBase Feedback Stats SQL-Side Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the in-memory row materialisation in `KnowledgeBaseRepository.GetFeedbackStatsAsync` with EF Core SQL-side `COUNT`/`AVG` aggregates so the Feedback page stats query stops scaling with table size.
+
+**Architecture:** Rewrite the body of a single repository method to issue four constant-size aggregate queries (`CountAsync` all, `CountAsync` with predicate, two `AverageAsync` with nullable-double cast over filtered sets) and assemble the existing `FeedbackAggregateStats` DTO from the four scalars. No contract or schema changes. Tests are added to an existing Testcontainers PostgreSQL integration class, whose schema setup is first extended to include the `KnowledgeBaseQuestionLogs` table (currently absent from the test schema, which is why no test currently covers this method).
+
+**Tech Stack:** .NET 8, EF Core (Npgsql provider), xUnit, Testcontainers PostgreSQL (`pgvector/pgvector:pg16` image), `KnowledgeBaseRepositoryIntegrationTests`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs` — replace the body of `GetFeedbackStatsAsync` (lines 299–322). Public method signature is unchanged.
+- `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — extend `SetupSchemaAsync` to create the `KnowledgeBaseQuestionLogs` table; add four new `[Fact]` tests covering FR-4 scenarios; add a private helper for inserting feedback-log rows.
+
+**No new files.** No new namespaces or interfaces. No schema migrations. No frontend/OpenAPI client regeneration.
+
+**Domain shapes (read-only references — do NOT modify):**
+- `backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/KnowledgeBaseQuestionLog.cs` — entity with `PrecisionScore int?`, `StyleScore int?` and other columns.
+- `backend/src/Anela.Heblo.Domain/Features/KnowledgeBase/FeedbackAggregateStats.cs` — DTO with `TotalQuestions`, `TotalWithFeedback`, `AvgPrecisionScore`, `AvgStyleScore`.
+- `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseQuestionLogConfiguration.cs` — EF Core mapping; the entity lives in the `public` schema.
+
+---
+
+## Task 1: Extend integration test schema to include `KnowledgeBaseQuestionLogs`
+
+**Why first:** Without this, no FR-4 test can run against the real Postgres container. The existing schema setup only creates `KnowledgeBaseDocuments` and `KnowledgeBaseChunks`. Inserting `KnowledgeBaseQuestionLog` rows via EF Core would fail at runtime with a missing-relation error.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs:52-91` — extend `SetupSchemaAsync`.
+
+- [ ] **Step 1: Write a failing schema-presence test**
+
+Add this `[Fact]` at the bottom of the class (just above the closing brace at line 331), so it runs against the post-setup schema. The intent is purely to assert the table exists; we will delete this scaffolding test in Task 2 once real feedback tests cover the same surface.
+
+```csharp
+    [Fact]
+    public async Task SetupSchema_CreatesKnowledgeBaseQuestionLogsTable()
+    {
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = 'KnowledgeBaseQuestionLogs'
+            );
+            """;
+
+        var exists = (bool)(await cmd.ExecuteScalarAsync())!;
+        Assert.True(exists, "KnowledgeBaseQuestionLogs table must be created by SetupSchemaAsync");
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SetupSchema_CreatesKnowledgeBaseQuestionLogsTable" --logger "console;verbosity=normal"`
+
+Expected: FAIL. Assertion fails with `KnowledgeBaseQuestionLogs table must be created by SetupSchemaAsync` because `SetupSchemaAsync` does not create it.
+
+- [ ] **Step 3: Extend `SetupSchemaAsync` to create the table**
+
+In `KnowledgeBaseRepositoryIntegrationTests.cs`, modify `SetupSchemaAsync` (currently lines 52–91). Append the `KnowledgeBaseQuestionLogs` table creation to the existing `cmd.CommandText` triple-quoted string. The column types and nullability must match the EF Core entity mapping in `KnowledgeBaseQuestionLogConfiguration` and the entity property types in `KnowledgeBaseQuestionLog.cs`. Note `CreatedAt` is `DateTimeOffset` so it maps to `timestamp with time zone` (`timestamptz`).
+
+Replace the existing `SetupSchemaAsync` method body with:
+
+```csharp
+    private async Task SetupSchemaAsync()
+    {
+        await using var conn = new NpgsqlConnection(_container.GetConnectionString());
+        await conn.OpenAsync();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE EXTENSION IF NOT EXISTS vector;
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseDocuments" (
+                "Id"           uuid NOT NULL PRIMARY KEY,
+                "Filename"     varchar(500) NOT NULL,
+                "SourcePath"   varchar(1000) NOT NULL,
+                "ContentType"  varchar(100) NOT NULL,
+                "ContentHash"  varchar(64) NOT NULL UNIQUE,
+                "Status"       varchar(50) NOT NULL,
+                "DocumentType" integer NOT NULL DEFAULT 0,
+                "CreatedAt"    timestamp NOT NULL,
+                "IndexedAt"    timestamp NULL,
+                "DriveId"      text NULL,
+                "GraphItemId"  text NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseChunks" (
+                "Id"           uuid NOT NULL PRIMARY KEY,
+                "DocumentId"   uuid NOT NULL REFERENCES public."KnowledgeBaseDocuments"("Id") ON DELETE CASCADE,
+                "ChunkIndex"   integer NOT NULL,
+                "Content"      text NOT NULL DEFAULT '',
+                "Summary"      text NOT NULL DEFAULT '',
+                "DocumentType" integer NOT NULL DEFAULT 0,
+                "Embedding"    vector(3)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_kb_chunks_embedding
+                ON public."KnowledgeBaseChunks"
+                USING hnsw ("Embedding" vector_cosine_ops)
+                WITH (m = 16, ef_construction = 64);
+
+            CREATE TABLE IF NOT EXISTS public."KnowledgeBaseQuestionLogs" (
+                "Id"              uuid NOT NULL PRIMARY KEY,
+                "Question"        text NOT NULL,
+                "Answer"          text NOT NULL,
+                "TopK"            integer NOT NULL,
+                "SourceCount"     integer NOT NULL,
+                "DurationMs"      bigint NOT NULL,
+                "CreatedAt"       timestamp with time zone NOT NULL,
+                "UserId"          text NULL,
+                "PrecisionScore"  integer NULL,
+                "StyleScore"      integer NULL,
+                "FeedbackComment" text NULL
+            );
+            """;
+        await cmd.ExecuteNonQueryAsync();
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SetupSchema_CreatesKnowledgeBaseQuestionLogsTable" --logger "console;verbosity=normal"`
+
+Expected: PASS — the table now exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+git commit -m "test(knowledge-base): create KnowledgeBaseQuestionLogs table in integration test schema"
+```
+
+---
+
+## Task 2: Write failing feedback-stats integration tests (TDD red phase)
+
+**Why:** Before changing `GetFeedbackStatsAsync`, lock in the four FR-4 scenarios against the real Postgres container so any regression in SQL translation or rounding is caught.
+
+The existing implementation already returns correct values for these scenarios (the bug is performance, not correctness). The tests below should therefore PASS against the current implementation — we use them to (a) prove the schema setup from Task 1 is usable and (b) provide a regression guard for the rewrite in Task 3. The "TDD red phase" here is on the schema-setup change, not on the production code; the existing scaffold test from Task 1 is replaced by these realistic tests.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — delete the scaffold `SetupSchema_CreatesKnowledgeBaseQuestionLogsTable` test from Task 1, add a private builder helper, and add four feedback-stats `[Fact]` tests.
+
+- [ ] **Step 1: Delete the scaffold test from Task 1**
+
+Remove the `SetupSchema_CreatesKnowledgeBaseQuestionLogsTable` method added in Task 1. The four new tests below cover the same schema indirectly by inserting and querying rows.
+
+- [ ] **Step 2: Add a private helper for building question-log rows**
+
+Insert this private static method directly below the existing `MakeDocument` helper (around line 110 in the current file, just before the first `[Fact]` test):
+
+```csharp
+    private static KnowledgeBaseQuestionLog MakeQuestionLog(
+        int? precisionScore = null,
+        int? styleScore = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Question = "q",
+            Answer = "a",
+            TopK = 5,
+            SourceCount = 1,
+            DurationMs = 100,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UserId = null,
+            PrecisionScore = precisionScore,
+            StyleScore = styleScore,
+            FeedbackComment = null,
+        };
+```
+
+- [ ] **Step 3: Add the empty-table test**
+
+Add this `[Fact]` at the bottom of the class (just above the closing brace):
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_EmptyTable_ReturnsZeroCountsAndNullAverages()
+    {
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(0, stats.TotalQuestions);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+```
+
+- [ ] **Step 4: Add the rows-but-no-feedback test**
+
+Add this `[Fact]` immediately after the previous one:
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_RowsWithoutScores_ReturnsTotalsAndNullAverages()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(),
+            MakeQuestionLog(),
+            MakeQuestionLog());
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(3, stats.TotalQuestions);
+        Assert.Equal(0, stats.TotalWithFeedback);
+        Assert.Null(stats.AvgPrecisionScore);
+        Assert.Null(stats.AvgStyleScore);
+    }
+```
+
+- [ ] **Step 5: Add the mixed-feedback test**
+
+Add this `[Fact]` immediately after the previous one. The dataset contains:
+- 1 row with neither score
+- 1 row with precision only (`PrecisionScore = 5`)
+- 1 row with style only (`StyleScore = 3`)
+- 1 row with both (`PrecisionScore = 4`, `StyleScore = 5`)
+
+So `TotalQuestions = 4`, `TotalWithFeedback = 3`, `AvgPrecisionScore = (5 + 4) / 2 = 4.5`, `AvgStyleScore = (3 + 5) / 2 = 4.0`.
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_MixedFeedback_ReturnsCorrectCountsAndAverages()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(),
+            MakeQuestionLog(precisionScore: 5),
+            MakeQuestionLog(styleScore: 3),
+            MakeQuestionLog(precisionScore: 4, styleScore: 5));
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(4, stats.TotalQuestions);
+        Assert.Equal(3, stats.TotalWithFeedback);
+        Assert.Equal(4.5, stats.AvgPrecisionScore);
+        Assert.Equal(4.0, stats.AvgStyleScore);
+    }
+```
+
+- [ ] **Step 6: Add the rounding test**
+
+Add this `[Fact]` immediately after the previous one. Three precision scores `5, 5, 4` average to `4.6666...`, which `Math.Round(_, 1)` (banker's rounding, default `MidpointRounding.ToEven`) rounds to `4.7`. Two style scores `2, 3` average to exactly `2.5`, which banker's rounding rounds to `2.5` (no rounding needed at 1 decimal — already exact). To exercise the banker's-rounding midpoint, also pick `3, 2` style scores so the average is `2.5` (already exact at 1 dp). Use precision `1, 2` → average `1.5` (exact at 1 dp). The point of this test is: rounding does not throw and matches `Math.Round(value, 1)` for a known computed value.
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_RoundsAveragesToOneDecimalUsingBankersRounding()
+    {
+        // PrecisionScore raw average = (5 + 5 + 4) / 3 = 4.6666... -> 4.7
+        // StyleScore raw average     = (1 + 2) / 2     = 1.5       -> 1.5
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(precisionScore: 5, styleScore: 1),
+            MakeQuestionLog(precisionScore: 5, styleScore: 2),
+            MakeQuestionLog(precisionScore: 4));
+        await _context.SaveChangesAsync();
+
+        var stats = await _repository.GetFeedbackStatsAsync();
+
+        Assert.Equal(3, stats.TotalQuestions);
+        Assert.Equal(3, stats.TotalWithFeedback);
+        Assert.NotNull(stats.AvgPrecisionScore);
+        Assert.NotNull(stats.AvgStyleScore);
+        Assert.Equal(Math.Round((5d + 5d + 4d) / 3d, 1), stats.AvgPrecisionScore!.Value);
+        Assert.Equal(Math.Round((1d + 2d) / 2d, 1), stats.AvgStyleScore!.Value);
+    }
+```
+
+- [ ] **Step 7: Run all four feedback tests to verify they pass against the current implementation**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetFeedbackStatsAsync" --logger "console;verbosity=normal"`
+
+Expected: 4 tests PASS. The current implementation already returns correct values; we are establishing a regression baseline before changing the implementation. Each test runs against a fresh Testcontainer instance because the class implements `IAsyncLifetime` and re-creates the schema per test class lifetime (each `[Fact]` shares the same container but the table is empty at start of class; tests inside the class share data. **Important:** rerun the tests one at a time if cross-test pollution becomes visible — current container lifecycle gives each test class one container, not one per test.)
+
+Actually, looking at the class, `_container` is per-instance (xUnit creates one instance per test by default), so each `[Fact]` gets a fresh container — good. No clean-up needed between tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+git commit -m "test(knowledge-base): cover GetFeedbackStatsAsync FR-4 scenarios"
+```
+
+---
+
+## Task 3: Rewrite `GetFeedbackStatsAsync` to use SQL-side aggregation
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs:299-322` — replace method body. Public signature, namespace, and return type are unchanged.
+
+- [ ] **Step 1: Replace the method body**
+
+Locate `GetFeedbackStatsAsync` (currently lines 299–322). Replace the entire method with the version below. All four DB calls forward the `CancellationToken`; no row materialisation occurs; the nullable-double cast in `AverageAsync` makes empty filter sets return `null` without throwing.
+
+```csharp
+    public async Task<FeedbackAggregateStats> GetFeedbackStatsAsync(CancellationToken ct = default)
+    {
+        var totalQuestions = await _context.KnowledgeBaseQuestionLogs
+            .CountAsync(ct);
+
+        var totalWithFeedback = await _context.KnowledgeBaseQuestionLogs
+            .CountAsync(l => l.PrecisionScore != null || l.StyleScore != null, ct);
+
+        var avgPrecision = await _context.KnowledgeBaseQuestionLogs
+            .Where(l => l.PrecisionScore != null)
+            .AverageAsync(l => (double?)l.PrecisionScore, ct);
+
+        var avgStyle = await _context.KnowledgeBaseQuestionLogs
+            .Where(l => l.StyleScore != null)
+            .AverageAsync(l => (double?)l.StyleScore, ct);
+
+        return new FeedbackAggregateStats
+        {
+            TotalQuestions = totalQuestions,
+            TotalWithFeedback = totalWithFeedback,
+            AvgPrecisionScore = avgPrecision.HasValue ? Math.Round(avgPrecision.Value, 1) : null,
+            AvgStyleScore = avgStyle.HasValue ? Math.Round(avgStyle.Value, 1) : null,
+        };
+    }
+```
+
+Notes:
+- `Math.Round(value, 1)` uses default `MidpointRounding.ToEven` — do **not** pass `MidpointRounding.AwayFromZero`. The spec requires exact UI parity with the prior implementation, which used the default.
+- Do not consolidate the four calls into a `GroupBy(_ => 1).Select(...)` projection. Arch-review Decision 1 explicitly rejects it.
+- Do not wrap in a transaction (arch-review Decision 3).
+
+- [ ] **Step 2: Build to confirm compilation**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 3: Run the four feedback-stats tests to confirm they still pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetFeedbackStatsAsync" --logger "console;verbosity=normal"`
+
+Expected: 4 tests PASS — same outputs as in Task 2 step 7, now produced by SQL-side aggregation.
+
+- [ ] **Step 4: Run the full integration test class to confirm no collateral damage**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseRepositoryIntegrationTests" --logger "console;verbosity=normal"`
+
+Expected: all tests in `KnowledgeBaseRepositoryIntegrationTests` PASS (existing tests for `AddChunksAsync`, `SearchSimilarAsync`, `GetChunkByIdAsync`, etc. plus the four new feedback tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs
+git commit -m "perf(knowledge-base): aggregate feedback stats in SQL instead of materialising rows"
+```
+
+---
+
+## Task 4: Verify SQL translation does not materialise rows (FR-1 acceptance)
+
+**Why:** FR-1's acceptance criterion includes verifying that the EF Core query log shows aggregate-only SQL — no `SELECT *` and no `Question`/`Answer` column projection. We add a one-off test that captures executed SQL via `DbContext` logging and asserts the patterns.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs` — add one `[Fact]` and a small private `LogCapturingLoggerProvider` class scoped to the test file.
+
+- [ ] **Step 1: Add a SQL-capture helper class inside the test file**
+
+At the end of the file (after the closing brace of `KnowledgeBaseRepositoryIntegrationTests`), append the following helper. It captures EF Core's `Microsoft.EntityFrameworkCore.Database.Command` log messages into a list for assertion.
+
+```csharp
+internal sealed class CapturingLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider
+{
+    public List<string> Messages { get; } = new();
+
+    public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) =>
+        new CapturingLogger(Messages);
+
+    public void Dispose() { }
+
+    private sealed class CapturingLogger : Microsoft.Extensions.Logging.ILogger
+    {
+        private readonly List<string> _messages;
+
+        public CapturingLogger(List<string> messages) => _messages = messages;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}
+```
+
+Add the required using directive at the top of the file if not already present:
+
+```csharp
+using Microsoft.Extensions.Logging;
+```
+
+- [ ] **Step 2: Add the SQL-shape test**
+
+Add this `[Fact]` to `KnowledgeBaseRepositoryIntegrationTests`, just below the rounding test from Task 2. It builds a *separate* `ApplicationDbContext` wired up with the capturing logger, invokes the repository, and asserts the executed SQL contains the expected aggregate forms and does **not** project the `Question` or `Answer` columns.
+
+```csharp
+    [Fact]
+    public async Task GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows()
+    {
+        _context.KnowledgeBaseQuestionLogs.AddRange(
+            MakeQuestionLog(precisionScore: 5, styleScore: 4),
+            MakeQuestionLog());
+        await _context.SaveChangesAsync();
+
+        var loggerProvider = new CapturingLoggerProvider();
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(loggerProvider);
+            builder.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Information);
+        });
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(_container.GetConnectionString());
+        dataSourceBuilder.UseVector();
+        await using var dataSource = dataSourceBuilder.Build();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(dataSource)
+            .UseLoggerFactory(loggerFactory)
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        await using var ctx = new ApplicationDbContext(options);
+        var repo = new KnowledgeBaseRepository(ctx);
+
+        var stats = await repo.GetFeedbackStatsAsync();
+
+        Assert.Equal(2, stats.TotalQuestions);
+
+        var sql = string.Join("\n", loggerProvider.Messages);
+        Assert.Contains("COUNT(*)", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AVG(", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"Question\"", sql);
+        Assert.DoesNotContain("\"Answer\"", sql);
+    }
+```
+
+- [ ] **Step 3: Run the new test**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows" --logger "console;verbosity=normal"`
+
+Expected: PASS. The captured SQL log contains `COUNT(*)` and `AVG(` substrings, and contains no `"Question"` or `"Answer"` identifiers.
+
+If FAIL with "did not contain COUNT(*)": EF Core may log the aggregate as `COUNT(*)::int` or wrap inside a subquery — adjust the substring search to `COUNT(` and re-run. The intent is to confirm aggregation, not match exact whitespace.
+
+If FAIL with "contains \"Question\"" — that is a real regression in the repository implementation and must be fixed in Task 3 before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs
+git commit -m "test(knowledge-base): assert GetFeedbackStatsAsync emits aggregate SQL without row materialisation"
+```
+
+---
+
+## Task 5: Final validation
+
+**Why:** Confirm the full backend solution builds, formats cleanly, and the integration test class passes end-to-end.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run `dotnet build` on the full backend solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+If the warning count is non-zero, check whether any new warning was introduced by Tasks 1–4. The repository policy is to keep warnings flat; address only warnings you introduced. Pre-existing warnings stay as-is.
+
+- [ ] **Step 2: Run `dotnet format` on the modified files**
+
+Run: `dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs backend/test/Anela.Heblo.Tests/KnowledgeBase/Integration/KnowledgeBaseRepositoryIntegrationTests.cs`
+
+Expected: command exits 0 with no formatting changes printed. If it makes edits, review them and amend the most recent commit:
+
+```bash
+git add -u
+git commit --amend --no-edit
+```
+
+- [ ] **Step 3: Run the full `KnowledgeBaseRepositoryIntegrationTests` class**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseRepositoryIntegrationTests" --logger "console;verbosity=normal"`
+
+Expected: all tests PASS, including:
+- Existing tests for `AddChunksAsync`, `SearchSimilarAsync`, `GetChunkByIdAsync`, `AddDocumentAsync`, `DeleteDocumentAsync`, `GetDocumentByGraphItemIdAsync`.
+- `GetFeedbackStatsAsync_EmptyTable_ReturnsZeroCountsAndNullAverages`
+- `GetFeedbackStatsAsync_RowsWithoutScores_ReturnsTotalsAndNullAverages`
+- `GetFeedbackStatsAsync_MixedFeedback_ReturnsCorrectCountsAndAverages`
+- `GetFeedbackStatsAsync_RoundsAveragesToOneDecimalUsingBankersRounding`
+- `GetFeedbackStatsAsync_ExecutesAggregateSqlWithoutMaterialisingRows`
+
+- [ ] **Step 4: Run the full backend test project (smoke check for cross-test regressions)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --logger "console;verbosity=minimal"`
+
+Expected: all tests PASS, including the unrelated unit/integration tests. If something unrelated fails, check whether it was already failing on the branch tip before the plan was executed; if so, it is out of scope.
+
+- [ ] **Step 5: No further commit needed**
+
+If Steps 1–4 produced no edits, there is nothing to commit. The change is complete.
+
+---
+
+## Spec Coverage Check
+
+| Spec / Arch-Review item | Covered by |
+|---|---|
+| FR-1: SQL-side aggregation, no `ToListAsync`, cancellation token propagation | Task 3 step 1; Task 4 step 2 (SQL-shape assertion) |
+| FR-2: Identical `FeedbackAggregateStats` shape and rounding (banker's rounding) | Task 3 step 1 (no DTO changes; `Math.Round(_, 1)` default); Task 2 step 6 (rounding test) |
+| FR-3: Empty / no-score behaviour does not throw | Task 2 step 3 (empty table); Task 2 step 4 (no scores anywhere); Task 3 step 1 (nullable-double cast) |
+| FR-4: Test coverage for empty / no-feedback / mixed / rounding cases | Task 2 steps 3, 4, 5, 6 |
+| FR-4 prerequisite (arch-review amendment 1): schema setup for `KnowledgeBaseQuestionLogs` | Task 1 step 3 |
+| FR-4 pinning (arch-review amendment 2): Testcontainers PostgreSQL, not InMemory | All tests live in `KnowledgeBaseRepositoryIntegrationTests`, which uses `PostgreSqlContainer` |
+| Arch-review amendment 3: do not use `GroupBy(_=>1)` projection | Task 3 step 1 explicit guidance + code |
+| Arch-review Decision 2: nullable-double cast in `AverageAsync` | Task 3 step 1 code |
+| Arch-review Decision 3: no explicit transaction | Task 3 step 1 (none added) |
+| NFR-1: bytes transferred constant; latency target — implicitly satisfied by FR-1 (four scalar aggregates) | Task 4 SQL-shape test confirms no row projection |
+| NFR-2: cancellation propagation | Task 3 step 1 — every `*Async` call receives `ct` |
+| NFR-3: backward compatibility — signature unchanged, DTO unchanged, no migration, no client regen | Task 3 step 1 (method signature unchanged); no migration file added; no contract file changed |
+| Out-of-scope items (caching, new indexes, UI changes, other repos) | Not touched in any task |
+
+No spec requirements are missing from the plan.


### PR DESCRIPTION
KnowledgeBase

## Finding
`KnowledgeBaseRepository.GetFeedbackStatsAsync` fetches every feedback row that has any score into a `List<>` in application memory and then averages them in C#:

```csharp
// backend/src/Anela.Heblo.Persistence/KnowledgeBase/KnowledgeBaseRepository.cs:303-321
var withFeedback = await _context.KnowledgeBaseQuestionLogs
    .Where(l => l.PrecisionScore != null || l.StyleScore != null)
    .ToListAsync(ct);                          // ← entire result set materialised

double? avgPrecision = withFeedback.Count > 0
    ? withFeedback.Where(l => l.PrecisionScore != null)
                  .Average(l => (double?)l.PrecisionScore)
    : null;
```

`KnowledgeBaseQuestionLogs` grows with every `/ask` call. As usage increases, this method will transfer an unbounded number of full log rows (including `Question` and `Answer` text fields) over the wire just to compute two scalar averages.

## Why it matters
SQL aggregation (`AVG`, `COUNT`) is far more efficient than client-side LINQ. This is a concrete performance regression path: the method is called every time the Feedback page loads its stats header. Loading full text columns (`Question`, `Answer`) into memory for averaging violates KISS — the DB can compute this in a single pass over an index.

## Suggested fix
Replace the in-memory aggregation with a single SQL-side query using EF Core:

```csharp
var totalQuestions = await _context.KnowledgeBaseQuestionLogs.CountAsync(ct);

var totalWithFeedback = await _context.KnowledgeBaseQuestionLogs
    .CountAsync(l => l.PrecisionScore != null || l.StyleScore != null, ct);

var avgPrecision = await _context.KnowledgeBaseQuestionLogs
    .Where(l => l.PrecisionScore != null)
    .AverageAsync(l => (double?)l.PrecisionScore, ct);

var avgStyle = await _context.KnowledgeBaseQuestionLogs
    .Where(l => l.StyleScore != null)
    .AverageAsync(l => (double?)l.StyleScore, ct);
```

That's 4 lightweight aggregation queries (or collapse into one via `GroupBy(_ => 1)` + `.Select`) instead of a full table scan materialised in memory.

---
_Filed by daily arch-review routine on 2026-05-13._

---

Closes #1179

### Tokens used
14721867
