### PR TITLE
feat: Remove Logistics → Purchase Module Coupling in GiftPackageDto

### DIFF
--- a/artifacts/feat-arch-review-logistics-giftpackagedto-imp/arch-review.r1.md
+++ b/artifacts/feat-arch-review-logistics-giftpackagedto-imp/arch-review.r1.md
@@ -1,0 +1,180 @@
+I have sufficient context. Writing the architecture review now.
+
+# Architecture Review: Remove Logistics → Purchase Module Coupling in GiftPackageDto
+
+## Skip Design: true
+
+No new UI surface area. Existing components keep rendering identically; only the imported enum symbol changes (and possibly a small cleanup of dead filter buttons — see Specification Amendments).
+
+## Architectural Fit Assessment
+
+The proposal aligns with the codebase's established Vertical Slice + module-isolation pattern documented in `docs/architecture/development_guidelines.md` and proven by the recent Leaflet → KnowledgeBase decoupling. Each module owns its contracts; cross-module type leakage is treated as a defect.
+
+The fix is a textbook "owned-contract" remediation: relocate the enum into the consuming module and break the `using` edge. There is no shared-abstraction temptation here — the type is genuinely module-local (severity classification rules differ per module: Purchase has six buckets, Manufacture has its own five-bucket `ManufacturingStockSeverity`, Logistics needs three). The spec correctly rejects a "shared severity" common namespace.
+
+**Two material gaps in the spec that this review must address:**
+
+1. **Wire/serialization claim is wrong but harmless.** The spec says ordinal integer values must match Purchase's `StockSeverity` for "in-flight client" compatibility. They don't: Purchase has `Critical=0, Severe=1, Low=2, Optimal=3, ...` while the proposed Logistics enum `{Optimal, Severe, Critical}` yields `Optimal=0, Severe=1, Critical=2`. **However**, `JsonStringEnumConverter` is globally registered (`backend/src/Anela.Heblo.API/Program.cs:118`) and the generated TS client confirms string-valued enums (`Critical = "Critical"`). Wire format depends on enum **member names**, not ordinals. As long as names (`Critical`, `Severe`, `Optimal`) are preserved, the wire is stable. Severity is also computed on the fly and never persisted to the DB (`GiftPackageManufactureLog` does not store it), so ordinals are entirely a no-op.
+2. **Frontend scope is understated.** Spec mentions only `CriticalGiftPackagesTile` (which is actually a **backend** tile at `backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/CriticalGiftPackagesTile.cs:54`, not a frontend component). The real frontend consumers are `frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx` and `GiftPackageManufacturingSummary.tsx`, which currently reference six `StockSeverity` values (`Critical`, `Severe`, `Low`, `Optimal`, `Overstocked`, `NotConfigured`) for filter buttons — even though the backend only ever emits three. See Specification Amendments.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before (violation):
+  ┌──────────────────────────────────────┐
+  │  Features/Logistics                  │
+  │   GiftPackageDto.Severity ─────────┐ │
+  │   GiftPackageManufactureService ───┼─┼──► Features/Purchase
+  │   CriticalGiftPackagesTile ────────┘ │       StockSeverity (6 values)
+  └──────────────────────────────────────┘
+
+After (decoupled):
+  ┌──────────────────────────────────────┐    ┌────────────────────────┐
+  │  Features/Logistics                  │    │  Features/Purchase     │
+  │   .../GiftPackageManufacture/        │    │   StockSeverity        │
+  │     Contracts/                       │    │   (unchanged, 6 values)│
+  │       GiftPackageDto                 │    └────────────────────────┘
+  │       GiftPackageSeverity ◄──┐       │
+  │   .../Services/              │       │
+  │     GiftPackageManufactureService    │
+  │   DashboardTiles/                    │
+  │     CriticalGiftPackagesTile         │
+  └──────────────────────────────────────┘
+  + backend/test/.../Architecture/ModuleBoundariesTests
+    extended with Logistics→Purchase forbidden-namespace assertion.
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where the new enum lives
+**Options considered:**
+- (a) `Features/Logistics/Contracts/GiftPackageSeverity.cs` (spec's proposal — module-root).
+- (b) `Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageSeverity.cs` (co-located with the DTO that owns it).
+- (c) Inside `GiftPackageDto.cs` as a peer type (Purchase's pattern — single file).
+
+**Chosen approach:** (b) — co-locate with `GiftPackageDto`.
+
+**Rationale:** The enum is used exclusively by the `GiftPackageManufacture` use case (DTO, service, dashboard tile). Vertical Slice cohesion says "all code for a feature in one place" (`development_guidelines.md`). The module-root `Features/Logistics/Contracts/` folder today holds **only** TransportBox DTOs that are shared across multiple Logistics use cases; gift-package severity is not in that league. (c) is rejected because Purchase's "everything-in-the-response-file" pattern is recognized in the brief as the *thing being fixed* elsewhere, and a standalone file makes the enum easier to find and grep for.
+
+#### Decision 2: Enum membership — three values or six
+**Options considered:**
+- (a) Three values `{Optimal, Severe, Critical}` matching what `CalculateSeverity` currently emits (spec's proposal).
+- (b) Six values mirroring Purchase's `StockSeverity` `{Critical, Severe, Low, Optimal, Overstocked, NotConfigured}` to keep frontend filter UI unchanged.
+
+**Chosen approach:** (a) — three values, **and** also clean up the now-dead filter buttons in `GiftPackageManufacturingSummary.tsx`.
+
+**Rationale:** The backend service has only ever emitted three severities for gift packages. The extra filter buttons for `Low`, `Overstocked`, `NotConfigured` in `GiftPackageManufacturingSummary.tsx` filter against values the backend never produces — they are dead UI. Carrying them forward "for compatibility" propagates the leaked Purchase model into the Logistics module conceptually, which defeats the point of decoupling. Truth-in-typing wins. This adds frontend cleanup scope; see Specification Amendments FR-4'.
+
+#### Decision 3: Enforce the boundary in CI
+**Options considered:**
+- (a) Rely on code review and discipline.
+- (b) Extend `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` with a Logistics→Purchase forbidden-namespace assertion mirroring the existing Leaflet→KnowledgeBase test.
+
+**Chosen approach:** (b).
+
+**Rationale:** The codebase already invested in a reflection-based architecture test for the Leaflet decoupling; reusing the same pattern here is cheap, prevents the next regression, and signals that module boundaries are first-class. Without it, this exact violation can reappear at the next "just import the type" PR.
+
+#### Decision 4: Wire/JSON compatibility strategy
+**Chosen approach:** Rely on the globally registered `JsonStringEnumConverter` (verified at `Program.cs:118`). Preserve member **names** (`Optimal`, `Severe`, `Critical`). Ordinals do not matter for the wire and are not persisted.
+
+**Rationale:** Members `Critical`/`Severe`/`Optimal` exist verbatim in both old and new enums, so any in-flight client deserializing `"severity":"Critical"` still works against the regenerated client. The spec's ordinal-matching requirement (FR-1) should be reworded to a name-matching requirement (see Specification Amendments).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create:**
+```
+backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/
+  GiftPackageSeverity.cs                  (new — 3-member enum)
+```
+
+**Modify:**
+```
+backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/
+  Contracts/GiftPackageDto.cs             (drop Purchase using; retype Severity)
+  Services/GiftPackageManufactureService.cs   (drop Purchase using; lines 338, 343, 349, 352)
+backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/
+  CriticalGiftPackagesTile.cs             (drop Purchase using; line 54)
+backend/test/Anela.Heblo.Tests/Architecture/
+  ModuleBoundariesTests.cs                (add Logistics→Purchase test)
+frontend/src/components/pages/GiftPackageManufacturing/
+  GiftPackageManufacturingList.tsx        (re-target StockSeverity → GiftPackageSeverity)
+  GiftPackageManufacturingSummary.tsx     (re-target + remove dead Low/Overstocked/NotConfigured buttons)
+```
+
+**Do not touch:** any file under `Features/Purchase/**`, any file under `Features/Manufacture/**`, `usePurchaseStockAnalysis.ts`, `PurchaseStockAnalysis.tsx`, `ManufacturingStockAnalysis.tsx`.
+
+### Interfaces and Contracts
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
+
+public enum GiftPackageSeverity
+{
+    Critical,
+    Severe,
+    Optimal,
+}
+```
+
+- File name matches the type (per C# coding style).
+- No `[JsonConverter]` attribute needed — global `JsonStringEnumConverter` covers all enums.
+- DTO stays a `class` (per project rule). Its `Severity` property becomes `public GiftPackageSeverity Severity { get; set; }`.
+
+### Data Flow
+
+For both `GET available gift packages` and `GET gift package detail`:
+
+```
+Catalog data ──► GiftPackageManufactureService.CalculateSeverity
+                   ├─ availableStock < overstockMinimal  → GiftPackageSeverity.Critical
+                   ├─ availableStock < suggestedQuantity → GiftPackageSeverity.Severe
+                   └─ otherwise                          → GiftPackageSeverity.Optimal
+                 │
+                 ▼
+              GiftPackageDto.Severity (GiftPackageSeverity)
+                 │
+                 ▼ JsonStringEnumConverter
+              HTTP response: { ..., "severity": "Critical" }
+                 │
+                 ▼ regenerated OpenAPI client (string enum)
+              frontend GiftPackageSeverity.Critical
+                 │
+                 ▼
+              GiftPackageManufacturingList / Summary / Tile UI
+```
+
+For the dashboard tile:
+```
+CriticalGiftPackagesTile.LoadDataAsync
+  → MediatR Send(GetAvailableGiftPackagesRequest)
+  → response.GiftPackages.Count(p => p.Severity == GiftPackageSeverity.Critical)
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Generated TS schema renames `StockSeverity` → `GiftPackageSeverity`, but if NSwag is keyed by C# type name, a *different* unrelated DTO with a `StockSeverity` property could see the schema collapse. | Low | Quickly grep generated `api-client.ts` after regen: confirm `StockSeverity` enum still exists for Purchase, and a new `GiftPackageSeverity` enum appears. The fact that `ManufacturingStockSeverity` already coexists with `StockSeverity` confirms NSwag handles parallel enums fine. |
+| Frontend filter buttons for the three dropped values (`Low`, `Overstocked`, `NotConfigured`) are referenced by tests, deep links, or URL query params. | Low | Grep `frontend/` for those literal strings before deleting. If a saved URL uses `?severity=Low`, the filter just defaults to "All" — acceptable. |
+| The new architecture test catches an existing, unrelated Logistics→Purchase reference (besides `StockSeverity`) and turns red. | Medium | Run the test once after writing it but **before** the cleanup commit. If it flags other violations, surface them in the PR and either fix in scope or add to an explicit `Allowlist` with justification (mirror the Leaflet allowlist pattern). |
+| Stale `using Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis;` left in untouched Logistics files. | Low | `dotnet format` will remove unused usings; the new architecture test will fail loudly if a reference remains. |
+| `dotnet format` on the new enum file produces a stylistic difference from existing enums. | Low | Run `dotnet format` as part of the PR per CLAUDE.md validation step. |
+
+## Specification Amendments
+
+1. **FR-1 (member ordering):** Replace the requirement *"The member ordering and underlying integer values match Purchase's `StockSeverity` so that any existing persisted/serialized values remain numerically equivalent."* with: *"Members are named `Critical`, `Severe`, `Optimal`. Names match the strings emitted on the wire by Purchase's enum for the same values, ensuring JSON wire compatibility under the globally registered `JsonStringEnumConverter`. Underlying ordinal values are unconstrained because severity is computed on-the-fly and never persisted."* Member order in the file should be `Critical, Severe, Optimal` (severity-descending), matching Purchase's stylistic ordering and `CalculateSeverity`'s return order.
+2. **FR-1 (location):** Change file path from `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/GiftPackageSeverity.cs` to `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageSeverity.cs`. Co-located with `GiftPackageDto`, matching vertical-slice ownership of the use case. Update the namespace accordingly to `Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts`.
+3. **FR-4 (frontend scope):** Expand from "`CriticalGiftPackagesTile`" (which is a backend file) to the actual frontend touch list: `GiftPackageManufacturingList.tsx`, `GiftPackageManufacturingSummary.tsx`. Add an explicit subtask: **remove the dead filter buttons for `Low`, `Overstocked`, `NotConfigured` in `GiftPackageManufacturingSummary.tsx`** — these reference Purchase-only severity buckets the gift-package backend never emits. Acceptance criterion: the filter UI shows exactly `All`, `Critical`, `Severe`, `Optimal`.
+4. **New FR-8 (architectural test):** Add the following requirement: *"Extend `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` with a new `[Fact]` `Logistics_types_should_not_reference_Purchase_owned_namespaces` that asserts no type whose namespace starts with `Anela.Heblo.Application.Features.Logistics` references any type in `Anela.Heblo.Application.Features.Purchase`, `Anela.Heblo.Domain.Features.Purchase`, or `Anela.Heblo.Persistence.Purchase`. Mirror the existing Leaflet test's structure including the `Allowlist` mechanism (initially empty). The test must pass once the refactor is complete."*
+5. **NFR-3 clarification:** Reword to reference string-enum wire format, not ordinal compatibility (see amendment 1).
+6. **Backend tile correction (background section):** The bullet describing "a frontend tile component (`CriticalGiftPackagesTile`)" is incorrect — that class is a backend `ITile` registered for the dashboard MediatR pipeline, not a React component. Update the wording.
+
+## Prerequisites
+
+- None blocking. No infrastructure, no migrations, no config, no new packages.
+- Confirm OpenAPI client auto-regenerates on `npm run build` (per `docs/development/api-client-generation.md`) — already standing project capability.
+- Existing `ModuleBoundariesTests.cs` is the template for the new assertion — no additional test harness work needed.

--- a/artifacts/feat-arch-review-logistics-giftpackagedto-imp/brief.md
+++ b/artifacts/feat-arch-review-logistics-giftpackagedto-imp/brief.md
@@ -1,0 +1,33 @@
+## Module
+Logistics
+
+## Finding
+`GiftPackageDto`, a Logistics contract DTO, directly imports and uses the `StockSeverity` enum that is defined inside the Purchase module's use-case response class:
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageDto.cs` — line 1: `using Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis;`
+- Line 14: `public StockSeverity Severity { get; set; }`
+
+`StockSeverity` is defined at line 96 of `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseStockAnalysis/GetPurchaseStockAnalysisResponse.cs`. `GiftPackageManufactureService` also imports and uses it (lines 343, 349, 352).
+
+Note: the Manufacture module independently defined a parallel `ManufacturingStockSeverity` enum in its own response, which is the correct pattern.
+
+## Why it matters
+A Logistics DTO must not reference a type owned by the Purchase module. The `using` import creates a compile-time dependency between the two modules. If Purchase renames or restructures `StockSeverity`, Logistics breaks. `development_guidelines.md` requires module communication exclusively through owned contracts.
+
+## Suggested fix
+Define a `GiftPackageSeverity` enum (or reuse a name like `StockSeverity`) in the Logistics module's own contracts folder:
+
+```
+backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/GiftPackageSeverity.cs
+```
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+public enum GiftPackageSeverity { Optimal, Severe, Critical }
+```
+
+Update `GiftPackageDto`, `GiftPackageManufactureService`, and `CriticalGiftPackagesTile` to use the new enum. Remove the `using` import from Purchase.
+
+---
+_Filed by daily arch-review routine on 2026-05-15._

--- a/artifacts/feat-arch-review-logistics-giftpackagedto-imp/impl/main.r1.md
+++ b/artifacts/feat-arch-review-logistics-giftpackagedto-imp/impl/main.r1.md
@@ -1,0 +1,77 @@
+All tasks complete. Writing the output artifact.
+
+---
+
+# Implementation: Remove Logistics → Purchase Module Coupling in GiftPackageDto
+
+## What was implemented
+
+Introduced a Logistics-owned `GiftPackageSeverity` enum (3 members: `Critical`, `Severe`, `Optimal`) and removed all compile-time dependencies from the Logistics module on the Purchase module's `StockSeverity`. Added a reflection-based architecture test to enforce the boundary in CI. Updated frontend components to use the new enum and removed dead filter UI that referenced Purchase-only severity values.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageSeverity.cs` — new enum, namespace `Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts`
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageDto.cs` — `Severity` property retyped to `GiftPackageSeverity`, Purchase `using` removed
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs` — `CalculateSeverity` return type and values swapped to `GiftPackageSeverity`, Purchase `using` removed
+- `backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/CriticalGiftPackagesTile.cs` — `GiftPackageSeverity.Critical` reference, Purchase `using` removed
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — new `[Fact]` `Logistics_types_should_not_reference_Purchase_owned_namespaces`
+- `frontend/src/api/generated/api-client.ts` — regenerated; now contains `GiftPackageSeverity` alongside unchanged `StockSeverity`
+- `frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx` — imports `GiftPackageSeverity`, `GiftPackageSummary` trimmed to 4 fields, helpers trimmed to 3-value switch, console.log removed, missing sort cases added
+- `frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingSummary.tsx` — imports `GiftPackageSeverity`, dead Low/Overstocked/NotConfigured filter buttons removed from both compact and full views, unused `Settings` import removed
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — `Logistics_types_should_not_reference_Purchase_owned_namespaces` passes (0 violations)
+- Both architecture tests (Leaflet + Logistics) pass: 2/2
+
+## How to verify
+
+```bash
+# Backend build (0 errors)
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+
+# dotnet format (no changes needed)
+dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --verify-no-changes
+
+# Architecture tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Architecture.ModuleBoundariesTests"
+
+# Frontend build (clean)
+cd frontend && npm run build
+
+# Lint — modified files are clean; pre-existing errors in unrelated test files not introduced by this change
+npx eslint src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx \
+           src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingSummary.tsx
+
+# Verify no StockSeverity references remain in Logistics
+grep -r "StockSeverity" backend/src/Anela.Heblo.Application/Features/Logistics/
+# → should return empty
+
+# Verify GiftPackageSeverity exists in generated TS client
+grep "GiftPackageSeverity" frontend/src/api/generated/api-client.ts
+```
+
+## Notes
+
+- The arch-review noted that `JsonStringEnumConverter` is globally registered in `Program.cs`, so the wire format is string-based (`"Critical"`, `"Severe"`, `"Optimal"`). No per-enum `[JsonConverter]` attribute was needed.
+- The arch-review's recommended enum location (`UseCases/GiftPackageManufacture/Contracts/`) was used instead of the spec's `Features/Logistics/Contracts/` to keep vertical-slice cohesion.
+- The frontend `GiftPackageSummary` interface dropped `lowStockCount`, `overstockedCount`, `notConfiguredCount` as the backend never emits those values for gift packages.
+- `npm run lint` reports 97 pre-existing errors in terminal and leaflet test files — none in the files modified by this change.
+
+## PR Summary
+
+Removed the cross-module compile-time dependency from Logistics on Purchase's `StockSeverity` by introducing a Logistics-owned `GiftPackageSeverity` enum (Critical, Severe, Optimal). The Logistics module now owns its severity classification contract end-to-end; Purchase's enum is untouched. A new reflection-based architecture test enforces this boundary in CI, mirroring the existing Leaflet→KnowledgeBase test. The frontend was updated to use the regenerated client type and trimmed of dead filter UI that referenced Purchase-only severity buckets the gift-package backend never emits.
+
+### Changes
+- `GiftPackageSeverity.cs` — new Logistics-owned enum (3 members)
+- `GiftPackageDto.cs` — `Severity` property retyped; Purchase `using` removed
+- `GiftPackageManufactureService.cs` — `CalculateSeverity` swapped to `GiftPackageSeverity`
+- `CriticalGiftPackagesTile.cs` — `GiftPackageSeverity.Critical` reference; Purchase `using` removed
+- `ModuleBoundariesTests.cs` — `Logistics_types_should_not_reference_Purchase_owned_namespaces` fact added
+- `api-client.ts` — regenerated with `GiftPackageSeverity` enum
+- `GiftPackageManufacturingList.tsx` — 3-value type, trimmed helpers, fixed sort cases, removed console.log
+- `GiftPackageManufacturingSummary.tsx` — 3-value filter buttons, removed dead Low/Overstocked/NotConfigured UI
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-logistics-giftpackagedto-imp/spec.r1.md
+++ b/artifacts/feat-arch-review-logistics-giftpackagedto-imp/spec.r1.md
@@ -1,0 +1,127 @@
+# Specification: Remove Logistics → Purchase Module Coupling in GiftPackageDto
+
+## Summary
+The Logistics module's `GiftPackageDto` currently depends on the `StockSeverity` enum owned by the Purchase module, violating the architectural rule that modules must communicate only through their own contracts. This spec defines the work to introduce a Logistics-owned severity enum and refactor all references so the cross-module compile-time dependency is removed.
+
+## Background
+Per `docs/architecture/development_guidelines.md`, each Vertical Slice module owns its contracts and must not import types from another module's internal namespaces. Today:
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageDto.cs` imports `Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis` and exposes `StockSeverity Severity { get; set; }`.
+- `StockSeverity` is defined inside Purchase's use-case response class at `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/GetPurchaseStockAnalysis/GetPurchaseStockAnalysisResponse.cs:96`.
+- `GiftPackageManufactureService` also imports and uses the Purchase enum (lines 343, 349, 352).
+- A frontend tile component (`CriticalGiftPackagesTile`) consumes the severity through the generated TypeScript client and is therefore indirectly bound to the same shared type.
+
+The Manufacture module already follows the correct pattern with its own `ManufacturingStockSeverity` enum — Logistics should mirror that approach.
+
+If Purchase renames, restructures, or narrows the meaning of `StockSeverity`, Logistics breaks unnecessarily. Removing the coupling restores module independence and prevents future cross-module ripple effects.
+
+## Functional Requirements
+
+### FR-1: Introduce a Logistics-owned severity enum
+A new enum representing gift-package stock severity must exist inside the Logistics module's contracts namespace.
+
+**Acceptance criteria:**
+- A new file is created at `backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/GiftPackageSeverity.cs`.
+- The enum is declared as `namespace Anela.Heblo.Application.Features.Logistics.Contracts; public enum GiftPackageSeverity { Optimal, Severe, Critical }`.
+- The member ordering and underlying integer values match Purchase's `StockSeverity` so that any existing persisted/serialized values remain numerically equivalent.
+
+### FR-2: Update `GiftPackageDto` to use the new enum
+The Logistics DTO must stop importing Purchase types.
+
+**Acceptance criteria:**
+- `GiftPackageDto.cs` no longer contains `using Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis;`.
+- The `Severity` property is typed as `GiftPackageSeverity` (from `Anela.Heblo.Application.Features.Logistics.Contracts`).
+- `GiftPackageDto` remains a class (per project rule — DTOs are not records).
+
+### FR-3: Update `GiftPackageManufactureService` to use the new enum
+The Logistics application service must use the Logistics-owned enum end-to-end.
+
+**Acceptance criteria:**
+- All occurrences of `StockSeverity` inside `GiftPackageManufactureService` (currently lines 343, 349, 352) are replaced with `GiftPackageSeverity`.
+- The Purchase `using` import is removed from this file.
+- Any helper/mapping logic that previously produced `StockSeverity` now produces `GiftPackageSeverity`.
+
+### FR-4: Update frontend consumers to use the regenerated client type
+The frontend `CriticalGiftPackagesTile` (and any sibling components that read `GiftPackageDto.severity`) must compile and behave identically against the new enum exposed by the regenerated TypeScript client.
+
+**Acceptance criteria:**
+- After OpenAPI client regeneration, the frontend builds with no type errors.
+- The component's branching on severity values yields the same UI states (Optimal / Severe / Critical) as before the change.
+- No frontend code imports or references the old `StockSeverity` symbol.
+
+### FR-5: Verify no other Logistics code depends on Purchase's `StockSeverity`
+Eliminate any remaining cross-module reference originating from Logistics.
+
+**Acceptance criteria:**
+- A repo-wide search for `Features.Purchase.UseCases.GetPurchaseStockAnalysis` from inside `Features/Logistics/**` returns zero matches.
+- A repo-wide search for `StockSeverity` from inside `Features/Logistics/**` returns zero matches.
+
+### FR-6: Preserve Purchase's own `StockSeverity`
+Purchase continues to own and use its enum unchanged.
+
+**Acceptance criteria:**
+- `StockSeverity` remains defined at its current location in `GetPurchaseStockAnalysisResponse.cs` for use by Purchase's own use cases.
+- Purchase code is not modified by this change.
+
+### FR-7: Tests reflect the new enum
+Any existing unit/integration test that asserts on `GiftPackageDto.Severity` or related Logistics service behavior must reference `GiftPackageSeverity`.
+
+**Acceptance criteria:**
+- All affected tests compile and pass.
+- Test enum comparisons use the new Logistics-owned type.
+- If no tests exist for the relevant code paths today, none are required to be added by this refactor (see Out of Scope).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact is expected. The change is purely a type relocation; enum values map 1:1 and have identical underlying integer representation.
+
+### NFR-2: Security
+No security impact. No auth, input validation, or data sensitivity boundaries are altered.
+
+### NFR-3: Backward compatibility (serialization)
+Because the project rule states DTOs use class (not record) generation and the enum members and ordinal values are preserved, JSON serialization output is identical. Any in-flight client built against the previous generated client must continue to deserialize successfully after the OpenAPI client regeneration step.
+
+### NFR-4: Architectural conformance
+The Logistics module must have zero compile-time dependencies on the Purchase module after this change, as required by `docs/architecture/development_guidelines.md`.
+
+### NFR-5: Build and lint cleanliness
+`dotnet build` + `dotnet format` and `npm run build` + `npm run lint` must all pass with no new warnings introduced by the refactor.
+
+## Data Model
+No database schema changes. The only data-model change is the C# type identity of the `Severity` field on `GiftPackageDto`:
+
+- Before: `Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis.StockSeverity`
+- After: `Anela.Heblo.Application.Features.Logistics.Contracts.GiftPackageSeverity`
+
+Members and ordinals (`Optimal = 0`, `Severe = 1`, `Critical = 2`) are preserved.
+
+## API / Interface Design
+
+### Backend
+- The HTTP endpoint(s) returning `GiftPackageDto` keep identical JSON shape; the `severity` field's numeric values are unchanged.
+- The OpenAPI schema name for the severity enum will change (e.g., from `StockSeverity` to `GiftPackageSeverity`). Downstream generated TypeScript client will reflect this rename.
+
+### Frontend
+- Regenerate the TypeScript OpenAPI client as part of build.
+- Update `CriticalGiftPackagesTile` (and any other consumer) to import `GiftPackageSeverity` from the regenerated client.
+- No UI/UX changes; the rendered output for each severity level stays the same.
+
+## Dependencies
+- Project rule: OpenAPI TypeScript client is auto-generated on build (`docs/development/api-client-generation.md`).
+- Project rule: DTOs are classes, never C# records (`docs/architecture/development_guidelines.md`).
+- Existing Logistics feature `GiftPackageManufacture` and its tile component on the dashboard.
+- No new external libraries or services.
+
+## Out of Scope
+- Any refactor of Purchase module code, including `StockSeverity` itself.
+- Renaming or refactoring `ManufacturingStockSeverity` in the Manufacture module.
+- Introducing a shared cross-module "severity" abstraction in a common namespace — explicitly rejected, as it would re-create the coupling problem.
+- Adding new tests for previously untested code paths; only existing tests touched by the type change need updating.
+- Database migrations (none required).
+- Behavioral changes to gift-package severity classification thresholds or business logic.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-logistics-giftpackagedto-imp/task-plan.r1.md
+++ b/artifacts/feat-arch-review-logistics-giftpackagedto-imp/task-plan.r1.md
@@ -1,0 +1,780 @@
+# Terminal Transport Box Receive Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Příjem boxu" (Receive box) workflow to the mobile terminal subapp — scan a transport box barcode, view its contents/history, then Accept (receive into warehouse) or Reject (dismiss), with re-scanning the loaded box as a no-tap Accept shortcut.
+
+**Architecture:** A new terminal screen `TransportBoxReceive` reuses the box-detail UI introduced by PR #1298 (extracted into a shared component) and the existing `ScanInput`. Receiving is a `ChangeTransportBoxState` transition to `Received`; no backend changes. Reject is a pure client-side dismiss. The "receive" route, currently a `ComingSoonPage` stub, is wired to the new screen and its home-tile is activated.
+
+**Tech Stack:** React 18 + TypeScript, react-router-dom, @tanstack/react-query, Tailwind, lucide-react, Jest + React Testing Library.
+
+---
+
+## Context
+
+PR #1298 (`claude/mobile-terminal-barcode-scanner-ZNwkv`) introduced the terminal subapp and its first workflow — **Box check** (`TransportBoxCheck.tsx`): scan a box barcode, view contents/history in two tabs. This plan adds the **second** workflow, **Receive box**, built on top of PR #1298 *before it merges to main*.
+
+It mirrors the existing desktop receive page (`frontend/src/components/pages/TransportBoxReceive.tsx`): scan → load → Accept/Reject. The terminal version adds a scanner convenience: re-scanning the loaded box's barcode triggers Accept without tapping.
+
+### Branch
+
+> **IMPORTANT:** Base this work on `origin/claude/mobile-terminal-barcode-scanner-ZNwkv` (PR #1298), **not** `main`. Create the feature branch from it so the commits stack on the PR.
+
+```bash
+git fetch origin claude/mobile-terminal-barcode-scanner-ZNwkv
+git checkout -b feature/terminal-box-receive origin/claude/mobile-terminal-barcode-scanner-ZNwkv
+```
+
+### Domain facts (confirmed via codebase exploration)
+
+- **Receiving** = a `ChangeTransportBoxState` transition with `newState = TransportBoxState.Received`. There is no dedicated receive command/endpoint.
+- A box is receivable only from `InTransit`, `Reserve`, or `Quarantine`. The backend `TransportBoxDto` exposes a precomputed boolean **`isReceivable`**.
+- There is **no "Rejected" backend state**. Per product decision, **Reject = dismiss the box and return to scanning** (no backend call — like the desktop "Storno" button).
+- `useTransportBoxByCodeQuery(code)` (added by PR #1298, in `frontend/src/api/hooks/useTransportBoxes.ts`) loads a box by barcode; returns `TransportBoxDto | null` (`null` = not found).
+- `useChangeTransportBoxState()` (pre-existing, same file) performs the state change. Its `mutationFn` accepts `{ boxId, newState, description?, boxNumber?, location? }` and returns a mutation with `.mutateAsync` and `.isPending`.
+
+### Product decisions
+
+- **Reject**: dismiss box, return to scan-ready. No backend call.
+- **Non-receivable box** (`isReceivable !== true`): show a "Box nelze přijmout" message, render Accept disabled, keep Reject enabled. Re-scanning a non-receivable box does **not** trigger Accept.
+- **After a successful Accept**: show a brief success confirmation, then auto-clear back to scan-ready (~2.5 s).
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `frontend/src/components/terminal/TransportBoxDetail.tsx` | **new** — shared box-detail card + contents/history tabs, extracted from `TransportBoxCheck.tsx` (DRY) |
+| `frontend/src/components/terminal/TransportBoxCheck.tsx` | **modify** — import the extracted `BoxDetail`, drop the inlined copy |
+| `frontend/src/components/terminal/TransportBoxReceive.tsx` | **new** — the receive workflow screen |
+| `frontend/src/components/terminal/TerminalHome.tsx` | **modify** — activate the `receive` tile |
+| `frontend/src/App.tsx` | **modify** — route `receive` → `TransportBoxReceive` |
+| `frontend/src/components/terminal/__tests__/TransportBoxReceive.test.tsx` | **new** — unit tests |
+| `frontend/src/components/terminal/__tests__/TerminalHome.test.tsx` | **modify** — coming-soon count 3 → 2 |
+
+No backend changes. No new API hook. No OpenAPI regeneration.
+
+---
+
+## Task 1: Extract the shared `BoxDetail` component
+
+Pure refactor — `TransportBoxCheck.tsx` currently inlines `BoxDetail`, `ContentsTab`, `HistoryTab`, `formatDate`, `formatDateTime`. Move them into a shared file so the receive screen can reuse them. Behavior must not change; the existing `TransportBoxCheck.test.tsx` is the safety net.
+
+**Files:**
+- Create: `frontend/src/components/terminal/TransportBoxDetail.tsx`
+- Modify: `frontend/src/components/terminal/TransportBoxCheck.tsx`
+- Test (existing, must keep passing): `frontend/src/components/terminal/__tests__/TransportBoxCheck.test.tsx`
+
+- [ ] **Step 1: Create `TransportBoxDetail.tsx`**
+
+Create `frontend/src/components/terminal/TransportBoxDetail.tsx` with the exact content below (this is the inlined code from `TransportBoxCheck.tsx`, now with `BoxDetail` as the default export):
+
+```tsx
+import React, { useState } from 'react';
+import TransportBoxStateBadge from '../transport/box-detail/components/TransportBoxStateBadge';
+import {
+  TransportBoxDto,
+  TransportBoxItemDto,
+  TransportBoxStateLogDto,
+} from '../../api/generated/api-client';
+
+type Tab = 'contents' | 'history';
+
+const formatDate = (d?: Date): string =>
+  d ? new Date(d).toLocaleDateString('cs-CZ') : '—';
+
+const formatDateTime = (d?: Date): string =>
+  d
+    ? new Date(d).toLocaleString('cs-CZ', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : '—';
+
+const ContentsTab: React.FC<{ items: TransportBoxItemDto[] }> = ({ items }) => {
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-neutral-gray py-6 text-center">
+        Box neobsahuje žádné položky
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="bg-white border border-border-light rounded-xl p-3"
+        >
+          <div className="flex justify-between gap-2">
+            <span className="font-medium text-neutral-slate">
+              {item.productName}
+            </span>
+            <span className="font-semibold text-neutral-slate whitespace-nowrap">
+              {item.amount}
+            </span>
+          </div>
+          <div className="text-xs text-neutral-gray">{item.productCode}</div>
+          {(item.lotNumber || item.expirationDate) && (
+            <div className="text-xs text-neutral-gray mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+              {item.lotNumber && <span>Šarže: {item.lotNumber}</span>}
+              {item.expirationDate && (
+                <span>Expirace: {formatDate(item.expirationDate)}</span>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const HistoryTab: React.FC<{ log: TransportBoxStateLogDto[] }> = ({ log }) => {
+  if (log.length === 0) {
+    return (
+      <p className="text-sm text-neutral-gray py-6 text-center">
+        Žádná historie změn
+      </p>
+    );
+  }
+  const ordered = [...log].sort(
+    (a, b) =>
+      (b.stateDate ? new Date(b.stateDate).getTime() : 0) -
+      (a.stateDate ? new Date(a.stateDate).getTime() : 0),
+  );
+  return (
+    <div className="space-y-2">
+      {ordered.map((entry) => (
+        <div
+          key={entry.id}
+          className="bg-white border border-border-light rounded-xl p-3 space-y-1"
+        >
+          <div className="flex justify-between items-center gap-2">
+            <TransportBoxStateBadge state={entry.state ?? ''} size="sm" />
+            <span className="text-xs text-neutral-gray">
+              {formatDateTime(entry.stateDate)}
+            </span>
+          </div>
+          {entry.user && (
+            <div className="text-xs text-neutral-gray">{entry.user}</div>
+          )}
+          {entry.description && (
+            <div className="text-sm text-neutral-slate">{entry.description}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const BoxDetail: React.FC<{ box: TransportBoxDto }> = ({ box }) => {
+  const [activeTab, setActiveTab] = useState<Tab>('contents');
+  const items = box.items ?? [];
+  const log = box.stateLog ?? [];
+
+  const tabClass = (tab: Tab) =>
+    `flex-1 py-2 text-sm font-medium border-b-2 transition-colors ${
+      activeTab === tab
+        ? 'border-primary-blue text-primary-blue'
+        : 'border-transparent text-neutral-gray'
+    }`;
+
+  return (
+    <div className="space-y-3">
+      <div className="bg-white border border-border-light rounded-xl p-4 shadow-soft space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-lg font-bold text-neutral-slate">
+            {box.code}
+          </span>
+          <TransportBoxStateBadge state={box.state ?? ''} size="lg" />
+        </div>
+        {box.location && (
+          <div className="text-sm text-neutral-gray">
+            Umístění: {box.location}
+          </div>
+        )}
+        {box.description && (
+          <div className="text-sm text-neutral-slate">{box.description}</div>
+        )}
+        <div className="text-sm text-neutral-gray">
+          Počet položek: {items.length}
+        </div>
+      </div>
+
+      <div className="flex border-b border-border-light">
+        <button
+          type="button"
+          data-testid="tab-contents"
+          className={tabClass('contents')}
+          onClick={() => setActiveTab('contents')}
+        >
+          Obsah ({items.length})
+        </button>
+        <button
+          type="button"
+          data-testid="tab-history"
+          className={tabClass('history')}
+          onClick={() => setActiveTab('history')}
+        >
+          Historie ({log.length})
+        </button>
+      </div>
+
+      {activeTab === 'contents' ? (
+        <ContentsTab items={items} />
+      ) : (
+        <HistoryTab log={log} />
+      )}
+    </div>
+  );
+};
+
+export default BoxDetail;
+```
+
+- [ ] **Step 2: Replace `TransportBoxCheck.tsx` with the slimmed version**
+
+Overwrite `frontend/src/components/terminal/TransportBoxCheck.tsx` with:
+
+```tsx
+import React, { useState } from 'react';
+import { Loader2, PackageX } from 'lucide-react';
+import ScanInput from './ScanInput';
+import { useTransportBoxByCodeQuery } from '../../api/hooks/useTransportBoxes';
+import BoxDetail from './TransportBoxDetail';
+
+const TransportBoxCheck: React.FC = () => {
+  const [scannedCode, setScannedCode] = useState<string | null>(null);
+  const { data: box, isFetching } = useTransportBoxByCodeQuery(scannedCode);
+
+  const showNotFound = !!scannedCode && !isFetching && !box;
+
+  return (
+    <div className="space-y-4">
+      <div className="sticky top-0 z-10 bg-background-gray pb-3">
+        <ScanInput
+          label="Kód boxu"
+          onScan={setScannedCode}
+          suppressKeyboard
+          allowKeyboardToggle
+        />
+      </div>
+
+      {isFetching && (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-8 w-8 animate-spin text-primary-blue" />
+        </div>
+      )}
+
+      {showNotFound && (
+        <div
+          data-testid="box-not-found"
+          className="bg-white border border-border-light rounded-xl p-6 flex flex-col items-center text-center gap-2"
+        >
+          <PackageX className="h-10 w-10 text-neutral-gray" />
+          <p className="font-semibold text-neutral-slate">
+            Box {scannedCode} nenalezen
+          </p>
+          <p className="text-sm text-neutral-gray">
+            Zkontrolujte kód a naskenujte znovu
+          </p>
+        </div>
+      )}
+
+      {!isFetching && box && <BoxDetail box={box} />}
+    </div>
+  );
+};
+
+export default TransportBoxCheck;
+```
+
+- [ ] **Step 3: Run the existing box-check test to verify the refactor is behavior-neutral**
+
+Run: `cd frontend && npm test -- --watchAll=false TransportBoxCheck`
+Expected: PASS — all 4 `TransportBoxCheck` tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/terminal/TransportBoxDetail.tsx frontend/src/components/terminal/TransportBoxCheck.tsx
+git commit -m "refactor(terminal): extract shared BoxDetail component"
+```
+
+---
+
+## Task 2: Build the `TransportBoxReceive` screen (TDD)
+
+**Files:**
+- Create: `frontend/src/components/terminal/TransportBoxReceive.tsx`
+- Test: `frontend/src/components/terminal/__tests__/TransportBoxReceive.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/terminal/__tests__/TransportBoxReceive.test.tsx`. The mocking + fake-timer pattern mirrors `TransportBoxCheck.test.tsx`; the accept flow is async so it uses `await act(async () => ...)`.
+
+```tsx
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TransportBoxReceive from '../TransportBoxReceive';
+import {
+  useTransportBoxByCodeQuery,
+  useChangeTransportBoxState,
+} from '../../../api/hooks/useTransportBoxes';
+
+jest.mock('../../../api/hooks/useTransportBoxes', () => ({
+  useTransportBoxByCodeQuery: jest.fn(),
+  useChangeTransportBoxState: jest.fn(),
+}));
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+const mockByCode = useTransportBoxByCodeQuery as jest.Mock;
+const mockChangeState = useChangeTransportBoxState as jest.Mock;
+
+const receivableBox = {
+  id: 1,
+  code: 'B001',
+  state: 'InTransit',
+  isReceivable: true,
+  location: 'Kumbal',
+  items: [{ id: 10, productCode: 'MED001', productName: 'Obvazy', amount: 5 }],
+  stateLog: [{ id: 1, state: 'InTransit', stateDate: new Date('2026-05-10'), user: 'jan' }],
+};
+
+const nonReceivableBox = { ...receivableBox, state: 'Stocked', isReceivable: false };
+
+let mutateAsync: jest.Mock;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockByCode.mockReset();
+  mockChangeState.mockReset();
+  mutateAsync = jest.fn().mockResolvedValue({});
+  mockChangeState.mockReturnValue({ mutateAsync, isPending: false });
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+const scan = (code: string) => {
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: code } });
+  fireEvent.submit(screen.getByRole('textbox').closest('form')!);
+};
+
+const byCodeFor = (target: string, box: unknown) => (code: string | null) =>
+  code === target
+    ? { data: box, isFetching: false }
+    : { data: undefined, isFetching: false };
+
+describe('TransportBoxReceive', () => {
+  it('renders a focused scan input on mount', () => {
+    mockByCode.mockReturnValue({ data: undefined, isFetching: false });
+    render(<TransportBoxReceive />);
+    expect(screen.getByRole('textbox')).toHaveFocus();
+  });
+
+  it('shows box detail and an enabled Accept button after a receivable scan', () => {
+    mockByCode.mockImplementation(byCodeFor('B001', receivableBox));
+    render(<TransportBoxReceive />);
+    act(() => scan('b001'));
+
+    expect(screen.getByText('B001')).toBeInTheDocument();
+    expect(screen.getByText('Obvazy')).toBeInTheDocument();
+    expect(screen.getByTestId('accept-box')).toBeEnabled();
+    expect(screen.getByTestId('reject-box')).toBeEnabled();
+  });
+
+  it('accepts a box: calls the state-change mutation and shows the success banner', async () => {
+    mockByCode.mockImplementation(byCodeFor('B001', receivableBox));
+    render(<TransportBoxReceive />);
+    act(() => scan('B001'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('accept-box'));
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith({ boxId: 1, newState: 'Received' });
+    expect(screen.getByTestId('receive-success')).toBeInTheDocument();
+    expect(screen.getByText('Box B001 přijat')).toBeInTheDocument();
+  });
+
+  it('re-scanning the loaded box code triggers Accept without a tap', async () => {
+    mockByCode.mockImplementation(byCodeFor('B001', receivableBox));
+    render(<TransportBoxReceive />);
+    act(() => scan('B001'));
+
+    await act(async () => {
+      scan('B001');
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith({ boxId: 1, newState: 'Received' });
+  });
+
+  it('Reject clears the box without calling the backend', () => {
+    mockByCode.mockImplementation(byCodeFor('B001', receivableBox));
+    render(<TransportBoxReceive />);
+    act(() => scan('B001'));
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('reject-box'));
+    });
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(screen.queryByText('B001')).not.toBeInTheDocument();
+  });
+
+  it('disables Accept and shows a warning for a non-receivable box', () => {
+    mockByCode.mockImplementation(byCodeFor('B002', nonReceivableBox));
+    render(<TransportBoxReceive />);
+    act(() => scan('B002'));
+
+    expect(screen.getByTestId('accept-box')).toBeDisabled();
+    expect(screen.getByTestId('not-receivable')).toBeInTheDocument();
+
+    // re-scanning a non-receivable box must NOT trigger Accept
+    act(() => scan('B002'));
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('shows a not-found message for an unknown code', () => {
+    mockByCode.mockImplementation((code: string | null) =>
+      code ? { data: null, isFetching: false } : { data: undefined, isFetching: false },
+    );
+    render(<TransportBoxReceive />);
+    act(() => scan('B999'));
+
+    expect(screen.getByTestId('box-not-found')).toBeInTheDocument();
+    expect(screen.getByText('Box B999 nenalezen')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npm test -- --watchAll=false TransportBoxReceive`
+Expected: FAIL — `Cannot find module '../TransportBoxReceive'`.
+
+- [ ] **Step 3: Implement `TransportBoxReceive.tsx`**
+
+Create `frontend/src/components/terminal/TransportBoxReceive.tsx`:
+
+```tsx
+import React, { useEffect, useState } from 'react';
+import { Loader2, PackageX, Check, X, CheckCircle2 } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import ScanInput from './ScanInput';
+import BoxDetail from './TransportBoxDetail';
+import {
+  useTransportBoxByCodeQuery,
+  useChangeTransportBoxState,
+} from '../../api/hooks/useTransportBoxes';
+import { QUERY_KEYS } from '../../api/client';
+import { TransportBoxState } from '../../api/generated/api-client';
+
+const SUCCESS_DISPLAY_MS = 2500;
+
+const TransportBoxReceive: React.FC = () => {
+  const [scannedCode, setScannedCode] = useState<string | null>(null);
+  const [receivedCode, setReceivedCode] = useState<string | null>(null);
+
+  const queryClient = useQueryClient();
+  const { data: box, isFetching } = useTransportBoxByCodeQuery(scannedCode);
+  const changeState = useChangeTransportBoxState();
+
+  const showNotFound = !!scannedCode && !isFetching && !box;
+  const canReceive = box?.isReceivable === true;
+
+  // Auto-dismiss the success banner back to scan-ready.
+  useEffect(() => {
+    if (!receivedCode) return;
+    const timer = setTimeout(() => setReceivedCode(null), SUCCESS_DISPLAY_MS);
+    return () => clearTimeout(timer);
+  }, [receivedCode]);
+
+  const handleAccept = async () => {
+    if (!box || box.isReceivable !== true || changeState.isPending) return;
+    try {
+      await changeState.mutateAsync({
+        boxId: box.id!,
+        newState: TransportBoxState.Received,
+      });
+      // The byCode cache is stale after a receive — drop it so a re-scan refetches.
+      queryClient.invalidateQueries({
+        queryKey: [...QUERY_KEYS.transportBox, 'byCode'],
+      });
+      setReceivedCode(box.code ?? null);
+      setScannedCode(null);
+    } catch {
+      // Backend errors surface via the global toast handler; keep the box
+      // on screen so the user can retry.
+    }
+  };
+
+  const handleReject = () => {
+    setScannedCode(null);
+    setReceivedCode(null);
+  };
+
+  const handleScan = (value: string) => {
+    // Re-scanning the already-loaded receivable box acts as Accept.
+    if (box?.isReceivable === true && box.code === value && !changeState.isPending) {
+      void handleAccept();
+      return;
+    }
+    setReceivedCode(null);
+    setScannedCode(value);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="sticky top-0 z-10 bg-background-gray pb-3">
+        <ScanInput
+          label="Kód boxu"
+          onScan={handleScan}
+          loading={changeState.isPending}
+          suppressKeyboard
+          allowKeyboardToggle
+        />
+      </div>
+
+      {isFetching && (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-8 w-8 animate-spin text-primary-blue" />
+        </div>
+      )}
+
+      {receivedCode && !box && (
+        <div
+          data-testid="receive-success"
+          className="bg-green-50 border border-green-200 rounded-xl p-6 flex flex-col items-center text-center gap-2"
+        >
+          <CheckCircle2 className="h-10 w-10 text-green-600" />
+          <p className="font-semibold text-neutral-slate">
+            Box {receivedCode} přijat
+          </p>
+          <p className="text-sm text-neutral-gray">Naskenujte další box</p>
+        </div>
+      )}
+
+      {showNotFound && (
+        <div
+          data-testid="box-not-found"
+          className="bg-white border border-border-light rounded-xl p-6 flex flex-col items-center text-center gap-2"
+        >
+          <PackageX className="h-10 w-10 text-neutral-gray" />
+          <p className="font-semibold text-neutral-slate">
+            Box {scannedCode} nenalezen
+          </p>
+          <p className="text-sm text-neutral-gray">
+            Zkontrolujte kód a naskenujte znovu
+          </p>
+        </div>
+      )}
+
+      {!isFetching && box && (
+        <div className="space-y-3">
+          <BoxDetail box={box} />
+
+          {!canReceive && (
+            <div
+              data-testid="not-receivable"
+              className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700"
+            >
+              Tento box nelze přijmout. Pro příjem musí být ve stavu V přepravě,
+              V rezervě nebo V karanténě.
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              data-testid="reject-box"
+              onClick={handleReject}
+              className="flex-1 h-14 flex items-center justify-center gap-2 rounded-xl border border-border-light text-neutral-slate font-semibold hover:border-primary-blue transition-colors"
+            >
+              <X className="h-5 w-5" />
+              Zamítnout
+            </button>
+            <button
+              type="button"
+              data-testid="accept-box"
+              onClick={handleAccept}
+              disabled={!canReceive || changeState.isPending}
+              className="flex-1 h-14 flex items-center justify-center gap-2 rounded-xl bg-green-600 text-white font-semibold hover:bg-green-700 transition-colors disabled:bg-gray-200 disabled:text-neutral-gray disabled:cursor-not-allowed"
+            >
+              {changeState.isPending ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <Check className="h-5 w-5" />
+              )}
+              {canReceive ? 'Potvrdit příjem' : 'Nelze přijmout'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TransportBoxReceive;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npm test -- --watchAll=false TransportBoxReceive`
+Expected: PASS — all 7 `TransportBoxReceive` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/terminal/TransportBoxReceive.tsx frontend/src/components/terminal/__tests__/TransportBoxReceive.test.tsx
+git commit -m "feat(terminal): add transport box receive workflow screen"
+```
+
+---
+
+## Task 3: Wire the route and activate the home tile
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/terminal/TerminalHome.tsx`
+- Modify: `frontend/src/components/terminal/__tests__/TerminalHome.test.tsx`
+
+- [ ] **Step 1: Update the failing `TerminalHome` test first**
+
+In `frontend/src/components/terminal/__tests__/TerminalHome.test.tsx`, the `receive` tile is no longer a stub. Change the coming-soon count in the last test:
+
+Replace:
+```tsx
+  it('shows coming-soon label only on the stub tiles', () => {
+    renderHome();
+    const labels = screen.getAllByText('Brzy k dispozici');
+    expect(labels).toHaveLength(3);
+  });
+```
+With:
+```tsx
+  it('shows coming-soon label only on the stub tiles', () => {
+    renderHome();
+    const labels = screen.getAllByText('Brzy k dispozici');
+    expect(labels).toHaveLength(2);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npm test -- --watchAll=false TerminalHome`
+Expected: FAIL — "shows coming-soon label only on the stub tiles" expects 2 but receives 3 (the `receive` tile is still `comingSoon: true`).
+
+- [ ] **Step 3: Activate the `receive` tile in `TerminalHome.tsx`**
+
+In `frontend/src/components/terminal/TerminalHome.tsx`, in the `WORKFLOWS` array, change the `receive` entry's `comingSoon` flag.
+
+Replace:
+```tsx
+  {
+    id: 'receive',
+    title: 'Příjem boxu',
+    description: 'Naskenujte kód boxu a potvrďte příjem zásilky do skladu',
+    href: '/terminal/receive',
+    icon: Package,
+    comingSoon: true,
+  },
+```
+With:
+```tsx
+  {
+    id: 'receive',
+    title: 'Příjem boxu',
+    description: 'Naskenujte kód boxu a potvrďte příjem zásilky do skladu',
+    href: '/terminal/receive',
+    icon: Package,
+    comingSoon: false,
+  },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npm test -- --watchAll=false TerminalHome`
+Expected: PASS — all `TerminalHome` tests pass.
+
+- [ ] **Step 5: Wire the route in `App.tsx`**
+
+In `frontend/src/App.tsx`, add the import directly after the existing `TransportBoxCheck` import (line ~69):
+
+```tsx
+import TransportBoxReceive from "./components/terminal/TransportBoxReceive";
+```
+
+Then, in the terminal `<Route>` block, replace:
+```tsx
+                        <Route path="receive" element={<ComingSoonPage title="Příjem boxu" />} />
+```
+With:
+```tsx
+                        <Route path="receive" element={<TransportBoxReceive />} />
+```
+
+(Leave the `ComingSoonPage` import — it is still used by the `stocktake` and `lot-identification` routes.)
+
+- [ ] **Step 6: Verify the build compiles**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/components/terminal/TerminalHome.tsx frontend/src/components/terminal/__tests__/TerminalHome.test.tsx
+git commit -m "feat(terminal): wire receive route and activate home tile"
+```
+
+---
+
+## Task 4: Full verification
+
+**No new files — verification only.**
+
+- [ ] **Step 1: Lint**
+
+Run: `cd frontend && npm run lint`
+Expected: no errors.
+
+- [ ] **Step 2: Build**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Run all touched + new test suites**
+
+Run: `cd frontend && npm test -- --watchAll=false TransportBoxReceive TransportBoxCheck TerminalHome ScanInput`
+Expected: PASS — all suites green.
+
+- [ ] **Step 4: Manual smoke test**
+
+Start the app, open `/terminal`, tap **Příjem boxu**:
+- scan a receivable box (state `InTransit`/`Reserve`/`Quarantine`) → detail loads with contents/history tabs, Accept enabled;
+- tap **Potvrdit příjem** → success banner "Box <code> přijat", then auto-returns to scan-ready;
+- scan a box, then scan the same code again → box is received without tapping Accept;
+- tap **Zamítnout** → screen clears, no state change;
+- scan a non-receivable box (e.g. `Stocked`) → "Tento box nelze přijmout" message, Accept disabled;
+- scan an unknown code → "Box <code> nenalezen".
+
+- [ ] **Step 5: E2E (optional follow-up)**
+
+If `frontend/test/e2e/fixtures/test-data.ts` contains a receivable transport-box fixture, add a Playwright spec under `frontend/test/e2e/logistics/` covering scan → Accept and scan → Reject (auth via `navigateToApp()`). If no such fixture exists, note it as a follow-up — the E2E suite runs nightly, not in PR CI.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** scan + load (Task 2 Step 3 `handleScan`/`useTransportBoxByCodeQuery`); contents + history (Task 1 `BoxDetail`); Accept button → `Received` transition (Task 2); Reject = dismiss, no backend (Task 2 `handleReject`); re-scan-to-Accept (Task 2 `handleScan`); non-receivable handling + success confirmation (Task 2, product decisions); route + tile activation (Task 3). All covered.
+- **Placeholder scan:** no TBD/TODO; every code step contains complete code.
+- **Type consistency:** `BoxDetail` exported as default from `TransportBoxDetail.tsx`, imported as default in both `TransportBoxCheck.tsx` and `TransportBoxReceive.tsx`. `useChangeTransportBoxState().mutateAsync` is called with `{ boxId, newState }` — a subset of its `{ boxId, newState, description?, boxNumber?, location? }` signature (optional fields omitted). `TransportBoxState.Received` serializes to the string `"Received"`, matching the test's `expect(...).toHaveBeenCalledWith({ boxId: 1, newState: 'Received' })`. `isReceivable` is the boolean field on `TransportBoxDto`.

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/CriticalGiftPackagesTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/CriticalGiftPackagesTile.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.UseCases.GetAvailableGiftPackages;
-using Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using MediatR;
 
@@ -51,7 +51,7 @@ public class CriticalGiftPackagesTile : ITile
             }
 
             var criticalCount = response.GiftPackages
-                .Count(package => package.Severity == StockSeverity.Critical);
+                .Count(package => package.Severity == GiftPackageSeverity.Critical);
 
             return new
             {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageDto.cs
@@ -1,5 +1,3 @@
-using Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis;
-
 namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
 
 public class GiftPackageDto
@@ -11,7 +9,7 @@ public class GiftPackageDto
     public int OverstockOptimal { get; set; }
     public int OverstockMinimal { get; set; }
     public int SuggestedQuantity { get; set; }
-    public StockSeverity Severity { get; set; }
+    public GiftPackageSeverity Severity { get; set; }
     public decimal StockCoveragePercent { get; set; }
     public List<GiftPackageIngredientDto>? Ingredients { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageSeverity.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Contracts/GiftPackageSeverity.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
+
+public enum GiftPackageSeverity
+{
+    Critical,
+    Severe,
+    Optimal,
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Anela.Heblo.Application.Features.Catalog.Services;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
-using Anela.Heblo.Application.Features.Purchase.UseCases.GetPurchaseStockAnalysis;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.GiftPackageManufacture;
@@ -335,21 +334,21 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
         };
     }
 
-    private static StockSeverity CalculateSeverity(int availableStock, int suggestedQuantity, int overstockMinimal)
+    private static GiftPackageSeverity CalculateSeverity(int availableStock, int suggestedQuantity, int overstockMinimal)
     {
         // If less than minimal (in any case), then severity is Critical (red on UI)
         if (availableStock < overstockMinimal)
         {
-            return StockSeverity.Critical;
+            return GiftPackageSeverity.Critical;
         }
 
         // If suggestedQuantity < availableStock but greater than overstockMinimal, then severity is Severe (orange on UI)
         if (availableStock < suggestedQuantity)
         {
-            return StockSeverity.Severe;
+            return GiftPackageSeverity.Severe;
         }
 
-        return StockSeverity.Optimal;
+        return GiftPackageSeverity.Optimal;
     }
 
     private static decimal CalculateStockCoveragePercent(int availableStock, decimal dailySales, int overstockOptimal)

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -89,6 +89,76 @@ public class ModuleBoundariesTests
             "Found:\n  " + string.Join("\n  ", violations));
     }
 
+    [Fact]
+    public void Logistics_types_should_not_reference_Purchase_owned_namespaces()
+    {
+        const string LogisticsNamespacePrefix = "Anela.Heblo.Application.Features.Logistics";
+
+        var forbiddenPrefixes = new[]
+        {
+            "Anela.Heblo.Domain.Features.Purchase",
+            "Anela.Heblo.Application.Features.Purchase",
+            "Anela.Heblo.Persistence.Purchase",
+        };
+
+        var logisticsAllowlist = new HashSet<string>(StringComparer.Ordinal);
+
+        bool IsLogisticsForbidden(Type type)
+        {
+            if (type.Namespace is null)
+                return false;
+
+            foreach (var prefix in forbiddenPrefixes)
+            {
+                if (type.Namespace.Equals(prefix, StringComparison.Ordinal) ||
+                    type.Namespace.StartsWith(prefix + ".", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var logisticsTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null && t.Namespace.StartsWith(LogisticsNamespacePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var logisticsType in logisticsTypes)
+        {
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(logisticsType))
+            {
+                if (!IsLogisticsForbidden(referencedType))
+                    continue;
+
+                var entry = $"{logisticsType.FullName} -> {referencedType.FullName}";
+                if (logisticsAllowlist.Contains(entry))
+                    continue;
+
+                // Also check if the declaring type of a compiler-generated nested type is in the allowlist.
+                // For example, if "SomeHandler+<>c__DisplayClass3_0" references a forbidden type,
+                // check if "SomeHandler" references that same forbidden type.
+                var baseType = logisticsType.DeclaringType;
+                if (baseType is not null)
+                {
+                    var baseEntry = $"{baseType.FullName} -> {referencedType.FullName}";
+                    if (logisticsAllowlist.Contains(baseEntry))
+                        continue;
+                }
+
+                violations.Add($"{entry} (via {memberDescription})");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "Logistics types must not reference Purchase-owned namespaces. " +
+            "Define a Logistics-owned contract and avoid importing Purchase types. " +
+            "Found:\n  " + string.Join("\n  ", violations));
+    }
+
     private static bool IsForbidden(Type type)
     {
         if (type.Namespace is null)

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -2315,6 +2315,164 @@ export class ApiClient {
         return Promise.resolve<FileResponse>(null as any);
     }
 
+    eans_GetEans(lotId: number | null | undefined, materialCode: string | null | undefined, page: number | undefined, pageSize: number | undefined): Promise<ListEansResponse> {
+        let url_ = this.baseUrl + "/api/eans?";
+        if (lotId !== undefined && lotId !== null)
+            url_ += "lotId=" + encodeURIComponent("" + lotId) + "&";
+        if (materialCode !== undefined && materialCode !== null)
+            url_ += "materialCode=" + encodeURIComponent("" + materialCode) + "&";
+        if (page === null)
+            throw new Error("The parameter 'page' cannot be null.");
+        else if (page !== undefined)
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processEans_GetEans(_response);
+        });
+    }
+
+    protected processEans_GetEans(response: Response): Promise<ListEansResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ListEansResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ListEansResponse>(null as any);
+    }
+
+    eans_CreateEans(request: CreateEansRequest): Promise<CreateEansResponse> {
+        let url_ = this.baseUrl + "/api/eans";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processEans_CreateEans(_response);
+        });
+    }
+
+    protected processEans_CreateEans(response: Response): Promise<CreateEansResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = CreateEansResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<CreateEansResponse>(null as any);
+    }
+
+    eans_GetEanByCode(code: string): Promise<GetEanByCodeResponse> {
+        let url_ = this.baseUrl + "/api/eans/by-code/{code}";
+        if (code === undefined || code === null)
+            throw new Error("The parameter 'code' must be defined.");
+        url_ = url_.replace("{code}", encodeURIComponent("" + code));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processEans_GetEanByCode(_response);
+        });
+    }
+
+    protected processEans_GetEanByCode(response: Response): Promise<GetEanByCodeResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetEanByCodeResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetEanByCodeResponse>(null as any);
+    }
+
+    eans_DeleteEan(id: number): Promise<DeleteEanResponse> {
+        let url_ = this.baseUrl + "/api/eans/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processEans_DeleteEan(_response);
+        });
+    }
+
+    protected processEans_DeleteEan(response: Response): Promise<DeleteEanResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = DeleteEanResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<DeleteEanResponse>(null as any);
+    }
+
     expeditionListArchive_GetDates(page: number | undefined, pageSize: number | undefined): Promise<GetExpeditionDatesResponse> {
         let url_ = this.baseUrl + "/api/expedition-list-archive/dates?";
         if (page === null)
@@ -4962,6 +5120,207 @@ export class ApiClient {
         return Promise.resolve<GetManufactureLogResponse>(null as any);
     }
 
+    lots_GetLots(materialCode: string | null | undefined, expirationFrom: Date | null | undefined, expirationTo: Date | null | undefined, page: number | undefined, pageSize: number | undefined): Promise<ListLotsResponse> {
+        let url_ = this.baseUrl + "/api/lots?";
+        if (materialCode !== undefined && materialCode !== null)
+            url_ += "materialCode=" + encodeURIComponent("" + materialCode) + "&";
+        if (expirationFrom !== undefined && expirationFrom !== null)
+            url_ += "expirationFrom=" + encodeURIComponent(expirationFrom ? "" + expirationFrom.toISOString() : "") + "&";
+        if (expirationTo !== undefined && expirationTo !== null)
+            url_ += "expirationTo=" + encodeURIComponent(expirationTo ? "" + expirationTo.toISOString() : "") + "&";
+        if (page === null)
+            throw new Error("The parameter 'page' cannot be null.");
+        else if (page !== undefined)
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processLots_GetLots(_response);
+        });
+    }
+
+    protected processLots_GetLots(response: Response): Promise<ListLotsResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ListLotsResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ListLotsResponse>(null as any);
+    }
+
+    lots_CreateLot(request: CreateLotRequest): Promise<CreateLotResponse> {
+        let url_ = this.baseUrl + "/api/lots";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processLots_CreateLot(_response);
+        });
+    }
+
+    protected processLots_CreateLot(response: Response): Promise<CreateLotResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = CreateLotResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<CreateLotResponse>(null as any);
+    }
+
+    lots_GetLotById(id: number): Promise<GetLotResponse> {
+        let url_ = this.baseUrl + "/api/lots/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processLots_GetLotById(_response);
+        });
+    }
+
+    protected processLots_GetLotById(response: Response): Promise<GetLotResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetLotResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetLotResponse>(null as any);
+    }
+
+    lots_UpdateLot(id: number, request: UpdateLotRequest): Promise<UpdateLotResponse> {
+        let url_ = this.baseUrl + "/api/lots/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processLots_UpdateLot(_response);
+        });
+    }
+
+    protected processLots_UpdateLot(response: Response): Promise<UpdateLotResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = UpdateLotResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<UpdateLotResponse>(null as any);
+    }
+
+    lots_DeleteLot(id: number): Promise<DeleteLotResponse> {
+        let url_ = this.baseUrl + "/api/lots/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processLots_DeleteLot(_response);
+        });
+    }
+
+    protected processLots_DeleteLot(response: Response): Promise<DeleteLotResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = DeleteLotResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<DeleteLotResponse>(null as any);
+    }
+
     manufactureBatch_GetBatchTemplate(productCode: string): Promise<CalculatedBatchSizeResponse> {
         let url_ = this.baseUrl + "/api/manufacture-batch/template/{productCode}";
         if (productCode === undefined || productCode === null)
@@ -6382,6 +6741,328 @@ export class ApiClient {
             });
         }
         return Promise.resolve<ImportFromOutlookResponse>(null as any);
+    }
+
+    meetingTasks_List(statusFilter: string | null | undefined, pageNumber: number | undefined, pageSize: number | undefined): Promise<GetTranscriptListResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks?";
+        if (statusFilter !== undefined && statusFilter !== null)
+            url_ += "StatusFilter=" + encodeURIComponent("" + statusFilter) + "&";
+        if (pageNumber === null)
+            throw new Error("The parameter 'pageNumber' cannot be null.");
+        else if (pageNumber !== undefined)
+            url_ += "PageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === null)
+            throw new Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "PageSize=" + encodeURIComponent("" + pageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_List(_response);
+        });
+    }
+
+    protected processMeetingTasks_List(response: Response): Promise<GetTranscriptListResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetTranscriptListResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetTranscriptListResponse>(null as any);
+    }
+
+    meetingTasks_Users(): Promise<GetMeetingUsersResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/users";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_Users(_response);
+        });
+    }
+
+    protected processMeetingTasks_Users(response: Response): Promise<GetMeetingUsersResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetMeetingUsersResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetMeetingUsersResponse>(null as any);
+    }
+
+    meetingTasks_Detail(id: string): Promise<GetTranscriptDetailResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_Detail(_response);
+        });
+    }
+
+    protected processMeetingTasks_Detail(response: Response): Promise<GetTranscriptDetailResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GetTranscriptDetailResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GetTranscriptDetailResponse>(null as any);
+    }
+
+    meetingTasks_UpdateTask(transcriptId: string, taskId: string, request: UpdateProposedTaskRequest): Promise<UpdateProposedTaskResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/{transcriptId}/tasks/{taskId}";
+        if (transcriptId === undefined || transcriptId === null)
+            throw new Error("The parameter 'transcriptId' must be defined.");
+        url_ = url_.replace("{transcriptId}", encodeURIComponent("" + transcriptId));
+        if (taskId === undefined || taskId === null)
+            throw new Error("The parameter 'taskId' must be defined.");
+        url_ = url_.replace("{taskId}", encodeURIComponent("" + taskId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_UpdateTask(_response);
+        });
+    }
+
+    protected processMeetingTasks_UpdateTask(response: Response): Promise<UpdateProposedTaskResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = UpdateProposedTaskResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<UpdateProposedTaskResponse>(null as any);
+    }
+
+    meetingTasks_UpdateTaskStatus(transcriptId: string, taskId: string, request: UpdateProposedTaskStatusRequest): Promise<UpdateProposedTaskStatusResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/{transcriptId}/tasks/{taskId}/status";
+        if (transcriptId === undefined || transcriptId === null)
+            throw new Error("The parameter 'transcriptId' must be defined.");
+        url_ = url_.replace("{transcriptId}", encodeURIComponent("" + transcriptId));
+        if (taskId === undefined || taskId === null)
+            throw new Error("The parameter 'taskId' must be defined.");
+        url_ = url_.replace("{taskId}", encodeURIComponent("" + taskId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_UpdateTaskStatus(_response);
+        });
+    }
+
+    protected processMeetingTasks_UpdateTaskStatus(response: Response): Promise<UpdateProposedTaskStatusResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = UpdateProposedTaskStatusResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<UpdateProposedTaskStatusResponse>(null as any);
+    }
+
+    meetingTasks_AddTask(transcriptId: string, request: AddProposedTaskRequest): Promise<AddProposedTaskResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/{transcriptId}/tasks";
+        if (transcriptId === undefined || transcriptId === null)
+            throw new Error("The parameter 'transcriptId' must be defined.");
+        url_ = url_.replace("{transcriptId}", encodeURIComponent("" + transcriptId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_AddTask(_response);
+        });
+    }
+
+    protected processMeetingTasks_AddTask(response: Response): Promise<AddProposedTaskResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AddProposedTaskResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AddProposedTaskResponse>(null as any);
+    }
+
+    meetingTasks_Submit(transcriptId: string): Promise<SubmitToTodoResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/{transcriptId}/submit";
+        if (transcriptId === undefined || transcriptId === null)
+            throw new Error("The parameter 'transcriptId' must be defined.");
+        url_ = url_.replace("{transcriptId}", encodeURIComponent("" + transcriptId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "POST",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_Submit(_response);
+        });
+    }
+
+    protected processMeetingTasks_Submit(response: Response): Promise<SubmitToTodoResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = SubmitToTodoResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<SubmitToTodoResponse>(null as any);
+    }
+
+    meetingTasks_ExplainSummary(transcriptId: string, request: ExplainSummaryRequest): Promise<ExplainSummaryResponse> {
+        let url_ = this.baseUrl + "/api/meeting-tasks/{transcriptId}/explain";
+        if (transcriptId === undefined || transcriptId === null)
+            throw new Error("The parameter 'transcriptId' must be defined.");
+        url_ = url_.replace("{transcriptId}", encodeURIComponent("" + transcriptId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processMeetingTasks_ExplainSummary(_response);
+        });
+    }
+
+    protected processMeetingTasks_ExplainSummary(response: Response): Promise<ExplainSummaryResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ExplainSummaryResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ExplainSummaryResponse>(null as any);
     }
 
     orgChart_GetOrganizationStructure(): Promise<OrgChartResponse> {
@@ -8686,6 +9367,65 @@ export class ApiClient {
         return Promise.resolve<GetConversationResponse>(null as any);
     }
 
+    smartsupp_GenerateDraftReply(id: string, body: GenerateDraftReplyBody | undefined): Promise<GenerateDraftReplyResponse> {
+        let url_ = this.baseUrl + "/api/smartsupp/conversations/{id}/draft-reply";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSmartsupp_GenerateDraftReply(_response);
+        });
+    }
+
+    protected processSmartsupp_GenerateDraftReply(response: Response): Promise<GenerateDraftReplyResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = GenerateDraftReplyResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 503) {
+            return response.text().then((_responseText) => {
+            return throwException("A server side error occurred.", status, _responseText, _headers);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<GenerateDraftReplyResponse>(null as any);
+    }
+
     smartsupp_RunSync(request: RunManualSyncRequest | undefined): Promise<RunManualSyncResponse> {
         let url_ = this.baseUrl + "/api/smartsupp/sync";
         url_ = url_.replace(/[?&]$/, "");
@@ -9428,6 +10168,44 @@ export class ApiClient {
         }
         return Promise.resolve<GetTransportBoxByCodeResponse>(null as any);
     }
+
+    transportBox_OpenOrResumeBoxByCode(request: OpenOrResumeBoxByCodeRequest): Promise<OpenOrResumeBoxByCodeResponse> {
+        let url_ = this.baseUrl + "/api/transport-boxes/open-by-code";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processTransportBox_OpenOrResumeBoxByCode(_response);
+        });
+    }
+
+    protected processTransportBox_OpenOrResumeBoxByCode(response: Response): Promise<OpenOrResumeBoxByCodeResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = OpenOrResumeBoxByCodeResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<OpenOrResumeBoxByCodeResponse>(null as any);
+    }
 }
 
 export abstract class BaseResponse implements IBaseResponse {
@@ -9941,6 +10719,14 @@ export enum ErrorCodes {
     PhotobankTagNotFound = "PhotobankTagNotFound",
     PhotobankInvalidRegexPattern = "PhotobankInvalidRegexPattern",
     SmartsuppConversationNotFound = "SmartsuppConversationNotFound",
+    SmartsuppDraftReplyAiUnavailable = "SmartsuppDraftReplyAiUnavailable",
+    SmartsuppConversationEmpty = "SmartsuppConversationEmpty",
+    LotNotFound = "LotNotFound",
+    EanNotFound = "EanNotFound",
+    LotAlreadyExists = "LotAlreadyExists",
+    InventoryMaterialNotFound = "InventoryMaterialNotFound",
+    InventoryMaterialInvalidType = "InventoryMaterialInvalidType",
+    LotHasEans = "LotHasEans",
     ExternalServiceError = "ExternalServiceError",
     FlexiApiError = "FlexiApiError",
     ShoptetApiError = "ShoptetApiError",
@@ -14247,6 +15033,384 @@ export class Department implements IDepartment {
 export interface IDepartment {
     id?: string;
     name?: string;
+}
+
+export class ListEansResponse extends BaseResponse implements IListEansResponse {
+    eans?: EanDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+
+    constructor(data?: IListEansResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["eans"])) {
+                this.eans = [] as any;
+                for (let item of _data["eans"])
+                    this.eans!.push(EanDto.fromJS(item));
+            }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+        }
+    }
+
+    static override fromJS(data: any): ListEansResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new ListEansResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.eans)) {
+            data["eans"] = [];
+            for (let item of this.eans)
+                data["eans"].push(item.toJSON());
+        }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IListEansResponse extends IBaseResponse {
+    eans?: EanDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+}
+
+export class EanDto implements IEanDto {
+    id?: number;
+    code?: string;
+    lotId?: number;
+    amount?: number;
+    unit?: string;
+    createdAt?: Date;
+    createdBy?: string;
+
+    constructor(data?: IEanDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.code = _data["code"];
+            this.lotId = _data["lotId"];
+            this.amount = _data["amount"];
+            this.unit = _data["unit"];
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.createdBy = _data["createdBy"];
+        }
+    }
+
+    static fromJS(data: any): EanDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new EanDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["code"] = this.code;
+        data["lotId"] = this.lotId;
+        data["amount"] = this.amount;
+        data["unit"] = this.unit;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["createdBy"] = this.createdBy;
+        return data;
+    }
+}
+
+export interface IEanDto {
+    id?: number;
+    code?: string;
+    lotId?: number;
+    amount?: number;
+    unit?: string;
+    createdAt?: Date;
+    createdBy?: string;
+}
+
+export class GetEanByCodeResponse extends BaseResponse implements IGetEanByCodeResponse {
+    ean?: EanDto;
+    lot?: LotDto2;
+
+    constructor(data?: IGetEanByCodeResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.ean = _data["ean"] ? EanDto.fromJS(_data["ean"]) : <any>undefined;
+            this.lot = _data["lot"] ? LotDto2.fromJS(_data["lot"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): GetEanByCodeResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetEanByCodeResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["ean"] = this.ean ? this.ean.toJSON() : <any>undefined;
+        data["lot"] = this.lot ? this.lot.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetEanByCodeResponse extends IBaseResponse {
+    ean?: EanDto;
+    lot?: LotDto2;
+}
+
+export class LotDto2 implements ILotDto2 {
+    id?: number;
+    materialCode?: string;
+    lotCode?: string;
+    expiration?: Date | undefined;
+    receivedDate?: Date;
+    notes?: string | undefined;
+    createdAt?: Date;
+    createdBy?: string;
+    updatedAt?: Date | undefined;
+    updatedBy?: string | undefined;
+
+    constructor(data?: ILotDto2) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.materialCode = _data["materialCode"];
+            this.lotCode = _data["lotCode"];
+            this.expiration = _data["expiration"] ? new Date(_data["expiration"].toString()) : <any>undefined;
+            this.receivedDate = _data["receivedDate"] ? new Date(_data["receivedDate"].toString()) : <any>undefined;
+            this.notes = _data["notes"];
+            this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.createdBy = _data["createdBy"];
+            this.updatedAt = _data["updatedAt"] ? new Date(_data["updatedAt"].toString()) : <any>undefined;
+            this.updatedBy = _data["updatedBy"];
+        }
+    }
+
+    static fromJS(data: any): LotDto2 {
+        data = typeof data === 'object' ? data : {};
+        let result = new LotDto2();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["materialCode"] = this.materialCode;
+        data["lotCode"] = this.lotCode;
+        data["expiration"] = this.expiration ? formatDate(this.expiration) : <any>undefined;
+        data["receivedDate"] = this.receivedDate ? formatDate(this.receivedDate) : <any>undefined;
+        data["notes"] = this.notes;
+        data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["createdBy"] = this.createdBy;
+        data["updatedAt"] = this.updatedAt ? this.updatedAt.toISOString() : <any>undefined;
+        data["updatedBy"] = this.updatedBy;
+        return data;
+    }
+}
+
+export interface ILotDto2 {
+    id?: number;
+    materialCode?: string;
+    lotCode?: string;
+    expiration?: Date | undefined;
+    receivedDate?: Date;
+    notes?: string | undefined;
+    createdAt?: Date;
+    createdBy?: string;
+    updatedAt?: Date | undefined;
+    updatedBy?: string | undefined;
+}
+
+export class CreateEansResponse extends BaseResponse implements ICreateEansResponse {
+    eans?: EanDto[];
+
+    constructor(data?: ICreateEansResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["eans"])) {
+                this.eans = [] as any;
+                for (let item of _data["eans"])
+                    this.eans!.push(EanDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): CreateEansResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateEansResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.eans)) {
+            data["eans"] = [];
+            for (let item of this.eans)
+                data["eans"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface ICreateEansResponse extends IBaseResponse {
+    eans?: EanDto[];
+}
+
+export class CreateEansRequest implements ICreateEansRequest {
+    lotId?: number;
+    items?: CreateEanItem[];
+
+    constructor(data?: ICreateEansRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.lotId = _data["lotId"];
+            if (Array.isArray(_data["items"])) {
+                this.items = [] as any;
+                for (let item of _data["items"])
+                    this.items!.push(CreateEanItem.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): CreateEansRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateEansRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["lotId"] = this.lotId;
+        if (Array.isArray(this.items)) {
+            data["items"] = [];
+            for (let item of this.items)
+                data["items"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface ICreateEansRequest {
+    lotId?: number;
+    items?: CreateEanItem[];
+}
+
+export class CreateEanItem implements ICreateEanItem {
+    amount?: number;
+    unit?: string;
+
+    constructor(data?: ICreateEanItem) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.amount = _data["amount"];
+            this.unit = _data["unit"];
+        }
+    }
+
+    static fromJS(data: any): CreateEanItem {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateEanItem();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["amount"] = this.amount;
+        data["unit"] = this.unit;
+        return data;
+    }
+}
+
+export interface ICreateEanItem {
+    amount?: number;
+    unit?: string;
+}
+
+export class DeleteEanResponse extends BaseResponse implements IDeleteEanResponse {
+
+    constructor(data?: IDeleteEanResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): DeleteEanResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new DeleteEanResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IDeleteEanResponse extends IBaseResponse {
 }
 
 export class GetExpeditionDatesResponse extends BaseResponse implements IGetExpeditionDatesResponse {
@@ -19003,7 +20167,7 @@ export class GiftPackageDto implements IGiftPackageDto {
     overstockOptimal?: number;
     overstockMinimal?: number;
     suggestedQuantity?: number;
-    severity?: StockSeverity;
+    severity?: GiftPackageSeverity;
     stockCoveragePercent?: number;
     ingredients?: GiftPackageIngredientDto[] | undefined;
 
@@ -19070,18 +20234,15 @@ export interface IGiftPackageDto {
     overstockOptimal?: number;
     overstockMinimal?: number;
     suggestedQuantity?: number;
-    severity?: StockSeverity;
+    severity?: GiftPackageSeverity;
     stockCoveragePercent?: number;
     ingredients?: GiftPackageIngredientDto[] | undefined;
 }
 
-export enum StockSeverity {
+export enum GiftPackageSeverity {
     Critical = "Critical",
     Severe = "Severe",
-    Low = "Low",
     Optimal = "Optimal",
-    Overstocked = "Overstocked",
-    NotConfigured = "NotConfigured",
 }
 
 export class GiftPackageIngredientDto implements IGiftPackageIngredientDto {
@@ -19659,6 +20820,297 @@ export class GetManufactureLogResponse extends BaseResponse implements IGetManuf
 
 export interface IGetManufactureLogResponse extends IBaseResponse {
     manufactureLogs?: GiftPackageManufactureDto[];
+}
+
+export class ListLotsResponse extends BaseResponse implements IListLotsResponse {
+    lots?: LotDto2[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+
+    constructor(data?: IListLotsResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["lots"])) {
+                this.lots = [] as any;
+                for (let item of _data["lots"])
+                    this.lots!.push(LotDto2.fromJS(item));
+            }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+        }
+    }
+
+    static override fromJS(data: any): ListLotsResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new ListLotsResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.lots)) {
+            data["lots"] = [];
+            for (let item of this.lots)
+                data["lots"].push(item.toJSON());
+        }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IListLotsResponse extends IBaseResponse {
+    lots?: LotDto2[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+}
+
+export class GetLotResponse extends BaseResponse implements IGetLotResponse {
+    lot?: LotDto2;
+    eans?: EanDto[];
+
+    constructor(data?: IGetLotResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.lot = _data["lot"] ? LotDto2.fromJS(_data["lot"]) : <any>undefined;
+            if (Array.isArray(_data["eans"])) {
+                this.eans = [] as any;
+                for (let item of _data["eans"])
+                    this.eans!.push(EanDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetLotResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetLotResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["lot"] = this.lot ? this.lot.toJSON() : <any>undefined;
+        if (Array.isArray(this.eans)) {
+            data["eans"] = [];
+            for (let item of this.eans)
+                data["eans"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetLotResponse extends IBaseResponse {
+    lot?: LotDto2;
+    eans?: EanDto[];
+}
+
+export class CreateLotResponse extends BaseResponse implements ICreateLotResponse {
+    lot?: LotDto2;
+
+    constructor(data?: ICreateLotResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.lot = _data["lot"] ? LotDto2.fromJS(_data["lot"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): CreateLotResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateLotResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["lot"] = this.lot ? this.lot.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface ICreateLotResponse extends IBaseResponse {
+    lot?: LotDto2;
+}
+
+export class CreateLotRequest implements ICreateLotRequest {
+    materialCode?: string;
+    lotCode?: string;
+    expiration?: Date | undefined;
+    receivedDate?: Date;
+    notes?: string | undefined;
+
+    constructor(data?: ICreateLotRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.materialCode = _data["materialCode"];
+            this.lotCode = _data["lotCode"];
+            this.expiration = _data["expiration"] ? new Date(_data["expiration"].toString()) : <any>undefined;
+            this.receivedDate = _data["receivedDate"] ? new Date(_data["receivedDate"].toString()) : <any>undefined;
+            this.notes = _data["notes"];
+        }
+    }
+
+    static fromJS(data: any): CreateLotRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateLotRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["materialCode"] = this.materialCode;
+        data["lotCode"] = this.lotCode;
+        data["expiration"] = this.expiration ? formatDate(this.expiration) : <any>undefined;
+        data["receivedDate"] = this.receivedDate ? formatDate(this.receivedDate) : <any>undefined;
+        data["notes"] = this.notes;
+        return data;
+    }
+}
+
+export interface ICreateLotRequest {
+    materialCode?: string;
+    lotCode?: string;
+    expiration?: Date | undefined;
+    receivedDate?: Date;
+    notes?: string | undefined;
+}
+
+export class UpdateLotResponse extends BaseResponse implements IUpdateLotResponse {
+    lot?: LotDto2;
+
+    constructor(data?: IUpdateLotResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.lot = _data["lot"] ? LotDto2.fromJS(_data["lot"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): UpdateLotResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateLotResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["lot"] = this.lot ? this.lot.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUpdateLotResponse extends IBaseResponse {
+    lot?: LotDto2;
+}
+
+export class UpdateLotRequest implements IUpdateLotRequest {
+    id?: number;
+    expiration?: Date | undefined;
+    receivedDate?: Date;
+    notes?: string | undefined;
+
+    constructor(data?: IUpdateLotRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.expiration = _data["expiration"] ? new Date(_data["expiration"].toString()) : <any>undefined;
+            this.receivedDate = _data["receivedDate"] ? new Date(_data["receivedDate"].toString()) : <any>undefined;
+            this.notes = _data["notes"];
+        }
+    }
+
+    static fromJS(data: any): UpdateLotRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateLotRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["expiration"] = this.expiration ? formatDate(this.expiration) : <any>undefined;
+        data["receivedDate"] = this.receivedDate ? formatDate(this.receivedDate) : <any>undefined;
+        data["notes"] = this.notes;
+        return data;
+    }
+}
+
+export interface IUpdateLotRequest {
+    id?: number;
+    expiration?: Date | undefined;
+    receivedDate?: Date;
+    notes?: string | undefined;
+}
+
+export class DeleteLotResponse extends BaseResponse implements IDeleteLotResponse {
+
+    constructor(data?: IDeleteLotResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): DeleteLotResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new DeleteLotResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IDeleteLotResponse extends IBaseResponse {
 }
 
 export class CalculatedBatchSizeResponse extends BaseResponse implements ICalculatedBatchSizeResponse {
@@ -24587,6 +26039,726 @@ export interface IImportFromOutlookRequest {
     dryRun?: boolean;
 }
 
+export class GetTranscriptListResponse extends BaseResponse implements IGetTranscriptListResponse {
+    items?: MeetingTranscriptDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+
+    constructor(data?: IGetTranscriptListResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["items"])) {
+                this.items = [] as any;
+                for (let item of _data["items"])
+                    this.items!.push(MeetingTranscriptDto.fromJS(item));
+            }
+            this.totalCount = _data["totalCount"];
+            this.pageNumber = _data["pageNumber"];
+            this.pageSize = _data["pageSize"];
+            this.totalPages = _data["totalPages"];
+        }
+    }
+
+    static override fromJS(data: any): GetTranscriptListResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetTranscriptListResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.items)) {
+            data["items"] = [];
+            for (let item of this.items)
+                data["items"].push(item.toJSON());
+        }
+        data["totalCount"] = this.totalCount;
+        data["pageNumber"] = this.pageNumber;
+        data["pageSize"] = this.pageSize;
+        data["totalPages"] = this.totalPages;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetTranscriptListResponse extends IBaseResponse {
+    items?: MeetingTranscriptDto[];
+    totalCount?: number;
+    pageNumber?: number;
+    pageSize?: number;
+    totalPages?: number;
+}
+
+export class MeetingTranscriptDto implements IMeetingTranscriptDto {
+    id?: string;
+    plaudRecordingId?: string;
+    plaudCreatedAt?: Date;
+    subject?: string;
+    summary?: string;
+    rawTranscript?: string;
+    status?: string;
+    receivedAt?: Date;
+    reviewedAt?: Date | undefined;
+    reviewedByUser?: string | undefined;
+    taskCount?: number;
+    approvedTaskCount?: number;
+    rejectedTaskCount?: number;
+    tasks?: ProposedTaskDto[];
+
+    constructor(data?: IMeetingTranscriptDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.plaudRecordingId = _data["plaudRecordingId"];
+            this.plaudCreatedAt = _data["plaudCreatedAt"] ? new Date(_data["plaudCreatedAt"].toString()) : <any>undefined;
+            this.subject = _data["subject"];
+            this.summary = _data["summary"];
+            this.rawTranscript = _data["rawTranscript"];
+            this.status = _data["status"];
+            this.receivedAt = _data["receivedAt"] ? new Date(_data["receivedAt"].toString()) : <any>undefined;
+            this.reviewedAt = _data["reviewedAt"] ? new Date(_data["reviewedAt"].toString()) : <any>undefined;
+            this.reviewedByUser = _data["reviewedByUser"];
+            this.taskCount = _data["taskCount"];
+            this.approvedTaskCount = _data["approvedTaskCount"];
+            this.rejectedTaskCount = _data["rejectedTaskCount"];
+            if (Array.isArray(_data["tasks"])) {
+                this.tasks = [] as any;
+                for (let item of _data["tasks"])
+                    this.tasks!.push(ProposedTaskDto.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): MeetingTranscriptDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new MeetingTranscriptDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["plaudRecordingId"] = this.plaudRecordingId;
+        data["plaudCreatedAt"] = this.plaudCreatedAt ? this.plaudCreatedAt.toISOString() : <any>undefined;
+        data["subject"] = this.subject;
+        data["summary"] = this.summary;
+        data["rawTranscript"] = this.rawTranscript;
+        data["status"] = this.status;
+        data["receivedAt"] = this.receivedAt ? this.receivedAt.toISOString() : <any>undefined;
+        data["reviewedAt"] = this.reviewedAt ? this.reviewedAt.toISOString() : <any>undefined;
+        data["reviewedByUser"] = this.reviewedByUser;
+        data["taskCount"] = this.taskCount;
+        data["approvedTaskCount"] = this.approvedTaskCount;
+        data["rejectedTaskCount"] = this.rejectedTaskCount;
+        if (Array.isArray(this.tasks)) {
+            data["tasks"] = [];
+            for (let item of this.tasks)
+                data["tasks"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+export interface IMeetingTranscriptDto {
+    id?: string;
+    plaudRecordingId?: string;
+    plaudCreatedAt?: Date;
+    subject?: string;
+    summary?: string;
+    rawTranscript?: string;
+    status?: string;
+    receivedAt?: Date;
+    reviewedAt?: Date | undefined;
+    reviewedByUser?: string | undefined;
+    taskCount?: number;
+    approvedTaskCount?: number;
+    rejectedTaskCount?: number;
+    tasks?: ProposedTaskDto[];
+}
+
+export class ProposedTaskDto implements IProposedTaskDto {
+    id?: string;
+    title?: string;
+    description?: string;
+    assignee?: string;
+    assigneeEmail?: string | undefined;
+    dueDate?: Date | undefined;
+    status?: string;
+    externalTaskId?: string | undefined;
+    isManuallyAdded?: boolean;
+
+    constructor(data?: IProposedTaskDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.title = _data["title"];
+            this.description = _data["description"];
+            this.assignee = _data["assignee"];
+            this.assigneeEmail = _data["assigneeEmail"];
+            this.dueDate = _data["dueDate"] ? new Date(_data["dueDate"].toString()) : <any>undefined;
+            this.status = _data["status"];
+            this.externalTaskId = _data["externalTaskId"];
+            this.isManuallyAdded = _data["isManuallyAdded"];
+        }
+    }
+
+    static fromJS(data: any): ProposedTaskDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new ProposedTaskDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["title"] = this.title;
+        data["description"] = this.description;
+        data["assignee"] = this.assignee;
+        data["assigneeEmail"] = this.assigneeEmail;
+        data["dueDate"] = this.dueDate ? this.dueDate.toISOString() : <any>undefined;
+        data["status"] = this.status;
+        data["externalTaskId"] = this.externalTaskId;
+        data["isManuallyAdded"] = this.isManuallyAdded;
+        return data;
+    }
+}
+
+export interface IProposedTaskDto {
+    id?: string;
+    title?: string;
+    description?: string;
+    assignee?: string;
+    assigneeEmail?: string | undefined;
+    dueDate?: Date | undefined;
+    status?: string;
+    externalTaskId?: string | undefined;
+    isManuallyAdded?: boolean;
+}
+
+export class GetMeetingUsersResponse extends BaseResponse implements IGetMeetingUsersResponse {
+    users?: MeetingUserDto[];
+
+    constructor(data?: IGetMeetingUsersResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["users"])) {
+                this.users = [] as any;
+                for (let item of _data["users"])
+                    this.users!.push(MeetingUserDto.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GetMeetingUsersResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetMeetingUsersResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.users)) {
+            data["users"] = [];
+            for (let item of this.users)
+                data["users"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetMeetingUsersResponse extends IBaseResponse {
+    users?: MeetingUserDto[];
+}
+
+export class MeetingUserDto implements IMeetingUserDto {
+    email?: string;
+    displayName?: string;
+    aliases?: string[];
+
+    constructor(data?: IMeetingUserDto) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.email = _data["email"];
+            this.displayName = _data["displayName"];
+            if (Array.isArray(_data["aliases"])) {
+                this.aliases = [] as any;
+                for (let item of _data["aliases"])
+                    this.aliases!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): MeetingUserDto {
+        data = typeof data === 'object' ? data : {};
+        let result = new MeetingUserDto();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["email"] = this.email;
+        data["displayName"] = this.displayName;
+        if (Array.isArray(this.aliases)) {
+            data["aliases"] = [];
+            for (let item of this.aliases)
+                data["aliases"].push(item);
+        }
+        return data;
+    }
+}
+
+export interface IMeetingUserDto {
+    email?: string;
+    displayName?: string;
+    aliases?: string[];
+}
+
+export class GetTranscriptDetailResponse extends BaseResponse implements IGetTranscriptDetailResponse {
+    transcript?: MeetingTranscriptDto;
+
+    constructor(data?: IGetTranscriptDetailResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.transcript = _data["transcript"] ? MeetingTranscriptDto.fromJS(_data["transcript"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): GetTranscriptDetailResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GetTranscriptDetailResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transcript"] = this.transcript ? this.transcript.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGetTranscriptDetailResponse extends IBaseResponse {
+    transcript?: MeetingTranscriptDto;
+}
+
+export class UpdateProposedTaskResponse extends BaseResponse implements IUpdateProposedTaskResponse {
+
+    constructor(data?: IUpdateProposedTaskResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): UpdateProposedTaskResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateProposedTaskResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUpdateProposedTaskResponse extends IBaseResponse {
+}
+
+export class UpdateProposedTaskRequest implements IUpdateProposedTaskRequest {
+    transcriptId?: string;
+    taskId?: string;
+    title!: string;
+    description?: string;
+    assignee!: string;
+    assigneeEmail?: string | undefined;
+    dueDate?: Date | undefined;
+
+    constructor(data?: IUpdateProposedTaskRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.transcriptId = _data["transcriptId"];
+            this.taskId = _data["taskId"];
+            this.title = _data["title"];
+            this.description = _data["description"];
+            this.assignee = _data["assignee"];
+            this.assigneeEmail = _data["assigneeEmail"];
+            this.dueDate = _data["dueDate"] ? new Date(_data["dueDate"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): UpdateProposedTaskRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateProposedTaskRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transcriptId"] = this.transcriptId;
+        data["taskId"] = this.taskId;
+        data["title"] = this.title;
+        data["description"] = this.description;
+        data["assignee"] = this.assignee;
+        data["assigneeEmail"] = this.assigneeEmail;
+        data["dueDate"] = this.dueDate ? this.dueDate.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IUpdateProposedTaskRequest {
+    transcriptId?: string;
+    taskId?: string;
+    title: string;
+    description?: string;
+    assignee: string;
+    assigneeEmail?: string | undefined;
+    dueDate?: Date | undefined;
+}
+
+export class UpdateProposedTaskStatusResponse extends BaseResponse implements IUpdateProposedTaskStatusResponse {
+
+    constructor(data?: IUpdateProposedTaskStatusResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+    }
+
+    static override fromJS(data: any): UpdateProposedTaskStatusResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateProposedTaskStatusResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IUpdateProposedTaskStatusResponse extends IBaseResponse {
+}
+
+export class UpdateProposedTaskStatusRequest implements IUpdateProposedTaskStatusRequest {
+    transcriptId?: string;
+    taskId?: string;
+    status!: string;
+
+    constructor(data?: IUpdateProposedTaskStatusRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.transcriptId = _data["transcriptId"];
+            this.taskId = _data["taskId"];
+            this.status = _data["status"];
+        }
+    }
+
+    static fromJS(data: any): UpdateProposedTaskStatusRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateProposedTaskStatusRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transcriptId"] = this.transcriptId;
+        data["taskId"] = this.taskId;
+        data["status"] = this.status;
+        return data;
+    }
+}
+
+export interface IUpdateProposedTaskStatusRequest {
+    transcriptId?: string;
+    taskId?: string;
+    status: string;
+}
+
+export class AddProposedTaskResponse extends BaseResponse implements IAddProposedTaskResponse {
+    task?: ProposedTaskDto | undefined;
+
+    constructor(data?: IAddProposedTaskResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.task = _data["task"] ? ProposedTaskDto.fromJS(_data["task"]) : <any>undefined;
+        }
+    }
+
+    static override fromJS(data: any): AddProposedTaskResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new AddProposedTaskResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["task"] = this.task ? this.task.toJSON() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IAddProposedTaskResponse extends IBaseResponse {
+    task?: ProposedTaskDto | undefined;
+}
+
+export class AddProposedTaskRequest implements IAddProposedTaskRequest {
+    transcriptId?: string;
+    title!: string;
+    description?: string;
+    assignee!: string;
+    assigneeEmail?: string | undefined;
+    dueDate?: Date | undefined;
+
+    constructor(data?: IAddProposedTaskRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.transcriptId = _data["transcriptId"];
+            this.title = _data["title"];
+            this.description = _data["description"];
+            this.assignee = _data["assignee"];
+            this.assigneeEmail = _data["assigneeEmail"];
+            this.dueDate = _data["dueDate"] ? new Date(_data["dueDate"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): AddProposedTaskRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new AddProposedTaskRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transcriptId"] = this.transcriptId;
+        data["title"] = this.title;
+        data["description"] = this.description;
+        data["assignee"] = this.assignee;
+        data["assigneeEmail"] = this.assigneeEmail;
+        data["dueDate"] = this.dueDate ? this.dueDate.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+export interface IAddProposedTaskRequest {
+    transcriptId?: string;
+    title: string;
+    description?: string;
+    assignee: string;
+    assigneeEmail?: string | undefined;
+    dueDate?: Date | undefined;
+}
+
+export class SubmitToTodoResponse extends BaseResponse implements ISubmitToTodoResponse {
+    successCount?: number;
+    failedCount?: number;
+    errors?: string[];
+
+    constructor(data?: ISubmitToTodoResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.successCount = _data["successCount"];
+            this.failedCount = _data["failedCount"];
+            if (Array.isArray(_data["errors"])) {
+                this.errors = [] as any;
+                for (let item of _data["errors"])
+                    this.errors!.push(item);
+            }
+        }
+    }
+
+    static override fromJS(data: any): SubmitToTodoResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new SubmitToTodoResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["successCount"] = this.successCount;
+        data["failedCount"] = this.failedCount;
+        if (Array.isArray(this.errors)) {
+            data["errors"] = [];
+            for (let item of this.errors)
+                data["errors"].push(item);
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface ISubmitToTodoResponse extends IBaseResponse {
+    successCount?: number;
+    failedCount?: number;
+    errors?: string[];
+}
+
+export class ExplainSummaryResponse extends BaseResponse implements IExplainSummaryResponse {
+    relevantTranscript?: string;
+    explanation?: string;
+
+    constructor(data?: IExplainSummaryResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.relevantTranscript = _data["relevantTranscript"];
+            this.explanation = _data["explanation"];
+        }
+    }
+
+    static override fromJS(data: any): ExplainSummaryResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new ExplainSummaryResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["relevantTranscript"] = this.relevantTranscript;
+        data["explanation"] = this.explanation;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IExplainSummaryResponse extends IBaseResponse {
+    relevantTranscript?: string;
+    explanation?: string;
+}
+
+export class ExplainSummaryRequest implements IExplainSummaryRequest {
+    transcriptId?: string;
+    selectedText!: string;
+
+    constructor(data?: IExplainSummaryRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.transcriptId = _data["transcriptId"];
+            this.selectedText = _data["selectedText"];
+        }
+    }
+
+    static fromJS(data: any): ExplainSummaryRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new ExplainSummaryRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transcriptId"] = this.transcriptId;
+        data["selectedText"] = this.selectedText;
+        return data;
+    }
+}
+
+export interface IExplainSummaryRequest {
+    transcriptId?: string;
+    selectedText: string;
+}
+
 export class OrgChartResponse extends BaseResponse implements IOrgChartResponse {
     organization?: OrganizationDto;
 
@@ -28558,6 +30730,15 @@ export interface IStockAnalysisItemDto {
     isConfigured?: boolean;
 }
 
+export enum StockSeverity {
+    Critical = "Critical",
+    Severe = "Severe",
+    Low = "Low",
+    Optimal = "Optimal",
+    Overstocked = "Overstocked",
+    NotConfigured = "NotConfigured",
+}
+
 export class LastPurchaseInfoDto implements ILastPurchaseInfoDto {
     date?: Date;
     supplierName?: string;
@@ -29124,6 +31305,20 @@ export class ConversationDto implements IConversationDto {
     lastMessagePreview?: string | undefined;
     createdAt?: Date;
     updatedAt?: Date;
+    rating?: number | undefined;
+    ratingText?: string | undefined;
+    closeType?: string | undefined;
+    closedByAgentId?: string | undefined;
+    assignedAgentIds?: string[];
+    channel?: string | undefined;
+    isServed?: boolean;
+    finishedAt?: Date | undefined;
+    domain?: string | undefined;
+    referer?: string | undefined;
+    locationCountry?: string | undefined;
+    locationCity?: string | undefined;
+    locationCode?: string | undefined;
+    tags?: string[];
 
     constructor(data?: IConversationDto) {
         if (data) {
@@ -29147,6 +31342,28 @@ export class ConversationDto implements IConversationDto {
             this.lastMessagePreview = _data["lastMessagePreview"];
             this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
             this.updatedAt = _data["updatedAt"] ? new Date(_data["updatedAt"].toString()) : <any>undefined;
+            this.rating = _data["rating"];
+            this.ratingText = _data["ratingText"];
+            this.closeType = _data["closeType"];
+            this.closedByAgentId = _data["closedByAgentId"];
+            if (Array.isArray(_data["assignedAgentIds"])) {
+                this.assignedAgentIds = [] as any;
+                for (let item of _data["assignedAgentIds"])
+                    this.assignedAgentIds!.push(item);
+            }
+            this.channel = _data["channel"];
+            this.isServed = _data["isServed"];
+            this.finishedAt = _data["finishedAt"] ? new Date(_data["finishedAt"].toString()) : <any>undefined;
+            this.domain = _data["domain"];
+            this.referer = _data["referer"];
+            this.locationCountry = _data["locationCountry"];
+            this.locationCity = _data["locationCity"];
+            this.locationCode = _data["locationCode"];
+            if (Array.isArray(_data["tags"])) {
+                this.tags = [] as any;
+                for (let item of _data["tags"])
+                    this.tags!.push(item);
+            }
         }
     }
 
@@ -29170,6 +31387,28 @@ export class ConversationDto implements IConversationDto {
         data["lastMessagePreview"] = this.lastMessagePreview;
         data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
         data["updatedAt"] = this.updatedAt ? this.updatedAt.toISOString() : <any>undefined;
+        data["rating"] = this.rating;
+        data["ratingText"] = this.ratingText;
+        data["closeType"] = this.closeType;
+        data["closedByAgentId"] = this.closedByAgentId;
+        if (Array.isArray(this.assignedAgentIds)) {
+            data["assignedAgentIds"] = [];
+            for (let item of this.assignedAgentIds)
+                data["assignedAgentIds"].push(item);
+        }
+        data["channel"] = this.channel;
+        data["isServed"] = this.isServed;
+        data["finishedAt"] = this.finishedAt ? this.finishedAt.toISOString() : <any>undefined;
+        data["domain"] = this.domain;
+        data["referer"] = this.referer;
+        data["locationCountry"] = this.locationCountry;
+        data["locationCity"] = this.locationCity;
+        data["locationCode"] = this.locationCode;
+        if (Array.isArray(this.tags)) {
+            data["tags"] = [];
+            for (let item of this.tags)
+                data["tags"].push(item);
+        }
         return data;
     }
 }
@@ -29186,6 +31425,20 @@ export interface IConversationDto {
     lastMessagePreview?: string | undefined;
     createdAt?: Date;
     updatedAt?: Date;
+    rating?: number | undefined;
+    ratingText?: string | undefined;
+    closeType?: string | undefined;
+    closedByAgentId?: string | undefined;
+    assignedAgentIds?: string[];
+    channel?: string | undefined;
+    isServed?: boolean;
+    finishedAt?: Date | undefined;
+    domain?: string | undefined;
+    referer?: string | undefined;
+    locationCountry?: string | undefined;
+    locationCity?: string | undefined;
+    locationCode?: string | undefined;
+    tags?: string[];
 }
 
 export class GetConversationResponse extends BaseResponse implements IGetConversationResponse {
@@ -29239,6 +31492,13 @@ export class MessageDto implements IMessageDto {
     authorName?: string | undefined;
     content?: string | undefined;
     createdAt?: Date;
+    agentId?: string | undefined;
+    subType?: string | undefined;
+    deliveryStatus?: string | undefined;
+    deliveredAt?: Date | undefined;
+    responseTime?: number | undefined;
+    isFirstReply?: boolean;
+    pageUrl?: string | undefined;
 
     constructor(data?: IMessageDto) {
         if (data) {
@@ -29256,6 +31516,13 @@ export class MessageDto implements IMessageDto {
             this.authorName = _data["authorName"];
             this.content = _data["content"];
             this.createdAt = _data["createdAt"] ? new Date(_data["createdAt"].toString()) : <any>undefined;
+            this.agentId = _data["agentId"];
+            this.subType = _data["subType"];
+            this.deliveryStatus = _data["deliveryStatus"];
+            this.deliveredAt = _data["deliveredAt"] ? new Date(_data["deliveredAt"].toString()) : <any>undefined;
+            this.responseTime = _data["responseTime"];
+            this.isFirstReply = _data["isFirstReply"];
+            this.pageUrl = _data["pageUrl"];
         }
     }
 
@@ -29273,6 +31540,13 @@ export class MessageDto implements IMessageDto {
         data["authorName"] = this.authorName;
         data["content"] = this.content;
         data["createdAt"] = this.createdAt ? this.createdAt.toISOString() : <any>undefined;
+        data["agentId"] = this.agentId;
+        data["subType"] = this.subType;
+        data["deliveryStatus"] = this.deliveryStatus;
+        data["deliveredAt"] = this.deliveredAt ? this.deliveredAt.toISOString() : <any>undefined;
+        data["responseTime"] = this.responseTime;
+        data["isFirstReply"] = this.isFirstReply;
+        data["pageUrl"] = this.pageUrl;
         return data;
     }
 }
@@ -29283,11 +31557,149 @@ export interface IMessageDto {
     authorName?: string | undefined;
     content?: string | undefined;
     createdAt?: Date;
+    agentId?: string | undefined;
+    subType?: string | undefined;
+    deliveryStatus?: string | undefined;
+    deliveredAt?: Date | undefined;
+    responseTime?: number | undefined;
+    isFirstReply?: boolean;
+    pageUrl?: string | undefined;
+}
+
+export class GenerateDraftReplyResponse extends BaseResponse implements IGenerateDraftReplyResponse {
+    answer?: string;
+    sources?: DraftReplySource[];
+
+    constructor(data?: IGenerateDraftReplyResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.answer = _data["answer"];
+            if (Array.isArray(_data["sources"])) {
+                this.sources = [] as any;
+                for (let item of _data["sources"])
+                    this.sources!.push(DraftReplySource.fromJS(item));
+            }
+        }
+    }
+
+    static override fromJS(data: any): GenerateDraftReplyResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new GenerateDraftReplyResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["answer"] = this.answer;
+        if (Array.isArray(this.sources)) {
+            data["sources"] = [];
+            for (let item of this.sources)
+                data["sources"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IGenerateDraftReplyResponse extends IBaseResponse {
+    answer?: string;
+    sources?: DraftReplySource[];
+}
+
+export class DraftReplySource implements IDraftReplySource {
+    documentId?: string;
+    filename?: string;
+    excerpt?: string;
+    score?: number;
+
+    constructor(data?: IDraftReplySource) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.documentId = _data["documentId"];
+            this.filename = _data["filename"];
+            this.excerpt = _data["excerpt"];
+            this.score = _data["score"];
+        }
+    }
+
+    static fromJS(data: any): DraftReplySource {
+        data = typeof data === 'object' ? data : {};
+        let result = new DraftReplySource();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["documentId"] = this.documentId;
+        data["filename"] = this.filename;
+        data["excerpt"] = this.excerpt;
+        data["score"] = this.score;
+        return data;
+    }
+}
+
+export interface IDraftReplySource {
+    documentId?: string;
+    filename?: string;
+    excerpt?: string;
+    score?: number;
+}
+
+export class GenerateDraftReplyBody implements IGenerateDraftReplyBody {
+    topic?: string | undefined;
+
+    constructor(data?: IGenerateDraftReplyBody) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.topic = _data["topic"];
+        }
+    }
+
+    static fromJS(data: any): GenerateDraftReplyBody {
+        data = typeof data === 'object' ? data : {};
+        let result = new GenerateDraftReplyBody();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["topic"] = this.topic;
+        return data;
+    }
+}
+
+export interface IGenerateDraftReplyBody {
+    topic?: string | undefined;
 }
 
 export class RunManualSyncResponse extends BaseResponse implements IRunManualSyncResponse {
     conversationsProcessed?: number;
     messagesProcessed?: number;
+    conversationsReconciled?: number;
+    conversationsClosedRemotely?: number;
     startedAt?: Date;
     completedAt?: Date;
 
@@ -29300,6 +31712,8 @@ export class RunManualSyncResponse extends BaseResponse implements IRunManualSyn
         if (_data) {
             this.conversationsProcessed = _data["conversationsProcessed"];
             this.messagesProcessed = _data["messagesProcessed"];
+            this.conversationsReconciled = _data["conversationsReconciled"];
+            this.conversationsClosedRemotely = _data["conversationsClosedRemotely"];
             this.startedAt = _data["startedAt"] ? new Date(_data["startedAt"].toString()) : <any>undefined;
             this.completedAt = _data["completedAt"] ? new Date(_data["completedAt"].toString()) : <any>undefined;
         }
@@ -29316,6 +31730,8 @@ export class RunManualSyncResponse extends BaseResponse implements IRunManualSyn
         data = typeof data === 'object' ? data : {};
         data["conversationsProcessed"] = this.conversationsProcessed;
         data["messagesProcessed"] = this.messagesProcessed;
+        data["conversationsReconciled"] = this.conversationsReconciled;
+        data["conversationsClosedRemotely"] = this.conversationsClosedRemotely;
         data["startedAt"] = this.startedAt ? this.startedAt.toISOString() : <any>undefined;
         data["completedAt"] = this.completedAt ? this.completedAt.toISOString() : <any>undefined;
         super.toJSON(data);
@@ -29326,6 +31742,8 @@ export class RunManualSyncResponse extends BaseResponse implements IRunManualSyn
 export interface IRunManualSyncResponse extends IBaseResponse {
     conversationsProcessed?: number;
     messagesProcessed?: number;
+    conversationsReconciled?: number;
+    conversationsClosedRemotely?: number;
     startedAt?: Date;
     completedAt?: Date;
 }
@@ -30685,6 +33103,79 @@ export class GetTransportBoxByCodeResponse extends BaseResponse implements IGetT
 
 export interface IGetTransportBoxByCodeResponse extends IBaseResponse {
     transportBox?: TransportBoxDto | undefined;
+}
+
+export class OpenOrResumeBoxByCodeResponse extends BaseResponse implements IOpenOrResumeBoxByCodeResponse {
+    transportBox?: TransportBoxDto | undefined;
+    resumed?: boolean;
+
+    constructor(data?: IOpenOrResumeBoxByCodeResponse) {
+        super(data);
+    }
+
+    override init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.transportBox = _data["transportBox"] ? TransportBoxDto.fromJS(_data["transportBox"]) : <any>undefined;
+            this.resumed = _data["resumed"];
+        }
+    }
+
+    static override fromJS(data: any): OpenOrResumeBoxByCodeResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new OpenOrResumeBoxByCodeResponse();
+        result.init(data);
+        return result;
+    }
+
+    override toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transportBox"] = this.transportBox ? this.transportBox.toJSON() : <any>undefined;
+        data["resumed"] = this.resumed;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+export interface IOpenOrResumeBoxByCodeResponse extends IBaseResponse {
+    transportBox?: TransportBoxDto | undefined;
+    resumed?: boolean;
+}
+
+export class OpenOrResumeBoxByCodeRequest implements IOpenOrResumeBoxByCodeRequest {
+    boxCode?: string;
+
+    constructor(data?: IOpenOrResumeBoxByCodeRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.boxCode = _data["boxCode"];
+        }
+    }
+
+    static fromJS(data: any): OpenOrResumeBoxByCodeRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new OpenOrResumeBoxByCodeRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["boxCode"] = this.boxCode;
+        return data;
+    }
+}
+
+export interface IOpenOrResumeBoxByCodeRequest {
+    boxCode?: string;
 }
 
 function formatDate(d: Date) {

--- a/frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx
+++ b/frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
 import { useAvailableGiftPackages } from "../../../api/hooks/useGiftPackageManufacturing";
-import { StockSeverity } from "../../../api/generated/api-client";
+import { GiftPackageSeverity } from "../../../api/generated/api-client";
 import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
 import GiftPackageManufacturingFilters from "./GiftPackageManufacturingFilters";
 import GiftPackageManufacturingSummary from "./GiftPackageManufacturingSummary";
@@ -24,7 +24,7 @@ interface GiftPackageFilters {
   fromDate: Date;
   toDate: Date;
   searchTerm: string;
-  severity: StockSeverity | "All";
+  severity: GiftPackageSeverity | "All";
   pageNumber: number;
   pageSize: number;
   sortBy: GiftPackageSortBy;
@@ -50,7 +50,7 @@ interface GiftPackage {
   availableStock: number;
   dailySales: number;
   suggestedQuantity: number;
-  severity: StockSeverity;
+  severity: GiftPackageSeverity;
   overstockOptimal: number;
   overstockMinimal: number;
   stockCoveragePercent: number;
@@ -60,10 +60,7 @@ interface GiftPackageSummary {
   totalPackages: number;
   criticalCount: number;
   severeCount: number;
-  lowStockCount: number;
   optimalCount: number;
-  overstockedCount: number;
-  notConfiguredCount: number;
 }
 
 interface GiftPackageManufacturingListProps {
@@ -84,11 +81,11 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
   // State for filters - initialize from URL parameters
   const [filters, setFilters] = useState<GiftPackageFilters>(() => {
     const severityParam = searchParams.get('severity');
-    
-    // Map URL parameter directly to StockSeverity enum or "All"
-    let severityValue: StockSeverity | "All" = "All";
-    if (severityParam && Object.values(StockSeverity).includes(severityParam as StockSeverity)) {
-      severityValue = severityParam as StockSeverity;
+
+    // Map URL parameter directly to GiftPackageSeverity enum or "All"
+    let severityValue: GiftPackageSeverity | "All" = "All";
+    if (severityParam && Object.values(GiftPackageSeverity).includes(severityParam as GiftPackageSeverity)) {
+      severityValue = severityParam as GiftPackageSeverity;
     }
     
     return {
@@ -128,7 +125,7 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
       availableStock: pkg.availableStock ?? 0,
       dailySales: pkg.dailySales ?? 0,
       suggestedQuantity: pkg.suggestedQuantity ?? 0,
-      severity: pkg.severity ?? StockSeverity.NotConfigured,
+      severity: pkg.severity ?? GiftPackageSeverity.Optimal,
       overstockOptimal: pkg.overstockOptimal ?? 0,
       overstockMinimal: pkg.overstockMinimal ?? 0,
       stockCoveragePercent: pkg.stockCoveragePercent ?? 0,
@@ -137,12 +134,9 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
     // Calculate summary
     const summaryData: GiftPackageSummary = {
       totalPackages: packages.length,
-      criticalCount: packages.filter(p => p.severity === StockSeverity.Critical).length,
-      severeCount: packages.filter(p => p.severity === StockSeverity.Severe).length,
-      lowStockCount: packages.filter(p => p.severity === StockSeverity.Low).length,
-      optimalCount: packages.filter(p => p.severity === StockSeverity.Optimal).length,
-      overstockedCount: packages.filter(p => p.severity === StockSeverity.Overstocked).length,
-      notConfiguredCount: packages.filter(p => p.severity === StockSeverity.NotConfigured).length,
+      criticalCount: packages.filter(p => p.severity === GiftPackageSeverity.Critical).length,
+      severeCount: packages.filter(p => p.severity === GiftPackageSeverity.Severe).length,
+      optimalCount: packages.filter(p => p.severity === GiftPackageSeverity.Optimal).length,
     };
     
     return { giftPackages: packages, summary: summaryData };
@@ -169,15 +163,12 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
     // Apply sorting
     filtered.sort((a, b) => {
       // Helper function to get severity order
-      const getSeverityOrder = (severity: StockSeverity) => {
+      const getSeverityOrder = (severity: GiftPackageSeverity) => {
         switch (severity) {
-          case StockSeverity.Critical: return 0;
-          case StockSeverity.Severe: return 1;
-          case StockSeverity.Low: return 2;
-          case StockSeverity.Optimal: return 3;
-          case StockSeverity.Overstocked: return 4;
-          case StockSeverity.NotConfigured: return 5;
-          default: return 6;
+          case GiftPackageSeverity.Critical: return 0;
+          case GiftPackageSeverity.Severe: return 1;
+          case GiftPackageSeverity.Optimal: return 2;
+          default: return 3;
         }
       };
 
@@ -295,7 +286,7 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
   };
 
   // Handle severity filter click from summary cards
-  const handleSeverityFilterClick = (severity: StockSeverity | "All") => {
+  const handleSeverityFilterClick = (severity: GiftPackageSeverity | "All") => {
     handleFilterChange({ severity });
   };
 
@@ -331,44 +322,32 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
   };
 
   // Get row background color based on severity
-  const getRowColorClass = (severity: StockSeverity) => {
+  const getRowColorClass = (severity: GiftPackageSeverity) => {
     switch (severity) {
-      case StockSeverity.Critical:
+      case GiftPackageSeverity.Critical:
         return "bg-red-50/30 hover:bg-red-50/50";
-      case StockSeverity.Severe:
+      case GiftPackageSeverity.Severe:
         return "bg-orange-50/30 hover:bg-orange-50/50";
-      case StockSeverity.Low:
-        return "bg-amber-50/30 hover:bg-amber-50/50";
-      case StockSeverity.Optimal:
+      case GiftPackageSeverity.Optimal:
         return "bg-emerald-50/30 hover:bg-emerald-50/50";
-      case StockSeverity.Overstocked:
-        return "bg-blue-50/30 hover:bg-blue-50/50";
-      case StockSeverity.NotConfigured:
-        return "bg-gray-50/30 hover:bg-gray-50/50";
       default:
         return "hover:bg-gray-50";
     }
   };
   
   // Get color strip for severity
-  const getSeverityStripColor = (severity: StockSeverity) => {
+  const getSeverityStripColor = (severity: GiftPackageSeverity) => {
     if (filters.severity !== "All") {
       return "";
     }
 
     switch (severity) {
-      case StockSeverity.Critical:
+      case GiftPackageSeverity.Critical:
         return "bg-red-500";
-      case StockSeverity.Severe:
+      case GiftPackageSeverity.Severe:
         return "bg-orange-500";
-      case StockSeverity.Low:
-        return "bg-amber-500";
-      case StockSeverity.Optimal:
+      case GiftPackageSeverity.Optimal:
         return "bg-emerald-500";
-      case StockSeverity.Overstocked:
-        return "bg-blue-500";
-      case StockSeverity.NotConfigured:
-        return "bg-gray-400";
       default:
         return "";
     }
@@ -510,39 +489,12 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
                       </div>
                     </div>
                     <div className="flex items-start">
-                      <div className="w-3 h-3 bg-amber-200 rounded-sm mr-2 mt-0.5 flex-shrink-0"></div>
-                      <div>
-                        <span className="font-medium text-amber-200">
-                          Nízké:
-                        </span>{" "}
-                        Doporučuje se výroba
-                      </div>
-                    </div>
-                    <div className="flex items-start">
                       <div className="w-3 h-3 bg-emerald-200 rounded-sm mr-2 mt-0.5 flex-shrink-0"></div>
                       <div>
                         <span className="font-medium text-emerald-200">
                           Optimální:
                         </span>{" "}
                         Zásoby jsou v pořádku
-                      </div>
-                    </div>
-                    <div className="flex items-start">
-                      <div className="w-3 h-3 bg-blue-200 rounded-sm mr-2 mt-0.5 flex-shrink-0"></div>
-                      <div>
-                        <span className="font-medium text-blue-200">
-                          Přeskladněno:
-                        </span>{" "}
-                        Vysoké zásoby
-                      </div>
-                    </div>
-                    <div className="flex items-start">
-                      <div className="w-3 h-3 bg-gray-200 rounded-sm mr-2 mt-0.5 flex-shrink-0"></div>
-                      <div>
-                        <span className="font-medium text-gray-200">
-                          Nezkonfigurováno:
-                        </span>{" "}
-                        Chybí data o prodeji
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx
+++ b/frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingList.tsx
@@ -212,6 +212,14 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
           aValue = a.stockCoveragePercent;
           bValue = b.stockCoveragePercent;
           break;
+        case GiftPackageSortBy.OverstockOptimal:
+          aValue = a.overstockOptimal;
+          bValue = b.overstockOptimal;
+          break;
+        case GiftPackageSortBy.OverstockMinimal:
+          aValue = a.overstockMinimal;
+          bValue = b.overstockMinimal;
+          break;
         default:
           aValue = a.code;
           bValue = b.code;
@@ -281,9 +289,7 @@ const GiftPackageManufacturingList: React.FC<GiftPackageManufacturingListProps> 
   };
 
   // Export functionality (placeholder)
-  const handleExport = () => {
-    console.log("Export to CSV");
-  };
+  const handleExport = () => {};
 
   // Handle severity filter click from summary cards
   const handleSeverityFilterClick = (severity: GiftPackageSeverity | "All") => {

--- a/frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingSummary.tsx
+++ b/frontend/src/components/pages/GiftPackageManufacturing/GiftPackageManufacturingSummary.tsx
@@ -4,15 +4,14 @@ import {
   TrendingDown,
   CheckCircle,
   Package,
-  Settings,
 } from "lucide-react";
-import { StockSeverity } from "../../../api/generated/api-client";
+import { GiftPackageSeverity } from "../../../api/generated/api-client";
 import { GiftPackageSummary, GiftPackageFilters } from "./GiftPackageManufacturingList";
 
 interface GiftPackageManufacturingSummaryProps {
   summary: GiftPackageSummary;
   filters: GiftPackageFilters;
-  onSeverityFilterClick: (severity: StockSeverity | "All") => void;
+  onSeverityFilterClick: (severity: GiftPackageSeverity | "All") => void;
   compact?: boolean;
 }
 
@@ -40,9 +39,9 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
         </button>
         <span className="text-gray-400">|</span>
         <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Critical)}
+          onClick={() => onSeverityFilterClick(GiftPackageSeverity.Critical)}
           className={`px-1 py-0.5 rounded transition-colors hover:bg-red-50 ${
-            filters.severity === StockSeverity.Critical
+            filters.severity === GiftPackageSeverity.Critical
               ? "bg-red-50 ring-1 ring-red-300"
               : ""
           }`}
@@ -53,9 +52,9 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
           </span>
         </button>
         <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Severe)}
+          onClick={() => onSeverityFilterClick(GiftPackageSeverity.Severe)}
           className={`px-1 py-0.5 rounded transition-colors hover:bg-orange-50 ${
-            filters.severity === StockSeverity.Severe
+            filters.severity === GiftPackageSeverity.Severe
               ? "bg-orange-50 ring-1 ring-orange-300"
               : ""
           }`}
@@ -66,22 +65,9 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
           </span>
         </button>
         <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Low)}
-          className={`px-1 py-0.5 rounded transition-colors hover:bg-amber-50 ${
-            filters.severity === StockSeverity.Low
-              ? "bg-amber-50 ring-1 ring-amber-300"
-              : ""
-          }`}
-          title="Nízké zásoby"
-        >
-          <span className="text-amber-600 font-medium">
-            {summary.lowStockCount}
-          </span>
-        </button>
-        <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Optimal)}
+          onClick={() => onSeverityFilterClick(GiftPackageSeverity.Optimal)}
           className={`px-1 py-0.5 rounded transition-colors hover:bg-emerald-50 ${
-            filters.severity === StockSeverity.Optimal
+            filters.severity === GiftPackageSeverity.Optimal
               ? "bg-emerald-50 ring-1 ring-emerald-300"
               : ""
           }`}
@@ -117,9 +103,9 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
         </button>
 
         <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Critical)}
+          onClick={() => onSeverityFilterClick(GiftPackageSeverity.Critical)}
           className={`flex items-center px-2 py-1 rounded-md transition-colors hover:bg-red-50 ${
-            filters.severity === StockSeverity.Critical
+            filters.severity === GiftPackageSeverity.Critical
               ? "bg-red-50 ring-1 ring-red-300"
               : ""
           }`}
@@ -132,9 +118,9 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
         </button>
 
         <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Severe)}
+          onClick={() => onSeverityFilterClick(GiftPackageSeverity.Severe)}
           className={`flex items-center px-2 py-1 rounded-md transition-colors hover:bg-orange-50 ${
-            filters.severity === StockSeverity.Severe
+            filters.severity === GiftPackageSeverity.Severe
               ? "bg-orange-50 ring-1 ring-orange-300"
               : ""
           }`}
@@ -147,24 +133,9 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
         </button>
 
         <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Low)}
-          className={`flex items-center px-2 py-1 rounded-md transition-colors hover:bg-amber-50 ${
-            filters.severity === StockSeverity.Low
-              ? "bg-amber-50 ring-1 ring-amber-300"
-              : ""
-          }`}
-        >
-          <TrendingDown className="h-3 w-3 text-amber-500 mr-1" />
-          <span className="text-gray-600">Nízké:</span>
-          <span className="font-semibold text-amber-600 ml-1">
-            {summary.lowStockCount}
-          </span>
-        </button>
-
-        <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Optimal)}
+          onClick={() => onSeverityFilterClick(GiftPackageSeverity.Optimal)}
           className={`flex items-center px-2 py-1 rounded-md transition-colors hover:bg-emerald-50 ${
-            filters.severity === StockSeverity.Optimal
+            filters.severity === GiftPackageSeverity.Optimal
               ? "bg-emerald-50 ring-1 ring-emerald-300"
               : ""
           }`}
@@ -173,36 +144,6 @@ const GiftPackageManufacturingSummary: React.FC<GiftPackageManufacturingSummaryP
           <span className="text-gray-600">Optimální:</span>
           <span className="font-semibold text-green-600 ml-1">
             {summary.optimalCount}
-          </span>
-        </button>
-
-        <button
-          onClick={() => onSeverityFilterClick(StockSeverity.Overstocked)}
-          className={`flex items-center px-2 py-1 rounded-md transition-colors hover:bg-blue-50 ${
-            filters.severity === StockSeverity.Overstocked
-              ? "bg-blue-50 ring-1 ring-blue-300"
-              : ""
-          }`}
-        >
-          <Package className="h-3 w-3 text-blue-500 mr-1" />
-          <span className="text-gray-600">Přeskladněno:</span>
-          <span className="font-semibold text-blue-600 ml-1">
-            {summary.overstockedCount}
-          </span>
-        </button>
-
-        <button
-          onClick={() => onSeverityFilterClick(StockSeverity.NotConfigured)}
-          className={`flex items-center px-2 py-1 rounded-md transition-colors hover:bg-gray-50 ${
-            filters.severity === StockSeverity.NotConfigured
-              ? "bg-gray-50 ring-1 ring-gray-300"
-              : ""
-          }`}
-        >
-          <Settings className="h-3 w-3 text-gray-500 mr-1" />
-          <span className="text-gray-600">Nezkonfigurováno:</span>
-          <span className="font-semibold text-gray-600 ml-1">
-            {summary.notConfiguredCount}
           </span>
         </button>
       </div>


### PR DESCRIPTION

Removed the cross-module compile-time dependency from Logistics on Purchase's `StockSeverity` by introducing a Logistics-owned `GiftPackageSeverity` enum (Critical, Severe, Optimal). The Logistics module now owns its severity classification contract end-to-end; Purchase's enum is untouched. A new reflection-based architecture test enforces this boundary in CI, mirroring the existing Leaflet→KnowledgeBase test. The frontend was updated to use the regenerated client type and trimmed of dead filter UI that referenced Purchase-only severity buckets the gift-package backend never emits.

### Changes
- `GiftPackageSeverity.cs` — new Logistics-owned enum (3 members)
- `GiftPackageDto.cs` — `Severity` property retyped; Purchase `using` removed
- `GiftPackageManufactureService.cs` — `CalculateSeverity` swapped to `GiftPackageSeverity`
- `CriticalGiftPackagesTile.cs` — `GiftPackageSeverity.Critical` reference; Purchase `using` removed
- `ModuleBoundariesTests.cs` — `Logistics_types_should_not_reference_Purchase_owned_namespaces` fact added
- `api-client.ts` — regenerated with `GiftPackageSeverity` enum
- `GiftPackageManufacturingList.tsx` — 3-value type, trimmed helpers, fixed sort cases, removed console.log
- `GiftPackageManufacturingSummary.tsx` — 3-value filter buttons, removed dead Low/Overstocked/NotConfigured UI

---

Closes #1290

### Tokens used
22611271
