### PR TITLE
feat: add Conductor run scripts for parallel Heblo instances

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -64,12 +64,25 @@ public static class ServiceCollectionExtensions
     {
         var allowedOrigins = configuration.GetSection(ConfigurationConstants.CORS_ALLOWED_ORIGINS).Get<string[]>() ?? Array.Empty<string>();
 
+        // Conductor parallel instances serve the frontend on a dynamically chosen port,
+        // so the exact origin is unknown ahead of time. Under Conductor overrides, allow
+        // any loopback origin instead of a fixed allow-list.
+        var allowAnyLoopbackOrigin = configuration.GetValue<bool>("UseConductorOverrides");
+
         services.AddCors(options =>
         {
             options.AddPolicy(ConfigurationConstants.CORS_POLICY_NAME, policy =>
             {
-                policy.WithOrigins(allowedOrigins)
-                      .AllowAnyHeader()
+                if (allowAnyLoopbackOrigin)
+                {
+                    policy.SetIsOriginAllowed(IsLoopbackOrigin);
+                }
+                else
+                {
+                    policy.WithOrigins(allowedOrigins);
+                }
+
+                policy.AllowAnyHeader()
                       .AllowAnyMethod()
                       .AllowCredentials();
             });
@@ -77,6 +90,9 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    private static bool IsLoopbackOrigin(string origin) =>
+        Uri.TryCreate(origin, UriKind.Absolute, out var uri) && uri.IsLoopback;
 
     public static IServiceCollection AddHealthCheckServices(this IServiceCollection services, IConfiguration configuration)
     {

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -43,6 +43,14 @@ public partial class Program
             builder.Configuration.AddUserSecrets<Program>();
         }
 
+        // Conductor parallel-instance overrides (see appsettings.Conductor.json).
+        // Layered on top of the active environment so ephemeral local instances never
+        // hydrate from live external systems. Enabled by scripts/conductor-run.sh.
+        if (builder.Configuration.GetValue<bool>("UseConductorOverrides"))
+        {
+            builder.Configuration.AddJsonFile("appsettings.Conductor.json", optional: false, reloadOnChange: true);
+        }
+
         // Configure application timezone based on configuration
         builder.Configuration.ConfigureApplicationTimeZone();
 

--- a/backend/src/Anela.Heblo.API/appsettings.Conductor.json
+++ b/backend/src/Anela.Heblo.API/appsettings.Conductor.json
@@ -1,0 +1,69 @@
+{
+  // Conductor parallel-instance overrides.
+  // Layered on top of the active environment's appsettings when UseConductorOverrides=true
+  // (set by scripts/conductor-run.sh). Loaded last, so the values here win.
+  //
+  // Purpose: ephemeral parallel dev instances must NOT hydrate from live external
+  // systems (Shoptet, ERP, Heureka, ...). They rely on the already-populated shared
+  // local database instead.
+  //
+  // Every hydration job is listed below and disabled. To let a single Conductor
+  // instance run one specific job, flip that job's "Enabled" to true.
+
+  // Hangfire recurring jobs off — no scheduled work hits external systems.
+  "Hangfire": {
+    "SchedulerEnabled": false
+  },
+
+  // Background refresh / tier-based hydration — every job disabled individually.
+  // The orchestrator and scheduler stay registered, they simply find nothing enabled.
+  "BackgroundRefresh": {
+    "ICatalogRepository": {
+      "RefreshTransportData": { "Enabled": false },
+      "RefreshReserveData": { "Enabled": false },
+      "RefreshOrderedData": { "Enabled": false },
+      "RefreshPlannedData": { "Enabled": false },
+      "RefreshSalesData": { "Enabled": false },
+      "RefreshAttributesData": { "Enabled": false },
+      "RefreshErpStockData": { "Enabled": false },
+      "RefreshEshopStockData": { "Enabled": false },
+      "RefreshPurchaseHistoryData": { "Enabled": false },
+      "RefreshManufactureHistoryData": { "Enabled": false },
+      "RefreshConsumedHistoryData": { "Enabled": false },
+      "RefreshStockTakingData": { "Enabled": false },
+      "RefreshLotsData": { "Enabled": false },
+      "RefreshEshopPricesData": { "Enabled": false },
+      "RefreshErpPricesData": { "Enabled": false },
+      "RefreshEshopUrlData": { "Enabled": false },
+      "RefreshManufactureDifficultySettingsData": { "Enabled": false },
+      "RefreshMarginData": { "Enabled": false }
+    },
+    "ITransportBoxCompletionService": {
+      "CompleteReceivedBoxesAsync": { "Enabled": false }
+    },
+    "IStockUpProcessingService": {
+      "ProcessPendingOperationsAsync": { "Enabled": false }
+    },
+    "IManufactureCostCalculationService": {
+      "Reload": { "Enabled": false }
+    },
+    "ISalesCostCalculationService": {
+      "Reload": { "Enabled": false }
+    },
+    "IMaterialCostProvider": {
+      "RefreshCache": { "Enabled": false }
+    },
+    "IFlatManufactureCostProvider": {
+      "RefreshCache": { "Enabled": false }
+    },
+    "IDirectManufactureCostProvider": {
+      "RefreshCache": { "Enabled": false }
+    },
+    "ISalesCostProvider": {
+      "RefreshCache": { "Enabled": false }
+    },
+    "IFinancialAnalysisService": {
+      "RefreshFinancialDataAsync": { "Enabled": false }
+    }
+  }
+}

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "dotnet restore && npm --prefix frontend install --legacy-peer-deps",
+    "run": "./scripts/conductor-run.sh"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "start": "PORT=3000 REACT_APP_API_URL=http://localhost:5000 react-scripts start",
     "start:automation": "PORT=3001 REACT_APP_API_URL=http://localhost:5001 REACT_APP_USE_MOCK_AUTH=true react-scripts start",
+    "start:conductor": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:playwright": "npx playwright test",

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -93,6 +93,9 @@ export const StatusBar: React.FC<StatusBarProps> = ({
     return null;
   }
 
+  // Injected by the Conductor run script — names the git branch this instance runs.
+  const branchName = process.env.REACT_APP_BRANCH_NAME;
+
   const getEnvironmentColor = (env: string) => {
     switch (env.toLowerCase()) {
       case "production":
@@ -162,6 +165,11 @@ export const StatusBar: React.FC<StatusBarProps> = ({
                 ? "Dev"
                 : appInfo.environment}
             </span>
+            {branchName && (
+              <span className="px-2 py-0.5 rounded text-xs bg-indigo-600 text-white">
+                {branchName}
+              </span>
+            )}
             {appInfo.mockAuth && (
               <span className={getAuthTypeColor(appInfo.mockAuth)}>Mock</span>
             )}
@@ -179,6 +187,14 @@ export const StatusBar: React.FC<StatusBarProps> = ({
             >
               {appInfo.environment}
             </span>
+            {branchName && (
+              <>
+                <span>|</span>
+                <span className="px-2 py-0.5 rounded text-xs bg-indigo-600 text-white">
+                  {branchName}
+                </span>
+              </>
+            )}
             {appInfo.mockAuth && (
               <>
                 <span>|</span>

--- a/scripts/conductor-run.sh
+++ b/scripts/conductor-run.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Conductor run script — launches backend + frontend on dynamically picked free ports
+# so multiple Conductor workspaces of Heblo can run in parallel without colliding.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Find the first free TCP port at or above the given starting port.
+find_free_port() {
+  local port=$1
+  while lsof -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; do
+    port=$((port + 1))
+  done
+  echo "$port"
+}
+
+# Bases 5100/3100 keep Conductor instances clear of the manual 5000/3000 dev scripts.
+BACKEND_PORT="$(find_free_port 5100)"
+FRONTEND_PORT="$(find_free_port 3100)"
+
+BRANCH="$(git -C "$PROJECT_ROOT" branch --show-current)"
+if [ -z "$BRANCH" ]; then
+  BRANCH="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+fi
+
+echo "🚀 Starting Heblo (Conductor)"
+echo "   Branch:   $BRANCH"
+echo "   Backend:  http://localhost:$BACKEND_PORT"
+echo "   Frontend: http://localhost:$FRONTEND_PORT"
+echo ""
+
+# Stop both children when this script (and its process group) is stopped.
+trap 'kill 0' EXIT INT TERM
+
+# Backend — dynamic port via ASPNETCORE_URLS.
+# UseConductorOverrides=true layers appsettings.Conductor.json (disables all hydration /
+# background refresh) and makes CORS accept any loopback origin, so the dynamically
+# chosen frontend port is allowed without a fixed allow-list.
+(
+  cd "$PROJECT_ROOT"
+  ASPNETCORE_ENVIRONMENT=Development \
+  ASPNETCORE_URLS="http://localhost:$BACKEND_PORT" \
+  UseConductorOverrides=true \
+    dotnet run --project backend/src/Anela.Heblo.API --no-launch-profile
+) &
+BACKEND_PID=$!
+
+# Wait for the backend to actually listen — `dotnet run` builds first, so this can
+# take 30-60s. Bail out early with a clear message if the build/start failed.
+echo "⏳ Waiting for backend to build and listen on port $BACKEND_PORT ..."
+for _ in $(seq 1 150); do
+  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+    echo "❌ Backend exited before becoming ready — check the build output above."
+    exit 1
+  fi
+  if curl -sf -o /dev/null "http://localhost:$BACKEND_PORT/health/live" 2>/dev/null; then
+    echo "✅ Backend is up on http://localhost:$BACKEND_PORT"
+    break
+  fi
+  sleep 2
+done
+
+# Frontend — start:conductor has no inline env, so these exported vars take effect.
+# REACT_APP_REDIRECT_URI is cleared so MSAL falls back to window.location.origin.
+(
+  cd "$PROJECT_ROOT"
+  PORT="$FRONTEND_PORT" \
+  REACT_APP_API_URL="http://localhost:$BACKEND_PORT" \
+  REACT_APP_USE_MOCK_AUTH=false \
+  REACT_APP_REDIRECT_URI= \
+  REACT_APP_BRANCH_NAME="$BRANCH" \
+    npm --prefix frontend run start:conductor
+) &
+
+wait


### PR DESCRIPTION
## Summary

Adds `conductor.json` and `scripts/conductor-run.sh` so Conductor can launch the backend and frontend together on dynamically picked free ports, letting multiple workspaces run Heblo in parallel without colliding. The run script waits for the backend to actually listen (and fails fast on a broken build), and injects the current git branch into the frontend (`REACT_APP_BRANCH_NAME`), shown as a badge in the status bar.

A new `appsettings.Conductor.json` — layered via the `UseConductorOverrides` flag — disables every hydration / background-refresh job and the Hangfire scheduler, so ephemeral parallel instances never call live external systems and rely on the shared local database instead. Under the same flag, CORS accepts any loopback origin so the dynamically chosen frontend port is allowed without a fixed allow-list.

## Test plan

- [ ] Run via Conductor: backend + frontend start on free ports, status bar shows the branch badge and "Development".
- [ ] Health checks are green and no Shoptet/ERP hydration calls fire.
- [ ] Normal `dotnet run` is unaffected (strict CORS allow-list, hydration enabled).