### PR TITLE
feat(ci): switch Teams notification from MessageCard to Adaptive Card

### DIFF
--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -557,40 +557,73 @@ jobs:
             --arg timestamp "$TIMESTAMP" \
             --arg app_url "$APP_URL" \
             --arg run_url "$RUN_URL" \
-            --arg workflow "$GITHUB_WORKFLOW" \
             --arg changelog "$CHANGELOG_CS" \
             '{
-              "@type": "MessageCard",
-              "@context": "https://schema.org/extensions",
-              "summary": "Heblo \($version) úspěšně nasazeno",
-              "themeColor": "00AA00",
-              "title": "🚀 Heblo \($version) úspěšně nasazeno",
-              "sections": (
-                [
-                  {
-                    "activityTitle": "Produkční nasazení dokončeno",
-                    "activitySubtitle": $timestamp,
-                    "facts": [
-                      { "name": "Verze:",      "value": $version },
-                      { "name": "Prostředí:",  "value": "Production" },
-                      { "name": "URL:",        "value": $app_url },
-                      { "name": "Workflow:",   "value": $workflow }
-                    ],
-                    "markdown": true
+              "type": "message",
+              "attachments": [
+                {
+                  "contentType": "application/vnd.microsoft.card.adaptive",
+                  "contentUrl": null,
+                  "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": (
+                      [
+                        {
+                          "type": "TextBlock",
+                          "text": "🚀 Heblo \($version) úspěšně nasazeno",
+                          "size": "extraLarge",
+                          "weight": "bolder",
+                          "color": "good",
+                          "wrap": true
+                        },
+                        {
+                          "type": "FactSet",
+                          "facts": [
+                            { "title": "Verze:",     "value": $version },
+                            { "title": "Prostředí:", "value": "Production" },
+                            { "title": "URL:",       "value": $app_url },
+                            { "title": "Čas:",       "value": $timestamp }
+                          ]
+                        }
+                      ]
+                      + (
+                        if ($changelog | length) > 0
+                        then [
+                          {
+                            "type": "TextBlock",
+                            "text": "📋 Změny ve verzi",
+                            "size": "large",
+                            "weight": "bolder",
+                            "separator": true,
+                            "spacing": "medium"
+                          },
+                          {
+                            "type": "TextBlock",
+                            "text": $changelog,
+                            "size": "medium",
+                            "wrap": true
+                          }
+                        ]
+                        else []
+                        end
+                      )
+                    ),
+                    "actions": [
+                      {
+                        "type": "Action.OpenUrl",
+                        "title": "Zobrazit aplikaci",
+                        "url": $app_url
+                      },
+                      {
+                        "type": "Action.OpenUrl",
+                        "title": "Zobrazit workflow run",
+                        "url": $run_url
+                      }
+                    ]
                   }
-                ]
-                + (
-                  if ($changelog | length) > 0
-                  then [{ "title": "**📋 Změny ve verzi**", "text": $changelog, "markdown": true }]
-                  else []
-                  end
-                )
-              ),
-              "potentialAction": [
-                { "@type": "OpenUri", "name": "Zobrazit aplikaci",
-                  "targets": [{ "os": "default", "uri": $app_url }] },
-                { "@type": "OpenUri", "name": "Zobrazit workflow run",
-                  "targets": [{ "os": "default", "uri": $run_url }] }
+                }
               ]
             }')
 
@@ -607,7 +640,6 @@ jobs:
           fi
         env:
           CHANGELOG_CS: ${{ needs.build-and-push.outputs.changelog-cs }}
-          GITHUB_WORKFLOW: ${{ github.workflow }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}


### PR DESCRIPTION
## Summary

- Replace legacy `MessageCard` Teams webhook payload with `Adaptive Card` v1.4 format
- Set changelog TextBlock `size: medium` so text is larger and more readable in Teams
- Change section headers from `## ...` markdown (unsupported in Adaptive Card) to `**bold**` text
- Remove unused `GITHUB_WORKFLOW` env var from notification step; replace `Workflow:` fact with `Čas:` (timestamp)

## Test Plan

- [ ] Merge to `main` and verify CI pipeline completes successfully
- [ ] Confirm Teams notification renders with larger text and correct card structure (title, FactSet, changelog section, two action buttons)