### PR TITLE
feat(smartsupp): redesign chat UI with status, agent attribution, contact panel, composer + KB suggestions

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ConversationDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ConversationDto.cs
@@ -13,4 +13,20 @@ public class ConversationDto
     public string? LastMessagePreview { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
+
+    // Rich context fields — sourced from SmartsuppConversation entity
+    public int? Rating { get; set; }
+    public string? RatingText { get; set; }
+    public string? CloseType { get; set; }
+    public string? ClosedByAgentId { get; set; }
+    public List<string> AssignedAgentIds { get; set; } = new();
+    public string? Channel { get; set; }
+    public bool IsServed { get; set; }
+    public DateTime? FinishedAt { get; set; }
+    public string? Domain { get; set; }
+    public string? Referer { get; set; }
+    public string? LocationCountry { get; set; }
+    public string? LocationCity { get; set; }
+    public string? LocationCode { get; set; }
+    public List<string> Tags { get; set; } = new();
 }

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/MessageDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/MessageDto.cs
@@ -8,5 +8,11 @@ public class MessageDto
     public string? Content { get; set; }
     public DateTime CreatedAt { get; set; }
 
-    // AttachmentsJson excluded — attachment rendering is out of scope for this phase.
+    public string? AgentId { get; set; }
+    public string? SubType { get; set; }
+    public string? DeliveryStatus { get; set; }
+    public DateTime? DeliveredAt { get; set; }
+    public int? ResponseTime { get; set; }
+    public bool IsFirstReply { get; set; }
+    public string? PageUrl { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetConversation/GetConversationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetConversation/GetConversationHandler.cs
@@ -66,6 +66,13 @@ public class GetConversationHandler : IRequestHandler<GetConversationRequest, Ge
             AuthorName = m.AuthorName,
             Content = m.Content,
             CreatedAt = m.CreatedAt,
+            AgentId = m.AgentId,
+            SubType = m.SubType,
+            DeliveryStatus = m.DeliveryStatus,
+            DeliveredAt = m.DeliveredAt,
+            ResponseTime = m.ResponseTime,
+            IsFirstReply = m.IsFirstReply,
+            PageUrl = m.PageUrl,
         };
 
     private static List<string> ParseStringList(string? json)

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetConversation/GetConversationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetConversation/GetConversationHandler.cs
@@ -42,6 +42,20 @@ public class GetConversationHandler : IRequestHandler<GetConversationRequest, Ge
             LastMessagePreview = c.LastMessagePreview,
             CreatedAt = c.CreatedAt,
             UpdatedAt = c.UpdatedAt,
+            Rating = c.Rating,
+            RatingText = c.RatingText,
+            CloseType = c.CloseType,
+            ClosedByAgentId = c.ClosedByAgentId,
+            AssignedAgentIds = ParseStringList(c.AssignedAgentIdsJson),
+            Channel = c.Channel,
+            IsServed = c.IsServed,
+            FinishedAt = c.FinishedAt,
+            Domain = c.Domain,
+            Referer = c.Referer,
+            LocationCountry = c.LocationCountry,
+            LocationCity = c.LocationCity,
+            LocationCode = c.LocationCode,
+            Tags = ParseStringList(c.TagsJson),
         };
 
     private static MessageDto MapMessageDto(SmartsuppMessage m) =>
@@ -53,4 +67,17 @@ public class GetConversationHandler : IRequestHandler<GetConversationRequest, Ge
             Content = m.Content,
             CreatedAt = m.CreatedAt,
         };
+
+    private static List<string> ParseStringList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<string>();
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return new List<string>();
+        }
+    }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/ListConversations/ListConversationsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/ListConversations/ListConversationsHandler.cs
@@ -45,5 +45,32 @@ public class ListConversationsHandler : IRequestHandler<ListConversationsRequest
             LastMessagePreview = c.LastMessagePreview,
             CreatedAt = c.CreatedAt,
             UpdatedAt = c.UpdatedAt,
+            Rating = c.Rating,
+            RatingText = c.RatingText,
+            CloseType = c.CloseType,
+            ClosedByAgentId = c.ClosedByAgentId,
+            AssignedAgentIds = ParseStringList(c.AssignedAgentIdsJson),
+            Channel = c.Channel,
+            IsServed = c.IsServed,
+            FinishedAt = c.FinishedAt,
+            Domain = c.Domain,
+            Referer = c.Referer,
+            LocationCountry = c.LocationCountry,
+            LocationCity = c.LocationCity,
+            LocationCode = c.LocationCode,
+            Tags = ParseStringList(c.TagsJson),
         };
+
+    private static List<string> ParseStringList(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new List<string>();
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return new List<string>();
+        }
+    }
 }

--- a/frontend/src/api/hooks/useSmartsupp.ts
+++ b/frontend/src/api/hooks/useSmartsupp.ts
@@ -13,6 +13,20 @@ export interface ConversationDto {
   lastMessagePreview?: string | null;
   createdAt: string;
   updatedAt: string;
+  rating?: number | null;
+  ratingText?: string | null;
+  closeType?: string | null;
+  closedByAgentId?: string | null;
+  assignedAgentIds: string[];
+  channel?: string | null;
+  isServed: boolean;
+  finishedAt?: string | null;
+  domain?: string | null;
+  referer?: string | null;
+  locationCountry?: string | null;
+  locationCity?: string | null;
+  locationCode?: string | null;
+  tags: string[];
 }
 
 export interface MessageDto {
@@ -21,6 +35,13 @@ export interface MessageDto {
   authorName?: string | null;
   content?: string | null;
   createdAt: string;
+  agentId?: string | null;
+  subType?: string | null;
+  deliveryStatus?: string | null;
+  deliveredAt?: string | null;
+  responseTime?: number | null;
+  isFirstReply: boolean;
+  pageUrl?: string | null;
 }
 
 export interface ListConversationsResponse {

--- a/frontend/src/components/customer-support/smartsupp/AgentBadge.tsx
+++ b/frontend/src/components/customer-support/smartsupp/AgentBadge.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { getAgentColor } from "./utils/agentColor";
+
+interface AgentBadgeProps {
+  agentId?: string | null;
+  name?: string | null;
+  showInitials?: boolean;
+}
+
+function getInitials(name?: string | null): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/);
+  return parts.length >= 2
+    ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+    : name.slice(0, 2).toUpperCase();
+}
+
+const AgentBadge: React.FC<AgentBadgeProps> = ({ agentId, name, showInitials = true }) => {
+  const color = getAgentColor(agentId);
+  const initials = getInitials(name);
+  const label = name ?? initials;
+
+  return (
+    <span
+      data-testid="agent-badge"
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${color.bg} ${color.text}`}
+    >
+      {showInitials && (
+        <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full ring-1 ${color.ring} bg-white text-[10px] font-semibold`}>
+          {initials}
+        </span>
+      )}
+      <span className="truncate max-w-[10rem]">{label}</span>
+    </span>
+  );
+};
+
+export default AgentBadge;

--- a/frontend/src/components/customer-support/smartsupp/ChatComposer.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ChatComposer.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { Send } from "lucide-react";
+import KnowledgeBaseSuggestions from "./KnowledgeBaseSuggestions";
+
+interface ChatComposerProps {
+  conversationId: string | null;
+  lastContactMessage: string | null;
+}
+
+const MAX_CHARS = 4000;
+
+const ChatComposer: React.FC<ChatComposerProps> = ({ conversationId, lastContactMessage }) => {
+  const [draft, setDraft] = useState<string>("");
+
+  const insertSuggestion = (content: string) => {
+    setDraft((prev) => (prev.length === 0 ? content : `${prev}\n\n${content}`));
+  };
+
+  return (
+    <div className="flex flex-col">
+      <KnowledgeBaseSuggestions
+        conversationId={conversationId}
+        lastContactMessage={lastContactMessage}
+        onSelect={insertSuggestion}
+      />
+      <div className="border-t border-gray-200 p-3 flex flex-col gap-2 bg-white">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value.slice(0, MAX_CHARS))}
+          placeholder="Napište odpověď..."
+          rows={3}
+          className="w-full resize-none rounded-md border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400"
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-gray-400">
+            {draft.length} / {MAX_CHARS}
+          </span>
+          <button
+            type="button"
+            disabled
+            title="Odpovídání bude přidáno později"
+            aria-label="Odeslat"
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md bg-blue-500 text-white opacity-50 cursor-not-allowed"
+          >
+            <Send className="w-4 h-4" />
+            Odeslat
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatComposer;

--- a/frontend/src/components/customer-support/smartsupp/ContactDetailsPanel.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ContactDetailsPanel.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { ConversationDto } from "../../../api/hooks/useSmartsupp";
+import StatusPill from "./StatusPill";
+import AgentBadge from "./AgentBadge";
+import { Star } from "lucide-react";
+
+interface ContactDetailsPanelProps {
+  conversation: ConversationDto;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="px-4 py-3 border-b border-gray-100">
+      <div className="text-[11px] uppercase tracking-wide text-gray-400 font-medium mb-1.5">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function formatLocation(c: ConversationDto): string | null {
+  const parts = [c.locationCity, c.locationCountry].filter(Boolean);
+  return parts.length ? parts.join(", ") : null;
+}
+
+const ContactDetailsPanel: React.FC<ContactDetailsPanelProps> = ({ conversation }) => {
+  const displayName = conversation.contactName ?? conversation.contactEmail ?? "Neznámý";
+  const location = formatLocation(conversation);
+  const hasRating = typeof conversation.rating === "number";
+
+  return (
+    <aside className="h-full w-full overflow-y-auto bg-white border-l border-gray-200">
+      <div className="px-4 py-4 border-b border-gray-200 flex items-center gap-3">
+        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-500 text-white flex items-center justify-center text-sm font-medium">
+          {displayName.slice(0, 2).toUpperCase()}
+        </div>
+        <div className="min-w-0">
+          <div className="font-semibold text-sm text-gray-900 truncate">{displayName}</div>
+          {conversation.contactEmail && (
+            <div className="text-xs text-gray-500 truncate">{conversation.contactEmail}</div>
+          )}
+        </div>
+      </div>
+
+      <Section title="Stav">
+        <StatusPill status={conversation.status} />
+        {conversation.closeType && (
+          <div className="text-xs text-gray-500 mt-1.5">Uzavřeno: {conversation.closeType}</div>
+        )}
+      </Section>
+
+      {hasRating && (
+        <Section title="Hodnocení">
+          <div data-testid="rating" className="flex items-center gap-1 text-amber-500">
+            <Star className="w-4 h-4 fill-amber-400" />
+            <span className="text-sm font-medium text-gray-900">{conversation.rating}</span>
+            <span className="text-xs text-gray-400">/ 5</span>
+          </div>
+          {conversation.ratingText && (
+            <p className="text-xs text-gray-600 mt-1.5 italic">"{conversation.ratingText}"</p>
+          )}
+        </Section>
+      )}
+
+      {conversation.assignedAgentIds.length > 0 && (
+        <Section title="Přiřazení operátoři">
+          <div className="flex flex-wrap gap-1.5">
+            {conversation.assignedAgentIds.map((id) => (
+              <AgentBadge key={id} agentId={id} name={id} />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {(location || conversation.locationCode) && (
+        <Section title="Lokalita">
+          <div className="text-sm text-gray-700">{location ?? conversation.locationCode}</div>
+        </Section>
+      )}
+
+      {(conversation.channel || conversation.domain || conversation.referer) && (
+        <Section title="Zdroj">
+          {conversation.channel && <div className="text-sm text-gray-700">{conversation.channel}</div>}
+          {conversation.domain && <div className="text-xs text-gray-500">{conversation.domain}</div>}
+          {conversation.referer && (
+            <a
+              href={conversation.referer}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-blue-600 hover:underline truncate block"
+            >
+              {conversation.referer}
+            </a>
+          )}
+        </Section>
+      )}
+
+      {conversation.tags.length > 0 && (
+        <Section title="Štítky">
+          <div className="flex flex-wrap gap-1.5">
+            {conversation.tags.map((t) => (
+              <span key={t} className="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-gray-100 text-gray-700">
+                {t}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+    </aside>
+  );
+};
+
+export default ContactDetailsPanel;

--- a/frontend/src/components/customer-support/smartsupp/ConversationDetail.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ConversationDetail.tsx
@@ -1,58 +1,107 @@
 import React, { useEffect, useRef } from "react";
-import { ConversationDto, useSmartsuppConversation } from "../../../api/hooks/useSmartsupp";
+import { ConversationDto, MessageDto, useSmartsuppConversation } from "../../../api/hooks/useSmartsupp";
 import MessageBubble from "./MessageBubble";
+import StatusPill from "./StatusPill";
+import AgentBadge from "./AgentBadge";
+import DaySeparator from "./DaySeparator";
+import ChatComposer from "./ChatComposer";
+import { PanelRight } from "lucide-react";
 
 interface ConversationDetailProps {
   conversationId: string;
   conversation: ConversationDto;
+  onToggleContactPanel: () => void;
 }
 
-function formatLastActivity(dateStr?: string | null): string {
-  if (!dateStr) return "";
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 1) return "právě teď";
-  if (minutes < 60) return `před ${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `před ${hours} h`;
-  return `před ${Math.floor(hours / 24)} dny`;
+function lastContactMessage(messages: MessageDto[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    const t = m.authorType.toLowerCase();
+    if (t === "visitor" || t === "contact") return m.content ?? null;
+  }
+  return null;
 }
 
-const ConversationDetail: React.FC<ConversationDetailProps> = ({ conversationId, conversation }) => {
+function groupByDay(messages: MessageDto[]): Array<{ day: string; items: MessageDto[] }> {
+  const groups: Array<{ day: string; items: MessageDto[] }> = [];
+  for (const m of messages) {
+    const day = new Date(m.createdAt).toISOString().slice(0, 10);
+    const last = groups[groups.length - 1];
+    if (last && last.day === day) {
+      last.items.push(m);
+    } else {
+      groups.push({ day, items: [m] });
+    }
+  }
+  return groups;
+}
+
+const ConversationDetail: React.FC<ConversationDetailProps> = ({
+  conversationId,
+  conversation,
+  onToggleContactPanel,
+}) => {
   const { data, isLoading } = useSmartsuppConversation(conversationId);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const messages = data?.messages ?? [];
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [data?.messages?.length, conversationId]);
+  }, [messages.length, conversationId]);
+
+  const displayName = conversation.contactName ?? conversation.contactEmail ?? "Neznámý";
+  const grouped = groupByDay(messages);
 
   return (
     <div className="flex flex-col h-full">
-      <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
-        <div>
-          <h3 className="font-semibold text-gray-900">{conversation.contactName ?? conversation.contactEmail ?? "Neznámý"}</h3>
-          <p className="text-xs text-gray-500">
-            Poslední aktivita{" "}
-            {formatLastActivity(conversation.lastMessageAt ?? conversation.updatedAt)}
-          </p>
+      <div className="px-6 py-3 border-b border-gray-200 flex items-center gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-gray-900 truncate">{displayName}</h3>
+            <StatusPill status={conversation.status} />
+          </div>
+          {conversation.contactEmail && (
+            <p className="text-xs text-gray-500 truncate">{conversation.contactEmail}</p>
+          )}
         </div>
-        {conversation.contactEmail && (
-          <span className="ml-auto text-sm text-gray-400">{conversation.contactEmail}</span>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          {conversation.assignedAgentIds.map((id) => (
+            <AgentBadge key={id} agentId={id} name={id} />
+          ))}
+          <button
+            type="button"
+            onClick={onToggleContactPanel}
+            data-testid="toggle-contact-panel"
+            aria-label="Detail kontaktu"
+            className="inline-flex items-center justify-center w-8 h-8 rounded-md text-gray-500 hover:bg-gray-100"
+          >
+            <PanelRight className="w-4 h-4" />
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 py-4">
         {isLoading && (
           <div className="text-sm text-gray-400 text-center py-8">Načítání zpráv...</div>
         )}
-        {!isLoading && (!data?.messages || data.messages.length === 0) && (
+        {!isLoading && messages.length === 0 && (
           <div className="text-sm text-gray-400 text-center py-8">Žádné zprávy</div>
         )}
-        {data?.messages?.map((message) => (
-          <MessageBubble key={message.id} message={message} />
+        {grouped.map((g) => (
+          <div key={g.day}>
+            <DaySeparator date={g.items[0].createdAt} />
+            {g.items.map((m) => (
+              <MessageBubble key={m.id} message={m} />
+            ))}
+          </div>
         ))}
         <div ref={bottomRef} />
       </div>
+
+      <ChatComposer
+        conversationId={conversationId}
+        lastContactMessage={lastContactMessage(messages)}
+      />
     </div>
   );
 };

--- a/frontend/src/components/customer-support/smartsupp/ConversationListItem.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ConversationListItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ConversationDto } from "../../../api/hooks/useSmartsupp";
+import StatusPill from "./StatusPill";
 
 interface ConversationListItemProps {
   conversation: ConversationDto;
@@ -9,7 +10,7 @@ interface ConversationListItemProps {
 
 function getInitials(name?: string | null): string {
   if (!name) return "?";
-  const parts = name.trim().split(" ");
+  const parts = name.trim().split(/\s+/);
   return parts.length >= 2
     ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
     : name.slice(0, 2).toUpperCase();
@@ -34,15 +35,16 @@ const ConversationListItem: React.FC<ConversationListItemProps> = ({
   const displayName = conversation.contactName ?? conversation.contactEmail ?? null;
   const initials = getInitials(displayName);
   const relativeTime = formatRelativeTime(conversation.lastMessageAt ?? conversation.updatedAt);
+  const isUnread = conversation.isUnread;
+
+  const containerClasses = [
+    "w-full text-left px-4 py-3 flex items-start gap-3 border-b border-gray-100 transition-colors",
+    isSelected ? "bg-blue-50" : "hover:bg-gray-50",
+    isUnread ? "border-l-4 border-l-blue-500" : "",
+  ].join(" ");
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`w-full text-left px-4 py-3 flex items-start gap-3 border-b border-gray-100 hover:bg-gray-50 transition-colors ${
-        isSelected ? "bg-blue-50 border-l-4 border-l-blue-500" : ""
-      }`}
-    >
+    <button type="button" onClick={onClick} className={containerClasses}>
       <div className="flex-shrink-0 w-9 h-9 rounded-full bg-blue-500 text-white flex items-center justify-center text-sm font-medium">
         {conversation.contactAvatarUrl ? (
           <img
@@ -56,18 +58,16 @@ const ConversationListItem: React.FC<ConversationListItemProps> = ({
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between gap-2">
-          <span className="font-medium text-sm text-gray-900 truncate">
+          <span className={`text-sm text-gray-900 truncate ${isUnread ? "font-semibold" : "font-medium"}`}>
             {displayName ?? "Neznámý"}
           </span>
           <span className="text-xs text-gray-400 flex-shrink-0">{relativeTime}</span>
         </div>
-        <div className="flex items-center gap-1 mt-0.5">
+        <div className="flex items-center gap-2 mt-1">
+          <StatusPill status={conversation.status} />
           <span className="text-xs text-gray-500 truncate flex-1">
             {conversation.lastMessagePreview ?? ""}
           </span>
-          {conversation.isUnread && (
-            <span className="flex-shrink-0 w-2 h-2 rounded-full bg-blue-500" />
-          )}
         </div>
       </div>
     </button>

--- a/frontend/src/components/customer-support/smartsupp/DaySeparator.tsx
+++ b/frontend/src/components/customer-support/smartsupp/DaySeparator.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface DaySeparatorProps {
+  date: string;
+}
+
+function formatDayLabel(dateStr: string): string {
+  const target = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+
+  const sameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+
+  if (sameDay(target, today)) return "Dnes";
+  if (sameDay(target, yesterday)) return "Včera";
+  return target.toLocaleDateString("cs-CZ", { day: "numeric", month: "long", year: "numeric" });
+}
+
+const DaySeparator: React.FC<DaySeparatorProps> = ({ date }) => (
+  <div className="flex items-center my-3" data-testid="day-separator">
+    <div className="flex-1 h-px bg-gray-200" />
+    <span className="mx-3 text-xs text-gray-400 font-medium">{formatDayLabel(date)}</span>
+    <div className="flex-1 h-px bg-gray-200" />
+  </div>
+);
+
+export default DaySeparator;

--- a/frontend/src/components/customer-support/smartsupp/KnowledgeBaseSuggestions.tsx
+++ b/frontend/src/components/customer-support/smartsupp/KnowledgeBaseSuggestions.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import { ChevronDown, ChevronUp, Sparkles } from "lucide-react";
+import { useKnowledgeBaseSuggestions } from "./hooks/useKnowledgeBaseSuggestions";
+
+interface KnowledgeBaseSuggestionsProps {
+  conversationId: string | null;
+  lastContactMessage: string | null;
+  onSelect: (content: string) => void;
+}
+
+const STORAGE_KEY = "smartsupp.kbSuggestions.collapsed";
+
+function readCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+const KnowledgeBaseSuggestions: React.FC<KnowledgeBaseSuggestionsProps> = ({
+  conversationId,
+  lastContactMessage,
+  onSelect,
+}) => {
+  const [collapsed, setCollapsed] = useState<boolean>(readCollapsed());
+  const { suggestions, isLoading } = useKnowledgeBaseSuggestions(conversationId, lastContactMessage);
+
+  if (!conversationId) return null;
+  if (suggestions.length === 0 && !isLoading) return null;
+
+  const toggle = () => {
+    const next = !collapsed;
+    setCollapsed(next);
+    window.localStorage.setItem(STORAGE_KEY, String(next));
+  };
+
+  return (
+    <div className="border-t border-gray-100 bg-gray-50">
+      <button
+        type="button"
+        onClick={toggle}
+        data-testid="kb-toggle"
+        className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-gray-600 hover:bg-gray-100"
+      >
+        <span className="inline-flex items-center gap-1.5">
+          <Sparkles className="w-3.5 h-3.5 text-blue-500" />
+          Návrhy odpovědí z databáze znalostí
+        </span>
+        {collapsed ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronUp className="w-3.5 h-3.5" />}
+      </button>
+      {!collapsed && (
+        <div className="px-4 pb-3 flex flex-wrap gap-2">
+          {suggestions.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => onSelect(s.content)}
+              className="inline-flex items-center rounded-full px-3 py-1 text-xs bg-white border border-gray-200 text-gray-700 hover:bg-blue-50 hover:border-blue-300 transition-colors"
+            >
+              {s.title}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default KnowledgeBaseSuggestions;

--- a/frontend/src/components/customer-support/smartsupp/MessageBubble.tsx
+++ b/frontend/src/components/customer-support/smartsupp/MessageBubble.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { MessageDto } from "../../../api/hooks/useSmartsupp";
+import AgentBadge from "./AgentBadge";
+import MessageDeliveryIcon from "./MessageDeliveryIcon";
 
 interface MessageBubbleProps {
   message: MessageDto;
@@ -9,9 +11,32 @@ function formatTime(dateStr: string): string {
   return new Date(dateStr).toLocaleTimeString("cs-CZ", { hour: "2-digit", minute: "2-digit" });
 }
 
+function formatResponseTime(seconds: number): string {
+  if (seconds < 60) return `Odpověď za ${seconds} s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `Odpověď za ${minutes} m`;
+  const hours = Math.round(minutes / 60);
+  return `Odpověď za ${hours} h`;
+}
+
 const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
-  const isVisitor = message.authorType.toLowerCase() === "visitor";
-  const isBot = message.authorType.toLowerCase() === "bot";
+  const authorType = message.authorType.toLowerCase();
+  const isVisitor = authorType === "visitor" || authorType === "contact";
+  const isBot = authorType === "bot";
+  const isSystem = authorType === "system" || (message.subType ?? "").toLowerCase() === "system";
+
+  if (isSystem) {
+    return (
+      <div className="flex justify-center my-2">
+        <span
+          data-testid="system-event"
+          className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-slate-100 text-slate-600 ring-1 ring-slate-200"
+        >
+          {message.content ?? ""}
+        </span>
+      </div>
+    );
+  }
 
   if (isBot) {
     return (
@@ -22,7 +47,12 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   }
 
   return (
-    <div className={`flex ${isVisitor ? "justify-start" : "justify-end"} mb-2`}>
+    <div className={`flex flex-col ${isVisitor ? "items-start" : "items-end"} mb-2`}>
+      {!isVisitor && (message.agentId || message.authorName) && (
+        <div className="mb-1">
+          <AgentBadge agentId={message.agentId} name={message.authorName} />
+        </div>
+      )}
       <div
         className={`max-w-[70%] rounded-2xl px-4 py-2 ${
           isVisitor
@@ -30,14 +60,17 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
             : "bg-blue-500 text-white rounded-tr-sm"
         }`}
       >
-        {!isVisitor && message.authorName && (
-          <div className="text-xs text-blue-200 mb-1">{message.authorName}</div>
-        )}
         <p className="text-sm whitespace-pre-wrap break-words">{message.content ?? ""}</p>
-        <div className={`text-xs mt-1 ${isVisitor ? "text-gray-400" : "text-blue-200"} text-right`}>
-          {formatTime(message.createdAt)}
+        <div className={`flex items-center gap-1.5 text-xs mt-1 ${isVisitor ? "text-gray-400 justify-end" : "text-blue-200 justify-end"}`}>
+          <span>{formatTime(message.createdAt)}</span>
+          {!isVisitor && <MessageDeliveryIcon status={message.deliveryStatus} />}
         </div>
       </div>
+      {!isVisitor && message.isFirstReply && typeof message.responseTime === "number" && (
+        <span className="mt-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-emerald-50 text-emerald-700">
+          {formatResponseTime(message.responseTime)}
+        </span>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/customer-support/smartsupp/MessageDeliveryIcon.tsx
+++ b/frontend/src/components/customer-support/smartsupp/MessageDeliveryIcon.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Check, CheckCheck, AlertCircle, Loader2 } from "lucide-react";
+
+interface MessageDeliveryIconProps {
+  status?: string | null;
+}
+
+interface IconSpec {
+  Icon: React.ComponentType<{ className?: string }>;
+  className: string;
+  label: string;
+}
+
+function resolveIcon(status: string): IconSpec | null {
+  switch (status.toLowerCase()) {
+    case "pending":
+      return { Icon: Loader2, className: "text-blue-100 animate-spin", label: "Odesílá se" };
+    case "sent":
+      return { Icon: Check, className: "text-blue-100", label: "Odesláno" };
+    case "delivered":
+    case "read":
+      return { Icon: CheckCheck, className: "text-blue-100", label: "Doručeno" };
+    case "failed":
+      return { Icon: AlertCircle, className: "text-red-200", label: "Doručení selhalo" };
+    default:
+      return { Icon: Check, className: "text-blue-200", label: status };
+  }
+}
+
+const MessageDeliveryIcon: React.FC<MessageDeliveryIconProps> = ({ status }) => {
+  if (!status) return null;
+  const spec = resolveIcon(status);
+  if (!spec) return null;
+  return (
+    <span
+      data-testid="delivery-icon"
+      title={spec.label}
+      className="inline-flex items-center"
+      aria-label={spec.label}
+    >
+      <spec.Icon className={`w-3 h-3 ${spec.className}`} />
+    </span>
+  );
+};
+
+export default MessageDeliveryIcon;

--- a/frontend/src/components/customer-support/smartsupp/StatusPill.tsx
+++ b/frontend/src/components/customer-support/smartsupp/StatusPill.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+interface StatusPillProps {
+  status: string;
+}
+
+interface PillStyle {
+  label: string;
+  className: string;
+}
+
+function resolvePill(status: string): PillStyle {
+  switch (status.toLowerCase()) {
+    case "open":
+      return {
+        label: "Aktivní",
+        className: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
+      };
+    case "pending":
+      return {
+        label: "Čeká",
+        className: "bg-amber-50 text-amber-700 ring-1 ring-amber-200",
+      };
+    case "closed":
+    case "resolved":
+      return {
+        label: "Vyřešeno",
+        className: "bg-slate-100 text-slate-600 ring-1 ring-slate-200",
+      };
+    default:
+      return {
+        label: status,
+        className: "bg-slate-100 text-slate-600 ring-1 ring-slate-200",
+      };
+  }
+}
+
+const StatusPill: React.FC<StatusPillProps> = ({ status }) => {
+  const { label, className } = resolvePill(status);
+  return (
+    <span
+      data-testid="status-pill"
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${className}`}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default StatusPill;

--- a/frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AgentBadge from "../AgentBadge";
+
+describe("AgentBadge", () => {
+  it("renders the agent name", () => {
+    render(<AgentBadge agentId="a1" name="Petr Novák" />);
+    expect(screen.getByText("Petr Novák")).toBeInTheDocument();
+  });
+
+  it("renders the initials when no name is provided", () => {
+    render(<AgentBadge agentId="a1" name={null} />);
+    expect(screen.getAllByText("?").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses the same color for the same agentId across renders", () => {
+    const { rerender } = render(<AgentBadge agentId="a1" name="Petr" />);
+    const first = screen.getByTestId("agent-badge").className;
+    rerender(<AgentBadge agentId="a1" name="Petr" />);
+    const second = screen.getByTestId("agent-badge").className;
+    expect(first).toBe(second);
+  });
+
+  it("renders different colors for different agentIds (sanity)", () => {
+    const { rerender } = render(<AgentBadge agentId="aaa" name="A" />);
+    const colorA = screen.getByTestId("agent-badge").className;
+    rerender(<AgentBadge agentId="zzz" name="Z" />);
+    const colorZ = screen.getByTestId("agent-badge").className;
+    expect(colorA).not.toBe(colorZ);
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/ChatComposer.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/ChatComposer.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ChatComposer from "../ChatComposer";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("ChatComposer", () => {
+  it("renders an empty textarea and a disabled Send button", () => {
+    render(<ChatComposer conversationId="c1" lastContactMessage={null} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("");
+    const send = screen.getByRole("button", { name: /odeslat/i });
+    expect(send).toBeDisabled();
+  });
+
+  it("updates draft text as the user types", () => {
+    render(<ChatComposer conversationId="c1" lastContactMessage={null} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Dobrý den" } });
+    expect(textarea.value).toBe("Dobrý den");
+  });
+
+  it("inserts a knowledge-base suggestion into the textarea when its chip is clicked", () => {
+    render(<ChatComposer conversationId="c1" lastContactMessage={null} />);
+    fireEvent.click(screen.getByText("Doprava a dodací lhůty"));
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toMatch(/balíky odesíláme/);
+  });
+
+  it("appends a suggestion to existing draft text (not overwrites)", () => {
+    render(<ChatComposer conversationId="c1" lastContactMessage={null} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Dobrý den, " } });
+    fireEvent.click(screen.getByText("Doprava a dodací lhůty"));
+    expect(textarea.value).toMatch(/Dobrý den, /);
+    expect(textarea.value).toMatch(/balíky odesíláme/);
+  });
+
+  it("displays a character counter", () => {
+    render(<ChatComposer conversationId="c1" lastContactMessage={null} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "hello" } });
+    expect(screen.getByText(/5/)).toBeInTheDocument();
+  });
+
+  it("Send button has an explanatory title attribute", () => {
+    render(<ChatComposer conversationId="c1" lastContactMessage={null} />);
+    expect(screen.getByRole("button", { name: /odeslat/i })).toHaveAttribute(
+      "title",
+      expect.stringMatching(/později/i)
+    );
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/ContactDetailsPanel.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/ContactDetailsPanel.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ContactDetailsPanel from "../ContactDetailsPanel";
+import { ConversationDto } from "../../../../api/hooks/useSmartsupp";
+
+const fullConv: ConversationDto = {
+  id: "c1",
+  subject: null,
+  contactName: "Jana Nováková",
+  contactEmail: "jana@example.com",
+  contactAvatarUrl: null,
+  status: "closed",
+  isUnread: false,
+  lastMessageAt: "2026-05-15T10:00:00Z",
+  lastMessagePreview: null,
+  createdAt: "2026-05-15T09:00:00Z",
+  updatedAt: "2026-05-15T10:00:00Z",
+  rating: 5,
+  ratingText: "Skvělé!",
+  closeType: "agent_closed",
+  closedByAgentId: "a-petr",
+  assignedAgentIds: ["a-petr", "a-anna"],
+  channel: "chat",
+  isServed: true,
+  finishedAt: "2026-05-15T10:00:00Z",
+  domain: "www.anela.cz",
+  referer: "https://www.anela.cz/produkt/abc",
+  locationCountry: "CZ",
+  locationCity: "Praha",
+  locationCode: "CZ-10",
+  tags: ["doprava", "reklamace"],
+};
+
+describe("ContactDetailsPanel", () => {
+  it("renders the contact name and email", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    expect(screen.getByText("Jana Nováková")).toBeInTheDocument();
+    expect(screen.getByText("jana@example.com")).toBeInTheDocument();
+  });
+
+  it("renders the status pill", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    expect(screen.getByTestId("status-pill")).toHaveTextContent("Vyřešeno");
+  });
+
+  it("renders the rating with stars and text", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    expect(screen.getByTestId("rating")).toHaveTextContent("5");
+    expect(screen.getByText(/Skvělé!/)).toBeInTheDocument();
+  });
+
+  it("renders the location (city, country)", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    expect(screen.getByText(/Praha/)).toBeInTheDocument();
+    expect(screen.getByText(/CZ/)).toBeInTheDocument();
+  });
+
+  it("renders all tags", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    expect(screen.getByText("doprava")).toBeInTheDocument();
+    expect(screen.getByText("reklamace")).toBeInTheDocument();
+  });
+
+  it("renders the assigned agents as agent badges", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    const badges = screen.getAllByTestId("agent-badge");
+    expect(badges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders the channel and domain", () => {
+    render(<ContactDetailsPanel conversation={fullConv} />);
+    expect(screen.getByText("chat")).toBeInTheDocument();
+    expect(screen.getByText("www.anela.cz")).toBeInTheDocument();
+  });
+
+  it("omits the rating block when no rating is set", () => {
+    render(<ContactDetailsPanel conversation={{ ...fullConv, rating: null, ratingText: null }} />);
+    expect(screen.queryByTestId("rating")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/ConversationDetail.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/ConversationDetail.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ConversationDetail from "../ConversationDetail";
+import { ConversationDto } from "../../../../api/hooks/useSmartsupp";
+
+jest.mock("../../../../api/hooks/useSmartsupp", () => {
+  const actual = jest.requireActual("../../../../api/hooks/useSmartsupp");
+  return {
+    ...actual,
+    useSmartsuppConversation: () => ({
+      data: {
+        success: true,
+        conversation: null,
+        messages: [
+          {
+            id: "m1",
+            authorType: "visitor",
+            authorName: "Jana",
+            content: "Dotaz",
+            createdAt: new Date().toISOString(),
+            isFirstReply: false,
+          },
+        ],
+      },
+      isLoading: false,
+    }),
+  };
+});
+
+const conv: ConversationDto = {
+  id: "c1",
+  subject: null,
+  contactName: "Jana Nováková",
+  contactEmail: "jana@example.com",
+  contactAvatarUrl: null,
+  status: "open",
+  isUnread: false,
+  lastMessageAt: new Date().toISOString(),
+  lastMessagePreview: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  assignedAgentIds: ["a-petr"],
+  isServed: true,
+  tags: [],
+};
+
+const wrap = (ui: React.ReactNode) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+};
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+describe("ConversationDetail", () => {
+  it("renders the contact name in the header", () => {
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} onToggleContactPanel={() => {}} />));
+    expect(screen.getByText("Jana Nováková")).toBeInTheDocument();
+  });
+
+  it("renders the status pill in the header", () => {
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} onToggleContactPanel={() => {}} />));
+    expect(screen.getByTestId("status-pill")).toHaveTextContent("Aktivní");
+  });
+
+  it("renders the assigned agent badges in the header", () => {
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} onToggleContactPanel={() => {}} />));
+    expect(screen.getAllByTestId("agent-badge").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("invokes onToggleContactPanel when the info icon is clicked", () => {
+    const toggle = jest.fn();
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} onToggleContactPanel={toggle} />));
+    fireEvent.click(screen.getByTestId("toggle-contact-panel"));
+    expect(toggle).toHaveBeenCalled();
+  });
+
+  it("renders a day separator before the message group", () => {
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} onToggleContactPanel={() => {}} />));
+    expect(screen.getByTestId("day-separator")).toBeInTheDocument();
+  });
+
+  it("renders the composer at the bottom", () => {
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} onToggleContactPanel={() => {}} />));
+    expect(screen.getByPlaceholderText("Napište odpověď...")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/ConversationListItem.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/ConversationListItem.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ConversationListItem from "../ConversationListItem";
+import { ConversationDto } from "../../../../api/hooks/useSmartsupp";
+
+const baseConv: ConversationDto = {
+  id: "c1",
+  subject: null,
+  contactName: "Jana Nováková",
+  contactEmail: "jana@example.com",
+  contactAvatarUrl: null,
+  status: "open",
+  isUnread: false,
+  lastMessageAt: new Date().toISOString(),
+  lastMessagePreview: "Mám dotaz na produkt.",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  assignedAgentIds: [],
+  isServed: false,
+  tags: [],
+};
+
+describe("ConversationListItem", () => {
+  it("renders the contact name and last message preview", () => {
+    render(<ConversationListItem conversation={baseConv} isSelected={false} onClick={() => {}} />);
+    expect(screen.getByText("Jana Nováková")).toBeInTheDocument();
+    expect(screen.getByText("Mám dotaz na produkt.")).toBeInTheDocument();
+  });
+
+  it("renders the status pill matching the conversation status", () => {
+    render(<ConversationListItem conversation={baseConv} isSelected={false} onClick={() => {}} />);
+    expect(screen.getByTestId("status-pill")).toHaveTextContent("Aktivní");
+  });
+
+  it("adds a left accent border when the conversation is unread", () => {
+    render(
+      <ConversationListItem conversation={{ ...baseConv, isUnread: true }} isSelected={false} onClick={() => {}} />
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toMatch(/border-l-4 border-l-blue-500/);
+  });
+
+  it("does NOT render the left accent border when unread is false", () => {
+    render(<ConversationListItem conversation={baseConv} isSelected={false} onClick={() => {}} />);
+    const button = screen.getByRole("button");
+    expect(button.className).not.toMatch(/border-l-blue-500/);
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = jest.fn();
+    render(<ConversationListItem conversation={baseConv} isSelected={false} onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("renders bold name when unread", () => {
+    render(
+      <ConversationListItem conversation={{ ...baseConv, isUnread: true }} isSelected={false} onClick={() => {}} />
+    );
+    expect(screen.getByText("Jana Nováková").className).toMatch(/font-semibold/);
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/DaySeparator.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/DaySeparator.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DaySeparator from "../DaySeparator";
+
+describe("DaySeparator", () => {
+  it("renders 'Dnes' for today's date", () => {
+    const today = new Date();
+    render(<DaySeparator date={today.toISOString()} />);
+    expect(screen.getByTestId("day-separator")).toHaveTextContent("Dnes");
+  });
+
+  it("renders 'Včera' for yesterday's date", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    render(<DaySeparator date={yesterday.toISOString()} />);
+    expect(screen.getByTestId("day-separator")).toHaveTextContent("Včera");
+  });
+
+  it("renders a locale date for dates older than yesterday", () => {
+    const old = new Date("2025-01-15T10:00:00Z");
+    render(<DaySeparator date={old.toISOString()} />);
+    const text = screen.getByTestId("day-separator").textContent ?? "";
+    expect(text).toMatch(/2025|leden/i);
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/KnowledgeBaseSuggestions.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/KnowledgeBaseSuggestions.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import KnowledgeBaseSuggestions from "../KnowledgeBaseSuggestions";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("KnowledgeBaseSuggestions", () => {
+  it("renders suggestion chips by title", () => {
+    render(
+      <KnowledgeBaseSuggestions conversationId="c1" lastContactMessage={null} onSelect={() => {}} />
+    );
+    expect(screen.getByText("Doprava a dodací lhůty")).toBeInTheDocument();
+    expect(screen.getByText("Reklamace")).toBeInTheDocument();
+  });
+
+  it("invokes onSelect with the suggestion content when a chip is clicked", () => {
+    const onSelect = jest.fn();
+    render(
+      <KnowledgeBaseSuggestions conversationId="c1" lastContactMessage={null} onSelect={onSelect} />
+    );
+    fireEvent.click(screen.getByText("Doprava a dodací lhůty"));
+    expect(onSelect).toHaveBeenCalledWith(expect.stringContaining("balíky odesíláme"));
+  });
+
+  it("collapses when the toggle is clicked and persists state in localStorage", () => {
+    render(
+      <KnowledgeBaseSuggestions conversationId="c1" lastContactMessage={null} onSelect={() => {}} />
+    );
+    fireEvent.click(screen.getByTestId("kb-toggle"));
+    expect(screen.queryByText("Doprava a dodací lhůty")).not.toBeInTheDocument();
+    expect(localStorage.getItem("smartsupp.kbSuggestions.collapsed")).toBe("true");
+  });
+
+  it("starts collapsed when localStorage has the collapsed flag", () => {
+    localStorage.setItem("smartsupp.kbSuggestions.collapsed", "true");
+    render(
+      <KnowledgeBaseSuggestions conversationId="c1" lastContactMessage={null} onSelect={() => {}} />
+    );
+    expect(screen.queryByText("Doprava a dodací lhůty")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when conversationId is null", () => {
+    const { container } = render(
+      <KnowledgeBaseSuggestions conversationId={null} lastContactMessage={null} onSelect={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MessageBubble from "../MessageBubble";
+import { MessageDto } from "../../../../api/hooks/useSmartsupp";
+
+const baseMessage: MessageDto = {
+  id: "m1",
+  authorType: "agent",
+  authorName: "Petr Novák",
+  content: "Dobrý den, jak mohu pomoci?",
+  createdAt: "2026-05-15T10:00:00Z",
+  agentId: "a-petr",
+  subType: "agent",
+  deliveryStatus: "delivered",
+  deliveredAt: "2026-05-15T10:00:01Z",
+  responseTime: 120,
+  isFirstReply: true,
+  pageUrl: null,
+};
+
+describe("MessageBubble", () => {
+  it("renders an agent bubble on the right with agent badge + delivery icon", () => {
+    render(<MessageBubble message={baseMessage} />);
+    expect(screen.getByText("Dobrý den, jak mohu pomoci?")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-badge")).toHaveTextContent("Petr Novák");
+    expect(screen.getByTestId("delivery-icon")).toHaveAttribute("title", "Doručeno");
+  });
+
+  it("renders the response-time pill only on the first agent reply", () => {
+    render(<MessageBubble message={baseMessage} />);
+    expect(screen.getByText("Odpověď za 2 m")).toBeInTheDocument();
+  });
+
+  it("does not render the response-time pill on follow-up agent replies", () => {
+    render(<MessageBubble message={{ ...baseMessage, isFirstReply: false }} />);
+    expect(screen.queryByText(/Odpověď za/)).not.toBeInTheDocument();
+  });
+
+  it("renders a visitor bubble on the left without agent badge", () => {
+    render(
+      <MessageBubble
+        message={{ ...baseMessage, authorType: "visitor", agentId: null, authorName: "Jana", deliveryStatus: null }}
+      />
+    );
+    expect(screen.queryByTestId("agent-badge")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("delivery-icon")).not.toBeInTheDocument();
+  });
+
+  it("renders system events as a centered slate pill (not a bubble)", () => {
+    render(
+      <MessageBubble
+        message={{ ...baseMessage, authorType: "system", subType: "system", content: "Konverzace přiřazena agentovi" }}
+      />
+    );
+    const pill = screen.getByTestId("system-event");
+    expect(pill).toHaveTextContent("Konverzace přiřazena agentovi");
+    expect(pill).toHaveClass("bg-slate-100");
+  });
+
+  it("renders a bot message as a centered italic line", () => {
+    render(
+      <MessageBubble
+        message={{ ...baseMessage, authorType: "bot", agentId: null, content: "Automatická odpověď" }}
+      />
+    );
+    expect(screen.getByText("Automatická odpověď")).toHaveClass("italic");
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/MessageDeliveryIcon.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/MessageDeliveryIcon.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import MessageDeliveryIcon from "../MessageDeliveryIcon";
+
+describe("MessageDeliveryIcon", () => {
+  it("renders nothing when status is null or empty", () => {
+    const { container } = render(<MessageDeliveryIcon status={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a tooltip with the localized label for 'delivered'", () => {
+    render(<MessageDeliveryIcon status="delivered" />);
+    expect(screen.getByTestId("delivery-icon")).toHaveAttribute("title", "Doručeno");
+  });
+
+  it("renders a tooltip with the localized label for 'failed'", () => {
+    render(<MessageDeliveryIcon status="failed" />);
+    expect(screen.getByTestId("delivery-icon")).toHaveAttribute("title", "Doručení selhalo");
+  });
+
+  it("renders a tooltip with the localized label for 'pending'", () => {
+    render(<MessageDeliveryIcon status="pending" />);
+    expect(screen.getByTestId("delivery-icon")).toHaveAttribute("title", "Odesílá se");
+  });
+
+  it("falls back to the raw status as tooltip for unknown values", () => {
+    render(<MessageDeliveryIcon status="weird" />);
+    expect(screen.getByTestId("delivery-icon")).toHaveAttribute("title", "weird");
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/__tests__/StatusPill.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/StatusPill.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import StatusPill from "../StatusPill";
+
+describe("StatusPill", () => {
+  it("renders 'Aktivní' for status 'open' with emerald colors", () => {
+    render(<StatusPill status="open" />);
+    const pill = screen.getByTestId("status-pill");
+    expect(pill).toHaveTextContent("Aktivní");
+    expect(pill).toHaveClass("bg-emerald-50");
+    expect(pill).toHaveClass("text-emerald-700");
+  });
+
+  it("renders 'Čeká' for status 'pending' with amber colors", () => {
+    render(<StatusPill status="pending" />);
+    const pill = screen.getByTestId("status-pill");
+    expect(pill).toHaveTextContent("Čeká");
+    expect(pill).toHaveClass("bg-amber-50");
+    expect(pill).toHaveClass("text-amber-700");
+  });
+
+  it("renders 'Vyřešeno' for status 'closed' with slate colors", () => {
+    render(<StatusPill status="closed" />);
+    const pill = screen.getByTestId("status-pill");
+    expect(pill).toHaveTextContent("Vyřešeno");
+    expect(pill).toHaveClass("bg-slate-100");
+    expect(pill).toHaveClass("text-slate-600");
+  });
+
+  it("is case-insensitive on status (handles 'Open' from backend enum.ToString())", () => {
+    render(<StatusPill status="Open" />);
+    expect(screen.getByTestId("status-pill")).toHaveTextContent("Aktivní");
+  });
+
+  it("falls back to slate pill with the raw status label for unknown values", () => {
+    render(<StatusPill status="weird" />);
+    const pill = screen.getByTestId("status-pill");
+    expect(pill).toHaveTextContent("weird");
+    expect(pill).toHaveClass("bg-slate-100");
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/hooks/__tests__/useKnowledgeBaseSuggestions.test.ts
+++ b/frontend/src/components/customer-support/smartsupp/hooks/__tests__/useKnowledgeBaseSuggestions.test.ts
@@ -1,0 +1,32 @@
+import { renderHook } from "@testing-library/react";
+import { useKnowledgeBaseSuggestions } from "../useKnowledgeBaseSuggestions";
+
+describe("useKnowledgeBaseSuggestions", () => {
+  it("returns a non-empty list of mock suggestions when given a conversation id", () => {
+    const { result } = renderHook(() =>
+      useKnowledgeBaseSuggestions("c1", "Mám dotaz na dopravu")
+    );
+    expect(result.current.suggestions.length).toBeGreaterThan(0);
+  });
+
+  it("returns suggestions with title + content", () => {
+    const { result } = renderHook(() =>
+      useKnowledgeBaseSuggestions("c1", "Dotaz")
+    );
+    const first = result.current.suggestions[0];
+    expect(typeof first.title).toBe("string");
+    expect(typeof first.content).toBe("string");
+    expect(first.title.length).toBeGreaterThan(0);
+    expect(first.content.length).toBeGreaterThan(0);
+  });
+
+  it("returns isLoading=false for the mock implementation", () => {
+    const { result } = renderHook(() => useKnowledgeBaseSuggestions("c1", null));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns an empty list when conversationId is null", () => {
+    const { result } = renderHook(() => useKnowledgeBaseSuggestions(null, null));
+    expect(result.current.suggestions).toEqual([]);
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/hooks/useKnowledgeBaseSuggestions.ts
+++ b/frontend/src/components/customer-support/smartsupp/hooks/useKnowledgeBaseSuggestions.ts
@@ -1,0 +1,49 @@
+export interface KnowledgeBaseSuggestion {
+  id: string;
+  title: string;
+  content: string;
+}
+
+interface UseKnowledgeBaseSuggestionsResult {
+  suggestions: KnowledgeBaseSuggestion[];
+  isLoading: boolean;
+}
+
+const MOCK_SUGGESTIONS: KnowledgeBaseSuggestion[] = [
+  {
+    id: "sug-doprava",
+    title: "Doprava a dodací lhůty",
+    content:
+      "Dobrý den, balíky odesíláme do 24 hodin po obdržení platby. Doručení Zásilkovnou trvá obvykle 1–2 pracovní dny.",
+  },
+  {
+    id: "sug-reklamace",
+    title: "Reklamace",
+    content:
+      "Dobrý den, reklamaci můžete uplatnit do 14 dnů od převzetí zboží. Stačí nám napsat na info@anela.cz se snímkem produktu.",
+  },
+  {
+    id: "sug-vraceni",
+    title: "Vrácení zboží",
+    content:
+      "Dobrý den, na vrácení zboží máte 14 dní od převzetí. Pošlete nám prosím nepoužité zboží zpět spolu s číslem objednávky.",
+  },
+  {
+    id: "sug-platba",
+    title: "Platební metody",
+    content:
+      "Dobrý den, přijímáme platbu kartou, převodem, dobírkou i přes Google/Apple Pay. Vše šifrované přes Comgate.",
+  },
+];
+
+// TODO: wire to /api/knowledge-base/ask once the conversation-context endpoint is ready.
+// Signature is intentionally identical to the future server-backed hook.
+export function useKnowledgeBaseSuggestions(
+  conversationId: string | null,
+  _lastContactMessage: string | null,
+): UseKnowledgeBaseSuggestionsResult {
+  if (!conversationId) {
+    return { suggestions: [], isLoading: false };
+  }
+  return { suggestions: MOCK_SUGGESTIONS, isLoading: false };
+}

--- a/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
+++ b/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
@@ -3,10 +3,21 @@ import { useSmartsuppConversations, useTriggerSmartsuppSync } from "../../../../
 import { useToast } from "../../../../contexts/ToastContext";
 import ConversationList from "../ConversationList";
 import ConversationDetail from "../ConversationDetail";
+import ContactDetailsPanel from "../ContactDetailsPanel";
+
+const CONTACT_PANEL_KEY = "smartsupp.contactPanel.open";
+
+function readContactPanelOpen(): boolean {
+  if (typeof window === "undefined") return true;
+  const stored = window.localStorage.getItem(CONTACT_PANEL_KEY);
+  if (stored === null) return true;
+  return stored === "true";
+}
 
 const SmartsuppChatsPage: React.FC = () => {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [status, setStatus] = useState<"Open" | "Resolved">("Open");
+  const [contactPanelOpen, setContactPanelOpen] = useState<boolean>(readContactPanelOpen());
 
   const { data, isLoading } = useSmartsuppConversations(status);
   const { showSuccess, showError } = useToast();
@@ -29,6 +40,14 @@ const SmartsuppChatsPage: React.FC = () => {
     });
   };
 
+  const toggleContactPanel = () => {
+    setContactPanelOpen((open) => {
+      const next = !open;
+      window.localStorage.setItem(CONTACT_PANEL_KEY, String(next));
+      return next;
+    });
+  };
+
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="flex items-center justify-end px-4 py-2 border-b border-gray-200 bg-white">
@@ -38,26 +57,7 @@ const SmartsuppChatsPage: React.FC = () => {
           disabled={syncMutation.isPending}
           className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          {syncMutation.isPending ? (
-            <>
-              <svg
-                className="animate-spin h-4 w-4 text-gray-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-                />
-              </svg>
-              Synchronizuji…
-            </>
-          ) : (
-            <>Sync now</>
-          )}
+          {syncMutation.isPending ? "Synchronizuji…" : "Sync now"}
         </button>
       </div>
 
@@ -76,15 +76,25 @@ const SmartsuppChatsPage: React.FC = () => {
           />
         </div>
 
-        <div className="flex-1 overflow-hidden">
+        <div className="flex-1 overflow-hidden min-w-0">
           {selectedConversation ? (
-            <ConversationDetail conversationId={selectedId!} conversation={selectedConversation} />
+            <ConversationDetail
+              conversationId={selectedId!}
+              conversation={selectedConversation}
+              onToggleContactPanel={toggleContactPanel}
+            />
           ) : (
             <div className="flex items-center justify-center h-full text-gray-400 text-sm">
               Vyberte konverzaci
             </div>
           )}
         </div>
+
+        {contactPanelOpen && selectedConversation && (
+          <div className="hidden lg:block w-80 flex-shrink-0 overflow-hidden">
+            <ContactDetailsPanel conversation={selectedConversation} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/customer-support/smartsupp/pages/__tests__/SmartsuppChatsPage.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/pages/__tests__/SmartsuppChatsPage.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SmartsuppChatsPage from "../SmartsuppChatsPage";
+
+jest.mock("../../../../../contexts/ToastContext", () => ({
+  useToast: () => ({ showSuccess: jest.fn(), showError: jest.fn() }),
+}));
+
+jest.mock("../../../../../api/hooks/useSmartsupp", () => ({
+  useSmartsuppConversations: () => ({
+    data: { success: true, items: [], total: 0, page: 1, pageSize: 100 },
+    isLoading: false,
+  }),
+  useSmartsuppConversation: () => ({ data: { messages: [] }, isLoading: false }),
+  useTriggerSmartsuppSync: () => ({ mutate: jest.fn(), isPending: false }),
+  SMARTSUPP_QUERY_KEYS: { conversations: () => [], conversation: () => [] },
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const wrap = (ui: React.ReactNode) => {
+  const qc = new QueryClient();
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+};
+
+describe("SmartsuppChatsPage", () => {
+  it("renders the sync button", () => {
+    render(wrap(<SmartsuppChatsPage />));
+    expect(screen.getByRole("button", { name: /sync/i })).toBeInTheDocument();
+  });
+
+  it("renders an empty-state message when no conversation is selected", () => {
+    render(wrap(<SmartsuppChatsPage />));
+    expect(screen.getByText("Vyberte konverzaci")).toBeInTheDocument();
+  });
+
+  it("persists the contact-panel toggle state in localStorage", () => {
+    localStorage.setItem("smartsupp.contactPanel.open", "false");
+    render(wrap(<SmartsuppChatsPage />));
+    expect(localStorage.getItem("smartsupp.contactPanel.open")).toBe("false");
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/utils/__tests__/agentColor.test.ts
+++ b/frontend/src/components/customer-support/smartsupp/utils/__tests__/agentColor.test.ts
@@ -1,0 +1,26 @@
+import { getAgentColor, AGENT_COLOR_PALETTE } from "../agentColor";
+
+describe("agentColor", () => {
+  it("returns the same palette entry for the same agentId across calls", () => {
+    const first = getAgentColor("agent-42");
+    const second = getAgentColor("agent-42");
+    expect(first).toEqual(second);
+  });
+
+  it("returns an entry from the fixed palette", () => {
+    const color = getAgentColor("agent-x");
+    expect(AGENT_COLOR_PALETTE).toContainEqual(color);
+  });
+
+  it("returns the neutral fallback for null/empty agentId", () => {
+    expect(getAgentColor(null)).toEqual({ bg: "bg-slate-100", text: "text-slate-700", ring: "ring-slate-200" });
+    expect(getAgentColor("")).toEqual({ bg: "bg-slate-100", text: "text-slate-700", ring: "ring-slate-200" });
+  });
+
+  it("distributes agentIds across more than one palette entry", () => {
+    const seen = new Set(
+      ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"].map((id) => getAgentColor(id).bg)
+    );
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/components/customer-support/smartsupp/utils/agentColor.ts
+++ b/frontend/src/components/customer-support/smartsupp/utils/agentColor.ts
@@ -1,0 +1,31 @@
+export interface AgentColor {
+  bg: string;
+  text: string;
+  ring: string;
+}
+
+export const AGENT_COLOR_PALETTE: readonly AgentColor[] = [
+  { bg: "bg-blue-100", text: "text-blue-700", ring: "ring-blue-200" },
+  { bg: "bg-emerald-100", text: "text-emerald-700", ring: "ring-emerald-200" },
+  { bg: "bg-violet-100", text: "text-violet-700", ring: "ring-violet-200" },
+  { bg: "bg-amber-100", text: "text-amber-700", ring: "ring-amber-200" },
+  { bg: "bg-rose-100", text: "text-rose-700", ring: "ring-rose-200" },
+  { bg: "bg-cyan-100", text: "text-cyan-700", ring: "ring-cyan-200" },
+  { bg: "bg-fuchsia-100", text: "text-fuchsia-700", ring: "ring-fuchsia-200" },
+  { bg: "bg-teal-100", text: "text-teal-700", ring: "ring-teal-200" },
+] as const;
+
+const NEUTRAL_AGENT_COLOR: AgentColor = {
+  bg: "bg-slate-100",
+  text: "text-slate-700",
+  ring: "ring-slate-200",
+};
+
+export function getAgentColor(agentId?: string | null): AgentColor {
+  if (!agentId) return NEUTRAL_AGENT_COLOR;
+  let hash = 0;
+  for (let i = 0; i < agentId.length; i++) {
+    hash = (hash * 31 + agentId.charCodeAt(i)) >>> 0;
+  }
+  return AGENT_COLOR_PALETTE[hash % AGENT_COLOR_PALETTE.length];
+}


### PR DESCRIPTION
## Summary

Redesigns the Smartsupp customer-support chat UI so operators can read state at a glance, see all available conversation context, and draft replies via a composer with a knowledge-base suggestion strip (Send disabled — wiring is a later task).

## What changed

**Backend** (DTO expansion only, no schema change):
- `ConversationDto` gains rating, ratingText, closeType, closedByAgentId, assignedAgentIds, channel, isServed, finishedAt, domain, referer, locationCountry/City/Code, tags.
- `MessageDto` gains agentId, subType, deliveryStatus, deliveredAt, responseTime, isFirstReply, pageUrl.
- `ListConversations` + `GetConversation` handlers now project all new fields. `AssignedAgentIdsJson`/`TagsJson` are parsed to arrays at the API boundary.

**Frontend** — new + redesigned UI under `frontend/src/components/customer-support/smartsupp/`:
- `StatusPill` — Active / Čeká / Vyřešeno with semantic colors, used in list + header + contact panel.
- `AgentBadge` + `utils/agentColor.ts` — deterministic hash-based color per agent so the same agent looks the same everywhere.
- `MessageDeliveryIcon` — pending / sent / delivered / failed states with Czech tooltips.
- `DaySeparator` — Dnes / Včera / locale date between message groups.
- `ContactDetailsPanel` — right-column panel surfacing status, close type, rating + text, assigned agents, location, channel, domain, referer, tags. Toggleable, state persisted in localStorage.
- `ChatComposer` — textarea, char counter, **disabled Send** with explanatory tooltip. Mounts the KB suggestions strip above it.
- `KnowledgeBaseSuggestions` (collapsible) + `useKnowledgeBaseSuggestions` hook — mock data for now; signature ready to wire into the existing KB Ask endpoint in a one-file change.
- Redesigned `MessageBubble`, `ConversationListItem`, `ConversationDetail`, `SmartsuppChatsPage` to compose the above.

3-column layout: list (w-96) | conversation (flex-1) | contact panel (w-80, toggleable, auto-hides below `lg`).

## Plan

Full implementation plan at \`~/.claude/plans/2026-05-15-smartsupp-chat-ui-redesign.md\` — 17 TDD-driven tasks plus a verification gate.

## Test plan

- [x] Backend build clean — 0 errors
- [x] Backend Smartsupp tests pass — 92/92
- [x] Frontend lint clean on touched files
- [x] Frontend test suite pass — 1354/1354 (5 pre-existing skipped)
- [x] Frontend production build clean
- [ ] Manual smoke: open /customer-support/smartsupp/chats, verify status pills, unread accent, agent badge colors, day separators, contact panel toggle persistence, KB chip insert, disabled Send tooltip
- [ ] Webhook smoke: POST a \`conversation.contact_replied\` via the Postman collection in docs/integrations/smartsupp-webhook.md and confirm the new message renders within the polling window

## Out of scope

Actually sending replies, real KB API wiring (hook returns mocks behind a seam), attachment rendering, push notifications, real-time updates. All deliberately deferred — no half-implementations.

@claude