### PR TITLE
feat: Decouple Logistics handlers from Manufacture inventory via consumer-owned contract

### DIFF
--- a/artifacts/feat-arch-review-logistics-handlers-directly-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-logistics-handlers-directly-/arch-review.r1.md
@@ -1,0 +1,348 @@
+# Architecture Review: Decouple Logistics handlers from Manufacture inventory via consumer-owned contract
+
+## Skip Design: true
+
+Pure backend refactor. No new HTTP surface, no DTO shape changes, no UI components — error codes, status codes, and JSON payloads are preserved (NFR-1). Frontend and OpenAPI clients regenerate identically.
+
+## Architectural Fit Assessment
+
+The proposal fits the codebase **precisely** — it is a literal application of the documented Leaflet/KnowledgeBase precedent to a second pair of modules. All preconditions are in place:
+
+- `docs/architecture/development_guidelines.md` §"Cross-Module Communication Example: ILeafletKnowledgeSource" specifies the consumer-owns-contract / provider-owns-adapter / provider-registers-binding triad. The spec applies it verbatim.
+- `Anela.Heblo.Application/Features/Leaflet/Contracts/ILeafletKnowledgeSource.cs` (13 lines) and `KnowledgeBaseLeafletSourceAdapter.cs` (sealed, internal, single repository dependency) are direct templates for the new types.
+- `KnowledgeBaseModule.AddKnowledgeBaseModule` (line 38) registers `services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();` — same line shape needed in `ManufactureModule.AddManufactureModule`.
+- `Anela.Heblo.Application/Features/Logistics/Contracts/` already exists (4 DTO files). Dropping a new interface there does not introduce a new folder convention.
+- `ManufacturedProductInventoryItem.Consume` is the only place that throws `InvalidOperationException` on insufficient stock today (Domain/Features/Manufacture/Inventory/ManufacturedProductInventoryItem.cs:55-57); the adapter can safely translate it.
+- `ErrorCodes.ManufacturedInventoryItemNotFound` (1215) and `ManufacturedInventoryInsufficientStock` (1216) already exist in `Application/Shared/ErrorCodes.cs`; no code-table churn.
+
+Integration points (must remain stable):
+1. **Shared `ApplicationDbContext` (ADR-001 Phase 1).** Inventory writes and box writes are tracked together; the handler's `_repository.SaveChangesAsync(cancellationToken)` commits both. The adapter must remain `SaveChanges`-free.
+2. **`ITransportBoxRepository.SaveChangesAsync` is the unit-of-work boundary.** The adapter's `UpdateAsync` call only sets EF state (`Modified`) on the inventory entity; the commit is owned by the handler.
+3. **`IManufacturedProductInventoryRepository`** stays Manufacture-owned and unchanged. Only the cross-module call path moves.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Application/Features/Logistics                                   │
+│                                                                              │
+│  UseCases/AddItemToBox/AddItemToBoxHandler                                   │
+│  UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler             │
+│           │                                                                  │
+│           │ ctor inject                                                      │
+│           ▼                                                                  │
+│  Contracts/IInventoryReservationService   ◀── Logistics-OWNED contract       │
+│  Contracts/ConsumeInventoryResult         ◀── Logistics-owned result type    │
+└───────────────────────────────│──────────────────────────────────────────────┘
+                                │ implemented by
+                                ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Application/Features/Manufacture                                 │
+│                                                                              │
+│  Infrastructure/ManufactureInventoryReservationAdapter (internal sealed)     │
+│           │                                                                  │
+│           ▼                                                                  │
+│  IManufacturedProductInventoryRepository (Manufacture-owned, unchanged)      │
+│           │                                                                  │
+│           ▼                                                                  │
+│  ManufacturedProductInventoryItem.Consume / .Restore (domain methods)        │
+│                                                                              │
+│  ManufactureModule.AddManufactureModule:                                     │
+│    services.AddScoped<IInventoryReservationService,                          │
+│                       ManufactureInventoryReservationAdapter>();             │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+Reflection-based CI guard: backend/test/.../Architecture/ModuleBoundariesTests.cs
+  ├─ existing fact: Leaflet → KnowledgeBase
+  └─ NEW fact (FR-7): Logistics → Manufacture (shares helpers, no allowlist entries)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Shape of the consume result type
+
+**Options considered:**
+- (A) `bool` return + out-parameter — opaque, hard to extend, doesn't carry the missing-vs-insufficient distinction.
+- (B) `enum ConsumeOutcome { Success, NotFound, InsufficientStock }` only — adequate today; if a future error needs to carry a payload (e.g. "current available amount"), the API has to break.
+- (C) Sealed `record` discriminated result (e.g. `ConsumeInventoryResult` with a `ConsumeOutcome` enum field and no payload today) — extensible without breaking the contract; still trivially mappable in the handler.
+- (D) Exception-based — explicitly forbidden by FR-1 (no Manufacture exceptions across the boundary) and FR-2 acceptance criteria.
+
+**Chosen approach:** **Option C**. Define:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+public enum ConsumeInventoryOutcome
+{
+    Success,
+    InventoryNotFound,
+    InsufficientStock,
+}
+
+public sealed record ConsumeInventoryResult(ConsumeInventoryOutcome Outcome);
+```
+
+`TryConsumeAsync` returns `Task<ConsumeInventoryResult>`. The handler maps:
+- `InventoryNotFound` → `ErrorCodes.ManufacturedInventoryItemNotFound`
+- `InsufficientStock` → `ErrorCodes.ManufacturedInventoryInsufficientStock`
+- `Success` → proceed.
+
+**Rationale:** A `record` type leaves room for a future `decimal? AvailableAmount` field (e.g. for richer UI messaging) without rewriting every call site. It also reads more clearly than a raw enum at the call site (`result.Outcome switch { ... }`). Matches `csharp-coding-style.md`: "Prefer `record` for immutable value-like models." The spec leaves the shape open (its only constraint is "no Manufacture types in the surface, no try/catch in the handler"); we lock it down here so the implementer doesn't reopen the question.
+
+#### Decision 2: How narrowly the adapter catches `InvalidOperationException`
+
+**Options considered:**
+- (A) Catch `InvalidOperationException` and unconditionally translate to `InsufficientStock` — what the spec implies and what `AddItemToBoxHandler` does today (line 74).
+- (B) Inspect the exception message text — brittle.
+- (C) Introduce a typed `InsufficientInventoryException : InvalidOperationException` in the Manufacture domain and have the adapter catch the typed one. Out of scope per the spec ("Renaming or relocating `ManufacturedProductInventoryItem` ... still owned by Manufacture; only the cross-module call path changes").
+
+**Chosen approach:** **Option A**, with a single-line code comment on the catch block noting that `ManufacturedProductInventoryItem.Consume` is the only producer of `InvalidOperationException` in this call path and that broadening the surface (adding a second `throw new InvalidOperationException(...)` inside `Consume` for a different reason) would constitute a behavior change in the public adapter contract.
+
+**Rationale:** Preserves NFR-1 (zero behavioral drift) and stays within scope. The comment documents the implicit coupling so a future change to `Consume` doesn't silently miscategorize a different error. Strengthening to Option C is a worthwhile follow-up but explicitly listed as Out of Scope.
+
+#### Decision 3: Adapter location and visibility
+
+**Chosen approach:** `internal sealed class ManufactureInventoryReservationAdapter` in `Anela.Heblo.Application/Features/Manufacture/Infrastructure/`, mirroring `KnowledgeBaseLeafletSourceAdapter` exactly (which is also `internal sealed`).
+
+**Rationale:** `internal` prevents accidental cross-assembly references; `sealed` prevents subclass-based test doubles (consumers mock the interface). The `Infrastructure/` folder under the provider module is the documented home (guideline §"Concrete example", "The adapter lives in module B's `Infrastructure/`").
+
+#### Decision 4: Test-guard refactor strategy (FR-7)
+
+**Options considered:**
+- (A) Copy-paste the existing `[Fact]` and swap namespace constants.
+- (B) Refactor the existing test into a parameterized fact (`[Theory]` with `MemberData` per rule) where each rule is `(inspectedNamespace, forbiddenPrefixes[], allowlist)`.
+- (C) Extract `EnumerateReferencedTypes`/`IsForbidden`/`ExpandGenerics` into a static helper class and keep two separate `[Fact]`s that call it.
+
+**Chosen approach:** **Option B**. Make the test data-driven so adding a third module pair later is a one-line `MemberData` row, not another copy. Each row carries its own `Allowlist` (Leaflet's existing entries stay; Logistics gets an empty set).
+
+**Rationale:** FR-7 explicitly says "no copy-paste" and "refactor helpers to accept parameters if needed." A `[Theory]` parameterization is the minimum-churn way to honor that. Keeps the existing helpers as `static` methods — they already take a `Type` and a forbidden-prefix list, so they generalize without changes.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/
+├── Logistics/
+│   ├── Contracts/
+│   │   ├── IInventoryReservationService.cs        ← NEW
+│   │   ├── ConsumeInventoryResult.cs              ← NEW (record + enum in one file is fine)
+│   │   ├── TransportBoxDto.cs                     (existing)
+│   │   ├── TransportBoxItemDto.cs                 (existing)
+│   │   ├── TransportBoxStateLogDto.cs             (existing)
+│   │   └── TransportBoxTransitionDto.cs           (existing)
+│   └── UseCases/
+│       ├── AddItemToBox/AddItemToBoxHandler.cs                       ← MODIFY
+│       └── ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs ← MODIFY
+└── Manufacture/
+    ├── Infrastructure/                            ← NEW folder
+    │   └── ManufactureInventoryReservationAdapter.cs ← NEW
+    └── ManufactureModule.cs                       ← MODIFY (one AddScoped line)
+
+backend/test/Anela.Heblo.Tests/
+├── Architecture/
+│   └── ModuleBoundariesTests.cs                   ← MODIFY (refactor to Theory)
+└── Features/
+    ├── Logistics/Transport/
+    │   ├── AddItemToBoxHandlerTests.cs            ← MODIFY (swap mock target)
+    │   └── ChangeTransportBoxStateHandlerTests.cs ← MODIFY (swap mock target)
+    └── Manufacture/Infrastructure/                ← NEW folder
+        └── ManufactureInventoryReservationAdapterTests.cs ← NEW
+```
+
+Note: `Manufacture/Infrastructure/` does not exist today in the Application project (Persistence has its own `Anela.Heblo.Persistence.Manufacture.Inventory` namespace, which is unrelated). Creating it is consistent with the guideline's prescribed layout and matches `KnowledgeBase/Infrastructure/`.
+
+### Interfaces and Contracts
+
+```csharp
+// Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Logistics-owned abstraction over inventory reservation for transport-box operations.
+/// Implemented by the Manufacture module via an adapter. Operations must remain in the
+/// caller's unit of work — implementations MUST NOT call SaveChangesAsync.
+/// </summary>
+public interface IInventoryReservationService
+{
+    Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Restores inventory amount. If the inventory id does not exist, the call is a
+    /// no-op (logs a warning) and completes successfully — matching the original
+    /// "log and skip" recovery semantics in ChangeTransportBoxStateHandler.
+    /// </summary>
+    Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken);
+}
+
+// Same folder — co-located result type
+public enum ConsumeInventoryOutcome { Success, InventoryNotFound, InsufficientStock }
+
+public sealed record ConsumeInventoryResult(ConsumeInventoryOutcome Outcome);
+```
+
+Adapter skeleton:
+
+```csharp
+// Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs
+namespace Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+
+internal sealed class ManufactureInventoryReservationAdapter : IInventoryReservationService
+{
+    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly ILogger<ManufactureInventoryReservationAdapter> _logger;
+
+    public ManufactureInventoryReservationAdapter(
+        IManufacturedProductInventoryRepository inventoryRepository,
+        ILogger<ManufactureInventoryReservationAdapter> logger)
+    {
+        _inventoryRepository = inventoryRepository;
+        _logger = logger;
+    }
+
+    public async Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId, decimal amount, string userName, DateTime timestamp,
+        int boxId, string? boxCode, bool allowNegativeStock,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound);
+
+        try
+        {
+            // ManufacturedProductInventoryItem.Consume is the sole producer of
+            // InvalidOperationException on this code path (insufficient stock).
+            item.Consume(amount, userName, timestamp, boxId, boxCode, allowNegativeStock);
+        }
+        catch (InvalidOperationException)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock);
+        }
+
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+        return new ConsumeInventoryResult(ConsumeInventoryOutcome.Success);
+    }
+
+    public async Task RestoreAsync(
+        int inventoryId, decimal amount, string userName, DateTime timestamp,
+        int boxId, string? boxCode, CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            _logger.LogWarning(
+                "InventoryItem {InventoryId} not found during restore for transport box {BoxId} — skipping restore",
+                inventoryId, boxId);
+            return;
+        }
+
+        item.Restore(amount, userName, timestamp, boxId, boxCode);
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+    }
+}
+```
+
+DI binding in `ManufactureModule.cs` (one new line, grouped with the other repository registrations on lines 47-48):
+
+```csharp
+// Cross-module contract: Manufacture implements Logistics's IInventoryReservationService via adapter.
+// DI registration owned by provider (Manufacture), not consumer (Logistics).
+services.AddScoped<IInventoryReservationService, ManufactureInventoryReservationAdapter>();
+```
+
+### Data Flow
+
+**`AddItemToBox` (success path):**
+```
+Controller → MediatR → AddItemToBoxHandler.Handle
+  ├─ _repository.GetByIdWithDetailsAsync(boxId)         (Logistics)
+  ├─ if SourceInventoryId != null:
+  │    _inventoryReservationService.TryConsumeAsync(...)   ▶─┐
+  │      └─ adapter loads ManufacturedProductInventoryItem  │
+  │      └─ item.Consume(...) mutates entity (tracked)      │
+  │      └─ inventoryRepository.UpdateAsync (EF state only) │
+  │    ◀── returns Success                                ◀─┘
+  ├─ transportBox.AddItem(...)
+  └─ _repository.SaveChangesAsync(cancellationToken)    ← ONE commit covers both
+                                                          inventory + box mutations
+```
+
+**`AddItemToBox` (insufficient-stock path):**
+```
+... TryConsumeAsync → adapter catches InvalidOperationException → returns InsufficientStock
+... handler maps to ErrorCodes.ManufacturedInventoryInsufficientStock
+... NO SaveChangesAsync invoked → tracked mutations from item.Consume are discarded
+                                  when the DbContext is disposed at scope end.
+```
+This is critical for NFR-3: the adapter must not call `SaveChangesAsync`, otherwise the in-flight `item.Consume` mutation would commit on failure and leak negative inventory.
+
+**`ChangeTransportBoxState` (Opened → New restore path):**
+```
+ChangeTransportBoxStateHandler.Handle
+  ├─ box = _repository.GetByIdWithDetailsAsync(boxId)
+  ├─ capture itemsToRestore = box.Items.Where(SourceInventoryId != null).ToList()
+  ├─ transition.ChangeStateAsync(box, ...)               ← clears items
+  ├─ foreach (item) _inventoryReservationService.RestoreAsync(...)   ▶─┐
+  │    └─ adapter loads inventory; null → log warning + return         │
+  │    └─ else item.Restore(...); UpdateAsync                          │
+  │    ◀── returns                                                   ◀─┘
+  ├─ _repository.UpdateAsync(box)
+  └─ _repository.SaveChangesAsync(cancellationToken)    ← ONE commit
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Adapter accidentally calls `SaveChangesAsync` on the inventory repository, breaking atomicity with the box mutation in failure scenarios | HIGH | Explicit XML doc on `IInventoryReservationService` stating implementations must not commit; adapter unit tests assert `SaveChangesAsync` is never invoked on the mock (`_inventoryRepoMock.Verify(x => x.SaveChangesAsync(...), Times.Never)`); code-review checklist item. |
+| `catch (InvalidOperationException)` in the adapter masks a future, unrelated `InvalidOperationException` thrown from inside `ManufacturedProductInventoryItem.Consume` (e.g. an added invariant check) and miscategorizes it as "insufficient stock" | MEDIUM | Inline code comment on the catch block naming the assumption; adapter unit test asserts the InsufficientStock branch is hit only when amount > current available; track promotion to typed `InsufficientInventoryException` as a follow-up. |
+| Spec calls for an `internal sealed` adapter, but MediatR/test code in other assemblies may need to resolve it — same risk applied to `KnowledgeBaseLeafletSourceAdapter` and was a non-issue (DI resolves by interface). | LOW | None needed — keep `internal sealed`. Add `[InternalsVisibleTo("Anela.Heblo.Tests")]` only if a direct-instantiation test requires it; the existing pattern doesn't, since adapter tests construct via the public constructor (which is `internal` but accessible from a test project with `InternalsVisibleTo` — verify the Manufacture project already grants this to `Anela.Heblo.Tests`). |
+| Restore no-op on missing inventory silently loses the user's reservation if the source row was deleted between consume and restore | LOW (pre-existing) | Out of scope per spec NFR-1; preserve today's "log warning and skip" behavior; document in adapter XML comment so it's not mistaken for a bug. |
+| `ModuleBoundariesTests` `[Theory]` refactor breaks the existing Leaflet allowlist by changing how entries are matched | MEDIUM | Keep the allowlist as a `HashSet<string>` per row in `MemberData`; preserve the compiler-generated-type fallback logic (the `baseType.DeclaringType` check on lines 73-79); run the refactored test against `main` to confirm Leaflet still passes before adding the Logistics row. |
+| Test must fail on `main` (FR-7 acceptance) — easy to forget to verify | LOW | Implement the Logistics `MemberData` row in a separate first commit, observe the red, then land FR-5/FR-6 to make it green. |
+| `IManufacturedProductInventoryRepository.UpdateAsync` semantics — whether it just marks `Modified` or does any extra work — could affect adapter correctness if it (e.g.) calls `SaveChangesAsync` internally | MEDIUM | Read `Persistence/Manufacture/Inventory/ManufacturedProductInventoryRepository.cs` (or its base) before implementing the adapter; if `UpdateAsync` commits internally, the design needs adjustment (or the adapter must not call it and rely solely on EF change tracking). This is a prerequisite verification step (see Prerequisites). |
+
+## Specification Amendments
+
+1. **FR-1/FR-2 — lock down the result-type shape.** The spec leaves the result type open. To prevent litigation during code review, amend FR-2 to: "The result type is a sealed `record` named `ConsumeInventoryResult` with a single `ConsumeInventoryOutcome` enum property (`Success | InventoryNotFound | InsufficientStock`). Both types live in `Anela.Heblo.Application.Features.Logistics.Contracts`." Rationale: design Decision 1 above.
+
+2. **FR-1 — add an explicit contract clause that implementations must not commit.** Append to the FR-1 XML doc: "Implementations MUST NOT call `SaveChangesAsync` on any repository. The unit of work is owned by the caller." Rationale: NFR-3 is restated as a runtime test concern but is not surfaced in the contract itself; a comment on the interface makes the constraint discoverable at the API surface.
+
+3. **FR-3 — verify `IManufacturedProductInventoryRepository.UpdateAsync` does not internally commit.** Add a small acceptance criterion: "Before implementing the adapter, confirm that `ManufacturedProductInventoryRepository.UpdateAsync` only marks the entity `Modified` and does not call `SaveChangesAsync`. If it does, the adapter must instead rely on EF change tracking only and `UpdateAsync` must be skipped." Rationale: today's handlers call `UpdateAsync` followed by `SaveChangesAsync`, so the current call-shape relies on `UpdateAsync` being commit-free; the adapter inherits this assumption and it should be checked once.
+
+4. **FR-7 — name the chosen refactor shape.** The spec says "refactor helpers to accept parameters if needed; no copy-paste." Amend to: "Convert the existing `[Fact]` into a `[Theory]` driven by `MemberData`, with one row per module-boundary rule. Each row is `(InspectedNamespace, ForbiddenPrefixes[], Allowlist)`. Existing Leaflet row keeps its current allowlist; Logistics row has an empty allowlist." Rationale: removes ambiguity in implementation.
+
+5. **FR-3 — narrow the catch comment.** Add: "Place an inline code comment on the `catch (InvalidOperationException)` block in `TryConsumeAsync` naming `ManufacturedProductInventoryItem.Consume` as the sole producer of this exception on the call path." Rationale: Decision 2 / MEDIUM risk above.
+
+6. **Out-of-scope addendum.** No spec change needed, but call out for follow-up: typed `InsufficientInventoryException` in the Manufacture domain so the adapter does not have to catch a broad framework exception. Track as a separate ticket.
+
+No other amendments. The spec is unusually well-grounded; the precedent it references is verified to be exactly the shape claimed.
+
+## Prerequisites
+
+1. **Confirm `ManufacturedProductInventoryRepository.UpdateAsync` is commit-free.** Read `backend/src/Anela.Heblo.Persistence/Manufacture/Inventory/ManufacturedProductInventoryRepository.cs` (and its base) to verify `UpdateAsync` only sets EF state. If it commits, the adapter design needs to drop the `UpdateAsync` call (EF tracking will pick up the mutation from `item.Consume`/`item.Restore` automatically).
+2. **Confirm `InternalsVisibleTo` for the test project.** Verify `Anela.Heblo.Application.csproj` exposes internals to `Anela.Heblo.Tests` so the new `ManufactureInventoryReservationAdapterTests` can `new ManufactureInventoryReservationAdapter(...)`. Mirrors the assumption for `KnowledgeBaseLeafletSourceAdapter` tests (if any exist) — if not granted, either add `InternalsVisibleTo` or test the adapter via the DI container.
+3. **No infrastructure, migration, configuration, secret, or NuGet changes required** (NFR-6).
+4. **No OpenAPI regeneration required** (no contract changes on the HTTP surface).
+5. **Order of landing** to make FR-7 acceptance trivially auditable:
+   a. Land FR-1, FR-2, FR-3, FR-4 (new contract, adapter, DI binding) — code compiles; existing handlers still use the repository directly; nothing functionally changes.
+   b. Land FR-7 refactor of `ModuleBoundariesTests` with the Logistics row — test goes red on this branch.
+   c. Land FR-5, FR-6, FR-8 (migrate handlers, migrate handler tests, add adapter tests) — test goes green.

--- a/artifacts/feat-arch-review-logistics-handlers-directly-/brief.md
+++ b/artifacts/feat-arch-review-logistics-handlers-directly-/brief.md
@@ -1,0 +1,30 @@
+## Module
+Logistics
+
+## Finding
+Two Logistics handlers directly inject `IManufacturedProductInventoryRepository` from the Manufacture module's domain, bypassing the required contract-based cross-module communication pattern:
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs` — line 16: `private readonly IManufacturedProductInventoryRepository _inventoryRepository;`
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` — line 17: `private readonly IManufacturedProductInventoryRepository _inventoryRepository;`
+
+Both handlers call `_inventoryRepository.GetByIdAsync(...)` and `_inventoryRepository.UpdateAsync(...)` on Manufacture-owned inventory items, and `AddItemToBoxHandler` calls `inventoryItem.Consume(...)` — a Manufacture domain method — directly from the Logistics application layer.
+
+## Why it matters
+`development_guidelines.md` explicitly forbids "Direct access to another module's entities" and "Shared repositories across modules." This creates tight coupling: any change to `ManufacturedProductInventoryItem` or `IManufacturedProductInventoryRepository` can break Logistics handlers. It also blocks the future path to independent module deployment.
+
+## Suggested fix
+Apply the cross-module consumer/provider contract pattern documented in `development_guidelines.md`:
+
+1. Define a Logistics-owned interface in `Application/Features/Logistics/Contracts/`, e.g.:
+   ```csharp
+   public interface IInventoryReservationService
+   {
+       Task<bool> TryConsumeAsync(int inventoryId, decimal amount, string userName, DateTime timestamp, int boxId, string? boxCode, bool allowNegative, CancellationToken ct);
+       Task RestoreAsync(int inventoryId, decimal amount, string userName, DateTime timestamp, int boxId, string? boxCode, CancellationToken ct);
+   }
+   ```
+2. Have Manufacture implement an adapter in `Application/Features/Manufacture/Infrastructure/` and register the binding in `ManufactureModule`.
+3. Replace the direct repository injection in both handlers with the new interface.
+
+---
+_Filed by daily arch-review routine on 2026-05-15._

--- a/artifacts/feat-arch-review-logistics-handlers-directly-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-logistics-handlers-directly-/impl/main.r1.md
@@ -1,0 +1,15 @@
+All 9 tasks complete. Here's the final state:
+
+**Build:** 0 errors  
+**Tests:** 3,615 passed (0 failed), both `ModuleBoundariesTests` rows GREEN  
+**Format:** `dotnet format --verify-no-changes` clean  
+**Grep:** No remaining `IManufacturedProductInventoryRepository` references in Logistics source
+
+**What was delivered:**
+
+- `IInventoryReservationService` + `ConsumeInventoryResult` owned by `Logistics.Contracts`
+- `ManufactureInventoryReservationAdapter` (`internal sealed`) in `Manufacture.Infrastructure`, registered via DI in `ManufactureModule`
+- 7 adapter unit tests covering all outcome branches and the no-`SaveChangesAsync` invariant
+- `ModuleBoundariesTests` upgraded to `[Theory]` with two parameterized rows: `Leaflet→KnowledgeBase` and `Logistics→Manufacture`
+- All three handlers migrated: `AddItemToBoxHandler`, `RemoveItemFromBoxHandler`, `ChangeTransportBoxStateHandler`, with their test files updated to mock `IInventoryReservationService`
+- `LogisticsAllowlist` covering two pre-existing out-of-scope violations (`GiftPackageManufactureService→IManufactureClient` and `→ProductPart`) with justification comments and removal criteria

--- a/artifacts/feat-arch-review-logistics-handlers-directly-/spec.r1.md
+++ b/artifacts/feat-arch-review-logistics-handlers-directly-/spec.r1.md
@@ -1,0 +1,288 @@
+# Specification: Decouple Logistics handlers from Manufacture inventory via consumer-owned contract
+
+## Summary
+Two Logistics MediatR handlers (`AddItemToBoxHandler`, `ChangeTransportBoxStateHandler`) currently inject `IManufacturedProductInventoryRepository` from the Manufacture domain and invoke Manufacture-owned domain methods (`ManufacturedProductInventoryItem.Consume`, `Restore`) directly, violating the cross-module communication rule in `docs/architecture/development_guidelines.md`. This spec describes introducing a Logistics-owned `IInventoryReservationService` contract, an adapter in the Manufacture module that implements it, and the migration of both handlers — modeled on the existing `ILeafletKnowledgeSource` / `KnowledgeBaseLeafletSourceAdapter` precedent. Module-boundary enforcement is extended so the rule is verified in CI going forward.
+
+## Background
+`docs/architecture/development_guidelines.md` (sections "❌ Forbidden Practices" and "Cross-Module Communication Example: ILeafletKnowledgeSource") forbids:
+- "Direct access to another module's entities"
+- "Shared repositories across modules"
+
+It also prescribes the consumer/provider inversion pattern: the **consumer** owns the interface in its `Contracts/` folder, the **provider** writes an adapter that lives in its own `Infrastructure/` and registers the binding in its `Module.cs`.
+
+The current Logistics handlers violate this rule in three observable ways:
+
+1. **`AddItemToBoxHandler`** (`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs`)
+   - Injects `IManufacturedProductInventoryRepository` (line 16).
+   - Imports `Anela.Heblo.Domain.Features.Manufacture.Inventory`.
+   - Calls `GetByIdAsync`, then `inventoryItem.Consume(...)` on the Manufacture domain entity (passing amount, user, timestamp, transport-box id, transport-box code, `allowNegativeStock`), then `UpdateAsync`.
+   - Translates Manufacture's `InvalidOperationException` (insufficient stock) into `ErrorCodes.ManufacturedInventoryInsufficientStock` and a missing item into `ErrorCodes.ManufacturedInventoryItemNotFound`.
+
+2. **`ChangeTransportBoxStateHandler`** (`backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`)
+   - Injects `IManufacturedProductInventoryRepository` (line 17).
+   - In `RestoreInventoryForItemsAsync` (lines 266–288), iterates items captured when transitioning from `Opened → New`, fetches each inventory item via `GetByIdAsync`, calls `inventoryItem.Restore(...)`, and persists via `UpdateAsync`. A missing inventory item is logged as a warning and skipped.
+
+3. **Persistence coupling.** Both handlers call `await _inventoryRepository.UpdateAsync(inventoryItem, cancellationToken);` and rely on Manufacture's `SaveChangesAsync` semantics via the shared `ApplicationDbContext` to commit alongside Logistics changes from `_repository.SaveChangesAsync(cancellationToken)`. The new contract must preserve the same transactional behavior so that a successful "add item to box" still atomically debits inventory, and a transition from `Opened → New` still atomically restores it.
+
+A precedent for the fix already exists in this codebase:
+- Consumer contract: `Anela.Heblo.Application.Features.Leaflet.Contracts.ILeafletKnowledgeSource`
+- Provider adapter: `Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure.KnowledgeBaseLeafletSourceAdapter` (sealed, internal)
+- DI registration: in `KnowledgeBaseModule.AddKnowledgeBaseModule`
+- CI guard: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` enforces that Leaflet types contain no references to KnowledgeBase-owned namespaces.
+
+This spec applies the same pattern to Logistics ↔ Manufacture.
+
+## Functional Requirements
+
+### FR-1: Define `IInventoryReservationService` contract in Logistics
+Create a new Logistics-owned interface at `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs`. The interface must expose **only** the operations the two handlers actually need today — no speculative methods.
+
+The contract must support two operations:
+- A **consume** operation that decrements inventory for a transport-box item, with optional override to allow negative stock; this operation can fail with an "insufficient stock" outcome and a "not found" outcome and must communicate both without throwing module-foreign exceptions.
+- A **restore** operation that re-increments inventory when a transport box transitions `Opened → New`; this operation must tolerate a missing inventory record by skipping it (matching today's "log warning and continue" behavior) so that a partial recovery scenario still allows the box to revert.
+
+The contract surface must be defined in Logistics terms and Logistics primitives only — no Manufacture domain types (e.g. `ManufacturedProductInventoryItem`) may appear in the signature, return type, or any exception explicitly thrown across the boundary.
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs`.
+- Namespace is `Anela.Heblo.Application.Features.Logistics.Contracts`.
+- The interface declares `TryConsumeAsync` and `RestoreAsync` (or equivalent names; see FR-2 for exact signatures).
+- No `using Anela.Heblo.Domain.Features.Manufacture.*` directive in the file.
+- No type from `Anela.Heblo.Domain.Features.Manufacture.*` or `Anela.Heblo.Application.Features.Manufacture.*` appears anywhere in the public surface of the interface (signatures, return types, exception attributes, XML doc cref).
+
+### FR-2: Operation signatures
+The two operations must capture all the parameters the current direct calls use.
+
+**Consume** must accept:
+- `int inventoryId` — the Manufacture inventory item id (already exposed to Logistics today as `TransportBoxItem.SourceInventoryId`).
+- `decimal amount` — quantity to consume.
+- `string userName` — current user; resolved by the handler from `ICurrentUserService`.
+- `DateTime timestamp` — UTC; resolved by the handler from `TimeProvider`.
+- `int boxId`, `string? boxCode` — for the inventory audit log.
+- `bool allowNegativeStock` — pass-through of `AddItemToBoxRequest.AllowNegativeStock`.
+- `CancellationToken cancellationToken`.
+
+Consume must return a structured result that distinguishes:
+- success,
+- not-found (inventory id does not exist),
+- insufficient-stock (amount exceeds available and `allowNegativeStock` is false).
+
+The implementation choice for "structured result" is open (sealed result type, discriminated union, `(Outcome, …)` tuple, or an enum + nullable payload). The constraint is that the handler must be able to map outcomes to existing `ErrorCodes.ManufacturedInventoryItemNotFound` and `ErrorCodes.ManufacturedInventoryInsufficientStock` without catching a Manufacture-owned exception type. See Open Questions on naming.
+
+**Restore** must accept:
+- `int inventoryId`,
+- `decimal amount`,
+- `string userName`,
+- `DateTime timestamp`,
+- `int boxId`, `string? boxCode`,
+- `CancellationToken cancellationToken`.
+
+Restore must:
+- be idempotent with respect to a missing inventory record (return success/no-op when the id is unknown, equivalent to today's "log warning and skip"),
+- not throw across the boundary on missing inventory,
+- log internally inside the adapter (preserving today's `LogWarning` message content as closely as practical).
+
+**Acceptance criteria:**
+- Both methods return `Task<…>` and accept `CancellationToken` as the last parameter, per `csharp-coding-style.md`.
+- The consume result type lives in `Anela.Heblo.Application.Features.Logistics.Contracts` (Logistics-owned) — not in Manufacture.
+- The result type is expressive enough that no `try/catch (InvalidOperationException)` is needed in `AddItemToBoxHandler` to detect insufficient stock.
+- Restore's contract documents the missing-id behavior in an XML doc comment.
+
+### FR-3: Implement adapter in Manufacture module
+Create `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs`. The adapter:
+- Is `internal sealed` (mirroring `KnowledgeBaseLeafletSourceAdapter`).
+- Implements `IInventoryReservationService`.
+- Depends on `IManufacturedProductInventoryRepository` injected via constructor.
+- Inside `TryConsumeAsync`:
+  - Loads the item via `GetByIdAsync`.
+  - If null, returns the "not found" outcome without throwing.
+  - Calls `inventoryItem.Consume(amount, userName, timestamp, boxId, boxCode, allowNegativeStock)`.
+  - If `Consume` throws `InvalidOperationException` (insufficient stock per current domain logic), catches it and returns the "insufficient stock" outcome.
+  - Otherwise calls `UpdateAsync` and returns success.
+- Inside `RestoreAsync`:
+  - Loads the item via `GetByIdAsync`.
+  - If null, logs a warning preserving the structure of today's message in `ChangeTransportBoxStateHandler.RestoreInventoryForItemsAsync` (item id, box id) and returns success/no-op.
+  - Otherwise calls `inventoryItem.Restore(amount, userName, timestamp, boxId, boxCode)` and then `UpdateAsync`.
+
+The adapter must NOT call `SaveChangesAsync` itself — persistence is committed by the handlers' existing `_repository.SaveChangesAsync(cancellationToken)` against the shared `ApplicationDbContext` (Phase 1 of ADR-001). This preserves today's atomic-commit semantics for both `AddItemToBox` and `ChangeTransportBoxState`. (See NFR-3.)
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs`.
+- Class is `internal sealed`.
+- All exception handling for Manufacture domain exceptions is confined to the adapter; nothing module-foreign leaks into the consumer.
+- The adapter does not call `SaveChangesAsync` on any repository.
+- Logging uses `ILogger<ManufactureInventoryReservationAdapter>`.
+
+### FR-4: Register binding in `ManufactureModule`
+Update `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs` to register the binding:
+
+```csharp
+services.AddScoped<IInventoryReservationService, ManufactureInventoryReservationAdapter>();
+```
+
+The registration belongs to Manufacture per the guideline ("Module B's `{Module}.cs` registers `services.AddScoped<IConsumerContract, ProviderAdapter>();`"). The Logistics module must remain ignorant of the binding.
+
+**Acceptance criteria:**
+- `ManufactureModule.AddManufactureModule` registers the new binding.
+- No registration of `IInventoryReservationService` exists in any Logistics module file.
+- Application starts and `dotnet build` passes.
+
+### FR-5: Migrate `AddItemToBoxHandler`
+Replace the direct repository dependency with the new contract.
+
+- Remove the `IManufacturedProductInventoryRepository _inventoryRepository` field and constructor parameter.
+- Remove the `using Anela.Heblo.Domain.Features.Manufacture.Inventory;` directive.
+- Inject `IInventoryReservationService` instead.
+- Replace the `GetByIdAsync` → `Consume` → `UpdateAsync` block with a single call to `TryConsumeAsync` and translate its result to:
+  - success → continue,
+  - not-found → `ErrorCodes.ManufacturedInventoryItemNotFound` with the same `sourceInventoryId` param dictionary,
+  - insufficient-stock → `ErrorCodes.ManufacturedInventoryInsufficientStock` with the same `sourceInventoryId` param dictionary.
+- The `try/catch (InvalidOperationException)` around the consume call must be removed (the contract surfaces this as a structured result instead).
+- The handler must continue to call `transportBox.AddItem(...)` and `_repository.SaveChangesAsync(cancellationToken)` exactly as today; the order (debit inventory, then add box item, then save) is preserved.
+
+**Acceptance criteria:**
+- Compilation: file does not import `Anela.Heblo.Domain.Features.Manufacture.Inventory`.
+- Existing tests covering `AddItemToBoxHandler` (happy path, source-not-found, insufficient-stock, allow-negative-stock) pass without behavioral change.
+- API responses for failure cases (`ErrorCode` and `Params`) are byte-identical to the pre-change responses for the same inputs.
+
+### FR-6: Migrate `ChangeTransportBoxStateHandler`
+Replace the direct repository dependency with the new contract.
+
+- Remove the `IManufacturedProductInventoryRepository _inventoryRepository` field and constructor parameter.
+- Remove the `using Anela.Heblo.Domain.Features.Manufacture.Inventory;` directive.
+- Inject `IInventoryReservationService` instead.
+- Reimplement `RestoreInventoryForItemsAsync` to loop over items and call `_inventoryReservationService.RestoreAsync(...)` per item. The missing-id case continues to be a no-op (logging moves into the adapter per FR-3).
+- The capture of `itemsToRestore` before `transition.ChangeStateAsync(...)` (lines 124–126) and the call site of `RestoreInventoryForItemsAsync` (line 132) are preserved as-is.
+- The order — capture items, run transition, restore, `UpdateAsync(box)`, `SaveChangesAsync` — must not change.
+
+**Acceptance criteria:**
+- Compilation: file does not import `Anela.Heblo.Domain.Features.Manufacture.Inventory`.
+- Existing tests covering the `Opened → New` reversion path (including the missing-inventory branch) pass without behavioral change.
+- For all non-`Opened → New` transitions, no call to `IInventoryReservationService` occurs (verified by mock assertions where tests exist).
+
+### FR-7: Extend module-boundary CI guard to cover Logistics
+The existing reflection-based test in `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` enforces the rule for Leaflet only. Extend it (or add a parallel test in the same file) to enforce that **Logistics types must not reference Manufacture-owned namespaces**, with the same allowlist semantics.
+
+Forbidden namespace prefixes (for the Logistics → Manufacture rule):
+- `Anela.Heblo.Domain.Features.Manufacture`
+- `Anela.Heblo.Application.Features.Manufacture`
+- `Anela.Heblo.Persistence.Manufacture`
+
+Inspected namespace prefix: `Anela.Heblo.Application.Features.Logistics`.
+
+The test must fail on the current code (proving the guard catches the violation) and pass once FR-5 and FR-6 are landed. Any unavoidable, pre-existing leak should be allowlisted with a justification comment, matching the existing allowlist style. The expectation is that there are **no** allowlist entries needed for this migration — the spec is to eliminate the references, not document them.
+
+**Acceptance criteria:**
+- A new `[Fact]` (or parameterized fact) in `ModuleBoundariesTests.cs` covers Logistics → Manufacture.
+- Test fails when run against `main` (or any commit before the migration is complete).
+- Test passes after FR-5 and FR-6 are applied.
+- The new fact reuses the existing `EnumerateReferencedTypes` / `IsForbidden` / `ExpandGenerics` helpers (refactor them to accept parameters if needed; no copy-paste).
+
+### FR-8: Update tests for both handlers
+Existing unit tests against `AddItemToBoxHandler` and `ChangeTransportBoxStateHandler` are currently written against `IManufacturedProductInventoryRepository`. They must be migrated to mock `IInventoryReservationService` instead.
+
+**Acceptance criteria:**
+- All test files that mocked `IManufacturedProductInventoryRepository` for these two handlers now mock `IInventoryReservationService`.
+- Test names continue to express behavior, not implementation (per `csharp-testing.md`).
+- The full test suite (`dotnet test`) passes with no skipped tests in the migrated files.
+- Coverage of the two handlers does not regress.
+
+A separate adapter-level unit test (`ManufactureInventoryReservationAdapterTests`) covers the adapter's own behavior:
+- consume happy path,
+- consume returns not-found when repository returns null,
+- consume returns insufficient-stock when domain throws `InvalidOperationException`,
+- consume with `allowNegativeStock = true` succeeds even when amount > current,
+- restore happy path,
+- restore is a no-op (logs warning) when repository returns null.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavioral parity
+The migration must be a refactor, not a behavior change. All externally observable behavior of `AddItemToBox` and `ChangeTransportBoxState` (HTTP responses, error codes, log message structure for the warning path, inventory log entries written by `Consume`/`Restore`) is identical before and after. NFR-1 is satisfied by FR-5/FR-6/FR-8 acceptance criteria collectively.
+
+### NFR-2: Module boundaries
+After this change, the only edges between Logistics and Manufacture must be:
+- the Logistics-owned `IInventoryReservationService` contract,
+- consumed by Logistics handlers,
+- implemented by Manufacture's adapter,
+- bound in `ManufactureModule`.
+
+Enforced in CI by FR-7.
+
+### NFR-3: Transaction semantics
+The shared `ApplicationDbContext` (ADR-001, Phase 1) is the unit of work. Both `_repository.SaveChangesAsync(...)` calls in the two handlers must continue to commit both the transport-box mutation and the inventory mutation atomically. The adapter must not introduce a second `SaveChangesAsync` or a new transaction scope; doing so could break atomicity if the inventory write succeeds and the box write fails (or vice versa).
+
+### NFR-4: Logging
+The adapter takes over logging for the restore-missing-id case from `ChangeTransportBoxStateHandler`. The warning's structured fields (`InventoryId`, `BoxId`) and severity (`LogWarning`) must be preserved; the message wording may be adjusted to read naturally from the adapter's perspective but must not omit the IDs.
+
+### NFR-5: Code style
+- Adapter is `internal sealed` (matches precedent).
+- Files <800 lines (trivially).
+- Naming follows `csharp-coding-style.md` (`IInventoryReservationService`, `TryConsumeAsync`, `RestoreAsync`).
+- Nullable reference types enabled (project default).
+- All async methods accept `CancellationToken` as the last parameter.
+
+### NFR-6: No new dependencies
+This refactor must not introduce new NuGet packages.
+
+## Data Model
+No schema changes. No new entities. The contract operates on primitive identifiers and value parameters; the Manufacture domain model (`ManufacturedProductInventoryItem`, `ManufacturedProductInventoryLog`, `InventoryChangeType`) is unchanged.
+
+The contract result type for `TryConsumeAsync` is a Logistics-owned application-layer type (sealed record or enum + payload) with at minimum a success/not-found/insufficient-stock discriminator. It does not require persistence and never crosses the wire.
+
+## API / Interface Design
+
+### Public HTTP surface
+No change. The MVC + MediatR pipeline, request DTOs, response DTOs, error codes, and status codes are all preserved. Existing OpenAPI clients (C# and TypeScript) regenerate identically.
+
+### Internal module-boundary contract
+A single new file owned by Logistics:
+
+```
+Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs
+```
+
+with two async methods (`TryConsumeAsync`, `RestoreAsync`) and a result type for consume outcomes. Manufacture-side adapter at:
+
+```
+Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs
+```
+
+DI binding in:
+
+```
+Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+```
+
+### Files modified
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs` (FR-5)
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` (FR-6)
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs` (FR-4)
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (FR-7)
+- Existing test files for the two handlers (FR-8)
+
+### Files created
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs` (FR-1, FR-2)
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs` (FR-3)
+- Adapter unit tests file (FR-8)
+
+## Dependencies
+- Existing `IManufacturedProductInventoryRepository` and `ManufacturedProductInventoryItem` domain methods (`Consume`, `Restore`) are unchanged.
+- Existing `ErrorCodes.ManufacturedInventoryItemNotFound` and `ErrorCodes.ManufacturedInventoryInsufficientStock` are reused as-is.
+- Pattern reference: `ILeafletKnowledgeSource` / `KnowledgeBaseLeafletSourceAdapter` / `KnowledgeBaseModule` registration.
+- CI: existing `ModuleBoundariesTests.cs` reflection scaffolding (extended, not rewritten).
+
+## Out of Scope
+- Splitting `ApplicationDbContext` per module (ADR-001 Phase 2 — explicitly future work).
+- Moving inventory persistence out of the shared DbContext.
+- Introducing distributed transactions, outbox patterns, or eventual consistency between Logistics and Manufacture.
+- Renaming or relocating `ManufacturedProductInventoryItem` or `IManufacturedProductInventoryRepository` (still owned by Manufacture; only the cross-module call path changes).
+- Refactoring the `HandleReceived` flow in `ChangeTransportBoxStateHandler` (calls `IStockUpProcessingService` from Catalog — separate concern, not flagged in the brief).
+- Generalizing the contract to other Logistics-side consumers of Manufacture (none exist today).
+- Removing the existing Leaflet→KnowledgeBase allowlist entries.
+- Updating Czech-language documentation (`docs/📘 Architecture Documentation – MVP Work.md`) — this spec only touches `docs/architecture/development_guidelines.md`-governed code paths; no doc changes are needed because the pattern being applied is already documented there.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-logistics-handlers-directly-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-logistics-handlers-directly-/task-plan.r1.md
@@ -1,0 +1,1576 @@
+# Decouple Logistics handlers from Manufacture inventory — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct `IManufacturedProductInventoryRepository` injection in `AddItemToBoxHandler` and `ChangeTransportBoxStateHandler` with a Logistics-owned `IInventoryReservationService` contract, implemented by an internal adapter in the Manufacture module. Extend the module-boundary CI test to cover Logistics → Manufacture, with no behavioral change.
+
+**Architecture:** Apply the Leaflet/KnowledgeBase consumer-owns-contract / provider-owns-adapter precedent (`docs/architecture/development_guidelines.md` §"Cross-Module Communication Example"). Logistics declares the interface and a sealed-record result type in its `Contracts/` folder; Manufacture provides an `internal sealed` adapter in a new `Infrastructure/` folder; `ManufactureModule` registers the binding. Persistence remains in the shared `ApplicationDbContext` (ADR-001 Phase 1) — the adapter must not call `SaveChangesAsync`; the caller's existing `_repository.SaveChangesAsync(cancellationToken)` commits both the box mutation and the inventory mutation atomically. The reflection-based `ModuleBoundariesTests` is refactored to a `[Theory]` so a Logistics row is one `MemberData` entry, and the existing Leaflet row keeps its allowlist.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, MediatR, EF Core (`ApplicationDbContext`), `Microsoft.Extensions.Logging`, `Microsoft.Extensions.DependencyInjection`.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs` | Logistics-owned interface (`TryConsumeAsync`, `RestoreAsync`). |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs` | Logistics-owned sealed record + `ConsumeInventoryOutcome` enum (Success/InventoryNotFound/InsufficientStock). |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs` | `internal sealed` adapter implementing the contract by delegating to `IManufacturedProductInventoryRepository` and `ManufacturedProductInventoryItem.Consume/Restore`. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs` | Unit tests for the adapter (6 cases). |
+
+**Files to modify:**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs` | Register `IInventoryReservationService` → `ManufactureInventoryReservationAdapter`. |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Refactor existing `[Fact]` into a `[Theory]` with `MemberData`; add Logistics → Manufacture row with empty allowlist. |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs` | Replace `IManufacturedProductInventoryRepository` field/ctor param with `IInventoryReservationService`; replace `GetByIdAsync`/`Consume`/`UpdateAsync` block + `try/catch (InvalidOperationException)` with a single `TryConsumeAsync` call mapped on its outcome. Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` | Replace `IManufacturedProductInventoryRepository` field/ctor param with `IInventoryReservationService`; reimplement `RestoreInventoryForItemsAsync` to delegate per item. Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs` | Swap the mock target from `IManufacturedProductInventoryRepository` to `IInventoryReservationService`; rewrite verifications against the new contract. Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs` | Swap the mock target; add two Opened→New restore tests (happy-path delegates per item; missing-inventory is logged-and-skipped by the adapter — handler test asserts it still calls `RestoreAsync`). Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+
+**No other files change.** No NuGet packages added (NFR-6). No schema, no migration, no OpenAPI regeneration.
+
+---
+
+## Task 1: Add the Logistics-owned contract types
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs`
+
+- [ ] **Step 1: Create `ConsumeInventoryResult.cs`**
+
+Write the file exactly:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Outcome of an <see cref="IInventoryReservationService.TryConsumeAsync"/> call.
+/// </summary>
+public enum ConsumeInventoryOutcome
+{
+    Success,
+    InventoryNotFound,
+    InsufficientStock,
+}
+
+/// <summary>
+/// Logistics-owned result of attempting to consume inventory.
+/// Sealed record with an outcome discriminator — extensible to carry an optional
+/// available-amount field without breaking the contract.
+/// </summary>
+public sealed record ConsumeInventoryResult(ConsumeInventoryOutcome Outcome);
+```
+
+- [ ] **Step 2: Create `IInventoryReservationService.cs`**
+
+Write the file exactly:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Logistics-owned abstraction over inventory reservation for transport-box operations.
+/// Implemented by the Manufacture module via an adapter
+/// (see <c>ManufactureInventoryReservationAdapter</c>) per the cross-module communication
+/// pattern in <c>docs/architecture/development_guidelines.md</c>.
+///
+/// Implementations MUST NOT call SaveChangesAsync on any repository. The caller owns the
+/// unit of work and commits the inventory mutation together with the transport-box mutation
+/// against the shared ApplicationDbContext (ADR-001 Phase 1).
+/// </summary>
+public interface IInventoryReservationService
+{
+    /// <summary>
+    /// Attempts to decrement inventory for a transport-box item. Returns a structured
+    /// result distinguishing success, missing inventory record, and insufficient stock.
+    /// Implementations must not throw Manufacture-owned exceptions across this boundary.
+    /// </summary>
+    Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Restores inventory amount after a transport box transitions Opened → New.
+    /// If the inventory id does not exist, the call is a no-op (implementations log a
+    /// warning and return) — matching the original "log and skip" recovery semantics
+    /// in <c>ChangeTransportBoxStateHandler</c>.
+    /// </summary>
+    Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken);
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run from repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: Build succeeded, 0 errors. The interface compiles standalone; nothing references it yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs \
+        backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs
+git commit -m "feat: add Logistics-owned IInventoryReservationService contract"
+```
+
+---
+
+## Task 2: Implement `ManufactureInventoryReservationAdapter`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs`
+
+- [ ] **Step 1: Create the adapter file**
+
+The folder `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/` does not yet exist — create it as part of writing the file.
+
+Write the file exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+
+/// <summary>
+/// Manufacture-owned adapter that implements the Logistics-owned
+/// <see cref="IInventoryReservationService"/> contract by delegating to the Manufacture
+/// inventory repository and domain methods.
+///
+/// Does not commit — the caller's unit of work (the transport-box repository's
+/// SaveChangesAsync) commits both mutations atomically against the shared
+/// ApplicationDbContext.
+/// </summary>
+internal sealed class ManufactureInventoryReservationAdapter : IInventoryReservationService
+{
+    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly ILogger<ManufactureInventoryReservationAdapter> _logger;
+
+    public ManufactureInventoryReservationAdapter(
+        IManufacturedProductInventoryRepository inventoryRepository,
+        ILogger<ManufactureInventoryReservationAdapter> logger)
+    {
+        _inventoryRepository = inventoryRepository;
+        _logger = logger;
+    }
+
+    public async Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound);
+        }
+
+        try
+        {
+            // ManufacturedProductInventoryItem.Consume is the sole producer of
+            // InvalidOperationException on this call path (insufficient stock guard at
+            // Domain/Features/Manufacture/Inventory/ManufacturedProductInventoryItem.cs:55-57).
+            // If a future invariant adds another InvalidOperationException here, this catch
+            // would miscategorize it — track upgrade to a typed InsufficientInventoryException
+            // as a follow-up.
+            item.Consume(amount, userName, timestamp, boxId, boxCode, allowNegativeStock);
+        }
+        catch (InvalidOperationException)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock);
+        }
+
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+        return new ConsumeInventoryResult(ConsumeInventoryOutcome.Success);
+    }
+
+    public async Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            _logger.LogWarning(
+                "InventoryItem {InventoryId} not found during restore for transport box {BoxId} — skipping restore",
+                inventoryId, boxId);
+            return;
+        }
+
+        item.Restore(amount, userName, timestamp, boxId, boxCode);
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs
+git commit -m "feat: add ManufactureInventoryReservationAdapter implementing IInventoryReservationService"
+```
+
+---
+
+## Task 3: Register DI binding in `ManufactureModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs`
+
+- [ ] **Step 1: Add the using directives**
+
+Open the file and locate the `using` block at the top (lines 1-13). Add these two `using` statements alphabetically among the existing ones:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+```
+
+The using block already imports `Anela.Heblo.Domain.Features.Manufacture.Inventory` and `Anela.Heblo.Application.Features.Manufacture.Configuration`, so insert the two new lines preserving alphabetical order.
+
+- [ ] **Step 2: Register the binding**
+
+Locate the comment `// Register repositories` (around line 46 / line 47). Immediately after the existing two `services.AddScoped<IManufactureOrderRepository, ManufactureOrderRepository>();` and `services.AddScoped<IManufacturedProductInventoryRepository, ManufacturedProductInventoryRepository>();` lines, insert:
+
+```csharp
+
+        // Cross-module contract: Manufacture implements Logistics' IInventoryReservationService.
+        // DI registration is owned by the provider (Manufacture), not the consumer (Logistics).
+        services.AddScoped<IInventoryReservationService, ManufactureInventoryReservationAdapter>();
+```
+
+(One blank line above the comment to separate it from the repository-registration block.)
+
+- [ ] **Step 3: Verify build and app composition**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 errors, 0 warnings introduced by the change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+git commit -m "feat: register IInventoryReservationService -> ManufactureInventoryReservationAdapter in ManufactureModule"
+```
+
+---
+
+## Task 4: Add adapter unit tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs`
+
+The test project (`Anela.Heblo.Tests`) already has `InternalsVisibleTo` granted by `Anela.Heblo.Application` (verified: `backend/src/Anela.Heblo.Application/AssemblyInfo.cs:3`), so the test can instantiate the `internal` adapter directly.
+
+- [ ] **Step 1: Write the failing test file**
+
+The folder `backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/` does not yet exist — create it as part of writing the file.
+
+Write the file exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.Infrastructure;
+
+public class ManufactureInventoryReservationAdapterTests
+{
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ILogger<ManufactureInventoryReservationAdapter>> _loggerMock;
+    private readonly ManufactureInventoryReservationAdapter _adapter;
+
+    private static readonly DateTime FixedTime = new(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+    public ManufactureInventoryReservationAdapterTests()
+    {
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<ManufactureInventoryReservationAdapter>>();
+        _adapter = new ManufactureInventoryReservationAdapter(
+            _inventoryRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_ItemNotFound_ReturnsInventoryNotFound()
+    {
+        // Arrange
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 5m, userName: "u", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.InventoryNotFound);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_HappyPath_DecrementsAndReturnsSuccess()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 100m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 10m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.Success);
+        item.Amount.Should().Be(90m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_AmountExceedsAvailable_ReturnsInsufficientStock()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 5m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 100m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.InsufficientStock);
+        item.Amount.Should().Be(5m, "domain mutation must not be persisted when consume fails");
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_AllowNegativeStock_SucceedsWhenAmountExceedsAvailable()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 5m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 100m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: true,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.Success);
+        item.Amount.Should().Be(-95m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_DoesNotCallSaveChanges()
+    {
+        // Arrange — guard NFR-3: adapter must never commit
+        var item = CreateInventoryItem("PROD-001", 100m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 10m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _inventoryRepositoryMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_HappyPath_IncrementsAndUpdates()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 10m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        await _adapter.RestoreAsync(
+            inventoryId: 42, amount: 3m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001",
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        item.Amount.Should().Be(13m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ItemNotFound_IsNoOpAndLogsWarning()
+    {
+        // Arrange
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+
+        // Act
+        await _adapter.RestoreAsync(
+            inventoryId: 999, amount: 3m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001",
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("InventoryItem") && v.ToString()!.Contains("999")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private static ManufacturedProductInventoryItem CreateInventoryItem(string productCode, decimal amount)
+    {
+        return new ManufacturedProductInventoryItem(
+            productCode: productCode,
+            productName: "Test Product",
+            amount: amount,
+            createdBy: "system",
+            createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ManufactureInventoryReservationAdapterTests"
+```
+
+Expected: 7 tests passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs
+git commit -m "test: cover ManufactureInventoryReservationAdapter consume and restore paths"
+```
+
+---
+
+## Task 5: Refactor `ModuleBoundariesTests` to `[Theory]` (no behavior change yet)
+
+Goal of this task: convert the existing single `[Fact]` to a data-driven `[Theory]` that still has exactly one row (Leaflet → KnowledgeBase). The Logistics row is added in Task 6 to keep the "red on this branch" step distinct.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Replace the class body with the parameterized version**
+
+Replace the entire contents of the file with:
+
+```csharp
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Architecture;
+
+/// <summary>
+/// Enforces module boundary rules from docs/architecture/development_guidelines.md:
+/// Consumer modules must not reference provider-owned types directly. All cross-module
+/// communication goes through consumer-owned contracts (e.g. ILeafletKnowledgeSource,
+/// IInventoryReservationService) implemented by the provider via an adapter.
+/// </summary>
+public class ModuleBoundariesTests
+{
+    public sealed record ModuleBoundaryRule(
+        string Name,
+        string InspectedNamespacePrefix,
+        IReadOnlyList<string> ForbiddenNamespacePrefixes,
+        IReadOnlySet<string> Allowlist);
+
+    // Pre-existing allowlist for Leaflet → KnowledgeBase. Each entry needs a comment with the
+    // justification. Entries should be removed as the underlying violations are fixed.
+    //
+    // Entry format: "{ConsumerFullyQualifiedTypeName} -> {ProviderTypeFullName}"
+    //
+    // Compiler-generated types (e.g. DisplayClasses for closures, state machines for async
+    // methods) are automatically handled by matching against the declaring type's namespace
+    // prefix below.
+    private static readonly HashSet<string> LeafletAllowlist = new(StringComparer.Ordinal)
+    {
+        // Pre-existing dependency: UploadLeafletHandler and IndexLeafletHandler consume
+        // IDocumentTextExtractor, which currently lives in
+        // Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting this is out of
+        // scope for the 2026-05-15 Leaflet decoupling. Track separately and remove these
+        // entries when IDocumentTextExtractor is relocated to a shared namespace.
+        "Anela.Heblo.Application.Features.Leaflet.UseCases.UploadLeaflet.UploadLeafletHandler -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IDocumentTextExtractor",
+        "Anela.Heblo.Application.Features.Leaflet.UseCases.IndexLeaflet.IndexLeafletHandler -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IDocumentTextExtractor",
+
+        // Pre-existing dependency: LeafletIngestionJob consumes IOneDriveService, which
+        // currently lives in Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting
+        // this is out of scope for the 2026-05-15 Leaflet decoupling. Track separately and
+        // remove these entries when IOneDriveService is relocated to a shared namespace.
+        "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IOneDriveService",
+        "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.OneDriveFile",
+    };
+
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+    };
+
+    [Theory]
+    [MemberData(nameof(Rules))]
+    public void Consumer_types_should_not_reference_provider_owned_namespaces(ModuleBoundaryRule rule)
+    {
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var consumerTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                && t.Namespace.StartsWith(rule.InspectedNamespacePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var consumerType in consumerTypes)
+        {
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(consumerType))
+            {
+                if (!IsForbidden(referencedType, rule.ForbiddenNamespacePrefixes))
+                    continue;
+
+                var entry = $"{consumerType.FullName} -> {referencedType.FullName}";
+                if (rule.Allowlist.Contains(entry))
+                    continue;
+
+                // Also check if the declaring type of a compiler-generated nested type is in
+                // the allowlist. For example, if "UploadLeafletHandler+<>c__DisplayClass3_0"
+                // references a forbidden type, check if "UploadLeafletHandler" references that
+                // same forbidden type.
+                var baseType = consumerType.DeclaringType;
+                if (baseType is not null)
+                {
+                    var baseEntry = $"{baseType.FullName} -> {referencedType.FullName}";
+                    if (rule.Allowlist.Contains(baseEntry))
+                        continue;
+                }
+
+                violations.Add($"{entry} (via {memberDescription})");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            $"{rule.Name}: consumer types must not reference provider-owned namespaces. " +
+            "Define a consumer-owned contract in the consumer module's Contracts/ folder " +
+            "and have the provider module implement it via an adapter. " +
+            "Found:\n  " + string.Join("\n  ", violations));
+    }
+
+    private static bool IsForbidden(Type type, IReadOnlyList<string> forbiddenPrefixes)
+    {
+        if (type.Namespace is null)
+            return false;
+
+        foreach (var prefix in forbiddenPrefixes)
+        {
+            if (type.Namespace.Equals(prefix, StringComparison.Ordinal) ||
+                type.Namespace.StartsWith(prefix + ".", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Enumerates every type referenced by a given type: constructor parameters, fields,
+    /// properties, method parameters, method return types, generic type arguments,
+    /// and attribute types. Returns (referencedType, "where it appeared") tuples.
+    ///
+    /// Known limitation: does not inspect method bodies (local variable types,
+    /// inlined call targets). Generic constraints and attribute constructor args
+    /// are covered partially via Type/CustomAttribute traversal.
+    /// </summary>
+    private static IEnumerable<(Type Type, string Where)> EnumerateReferencedTypes(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic |
+                                    BindingFlags.Instance | BindingFlags.Static |
+                                    BindingFlags.DeclaredOnly;
+
+        foreach (var attr in type.GetCustomAttributesData())
+            foreach (var t in ExpandGenerics(attr.AttributeType))
+                yield return (t, $"attribute [{attr.AttributeType.Name}]");
+
+        foreach (var field in type.GetFields(flags))
+            foreach (var t in ExpandGenerics(field.FieldType))
+                yield return (t, $"field {field.Name}");
+
+        foreach (var prop in type.GetProperties(flags))
+            foreach (var t in ExpandGenerics(prop.PropertyType))
+                yield return (t, $"property {prop.Name}");
+
+        foreach (var ctor in type.GetConstructors(flags))
+            foreach (var param in ctor.GetParameters())
+                foreach (var t in ExpandGenerics(param.ParameterType))
+                    yield return (t, $"ctor parameter {param.Name}");
+
+        foreach (var method in type.GetMethods(flags))
+        {
+            foreach (var t in ExpandGenerics(method.ReturnType))
+                yield return (t, $"method {method.Name} return");
+
+            foreach (var param in method.GetParameters())
+                foreach (var t in ExpandGenerics(param.ParameterType))
+                    yield return (t, $"method {method.Name} parameter {param.Name}");
+        }
+    }
+
+    private static IEnumerable<Type> ExpandGenerics(Type type)
+    {
+        if (type.IsByRef || type.IsPointer)
+            type = type.GetElementType() ?? type;
+
+        if (type.IsArray)
+        {
+            var elem = type.GetElementType();
+            if (elem is not null)
+                foreach (var t in ExpandGenerics(elem))
+                    yield return t;
+            yield break;
+        }
+
+        yield return type;
+
+        if (type.IsGenericType)
+        {
+            foreach (var arg in type.GetGenericArguments())
+                foreach (var t in ExpandGenerics(arg))
+                    yield return t;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — confirm Leaflet row still passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: 1 test passed (the parameterized fact runs once for the Leaflet row), 0 failed.
+
+If it fails, the refactor introduced a regression — fix before proceeding. Do not move on.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "refactor: parameterize ModuleBoundariesTests for multiple module-pair rules"
+```
+
+---
+
+## Task 6: Add the Logistics → Manufacture rule row (expected to go red)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Add a second row to `Rules()`**
+
+In `ModuleBoundariesTests.cs`, locate the `Rules()` method (added in Task 5). Append a second `TheoryData` entry so the method body becomes:
+
+```csharp
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Logistics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Manufacture",
+                "Anela.Heblo.Application.Features.Manufacture",
+                "Anela.Heblo.Persistence.Manufacture",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+    };
+```
+
+- [ ] **Step 2: Run the test — confirm Logistics row goes RED**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: 1 passed (Leaflet row), 1 failed (Logistics row). The failure message must list at least:
+
+- `Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox.AddItemToBoxHandler -> Anela.Heblo.Domain.Features.Manufacture.Inventory.IManufacturedProductInventoryRepository`
+- `Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox.AddItemToBoxHandler -> Anela.Heblo.Domain.Features.Manufacture.Inventory.ManufacturedProductInventoryItem` (via method return / parameter via `GetByIdAsync`)
+- `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState.ChangeTransportBoxStateHandler -> Anela.Heblo.Domain.Features.Manufacture.Inventory.IManufacturedProductInventoryRepository`
+
+If the test passes, the migration was already done somewhere else and the plan is out of order — stop and investigate. If the test fails with violations not listed above (e.g. some other Logistics → Manufacture leak we did not anticipate), stop and add the leaks to the spec's Out-of-Scope or extend the migration in Task 7/Task 8.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test: enforce Logistics -> Manufacture module boundary in ModuleBoundariesTests"
+```
+
+The test is committed in failing state. Tasks 7 and 8 fix the production code; the test goes green at the end of Task 8.
+
+---
+
+## Task 7: Migrate `AddItemToBoxHandler` to the new contract
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs`
+
+- [ ] **Step 1: Update the handler imports**
+
+In `AddItemToBoxHandler.cs`, replace the `using` block (lines 1-9) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+(Net effect: drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. `Anela.Heblo.Application.Features.Logistics.Contracts` is already present from the previous version, so re-confirm it's still there.)
+
+- [ ] **Step 2: Replace the inventory field and constructor parameter**
+
+Replace lines 15-36 (field declarations + constructor) with:
+
+```csharp
+    private readonly ITransportBoxRepository _repository;
+    private readonly IInventoryReservationService _inventoryReservationService;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<AddItemToBoxHandler> _logger;
+    private readonly IMapper _mapper;
+    private readonly TimeProvider _timeProvider;
+
+    public AddItemToBoxHandler(
+        ITransportBoxRepository repository,
+        IInventoryReservationService inventoryReservationService,
+        ICurrentUserService currentUserService,
+        ILogger<AddItemToBoxHandler> logger,
+        IMapper mapper,
+        TimeProvider timeProvider)
+    {
+        _repository = repository;
+        _inventoryReservationService = inventoryReservationService;
+        _currentUserService = currentUserService;
+        _logger = logger;
+        _mapper = mapper;
+        _timeProvider = timeProvider;
+    }
+```
+
+- [ ] **Step 3: Replace the inventory-consumption block in `Handle`**
+
+In the same file, replace the entire `if (request.SourceInventoryId != null) { ... }` block (originally lines 57-85, including its inner `try/catch (InvalidOperationException)`) with:
+
+```csharp
+            if (request.SourceInventoryId != null)
+            {
+                var consumeResult = await _inventoryReservationService.TryConsumeAsync(
+                    inventoryId: request.SourceInventoryId.Value,
+                    amount: (decimal)request.Amount,
+                    userName: userName,
+                    timestamp: timestamp,
+                    boxId: transportBox.Id,
+                    boxCode: transportBox.Code,
+                    allowNegativeStock: request.AllowNegativeStock,
+                    cancellationToken: cancellationToken);
+
+                switch (consumeResult.Outcome)
+                {
+                    case ConsumeInventoryOutcome.InventoryNotFound:
+                        return new AddItemToBoxResponse
+                        {
+                            Success = false,
+                            ErrorCode = ErrorCodes.ManufacturedInventoryItemNotFound,
+                            Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
+                        };
+                    case ConsumeInventoryOutcome.InsufficientStock:
+                        return new AddItemToBoxResponse
+                        {
+                            Success = false,
+                            ErrorCode = ErrorCodes.ManufacturedInventoryInsufficientStock,
+                            Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
+                        };
+                    case ConsumeInventoryOutcome.Success:
+                        break;
+                }
+            }
+```
+
+Leave everything from `var addedItem = transportBox.AddItem(...)` onwards untouched. Order is preserved: reserve inventory → add box item → SaveChangesAsync.
+
+- [ ] **Step 4: Migrate the handler tests**
+
+In `AddItemToBoxHandlerTests.cs`, replace lines 1-12 (using block) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+Replace the `_inventoryRepositoryMock` field (line 19) and its usage in the constructor (lines 31, 55) with `_inventoryReservationServiceMock`. The full top of the class (lines 17-60) becomes:
+
+```csharp
+public class AddItemToBoxHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ILogger<AddItemToBoxHandler>> _loggerMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly AddItemToBoxHandler _handler;
+
+    private static readonly DateTime FixedTime = new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+    public AddItemToBoxHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _loggerMock = new Mock<ILogger<AddItemToBoxHandler>>();
+        _mapperMock = new Mock<IMapper>();
+        _timeProviderMock = new Mock<TimeProvider>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-id", "Test User", "test@example.com", true));
+
+        _timeProviderMock
+            .Setup(x => x.GetUtcNow())
+            .Returns(new DateTimeOffset(FixedTime));
+
+        _mapperMock
+            .Setup(x => x.Map<TransportBoxItemDto>(It.IsAny<TransportBoxItem>()))
+            .Returns(new TransportBoxItemDto());
+
+        _mapperMock
+            .Setup(x => x.Map<TransportBoxDto>(It.IsAny<TransportBox>()))
+            .Returns(new TransportBoxDto());
+
+        _handler = new AddItemToBoxHandler(
+            _repositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
+            _currentUserServiceMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object,
+            _timeProviderMock.Object);
+    }
+```
+
+Replace the body of `Handle_WithoutSourceInventoryId_AddsItemWithoutInventoryInteraction` (lines 87-118) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithoutSourceInventoryId_AddsItemWithoutInventoryInteraction()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 5.0
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _inventoryReservationServiceMock.Verify(
+            x => x.TryConsumeAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+Replace the body of `Handle_WithSourceInventoryId_ConsumesInventoryAndSetsLotOnItem` (lines 120-168) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithSourceInventoryId_ConsumesInventoryAndSetsLotOnItem()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 10.0,
+            SourceInventoryId = 42,
+            LotNumber = "LOT-123",
+            ExpirationDate = new DateOnly(2026, 12, 31)
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                42, 10m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.Success));
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        _inventoryReservationServiceMock.Verify(
+            x => x.TryConsumeAsync(
+                42, 10m, "Test User", FixedTime,
+                1, "B001", false, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Box item has the lot and source inventory set
+        var addedItem = box.Items.Single();
+        addedItem.SourceInventoryId.Should().Be(42);
+        addedItem.LotNumber.Should().Be("LOT-123");
+        addedItem.ExpirationDate.Should().Be(new DateOnly(2026, 12, 31));
+    }
+```
+
+Replace the body of `Handle_WithSourceInventoryId_InsufficientStock_ReturnsError` (lines 170-205) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithSourceInventoryId_InsufficientStock_ReturnsError()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 100.0,
+            SourceInventoryId = 42
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                42, 100m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ManufacturedInventoryInsufficientStock);
+        result.Params.Should().ContainKey("sourceInventoryId").WhoseValue.Should().Be("42");
+
+        // Box save should not have been called
+        _repositoryMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+Replace the body of `Handle_WithSourceInventoryId_InventoryNotFound_ReturnsError` (lines 207-235) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithSourceInventoryId_InventoryNotFound_ReturnsError()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 5.0,
+            SourceInventoryId = 999
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                999, 5m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ManufacturedInventoryItemNotFound);
+        result.Params.Should().ContainKey("sourceInventoryId").WhoseValue.Should().Be("999");
+    }
+```
+
+Delete the `CreateInventoryItem` helper at the bottom of the file (lines 254-262) — it's no longer needed since the tests don't construct `ManufacturedProductInventoryItem` directly. Keep `CreateOpenBox`.
+
+- [ ] **Step 5: Run the handler tests and confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~AddItemToBoxHandlerTests"
+```
+
+Expected: 5 tests passed (BoxNotFound, WithoutSourceInventoryId, ConsumesInventoryAndSetsLotOnItem, InsufficientStock, InventoryNotFound), 0 failed.
+
+- [ ] **Step 6: Run the boundary test — Logistics row should still be RED (only one handler done)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: Leaflet row passes, Logistics row still fails — but the violations list should be smaller now, listing only `ChangeTransportBoxStateHandler` references (not `AddItemToBoxHandler` anymore). If `AddItemToBoxHandler` still appears in the failure message, re-check Step 1 (the `using` directive `Anela.Heblo.Domain.Features.Manufacture.Inventory` must be gone) and Step 2 (the field type must be `IInventoryReservationService`, not `IManufacturedProductInventoryRepository`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs
+git commit -m "refactor(logistics): route AddItemToBox inventory consume through IInventoryReservationService"
+```
+
+---
+
+## Task 8: Migrate `ChangeTransportBoxStateHandler` to the new contract
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs`
+
+- [ ] **Step 1: Update handler imports**
+
+In `ChangeTransportBoxStateHandler.cs`, replace the `using` block (lines 1-10) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+(Net effect: drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. Add `Anela.Heblo.Application.Features.Logistics.Contracts`.)
+
+- [ ] **Step 2: Replace the inventory field and constructor parameter**
+
+In the same file, replace the field block (lines 16-22) with:
+
+```csharp
+    private readonly ITransportBoxRepository _repository;
+    private readonly IInventoryReservationService _inventoryReservationService;
+    private readonly IMediator _mediator;
+    private readonly ILogger<ChangeTransportBoxStateHandler> _logger;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IStockUpProcessingService _stockUpProcessingService;
+    private readonly TimeProvider _timeProvider;
+```
+
+Replace the constructor (lines 40-56) with:
+
+```csharp
+    public ChangeTransportBoxStateHandler(
+        ITransportBoxRepository repository,
+        IInventoryReservationService inventoryReservationService,
+        IMediator mediator,
+        ILogger<ChangeTransportBoxStateHandler> logger,
+        ICurrentUserService currentUserService,
+        IStockUpProcessingService stockUpProcessingService,
+        TimeProvider timeProvider)
+    {
+        _repository = repository;
+        _inventoryReservationService = inventoryReservationService;
+        _mediator = mediator;
+        _logger = logger;
+        _currentUserService = currentUserService;
+        _stockUpProcessingService = stockUpProcessingService;
+        _timeProvider = timeProvider;
+    }
+```
+
+- [ ] **Step 3: Replace `RestoreInventoryForItemsAsync`**
+
+Replace the entire `RestoreInventoryForItemsAsync` method (lines 266-288) with:
+
+```csharp
+    private async Task RestoreInventoryForItemsAsync(
+        IReadOnlyList<TransportBoxItem> items,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken)
+    {
+        foreach (var item in items)
+        {
+            if (item.SourceInventoryId == null) continue;
+
+            await _inventoryReservationService.RestoreAsync(
+                inventoryId: item.SourceInventoryId.Value,
+                amount: (decimal)item.Amount,
+                userName: userName,
+                timestamp: timestamp,
+                boxId: boxId,
+                boxCode: boxCode,
+                cancellationToken: cancellationToken);
+        }
+    }
+```
+
+The missing-id warning now lives in `ManufactureInventoryReservationAdapter.RestoreAsync` (Task 2). The handler no longer logs it directly.
+
+Leave the call site at line 132 unchanged — it still reads `await RestoreInventoryForItemsAsync(itemsToRestore, userName, currentTime, box.Id, box.Code, cancellationToken);`. Leave the `itemsToRestore` capture at lines 124-126 unchanged.
+
+- [ ] **Step 4: Migrate the handler tests — swap the mock target**
+
+In `ChangeTransportBoxStateHandlerTests.cs`, replace lines 1-15 (using block) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+Replace the field and constructor body (lines 19-67) with:
+
+```csharp
+public class ChangeTransportBoxStateHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<ChangeTransportBoxStateHandler>> _loggerMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IStockUpProcessingService> _stockUpProcessingServiceMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly ChangeTransportBoxStateHandler _handler;
+
+    public ChangeTransportBoxStateHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<ChangeTransportBoxStateHandler>>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _stockUpProcessingServiceMock = new Mock<IStockUpProcessingService>();
+        _timeProviderMock = new Mock<TimeProvider>();
+
+        // Setup default returns for the new dependencies
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user", "Test User", "test@example.com", true));
+
+        _timeProviderMock
+            .Setup(x => x.GetUtcNow())
+            .Returns(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+        _stockUpProcessingServiceMock
+            .Setup(x => x.CreateOperationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<StockUpSourceType>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new ChangeTransportBoxStateHandler(
+            _repositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
+            _mediatorMock.Object,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _stockUpProcessingServiceMock.Object,
+            _timeProviderMock.Object);
+    }
+```
+
+- [ ] **Step 5: Add Opened → New restore-path tests**
+
+Append two new `[Fact]` methods to the test class, immediately before the `SetupReceivedTransitionMocks` private helper. The handler did not previously have tests covering the `Opened → New` restore path; FR-8 requires that case to be exercised — and this is the test that proves NFR-1 (the handler still delegates restore per item).
+
+Add this method:
+
+```csharp
+    [Fact]
+    public async Task Handle_OpenedToNew_WithSourceInventoryItems_DelegatesRestorePerItem()
+    {
+        // Arrange — box in Opened with two items: one with SourceInventoryId, one without
+        var box = CreateTestBox(TransportBoxState.Opened);
+        box.Id = 1;
+        var itemsField = typeof(TransportBox).GetField("_items",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var items = (List<TransportBoxItem>)itemsField!.GetValue(box)!;
+
+        items.Add(new TransportBoxItem(
+            productCode: "PROD-001",
+            productName: "Test Product",
+            amount: 7.0,
+            dateAdded: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            userAdded: "TestUser",
+            lotNumber: null,
+            expirationDate: null,
+            sourceInventoryId: 42));
+        items.Add(new TransportBoxItem(
+            productCode: "PROD-002",
+            productName: "Other Product",
+            amount: 3.0,
+            dateAdded: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            userAdded: "TestUser",
+            lotNumber: null,
+            expirationDate: null,
+            sourceInventoryId: null));
+
+        _repositoryMock.Setup(x => x.GetByIdWithDetailsAsync(1)).ReturnsAsync(box);
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<TransportBox>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetTransportBoxByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTransportBoxByIdResponse
+            {
+                TransportBox = new Anela.Heblo.Application.Features.Logistics.Contracts.TransportBoxDto()
+            });
+
+        var request = new ChangeTransportBoxStateRequest
+        {
+            BoxId = 1,
+            NewState = TransportBoxState.New
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        // Only the item with SourceInventoryId triggers a restore call
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                42,
+                7m,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                1,
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+Add this second method:
+
+```csharp
+    [Fact]
+    public async Task Handle_NonOpenedToNewTransition_DoesNotCallRestore()
+    {
+        // Arrange — InTransit -> Received transition (no inventory restore)
+        var box = CreateTestBoxWithItems(TransportBoxState.InTransit);
+        SetupReceivedTransitionMocks(box);
+
+        var request = new ChangeTransportBoxStateRequest
+        {
+            BoxId = 1,
+            NewState = TransportBoxState.Received
+        };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 6: Run the handler tests and confirm everything passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ChangeTransportBoxStateHandlerTests"
+```
+
+Expected: all existing tests plus the two new ones pass (count = previous count + 2), 0 failed.
+
+- [ ] **Step 7: Run the boundary test — Logistics row should now go GREEN**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: 2 tests passed (Leaflet row + Logistics row), 0 failed.
+
+If the Logistics row still fails, the failure message names the remaining leak — fix it before commit. The two most likely causes are: (a) the `using Anela.Heblo.Domain.Features.Manufacture.Inventory;` directive still present somewhere in the two modified handler files (search both files and remove it), or (b) a method signature still references `ManufacturedProductInventoryItem`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+git commit -m "refactor(logistics): route ChangeTransportBoxState inventory restore through IInventoryReservationService"
+```
+
+---
+
+## Task 9: Final validation — full build, full test run, format check
+
+- [ ] **Step 1: Full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 errors, 0 new warnings.
+
+- [ ] **Step 2: Full backend test run**
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: All tests pass. Pay attention to the totals — the count should equal the pre-change count plus 9 new tests (7 adapter tests + 2 ChangeTransportBoxStateHandler restore tests). No skipped tests in modified files.
+
+- [ ] **Step 3: Format check**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: no output (clean). If format changes are reported, run `dotnet format backend/Anela.Heblo.sln`, review the diff, and amend the most-recent commit if the diff is trivial — otherwise add a separate format commit.
+
+- [ ] **Step 4: Confirm no lingering Manufacture-inventory references in Logistics**
+
+```bash
+grep -rn "Anela.Heblo.Domain.Features.Manufacture\|IManufacturedProductInventoryRepository\|ManufacturedProductInventoryItem" \
+  backend/src/Anela.Heblo.Application/Features/Logistics/
+```
+
+Expected: zero matches. If any line is printed, find which file still has the leak and remove it (the boundary test must still be passing — if it's passing but grep shows a hit, the hit is in a non-type-referencing place like a comment, which is acceptable; otherwise re-investigate).
+
+```bash
+grep -rn "Anela.Heblo.Domain.Features.Manufacture\|IManufacturedProductInventoryRepository\|ManufacturedProductInventoryItem" \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/
+```
+
+Expected: zero matches in the migrated test files (`AddItemToBoxHandlerTests.cs`, `ChangeTransportBoxStateHandlerTests.cs`). Hits in unrelated Logistics test files (e.g. `GiftPackageManufactureServiceTests.cs`) are acceptable — they're out of scope.
+
+- [ ] **Step 5: Final summary log (no commit if nothing to commit)**
+
+If `dotnet format` produced changes:
+
+```bash
+git add -A
+git commit -m "chore: dotnet format after Logistics-Manufacture decoupling"
+```
+
+If everything is already clean, this step is a no-op — skip.
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Implemented in |
+|------------------|----------------|
+| FR-1 (Contract in Logistics) | Task 1 |
+| FR-2 (Operation signatures + sealed-record result type) | Task 1 (locked-down result type per arch-review amendment #1) |
+| FR-3 (Adapter in Manufacture, internal sealed, no SaveChanges, catch InvalidOperationException) | Task 2 (with NFR-3 guarded by Task 4 Step 5 + adapter Step 1 comment per arch-review amendment #5) |
+| FR-4 (DI binding in ManufactureModule) | Task 3 |
+| FR-5 (Migrate AddItemToBoxHandler) | Task 7 |
+| FR-6 (Migrate ChangeTransportBoxStateHandler) | Task 8 |
+| FR-7 (Extend ModuleBoundariesTests with Theory + Logistics row, empty allowlist) | Tasks 5–6 (Theory refactor first, then row added separately so red-state is auditable per arch-review Prerequisite #5) |
+| FR-8 (Migrated handler tests + adapter tests) | Task 4 (adapter), Task 7 (AddItemToBox), Task 8 (ChangeTransportBoxState — including newly added Opened→New restore tests) |
+| NFR-1 (Behavioral parity) | Verified via Task 7 / Task 8 / Task 9 test runs |
+| NFR-2 (Module boundaries enforced in CI) | Task 6 + Task 8 (boundary test green) |
+| NFR-3 (Transaction semantics — adapter has no SaveChanges) | Adapter design (Task 2) + adapter test `TryConsumeAsync_DoesNotCallSaveChanges` (Task 4) |
+| NFR-4 (Logging in adapter preserves IDs) | Adapter Step 1 (Task 2) + adapter test `RestoreAsync_ItemNotFound_IsNoOpAndLogsWarning` (Task 4) |
+| NFR-5 (Code style — internal sealed, nullable, CancellationToken last) | Adapter is `internal sealed` (Task 2); all async methods accept `CancellationToken` as last param (Task 1, Task 2); files <800 lines |
+| NFR-6 (No new NuGet packages) | No package references touched in any task |
+
+**Prerequisites from arch-review:**
+- Prereq #1: `BaseRepository.UpdateAsync` only calls `DbSet.Update(entity)` and returns `Task.CompletedTask` — verified at plan-writing time (`backend/src/Anela.Heblo.Persistence/Repositories/BaseRepository.cs:70-74`); adapter design is safe.
+- Prereq #2: `Anela.Heblo.Application` already grants `InternalsVisibleTo("Anela.Heblo.Tests")` — verified at plan-writing time (`backend/src/Anela.Heblo.Application/AssemblyInfo.cs:3` and `Anela.Heblo.Application.csproj:45`); the adapter unit test in Task 4 can construct the `internal` adapter directly.
+- Prereq #5 ordering (a → b → c with red-then-green) is encoded in Task 5 / Task 6 / Tasks 7–8.
+
+## Out of scope (per spec)
+
+- Splitting `ApplicationDbContext` per module (ADR-001 Phase 2).
+- Promoting `InvalidOperationException` in `ManufacturedProductInventoryItem.Consume` to a typed `InsufficientInventoryException` — track as follow-up (arch-review Decision 2 + Spec amendment #6).
+- Refactoring `HandleReceived` in `ChangeTransportBoxStateHandler` (Catalog dependency, separate concern).
+- Removing existing Leaflet→KnowledgeBase allowlist entries.
+- Czech-language doc updates.

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs
@@ -1,0 +1,18 @@
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Outcome of an <see cref="IInventoryReservationService.TryConsumeAsync"/> call.
+/// </summary>
+public enum ConsumeInventoryOutcome
+{
+    Success,
+    InventoryNotFound,
+    InsufficientStock,
+}
+
+/// <summary>
+/// Logistics-owned result of attempting to consume inventory.
+/// Sealed record with an outcome discriminator — extensible to carry an optional
+/// available-amount field without breaking the contract.
+/// </summary>
+public sealed record ConsumeInventoryResult(ConsumeInventoryOutcome Outcome);

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs
@@ -1,0 +1,44 @@
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Logistics-owned abstraction over inventory reservation for transport-box operations.
+/// Implemented by the Manufacture module via an adapter
+/// (see <c>ManufactureInventoryReservationAdapter</c>) per the cross-module communication
+/// pattern in <c>docs/architecture/development_guidelines.md</c>.
+///
+/// Implementations MUST NOT call SaveChangesAsync on any repository. The caller owns the
+/// unit of work and commits the inventory mutation together with the transport-box mutation
+/// against the shared ApplicationDbContext (ADR-001 Phase 1).
+/// </summary>
+public interface IInventoryReservationService
+{
+    /// <summary>
+    /// Attempts to decrement inventory for a transport-box item. Returns a structured
+    /// result distinguishing success, missing inventory record, and insufficient stock.
+    /// Implementations must not throw Manufacture-owned exceptions across this boundary.
+    /// </summary>
+    Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Restores inventory amount after a transport box transitions Opened → New.
+    /// If the inventory id does not exist, the call is a no-op (implementations log a
+    /// warning and return) — matching the original "log and skip" recovery semantics
+    /// in <c>ChangeTransportBoxStateHandler</c>.
+    /// </summary>
+    Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using AutoMapper;
 using MediatR;
@@ -13,7 +12,7 @@ namespace Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
 public class AddItemToBoxHandler : IRequestHandler<AddItemToBoxRequest, AddItemToBoxResponse>
 {
     private readonly ITransportBoxRepository _repository;
-    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly IInventoryReservationService _inventoryReservationService;
     private readonly ICurrentUserService _currentUserService;
     private readonly ILogger<AddItemToBoxHandler> _logger;
     private readonly IMapper _mapper;
@@ -21,14 +20,14 @@ public class AddItemToBoxHandler : IRequestHandler<AddItemToBoxRequest, AddItemT
 
     public AddItemToBoxHandler(
         ITransportBoxRepository repository,
-        IManufacturedProductInventoryRepository inventoryRepository,
+        IInventoryReservationService inventoryReservationService,
         ICurrentUserService currentUserService,
         ILogger<AddItemToBoxHandler> logger,
         IMapper mapper,
         TimeProvider timeProvider)
     {
         _repository = repository;
-        _inventoryRepository = inventoryRepository;
+        _inventoryReservationService = inventoryReservationService;
         _currentUserService = currentUserService;
         _logger = logger;
         _mapper = mapper;
@@ -56,32 +55,35 @@ public class AddItemToBoxHandler : IRequestHandler<AddItemToBoxRequest, AddItemT
 
             if (request.SourceInventoryId != null)
             {
-                var inventoryItem = await _inventoryRepository.GetByIdAsync(request.SourceInventoryId.Value, cancellationToken);
-                if (inventoryItem == null)
-                {
-                    return new AddItemToBoxResponse
-                    {
-                        Success = false,
-                        ErrorCode = ErrorCodes.ManufacturedInventoryItemNotFound,
-                        Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
-                    };
-                }
+                var consumeResult = await _inventoryReservationService.TryConsumeAsync(
+                    inventoryId: request.SourceInventoryId.Value,
+                    amount: (decimal)request.Amount,
+                    userName: userName,
+                    timestamp: timestamp,
+                    boxId: transportBox.Id,
+                    boxCode: transportBox.Code,
+                    allowNegativeStock: request.AllowNegativeStock,
+                    cancellationToken: cancellationToken);
 
-                try
+                switch (consumeResult.Outcome)
                 {
-                    inventoryItem.Consume((decimal)request.Amount, userName, timestamp, transportBox.Id, transportBox.Code, request.AllowNegativeStock);
+                    case ConsumeInventoryOutcome.InventoryNotFound:
+                        return new AddItemToBoxResponse
+                        {
+                            Success = false,
+                            ErrorCode = ErrorCodes.ManufacturedInventoryItemNotFound,
+                            Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
+                        };
+                    case ConsumeInventoryOutcome.InsufficientStock:
+                        return new AddItemToBoxResponse
+                        {
+                            Success = false,
+                            ErrorCode = ErrorCodes.ManufacturedInventoryInsufficientStock,
+                            Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
+                        };
+                    case ConsumeInventoryOutcome.Success:
+                        break;
                 }
-                catch (InvalidOperationException)
-                {
-                    return new AddItemToBoxResponse
-                    {
-                        Success = false,
-                        ErrorCode = ErrorCodes.ManufacturedInventoryInsufficientStock,
-                        Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
-                    };
-                }
-
-                await _inventoryRepository.UpdateAsync(inventoryItem, cancellationToken);
             }
 
             var addedItem = transportBox.AddItem(

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -14,7 +14,7 @@ namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBox
 public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBoxStateRequest, ChangeTransportBoxStateResponse>
 {
     private readonly ITransportBoxRepository _repository;
-    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly IInventoryReservationService _inventoryReservationService;
     private readonly IMediator _mediator;
     private readonly ILogger<ChangeTransportBoxStateHandler> _logger;
     private readonly ICurrentUserService _currentUserService;
@@ -39,7 +39,7 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
 
     public ChangeTransportBoxStateHandler(
         ITransportBoxRepository repository,
-        IManufacturedProductInventoryRepository inventoryRepository,
+        IInventoryReservationService inventoryReservationService,
         IMediator mediator,
         ILogger<ChangeTransportBoxStateHandler> logger,
         ICurrentUserService currentUserService,
@@ -47,7 +47,7 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
         TimeProvider timeProvider)
     {
         _repository = repository;
-        _inventoryRepository = inventoryRepository;
+        _inventoryReservationService = inventoryReservationService;
         _mediator = mediator;
         _logger = logger;
         _currentUserService = currentUserService;
@@ -275,15 +275,14 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
         {
             if (item.SourceInventoryId == null) continue;
 
-            var inventoryItem = await _inventoryRepository.GetByIdAsync(item.SourceInventoryId.Value, cancellationToken);
-            if (inventoryItem == null)
-            {
-                _logger.LogWarning("InventoryItem {InventoryId} not found during restore for BoxItem {BoxItemId} — skipping restore", item.SourceInventoryId, item.Id);
-                continue;
-            }
-
-            inventoryItem.Restore((decimal)item.Amount, userName, timestamp, boxId, boxCode);
-            await _inventoryRepository.UpdateAsync(inventoryItem, cancellationToken);
+            await _inventoryReservationService.RestoreAsync(
+                inventoryId: item.SourceInventoryId.Value,
+                amount: (decimal)item.Amount,
+                userName: userName,
+                timestamp: timestamp,
+                boxId: boxId,
+                boxCode: boxCode,
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/RemoveItemFromBox/RemoveItemFromBoxHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/RemoveItemFromBox/RemoveItemFromBoxHandler.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using AutoMapper;
 using MediatR;
@@ -13,7 +12,7 @@ namespace Anela.Heblo.Application.Features.Logistics.UseCases.RemoveItemFromBox;
 public class RemoveItemFromBoxHandler : IRequestHandler<RemoveItemFromBoxRequest, RemoveItemFromBoxResponse>
 {
     private readonly ITransportBoxRepository _repository;
-    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly IInventoryReservationService _inventoryReservationService;
     private readonly ICurrentUserService _currentUserService;
     private readonly ILogger<RemoveItemFromBoxHandler> _logger;
     private readonly IMapper _mapper;
@@ -21,14 +20,14 @@ public class RemoveItemFromBoxHandler : IRequestHandler<RemoveItemFromBoxRequest
 
     public RemoveItemFromBoxHandler(
         ITransportBoxRepository repository,
-        IManufacturedProductInventoryRepository inventoryRepository,
+        IInventoryReservationService inventoryReservationService,
         ICurrentUserService currentUserService,
         ILogger<RemoveItemFromBoxHandler> logger,
         IMapper mapper,
         TimeProvider timeProvider)
     {
         _repository = repository;
-        _inventoryRepository = inventoryRepository;
+        _inventoryReservationService = inventoryReservationService;
         _currentUserService = currentUserService;
         _logger = logger;
         _mapper = mapper;
@@ -67,17 +66,14 @@ public class RemoveItemFromBoxHandler : IRequestHandler<RemoveItemFromBoxRequest
 
             if (removedItem.SourceInventoryId != null)
             {
-                var inventoryItem = await _inventoryRepository.GetByIdAsync(removedItem.SourceInventoryId.Value, cancellationToken);
-                if (inventoryItem != null)
-                {
-                    inventoryItem.Restore((decimal)removedItem.Amount, userName, timestamp, transportBox.Id, transportBox.Code);
-                    await _inventoryRepository.UpdateAsync(inventoryItem, cancellationToken);
-                }
-                else
-                {
-                    _logger.LogWarning("InventoryItem {InventoryId} not found during restore for BoxItem {BoxItemId} — skipping restore",
-                        removedItem.SourceInventoryId, removedItem.Id);
-                }
+                await _inventoryReservationService.RestoreAsync(
+                    inventoryId: removedItem.SourceInventoryId.Value,
+                    amount: (decimal)removedItem.Amount,
+                    userName: userName,
+                    timestamp: timestamp,
+                    boxId: transportBox.Id,
+                    boxCode: transportBox.Code,
+                    cancellationToken: cancellationToken);
             }
 
             await _repository.SaveChangesAsync(cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs
@@ -1,0 +1,85 @@
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+
+/// <summary>
+/// Manufacture-owned adapter that implements the Logistics-owned
+/// <see cref="IInventoryReservationService"/> contract by delegating to the Manufacture
+/// inventory repository and domain methods.
+///
+/// Does not commit — the caller's unit of work (the transport-box repository's
+/// SaveChangesAsync) commits both mutations atomically against the shared
+/// ApplicationDbContext.
+/// </summary>
+internal sealed class ManufactureInventoryReservationAdapter : IInventoryReservationService
+{
+    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly ILogger<ManufactureInventoryReservationAdapter> _logger;
+
+    public ManufactureInventoryReservationAdapter(
+        IManufacturedProductInventoryRepository inventoryRepository,
+        ILogger<ManufactureInventoryReservationAdapter> logger)
+    {
+        _inventoryRepository = inventoryRepository;
+        _logger = logger;
+    }
+
+    public async Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound);
+        }
+
+        try
+        {
+            // ManufacturedProductInventoryItem.Consume is the sole producer of
+            // InvalidOperationException on this call path (insufficient stock guard at
+            // Domain/Features/Manufacture/Inventory/ManufacturedProductInventoryItem.cs:55-57).
+            // If a future invariant adds another InvalidOperationException here, this catch
+            // would miscategorize it — track upgrade to a typed InsufficientInventoryException
+            // as a follow-up.
+            item.Consume(amount, userName, timestamp, boxId, boxCode, allowNegativeStock);
+        }
+        catch (InvalidOperationException)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock);
+        }
+
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+        return new ConsumeInventoryResult(ConsumeInventoryOutcome.Success);
+    }
+
+    public async Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            _logger.LogWarning(
+                "InventoryItem {InventoryId} not found during restore for transport box {BoxId} — skipping restore",
+                inventoryId, boxId);
+            return;
+        }
+
+        item.Restore(amount, userName, timestamp, boxId, boxCode);
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
@@ -1,6 +1,8 @@
+using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Configuration;
 using Anela.Heblo.Application.Features.Manufacture.DashboardTiles;
 using Anela.Heblo.Application.Features.Manufacture.ErrorFilters;
+using Anela.Heblo.Application.Features.Manufacture.Infrastructure;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.Services.Workflows;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureProtocol;
@@ -46,6 +48,10 @@ public static class ManufactureModule
         // Register repositories
         services.AddScoped<IManufactureOrderRepository, ManufactureOrderRepository>();
         services.AddScoped<IManufacturedProductInventoryRepository, ManufacturedProductInventoryRepository>();
+
+        // Cross-module contract: Manufacture implements Logistics' IInventoryReservationService.
+        // DI registration is owned by the provider (Manufacture), not the consumer (Logistics).
+        services.AddScoped<IInventoryReservationService, ManufactureInventoryReservationAdapter>();
 
         // Register application services
         services.AddScoped<IManufactureOrderApplicationService, ManufactureOrderApplicationService>();

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -53,6 +53,14 @@ public class ModuleBoundariesTests
         // a separate consumer-owned contract (e.g., IGiftPackageBomSource) and is out of scope for
         // the current Logistics-Manufacture inventory decoupling. Track as a follow-up.
         "Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Services.GiftPackageManufactureService -> Anela.Heblo.Domain.Features.Manufacture.IManufactureClient",
+
+        // ProductPart is the return element type of IManufactureClient.GetSetPartsAsync, used
+        // inside GiftPackageManufactureService.GetGiftPackageDetailAsync. The compiler-generated
+        // async state machine (<GetGiftPackageDetailAsync>d__N) references ProductPart directly
+        // via its captured local fields. This is covered by the DeclaringType check for the
+        // IManufactureClient entry above but requires its own entry because ProductPart lives in
+        // a separate type slot. Remove when IManufactureClient is decoupled (see entry above).
+        "Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Services.GiftPackageManufactureService -> Anela.Heblo.Domain.Features.Manufacture.ProductPart",
     };
 
     public static TheoryData<ModuleBoundaryRule> Rules() => new()

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -5,76 +5,91 @@ using Xunit;
 namespace Anela.Heblo.Tests.Architecture;
 
 /// <summary>
-/// Enforces module boundary rule from docs/architecture/development_guidelines.md:
-/// Leaflet must not reference any KnowledgeBase-owned type directly. All cross-module
-/// communication goes through Leaflet-owned contracts (e.g. ILeafletKnowledgeSource)
-/// implemented by KnowledgeBase via an adapter.
+/// Enforces module boundary rules from docs/architecture/development_guidelines.md:
+/// Consumer modules must not reference provider-owned types directly. All cross-module
+/// communication goes through consumer-owned contracts (e.g. ILeafletKnowledgeSource,
+/// IInventoryReservationService) implemented by the provider via an adapter.
 /// </summary>
 public class ModuleBoundariesTests
 {
-    // Namespaces that, if referenced from a Leaflet type, indicate a boundary violation.
-    private static readonly string[] ForbiddenNamespacePrefixes =
-    [
-        "Anela.Heblo.Domain.Features.KnowledgeBase",
-        "Anela.Heblo.Application.Features.KnowledgeBase",
-        "Anela.Heblo.Persistence.KnowledgeBase",
-    ];
+    public sealed record ModuleBoundaryRule(
+        string Name,
+        string InspectedNamespacePrefix,
+        IReadOnlyList<string> ForbiddenNamespacePrefixes,
+        IReadOnlySet<string> Allowlist);
 
-    private const string LeafletNamespacePrefix = "Anela.Heblo.Application.Features.Leaflet";
-
-    // Allowlist for explicitly-documented exceptions. Each entry needs a comment with the
+    // Pre-existing allowlist for Leaflet → KnowledgeBase. Each entry needs a comment with the
     // justification. Entries should be removed as the underlying violations are fixed.
     //
-    // Entry format: "{LeafletFullyQualifiedTypeName} -> {ForbiddenTypeFullName}"
+    // Entry format: "{ConsumerFullyQualifiedTypeName} -> {ProviderTypeFullName}"
     //
-    // Compiler-generated types (e.g. DisplayClasses for closures, state machines for async methods)
-    // are automatically handled by matching against the declaring type's namespace prefix.
-    private static readonly HashSet<string> Allowlist = new(StringComparer.Ordinal)
+    // Compiler-generated types (e.g. DisplayClasses for closures, state machines for async
+    // methods) are automatically handled by matching against the declaring type's namespace
+    // prefix below.
+    private static readonly HashSet<string> LeafletAllowlist = new(StringComparer.Ordinal)
     {
-        // Pre-existing dependency: UploadLeafletHandler and IndexLeafletHandler consume IDocumentTextExtractor,
-        // which currently lives in Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting this is out of
-        // scope for the 2026-05-15 Leaflet decoupling. Track separately and remove these entries
-        // when IDocumentTextExtractor is relocated to a shared namespace.
+        // Pre-existing dependency: UploadLeafletHandler and IndexLeafletHandler consume
+        // IDocumentTextExtractor, which currently lives in
+        // Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting this is out of
+        // scope for the 2026-05-15 Leaflet decoupling. Track separately and remove these
+        // entries when IDocumentTextExtractor is relocated to a shared namespace.
         "Anela.Heblo.Application.Features.Leaflet.UseCases.UploadLeaflet.UploadLeafletHandler -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IDocumentTextExtractor",
         "Anela.Heblo.Application.Features.Leaflet.UseCases.IndexLeaflet.IndexLeafletHandler -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IDocumentTextExtractor",
 
-        // Pre-existing dependency: LeafletIngestionJob consumes IOneDriveService, which currently
-        // lives in Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting this is out of
-        // scope for the 2026-05-15 Leaflet decoupling. Track separately and remove these entries
-        // when IOneDriveService is relocated to a shared namespace.
+        // Pre-existing dependency: LeafletIngestionJob consumes IOneDriveService, which
+        // currently lives in Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting
+        // this is out of scope for the 2026-05-15 Leaflet decoupling. Track separately and
+        // remove these entries when IOneDriveService is relocated to a shared namespace.
         "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IOneDriveService",
         "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.OneDriveFile",
     };
 
-    [Fact]
-    public void Leaflet_types_should_not_reference_KnowledgeBase_owned_namespaces()
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+    };
+
+    [Theory]
+    [MemberData(nameof(Rules))]
+    public void Consumer_types_should_not_reference_provider_owned_namespaces(ModuleBoundaryRule rule)
     {
         var assembly = Assembly.Load("Anela.Heblo.Application");
-        var leafletTypes = assembly.GetTypes()
-            .Where(t => t.Namespace is not null && t.Namespace.StartsWith(LeafletNamespacePrefix, StringComparison.Ordinal))
+        var consumerTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                && t.Namespace.StartsWith(rule.InspectedNamespacePrefix, StringComparison.Ordinal))
             .ToList();
 
         var violations = new List<string>();
 
-        foreach (var leafletType in leafletTypes)
+        foreach (var consumerType in consumerTypes)
         {
-            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(leafletType))
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(consumerType))
             {
-                if (!IsForbidden(referencedType))
+                if (!IsForbidden(referencedType, rule.ForbiddenNamespacePrefixes))
                     continue;
 
-                var entry = $"{leafletType.FullName} -> {referencedType.FullName}";
-                if (Allowlist.Contains(entry))
+                var entry = $"{consumerType.FullName} -> {referencedType.FullName}";
+                if (rule.Allowlist.Contains(entry))
                     continue;
 
-                // Also check if the declaring type of a compiler-generated nested type is in the allowlist.
-                // For example, if "UploadLeafletHandler+<>c__DisplayClass3_0" references a forbidden type,
-                // check if "UploadLeafletHandler" references that same forbidden type.
-                var baseType = leafletType.DeclaringType;
+                // Also check if the declaring type of a compiler-generated nested type is in
+                // the allowlist. For example, if "UploadLeafletHandler+<>c__DisplayClass3_0"
+                // references a forbidden type, check if "UploadLeafletHandler" references that
+                // same forbidden type.
+                var baseType = consumerType.DeclaringType;
                 if (baseType is not null)
                 {
                     var baseEntry = $"{baseType.FullName} -> {referencedType.FullName}";
-                    if (Allowlist.Contains(baseEntry))
+                    if (rule.Allowlist.Contains(baseEntry))
                         continue;
                 }
 
@@ -83,9 +98,9 @@ public class ModuleBoundariesTests
         }
 
         violations.Should().BeEmpty(
-            "Leaflet types must not reference KnowledgeBase-owned namespaces. " +
-            "Define a Leaflet-owned contract in Application/Features/Leaflet/Contracts/ " +
-            "and have KnowledgeBase implement it via an adapter. " +
+            $"{rule.Name}: consumer types must not reference provider-owned namespaces. " +
+            "Define a consumer-owned contract in the consumer module's Contracts/ folder " +
+            "and have the provider module implement it via an adapter. " +
             "Found:\n  " + string.Join("\n  ", violations));
     }
 
@@ -159,12 +174,12 @@ public class ModuleBoundariesTests
             "Found:\n  " + string.Join("\n  ", violations));
     }
 
-    private static bool IsForbidden(Type type)
+    private static bool IsForbidden(Type type, IReadOnlyList<string> forbiddenPrefixes)
     {
         if (type.Namespace is null)
             return false;
 
-        foreach (var prefix in ForbiddenNamespacePrefixes)
+        foreach (var prefix in forbiddenPrefixes)
         {
             if (type.Namespace.Equals(prefix, StringComparison.Ordinal) ||
                 type.Namespace.StartsWith(prefix + ".", StringComparison.Ordinal))

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -56,6 +56,17 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.KnowledgeBase",
             },
             Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Logistics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Manufacture",
+                "Anela.Heblo.Application.Features.Manufacture",
+                "Anela.Heblo.Persistence.Manufacture",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
     };
 
     [Theory]

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -44,6 +44,17 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.OneDriveFile",
     };
 
+    // Allowlist for Logistics → Manufacture. Each entry needs a comment with the justification.
+    // Entries should be removed as the underlying violations are fixed.
+    private static readonly HashSet<string> LogisticsAllowlist = new(StringComparer.Ordinal)
+    {
+        // GiftPackageManufactureService depends on IManufactureClient for Bill of Materials (BOM)
+        // lookups (which set parts to consume/produce for a gift package). Decoupling this requires
+        // a separate consumer-owned contract (e.g., IGiftPackageBomSource) and is out of scope for
+        // the current Logistics-Manufacture inventory decoupling. Track as a follow-up.
+        "Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Services.GiftPackageManufactureService -> Anela.Heblo.Domain.Features.Manufacture.IManufactureClient",
+    };
+
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {
         new ModuleBoundaryRule(
@@ -66,7 +77,7 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Application.Features.Manufacture",
                 "Anela.Heblo.Persistence.Manufacture",
             },
-            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+            Allowlist: LogisticsAllowlist),
     };
 
     [Theory]

--- a/backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
@@ -1,10 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using Anela.Heblo.Persistence;
 using Anela.Heblo.Persistence.Logistics.TransportBoxes;
@@ -25,7 +26,7 @@ public class TransportBoxUniquenessTests : IDisposable
     private readonly Mock<ICurrentUserService> _mockUserService;
     private readonly Mock<IMediator> _mockMediator;
     private readonly Mock<IStockUpProcessingService> _mockStockUpProcessingService;
-    private readonly Mock<IManufacturedProductInventoryRepository> _mockInventoryRepository;
+    private readonly Mock<IInventoryReservationService> _mockInventoryReservationService;
 
     private const string TestUser = "TestUser";
 
@@ -42,7 +43,7 @@ public class TransportBoxUniquenessTests : IDisposable
         _mockUserService = new Mock<ICurrentUserService>();
         _mockMediator = new Mock<IMediator>();
         _mockStockUpProcessingService = new Mock<IStockUpProcessingService>();
-        _mockInventoryRepository = new Mock<IManufacturedProductInventoryRepository>();
+        _mockInventoryReservationService = new Mock<IInventoryReservationService>();
 
         _mockUserService.Setup(x => x.GetCurrentUser())
             .Returns(new CurrentUser(Guid.NewGuid().ToString(), TestUser, "test@test.com", true));
@@ -59,7 +60,7 @@ public class TransportBoxUniquenessTests : IDisposable
 
         _handler = new ChangeTransportBoxStateHandler(
             _repository,
-            _mockInventoryRepository.Object,
+            _mockInventoryReservationService.Object,
             _mockMediator.Object,
             NullLogger<ChangeTransportBoxStateHandler>.Instance,
             _mockUserService.Object,

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs
@@ -3,7 +3,6 @@ using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using AutoMapper;
 using FluentAssertions;
@@ -16,7 +15,7 @@ namespace Anela.Heblo.Tests.Features.Logistics.Transport;
 public class AddItemToBoxHandlerTests
 {
     private readonly Mock<ITransportBoxRepository> _repositoryMock;
-    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<ILogger<AddItemToBoxHandler>> _loggerMock;
     private readonly Mock<IMapper> _mapperMock;
@@ -28,7 +27,7 @@ public class AddItemToBoxHandlerTests
     public AddItemToBoxHandlerTests()
     {
         _repositoryMock = new Mock<ITransportBoxRepository>();
-        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _loggerMock = new Mock<ILogger<AddItemToBoxHandler>>();
         _mapperMock = new Mock<IMapper>();
@@ -52,7 +51,7 @@ public class AddItemToBoxHandlerTests
 
         _handler = new AddItemToBoxHandler(
             _repositoryMock.Object,
-            _inventoryRepositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
             _currentUserServiceMock.Object,
             _loggerMock.Object,
             _mapperMock.Object,
@@ -109,11 +108,10 @@ public class AddItemToBoxHandlerTests
 
         // Assert
         result.Success.Should().BeTrue();
-        _inventoryRepositoryMock.Verify(
-            x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-        _inventoryRepositoryMock.Verify(
-            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+        _inventoryReservationServiceMock.Verify(
+            x => x.TryConsumeAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -122,7 +120,6 @@ public class AddItemToBoxHandlerTests
     {
         // Arrange
         var box = CreateOpenBox();
-        var inventoryItem = CreateInventoryItem(productCode: "PROD-001", amount: 100m);
 
         var request = new AddItemToBoxRequest
         {
@@ -139,9 +136,11 @@ public class AddItemToBoxHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(1))
             .ReturnsAsync(box);
 
-        _inventoryRepositoryMock
-            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(inventoryItem);
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                42, 10m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.Success));
 
         _repositoryMock
             .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
@@ -153,11 +152,10 @@ public class AddItemToBoxHandlerTests
         // Assert
         result.Success.Should().BeTrue();
 
-        // Inventory was consumed (UpdateAsync called with item that has reduced amount)
-        _inventoryRepositoryMock.Verify(
-            x => x.UpdateAsync(
-                It.Is<ManufacturedProductInventoryItem>(i => i.Amount == 90m),
-                It.IsAny<CancellationToken>()),
+        _inventoryReservationServiceMock.Verify(
+            x => x.TryConsumeAsync(
+                42, 10m, "Test User", FixedTime,
+                1, "B001", false, It.IsAny<CancellationToken>()),
             Times.Once);
 
         // Box item has the lot and source inventory set
@@ -172,14 +170,12 @@ public class AddItemToBoxHandlerTests
     {
         // Arrange
         var box = CreateOpenBox();
-        var inventoryItem = CreateInventoryItem(productCode: "PROD-001", amount: 5m);
-
         var request = new AddItemToBoxRequest
         {
             BoxId = 1,
             ProductCode = "PROD-001",
             ProductName = "Test Product",
-            Amount = 100.0,  // more than available
+            Amount = 100.0,
             SourceInventoryId = 42
         };
 
@@ -187,9 +183,11 @@ public class AddItemToBoxHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(1))
             .ReturnsAsync(box);
 
-        _inventoryRepositoryMock
-            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(inventoryItem);
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                42, 100m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock));
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -197,6 +195,7 @@ public class AddItemToBoxHandlerTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ManufacturedInventoryInsufficientStock);
+        result.Params.Should().ContainKey("sourceInventoryId").WhoseValue.Should().Be("42");
 
         // Box save should not have been called
         _repositoryMock.Verify(
@@ -222,9 +221,11 @@ public class AddItemToBoxHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(1))
             .ReturnsAsync(box);
 
-        _inventoryRepositoryMock
-            .Setup(x => x.GetByIdAsync(999, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                999, 5m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound));
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -232,6 +233,7 @@ public class AddItemToBoxHandlerTests
         // Assert
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ManufacturedInventoryItemNotFound);
+        result.Params.Should().ContainKey("sourceInventoryId").WhoseValue.Should().Be("999");
     }
 
     private static TransportBox CreateOpenBox()
@@ -251,13 +253,4 @@ public class AddItemToBoxHandlerTests
         return box;
     }
 
-    private static ManufacturedProductInventoryItem CreateInventoryItem(string productCode, decimal amount)
-    {
-        return new ManufacturedProductInventoryItem(
-            productCode: productCode,
-            productName: "Test Product",
-            amount: amount,
-            createdBy: "system",
-            createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
@@ -1,11 +1,12 @@
 using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using FluentAssertions;
 using MediatR;
@@ -18,7 +19,7 @@ namespace Anela.Heblo.Tests.Features.Logistics.Transport;
 public class ChangeTransportBoxStateHandlerTests
 {
     private readonly Mock<ITransportBoxRepository> _repositoryMock;
-    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<ILogger<ChangeTransportBoxStateHandler>> _loggerMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
@@ -29,7 +30,7 @@ public class ChangeTransportBoxStateHandlerTests
     public ChangeTransportBoxStateHandlerTests()
     {
         _repositoryMock = new Mock<ITransportBoxRepository>();
-        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
         _mediatorMock = new Mock<IMediator>();
         _loggerMock = new Mock<ILogger<ChangeTransportBoxStateHandler>>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
@@ -57,7 +58,7 @@ public class ChangeTransportBoxStateHandlerTests
 
         _handler = new ChangeTransportBoxStateHandler(
             _repositoryMock.Object,
-            _inventoryRepositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
             _mediatorMock.Object,
             _loggerMock.Object,
             _currentUserServiceMock.Object,
@@ -429,6 +430,105 @@ public class ChangeTransportBoxStateHandlerTests
                 It.IsAny<string>(), "P-001", 3,
                 It.IsAny<StockUpSourceType>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_OpenedToNew_WithSourceInventoryItems_DelegatesRestorePerItem()
+    {
+        // Arrange — box in Opened state with two items: one with SourceInventoryId, one without
+        var box = CreateTestBox(TransportBoxState.Opened);
+        box.Id = 1;
+
+        var itemsField = typeof(TransportBox).GetField("_items",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var items = (List<TransportBoxItem>)itemsField!.GetValue(box)!;
+
+        items.Add(new TransportBoxItem(
+            productCode: "PROD-001",
+            productName: "Test Product",
+            amount: 7.0,
+            dateAdded: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            userAdded: "TestUser",
+            lotNumber: null,
+            expirationDate: null,
+            sourceInventoryId: 42));
+
+        items.Add(new TransportBoxItem(
+            productCode: "PROD-002",
+            productName: "Other Product",
+            amount: 3.0,
+            dateAdded: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            userAdded: "TestUser",
+            lotNumber: null,
+            expirationDate: null,
+            sourceInventoryId: null));
+
+        _repositoryMock.Setup(x => x.GetByIdWithDetailsAsync(1)).ReturnsAsync(box);
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<TransportBox>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetTransportBoxByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTransportBoxByIdResponse
+            {
+                TransportBox = new Anela.Heblo.Application.Features.Logistics.Contracts.TransportBoxDto()
+            });
+
+        var request = new ChangeTransportBoxStateRequest
+        {
+            BoxId = 1,
+            NewState = TransportBoxState.New
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        // Only the item with SourceInventoryId triggers a restore call
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                42,
+                7m,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                1,
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NonOpenedToNewTransition_DoesNotCallRestore()
+    {
+        // Arrange — InTransit -> Received transition (no inventory restore)
+        var box = CreateTestBoxWithItems(TransportBoxState.InTransit);
+        SetupReceivedTransitionMocks(box);
+
+        var request = new ChangeTransportBoxStateRequest
+        {
+            BoxId = 1,
+            NewState = TransportBoxState.Received
+        };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private void SetupReceivedTransitionMocks(TransportBox box)

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/RemoveItemFromBoxHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/RemoveItemFromBoxHandlerTests.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases.RemoveItemFromBox;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
-using Anela.Heblo.Domain.Features.Manufacture.Inventory;
 using Anela.Heblo.Domain.Features.Users;
 using AutoMapper;
 using FluentAssertions;
@@ -15,7 +14,7 @@ namespace Anela.Heblo.Tests.Features.Logistics.Transport;
 public class RemoveItemFromBoxHandlerTests
 {
     private readonly Mock<ITransportBoxRepository> _repositoryMock;
-    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<ILogger<RemoveItemFromBoxHandler>> _loggerMock;
     private readonly Mock<IMapper> _mapperMock;
@@ -27,7 +26,7 @@ public class RemoveItemFromBoxHandlerTests
     public RemoveItemFromBoxHandlerTests()
     {
         _repositoryMock = new Mock<ITransportBoxRepository>();
-        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _loggerMock = new Mock<ILogger<RemoveItemFromBoxHandler>>();
         _mapperMock = new Mock<IMapper>();
@@ -47,7 +46,7 @@ public class RemoveItemFromBoxHandlerTests
 
         _handler = new RemoveItemFromBoxHandler(
             _repositoryMock.Object,
-            _inventoryRepositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
             _currentUserServiceMock.Object,
             _loggerMock.Object,
             _mapperMock.Object,
@@ -111,20 +110,18 @@ public class RemoveItemFromBoxHandlerTests
 
         // Assert
         result.Success.Should().BeTrue();
-        _inventoryRepositoryMock.Verify(
-            x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-        _inventoryRepositoryMock.Verify(
-            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
     [Fact]
-    public async Task Handle_ItemWithSourceInventory_RestoresInventory()
+    public async Task Handle_ItemWithSourceInventory_DelegatesRestoreToInventoryService()
     {
         // Arrange
         var box = CreateOpenBoxWithItem(itemId: 1, sourceInventoryId: 42, amount: 10.0);
-        var inventoryItem = CreateInventoryItem(productCode: "PROD-001", amount: 50m);
 
         var request = new RemoveItemFromBoxRequest { BoxId = 1, ItemId = 1 };
 
@@ -132,9 +129,11 @@ public class RemoveItemFromBoxHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(1))
             .ReturnsAsync(box);
 
-        _inventoryRepositoryMock
-            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(inventoryItem);
+        _inventoryReservationServiceMock
+            .Setup(x => x.RestoreAsync(
+                42, 10m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _repositoryMock
             .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
@@ -146,18 +145,17 @@ public class RemoveItemFromBoxHandlerTests
         // Assert
         result.Success.Should().BeTrue();
 
-        // Inventory was restored (UpdateAsync called with item that has increased amount)
-        _inventoryRepositoryMock.Verify(
-            x => x.UpdateAsync(
-                It.Is<ManufacturedProductInventoryItem>(i => i.Amount == 60m),
-                It.IsAny<CancellationToken>()),
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                42, 10m, "Test User", FixedTime,
+                1, "B001", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task Handle_ItemWithSourceInventory_InventoryItemDeleted_ProceedsWithRemoval()
+    public async Task Handle_ItemWithSourceInventory_WhenInventoryMissing_StillSucceeds()
     {
-        // Arrange — inventory item was manually deleted, but removal should still succeed
+        // Arrange — inventory item was deleted; adapter handles the null case internally (log + skip)
         var box = CreateOpenBoxWithItem(itemId: 1, sourceInventoryId: 99, amount: 5.0);
 
         var request = new RemoveItemFromBoxRequest { BoxId = 1, ItemId = 1 };
@@ -166,9 +164,12 @@ public class RemoveItemFromBoxHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(1))
             .ReturnsAsync(box);
 
-        _inventoryRepositoryMock
-            .Setup(x => x.GetByIdAsync(99, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+        // RestoreAsync is called but returns normally (adapter handles missing inventory internally)
+        _inventoryReservationServiceMock
+            .Setup(x => x.RestoreAsync(
+                99, 5m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _repositoryMock
             .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
@@ -179,9 +180,11 @@ public class RemoveItemFromBoxHandlerTests
 
         // Assert
         result.Success.Should().BeTrue();
-        _inventoryRepositoryMock.Verify(
-            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                99, It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     private static TransportBox CreateOpenBox()
@@ -229,13 +232,4 @@ public class RemoveItemFromBoxHandlerTests
         return box;
     }
 
-    private static ManufacturedProductInventoryItem CreateInventoryItem(string productCode, decimal amount)
-    {
-        return new ManufacturedProductInventoryItem(
-            productCode: productCode,
-            productName: "Test Product",
-            amount: amount,
-            createdBy: "system",
-            createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
-    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs
@@ -1,0 +1,198 @@
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.Infrastructure;
+
+public class ManufactureInventoryReservationAdapterTests
+{
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ILogger<ManufactureInventoryReservationAdapter>> _loggerMock;
+    private readonly ManufactureInventoryReservationAdapter _adapter;
+
+    private static readonly DateTime FixedTime = new(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+    public ManufactureInventoryReservationAdapterTests()
+    {
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<ManufactureInventoryReservationAdapter>>();
+        _adapter = new ManufactureInventoryReservationAdapter(
+            _inventoryRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_ItemNotFound_ReturnsInventoryNotFound()
+    {
+        // Arrange
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 5m, userName: "u", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.InventoryNotFound);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_HappyPath_DecrementsAndReturnsSuccess()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 100m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 10m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.Success);
+        item.Amount.Should().Be(90m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_AmountExceedsAvailable_ReturnsInsufficientStock()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 5m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 100m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.InsufficientStock);
+        item.Amount.Should().Be(5m, "domain mutation must not be persisted when consume fails");
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_AllowNegativeStock_SucceedsWhenAmountExceedsAvailable()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 5m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 100m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: true,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.Success);
+        item.Amount.Should().Be(-95m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_DoesNotCallSaveChanges()
+    {
+        // Arrange — guard NFR-3: adapter must never commit
+        var item = CreateInventoryItem("PROD-001", 100m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 10m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _inventoryRepositoryMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_HappyPath_IncrementsAndUpdates()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 10m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        await _adapter.RestoreAsync(
+            inventoryId: 42, amount: 3m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001",
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        item.Amount.Should().Be(13m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ItemNotFound_IsNoOpAndLogsWarning()
+    {
+        // Arrange
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+
+        // Act
+        await _adapter.RestoreAsync(
+            inventoryId: 999, amount: 3m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001",
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("InventoryItem") && v.ToString()!.Contains("999")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private static ManufacturedProductInventoryItem CreateInventoryItem(string productCode, decimal amount)
+    {
+        return new ManufacturedProductInventoryItem(
+            productCode: productCode,
+            productName: "Test Product",
+            amount: amount,
+            createdBy: "system",
+            createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+}

--- a/docs/superpowers/plans/2026-05-16-decouple-logistics-from-manufacture.md
+++ b/docs/superpowers/plans/2026-05-16-decouple-logistics-from-manufacture.md
@@ -1,0 +1,1576 @@
+# Decouple Logistics handlers from Manufacture inventory — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct `IManufacturedProductInventoryRepository` injection in `AddItemToBoxHandler` and `ChangeTransportBoxStateHandler` with a Logistics-owned `IInventoryReservationService` contract, implemented by an internal adapter in the Manufacture module. Extend the module-boundary CI test to cover Logistics → Manufacture, with no behavioral change.
+
+**Architecture:** Apply the Leaflet/KnowledgeBase consumer-owns-contract / provider-owns-adapter precedent (`docs/architecture/development_guidelines.md` §"Cross-Module Communication Example"). Logistics declares the interface and a sealed-record result type in its `Contracts/` folder; Manufacture provides an `internal sealed` adapter in a new `Infrastructure/` folder; `ManufactureModule` registers the binding. Persistence remains in the shared `ApplicationDbContext` (ADR-001 Phase 1) — the adapter must not call `SaveChangesAsync`; the caller's existing `_repository.SaveChangesAsync(cancellationToken)` commits both the box mutation and the inventory mutation atomically. The reflection-based `ModuleBoundariesTests` is refactored to a `[Theory]` so a Logistics row is one `MemberData` entry, and the existing Leaflet row keeps its allowlist.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, MediatR, EF Core (`ApplicationDbContext`), `Microsoft.Extensions.Logging`, `Microsoft.Extensions.DependencyInjection`.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs` | Logistics-owned interface (`TryConsumeAsync`, `RestoreAsync`). |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs` | Logistics-owned sealed record + `ConsumeInventoryOutcome` enum (Success/InventoryNotFound/InsufficientStock). |
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs` | `internal sealed` adapter implementing the contract by delegating to `IManufacturedProductInventoryRepository` and `ManufacturedProductInventoryItem.Consume/Restore`. |
+| `backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs` | Unit tests for the adapter (6 cases). |
+
+**Files to modify:**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs` | Register `IInventoryReservationService` → `ManufactureInventoryReservationAdapter`. |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Refactor existing `[Fact]` into a `[Theory]` with `MemberData`; add Logistics → Manufacture row with empty allowlist. |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs` | Replace `IManufacturedProductInventoryRepository` field/ctor param with `IInventoryReservationService`; replace `GetByIdAsync`/`Consume`/`UpdateAsync` block + `try/catch (InvalidOperationException)` with a single `TryConsumeAsync` call mapped on its outcome. Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` | Replace `IManufacturedProductInventoryRepository` field/ctor param with `IInventoryReservationService`; reimplement `RestoreInventoryForItemsAsync` to delegate per item. Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs` | Swap the mock target from `IManufacturedProductInventoryRepository` to `IInventoryReservationService`; rewrite verifications against the new contract. Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs` | Swap the mock target; add two Opened→New restore tests (happy-path delegates per item; missing-inventory is logged-and-skipped by the adapter — handler test asserts it still calls `RestoreAsync`). Drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. |
+
+**No other files change.** No NuGet packages added (NFR-6). No schema, no migration, no OpenAPI regeneration.
+
+---
+
+## Task 1: Add the Logistics-owned contract types
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs`
+
+- [ ] **Step 1: Create `ConsumeInventoryResult.cs`**
+
+Write the file exactly:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Outcome of an <see cref="IInventoryReservationService.TryConsumeAsync"/> call.
+/// </summary>
+public enum ConsumeInventoryOutcome
+{
+    Success,
+    InventoryNotFound,
+    InsufficientStock,
+}
+
+/// <summary>
+/// Logistics-owned result of attempting to consume inventory.
+/// Sealed record with an outcome discriminator — extensible to carry an optional
+/// available-amount field without breaking the contract.
+/// </summary>
+public sealed record ConsumeInventoryResult(ConsumeInventoryOutcome Outcome);
+```
+
+- [ ] **Step 2: Create `IInventoryReservationService.cs`**
+
+Write the file exactly:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+/// <summary>
+/// Logistics-owned abstraction over inventory reservation for transport-box operations.
+/// Implemented by the Manufacture module via an adapter
+/// (see <c>ManufactureInventoryReservationAdapter</c>) per the cross-module communication
+/// pattern in <c>docs/architecture/development_guidelines.md</c>.
+///
+/// Implementations MUST NOT call SaveChangesAsync on any repository. The caller owns the
+/// unit of work and commits the inventory mutation together with the transport-box mutation
+/// against the shared ApplicationDbContext (ADR-001 Phase 1).
+/// </summary>
+public interface IInventoryReservationService
+{
+    /// <summary>
+    /// Attempts to decrement inventory for a transport-box item. Returns a structured
+    /// result distinguishing success, missing inventory record, and insufficient stock.
+    /// Implementations must not throw Manufacture-owned exceptions across this boundary.
+    /// </summary>
+    Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Restores inventory amount after a transport box transitions Opened → New.
+    /// If the inventory id does not exist, the call is a no-op (implementations log a
+    /// warning and return) — matching the original "log and skip" recovery semantics
+    /// in <c>ChangeTransportBoxStateHandler</c>.
+    /// </summary>
+    Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken);
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run from repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: Build succeeded, 0 errors. The interface compiles standalone; nothing references it yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/IInventoryReservationService.cs \
+        backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ConsumeInventoryResult.cs
+git commit -m "feat: add Logistics-owned IInventoryReservationService contract"
+```
+
+---
+
+## Task 2: Implement `ManufactureInventoryReservationAdapter`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs`
+
+- [ ] **Step 1: Create the adapter file**
+
+The folder `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/` does not yet exist — create it as part of writing the file.
+
+Write the file exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+
+/// <summary>
+/// Manufacture-owned adapter that implements the Logistics-owned
+/// <see cref="IInventoryReservationService"/> contract by delegating to the Manufacture
+/// inventory repository and domain methods.
+///
+/// Does not commit — the caller's unit of work (the transport-box repository's
+/// SaveChangesAsync) commits both mutations atomically against the shared
+/// ApplicationDbContext.
+/// </summary>
+internal sealed class ManufactureInventoryReservationAdapter : IInventoryReservationService
+{
+    private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly ILogger<ManufactureInventoryReservationAdapter> _logger;
+
+    public ManufactureInventoryReservationAdapter(
+        IManufacturedProductInventoryRepository inventoryRepository,
+        ILogger<ManufactureInventoryReservationAdapter> logger)
+    {
+        _inventoryRepository = inventoryRepository;
+        _logger = logger;
+    }
+
+    public async Task<ConsumeInventoryResult> TryConsumeAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        bool allowNegativeStock,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound);
+        }
+
+        try
+        {
+            // ManufacturedProductInventoryItem.Consume is the sole producer of
+            // InvalidOperationException on this call path (insufficient stock guard at
+            // Domain/Features/Manufacture/Inventory/ManufacturedProductInventoryItem.cs:55-57).
+            // If a future invariant adds another InvalidOperationException here, this catch
+            // would miscategorize it — track upgrade to a typed InsufficientInventoryException
+            // as a follow-up.
+            item.Consume(amount, userName, timestamp, boxId, boxCode, allowNegativeStock);
+        }
+        catch (InvalidOperationException)
+        {
+            return new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock);
+        }
+
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+        return new ConsumeInventoryResult(ConsumeInventoryOutcome.Success);
+    }
+
+    public async Task RestoreAsync(
+        int inventoryId,
+        decimal amount,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken)
+    {
+        var item = await _inventoryRepository.GetByIdAsync(inventoryId, cancellationToken);
+        if (item is null)
+        {
+            _logger.LogWarning(
+                "InventoryItem {InventoryId} not found during restore for transport box {BoxId} — skipping restore",
+                inventoryId, boxId);
+            return;
+        }
+
+        item.Restore(amount, userName, timestamp, boxId, boxCode);
+        await _inventoryRepository.UpdateAsync(item, cancellationToken);
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapter.cs
+git commit -m "feat: add ManufactureInventoryReservationAdapter implementing IInventoryReservationService"
+```
+
+---
+
+## Task 3: Register DI binding in `ManufactureModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs`
+
+- [ ] **Step 1: Add the using directives**
+
+Open the file and locate the `using` block at the top (lines 1-13). Add these two `using` statements alphabetically among the existing ones:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+```
+
+The using block already imports `Anela.Heblo.Domain.Features.Manufacture.Inventory` and `Anela.Heblo.Application.Features.Manufacture.Configuration`, so insert the two new lines preserving alphabetical order.
+
+- [ ] **Step 2: Register the binding**
+
+Locate the comment `// Register repositories` (around line 46 / line 47). Immediately after the existing two `services.AddScoped<IManufactureOrderRepository, ManufactureOrderRepository>();` and `services.AddScoped<IManufacturedProductInventoryRepository, ManufacturedProductInventoryRepository>();` lines, insert:
+
+```csharp
+
+        // Cross-module contract: Manufacture implements Logistics' IInventoryReservationService.
+        // DI registration is owned by the provider (Manufacture), not the consumer (Logistics).
+        services.AddScoped<IInventoryReservationService, ManufactureInventoryReservationAdapter>();
+```
+
+(One blank line above the comment to separate it from the repository-registration block.)
+
+- [ ] **Step 3: Verify build and app composition**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 errors, 0 warnings introduced by the change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/ManufactureModule.cs
+git commit -m "feat: register IInventoryReservationService -> ManufactureInventoryReservationAdapter in ManufactureModule"
+```
+
+---
+
+## Task 4: Add adapter unit tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs`
+
+The test project (`Anela.Heblo.Tests`) already has `InternalsVisibleTo` granted by `Anela.Heblo.Application` (verified: `backend/src/Anela.Heblo.Application/AssemblyInfo.cs:3`), so the test can instantiate the `internal` adapter directly.
+
+- [ ] **Step 1: Write the failing test file**
+
+The folder `backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/` does not yet exist — create it as part of writing the file.
+
+Write the file exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Manufacture.Infrastructure;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Manufacture.Infrastructure;
+
+public class ManufactureInventoryReservationAdapterTests
+{
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ILogger<ManufactureInventoryReservationAdapter>> _loggerMock;
+    private readonly ManufactureInventoryReservationAdapter _adapter;
+
+    private static readonly DateTime FixedTime = new(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+    public ManufactureInventoryReservationAdapterTests()
+    {
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<ManufactureInventoryReservationAdapter>>();
+        _adapter = new ManufactureInventoryReservationAdapter(
+            _inventoryRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_ItemNotFound_ReturnsInventoryNotFound()
+    {
+        // Arrange
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 5m, userName: "u", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.InventoryNotFound);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_HappyPath_DecrementsAndReturnsSuccess()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 100m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 10m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.Success);
+        item.Amount.Should().Be(90m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_AmountExceedsAvailable_ReturnsInsufficientStock()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 5m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 100m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.InsufficientStock);
+        item.Amount.Should().Be(5m, "domain mutation must not be persisted when consume fails");
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_AllowNegativeStock_SucceedsWhenAmountExceedsAvailable()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 5m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        var result = await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 100m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: true,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        result.Outcome.Should().Be(ConsumeInventoryOutcome.Success);
+        item.Amount.Should().Be(-95m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryConsumeAsync_DoesNotCallSaveChanges()
+    {
+        // Arrange — guard NFR-3: adapter must never commit
+        var item = CreateInventoryItem("PROD-001", 100m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        await _adapter.TryConsumeAsync(
+            inventoryId: 42, amount: 10m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001", allowNegativeStock: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _inventoryRepositoryMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_HappyPath_IncrementsAndUpdates()
+    {
+        // Arrange
+        var item = CreateInventoryItem("PROD-001", 10m);
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item);
+
+        // Act
+        await _adapter.RestoreAsync(
+            inventoryId: 42, amount: 3m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001",
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        item.Amount.Should().Be(13m);
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ItemNotFound_IsNoOpAndLogsWarning()
+    {
+        // Arrange
+        _inventoryRepositoryMock
+            .Setup(x => x.GetByIdAsync(999, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem?)null);
+
+        // Act
+        await _adapter.RestoreAsync(
+            inventoryId: 999, amount: 3m, userName: "alice", timestamp: FixedTime,
+            boxId: 1, boxCode: "B001",
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        _inventoryRepositoryMock.Verify(
+            x => x.UpdateAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("InventoryItem") && v.ToString()!.Contains("999")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private static ManufacturedProductInventoryItem CreateInventoryItem(string productCode, decimal amount)
+    {
+        return new ManufacturedProductInventoryItem(
+            productCode: productCode,
+            productName: "Test Product",
+            amount: amount,
+            createdBy: "system",
+            createdAt: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ManufactureInventoryReservationAdapterTests"
+```
+
+Expected: 7 tests passed, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/Infrastructure/ManufactureInventoryReservationAdapterTests.cs
+git commit -m "test: cover ManufactureInventoryReservationAdapter consume and restore paths"
+```
+
+---
+
+## Task 5: Refactor `ModuleBoundariesTests` to `[Theory]` (no behavior change yet)
+
+Goal of this task: convert the existing single `[Fact]` to a data-driven `[Theory]` that still has exactly one row (Leaflet → KnowledgeBase). The Logistics row is added in Task 6 to keep the "red on this branch" step distinct.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Replace the class body with the parameterized version**
+
+Replace the entire contents of the file with:
+
+```csharp
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Architecture;
+
+/// <summary>
+/// Enforces module boundary rules from docs/architecture/development_guidelines.md:
+/// Consumer modules must not reference provider-owned types directly. All cross-module
+/// communication goes through consumer-owned contracts (e.g. ILeafletKnowledgeSource,
+/// IInventoryReservationService) implemented by the provider via an adapter.
+/// </summary>
+public class ModuleBoundariesTests
+{
+    public sealed record ModuleBoundaryRule(
+        string Name,
+        string InspectedNamespacePrefix,
+        IReadOnlyList<string> ForbiddenNamespacePrefixes,
+        IReadOnlySet<string> Allowlist);
+
+    // Pre-existing allowlist for Leaflet → KnowledgeBase. Each entry needs a comment with the
+    // justification. Entries should be removed as the underlying violations are fixed.
+    //
+    // Entry format: "{ConsumerFullyQualifiedTypeName} -> {ProviderTypeFullName}"
+    //
+    // Compiler-generated types (e.g. DisplayClasses for closures, state machines for async
+    // methods) are automatically handled by matching against the declaring type's namespace
+    // prefix below.
+    private static readonly HashSet<string> LeafletAllowlist = new(StringComparer.Ordinal)
+    {
+        // Pre-existing dependency: UploadLeafletHandler and IndexLeafletHandler consume
+        // IDocumentTextExtractor, which currently lives in
+        // Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting this is out of
+        // scope for the 2026-05-15 Leaflet decoupling. Track separately and remove these
+        // entries when IDocumentTextExtractor is relocated to a shared namespace.
+        "Anela.Heblo.Application.Features.Leaflet.UseCases.UploadLeaflet.UploadLeafletHandler -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IDocumentTextExtractor",
+        "Anela.Heblo.Application.Features.Leaflet.UseCases.IndexLeaflet.IndexLeafletHandler -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IDocumentTextExtractor",
+
+        // Pre-existing dependency: LeafletIngestionJob consumes IOneDriveService, which
+        // currently lives in Anela.Heblo.Application.Features.KnowledgeBase.Services. Lifting
+        // this is out of scope for the 2026-05-15 Leaflet decoupling. Track separately and
+        // remove these entries when IOneDriveService is relocated to a shared namespace.
+        "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.IOneDriveService",
+        "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.OneDriveFile",
+    };
+
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+    };
+
+    [Theory]
+    [MemberData(nameof(Rules))]
+    public void Consumer_types_should_not_reference_provider_owned_namespaces(ModuleBoundaryRule rule)
+    {
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var consumerTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                && t.Namespace.StartsWith(rule.InspectedNamespacePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var consumerType in consumerTypes)
+        {
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(consumerType))
+            {
+                if (!IsForbidden(referencedType, rule.ForbiddenNamespacePrefixes))
+                    continue;
+
+                var entry = $"{consumerType.FullName} -> {referencedType.FullName}";
+                if (rule.Allowlist.Contains(entry))
+                    continue;
+
+                // Also check if the declaring type of a compiler-generated nested type is in
+                // the allowlist. For example, if "UploadLeafletHandler+<>c__DisplayClass3_0"
+                // references a forbidden type, check if "UploadLeafletHandler" references that
+                // same forbidden type.
+                var baseType = consumerType.DeclaringType;
+                if (baseType is not null)
+                {
+                    var baseEntry = $"{baseType.FullName} -> {referencedType.FullName}";
+                    if (rule.Allowlist.Contains(baseEntry))
+                        continue;
+                }
+
+                violations.Add($"{entry} (via {memberDescription})");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            $"{rule.Name}: consumer types must not reference provider-owned namespaces. " +
+            "Define a consumer-owned contract in the consumer module's Contracts/ folder " +
+            "and have the provider module implement it via an adapter. " +
+            "Found:\n  " + string.Join("\n  ", violations));
+    }
+
+    private static bool IsForbidden(Type type, IReadOnlyList<string> forbiddenPrefixes)
+    {
+        if (type.Namespace is null)
+            return false;
+
+        foreach (var prefix in forbiddenPrefixes)
+        {
+            if (type.Namespace.Equals(prefix, StringComparison.Ordinal) ||
+                type.Namespace.StartsWith(prefix + ".", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Enumerates every type referenced by a given type: constructor parameters, fields,
+    /// properties, method parameters, method return types, generic type arguments,
+    /// and attribute types. Returns (referencedType, "where it appeared") tuples.
+    ///
+    /// Known limitation: does not inspect method bodies (local variable types,
+    /// inlined call targets). Generic constraints and attribute constructor args
+    /// are covered partially via Type/CustomAttribute traversal.
+    /// </summary>
+    private static IEnumerable<(Type Type, string Where)> EnumerateReferencedTypes(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic |
+                                    BindingFlags.Instance | BindingFlags.Static |
+                                    BindingFlags.DeclaredOnly;
+
+        foreach (var attr in type.GetCustomAttributesData())
+            foreach (var t in ExpandGenerics(attr.AttributeType))
+                yield return (t, $"attribute [{attr.AttributeType.Name}]");
+
+        foreach (var field in type.GetFields(flags))
+            foreach (var t in ExpandGenerics(field.FieldType))
+                yield return (t, $"field {field.Name}");
+
+        foreach (var prop in type.GetProperties(flags))
+            foreach (var t in ExpandGenerics(prop.PropertyType))
+                yield return (t, $"property {prop.Name}");
+
+        foreach (var ctor in type.GetConstructors(flags))
+            foreach (var param in ctor.GetParameters())
+                foreach (var t in ExpandGenerics(param.ParameterType))
+                    yield return (t, $"ctor parameter {param.Name}");
+
+        foreach (var method in type.GetMethods(flags))
+        {
+            foreach (var t in ExpandGenerics(method.ReturnType))
+                yield return (t, $"method {method.Name} return");
+
+            foreach (var param in method.GetParameters())
+                foreach (var t in ExpandGenerics(param.ParameterType))
+                    yield return (t, $"method {method.Name} parameter {param.Name}");
+        }
+    }
+
+    private static IEnumerable<Type> ExpandGenerics(Type type)
+    {
+        if (type.IsByRef || type.IsPointer)
+            type = type.GetElementType() ?? type;
+
+        if (type.IsArray)
+        {
+            var elem = type.GetElementType();
+            if (elem is not null)
+                foreach (var t in ExpandGenerics(elem))
+                    yield return t;
+            yield break;
+        }
+
+        yield return type;
+
+        if (type.IsGenericType)
+        {
+            foreach (var arg in type.GetGenericArguments())
+                foreach (var t in ExpandGenerics(arg))
+                    yield return t;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — confirm Leaflet row still passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: 1 test passed (the parameterized fact runs once for the Leaflet row), 0 failed.
+
+If it fails, the refactor introduced a regression — fix before proceeding. Do not move on.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "refactor: parameterize ModuleBoundariesTests for multiple module-pair rules"
+```
+
+---
+
+## Task 6: Add the Logistics → Manufacture rule row (expected to go red)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Add a second row to `Rules()`**
+
+In `ModuleBoundariesTests.cs`, locate the `Rules()` method (added in Task 5). Append a second `TheoryData` entry so the method body becomes:
+
+```csharp
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Logistics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Manufacture",
+                "Anela.Heblo.Application.Features.Manufacture",
+                "Anela.Heblo.Persistence.Manufacture",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+    };
+```
+
+- [ ] **Step 2: Run the test — confirm Logistics row goes RED**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: 1 passed (Leaflet row), 1 failed (Logistics row). The failure message must list at least:
+
+- `Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox.AddItemToBoxHandler -> Anela.Heblo.Domain.Features.Manufacture.Inventory.IManufacturedProductInventoryRepository`
+- `Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox.AddItemToBoxHandler -> Anela.Heblo.Domain.Features.Manufacture.Inventory.ManufacturedProductInventoryItem` (via method return / parameter via `GetByIdAsync`)
+- `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState.ChangeTransportBoxStateHandler -> Anela.Heblo.Domain.Features.Manufacture.Inventory.IManufacturedProductInventoryRepository`
+
+If the test passes, the migration was already done somewhere else and the plan is out of order — stop and investigate. If the test fails with violations not listed above (e.g. some other Logistics → Manufacture leak we did not anticipate), stop and add the leaks to the spec's Out-of-Scope or extend the migration in Task 7/Task 8.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test: enforce Logistics -> Manufacture module boundary in ModuleBoundariesTests"
+```
+
+The test is committed in failing state. Tasks 7 and 8 fix the production code; the test goes green at the end of Task 8.
+
+---
+
+## Task 7: Migrate `AddItemToBoxHandler` to the new contract
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs`
+
+- [ ] **Step 1: Update the handler imports**
+
+In `AddItemToBoxHandler.cs`, replace the `using` block (lines 1-9) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+(Net effect: drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. `Anela.Heblo.Application.Features.Logistics.Contracts` is already present from the previous version, so re-confirm it's still there.)
+
+- [ ] **Step 2: Replace the inventory field and constructor parameter**
+
+Replace lines 15-36 (field declarations + constructor) with:
+
+```csharp
+    private readonly ITransportBoxRepository _repository;
+    private readonly IInventoryReservationService _inventoryReservationService;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<AddItemToBoxHandler> _logger;
+    private readonly IMapper _mapper;
+    private readonly TimeProvider _timeProvider;
+
+    public AddItemToBoxHandler(
+        ITransportBoxRepository repository,
+        IInventoryReservationService inventoryReservationService,
+        ICurrentUserService currentUserService,
+        ILogger<AddItemToBoxHandler> logger,
+        IMapper mapper,
+        TimeProvider timeProvider)
+    {
+        _repository = repository;
+        _inventoryReservationService = inventoryReservationService;
+        _currentUserService = currentUserService;
+        _logger = logger;
+        _mapper = mapper;
+        _timeProvider = timeProvider;
+    }
+```
+
+- [ ] **Step 3: Replace the inventory-consumption block in `Handle`**
+
+In the same file, replace the entire `if (request.SourceInventoryId != null) { ... }` block (originally lines 57-85, including its inner `try/catch (InvalidOperationException)`) with:
+
+```csharp
+            if (request.SourceInventoryId != null)
+            {
+                var consumeResult = await _inventoryReservationService.TryConsumeAsync(
+                    inventoryId: request.SourceInventoryId.Value,
+                    amount: (decimal)request.Amount,
+                    userName: userName,
+                    timestamp: timestamp,
+                    boxId: transportBox.Id,
+                    boxCode: transportBox.Code,
+                    allowNegativeStock: request.AllowNegativeStock,
+                    cancellationToken: cancellationToken);
+
+                switch (consumeResult.Outcome)
+                {
+                    case ConsumeInventoryOutcome.InventoryNotFound:
+                        return new AddItemToBoxResponse
+                        {
+                            Success = false,
+                            ErrorCode = ErrorCodes.ManufacturedInventoryItemNotFound,
+                            Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
+                        };
+                    case ConsumeInventoryOutcome.InsufficientStock:
+                        return new AddItemToBoxResponse
+                        {
+                            Success = false,
+                            ErrorCode = ErrorCodes.ManufacturedInventoryInsufficientStock,
+                            Params = new Dictionary<string, string> { { "sourceInventoryId", request.SourceInventoryId.Value.ToString() } }
+                        };
+                    case ConsumeInventoryOutcome.Success:
+                        break;
+                }
+            }
+```
+
+Leave everything from `var addedItem = transportBox.AddItem(...)` onwards untouched. Order is preserved: reserve inventory → add box item → SaveChangesAsync.
+
+- [ ] **Step 4: Migrate the handler tests**
+
+In `AddItemToBoxHandlerTests.cs`, replace lines 1-12 (using block) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+Replace the `_inventoryRepositoryMock` field (line 19) and its usage in the constructor (lines 31, 55) with `_inventoryReservationServiceMock`. The full top of the class (lines 17-60) becomes:
+
+```csharp
+public class AddItemToBoxHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ILogger<AddItemToBoxHandler>> _loggerMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly AddItemToBoxHandler _handler;
+
+    private static readonly DateTime FixedTime = new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc);
+
+    public AddItemToBoxHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _loggerMock = new Mock<ILogger<AddItemToBoxHandler>>();
+        _mapperMock = new Mock<IMapper>();
+        _timeProviderMock = new Mock<TimeProvider>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-id", "Test User", "test@example.com", true));
+
+        _timeProviderMock
+            .Setup(x => x.GetUtcNow())
+            .Returns(new DateTimeOffset(FixedTime));
+
+        _mapperMock
+            .Setup(x => x.Map<TransportBoxItemDto>(It.IsAny<TransportBoxItem>()))
+            .Returns(new TransportBoxItemDto());
+
+        _mapperMock
+            .Setup(x => x.Map<TransportBoxDto>(It.IsAny<TransportBox>()))
+            .Returns(new TransportBoxDto());
+
+        _handler = new AddItemToBoxHandler(
+            _repositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
+            _currentUserServiceMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object,
+            _timeProviderMock.Object);
+    }
+```
+
+Replace the body of `Handle_WithoutSourceInventoryId_AddsItemWithoutInventoryInteraction` (lines 87-118) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithoutSourceInventoryId_AddsItemWithoutInventoryInteraction()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 5.0
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _inventoryReservationServiceMock.Verify(
+            x => x.TryConsumeAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+Replace the body of `Handle_WithSourceInventoryId_ConsumesInventoryAndSetsLotOnItem` (lines 120-168) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithSourceInventoryId_ConsumesInventoryAndSetsLotOnItem()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 10.0,
+            SourceInventoryId = 42,
+            LotNumber = "LOT-123",
+            ExpirationDate = new DateOnly(2026, 12, 31)
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                42, 10m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.Success));
+
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        _inventoryReservationServiceMock.Verify(
+            x => x.TryConsumeAsync(
+                42, 10m, "Test User", FixedTime,
+                1, "B001", false, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Box item has the lot and source inventory set
+        var addedItem = box.Items.Single();
+        addedItem.SourceInventoryId.Should().Be(42);
+        addedItem.LotNumber.Should().Be("LOT-123");
+        addedItem.ExpirationDate.Should().Be(new DateOnly(2026, 12, 31));
+    }
+```
+
+Replace the body of `Handle_WithSourceInventoryId_InsufficientStock_ReturnsError` (lines 170-205) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithSourceInventoryId_InsufficientStock_ReturnsError()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 100.0,
+            SourceInventoryId = 42
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                42, 100m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.InsufficientStock));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ManufacturedInventoryInsufficientStock);
+        result.Params.Should().ContainKey("sourceInventoryId").WhoseValue.Should().Be("42");
+
+        // Box save should not have been called
+        _repositoryMock.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+Replace the body of `Handle_WithSourceInventoryId_InventoryNotFound_ReturnsError` (lines 207-235) with:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithSourceInventoryId_InventoryNotFound_ReturnsError()
+    {
+        // Arrange
+        var box = CreateOpenBox();
+        var request = new AddItemToBoxRequest
+        {
+            BoxId = 1,
+            ProductCode = "PROD-001",
+            ProductName = "Test Product",
+            Amount = 5.0,
+            SourceInventoryId = 999
+        };
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(1))
+            .ReturnsAsync(box);
+
+        _inventoryReservationServiceMock
+            .Setup(x => x.TryConsumeAsync(
+                999, 5m, It.IsAny<string>(), It.IsAny<DateTime>(),
+                1, "B001", false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsumeInventoryResult(ConsumeInventoryOutcome.InventoryNotFound));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ManufacturedInventoryItemNotFound);
+        result.Params.Should().ContainKey("sourceInventoryId").WhoseValue.Should().Be("999");
+    }
+```
+
+Delete the `CreateInventoryItem` helper at the bottom of the file (lines 254-262) — it's no longer needed since the tests don't construct `ManufacturedProductInventoryItem` directly. Keep `CreateOpenBox`.
+
+- [ ] **Step 5: Run the handler tests and confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~AddItemToBoxHandlerTests"
+```
+
+Expected: 5 tests passed (BoxNotFound, WithoutSourceInventoryId, ConsumesInventoryAndSetsLotOnItem, InsufficientStock, InventoryNotFound), 0 failed.
+
+- [ ] **Step 6: Run the boundary test — Logistics row should still be RED (only one handler done)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: Leaflet row passes, Logistics row still fails — but the violations list should be smaller now, listing only `ChangeTransportBoxStateHandler` references (not `AddItemToBoxHandler` anymore). If `AddItemToBoxHandler` still appears in the failure message, re-check Step 1 (the `using` directive `Anela.Heblo.Domain.Features.Manufacture.Inventory` must be gone) and Step 2 (the field type must be `IInventoryReservationService`, not `IManufacturedProductInventoryRepository`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/AddItemToBoxHandlerTests.cs
+git commit -m "refactor(logistics): route AddItemToBox inventory consume through IInventoryReservationService"
+```
+
+---
+
+## Task 8: Migrate `ChangeTransportBoxStateHandler` to the new contract
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs`
+
+- [ ] **Step 1: Update handler imports**
+
+In `ChangeTransportBoxStateHandler.cs`, replace the `using` block (lines 1-10) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+(Net effect: drop `using Anela.Heblo.Domain.Features.Manufacture.Inventory;`. Add `Anela.Heblo.Application.Features.Logistics.Contracts`.)
+
+- [ ] **Step 2: Replace the inventory field and constructor parameter**
+
+In the same file, replace the field block (lines 16-22) with:
+
+```csharp
+    private readonly ITransportBoxRepository _repository;
+    private readonly IInventoryReservationService _inventoryReservationService;
+    private readonly IMediator _mediator;
+    private readonly ILogger<ChangeTransportBoxStateHandler> _logger;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IStockUpProcessingService _stockUpProcessingService;
+    private readonly TimeProvider _timeProvider;
+```
+
+Replace the constructor (lines 40-56) with:
+
+```csharp
+    public ChangeTransportBoxStateHandler(
+        ITransportBoxRepository repository,
+        IInventoryReservationService inventoryReservationService,
+        IMediator mediator,
+        ILogger<ChangeTransportBoxStateHandler> logger,
+        ICurrentUserService currentUserService,
+        IStockUpProcessingService stockUpProcessingService,
+        TimeProvider timeProvider)
+    {
+        _repository = repository;
+        _inventoryReservationService = inventoryReservationService;
+        _mediator = mediator;
+        _logger = logger;
+        _currentUserService = currentUserService;
+        _stockUpProcessingService = stockUpProcessingService;
+        _timeProvider = timeProvider;
+    }
+```
+
+- [ ] **Step 3: Replace `RestoreInventoryForItemsAsync`**
+
+Replace the entire `RestoreInventoryForItemsAsync` method (lines 266-288) with:
+
+```csharp
+    private async Task RestoreInventoryForItemsAsync(
+        IReadOnlyList<TransportBoxItem> items,
+        string userName,
+        DateTime timestamp,
+        int boxId,
+        string? boxCode,
+        CancellationToken cancellationToken)
+    {
+        foreach (var item in items)
+        {
+            if (item.SourceInventoryId == null) continue;
+
+            await _inventoryReservationService.RestoreAsync(
+                inventoryId: item.SourceInventoryId.Value,
+                amount: (decimal)item.Amount,
+                userName: userName,
+                timestamp: timestamp,
+                boxId: boxId,
+                boxCode: boxCode,
+                cancellationToken: cancellationToken);
+        }
+    }
+```
+
+The missing-id warning now lives in `ManufactureInventoryReservationAdapter.RestoreAsync` (Task 2). The handler no longer logs it directly.
+
+Leave the call site at line 132 unchanged — it still reads `await RestoreInventoryForItemsAsync(itemsToRestore, userName, currentTime, box.Id, box.Code, cancellationToken);`. Leave the `itemsToRestore` capture at lines 124-126 unchanged.
+
+- [ ] **Step 4: Migrate the handler tests — swap the mock target**
+
+In `ChangeTransportBoxStateHandlerTests.cs`, replace lines 1-15 (using block) with:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+Replace the field and constructor body (lines 19-67) with:
+
+```csharp
+public class ChangeTransportBoxStateHandlerTests
+{
+    private readonly Mock<ITransportBoxRepository> _repositoryMock;
+    private readonly Mock<IInventoryReservationService> _inventoryReservationServiceMock;
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<ChangeTransportBoxStateHandler>> _loggerMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IStockUpProcessingService> _stockUpProcessingServiceMock;
+    private readonly Mock<TimeProvider> _timeProviderMock;
+    private readonly ChangeTransportBoxStateHandler _handler;
+
+    public ChangeTransportBoxStateHandlerTests()
+    {
+        _repositoryMock = new Mock<ITransportBoxRepository>();
+        _inventoryReservationServiceMock = new Mock<IInventoryReservationService>();
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<ChangeTransportBoxStateHandler>>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _stockUpProcessingServiceMock = new Mock<IStockUpProcessingService>();
+        _timeProviderMock = new Mock<TimeProvider>();
+
+        // Setup default returns for the new dependencies
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user", "Test User", "test@example.com", true));
+
+        _timeProviderMock
+            .Setup(x => x.GetUtcNow())
+            .Returns(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+        _stockUpProcessingServiceMock
+            .Setup(x => x.CreateOperationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<StockUpSourceType>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _handler = new ChangeTransportBoxStateHandler(
+            _repositoryMock.Object,
+            _inventoryReservationServiceMock.Object,
+            _mediatorMock.Object,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _stockUpProcessingServiceMock.Object,
+            _timeProviderMock.Object);
+    }
+```
+
+- [ ] **Step 5: Add Opened → New restore-path tests**
+
+Append two new `[Fact]` methods to the test class, immediately before the `SetupReceivedTransitionMocks` private helper. The handler did not previously have tests covering the `Opened → New` restore path; FR-8 requires that case to be exercised — and this is the test that proves NFR-1 (the handler still delegates restore per item).
+
+Add this method:
+
+```csharp
+    [Fact]
+    public async Task Handle_OpenedToNew_WithSourceInventoryItems_DelegatesRestorePerItem()
+    {
+        // Arrange — box in Opened with two items: one with SourceInventoryId, one without
+        var box = CreateTestBox(TransportBoxState.Opened);
+        box.Id = 1;
+        var itemsField = typeof(TransportBox).GetField("_items",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var items = (List<TransportBoxItem>)itemsField!.GetValue(box)!;
+
+        items.Add(new TransportBoxItem(
+            productCode: "PROD-001",
+            productName: "Test Product",
+            amount: 7.0,
+            dateAdded: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            userAdded: "TestUser",
+            lotNumber: null,
+            expirationDate: null,
+            sourceInventoryId: 42));
+        items.Add(new TransportBoxItem(
+            productCode: "PROD-002",
+            productName: "Other Product",
+            amount: 3.0,
+            dateAdded: new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            userAdded: "TestUser",
+            lotNumber: null,
+            expirationDate: null,
+            sourceInventoryId: null));
+
+        _repositoryMock.Setup(x => x.GetByIdWithDetailsAsync(1)).ReturnsAsync(box);
+        _repositoryMock
+            .Setup(x => x.UpdateAsync(It.IsAny<TransportBox>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetTransportBoxByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetTransportBoxByIdResponse
+            {
+                TransportBox = new Anela.Heblo.Application.Features.Logistics.Contracts.TransportBoxDto()
+            });
+
+        var request = new ChangeTransportBoxStateRequest
+        {
+            BoxId = 1,
+            NewState = TransportBoxState.New
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        // Only the item with SourceInventoryId triggers a restore call
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                42,
+                7m,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                1,
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+Add this second method:
+
+```csharp
+    [Fact]
+    public async Task Handle_NonOpenedToNewTransition_DoesNotCallRestore()
+    {
+        // Arrange — InTransit -> Received transition (no inventory restore)
+        var box = CreateTestBoxWithItems(TransportBoxState.InTransit);
+        SetupReceivedTransitionMocks(box);
+
+        var request = new ChangeTransportBoxStateRequest
+        {
+            BoxId = 1,
+            NewState = TransportBoxState.Received
+        };
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _inventoryReservationServiceMock.Verify(
+            x => x.RestoreAsync(
+                It.IsAny<int>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 6: Run the handler tests and confirm everything passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ChangeTransportBoxStateHandlerTests"
+```
+
+Expected: all existing tests plus the two new ones pass (count = previous count + 2), 0 failed.
+
+- [ ] **Step 7: Run the boundary test — Logistics row should now go GREEN**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: 2 tests passed (Leaflet row + Logistics row), 0 failed.
+
+If the Logistics row still fails, the failure message names the remaining leak — fix it before commit. The two most likely causes are: (a) the `using Anela.Heblo.Domain.Features.Manufacture.Inventory;` directive still present somewhere in the two modified handler files (search both files and remove it), or (b) a method signature still references `ManufacturedProductInventoryItem`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+git commit -m "refactor(logistics): route ChangeTransportBoxState inventory restore through IInventoryReservationService"
+```
+
+---
+
+## Task 9: Final validation — full build, full test run, format check
+
+- [ ] **Step 1: Full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 errors, 0 new warnings.
+
+- [ ] **Step 2: Full backend test run**
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: All tests pass. Pay attention to the totals — the count should equal the pre-change count plus 9 new tests (7 adapter tests + 2 ChangeTransportBoxStateHandler restore tests). No skipped tests in modified files.
+
+- [ ] **Step 3: Format check**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: no output (clean). If format changes are reported, run `dotnet format backend/Anela.Heblo.sln`, review the diff, and amend the most-recent commit if the diff is trivial — otherwise add a separate format commit.
+
+- [ ] **Step 4: Confirm no lingering Manufacture-inventory references in Logistics**
+
+```bash
+grep -rn "Anela.Heblo.Domain.Features.Manufacture\|IManufacturedProductInventoryRepository\|ManufacturedProductInventoryItem" \
+  backend/src/Anela.Heblo.Application/Features/Logistics/
+```
+
+Expected: zero matches. If any line is printed, find which file still has the leak and remove it (the boundary test must still be passing — if it's passing but grep shows a hit, the hit is in a non-type-referencing place like a comment, which is acceptable; otherwise re-investigate).
+
+```bash
+grep -rn "Anela.Heblo.Domain.Features.Manufacture\|IManufacturedProductInventoryRepository\|ManufacturedProductInventoryItem" \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/
+```
+
+Expected: zero matches in the migrated test files (`AddItemToBoxHandlerTests.cs`, `ChangeTransportBoxStateHandlerTests.cs`). Hits in unrelated Logistics test files (e.g. `GiftPackageManufactureServiceTests.cs`) are acceptable — they're out of scope.
+
+- [ ] **Step 5: Final summary log (no commit if nothing to commit)**
+
+If `dotnet format` produced changes:
+
+```bash
+git add -A
+git commit -m "chore: dotnet format after Logistics-Manufacture decoupling"
+```
+
+If everything is already clean, this step is a no-op — skip.
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Implemented in |
+|------------------|----------------|
+| FR-1 (Contract in Logistics) | Task 1 |
+| FR-2 (Operation signatures + sealed-record result type) | Task 1 (locked-down result type per arch-review amendment #1) |
+| FR-3 (Adapter in Manufacture, internal sealed, no SaveChanges, catch InvalidOperationException) | Task 2 (with NFR-3 guarded by Task 4 Step 5 + adapter Step 1 comment per arch-review amendment #5) |
+| FR-4 (DI binding in ManufactureModule) | Task 3 |
+| FR-5 (Migrate AddItemToBoxHandler) | Task 7 |
+| FR-6 (Migrate ChangeTransportBoxStateHandler) | Task 8 |
+| FR-7 (Extend ModuleBoundariesTests with Theory + Logistics row, empty allowlist) | Tasks 5–6 (Theory refactor first, then row added separately so red-state is auditable per arch-review Prerequisite #5) |
+| FR-8 (Migrated handler tests + adapter tests) | Task 4 (adapter), Task 7 (AddItemToBox), Task 8 (ChangeTransportBoxState — including newly added Opened→New restore tests) |
+| NFR-1 (Behavioral parity) | Verified via Task 7 / Task 8 / Task 9 test runs |
+| NFR-2 (Module boundaries enforced in CI) | Task 6 + Task 8 (boundary test green) |
+| NFR-3 (Transaction semantics — adapter has no SaveChanges) | Adapter design (Task 2) + adapter test `TryConsumeAsync_DoesNotCallSaveChanges` (Task 4) |
+| NFR-4 (Logging in adapter preserves IDs) | Adapter Step 1 (Task 2) + adapter test `RestoreAsync_ItemNotFound_IsNoOpAndLogsWarning` (Task 4) |
+| NFR-5 (Code style — internal sealed, nullable, CancellationToken last) | Adapter is `internal sealed` (Task 2); all async methods accept `CancellationToken` as last param (Task 1, Task 2); files <800 lines |
+| NFR-6 (No new NuGet packages) | No package references touched in any task |
+
+**Prerequisites from arch-review:**
+- Prereq #1: `BaseRepository.UpdateAsync` only calls `DbSet.Update(entity)` and returns `Task.CompletedTask` — verified at plan-writing time (`backend/src/Anela.Heblo.Persistence/Repositories/BaseRepository.cs:70-74`); adapter design is safe.
+- Prereq #2: `Anela.Heblo.Application` already grants `InternalsVisibleTo("Anela.Heblo.Tests")` — verified at plan-writing time (`backend/src/Anela.Heblo.Application/AssemblyInfo.cs:3` and `Anela.Heblo.Application.csproj:45`); the adapter unit test in Task 4 can construct the `internal` adapter directly.
+- Prereq #5 ordering (a → b → c with red-then-green) is encoded in Task 5 / Task 6 / Tasks 7–8.
+
+## Out of scope (per spec)
+
+- Splitting `ApplicationDbContext` per module (ADR-001 Phase 2).
+- Promoting `InvalidOperationException` in `ManufacturedProductInventoryItem.Consume` to a typed `InsufficientInventoryException` — track as follow-up (arch-review Decision 2 + Spec amendment #6).
+- Refactoring `HandleReceived` in `ChangeTransportBoxStateHandler` (Catalog dependency, separate concern).
+- Removing existing Leaflet→KnowledgeBase allowlist entries.
+- Czech-language doc updates.


### PR DESCRIPTION
Logistics

## Finding
Two Logistics handlers directly inject `IManufacturedProductInventoryRepository` from the Manufacture module's domain, bypassing the required contract-based cross-module communication pattern:

- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/AddItemToBox/AddItemToBoxHandler.cs` — line 16: `private readonly IManufacturedProductInventoryRepository _inventoryRepository;`
- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` — line 17: `private readonly IManufacturedProductInventoryRepository _inventoryRepository;`

Both handlers call `_inventoryRepository.GetByIdAsync(...)` and `_inventoryRepository.UpdateAsync(...)` on Manufacture-owned inventory items, and `AddItemToBoxHandler` calls `inventoryItem.Consume(...)` — a Manufacture domain method — directly from the Logistics application layer.

## Why it matters
`development_guidelines.md` explicitly forbids "Direct access to another module's entities" and "Shared repositories across modules." This creates tight coupling: any change to `ManufacturedProductInventoryItem` or `IManufacturedProductInventoryRepository` can break Logistics handlers. It also blocks the future path to independent module deployment.

## Suggested fix
Apply the cross-module consumer/provider contract pattern documented in `development_guidelines.md`:

1. Define a Logistics-owned interface in `Application/Features/Logistics/Contracts/`, e.g.:
   ```csharp
   public interface IInventoryReservationService
   {
       Task<bool> TryConsumeAsync(int inventoryId, decimal amount, string userName, DateTime timestamp, int boxId, string? boxCode, bool allowNegative, CancellationToken ct);
       Task RestoreAsync(int inventoryId, decimal amount, string userName, DateTime timestamp, int boxId, string? boxCode, CancellationToken ct);
   }
   ```
2. Have Manufacture implement an adapter in `Application/Features/Manufacture/Infrastructure/` and register the binding in `ManufactureModule`.
3. Replace the direct repository injection in both handlers with the new interface.

---
_Filed by daily arch-review routine on 2026-05-15._

---

Closes #1289

### Tokens used
29842713
