### PR TITLE
fix(terminal): install terminal subapp as its own PWA

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -11,6 +11,16 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <script>
+      if (
+        location.pathname === '/terminal' ||
+        location.pathname.startsWith('/terminal/')
+      ) {
+        document
+          .querySelector('link[rel="manifest"]')
+          .setAttribute('href', '/manifest.terminal.json');
+      }
+    </script>
     <title>Anela Heblo</title>
   </head>
   <body>

--- a/frontend/public/manifest.terminal.json
+++ b/frontend/public/manifest.terminal.json
@@ -19,8 +19,9 @@
       "sizes": "512x512"
     }
   ],
+  "id": "/terminal",
   "start_url": "/terminal",
-  "scope": "/terminal/",
+  "scope": "/terminal",
   "display": "standalone",
   "orientation": "portrait",
   "theme_color": "#2563EB",

--- a/frontend/src/components/terminal/TerminalLayout.tsx
+++ b/frontend/src/components/terminal/TerminalLayout.tsx
@@ -12,10 +12,9 @@ const TerminalLayout: React.FC = () => {
 
   useEffect(() => {
     const link = document.querySelector<HTMLLinkElement>('link[rel="manifest"]');
-    const prev = link?.getAttribute("href") ?? null;
     link?.setAttribute("href", "/manifest.terminal.json");
     return () => {
-      if (link && prev !== null) link.setAttribute("href", prev);
+      link?.setAttribute("href", "/manifest.json");
     };
   }, []);
 

--- a/frontend/src/components/terminal/__tests__/TerminalLayout.test.tsx
+++ b/frontend/src/components/terminal/__tests__/TerminalLayout.test.tsx
@@ -20,7 +20,22 @@ const renderWithRouter = (initialPath: string) =>
     </MemoryRouter>,
   );
 
+// The manifest <link> lives in document.head, outside the render tree, so
+// Testing Library queries cannot reach it — direct DOM access is required here.
+const getManifestHref = () =>
+  // eslint-disable-next-line testing-library/no-node-access
+  document.head.querySelector('link[rel="manifest"]')?.getAttribute('href');
+
 describe('TerminalLayout', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line testing-library/no-node-access
+    document.head.querySelectorAll('link[rel="manifest"]').forEach((link) => link.remove());
+    const link = document.createElement('link');
+    link.setAttribute('rel', 'manifest');
+    link.setAttribute('href', '/manifest.json');
+    document.head.appendChild(link);
+  });
+
   it('renders the app title', () => {
     renderWithRouter('/terminal');
     expect(screen.getByText('Heblo Terminál')).toBeInTheDocument();
@@ -44,5 +59,18 @@ describe('TerminalLayout', () => {
   it('renders user profile', () => {
     renderWithRouter('/terminal');
     expect(screen.getByTestId('user-profile')).toBeInTheDocument();
+  });
+
+  it('links the terminal manifest while mounted', () => {
+    renderWithRouter('/terminal');
+    expect(getManifestHref()).toBe('/manifest.terminal.json');
+  });
+
+  it('restores the main manifest on unmount', () => {
+    const { unmount } = renderWithRouter('/terminal');
+    expect(getManifestHref()).toBe('/manifest.terminal.json');
+
+    unmount();
+    expect(getManifestHref()).toBe('/manifest.json');
   });
 });


### PR DESCRIPTION
## Summary

Installing a PWA from the `/terminal` subpage installed the main Anela Heblo app instead of the dedicated terminal subapp. This fixes three causes: `manifest.terminal.json` was invalid (`start_url` sat outside `scope`), `index.html` always linked the main manifest so direct `/terminal` loads were parsed against it, and `TerminalLayout`'s runtime swap restored the wrong href on cleanup. The terminal manifest is now valid (consistent `start_url`/`scope`, explicit `id`), an inline `<head>` script links it during parsing on direct `/terminal` loads, and the cleanup restores the main manifest. Added unit tests covering the manifest link on mount and unmount.

## Test plan

- [x] `npm run build` passes
- [x] `TerminalLayout` unit tests pass (7/7)
- [ ] Manual: serve build, open `/terminal` directly, confirm DevTools → Application → Manifest shows "Heblo Terminál" with no scope warnings and "Install app" yields the terminal app; confirm `/` still installs the main app