### PR TITLE
fix: make toast container responsive on narrow viewports

### DIFF
--- a/docs/superpowers/plans/2026-05-17-terminal-version-banner-fit.md
+++ b/docs/superpowers/plans/2026-05-17-terminal-version-banner-fit.md
@@ -1,0 +1,112 @@
+# Terminal Version Banner Fit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the "New Version Available" toast fit on narrow viewports (≤ 640 px, e.g. the `/terminal` route) without overflowing horizontally.
+
+**Architecture:** Replace the hardcoded `min-w-[600px]` on `ToastContainer`'s fixed wrapper with a responsive Tailwind class set: full-bleed (left-4 … right-4) on small screens, and the original right-anchored 600 px width on `sm` and above. No changes to `Toast.tsx` — it already uses `w-full max-w-2xl` which adapts to its container.
+
+**Tech Stack:** React 18, Tailwind CSS, Jest + React Testing Library
+
+---
+
+## File Map
+
+| Action  | Path |
+|---------|------|
+| Modify  | `frontend/src/components/ui/ToastContainer.tsx:14` |
+| Create  | `frontend/src/components/ui/__tests__/ToastContainer.test.tsx` |
+
+---
+
+### Task 1: Write the failing test for responsive container classes
+
+**Files:**
+- Create: `frontend/src/components/ui/__tests__/ToastContainer.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+`createPortal` renders outside the React tree; mock it so the test can inspect the rendered output.
+
+```tsx
+import React from 'react';
+import { render } from '@testing-library/react';
+import * as ReactDOM from 'react-dom';
+import ToastContainer from '../ToastContainer';
+
+jest.spyOn(ReactDOM, 'createPortal').mockImplementation((node) => node as React.ReactPortal);
+
+describe('ToastContainer', () => {
+  it('uses responsive classes — full-bleed on mobile, right-anchored on sm+', () => {
+    const toast = {
+      id: '1',
+      type: 'info' as const,
+      title: 'Test toast',
+      onClose: jest.fn(),
+    };
+
+    const { container } = render(
+      <ToastContainer toasts={[toast]} onClose={jest.fn()} />,
+    );
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain('left-4');
+    expect(wrapper.className).toContain('sm:left-auto');
+    expect(wrapper.className).toContain('sm:min-w-[600px]');
+    expect(wrapper.className).not.toContain('min-w-[600px]');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — it must fail**
+
+```bash
+cd frontend && npx jest src/components/ui/__tests__/ToastContainer.test.tsx --no-coverage
+```
+
+Expected output: `FAIL` — assertion `not.toContain('min-w-[600px]')` fails because the current class string contains `min-w-[600px]` without the `sm:` prefix.
+
+---
+
+### Task 2: Apply the responsive fix to ToastContainer
+
+**Files:**
+- Modify: `frontend/src/components/ui/ToastContainer.tsx:14`
+
+- [ ] **Step 1: Edit the container className**
+
+In `frontend/src/components/ui/ToastContainer.tsx`, change line 14 from:
+
+```tsx
+<div className="fixed top-4 right-4 z-50 space-y-4 min-w-[600px]">
+```
+
+to:
+
+```tsx
+<div className="fixed top-4 right-4 left-4 z-50 space-y-4 sm:left-auto sm:min-w-[600px]">
+```
+
+- [ ] **Step 2: Run the test — it must pass**
+
+```bash
+cd frontend && npx jest src/components/ui/__tests__/ToastContainer.test.tsx --no-coverage
+```
+
+Expected output: `PASS` — all assertions green.
+
+- [ ] **Step 3: Run build and lint**
+
+```bash
+cd frontend && npm run build && npm run lint
+```
+
+Expected output: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/ui/ToastContainer.tsx \
+        frontend/src/components/ui/__tests__/ToastContainer.test.tsx
+git commit -m "fix: make toast container responsive on narrow viewports"
+```

--- a/frontend/src/components/ui/ToastContainer.tsx
+++ b/frontend/src/components/ui/ToastContainer.tsx
@@ -11,7 +11,7 @@ const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, onClose }) => {
   if (toasts.length === 0) return null;
 
   return createPortal(
-    <div className="fixed top-4 right-4 z-50 space-y-4 min-w-[600px]">
+    <div className="fixed top-4 right-4 left-4 z-50 space-y-4 sm:left-auto sm:min-w-[600px]">
       {toasts.map((toast) => (
         <Toast key={toast.id} {...toast} onClose={onClose} />
       ))}

--- a/frontend/src/components/ui/__tests__/ToastContainer.test.tsx
+++ b/frontend/src/components/ui/__tests__/ToastContainer.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import * as ReactDOM from "react-dom";
+import ToastContainer from "../ToastContainer";
+
+jest.spyOn(ReactDOM, "createPortal").mockImplementation(function (node) {
+  return node;
+});
+
+describe("ToastContainer", () => {
+  it("uses responsive classes — full-bleed on mobile, right-anchored on sm+", () => {
+    const toast = {
+      id: "1",
+      type: "info",
+      title: "Test toast",
+      onClose: jest.fn(),
+    };
+
+    render(
+      <div data-testid="portal-root">
+        <ToastContainer toasts={[toast]} onClose={jest.fn()} />
+      </div>,
+    );
+
+    const wrapper = document.querySelector("div.fixed");
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.className).toContain("left-4");
+    expect(wrapper.className).toContain("sm:left-auto");
+    expect(wrapper.className).toContain("sm:min-w-[600px]");
+    expect(wrapper.className).not.toContain("min-w-[600px]");
+  });
+});

--- a/frontend/src/components/ui/__tests__/ToastContainer.test.tsx
+++ b/frontend/src/components/ui/__tests__/ToastContainer.test.tsx
@@ -8,12 +8,11 @@ jest.spyOn(ReactDOM, "createPortal").mockImplementation(function (node) {
 });
 
 describe("ToastContainer", () => {
-  it("uses responsive classes — full-bleed on mobile, right-anchored on sm+", () => {
+  it("uses responsive classes - full-bleed on mobile, right-anchored on sm+", () => {
     const toast = {
       id: "1",
       type: "info",
       title: "Test toast",
-      onClose: jest.fn(),
     };
 
     render(
@@ -22,11 +21,13 @@ describe("ToastContainer", () => {
       </div>,
     );
 
-    const wrapper = document.querySelector("div.fixed");
-    expect(wrapper).toBeTruthy();
-    expect(wrapper.className).toContain("left-4");
-    expect(wrapper.className).toContain("sm:left-auto");
-    expect(wrapper.className).toContain("sm:min-w-[600px]");
-    expect(wrapper.className).not.toContain("min-w-[600px]");
+    // eslint-disable-next-line testing-library/no-node-access
+    const wrapper = document.querySelector("div.fixed") as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    const classes = wrapper.className.split(/\s+/);
+    expect(classes).toContain("left-4");
+    expect(classes).toContain("sm:left-auto");
+    expect(classes).toContain("sm:min-w-[600px]");
+    expect(classes).not.toContain("min-w-[600px]");
   });
 });


### PR DESCRIPTION
## Summary
- Replace hardcoded `min-w-[600px]` on `ToastContainer` with responsive Tailwind classes: full-bleed (`left-4` → `right-4`) on mobile, right-anchored 600 px minimum on `sm+`
- Fixes "New Version Available" banner overflow on `/terminal` routes (≤640 px viewports)
- Adds a focused unit test asserting the correct responsive class tokens are present

## Test Plan
- [ ] Run `npm test -- --testPathPattern=ToastContainer` — 1 test should pass
- [ ] Open the app on a `/terminal` route at ~390 px width (DevTools device toolbar) and trigger a toast — confirm it fits without horizontal overflow
- [ ] Resize to desktop width and confirm the toast still renders at its original 600 px width, anchored top-right