### PR TITLE
feat: Rename `LeafletGenerationLoggingBehavior` to reflect persistence responsibility

### DIFF
--- a/artifacts/feat-arch-review-leaflet-leafletgenerationlog/arch-review.r1.md
+++ b/artifacts/feat-arch-review-leaflet-leafletgenerationlog/arch-review.r1.md
@@ -1,0 +1,134 @@
+# Architecture Review: Rename `LeafletGenerationLoggingBehavior` to `LeafletGenerationPersistenceBehavior`
+
+## Skip Design: true
+
+Pure backend identifier rename. No UI components, screens, or visual surface area touched.
+
+## Architectural Fit Assessment
+
+The rename aligns with the codebase's Vertical Slice / Clean Architecture conventions: the file already lives in the correct slice (`Application/Features/Leaflet/Pipeline/`), uses the established `IPipelineBehavior<TRequest, TResponse>` contract, and is registered through the feature's own module (`LeafletModule.AddLeafletModule`). Renaming touches three artifacts (production class, DI registration, test fixture) plus one historical plan document — no module boundaries, persistence contracts, MediatR ordering, or HTTP contracts are crossed.
+
+**One non-trivial architectural observation that the spec does not address:** the KnowledgeBase slice contains a structurally identical pipeline behavior, `QuestionLoggingBehavior` (`backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/QuestionLoggingBehavior.cs`), which is also misnamed by the same criterion — it persists `KnowledgeBaseQuestionLog` via `_repository.SaveQuestionLogAsync` and mutates `response.Id = log.Id`. Renaming only the Leaflet variant introduces a cross-slice naming inconsistency: two behaviors with the same shape and responsibility will diverge in name. This is acceptable for a surgical rename, but the team should know the inconsistency exists and decide whether KB will follow. See **Specification Amendments** below.
+
+There are no other `*Pipeline` behaviors registered against `GenerateLeafletRequest`, so MediatR ordering is a non-issue.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GenerateLeafletRequest (MediatR pipeline)
+       │
+       ▼
+┌───────────────────────────────────────────────┐
+│ IPipelineBehavior<                            │
+│   GenerateLeafletRequest,                     │
+│   GenerateLeafletResponse>                    │
+│                                               │
+│  Implementation: LeafletGenerationPersistence │
+│                  Behavior  (renamed)          │
+│                                               │
+│  Dependencies:                                │
+│   • ILeafletRepository                        │
+│   • ICurrentUserService                       │
+│   • ILogger<LeafletGenerationPersistence-     │
+│             Behavior>                         │
+└───────────────────────────────────────────────┘
+       │
+       ▼
+GenerateLeafletHandler → GenerateLeafletResponse (Id stamped on the way back)
+```
+
+The component graph is unchanged. Only the identifier on the box changes.
+
+### Key Design Decisions
+
+#### Decision 1: Class name choice — `LeafletGenerationPersistenceBehavior` (vs. `SaveLeafletGenerationBehavior`)
+**Options considered:** `LeafletGenerationPersistenceBehavior`, `SaveLeafletGenerationBehavior`, `PersistLeafletGenerationBehavior`.
+**Chosen approach:** `LeafletGenerationPersistenceBehavior` (already selected in the spec).
+**Rationale:** Matches the noun-based `<Subject><Responsibility>Behavior` form used elsewhere in MediatR pipeline behaviors in this codebase (e.g., `QuestionLoggingBehavior`). It cleanly conveys both subject (LeafletGeneration) and responsibility (Persistence). The `Save…` verb-first form would diverge from the existing naming pattern.
+
+#### Decision 2: Scope is rename-only — do not split observability
+**Options considered:** (a) Pure rename; (b) Rename + extract timing into a separate `LeafletGenerationLoggingBehavior`.
+**Chosen approach:** Pure rename (option a).
+**Rationale:** The spec explicitly marks the split as out of scope. Splitting requires deciding pipeline ordering (logging must wrap persistence to record duration of the persisted write, not before it), adding a second DI registration, and creating new tests. This rename is intended as a surgical correctness fix, not a refactor. The split is tracked as a follow-up.
+
+#### Decision 3: Preserve the swallow-and-log `catch (Exception ex)` block
+**Options considered:** (a) Preserve as-is; (b) Tighten to specific exception types.
+**Chosen approach:** Preserve as-is.
+**Rationale:** The existing tests (`Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`) assert that a DB failure does not break the response. Tightening the catch would change semantics and risk regression. Tracked as follow-up.
+
+#### Decision 4: Frozen historical plan stays untouched
+**Options considered:** (a) Update `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` to the new name; (b) Leave references as historical record.
+**Chosen approach:** Leave references in `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` unchanged.
+**Rationale:** That document is a frozen implementation plan describing the state of the world on its authoring date. Rewriting it would falsify the historical record. The spec already foresaw this exception ("frozen historical plans excepted"). The `rg` grep assertion in FR-4 should therefore explicitly exclude `docs/superpowers/plans/`.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Files to rename (no new files, no moves between directories):
+
+```
+backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/
+├── LeafletGenerationLoggingBehavior.cs        →  LeafletGenerationPersistenceBehavior.cs
+
+backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/
+├── LeafletGenerationLoggingBehaviorTests.cs   →  LeafletGenerationPersistenceBehaviorTests.cs
+```
+
+Files to edit (identifier replacement only):
+
+```
+backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs (lines 24–26)
+```
+
+Namespace: `Anela.Heblo.Application.Features.Leaflet.Pipeline` — unchanged.
+
+### Interfaces and Contracts
+
+- **MediatR contract**: `IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>` — unchanged.
+- **Public consumers**: none. The class is internal to the Application assembly and is only resolved through DI. No other code holds a reference to the type name.
+- **Response shape**: `GenerateLeafletResponse.Id` (`Guid?` with public setter) is still mutated by this behavior. Unchanged.
+- **Logger generic argument**: `ILogger<LeafletGenerationPersistenceBehavior>` — this is the one place in the rename where the renamed type appears in a generic position. Verify the test fixture's `Mock<ILogger<…>>` is updated correspondingly.
+
+### Data Flow
+
+Unchanged from the current implementation. For traceability:
+
+1. `GenerateLeafletRequest` enters the MediatR pipeline.
+2. The renamed behavior's `Handle` starts a `Stopwatch`.
+3. `next()` invokes `GenerateLeafletHandler`, which returns `GenerateLeafletResponse { Id = null, … }`.
+4. If `response.Success`, the behavior constructs a `LeafletGeneration`, calls `_repository.SaveGenerationAsync(generation, cancellationToken)`, and assigns `response.Id = generation.Id`.
+5. On exception, the failure is logged via `_logger` and the response is returned with `Id == null`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| MediatR DI registration silently broken (e.g., wrong generic) → core write lost at runtime, build still green | High | Ensure `dotnet test` covers the persistence behavior path; the three existing tests assert the save call. Re-run them after the rename and confirm `Handle_SavesGenerationRow_AndSetsResponseId` passes. |
+| Leftover references in `dotnet`/EF model snapshots, IDE-generated files, or hidden friend assemblies | Low | Run `rg "LeafletGenerationLoggingBehavior"` across `backend/src/`, `backend/test/`, and `frontend/` after the rename; expect zero matches in those paths. |
+| Cross-slice naming inconsistency vs. `QuestionLoggingBehavior` (KB analog has the same misnomer) | Medium | File a follow-up brief to evaluate `QuestionLoggingBehavior` rename. Out of scope for this change but should not be forgotten. See Spec Amendment 1. |
+| Historical plan document `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` flagged by the `rg` assertion | Low | Exclude `docs/superpowers/plans/` from the FR-4 grep assertion explicitly. See Spec Amendment 2. |
+| `dotnet format` ordering of `using` directives or whitespace differing after rename | Low | Run `dotnet format` after the rename; the spec already requires this. |
+| Git history loss on file rename (rename detection failure) | Low | Use `git mv` for both source and test file renames so blame/history surface as moves. |
+
+## Specification Amendments
+
+1. **Add cross-slice consistency note (informational, no implementation impact).** The same pattern (pipeline behavior that persists + mutates `response.Id`) exists in `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Pipeline/QuestionLoggingBehavior.cs`. Add a short note in the spec's **Out of Scope** section: *"Renaming `QuestionLoggingBehavior` in the KnowledgeBase slice for the same reason is explicitly out of scope here and tracked as a separate follow-up."* This prevents reviewers from later filing the same defect against KB without context.
+
+2. **Tighten FR-4's grep assertion to explicitly exclude frozen plan docs.** Replace the current FR-4 acceptance criterion with: *"`rg "LeafletGenerationLoggingBehavior"` returns no matches under `backend/src/`, `backend/test/`, and `frontend/`. Matches in `docs/superpowers/plans/` are expected and intentionally preserved as historical record."* This removes the implicit ambiguity in Open Question OQ-1, which the spec marks as resolved but does not codify in the assertion itself.
+
+3. **Add `git mv` to the implementation instruction.** Add to FR-1 and FR-3 acceptance criteria: *"The file rename is performed with `git mv` so that history follows the file."* Avoids accidental delete-and-create which would obscure blame.
+
+4. **Clarify the `dotnet format` expectation.** NFR-2 says "reports no diffs." After a rename, `dotnet format` may legitimately reorder `using` directives or fix the file header. Reframe as: *"`dotnet format` is run as part of the change; the resulting diff contains no formatting-only changes outside the renamed files."*
+
+## Prerequisites
+
+None. All required infrastructure is already in place:
+
+- `ILeafletRepository` registered in `PersistenceModule`.
+- `ICurrentUserService` available.
+- MediatR pipeline infrastructure wired in `AddApplicationServices()`.
+- xUnit + Moq test infrastructure already used by the existing fixture.
+- No database migration, configuration entry, or feature flag is required.

--- a/artifacts/feat-arch-review-leaflet-leafletgenerationlog/brief.md
+++ b/artifacts/feat-arch-review-leaflet-leafletgenerationlog/brief.md
@@ -1,0 +1,28 @@
+## Module
+Leaflet
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` is named and registered as a "logging" pipeline behavior, but its `Handle` method (lines 27–65) does two non-logging things:
+
+1. **Persists the generation record** (lines 42–56):
+   ```csharp
+   await _repository.SaveGenerationAsync(generation, cancellationToken);
+   ```
+   This is a core business write operation — creating the `LeafletGeneration` record that the feedback and history features depend on.
+
+2. **Mutates the handler's response** (line 57):
+   ```csharp
+   response.Id = generation.Id;
+   ```
+   The `GenerateLeafletResponse.Id` that is returned to the client is set here, not in the handler. The handler returns `Id = null`.
+
+The class name suggests cross-cutting observability infrastructure. A developer searching for "where is the generation record saved" would look in `GenerateLeafletHandler` and not find it.
+
+## Why it matters
+Single Responsibility: the behavior conflates observability (timing/logging) with domain persistence (saving a generation) and response shaping (setting the ID). The name actively misleads. If the behavior is disabled or removed for any reason, a core write is silently lost. Tests for the generation save must mock `ILeafletRepository` in a pipeline behavior, not in a handler.
+
+## Suggested fix
+Rename the class to `LeafletGenerationPersistenceBehavior` (or `SaveLeafletGenerationBehavior`) to accurately describe its responsibility. If timing/logging is also desired, extract that into a separate `LeafletGenerationLoggingBehavior`. This is a rename + optional split — no logic needs to change.
+
+---
+_Filed by daily arch-review routine on 2026-05-14._

--- a/artifacts/feat-arch-review-leaflet-leafletgenerationlog/impl/main.r1.md
+++ b/artifacts/feat-arch-review-leaflet-leafletgenerationlog/impl/main.r1.md
@@ -1,0 +1,48 @@
+Both reviews passed. The implementation is complete.
+
+---
+
+# Implementation: Rename `LeafletGenerationLoggingBehavior` to `LeafletGenerationPersistenceBehavior`
+
+## What was implemented
+Pure identifier rename across three artifacts in the Leaflet vertical slice. No logic, no tests, no DI lifetime, and no runtime behavior changed — only the type name, file names, and logger generic argument.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` — renamed (git mv) + class/constructor/`ILogger<T>` generic updated
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — DI registration updated to new type name
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` — renamed (git mv) + test class, mock generic, `CreateBehavior` return type updated
+
+## Tests
+`LeafletGenerationPersistenceBehaviorTests` — all 3 tests pass:
+- `Handle_SavesGenerationRow_AndSetsResponseId`
+- `Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`
+- `Handle_ReturnsOriginalResponse`
+
+## How to verify
+```bash
+# Build
+dotnet build backend/Anela.Heblo.sln
+
+# Run renamed fixture
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationPersistenceBehaviorTests" --no-build
+
+# Confirm old name gone from source/test
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/
+# Expected: no output (exit 1)
+```
+
+## Notes
+- Frozen historical plan `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` intentionally left untouched per spec FR-4.
+- `QuestionLoggingBehavior` in the KnowledgeBase slice has the same misnomer but is explicitly out of scope per arch review — tracked as a separate follow-up.
+
+## PR Summary
+Renames `LeafletGenerationLoggingBehavior` to `LeafletGenerationPersistenceBehavior` to reflect the behavior's true responsibility: persisting the `LeafletGeneration` record and stamping `GenerateLeafletResponse.Id`. The previous "Logging" name misled readers about where the core persistence write happens. Pure rename — method body, DI lifetime, test assertions, and all runtime behavior are unchanged.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` — renamed + class/constructor/logger generic updated
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — DI registration updated
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` — renamed + test class/mock/factory updated
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-leaflet-leafletgenerationlog/spec.r1.md
+++ b/artifacts/feat-arch-review-leaflet-leafletgenerationlog/spec.r1.md
@@ -1,0 +1,102 @@
+# Specification: Rename `LeafletGenerationLoggingBehavior` to reflect persistence responsibility
+
+## Summary
+Rename the misleadingly named `LeafletGenerationLoggingBehavior` MediatR pipeline behavior to `LeafletGenerationPersistenceBehavior`, which accurately reflects its true responsibility: persisting the `LeafletGeneration` record and stamping the response with its ID. No business logic, ordering, or runtime behavior changes — this is a pure rename across the production class, its DI registration, and its test fixture.
+
+## Background
+`backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` is named and registered as a "logging" pipeline behavior, but its `Handle` method (lines 27–65) performs two non-logging responsibilities that materially affect the feature:
+
+1. **Persists the generation record** via `_repository.SaveGenerationAsync(generation, cancellationToken)` (line 56) — a core business write the `GetLeafletGeneration` history and `SubmitLeafletFeedback` use cases depend on.
+2. **Mutates the handler's response** by assigning `response.Id = generation.Id` (line 57) — the only place `GenerateLeafletResponse.Id` is populated. The handler itself returns `Id = null`.
+
+The current name actively misleads readers: a developer searching for "where is the generation record saved" would inspect `GenerateLeafletHandler` and find nothing. If the behavior is disabled or unregistered, a core write is silently lost. The arch review filed on 2026-05-14 flagged this as a Single Responsibility / naming defect.
+
+This spec covers only the rename — preserving exact runtime behavior and existing test assertions. Splitting timing/observability into a separate behavior is explicitly out of scope (see Out of Scope).
+
+## Functional Requirements
+
+### FR-1: Rename production class
+Rename `LeafletGenerationLoggingBehavior` to `LeafletGenerationPersistenceBehavior`, including the source file, class declaration, constructor, and the `ILogger<T>` generic argument.
+
+**Acceptance criteria:**
+- File renamed: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs`.
+- Class identifier renamed to `LeafletGenerationPersistenceBehavior`.
+- Constructor name updated to match.
+- `ILogger<LeafletGenerationLoggingBehavior>` updated to `ILogger<LeafletGenerationPersistenceBehavior>`.
+- Namespace remains `Anela.Heblo.Application.Features.Leaflet.Pipeline`.
+- `Handle` method body, ordering, error handling, and the catch-and-log fallback are unchanged byte-for-byte (other than the type name in the logger generic).
+
+### FR-2: Update DI registration
+Update the registration in `LeafletModule.AddLeafletModule` so MediatR continues to wire the behavior into the `GenerateLeafletRequest` pipeline.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` lines 24–26: the `AddScoped<IPipelineBehavior<…>, LeafletGenerationLoggingBehavior>()` registration references `LeafletGenerationPersistenceBehavior` instead.
+- Scope/lifetime remains `Scoped`.
+- No additional pipeline behaviors are registered as part of this change.
+
+### FR-3: Update test fixture
+Rename the test class, test file, and all type references so existing assertions continue to compile and run.
+
+**Acceptance criteria:**
+- File renamed: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs`.
+- Test class renamed to `LeafletGenerationPersistenceBehaviorTests`.
+- `Mock<ILogger<LeafletGenerationLoggingBehavior>>` updated to `Mock<ILogger<LeafletGenerationPersistenceBehavior>>`.
+- `CreateBehavior()` return type and constructor invocation updated to `LeafletGenerationPersistenceBehavior`.
+- All three existing test cases pass unchanged:
+  - `Handle_SavesGenerationRow_AndSetsResponseId`
+  - `Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`
+  - `Handle_ReturnsOriginalResponse`
+- Test logic, assertions, and arrange/act/assert structure are unchanged.
+
+### FR-4: Find and update remaining references
+Search the repository for `LeafletGenerationLoggingBehavior` and replace every occurrence outside the renamed files (e.g., documentation, plans). The repository-wide search before merge must show zero matches for the old identifier in source/test/doc files (frozen historical plans excepted — see Open Questions).
+
+**Acceptance criteria:**
+- `rg "LeafletGenerationLoggingBehavior"` returns no matches under `backend/src/`, `backend/test/`, and `frontend/`.
+- Any references in `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` are either updated or explicitly left in place per Open Question OQ-1.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavior parity
+Runtime behavior of the `GenerateLeaflet` pipeline must be byte-identical to the pre-rename behavior. The persistence step, response ID assignment, exception swallowing, and timing measurement all execute in the same order with the same arguments.
+
+### NFR-2: Build & format
+- `dotnet build` succeeds for the entire solution.
+- `dotnet format` reports no diffs.
+- No new warnings introduced; the `ILogger<>` rename does not produce nullable-reference or analyzer warnings.
+
+### NFR-3: Test coverage parity
+- All three existing tests in `LeafletGenerationPersistenceBehaviorTests` pass.
+- `dotnet test` reports no new failures elsewhere in the solution.
+- Line/branch coverage of the renamed class is unchanged from the pre-rename baseline.
+
+### NFR-4: Surgical change discipline
+No adjacent code is refactored. The class internals, including the `try/catch` swallow-and-log pattern and the response mutation, are preserved as-is — even where they would warrant a future redesign (handled in a follow-up; see Out of Scope).
+
+## Data Model
+No data model changes. The `LeafletGeneration` entity, `ILeafletRepository.SaveGenerationAsync`, and the `GenerateLeafletResponse` shape (with its mutable `Id` setter) are untouched.
+
+## API / Interface Design
+No public API changes. The MediatR pipeline still exposes the same `IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>` contract; the implementing type's name is the only difference. No HTTP endpoints, request/response DTOs, or frontend contracts are affected.
+
+## Dependencies
+- MediatR pipeline behavior infrastructure (`IPipelineBehavior<TRequest, TResponse>`).
+- `ILeafletRepository` (registered in `PersistenceModule`).
+- `ICurrentUserService`.
+- `ILogger<T>` from `Microsoft.Extensions.Logging`.
+
+No new dependencies, package upgrades, or migrations.
+
+## Out of Scope
+The following improvements were considered and **explicitly excluded** from this revision to keep the change surgical. They may be addressed in follow-up work:
+
+1. **Extracting timing/observability into a separate `LeafletGenerationLoggingBehavior`.** The brief mentions this as optional. Splitting it would require designing pipeline ordering (logging must wrap persistence) and adding a second DI registration; it expands blast radius beyond a rename.
+2. **Moving response ID assignment into `GenerateLeafletHandler`.** The mutation of `response.Id` from a pipeline behavior is the architectural smell that triggered the review, but moving it changes the handler contract and persistence ownership boundary — out of scope for a rename.
+3. **Replacing the swallow-and-log `catch (Exception ex)` block** with a more specific exception filter or by making persistence failures observable to callers.
+4. **Renaming `LeafletGeneration.Id` ownership semantics** or making `GenerateLeafletResponse.Id` `init`-only.
+5. **Database schema changes**, new repository methods, or new endpoints.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-leaflet-leafletgenerationlog/task-plan.r1.md
+++ b/artifacts/feat-arch-review-leaflet-leafletgenerationlog/task-plan.r1.md
@@ -1,0 +1,605 @@
+# Rename `LeafletGenerationLoggingBehavior` → `LeafletGenerationPersistenceBehavior` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the misnamed `LeafletGenerationLoggingBehavior` MediatR pipeline behavior (and its test fixture + DI registration) to `LeafletGenerationPersistenceBehavior` to reflect its actual responsibility (persisting `LeafletGeneration` and stamping the response with its ID), without changing any runtime behavior.
+
+**Architecture:** Pure identifier rename across three artifacts in the Leaflet vertical slice. The production class lives in `Application/Features/Leaflet/Pipeline/`, is wired through `LeafletModule.AddLeafletModule`, and has a Moq/xUnit test fixture. The class body, MediatR contract, DI lifetime, and test assertions are preserved byte-for-byte; only the type name, file name, and logger generic argument change. Renames use `git mv` so blame/history follows the files. Frozen historical plan docs are intentionally left untouched.
+
+**Tech Stack:** .NET 8, MediatR `IPipelineBehavior<TRequest, TResponse>`, xUnit + Moq for tests, Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging, `git mv` for rename-with-history.
+
+---
+
+## File Map
+
+**Renamed (via `git mv`):**
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs`
+
+**Edited (identifier replacement only):**
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` — class name, constructor name, `ILogger<T>` generic
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — DI registration on lines 24–26
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` — test class name, `Mock<ILogger<T>>` generic, `CreateBehavior` return + constructor
+
+**Intentionally NOT touched:**
+- `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` — frozen historical plan, references remain as historical record (per spec FR-4 and arch-review Spec Amendment 2).
+
+---
+
+## Working Directory
+
+All steps run from the worktree root:
+```
+/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-leaflet-leafletgenerationlog
+```
+
+---
+
+### Task 1: Baseline — confirm tests pass before the rename
+
+This establishes a green baseline so any post-rename test break is provably caused by the rename, not pre-existing flakiness.
+
+**Files:**
+- Read-only verification.
+
+- [ ] **Step 1: Confirm the current production class and test file exist with their old names**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs
+ls backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+```
+Expected: both files print without error.
+
+- [ ] **Step 2: Confirm the four expected references and nothing else**
+
+Run:
+```bash
+rg -l "LeafletGenerationLoggingBehavior"
+```
+Expected: exactly these four paths print (order may vary):
+```
+backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs
+backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md
+```
+If any **other** file is listed, STOP and report — the plan does not cover that surface and needs amendment before continuing.
+
+- [ ] **Step 3: Build the solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors.
+
+- [ ] **Step 4: Run the existing fixture's three tests as the baseline**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests" \
+  --no-build
+```
+Expected: `Passed!  - Failed: 0, Passed: 3, Skipped: 0`. The three test names are:
+- `Handle_SavesGenerationRow_AndSetsResponseId`
+- `Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`
+- `Handle_ReturnsOriginalResponse`
+
+If any test fails here, STOP — pre-existing failure must be triaged before the rename starts.
+
+---
+
+### Task 2: Rename the production class file with `git mv`
+
+**Files:**
+- Rename: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs`
+
+- [ ] **Step 1: Rename the file using `git mv`**
+
+Run:
+```bash
+git mv backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs \
+       backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+```
+Expected: no output. `git mv` exits silently on success.
+
+- [ ] **Step 2: Verify the rename registered as a rename (not delete + create)**
+
+Run:
+```bash
+git status
+```
+Expected output contains a single rename line (similar wording):
+```
+renamed: backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs -> backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+```
+If Git instead shows a `deleted:` plus an `untracked:` entry, STOP and run `git mv` again — rename detection must succeed so blame follows the file.
+
+- [ ] **Step 3: Confirm the build now FAILS (filename moved, identifiers stale)**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: build still succeeds (C# does not require filename == class name; the type still compiles under its old identifier). If it succeeds, that is the expected state — proceed. If it fails, read the error: it should be solely caused by the file move, not by something unrelated.
+
+Note: the build is expected to stay green at this step. The actual breaking change (the class identifier) happens in Task 3.
+
+---
+
+### Task 3: Update the production class identifier and logger generic
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs`
+
+- [ ] **Step 1: Update the class name, constructor name, and `ILogger<T>` generic**
+
+The full updated file content is:
+
+```csharp
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationPersistenceBehavior
+    : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<LeafletGenerationPersistenceBehavior> _logger;
+
+    public LeafletGenerationPersistenceBehavior(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService,
+        ILogger<LeafletGenerationPersistenceBehavior> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GenerateLeafletResponse> Handle(
+        GenerateLeafletRequest request,
+        RequestHandlerDelegate<GenerateLeafletResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var response = await next();
+        sw.Stop();
+
+        if (!response.Success)
+            return response;
+
+        try
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            var generation = new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = request.Topic,
+                Audience = request.Audience.ToString(),
+                Length = request.Length.ToString(),
+                FinalMarkdown = response.Content,
+                KbSourceCount = response.KbSourceCount,
+                LeafletSourceCount = response.LeafletSourceCount,
+                DurationMs = sw.ElapsedMilliseconds,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UserId = currentUser.Id,
+            };
+
+            await _repository.SaveGenerationAsync(generation, cancellationToken);
+            response.Id = generation.Id;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to log leaflet generation. Topic: {Topic}", request.Topic);
+        }
+
+        return response;
+    }
+}
+```
+
+Use the `Write` tool to overwrite the file at `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` with the content above.
+
+The only changes vs. the prior file content are:
+- `class LeafletGenerationLoggingBehavior` → `class LeafletGenerationPersistenceBehavior`
+- `ILogger<LeafletGenerationLoggingBehavior> _logger` → `ILogger<LeafletGenerationPersistenceBehavior> _logger`
+- `public LeafletGenerationLoggingBehavior(` → `public LeafletGenerationPersistenceBehavior(`
+- `ILogger<LeafletGenerationLoggingBehavior> logger` constructor parameter type → `ILogger<LeafletGenerationPersistenceBehavior> logger`
+
+Method body, error handling, stopwatch usage, response mutation, and the catch-and-log block are byte-identical.
+
+- [ ] **Step 2: Verify the build now fails at the consumers (DI + tests)**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: build FAILS with errors in:
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — `LeafletGenerationLoggingBehavior` does not exist
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` — same type-not-found errors
+
+These are expected and will be fixed in Tasks 4 and 5. Do not commit yet.
+
+---
+
+### Task 4: Update DI registration in `LeafletModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs:24-26`
+
+- [ ] **Step 1: Replace the registration identifier**
+
+Use `Edit` to replace this exact block in `LeafletModule.cs`:
+
+Old:
+```csharp
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationLoggingBehavior>();
+```
+
+New:
+```csharp
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationPersistenceBehavior>();
+```
+
+The surrounding `using` directives, namespace, class definition, options binding, other `AddScoped` calls, and comments are unchanged. Lifetime stays `Scoped`. The `IPipelineBehavior<,>` generic argument tuple is unchanged.
+
+- [ ] **Step 2: Confirm the production assembly now builds**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+Expected: `Build succeeded` with 0 errors. The test project will still fail to build until Task 5 — that's fine for now.
+
+---
+
+### Task 5: Rename the test file with `git mv` and update its identifiers
+
+**Files:**
+- Rename: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs`
+
+- [ ] **Step 1: Rename the test file using `git mv`**
+
+Run:
+```bash
+git mv backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs \
+       backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs
+```
+Expected: no output.
+
+- [ ] **Step 2: Verify the second rename also registered as a rename**
+
+Run:
+```bash
+git status
+```
+Expected: a second `renamed:` line for the test file, in addition to the production-class rename from Task 2.
+
+- [ ] **Step 3: Update class name, mock generic, and helper method**
+
+Use the `Write` tool to overwrite `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationPersistenceBehaviorTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _userService = new();
+    private readonly Mock<ILogger<LeafletGenerationPersistenceBehavior>> _logger = new();
+
+    private LeafletGenerationPersistenceBehavior CreateBehavior() =>
+        new(_repository.Object, _userService.Object, _logger.Object);
+
+    private static GenerateLeafletRequest MakeRequest() =>
+        new()
+        {
+            Topic = "Vitamin C serum",
+            Audience = AudienceType.EndConsumer,
+            Length = LeafletLength.Medium,
+        };
+
+    private static GenerateLeafletResponse MakeResponse() =>
+        new()
+        {
+            Content = "# Vitamin C serum\n\nGreat for skin.",
+            KbSourceCount = 3,
+            LeafletSourceCount = 1,
+        };
+
+    [Fact]
+    public async Task Handle_SavesGenerationRow_AndSetsResponseId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+
+        LeafletGeneration? captured = null;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((g, _) => captured = g)
+            .Returns(Task.CompletedTask);
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.NotNull(captured);
+        Assert.Equal("Vitamin C serum", captured.Topic);
+        Assert.Equal("EndConsumer", captured.Audience);
+        Assert.Equal("Medium", captured.Length);
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", captured.FinalMarkdown);
+        Assert.Equal(3, captured.KbSourceCount);
+        Assert.Equal(1, captured.LeafletSourceCount);
+        Assert.Equal("user-1", captured.UserId);
+        Assert.True(captured.DurationMs >= 0);
+        Assert.NotEqual(Guid.Empty, captured.Id);
+        Assert.Equal(captured.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB down"));
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", result.Content);
+        Assert.Null(result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOriginalResponse()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.Equal(response, result);
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", result.Content);
+    }
+}
+```
+
+The only changes vs. the prior content are:
+- `public class LeafletGenerationLoggingBehaviorTests` → `public class LeafletGenerationPersistenceBehaviorTests`
+- `Mock<ILogger<LeafletGenerationLoggingBehavior>>` → `Mock<ILogger<LeafletGenerationPersistenceBehavior>>`
+- `private LeafletGenerationLoggingBehavior CreateBehavior()` → `private LeafletGenerationPersistenceBehavior CreateBehavior()`
+
+All three `[Fact]` tests, their AAA bodies, helpers, and assertions are unchanged.
+
+- [ ] **Step 4: Build the whole solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors and 0 warnings related to this change.
+
+- [ ] **Step 5: Run the renamed test fixture**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationPersistenceBehaviorTests" \
+  --no-build
+```
+Expected: `Passed!  - Failed: 0, Passed: 3, Skipped: 0`. Same three test names as in Task 1, Step 4 (they're not renamed):
+- `Handle_SavesGenerationRow_AndSetsResponseId`
+- `Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`
+- `Handle_ReturnsOriginalResponse`
+
+- [ ] **Step 6: Confirm no test refers to the old fixture name (e.g., leftover via filter)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests" \
+  --no-build
+```
+Expected: `Passed!  - Failed: 0, Passed: 0, Skipped: 0` (no matching tests found — i.e., the old fixture name truly is gone).
+
+---
+
+### Task 6: Full-repo grep assertion (FR-4)
+
+**Files:**
+- Read-only verification.
+
+- [ ] **Step 1: Confirm zero matches under `backend/` and `frontend/`**
+
+Run:
+```bash
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/ frontend/
+```
+Expected: no output, exit code 1 (rg's "no matches" exit code). If the shell hides exit codes, you can verify with:
+```bash
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/ frontend/; echo "exit=$?"
+```
+Expected: `exit=1` (no matches).
+
+If `frontend/` does not exist as a directory in the worktree, the command above will print a warning for that path but still return 1 overall — that is acceptable. The contract is that **no matching content** is found.
+
+- [ ] **Step 2: Confirm the historical plan reference is intentionally still present**
+
+Run:
+```bash
+rg -l "LeafletGenerationLoggingBehavior" docs/superpowers/plans/
+```
+Expected output (exactly one file):
+```
+docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md
+```
+This is the frozen historical plan and is intentionally preserved per arch-review Spec Amendment 2. Do not modify it.
+
+- [ ] **Step 3: Final whole-repo sanity check excluding the historical plan**
+
+Run:
+```bash
+rg "LeafletGenerationLoggingBehavior" \
+  --glob '!docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md'
+```
+Expected: no output. If anything else matches, STOP and update this plan to cover the new surface before continuing.
+
+---
+
+### Task 7: Full validation — build, format, full test pass
+
+**Files:**
+- Read-only validation.
+
+- [ ] **Step 1: Solution-wide build (no warnings policy)**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded. 0 Error(s)`. Warning count must be the same as the pre-rename baseline. If new warnings appear (e.g., nullable, unused using directives in the renamed files), STOP and resolve before committing.
+
+- [ ] **Step 2: `dotnet format` — apply, then verify the resulting diff is rename-scoped only**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+Expected: command exits 0.
+
+Then:
+```bash
+git status
+git diff --stat
+```
+Expected: the only modified files are the three renamed/edited files from Tasks 2–5 (`LeafletGenerationPersistenceBehavior.cs`, `LeafletModule.cs`, `LeafletGenerationPersistenceBehaviorTests.cs`). If `dotnet format` touched any *other* file, STOP — that is collateral damage and must be reverted (`git checkout -- <unrelated-file>`) before continuing.
+
+- [ ] **Step 3: Run the full test suite to confirm no other tests broke**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: all tests pass. Note the failure count is `0`. If any test outside the renamed fixture starts failing, it is almost certainly a pre-existing flake (compare with the Task 1 baseline) — but treat any new failure as a blocker until proven otherwise.
+
+- [ ] **Step 4: One final grep to confirm the rename is complete**
+
+Run:
+```bash
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/
+rg "LeafletGenerationPersistenceBehavior" backend/src/ backend/test/
+```
+Expected:
+- First command: no output (exit 1).
+- Second command: matches in exactly two files — `LeafletGenerationPersistenceBehavior.cs` (production) and `LeafletGenerationPersistenceBehaviorTests.cs` (test), plus `LeafletModule.cs` (DI). Three files total.
+
+---
+
+### Task 8: Commit
+
+**Files:**
+- All staged changes from Tasks 2–7.
+
+- [ ] **Step 1: Review the staged diff**
+
+Run:
+```bash
+git status
+git diff --staged --stat
+```
+Expected: two `renamed:` entries plus modifications inside the renamed files and `LeafletModule.cs`. Confirm:
+- `LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs` (rename detected)
+- `LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs` (rename detected)
+- `LeafletModule.cs` (modified)
+
+If Git shows delete+add instead of rename for either file, STOP — re-do the rename using `git mv` so the history follows the file.
+
+- [ ] **Step 2: Stage anything not already staged**
+
+`git mv` stages renames automatically, but if `dotnet format` produced edits, ensure they are staged too:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+git add backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git commit -m "refactor(leaflet): rename LeafletGenerationLoggingBehavior to LeafletGenerationPersistenceBehavior
+
+The MediatR pipeline behavior persists the LeafletGeneration record and
+stamps the response with its ID — its previous 'Logging' name actively
+misled readers. Pure rename: file, class, ILogger<T> generic, DI
+registration, and test fixture identifiers updated. Method body,
+DI lifetime, exception swallow-and-log, response mutation, and all
+three existing test assertions are unchanged."
+```
+Expected: commit succeeds. Pre-commit hooks (if any) pass. If a hook fails, fix the underlying issue and create a new commit (do not amend).
+
+- [ ] **Step 4: Verify the commit recorded the renames**
+
+Run:
+```bash
+git show --stat HEAD
+```
+Expected: the diff stat lists both file renames as `path/old.cs => path/new.cs` (rename detection succeeded), plus the `LeafletModule.cs` modification.
+
+---
+
+## Out-of-Scope Reminders (do NOT do)
+
+These were considered and explicitly excluded by the spec and arch review. Do not opportunistically include them:
+
+1. Do **not** split timing/observability into a second `LeafletGenerationLoggingBehavior` — pipeline ordering and a second registration are out of scope.
+2. Do **not** move `response.Id = generation.Id` into `GenerateLeafletHandler` — that changes the handler contract.
+3. Do **not** tighten the `catch (Exception ex)` block — existing tests assert the swallow behavior.
+4. Do **not** make `GenerateLeafletResponse.Id` `init`-only or rename `LeafletGeneration.Id` semantics.
+5. Do **not** rename the analogous `QuestionLoggingBehavior` in the KnowledgeBase slice (tracked as a separate follow-up per arch-review Spec Amendment 1).
+6. Do **not** edit `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` — it is a frozen historical record.
+
+---
+
+## Acceptance Checklist (matches spec FR/NFR)
+
+- [x] FR-1: Production class renamed (file, class, constructor, logger generic). — Tasks 2–3.
+- [x] FR-2: DI registration updated to `LeafletGenerationPersistenceBehavior`, scope remains `Scoped`. — Task 4.
+- [x] FR-3: Test file renamed, test class renamed, mock generic updated, all three tests pass unchanged. — Task 5.
+- [x] FR-4: `rg "LeafletGenerationLoggingBehavior"` under `backend/src/`, `backend/test/`, `frontend/` returns zero; historical plan doc intentionally preserved. — Task 6.
+- [x] NFR-1: Behavior parity — `Handle` body, ordering, exception handling unchanged. — Task 3, Step 1 (byte-identical method body).
+- [x] NFR-2: `dotnet build` succeeds; `dotnet format` diff is rename-scoped only. — Task 7.
+- [x] NFR-3: All three tests pass; full test suite has no new failures. — Tasks 5 and 7.
+- [x] NFR-4: Surgical change — no adjacent refactor; only identifier replacements. — Out-of-scope reminders above; Tasks 3/5 use exact replacement content.
+- [x] Renames use `git mv` so blame/history follow. — Tasks 2, 5 (verified in steps that check `git status` shows `renamed:`).

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
@@ -23,7 +23,7 @@ public static class LeafletModule
 
         services.AddScoped<
             IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
-            LeafletGenerationLoggingBehavior>();
+            LeafletGenerationPersistenceBehavior>();
 
         // LeafletIngestionJob is auto-discovered via IRecurringJob assembly scan in AddRecurringJobs()
         // ILeafletRepository is registered in PersistenceModule

--- a/backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
@@ -7,17 +7,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
 
-public class LeafletGenerationLoggingBehavior
+public class LeafletGenerationPersistenceBehavior
     : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
 {
     private readonly ILeafletRepository _repository;
     private readonly ICurrentUserService _currentUserService;
-    private readonly ILogger<LeafletGenerationLoggingBehavior> _logger;
+    private readonly ILogger<LeafletGenerationPersistenceBehavior> _logger;
 
-    public LeafletGenerationLoggingBehavior(
+    public LeafletGenerationPersistenceBehavior(
         ILeafletRepository repository,
         ICurrentUserService currentUserService,
-        ILogger<LeafletGenerationLoggingBehavior> logger)
+        ILogger<LeafletGenerationPersistenceBehavior> logger)
     {
         _repository = repository;
         _currentUserService = currentUserService;

--- a/backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs
@@ -8,13 +8,13 @@ using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Leaflet.Pipeline;
 
-public class LeafletGenerationLoggingBehaviorTests
+public class LeafletGenerationPersistenceBehaviorTests
 {
     private readonly Mock<ILeafletRepository> _repository = new();
     private readonly Mock<ICurrentUserService> _userService = new();
-    private readonly Mock<ILogger<LeafletGenerationLoggingBehavior>> _logger = new();
+    private readonly Mock<ILogger<LeafletGenerationPersistenceBehavior>> _logger = new();
 
-    private LeafletGenerationLoggingBehavior CreateBehavior() =>
+    private LeafletGenerationPersistenceBehavior CreateBehavior() =>
         new(_repository.Object, _userService.Object, _logger.Object);
 
     private static GenerateLeafletRequest MakeRequest() =>

--- a/docs/superpowers/plans/2026-05-15-leaflet-generation-persistence-behavior-rename.md
+++ b/docs/superpowers/plans/2026-05-15-leaflet-generation-persistence-behavior-rename.md
@@ -1,0 +1,605 @@
+# Rename `LeafletGenerationLoggingBehavior` → `LeafletGenerationPersistenceBehavior` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the misnamed `LeafletGenerationLoggingBehavior` MediatR pipeline behavior (and its test fixture + DI registration) to `LeafletGenerationPersistenceBehavior` to reflect its actual responsibility (persisting `LeafletGeneration` and stamping the response with its ID), without changing any runtime behavior.
+
+**Architecture:** Pure identifier rename across three artifacts in the Leaflet vertical slice. The production class lives in `Application/Features/Leaflet/Pipeline/`, is wired through `LeafletModule.AddLeafletModule`, and has a Moq/xUnit test fixture. The class body, MediatR contract, DI lifetime, and test assertions are preserved byte-for-byte; only the type name, file name, and logger generic argument change. Renames use `git mv` so blame/history follows the files. Frozen historical plan docs are intentionally left untouched.
+
+**Tech Stack:** .NET 8, MediatR `IPipelineBehavior<TRequest, TResponse>`, xUnit + Moq for tests, Microsoft.Extensions.DependencyInjection, Microsoft.Extensions.Logging, `git mv` for rename-with-history.
+
+---
+
+## File Map
+
+**Renamed (via `git mv`):**
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs`
+
+**Edited (identifier replacement only):**
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` — class name, constructor name, `ILogger<T>` generic
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — DI registration on lines 24–26
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` — test class name, `Mock<ILogger<T>>` generic, `CreateBehavior` return + constructor
+
+**Intentionally NOT touched:**
+- `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` — frozen historical plan, references remain as historical record (per spec FR-4 and arch-review Spec Amendment 2).
+
+---
+
+## Working Directory
+
+All steps run from the worktree root:
+```
+/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-leaflet-leafletgenerationlog
+```
+
+---
+
+### Task 1: Baseline — confirm tests pass before the rename
+
+This establishes a green baseline so any post-rename test break is provably caused by the rename, not pre-existing flakiness.
+
+**Files:**
+- Read-only verification.
+
+- [ ] **Step 1: Confirm the current production class and test file exist with their old names**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs
+ls backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+```
+Expected: both files print without error.
+
+- [ ] **Step 2: Confirm the four expected references and nothing else**
+
+Run:
+```bash
+rg -l "LeafletGenerationLoggingBehavior"
+```
+Expected: exactly these four paths print (order may vary):
+```
+backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs
+backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs
+docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md
+```
+If any **other** file is listed, STOP and report — the plan does not cover that surface and needs amendment before continuing.
+
+- [ ] **Step 3: Build the solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors.
+
+- [ ] **Step 4: Run the existing fixture's three tests as the baseline**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests" \
+  --no-build
+```
+Expected: `Passed!  - Failed: 0, Passed: 3, Skipped: 0`. The three test names are:
+- `Handle_SavesGenerationRow_AndSetsResponseId`
+- `Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`
+- `Handle_ReturnsOriginalResponse`
+
+If any test fails here, STOP — pre-existing failure must be triaged before the rename starts.
+
+---
+
+### Task 2: Rename the production class file with `git mv`
+
+**Files:**
+- Rename: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs`
+
+- [ ] **Step 1: Rename the file using `git mv`**
+
+Run:
+```bash
+git mv backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs \
+       backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+```
+Expected: no output. `git mv` exits silently on success.
+
+- [ ] **Step 2: Verify the rename registered as a rename (not delete + create)**
+
+Run:
+```bash
+git status
+```
+Expected output contains a single rename line (similar wording):
+```
+renamed: backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehavior.cs -> backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+```
+If Git instead shows a `deleted:` plus an `untracked:` entry, STOP and run `git mv` again — rename detection must succeed so blame follows the file.
+
+- [ ] **Step 3: Confirm the build now FAILS (filename moved, identifiers stale)**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: build still succeeds (C# does not require filename == class name; the type still compiles under its old identifier). If it succeeds, that is the expected state — proceed. If it fails, read the error: it should be solely caused by the file move, not by something unrelated.
+
+Note: the build is expected to stay green at this step. The actual breaking change (the class identifier) happens in Task 3.
+
+---
+
+### Task 3: Update the production class identifier and logger generic
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs`
+
+- [ ] **Step 1: Update the class name, constructor name, and `ILogger<T>` generic**
+
+The full updated file content is:
+
+```csharp
+using System.Diagnostics;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationPersistenceBehavior
+    : IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>
+{
+    private readonly ILeafletRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<LeafletGenerationPersistenceBehavior> _logger;
+
+    public LeafletGenerationPersistenceBehavior(
+        ILeafletRepository repository,
+        ICurrentUserService currentUserService,
+        ILogger<LeafletGenerationPersistenceBehavior> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GenerateLeafletResponse> Handle(
+        GenerateLeafletRequest request,
+        RequestHandlerDelegate<GenerateLeafletResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var response = await next();
+        sw.Stop();
+
+        if (!response.Success)
+            return response;
+
+        try
+        {
+            var currentUser = _currentUserService.GetCurrentUser();
+            var generation = new LeafletGeneration
+            {
+                Id = Guid.NewGuid(),
+                Topic = request.Topic,
+                Audience = request.Audience.ToString(),
+                Length = request.Length.ToString(),
+                FinalMarkdown = response.Content,
+                KbSourceCount = response.KbSourceCount,
+                LeafletSourceCount = response.LeafletSourceCount,
+                DurationMs = sw.ElapsedMilliseconds,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UserId = currentUser.Id,
+            };
+
+            await _repository.SaveGenerationAsync(generation, cancellationToken);
+            response.Id = generation.Id;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to log leaflet generation. Topic: {Topic}", request.Topic);
+        }
+
+        return response;
+    }
+}
+```
+
+Use the `Write` tool to overwrite the file at `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` with the content above.
+
+The only changes vs. the prior file content are:
+- `class LeafletGenerationLoggingBehavior` → `class LeafletGenerationPersistenceBehavior`
+- `ILogger<LeafletGenerationLoggingBehavior> _logger` → `ILogger<LeafletGenerationPersistenceBehavior> _logger`
+- `public LeafletGenerationLoggingBehavior(` → `public LeafletGenerationPersistenceBehavior(`
+- `ILogger<LeafletGenerationLoggingBehavior> logger` constructor parameter type → `ILogger<LeafletGenerationPersistenceBehavior> logger`
+
+Method body, error handling, stopwatch usage, response mutation, and the catch-and-log block are byte-identical.
+
+- [ ] **Step 2: Verify the build now fails at the consumers (DI + tests)**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: build FAILS with errors in:
+- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — `LeafletGenerationLoggingBehavior` does not exist
+- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` — same type-not-found errors
+
+These are expected and will be fixed in Tasks 4 and 5. Do not commit yet.
+
+---
+
+### Task 4: Update DI registration in `LeafletModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs:24-26`
+
+- [ ] **Step 1: Replace the registration identifier**
+
+Use `Edit` to replace this exact block in `LeafletModule.cs`:
+
+Old:
+```csharp
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationLoggingBehavior>();
+```
+
+New:
+```csharp
+        services.AddScoped<
+            IPipelineBehavior<GenerateLeafletRequest, GenerateLeafletResponse>,
+            LeafletGenerationPersistenceBehavior>();
+```
+
+The surrounding `using` directives, namespace, class definition, options binding, other `AddScoped` calls, and comments are unchanged. Lifetime stays `Scoped`. The `IPipelineBehavior<,>` generic argument tuple is unchanged.
+
+- [ ] **Step 2: Confirm the production assembly now builds**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+Expected: `Build succeeded` with 0 errors. The test project will still fail to build until Task 5 — that's fine for now.
+
+---
+
+### Task 5: Rename the test file with `git mv` and update its identifiers
+
+**Files:**
+- Rename: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs`
+
+- [ ] **Step 1: Rename the test file using `git mv`**
+
+Run:
+```bash
+git mv backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationLoggingBehaviorTests.cs \
+       backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs
+```
+Expected: no output.
+
+- [ ] **Step 2: Verify the second rename also registered as a rename**
+
+Run:
+```bash
+git status
+```
+Expected: a second `renamed:` line for the test file, in addition to the production-class rename from Task 2.
+
+- [ ] **Step 3: Update class name, mock generic, and helper method**
+
+Use the `Write` tool to overwrite `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Pipeline;
+using Anela.Heblo.Application.Features.Leaflet.UseCases.GenerateLeaflet;
+using Anela.Heblo.Domain.Features.Leaflet;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Leaflet.Pipeline;
+
+public class LeafletGenerationPersistenceBehaviorTests
+{
+    private readonly Mock<ILeafletRepository> _repository = new();
+    private readonly Mock<ICurrentUserService> _userService = new();
+    private readonly Mock<ILogger<LeafletGenerationPersistenceBehavior>> _logger = new();
+
+    private LeafletGenerationPersistenceBehavior CreateBehavior() =>
+        new(_repository.Object, _userService.Object, _logger.Object);
+
+    private static GenerateLeafletRequest MakeRequest() =>
+        new()
+        {
+            Topic = "Vitamin C serum",
+            Audience = AudienceType.EndConsumer,
+            Length = LeafletLength.Medium,
+        };
+
+    private static GenerateLeafletResponse MakeResponse() =>
+        new()
+        {
+            Content = "# Vitamin C serum\n\nGreat for skin.",
+            KbSourceCount = 3,
+            LeafletSourceCount = 1,
+        };
+
+    [Fact]
+    public async Task Handle_SavesGenerationRow_AndSetsResponseId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+
+        LeafletGeneration? captured = null;
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Callback<LeafletGeneration, CancellationToken>((g, _) => captured = g)
+            .Returns(Task.CompletedTask);
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.NotNull(captured);
+        Assert.Equal("Vitamin C serum", captured.Topic);
+        Assert.Equal("EndConsumer", captured.Audience);
+        Assert.Equal("Medium", captured.Length);
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", captured.FinalMarkdown);
+        Assert.Equal(3, captured.KbSourceCount);
+        Assert.Equal(1, captured.LeafletSourceCount);
+        Assert.Equal("user-1", captured.UserId);
+        Assert.True(captured.DurationMs >= 0);
+        Assert.NotEqual(Guid.Empty, captured.Id);
+        Assert.Equal(captured.Id, result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("DB down"));
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", result.Content);
+        Assert.Null(result.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOriginalResponse()
+    {
+        _userService.Setup(s => s.GetCurrentUser())
+            .Returns(new CurrentUser("user-1", "Test", null, true));
+        _repository
+            .Setup(r => r.SaveGenerationAsync(It.IsAny<LeafletGeneration>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var behavior = CreateBehavior();
+        var response = MakeResponse();
+        var result = await behavior.Handle(MakeRequest(), () => Task.FromResult(response), default);
+
+        Assert.Equal(response, result);
+        Assert.Equal("# Vitamin C serum\n\nGreat for skin.", result.Content);
+    }
+}
+```
+
+The only changes vs. the prior content are:
+- `public class LeafletGenerationLoggingBehaviorTests` → `public class LeafletGenerationPersistenceBehaviorTests`
+- `Mock<ILogger<LeafletGenerationLoggingBehavior>>` → `Mock<ILogger<LeafletGenerationPersistenceBehavior>>`
+- `private LeafletGenerationLoggingBehavior CreateBehavior()` → `private LeafletGenerationPersistenceBehavior CreateBehavior()`
+
+All three `[Fact]` tests, their AAA bodies, helpers, and assertions are unchanged.
+
+- [ ] **Step 4: Build the whole solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors and 0 warnings related to this change.
+
+- [ ] **Step 5: Run the renamed test fixture**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationPersistenceBehaviorTests" \
+  --no-build
+```
+Expected: `Passed!  - Failed: 0, Passed: 3, Skipped: 0`. Same three test names as in Task 1, Step 4 (they're not renamed):
+- `Handle_SavesGenerationRow_AndSetsResponseId`
+- `Handle_WhenDbWriteFails_StillReturnsResponse_WithNullId`
+- `Handle_ReturnsOriginalResponse`
+
+- [ ] **Step 6: Confirm no test refers to the old fixture name (e.g., leftover via filter)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~LeafletGenerationLoggingBehaviorTests" \
+  --no-build
+```
+Expected: `Passed!  - Failed: 0, Passed: 0, Skipped: 0` (no matching tests found — i.e., the old fixture name truly is gone).
+
+---
+
+### Task 6: Full-repo grep assertion (FR-4)
+
+**Files:**
+- Read-only verification.
+
+- [ ] **Step 1: Confirm zero matches under `backend/` and `frontend/`**
+
+Run:
+```bash
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/ frontend/
+```
+Expected: no output, exit code 1 (rg's "no matches" exit code). If the shell hides exit codes, you can verify with:
+```bash
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/ frontend/; echo "exit=$?"
+```
+Expected: `exit=1` (no matches).
+
+If `frontend/` does not exist as a directory in the worktree, the command above will print a warning for that path but still return 1 overall — that is acceptable. The contract is that **no matching content** is found.
+
+- [ ] **Step 2: Confirm the historical plan reference is intentionally still present**
+
+Run:
+```bash
+rg -l "LeafletGenerationLoggingBehavior" docs/superpowers/plans/
+```
+Expected output (exactly one file):
+```
+docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md
+```
+This is the frozen historical plan and is intentionally preserved per arch-review Spec Amendment 2. Do not modify it.
+
+- [ ] **Step 3: Final whole-repo sanity check excluding the historical plan**
+
+Run:
+```bash
+rg "LeafletGenerationLoggingBehavior" \
+  --glob '!docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md'
+```
+Expected: no output. If anything else matches, STOP and update this plan to cover the new surface before continuing.
+
+---
+
+### Task 7: Full validation — build, format, full test pass
+
+**Files:**
+- Read-only validation.
+
+- [ ] **Step 1: Solution-wide build (no warnings policy)**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded. 0 Error(s)`. Warning count must be the same as the pre-rename baseline. If new warnings appear (e.g., nullable, unused using directives in the renamed files), STOP and resolve before committing.
+
+- [ ] **Step 2: `dotnet format` — apply, then verify the resulting diff is rename-scoped only**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+Expected: command exits 0.
+
+Then:
+```bash
+git status
+git diff --stat
+```
+Expected: the only modified files are the three renamed/edited files from Tasks 2–5 (`LeafletGenerationPersistenceBehavior.cs`, `LeafletModule.cs`, `LeafletGenerationPersistenceBehaviorTests.cs`). If `dotnet format` touched any *other* file, STOP — that is collateral damage and must be reverted (`git checkout -- <unrelated-file>`) before continuing.
+
+- [ ] **Step 3: Run the full test suite to confirm no other tests broke**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: all tests pass. Note the failure count is `0`. If any test outside the renamed fixture starts failing, it is almost certainly a pre-existing flake (compare with the Task 1 baseline) — but treat any new failure as a blocker until proven otherwise.
+
+- [ ] **Step 4: One final grep to confirm the rename is complete**
+
+Run:
+```bash
+rg "LeafletGenerationLoggingBehavior" backend/src/ backend/test/
+rg "LeafletGenerationPersistenceBehavior" backend/src/ backend/test/
+```
+Expected:
+- First command: no output (exit 1).
+- Second command: matches in exactly two files — `LeafletGenerationPersistenceBehavior.cs` (production) and `LeafletGenerationPersistenceBehaviorTests.cs` (test), plus `LeafletModule.cs` (DI). Three files total.
+
+---
+
+### Task 8: Commit
+
+**Files:**
+- All staged changes from Tasks 2–7.
+
+- [ ] **Step 1: Review the staged diff**
+
+Run:
+```bash
+git status
+git diff --staged --stat
+```
+Expected: two `renamed:` entries plus modifications inside the renamed files and `LeafletModule.cs`. Confirm:
+- `LeafletGenerationLoggingBehavior.cs` → `LeafletGenerationPersistenceBehavior.cs` (rename detected)
+- `LeafletGenerationLoggingBehaviorTests.cs` → `LeafletGenerationPersistenceBehaviorTests.cs` (rename detected)
+- `LeafletModule.cs` (modified)
+
+If Git shows delete+add instead of rename for either file, STOP — re-do the rename using `git mv` so the history follows the file.
+
+- [ ] **Step 2: Stage anything not already staged**
+
+`git mv` stages renames automatically, but if `dotnet format` produced edits, ensure they are staged too:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs
+git add backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs
+git add backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+```bash
+git commit -m "refactor(leaflet): rename LeafletGenerationLoggingBehavior to LeafletGenerationPersistenceBehavior
+
+The MediatR pipeline behavior persists the LeafletGeneration record and
+stamps the response with its ID — its previous 'Logging' name actively
+misled readers. Pure rename: file, class, ILogger<T> generic, DI
+registration, and test fixture identifiers updated. Method body,
+DI lifetime, exception swallow-and-log, response mutation, and all
+three existing test assertions are unchanged."
+```
+Expected: commit succeeds. Pre-commit hooks (if any) pass. If a hook fails, fix the underlying issue and create a new commit (do not amend).
+
+- [ ] **Step 4: Verify the commit recorded the renames**
+
+Run:
+```bash
+git show --stat HEAD
+```
+Expected: the diff stat lists both file renames as `path/old.cs => path/new.cs` (rename detection succeeded), plus the `LeafletModule.cs` modification.
+
+---
+
+## Out-of-Scope Reminders (do NOT do)
+
+These were considered and explicitly excluded by the spec and arch review. Do not opportunistically include them:
+
+1. Do **not** split timing/observability into a second `LeafletGenerationLoggingBehavior` — pipeline ordering and a second registration are out of scope.
+2. Do **not** move `response.Id = generation.Id` into `GenerateLeafletHandler` — that changes the handler contract.
+3. Do **not** tighten the `catch (Exception ex)` block — existing tests assert the swallow behavior.
+4. Do **not** make `GenerateLeafletResponse.Id` `init`-only or rename `LeafletGeneration.Id` semantics.
+5. Do **not** rename the analogous `QuestionLoggingBehavior` in the KnowledgeBase slice (tracked as a separate follow-up per arch-review Spec Amendment 1).
+6. Do **not** edit `docs/superpowers/plans/2026-05-05-leaflet-persistence-feedback.md` — it is a frozen historical record.
+
+---
+
+## Acceptance Checklist (matches spec FR/NFR)
+
+- [x] FR-1: Production class renamed (file, class, constructor, logger generic). — Tasks 2–3.
+- [x] FR-2: DI registration updated to `LeafletGenerationPersistenceBehavior`, scope remains `Scoped`. — Task 4.
+- [x] FR-3: Test file renamed, test class renamed, mock generic updated, all three tests pass unchanged. — Task 5.
+- [x] FR-4: `rg "LeafletGenerationLoggingBehavior"` under `backend/src/`, `backend/test/`, `frontend/` returns zero; historical plan doc intentionally preserved. — Task 6.
+- [x] NFR-1: Behavior parity — `Handle` body, ordering, exception handling unchanged. — Task 3, Step 1 (byte-identical method body).
+- [x] NFR-2: `dotnet build` succeeds; `dotnet format` diff is rename-scoped only. — Task 7.
+- [x] NFR-3: All three tests pass; full test suite has no new failures. — Tasks 5 and 7.
+- [x] NFR-4: Surgical change — no adjacent refactor; only identifier replacements. — Out-of-scope reminders above; Tasks 3/5 use exact replacement content.
+- [x] Renames use `git mv` so blame/history follow. — Tasks 2, 5 (verified in steps that check `git status` shows `renamed:`).


### PR DESCRIPTION
Renames `LeafletGenerationLoggingBehavior` to `LeafletGenerationPersistenceBehavior` to reflect the behavior's true responsibility: persisting the `LeafletGeneration` record and stamping `GenerateLeafletResponse.Id`. The previous "Logging" name misled readers about where the core persistence write happens. Pure rename — method body, DI lifetime, test assertions, and all runtime behavior are unchanged.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehavior.cs` — renamed + class/constructor/logger generic updated
- `backend/src/Anela.Heblo.Application/Features/Leaflet/LeafletModule.cs` — DI registration updated
- `backend/test/Anela.Heblo.Tests/Features/Leaflet/Pipeline/LeafletGenerationPersistenceBehaviorTests.cs` — renamed + test class/mock/factory updated

---

Closes #1262

### Tokens used
8907762
