### PR TITLE
feat: Relocate ChangeTransportBoxState Request/Response into Use Case Subfolder

### DIFF
--- a/artifacts/feat-arch-review-logistics-changetransportbox/arch-review.r1.md
+++ b/artifacts/feat-arch-review-logistics-changetransportbox/arch-review.r1.md
@@ -1,0 +1,142 @@
+# Architecture Review: Relocate ChangeTransportBoxState Request/Response into Use Case Subfolder
+
+## Skip Design: true
+
+This is a structural refactor with no UI/UX surface — no visual components, no API contract change, no design decisions affecting user experience.
+
+## Architectural Fit Assessment
+
+The proposal **strengthens** alignment with the documented architecture. `docs/architecture/filesystem.md` (lines 99–110) explicitly defines the "Complex Features" pattern: each use case lives in `UseCases/{UseCaseName}/` containing `Handler.cs`, `Request.cs`, and `Response.cs`. All twelve sibling use cases in `Features/Logistics/UseCases/` already comply; only `ChangeTransportBoxState` has its handler in a subfolder while its DTOs remained at the root.
+
+Integration points (verified):
+- **Handler** (`UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`) already declares the target namespace and references the DTOs without a `using` (resolved via the implicit parent-namespace lookup C# performs from a nested namespace).
+- **Controller** `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs:6` carries `using Anela.Heblo.Application.Features.Logistics.UseCases;` solely to bind `ChangeTransportBoxStateRequest`/`Response` (line 81–83). Every other use case it consumes has its own per-use-case `using`.
+- **Tests** (3 files) similarly carry the bare `UseCases` import only for these two types.
+
+No deviation from existing conventions; this is convergence to the established pattern.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Features/Logistics/UseCases/
+├── AddItemToBox/                      ← pattern reference
+│   ├── AddItemToBoxHandler.cs
+│   ├── AddItemToBoxRequest.cs
+│   └── AddItemToBoxResponse.cs
+├── ChangeTransportBoxState/           ← target after refactor
+│   ├── ChangeTransportBoxStateHandler.cs    (unchanged)
+│   ├── ChangeTransportBoxStateRequest.cs    (MOVED + namespace updated)
+│   └── ChangeTransportBoxStateResponse.cs   (MOVED + namespace updated)
+├── CreateNewTransportBox/             ← pattern reference
+├── GetTransportBoxById/
+├── ...
+(no more stray files at UseCases/ root)
+```
+
+Compile-time consumers (must update `using` directives, no logic touch):
+```
+TransportBoxController ──┐
+ChangeTransportBoxStateHandlerTests ──┼──→ UseCases.ChangeTransportBoxState (new home)
+TransportBoxControllerTests ──┤
+TransportBoxUniquenessTests ──┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Use C# file-scoped namespace declaration
+**Options considered:** File-scoped (`namespace X;`) vs block-scoped (`namespace X { ... }`).
+**Chosen approach:** File-scoped, matching the current style of both files (line 4 in each is a file-scoped declaration) and the sibling handler.
+**Rationale:** Preserves the byte-level diff to just the namespace identifier; avoids reformatting the bodies and risking a `dotnet format` follow-up commit.
+
+#### Decision 2: Remove now-redundant `using Anela.Heblo.Application.Features.Logistics.UseCases;` directives where they are no longer needed
+**Options considered:** (a) Leave the orphaned `using` in place; (b) remove it from each consumer.
+**Chosen approach:** Remove it where it is no longer required (controller + 3 test files).
+**Rationale:** `dotnet format` removes unused usings by default in this repo's profile and would create churn on the next format run. Removing them now keeps the refactor self-contained and satisfies NFR-4 ("`dotnet format` must report no changes after the refactor"). Confirmed by inspection: in the controller, line 6 (`using ...UseCases;`) has no other consumer — all other use cases are imported via their own per-use-case `using` (lines 7–15).
+
+#### Decision 3: Do not modify `ChangeTransportBoxStateHandler.cs`
+**Options considered:** Add an explicit `using` for the DTOs to be defensive; leave handler untouched.
+**Chosen approach:** Leave it untouched.
+**Rationale:** The handler already sits in `UseCases.ChangeTransportBoxState`. After the move, the DTOs share that namespace, so C#'s implicit parent-namespace resolution still works and no `using` is needed. Adding one would be redundant and would create a phantom diff.
+
+#### Decision 4: Keep DTOs as classes (not records)
+**Options considered:** Convert to records during the move (they are immutable-shaped DTOs).
+**Chosen approach:** Keep as classes.
+**Rationale:** Project rule (CLAUDE.md, `docs/architecture/development_guidelines.md`): DTOs exposed via the OpenAPI generator must be classes — records cause parameter-order issues in the generated client. The spec correctly enforces this in §"Data Model".
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Move (preserve file content; only namespace line changes):
+
+| From | To |
+|------|----|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs` | `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs` | `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` |
+
+Use `git mv` so the move is tracked as a rename (history is preserved; reviewers see one rename + one-line namespace edit instead of delete+add).
+
+### Interfaces and Contracts
+
+**Unchanged:**
+- `class ChangeTransportBoxStateRequest : IRequest<ChangeTransportBoxStateResponse>` — same property set, same MediatR contract.
+- `class ChangeTransportBoxStateResponse : BaseResponse` — same property set, same base class.
+
+**Changed (C# only — not a public/wire contract):**
+- Namespace: `Anela.Heblo.Application.Features.Logistics.UseCases` → `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState` (matches sibling pattern and the handler at `ChangeTransportBoxStateHandler.cs:12`).
+
+### Data Flow
+
+Unchanged. Request travels: HTTP `POST /api/...` → `TransportBoxController.ChangeTransportBoxState` (`TransportBoxController.cs:81`) → `IMediator.Send` → `ChangeTransportBoxStateHandler.Handle` → `ChangeTransportBoxStateResponse`. The only difference post-refactor is the CLR namespace of the two DTO types involved — serialization, routing, and MediatR registration are unaffected.
+
+### Exact `using` edits required
+
+Four C# files need a minimal edit:
+
+| File | Edit |
+|------|------|
+| `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs` | Replace `using Anela.Heblo.Application.Features.Logistics.UseCases;` (line 6) with `using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;`. Keep `using` list alphabetically sorted (insert in correct position; other usings on lines 7–15 already follow alphabetical order). |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs` | Remove `using Anela.Heblo.Application.Features.Logistics.UseCases;` (line 2) — the `ChangeTransportBoxState` sub-namespace is already imported on line 3. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs` | Remove `using Anela.Heblo.Application.Features.Logistics.UseCases;` (line 3) — `ChangeTransportBoxState` sub-namespace already on line 4. |
+| `backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs` | Remove `using Anela.Heblo.Application.Features.Logistics.UseCases;` (line 3) — `ChangeTransportBoxState` sub-namespace already on line 4. |
+
+No edits to `ChangeTransportBoxStateHandler.cs` (it already lives in the target namespace).
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Stale build cache references the old namespace, masking missed call sites | Low | Run `dotnet clean && dotnet build` on the solution after the move; CI will catch any remaining unqualified reference. |
+| `dotnet format` introduces a follow-up diff (unused usings, sort order) | Low | Decision 2 above removes the now-unused usings as part of this change. After the edit run `dotnet format --verify-no-changes`. |
+| OpenAPI generator emits a different `$ref`/type name and the regenerated TS client diffs | Low | NSwag identifies DTOs by simple class name, not by CLR namespace. Class names (`ChangeTransportBoxStateRequest`, `ChangeTransportBoxStateResponse`) and property shapes are unchanged, so the spec must be byte-identical. Verify by running the Debug build's NSwag PostBuild and `git diff -- backend/src/Anela.Heblo.API.Client frontend/src/api/generated`. |
+| Reflection-based lookup (e.g., MediatR scanning, DI registration) breaks because of namespace change | Very low | MediatR scans assemblies by `IRequest<>`/`IRequestHandler<>` interfaces, not by namespace. The DI registration in `LogisticsModule` (if any) is by type, not by namespace string. No change needed. Confirm by full test pass. |
+| Another file accidentally relies on `using ...UseCases;` to reach an unrelated type co-located at the root | Very low | Verified: no other types remain in `UseCases/` root after the move; the directory listing shows only subfolders. The bare `using` becomes provably orphaned for all listed consumers. |
+| Git treats the move as delete+add, losing history | Low | Use `git mv` rather than copy/delete. CI should preserve `.gitattributes` rename detection (`-M` is default in `git log --follow`). |
+
+## Specification Amendments
+
+The spec is correct in every functional aspect. Three small additions for completeness:
+
+1. **§FR-4 Acceptance criteria — make Decision 2 explicit.** Add: "In `TransportBoxControllerTests.cs`, `ChangeTransportBoxStateHandlerTests.cs`, and `TransportBoxUniquenessTests.cs`, the bare `using Anela.Heblo.Application.Features.Logistics.UseCases;` directive is removed (it serves no other purpose after the move). In `TransportBoxController.cs`, the same bare directive is replaced with `using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;`."
+
+2. **§FR-3 — clarify Handler is intentionally untouched.** Add: "`ChangeTransportBoxStateHandler.cs` requires no change: it already declares `namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;` and resolves the DTOs implicitly via the shared namespace."
+
+3. **§NFR-4 — add explicit verification commands.** Add:
+   - `dotnet build` produces no errors or new warnings.
+   - `dotnet format --verify-no-changes` exits with code 0.
+   - `git diff -- backend/src/Anela.Heblo.API.Client frontend/src/api/generated` after a Debug build is empty.
+   - `dotnet test` for `backend/test/Anela.Heblo.Tests` passes with only the `using`-line diffs in the three test files.
+
+These are clarifications, not scope changes — the spec's intent is preserved.
+
+## Prerequisites
+
+None. The refactor is self-contained:
+
+- No database migration.
+- No infrastructure or configuration change.
+- No new package or dependency.
+- No regeneration of the OpenAPI client required to ship the change (it should produce no diff; if CI regenerates, the produced artifacts must be identical).
+- Branch is already isolated as a worktree (`feat-arch-review-logistics-changetransportbox`); proceed directly to implementation with `git mv` + four small `using` edits.

--- a/artifacts/feat-arch-review-logistics-changetransportbox/brief.md
+++ b/artifacts/feat-arch-review-logistics-changetransportbox/brief.md
@@ -1,0 +1,19 @@
+## Module
+Logistics
+
+## Finding
+The request and response for the `ChangeTransportBoxState` use case are located directly in the `UseCases/` root folder, breaking the pattern established by every other use case in the same module:
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs` — namespace: `Anela.Heblo.Application.Features.Logistics.UseCases` (line 4)
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs` — namespace: `Anela.Heblo.Application.Features.Logistics.UseCases` (line 4)
+
+The handler itself is correctly placed in `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`, as are all other use cases (`AddItemToBox/`, `CreateNewTransportBox/`, `GetTransportBoxById/`, etc.). The request and response are the only files that did not move into the subfolder.
+
+## Why it matters
+`filesystem.md` specifies that complex features place each use case in its own folder containing Handler, Request, and Response. The inconsistency makes the folder harder to navigate and the namespace mismatch (`UseCases` vs `UseCases.ChangeTransportBoxState`) makes the handler's `using` reference confusing compared to every other handler in the module.
+
+## Suggested fix
+Move the two files into `UseCases/ChangeTransportBoxState/` and update their namespaces from `Anela.Heblo.Application.Features.Logistics.UseCases` to `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState`. No logic changes required — only file location and namespace declaration.
+
+---
+_Filed by daily arch-review routine on 2026-05-15._

--- a/artifacts/feat-arch-review-logistics-changetransportbox/impl/main.r1.md
+++ b/artifacts/feat-arch-review-logistics-changetransportbox/impl/main.r1.md
@@ -1,0 +1,53 @@
+---
+
+# Implementation: Relocate ChangeTransportBoxState Request/Response into Use Case Subfolder
+
+## What was implemented
+
+A pure structural refactor bringing `ChangeTransportBoxStateRequest.cs` and `ChangeTransportBoxStateResponse.cs` from the `UseCases/` root into the `UseCases/ChangeTransportBoxState/` subfolder. The namespace declarations in both files were updated to match. Four consuming files had their `using` directives fixed.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` — moved here (was at `UseCases/`); namespace updated to `...UseCases.ChangeTransportBoxState`
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` — moved here; namespace updated
+- `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs` — bare `UseCases` using replaced with `UseCases.ChangeTransportBoxState`
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs` — orphaned bare `UseCases` using removed
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs` — orphaned bare `UseCases` using removed
+- `backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs` — orphaned bare `UseCases` using removed
+
+## Tests
+
+No new tests added (spec's FR-5 and §Out of Scope confirm existing tests are sufficient). All 3,313 pre-existing tests pass unchanged.
+
+## How to verify
+
+```bash
+cd /path/to/worktree
+git show HEAD --stat          # 6 files: 2 renames + 4 using edits
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+grep -r "using Anela.Heblo.Application.Features.Logistics.UseCases;" backend --include="*.cs"
+# Last command: zero matches expected
+```
+
+## Notes
+
+- `git mv` was used for both files so history is preserved as renames, not delete+add.
+- `ChangeTransportBoxStateHandler.cs` was intentionally left untouched — it already declares the target namespace and C# resolves the DTOs implicitly via the shared namespace.
+- OpenAPI/NSwag identifies DTOs by class name, not CLR namespace — generated TypeScript client is unchanged.
+
+## PR Summary
+
+Relocates `ChangeTransportBoxStateRequest` and `ChangeTransportBoxStateResponse` from the `UseCases/` root into the `ChangeTransportBoxState/` subfolder to match the per-use-case layout used by every other use case in the Logistics module. The handler was already correctly placed; only the two DTO files and four `using` directives in consuming files required changes.
+
+NSwag identifies DTOs by class name rather than CLR namespace, so the generated TypeScript client requires no changes.
+
+### Changes
+- `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` — moved from `UseCases/` root; namespace updated
+- `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` — moved from `UseCases/` root; namespace updated
+- `Controllers/TransportBoxController.cs` — bare `UseCases` import replaced with specific `UseCases.ChangeTransportBoxState` import
+- `Tests/.../TransportBoxControllerTests.cs`, `ChangeTransportBoxStateHandlerTests.cs`, `TransportBoxUniquenessTests.cs` — orphaned bare `UseCases` import removed
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-logistics-changetransportbox/spec.r1.md
+++ b/artifacts/feat-arch-review-logistics-changetransportbox/spec.r1.md
@@ -1,0 +1,96 @@
+# Specification: Relocate ChangeTransportBoxState Request/Response into Use Case Subfolder
+
+## Summary
+The `ChangeTransportBoxStateRequest` and `ChangeTransportBoxStateResponse` files currently live in the `UseCases/` root of the Logistics module, while every other use case (handler, request, response) is grouped under a per-use-case subfolder. This spec defines a surgical file move plus namespace rename that brings these two files into compliance with the established filesystem convention.
+
+## Background
+`docs/architecture/filesystem.md` mandates that complex features place each use case in its own folder containing `Handler`, `Request`, and `Response`. All sibling use cases in `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/` already follow this pattern (`AddItemToBox/`, `CreateNewTransportBox/`, `GetTransportBoxById/`, etc.). For `ChangeTransportBoxState`, the handler was correctly placed in its own subfolder, but the request and response files were left in the parent `UseCases/` folder with the parent namespace (`Anela.Heblo.Application.Features.Logistics.UseCases` instead of `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState`).
+
+This inconsistency:
+- Makes the Logistics `UseCases/` folder harder to navigate (two stray files at the root).
+- Forces the handler to reference a different namespace than every other handler in the module, which is confusing for readers and grep-based searches.
+- Drifts from the documented architecture, weakening enforcement for future contributions.
+
+## Functional Requirements
+
+### FR-1: Move request file into the use case subfolder
+Relocate `ChangeTransportBoxStateRequest.cs` from `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/` into `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/`.
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`.
+- File no longer exists at the previous location.
+- File contents are byte-identical to the original except for the namespace declaration (see FR-3).
+
+### FR-2: Move response file into the use case subfolder
+Relocate `ChangeTransportBoxStateResponse.cs` from `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/` into `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/`.
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs`.
+- File no longer exists at the previous location.
+- File contents are byte-identical to the original except for the namespace declaration (see FR-3).
+
+### FR-3: Update namespace declarations
+Change the namespace declaration in both relocated files from `Anela.Heblo.Application.Features.Logistics.UseCases` to `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState`.
+
+**Acceptance criteria:**
+- Both files declare `namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;` (or block form, matching the existing file style).
+- The new namespace matches that of `ChangeTransportBoxStateHandler.cs` in the same folder.
+
+### FR-4: Update all references to the moved types
+Every file in the solution (backend project + tests) that previously imported `Anela.Heblo.Application.Features.Logistics.UseCases` solely to reach `ChangeTransportBoxStateRequest` or `ChangeTransportBoxStateResponse` must be updated to import `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState` instead.
+
+**Acceptance criteria:**
+- No file references `Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxStateRequest` or `...ChangeTransportBoxStateResponse` under the old namespace.
+- The handler in `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` no longer requires a special `using` for these types (since they now share its namespace), unless other unrelated types still require it.
+- Existing `using` directives that were needed only for these two types are removed; directives required for other types remain untouched.
+- Controllers, tests, MediatR registrations, and any DI wiring referencing these types compile against the new namespace.
+
+### FR-5: Behavioural preservation
+The refactor is purely structural. No logic, contract, serialization, or API surface change is allowed.
+
+**Acceptance criteria:**
+- The HTTP endpoint(s) that drive `ChangeTransportBoxState` accept and return identical JSON payloads as before.
+- The generated OpenAPI specification is unchanged for any operation backed by these types (DTO names, properties, and order remain identical).
+- The generated TypeScript client requires no manual changes.
+- All pre-existing tests covering `ChangeTransportBoxState` pass without modification beyond `using` statements.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected or permitted. Runtime behaviour, allocations, and request handling cost must be identical.
+
+### NFR-2: Security
+No security surface change. Authentication, authorization attributes, and validation rules on the request/response are untouched.
+
+### NFR-3: Maintainability
+The resulting `UseCases/` folder layout must match the established pattern across the Logistics module (and the wider project), reducing cognitive load for navigation and grep-based discovery.
+
+### NFR-4: Build & tooling
+- Solution builds cleanly: `dotnet build` must succeed with no new warnings.
+- `dotnet format` must report no changes after the refactor (formatting preserved).
+- OpenAPI client regeneration must produce an identical TypeScript client; if regeneration runs in CI, it must not produce diffs.
+
+## Data Model
+No data model changes. The two DTO classes (`ChangeTransportBoxStateRequest`, `ChangeTransportBoxStateResponse`) retain their existing properties, types, and serialization behaviour. Per project rule, these remain plain classes (not C# records) because they are exposed via the OpenAPI client generator.
+
+## API / Interface Design
+No external API change. HTTP routes, verbs, request/response schemas, status codes, and error envelopes are preserved exactly. The only internal interface change is the C# namespace of the two DTO classes.
+
+## Dependencies
+- The existing `ChangeTransportBoxStateHandler` (already in `UseCases/ChangeTransportBoxState/`).
+- The MVC controller(s) and MediatR registration that wire this use case to its HTTP endpoint.
+- Any backend unit/integration tests targeting this use case.
+- The OpenAPI generation pipeline (must produce an unchanged spec).
+
+## Out of Scope
+- Any change to the use case's logic, validation, or state-transition rules.
+- Renaming the request/response classes or properties.
+- Auditing other modules for similar inconsistencies — this spec covers only `ChangeTransportBoxState` in the Logistics module.
+- Adding new tests; existing tests are sufficient since behaviour does not change.
+- Converting the DTOs between class and record forms.
+- Frontend or generated TypeScript client edits (regeneration alone, if any, must produce no diff).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-logistics-changetransportbox/task-plan.r1.md
+++ b/artifacts/feat-arch-review-logistics-changetransportbox/task-plan.r1.md
@@ -1,0 +1,565 @@
+# Relocate ChangeTransportBoxState Request/Response Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `ChangeTransportBoxStateRequest.cs` and `ChangeTransportBoxStateResponse.cs` from `Features/Logistics/UseCases/` into the `ChangeTransportBoxState/` subfolder (matching every other use case in the module), update the namespace declaration in both files, and fix `using` directives in the four consuming files so the solution still builds and tests still pass.
+
+**Architecture:** Pure structural refactor. No logic, contract, serialization, MediatR, DI, OpenAPI, or HTTP-surface changes. Use `git mv` to preserve history. The handler at `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` already lives in the target namespace and is intentionally left untouched — C# resolves the relocated DTOs implicitly via the shared namespace.
+
+**Tech Stack:** .NET 8, C# 12 file-scoped namespaces, MediatR, xUnit, FluentAssertions, NSwag (OpenAPI generator), `dotnet format`.
+
+---
+
+## File Structure
+
+**Moved (file body untouched except the `namespace` line — one-line edit):**
+
+| From | To |
+|------|----|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs` | `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs` | `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` |
+
+**Edited (using-directive only):**
+
+| File | Edit |
+|------|------|
+| `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs` | Replace bare `UseCases` using with `UseCases.ChangeTransportBoxState` using. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs` | Remove bare `UseCases` using (sub-namespace already imported). |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs` | Remove bare `UseCases` using (sub-namespace already imported). |
+| `backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs` | Remove bare `UseCases` using (sub-namespace already imported). |
+
+**Untouched (handler already in target namespace):**
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`
+
+---
+
+## Task 1: Verify baseline (clean build + tests pass before any change)
+
+**Why:** Confirms the worktree starts in a known-good state so any later failure is attributable to this refactor.
+
+**Files:** None edited.
+
+- [ ] **Step 1: Build the backend solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Note the warning count — it must not increase after the refactor.
+
+- [ ] **Step 2: Run the test project that covers these DTOs**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: All tests pass (no failures, no skips related to ChangeTransportBoxState).
+
+- [ ] **Step 3: Confirm `dotnet format` is clean on the baseline**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0` with no output. (If non-zero, stop and report — refactor must not start from a dirty formatting state.)
+
+- [ ] **Step 4: Confirm working tree is clean**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: empty output. No commit at this step — this task only validates the baseline.
+
+---
+
+## Task 2: Move `ChangeTransportBoxStateRequest.cs` with `git mv`
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs` → `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`
+
+- [ ] **Step 1: Move the file with `git mv`**
+
+Run:
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs
+```
+
+Expected: no output, exit code `0`.
+
+- [ ] **Step 2: Verify the move is staged as a rename**
+
+Run:
+
+```bash
+git status
+```
+
+Expected: under "Changes to be committed", a single line `renamed: ...UseCases/ChangeTransportBoxStateRequest.cs -> ...UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`. No "deleted" + "new file" pair.
+
+- [ ] **Step 3: Update the namespace in the moved file**
+
+The file currently reads (line 4):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases;
+```
+
+Edit `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` to:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+```
+
+Leave every other line (using directives, class declaration, properties) byte-identical.
+
+The full expected file content after the edit:
+
+```csharp
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+
+public class ChangeTransportBoxStateRequest : IRequest<ChangeTransportBoxStateResponse>
+{
+    public int BoxId { get; set; }
+    public TransportBoxState NewState { get; set; }
+    public string? Description { get; set; }
+    public string? BoxCode { get; set; }
+    public string? Location { get; set; }
+}
+```
+
+- [ ] **Step 4: Verify the diff is minimal (rename + one-line namespace edit)**
+
+Run:
+
+```bash
+git diff --staged --stat
+```
+
+Expected: one renamed file with a tiny diff size. Then:
+
+```bash
+git diff --staged backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs
+```
+
+Expected: a single hunk changing the namespace from `...UseCases;` to `...UseCases.ChangeTransportBoxState;`. Nothing else.
+
+- [ ] **Step 5: Do NOT build yet** — the controller still has the old `using` and would fail. Proceed straight to Task 3 to keep the staged changeset small but cohesive.
+
+No commit in this task — Task 2 + Task 3 are committed together at the end of Task 3 since the build is only green when both moves and their namespace updates are done.
+
+---
+
+## Task 3: Move `ChangeTransportBoxStateResponse.cs` with `git mv`
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs` → `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs`
+
+- [ ] **Step 1: Move the file with `git mv`**
+
+Run:
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs
+```
+
+Expected: no output, exit code `0`.
+
+- [ ] **Step 2: Verify the move is staged as a rename**
+
+Run:
+
+```bash
+git status
+```
+
+Expected: a second `renamed: ...` line for the response file, in addition to the request rename from Task 2.
+
+- [ ] **Step 3: Update the namespace in the moved file**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` so its line-4 namespace becomes the sub-namespace.
+
+The full expected file content after the edit:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+
+public class ChangeTransportBoxStateResponse : BaseResponse
+{
+    public GetTransportBoxByIdResponse? UpdatedBox { get; set; }
+}
+```
+
+Every line other than the namespace declaration must be byte-identical to the original.
+
+- [ ] **Step 4: Verify the response-file diff is minimal**
+
+Run:
+
+```bash
+git diff --staged backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs
+```
+
+Expected: a single hunk changing only the namespace line.
+
+- [ ] **Step 5: Confirm no stray files remain at the `UseCases/` root**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/
+```
+
+Expected: only subfolders (`AddItemToBox`, `ChangeTransportBoxState`, `CreateNewTransportBox`, `GetTransportBoxByCode`, `GetTransportBoxById`, `GetTransportBoxSummary`, `GetTransportBoxes`, `GiftPackageManufacture`, `OpenOrResumeBoxByCode`, `RemoveItemFromBox`, `UpdateTransportBoxDescription`). No `.cs` files at the top level.
+
+- [ ] **Step 6: Confirm both files now sit inside the use case subfolder**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/
+```
+
+Expected exactly three files:
+
+```
+ChangeTransportBoxStateHandler.cs
+ChangeTransportBoxStateRequest.cs
+ChangeTransportBoxStateResponse.cs
+```
+
+- [ ] **Step 7: Do NOT build or commit yet** — `TransportBoxController.cs` still imports the old namespace and will compile-error against the moved types. Proceed to Task 4.
+
+---
+
+## Task 4: Update `TransportBoxController.cs` `using` directive
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs:6`
+
+- [ ] **Step 1: Replace the bare-`UseCases` `using` with the sub-namespace `using`**
+
+Current line 6:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+```
+
+After the edit, line 6 must read:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+```
+
+This single edit:
+- Removes the bare-`UseCases` import (which was only present for `ChangeTransportBoxStateRequest`/`Response`).
+- Adds the new sub-namespace import.
+- Keeps the using list in roughly alphabetical order — `...UseCases.ChangeTransportBoxState` sorts before `...UseCases.CreateNewTransportBox` (already on the next line) and after no other `UseCases.*` import, so just replacing line 6 keeps order correct.
+
+Expected `using` block (lines 1–15) after the edit:
+
+```csharp
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.API.Infrastructure;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
+using Anela.Heblo.Application.Features.Logistics.UseCases.CreateNewTransportBox;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxes;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxSummary;
+using Anela.Heblo.Application.Features.Logistics.UseCases.RemoveItemFromBox;
+using Anela.Heblo.Application.Features.Logistics.UseCases.UpdateTransportBoxDescription;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxByCode;
+using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
+```
+
+Note: the existing file does not strictly sort all using directives alphabetically (e.g. `AddItemToBox` appears after `ChangeTransportBoxState` would in alphabetical order), but we are matching the file's existing minimal-edit convention — replace line 6 in place, do not reorder the rest.
+
+- [ ] **Step 2: Build the backend solution to confirm controller resolves the DTOs**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Warning count must equal the baseline from Task 1 Step 1. If any `CS0246` or `CS0234` error mentions `ChangeTransportBoxState`, the namespace or `using` change is wrong — fix before moving on.
+
+- [ ] **Step 3: Do NOT commit yet** — three test files still carry orphan `using` directives that `dotnet format --verify-no-changes` will flag. Proceed to Task 5.
+
+---
+
+## Task 5: Remove orphan `using` directive from `TransportBoxControllerTests.cs`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs:2`
+
+- [ ] **Step 1: Delete the bare-`UseCases` `using`**
+
+Current lines 1–5:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
+using Anela.Heblo.Application.Shared;
+```
+
+After the edit, line 2 (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) is removed entirely. The remaining `using` block must be:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
+using Anela.Heblo.Application.Shared;
+```
+
+No other line in the file changes.
+
+- [ ] **Step 2: Verify the diff is exactly one deleted line**
+
+Run:
+
+```bash
+git diff backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs
+```
+
+Expected: a single hunk with one `-` line (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) and no `+` lines.
+
+---
+
+## Task 6: Remove orphan `using` directive from `ChangeTransportBoxStateHandlerTests.cs`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs:3`
+
+- [ ] **Step 1: Delete the bare-`UseCases` `using`**
+
+Current lines 1–6:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+```
+
+After the edit, line 3 (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) is removed entirely. The remaining `using` block must be:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+```
+
+No other line in the file changes.
+
+- [ ] **Step 2: Verify the diff is exactly one deleted line**
+
+Run:
+
+```bash
+git diff backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+```
+
+Expected: a single hunk with one `-` line and no `+` lines.
+
+---
+
+## Task 7: Remove orphan `using` directive from `TransportBoxUniquenessTests.cs`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs:3`
+
+- [ ] **Step 1: Delete the bare-`UseCases` `using`**
+
+Current lines 1–5:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Shared;
+```
+
+After the edit, line 3 (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) is removed entirely. The remaining `using` block must be:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Shared;
+```
+
+No other line in the file changes.
+
+- [ ] **Step 2: Verify the diff is exactly one deleted line**
+
+Run:
+
+```bash
+git diff backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+```
+
+Expected: a single hunk with one `-` line and no `+` lines.
+
+---
+
+## Task 8: Verify full build, tests, format, and OpenAPI parity
+
+**Why:** Single end-to-end gate that satisfies every acceptance criterion in `spec.r1.md` §NFR-4 and the arch-review's §"Specification Amendments" item 3.
+
+**Files:** None edited.
+
+- [ ] **Step 1: Full solution build**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded`, `0 Error(s)`, and warning count equal to the baseline from Task 1 Step 1.
+
+- [ ] **Step 2: Full test pass**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests pass (same totals as Task 1 Step 2). Pay particular attention to `ChangeTransportBoxStateHandlerTests`, `TransportBoxControllerTests`, and `TransportBoxUniquenessTests` — these must all be green.
+
+- [ ] **Step 3: Format check — must report no changes**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0`, no output. If `dotnet format` reports diffs, the refactor is incomplete (the leftover orphan `using` from one of Tasks 5–7 was missed, or the namespace edit reformatted whitespace).
+
+- [ ] **Step 4: OpenAPI client parity check**
+
+The OpenAPI/NSwag generator runs as part of the Debug build PostBuild step and writes to `backend/src/Anela.Heblo.API.Client/` and `frontend/src/api/generated/`. Confirm the move did not perturb the generated artifacts.
+
+Run:
+
+```bash
+git diff -- backend/src/Anela.Heblo.API.Client frontend/src/api/generated
+```
+
+Expected: empty output. NSwag identifies DTOs by simple class name, not by CLR namespace — `ChangeTransportBoxStateRequest`/`Response` and their property shapes are unchanged, so the spec and generated client must be byte-identical.
+
+If diffs appear, stop and investigate before committing — this would mean the OpenAPI surface drifted.
+
+- [ ] **Step 5: Sanity-check the final staged diff**
+
+Run:
+
+```bash
+git status
+git diff --staged --stat
+```
+
+Expected staged changes (after `git add` in Step 6):
+
+```
+ backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs                                          | 2 +-
+ .../Features/Logistics/UseCases/{ => ChangeTransportBoxState}/ChangeTransportBoxStateRequest.cs            | 2 +-
+ .../Features/Logistics/UseCases/{ => ChangeTransportBoxState}/ChangeTransportBoxStateResponse.cs           | 2 +-
+ backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs                             | 1 -
+ backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs         | 1 -
+ backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs                 | 1 -
+ 6 files changed, 3 insertions(+), 6 deletions(-)
+```
+
+(The exact path-shortening output may vary; what matters is six files touched — two renames + four `using` edits — and zero changes outside that set.)
+
+- [ ] **Step 6: Stage and commit**
+
+Run:
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs \
+  backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: relocate ChangeTransportBoxState DTOs into use case subfolder
+
+Move ChangeTransportBoxStateRequest and ChangeTransportBoxStateResponse
+from Features/Logistics/UseCases/ into the ChangeTransportBoxState/
+subfolder, matching the per-use-case layout used by every other use
+case in the Logistics module. Update their namespaces to
+...UseCases.ChangeTransportBoxState; remove the now-orphan
+...UseCases using directives from the controller and three test files.
+
+No logic, contract, MediatR, DI, or OpenAPI surface change — NSwag
+identifies DTOs by class name, so the generated TypeScript client is
+unchanged.
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails (formatter, analyzer), fix the underlying issue, re-stage, and create a NEW commit (do not `--amend`).
+
+- [ ] **Step 7: Confirm working tree is clean and history is sensible**
+
+Run:
+
+```bash
+git status
+git log -1 --stat
+```
+
+Expected: `git status` reports a clean working tree; `git log -1 --stat` shows the six files above with the renames presented as `R` entries (history preserved).
+
+---
+
+## Acceptance Criteria Recap
+
+Mapped to `spec.r1.md`:
+
+- **FR-1 (move request):** Task 2 — file now at `.../ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`; absent from the parent; body byte-identical except namespace.
+- **FR-2 (move response):** Task 3 — file now at `.../ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs`; absent from the parent; body byte-identical except namespace.
+- **FR-3 (namespace declarations):** Task 2 Step 3 & Task 3 Step 3 — both files declare `namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;` (file-scoped, matching the handler).
+- **FR-4 (references updated):** Tasks 4–7 — controller's `using` replaced with the sub-namespace; three test files' orphan `using` removed. Handler is intentionally untouched per arch-review Decision 3.
+- **FR-5 (behavioural preservation):** Task 8 Steps 1–4 — build + tests + format check + OpenAPI/TS-client diff check, all expected to be clean and zero-diff.
+- **NFR-1/2/3 (perf/security/maintainability):** No code touched beyond namespace + `using` directives. Folder layout now matches every sibling use case.
+- **NFR-4 (build & tooling):** Task 8 Steps 1, 3, 4 — `dotnet build` clean, `dotnet format --verify-no-changes` exits 0, OpenAPI artifacts byte-identical.

--- a/backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.API.Infrastructure;
-using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
 using Anela.Heblo.Application.Features.Logistics.UseCases.CreateNewTransportBox;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using MediatR;
 
-namespace Anela.Heblo.Application.Features.Logistics.UseCases;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 
 public class ChangeTransportBoxStateRequest : IRequest<ChangeTransportBoxStateResponse>
 {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
 using Anela.Heblo.Application.Shared;
 
-namespace Anela.Heblo.Application.Features.Logistics.UseCases;
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 
 public class ChangeTransportBoxStateResponse : BaseResponse
 {

--- a/backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Catalog.Services;
-using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog.Stock;

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.Catalog.Services;
-using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
 using Anela.Heblo.Application.Shared;

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs
@@ -1,5 +1,4 @@
 using Anela.Heblo.API.Controllers;
-using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
 using Anela.Heblo.Application.Shared;

--- a/docs/superpowers/plans/2026-05-17-relocate-changetransportboxstate-dtos.md
+++ b/docs/superpowers/plans/2026-05-17-relocate-changetransportboxstate-dtos.md
@@ -1,0 +1,565 @@
+# Relocate ChangeTransportBoxState Request/Response Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `ChangeTransportBoxStateRequest.cs` and `ChangeTransportBoxStateResponse.cs` from `Features/Logistics/UseCases/` into the `ChangeTransportBoxState/` subfolder (matching every other use case in the module), update the namespace declaration in both files, and fix `using` directives in the four consuming files so the solution still builds and tests still pass.
+
+**Architecture:** Pure structural refactor. No logic, contract, serialization, MediatR, DI, OpenAPI, or HTTP-surface changes. Use `git mv` to preserve history. The handler at `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs` already lives in the target namespace and is intentionally left untouched — C# resolves the relocated DTOs implicitly via the shared namespace.
+
+**Tech Stack:** .NET 8, C# 12 file-scoped namespaces, MediatR, xUnit, FluentAssertions, NSwag (OpenAPI generator), `dotnet format`.
+
+---
+
+## File Structure
+
+**Moved (file body untouched except the `namespace` line — one-line edit):**
+
+| From | To |
+|------|----|
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs` | `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` |
+| `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs` | `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` |
+
+**Edited (using-directive only):**
+
+| File | Edit |
+|------|------|
+| `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs` | Replace bare `UseCases` using with `UseCases.ChangeTransportBoxState` using. |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs` | Remove bare `UseCases` using (sub-namespace already imported). |
+| `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs` | Remove bare `UseCases` using (sub-namespace already imported). |
+| `backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs` | Remove bare `UseCases` using (sub-namespace already imported). |
+
+**Untouched (handler already in target namespace):**
+
+- `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs`
+
+---
+
+## Task 1: Verify baseline (clean build + tests pass before any change)
+
+**Why:** Confirms the worktree starts in a known-good state so any later failure is attributable to this refactor.
+
+**Files:** None edited.
+
+- [ ] **Step 1: Build the backend solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Note the warning count — it must not increase after the refactor.
+
+- [ ] **Step 2: Run the test project that covers these DTOs**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: All tests pass (no failures, no skips related to ChangeTransportBoxState).
+
+- [ ] **Step 3: Confirm `dotnet format` is clean on the baseline**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0` with no output. (If non-zero, stop and report — refactor must not start from a dirty formatting state.)
+
+- [ ] **Step 4: Confirm working tree is clean**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: empty output. No commit at this step — this task only validates the baseline.
+
+---
+
+## Task 2: Move `ChangeTransportBoxStateRequest.cs` with `git mv`
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs` → `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`
+
+- [ ] **Step 1: Move the file with `git mv`**
+
+Run:
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs
+```
+
+Expected: no output, exit code `0`.
+
+- [ ] **Step 2: Verify the move is staged as a rename**
+
+Run:
+
+```bash
+git status
+```
+
+Expected: under "Changes to be committed", a single line `renamed: ...UseCases/ChangeTransportBoxStateRequest.cs -> ...UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`. No "deleted" + "new file" pair.
+
+- [ ] **Step 3: Update the namespace in the moved file**
+
+The file currently reads (line 4):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases;
+```
+
+Edit `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` to:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+```
+
+Leave every other line (using directives, class declaration, properties) byte-identical.
+
+The full expected file content after the edit:
+
+```csharp
+using Anela.Heblo.Domain.Features.Logistics.Transport;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+
+public class ChangeTransportBoxStateRequest : IRequest<ChangeTransportBoxStateResponse>
+{
+    public int BoxId { get; set; }
+    public TransportBoxState NewState { get; set; }
+    public string? Description { get; set; }
+    public string? BoxCode { get; set; }
+    public string? Location { get; set; }
+}
+```
+
+- [ ] **Step 4: Verify the diff is minimal (rename + one-line namespace edit)**
+
+Run:
+
+```bash
+git diff --staged --stat
+```
+
+Expected: one renamed file with a tiny diff size. Then:
+
+```bash
+git diff --staged backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs
+```
+
+Expected: a single hunk changing the namespace from `...UseCases;` to `...UseCases.ChangeTransportBoxState;`. Nothing else.
+
+- [ ] **Step 5: Do NOT build yet** — the controller still has the old `using` and would fail. Proceed straight to Task 3 to keep the staged changeset small but cohesive.
+
+No commit in this task — Task 2 + Task 3 are committed together at the end of Task 3 since the build is only green when both moves and their namespace updates are done.
+
+---
+
+## Task 3: Move `ChangeTransportBoxStateResponse.cs` with `git mv`
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs` → `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs`
+
+- [ ] **Step 1: Move the file with `git mv`**
+
+Run:
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxStateResponse.cs \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs
+```
+
+Expected: no output, exit code `0`.
+
+- [ ] **Step 2: Verify the move is staged as a rename**
+
+Run:
+
+```bash
+git status
+```
+
+Expected: a second `renamed: ...` line for the response file, in addition to the request rename from Task 2.
+
+- [ ] **Step 3: Update the namespace in the moved file**
+
+Edit `backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` so its line-4 namespace becomes the sub-namespace.
+
+The full expected file content after the edit:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+
+public class ChangeTransportBoxStateResponse : BaseResponse
+{
+    public GetTransportBoxByIdResponse? UpdatedBox { get; set; }
+}
+```
+
+Every line other than the namespace declaration must be byte-identical to the original.
+
+- [ ] **Step 4: Verify the response-file diff is minimal**
+
+Run:
+
+```bash
+git diff --staged backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs
+```
+
+Expected: a single hunk changing only the namespace line.
+
+- [ ] **Step 5: Confirm no stray files remain at the `UseCases/` root**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/
+```
+
+Expected: only subfolders (`AddItemToBox`, `ChangeTransportBoxState`, `CreateNewTransportBox`, `GetTransportBoxByCode`, `GetTransportBoxById`, `GetTransportBoxSummary`, `GetTransportBoxes`, `GiftPackageManufacture`, `OpenOrResumeBoxByCode`, `RemoveItemFromBox`, `UpdateTransportBoxDescription`). No `.cs` files at the top level.
+
+- [ ] **Step 6: Confirm both files now sit inside the use case subfolder**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/
+```
+
+Expected exactly three files:
+
+```
+ChangeTransportBoxStateHandler.cs
+ChangeTransportBoxStateRequest.cs
+ChangeTransportBoxStateResponse.cs
+```
+
+- [ ] **Step 7: Do NOT build or commit yet** — `TransportBoxController.cs` still imports the old namespace and will compile-error against the moved types. Proceed to Task 4.
+
+---
+
+## Task 4: Update `TransportBoxController.cs` `using` directive
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs:6`
+
+- [ ] **Step 1: Replace the bare-`UseCases` `using` with the sub-namespace `using`**
+
+Current line 6:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+```
+
+After the edit, line 6 must read:
+
+```csharp
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+```
+
+This single edit:
+- Removes the bare-`UseCases` import (which was only present for `ChangeTransportBoxStateRequest`/`Response`).
+- Adds the new sub-namespace import.
+- Keeps the using list in roughly alphabetical order — `...UseCases.ChangeTransportBoxState` sorts before `...UseCases.CreateNewTransportBox` (already on the next line) and after no other `UseCases.*` import, so just replacing line 6 keeps order correct.
+
+Expected `using` block (lines 1–15) after the edit:
+
+```csharp
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.API.Infrastructure;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.AddItemToBox;
+using Anela.Heblo.Application.Features.Logistics.UseCases.CreateNewTransportBox;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxes;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxSummary;
+using Anela.Heblo.Application.Features.Logistics.UseCases.RemoveItemFromBox;
+using Anela.Heblo.Application.Features.Logistics.UseCases.UpdateTransportBoxDescription;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxByCode;
+using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
+```
+
+Note: the existing file does not strictly sort all using directives alphabetically (e.g. `AddItemToBox` appears after `ChangeTransportBoxState` would in alphabetical order), but we are matching the file's existing minimal-edit convention — replace line 6 in place, do not reorder the rest.
+
+- [ ] **Step 2: Build the backend solution to confirm controller resolves the DTOs**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Warning count must equal the baseline from Task 1 Step 1. If any `CS0246` or `CS0234` error mentions `ChangeTransportBoxState`, the namespace or `using` change is wrong — fix before moving on.
+
+- [ ] **Step 3: Do NOT commit yet** — three test files still carry orphan `using` directives that `dotnet format --verify-no-changes` will flag. Proceed to Task 5.
+
+---
+
+## Task 5: Remove orphan `using` directive from `TransportBoxControllerTests.cs`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs:2`
+
+- [ ] **Step 1: Delete the bare-`UseCases` `using`**
+
+Current lines 1–5:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
+using Anela.Heblo.Application.Shared;
+```
+
+After the edit, line 2 (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) is removed entirely. The remaining `using` block must be:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.OpenOrResumeBoxByCode;
+using Anela.Heblo.Application.Shared;
+```
+
+No other line in the file changes.
+
+- [ ] **Step 2: Verify the diff is exactly one deleted line**
+
+Run:
+
+```bash
+git diff backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs
+```
+
+Expected: a single hunk with one `-` line (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) and no `+` lines.
+
+---
+
+## Task 6: Remove orphan `using` directive from `ChangeTransportBoxStateHandlerTests.cs`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs:3`
+
+- [ ] **Step 1: Delete the bare-`UseCases` `using`**
+
+Current lines 1–6:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+```
+
+After the edit, line 3 (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) is removed entirely. The remaining `using` block must be:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
+using Anela.Heblo.Application.Shared;
+```
+
+No other line in the file changes.
+
+- [ ] **Step 2: Verify the diff is exactly one deleted line**
+
+Run:
+
+```bash
+git diff backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+```
+
+Expected: a single hunk with one `-` line and no `+` lines.
+
+---
+
+## Task 7: Remove orphan `using` directive from `TransportBoxUniquenessTests.cs`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs:3`
+
+- [ ] **Step 1: Delete the bare-`UseCases` `using`**
+
+Current lines 1–5:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Shared;
+```
+
+After the edit, line 3 (`using Anela.Heblo.Application.Features.Logistics.UseCases;`) is removed entirely. The remaining `using` block must be:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
+using Anela.Heblo.Application.Shared;
+```
+
+No other line in the file changes.
+
+- [ ] **Step 2: Verify the diff is exactly one deleted line**
+
+Run:
+
+```bash
+git diff backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+```
+
+Expected: a single hunk with one `-` line and no `+` lines.
+
+---
+
+## Task 8: Verify full build, tests, format, and OpenAPI parity
+
+**Why:** Single end-to-end gate that satisfies every acceptance criterion in `spec.r1.md` §NFR-4 and the arch-review's §"Specification Amendments" item 3.
+
+**Files:** None edited.
+
+- [ ] **Step 1: Full solution build**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded`, `0 Error(s)`, and warning count equal to the baseline from Task 1 Step 1.
+
+- [ ] **Step 2: Full test pass**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests pass (same totals as Task 1 Step 2). Pay particular attention to `ChangeTransportBoxStateHandlerTests`, `TransportBoxControllerTests`, and `TransportBoxUniquenessTests` — these must all be green.
+
+- [ ] **Step 3: Format check — must report no changes**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0`, no output. If `dotnet format` reports diffs, the refactor is incomplete (the leftover orphan `using` from one of Tasks 5–7 was missed, or the namespace edit reformatted whitespace).
+
+- [ ] **Step 4: OpenAPI client parity check**
+
+The OpenAPI/NSwag generator runs as part of the Debug build PostBuild step and writes to `backend/src/Anela.Heblo.API.Client/` and `frontend/src/api/generated/`. Confirm the move did not perturb the generated artifacts.
+
+Run:
+
+```bash
+git diff -- backend/src/Anela.Heblo.API.Client frontend/src/api/generated
+```
+
+Expected: empty output. NSwag identifies DTOs by simple class name, not by CLR namespace — `ChangeTransportBoxStateRequest`/`Response` and their property shapes are unchanged, so the spec and generated client must be byte-identical.
+
+If diffs appear, stop and investigate before committing — this would mean the OpenAPI surface drifted.
+
+- [ ] **Step 5: Sanity-check the final staged diff**
+
+Run:
+
+```bash
+git status
+git diff --staged --stat
+```
+
+Expected staged changes (after `git add` in Step 6):
+
+```
+ backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs                                          | 2 +-
+ .../Features/Logistics/UseCases/{ => ChangeTransportBoxState}/ChangeTransportBoxStateRequest.cs            | 2 +-
+ .../Features/Logistics/UseCases/{ => ChangeTransportBoxState}/ChangeTransportBoxStateResponse.cs           | 2 +-
+ backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs                             | 1 -
+ backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs         | 1 -
+ backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs                 | 1 -
+ 6 files changed, 3 insertions(+), 6 deletions(-)
+```
+
+(The exact path-shortening output may vary; what matters is six files touched — two renames + four `using` edits — and zero changes outside that set.)
+
+- [ ] **Step 6: Stage and commit**
+
+Run:
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs \
+  backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs \
+  backend/src/Anela.Heblo.API/Controllers/TransportBoxController.cs \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/TransportBoxControllerTests.cs \
+  backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: relocate ChangeTransportBoxState DTOs into use case subfolder
+
+Move ChangeTransportBoxStateRequest and ChangeTransportBoxStateResponse
+from Features/Logistics/UseCases/ into the ChangeTransportBoxState/
+subfolder, matching the per-use-case layout used by every other use
+case in the Logistics module. Update their namespaces to
+...UseCases.ChangeTransportBoxState; remove the now-orphan
+...UseCases using directives from the controller and three test files.
+
+No logic, contract, MediatR, DI, or OpenAPI surface change — NSwag
+identifies DTOs by class name, so the generated TypeScript client is
+unchanged.
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails (formatter, analyzer), fix the underlying issue, re-stage, and create a NEW commit (do not `--amend`).
+
+- [ ] **Step 7: Confirm working tree is clean and history is sensible**
+
+Run:
+
+```bash
+git status
+git log -1 --stat
+```
+
+Expected: `git status` reports a clean working tree; `git log -1 --stat` shows the six files above with the renames presented as `R` entries (history preserved).
+
+---
+
+## Acceptance Criteria Recap
+
+Mapped to `spec.r1.md`:
+
+- **FR-1 (move request):** Task 2 — file now at `.../ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs`; absent from the parent; body byte-identical except namespace.
+- **FR-2 (move response):** Task 3 — file now at `.../ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs`; absent from the parent; body byte-identical except namespace.
+- **FR-3 (namespace declarations):** Task 2 Step 3 & Task 3 Step 3 — both files declare `namespace Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;` (file-scoped, matching the handler).
+- **FR-4 (references updated):** Tasks 4–7 — controller's `using` replaced with the sub-namespace; three test files' orphan `using` removed. Handler is intentionally untouched per arch-review Decision 3.
+- **FR-5 (behavioural preservation):** Task 8 Steps 1–4 — build + tests + format check + OpenAPI/TS-client diff check, all expected to be clean and zero-diff.
+- **NFR-1/2/3 (perf/security/maintainability):** No code touched beyond namespace + `using` directives. Folder layout now matches every sibling use case.
+- **NFR-4 (build & tooling):** Task 8 Steps 1, 3, 4 — `dotnet build` clean, `dotnet format --verify-no-changes` exits 0, OpenAPI artifacts byte-identical.


### PR DESCRIPTION

Relocates `ChangeTransportBoxStateRequest` and `ChangeTransportBoxStateResponse` from the `UseCases/` root into the `ChangeTransportBoxState/` subfolder to match the per-use-case layout used by every other use case in the Logistics module. The handler was already correctly placed; only the two DTO files and four `using` directives in consuming files required changes.

NSwag identifies DTOs by class name rather than CLR namespace, so the generated TypeScript client requires no changes.

### Changes
- `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateRequest.cs` — moved from `UseCases/` root; namespace updated
- `UseCases/ChangeTransportBoxState/ChangeTransportBoxStateResponse.cs` — moved from `UseCases/` root; namespace updated
- `Controllers/TransportBoxController.cs` — bare `UseCases` import replaced with specific `UseCases.ChangeTransportBoxState` import
- `Tests/.../TransportBoxControllerTests.cs`, `ChangeTransportBoxStateHandlerTests.cs`, `TransportBoxUniquenessTests.cs` — orphaned bare `UseCases` import removed

---

Closes #1292

### Tokens used
15744595
