### PR TITLE
fix: install Node.js and @plaud-ai/cli in Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,12 @@ RUN apt-get update && apt-get install -y \
     && echo "Europe/Prague" > /etc/timezone \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Node.js and Plaud CLI (@plaud-ai/cli is a Node.js tool)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g @plaud-ai/cli \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Copy published backend
 COPY --from=backend-build /app/publish ./
 


### PR DESCRIPTION
The `PlaudCliClient` spawns the `plaud` process to poll meeting recordings, but the `plaud` CLI (`@plaud-ai/cli`) is a Node.js tool that was not present in the Docker runtime image, causing a `Win32Exception: No such file or directory` on every polling job execution.

Adds a `RUN` block to the runtime stage that installs Node.js 20 (via NodeSource) and then installs `@plaud-ai/cli` globally, making the `plaud` binary available on `PATH` at `/usr/bin/plaud`.