### PR TITLE
feat: Fix `MarketingAction.AssociateWithProduct` Duplicate Detection

### DIFF
--- a/artifacts/feat-arch-review-marketing-associatewithprodu/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketing-associatewithprodu/arch-review.r1.md
@@ -1,0 +1,135 @@
+# Architecture Review: Fix `MarketingAction.AssociateWithProduct` Duplicate Detection
+
+## Skip Design: true
+
+This is a domain-layer bug fix with no API, DTO, or UI changes. No new visual components or layout decisions are required.
+
+## Architectural Fit Assessment
+
+The change sits cleanly inside an existing aggregate root (`MarketingAction`) in the Domain layer, exactly where invariant enforcement belongs in the project's Clean Architecture / Vertical Slice setup. The fix moves a normalization step that already exists for the *write* path (`ProductCodePrefix = productCode.Trim().ToUpperInvariant()`) up so the same value drives the *guard*. No layer boundaries are crossed, no contracts shift, no new dependencies appear. Two MediatR handlers in the Application layer drive this method (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`) and both already iterate `.Distinct()`-filtered code lists — but `Enumerable.Distinct` is case-sensitive, so the domain-level dedup is the only line of defence today. Tightening the entity's guard preserves the contract direction (Application → Domain) and removes a leaky abstraction where the EF persistence layer's composite key was silently handling what the entity claims to handle.
+
+Note on spec accuracy: the spec's Background section names `ImportFromOutlookHandler` as a caller of `AssociateWithProduct`. The current code at `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/ImportFromOutlookHandler.cs` and its mapper (`OutlookEventImportMapper`) do not call this method — product codes are not parsed out of Outlook event content today. Real callers are `CreateMarketingActionHandler` and `UpdateMarketingActionHandler`. This belongs in the spec as an amendment.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Application (MediatR handlers — unchanged)          │
+│  ├── CreateMarketingActionHandler  ─┐                            │
+│  └── UpdateMarketingActionHandler  ─┤  foreach (...Distinct())   │
+│                                     │  action.AssociateWithProduct(code)
+│                                     ▼                            │
+├─────────────────────────────────────────────────────────────────┤
+│ Anela.Heblo.Domain (THE ONLY CHANGE LIVES HERE)                 │
+│  └── MarketingAction.AssociateWithProduct(string productCode)   │
+│        1. Guard: throw on null/empty/whitespace                 │
+│        2. var normalized = productCode.Trim().ToUpperInvariant()│
+│        3. Dedup guard against `normalized` (in-memory)          │
+│        4. Add MarketingActionProduct with normalized prefix     │
+├─────────────────────────────────────────────────────────────────┤
+│ Anela.Heblo.Persistence (unchanged)                             │
+│  └── Composite PK (MarketingActionId, ProductCodePrefix)        │
+│      remains the safety net — never the primary defence.        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Normalize once, compare and store the same value
+**Options considered:**
+- (A) Normalize input once at the top; use the normalized value for both the `Any()` guard and the new row's `ProductCodePrefix`.
+- (B) Keep raw input around; change the comparison to `StringComparer.OrdinalIgnoreCase` but persist `Trim().ToUpperInvariant()`.
+- (C) Push normalization down into a configured EF Core value converter / case-insensitive DB collation and remove the domain normalization entirely.
+
+**Chosen approach:** (A).
+
+**Rationale:** Single source of truth for "what is this prefix?". Option B leaves two normalization paths in the same method (read uses one rule, write uses another), which is the exact class of bug we are fixing. Option C is a larger surface change — schema/collation, value converter, migration risk — and is explicitly out of scope per the spec; it also moves invariant enforcement out of the entity, weakening the domain model. (A) is the smallest change that restores the entity as the source of truth.
+
+#### Decision 2: Throw `ArgumentException` (do not silently no-op on empty input)
+**Options considered:**
+- (A) Throw `ArgumentException` with `paramName = "productCode"` (current spec).
+- (B) Silently return on null/empty/whitespace.
+
+**Chosen approach:** (A) — already implemented in the current file at lines 73–74.
+
+**Rationale:** The existing entity already throws (the spec's FR-2 is partially fulfilled; only the guard-line bug is open). Both call sites pre-feed values through `.Distinct()` over a list that comes from a validated request DTO; an empty value reaching the entity is a programmer error, not a data condition, so an exception is the right contract. We keep this behaviour rather than weakening it.
+
+#### Decision 3: Do not refactor `UpdateMarketingActionHandler.ProductAssociations.Clear()` / re-add pattern
+**Options considered:**
+- (A) Leave the Clear() + re-add loop as-is; the entity's own guard makes duplicates harmless either way.
+- (B) Switch the update handler to a diff-based merge (compute add/remove sets, only mutate what changed).
+
+**Chosen approach:** (A). Out of scope per the spec.
+
+**Rationale:** Spec is surgical. Re-evaluating the Clear/re-add pattern (which interacts with EF Core change tracking and is currently functioning) is a separate concern and a separate PR. Flag for follow-up if perf or audit-trail concerns arise.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` — change one line (line 76) from `pa.ProductCodePrefix == productCode` to `pa.ProductCodePrefix == normalized`; introduce the `normalized` local above the guard; move the `Trim().ToUpperInvariant()` call out of the `Add` initializer so the same value is used twice.
+
+**Files to add (tests):**
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs` — new xUnit test class adjacent to existing `MarketingActionSyncTests.cs`. Same conventions: xUnit + FluentAssertions, no mocks needed (pure domain), shared `CreateAction()` factory pattern.
+
+**Files to leave untouched:**
+- `MarketingActionProduct.cs`, `IMarketingActionRepository.cs`, EF configurations, migrations, `ImportFromOutlookHandler.cs`, `UpdateMarketingActionHandler.cs`, `CreateMarketingActionHandler.cs`, all DTOs, all controllers, all frontend code.
+
+### Interfaces and Contracts
+
+No interface changes. Method signature stays:
+
+```csharp
+public void AssociateWithProduct(string productCode)
+```
+
+Contract pre/post:
+- **Pre:** `productCode` is non-null, non-empty, non-whitespace. Mixed casing and surrounding whitespace are tolerated.
+- **Post (no-op):** If `productCode.Trim().ToUpperInvariant()` already exists in `ProductAssociations.ProductCodePrefix`, return without mutation.
+- **Post (add):** A new `MarketingActionProduct` is appended with `ProductCodePrefix == productCode.Trim().ToUpperInvariant()`, `MarketingActionId == this.Id`, `CreatedAt == DateTime.UtcNow`.
+- **Throws:** `ArgumentException(paramName: "productCode")` on null/empty/whitespace.
+
+### Data Flow
+
+**Create / Update path (unchanged at the handler, fixed at the entity):**
+
+1. Controller receives `Create/UpdateMarketingActionRequest` with `List<string>? AssociatedProducts` (may contain mixed casing).
+2. Handler iterates `request.AssociatedProducts.Distinct()` — note this is a case-sensitive distinct, so `["abc", "ABC"]` survives as two entries.
+3. For each, handler calls `action.AssociateWithProduct(code)`.
+4. **(Fix lands here)** Entity normalizes, dedups against normalized value, only the first wins.
+5. `_repository.SaveChangesAsync()` writes the single row; the composite-PK safety net never fires for in-batch duplicates.
+
+**Update path edge case:** `action.ProductAssociations.Clear()` is called before re-adding, so within a single Update call the dedup is effectively against an empty collection at first and accumulates as the loop runs. The fix correctly handles in-loop duplicates from the *same* request.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec names `ImportFromOutlookHandler` as a caller; it isn't one today. Reviewer/test author could waste time on it. | Low | Amend spec (see below). Tests target the entity directly — they don't depend on the handler claim. |
+| `Distinct()` in handlers stays case-sensitive after the fix. If a future caller bypasses the entity method, the duplicate bug reappears at the persistence layer. | Low | Long-term: consider switching handler-side `Distinct()` to `Distinct(StringComparer.OrdinalIgnoreCase)` for efficiency (avoids redundant calls into the entity). Out of scope for this PR — record as follow-up. |
+| Behavioural change: callers that previously got `DbUpdateException` on duplicate now get a silent no-op. If any caller (or test) currently relies on the exception, it breaks silently. | Low | Grep confirms no production code depends on the duplicate-throws behaviour. Tests assert the new (intended) behaviour explicitly. |
+| `ToUpperInvariant()` uses invariant culture; a future Turkish-locale deployment could produce surprising results — but only if normalization moves to a culture-sensitive variant. | Very Low | Existing code already uses `ToUpperInvariant`. Keep this exact call. Do not switch to `ToUpper()`. |
+| EF Core change-tracking with `ProductAssociations.Clear()` in the update path is not affected, but if the dedup guard were moved out of the entity later, lazy-loading state could re-introduce the bug. | Very Low | Keep the guard in the aggregate. Document in code only if non-obvious — current spec is sufficient. |
+| Inconsistent normalization with sibling method `LinkToFolder` (which only trims, no case fold). Could mislead a reader into assuming both behave the same. | Low | Out of scope — the spec is explicit. File a follow-up if folder-key duplication ever surfaces. |
+
+## Specification Amendments
+
+1. **Background paragraph 1 is inaccurate.** Replace "Two handlers call it: `UpdateMarketingActionHandler` … and `ImportFromOutlookHandler`" with: "Three handlers depend on the method indirectly through their entity mutations, but only `CreateMarketingActionHandler` (`backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs:64`) and `UpdateMarketingActionHandler` (`...UpdateMarketingActionHandler.cs:99`) call it directly. `ImportFromOutlookHandler` does not parse product codes today and is not a caller."
+
+2. **FR-2 is partially already implemented.** Lines 73–74 of `MarketingAction.cs` already throw `ArgumentException` with `paramName = "productCode"`. The remaining real change is line 76 — the comparison against raw `productCode` instead of `normalized`. The spec's "reference implementation" block is correct; just note that the empty-check is not new behaviour.
+
+3. **Add explicit test for in-loop duplicate within a single handler call.** Mixed-case duplicates can arrive within one `request.AssociatedProducts` list (handler's `Distinct()` is case-sensitive). Add an acceptance test: calling `AssociateWithProduct("abc")` and `AssociateWithProduct("ABC")` on the same entity instance, in sequence, leaves exactly one row. This is the realistic production scenario, not just successive calls across requests. (The spec already mentions this in FR-1's last bullet — good — but emphasise it represents the actual handler-loop scenario.)
+
+4. **Recommended (non-blocking) follow-up to record in spec's "Out of scope" or as a linked future issue:** Switch handler-side `request.AssociatedProducts.Distinct()` to `Distinct(StringComparer.OrdinalIgnoreCase)` to avoid redundant calls into the entity. Pure perf/clarity; correctness is fully handled by the domain fix.
+
+## Prerequisites
+
+None. The change is self-contained:
+- No DB migration (existing rows already uppercase by construction of the buggy-but-write-correct code).
+- No new configuration or feature flag.
+- No new package dependency.
+- No infrastructure change.
+- Validation gates per `CLAUDE.md`: `dotnet build`, `dotnet format`, run `backend/test/Anela.Heblo.Tests/Domain/Marketing/*` and `backend/test/Anela.Heblo.Tests/Application/Marketing/*` tests touched by the change. No E2E impact (API contract unchanged).

--- a/artifacts/feat-arch-review-marketing-associatewithprodu/brief.md
+++ b/artifacts/feat-arch-review-marketing-associatewithprodu/brief.md
@@ -1,0 +1,48 @@
+## Module
+Marketing
+
+## Finding
+`MarketingAction.AssociateWithProduct` checks for a duplicate using the raw (un-normalized) input, but stores the normalized value:
+
+`backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:76–84`
+```csharp
+if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))  // raw, case-sensitive
+    return;
+
+ProductAssociations.Add(new MarketingActionProduct
+{
+    ProductCodePrefix = productCode.Trim().ToUpperInvariant(),  // stored uppercase
+    ...
+});
+```
+
+Calling `AssociateWithProduct("abc")` when `"ABC"` is already stored passes the guard (`"ABC" != "abc"`) and attempts to insert a second row with `ProductCodePrefix = "ABC"`. The DB composite key then raises an exception at save time instead of the domain method silently deduplicating.
+
+## Why it matters
+The domain entity's guard is the intended defence; the DB constraint is a safety net. Relying on the constraint to catch what the entity method should handle means an unhandled DB exception surfaces instead of a clean no-op — affecting `UpdateMarketingActionHandler` and `ImportFromOutlookHandler` whenever product codes are passed with mixed casing.
+
+## Suggested fix
+Normalize before the dedup check:
+
+```csharp
+public void AssociateWithProduct(string productCode)
+{
+    if (string.IsNullOrWhiteSpace(productCode))
+        throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+    var normalized = productCode.Trim().ToUpperInvariant();
+
+    if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
+        return;
+
+    ProductAssociations.Add(new MarketingActionProduct
+    {
+        MarketingActionId = Id,
+        ProductCodePrefix = normalized,
+        CreatedAt = DateTime.UtcNow,
+    });
+}
+```
+
+---
+_Filed by daily arch-review routine on 2026-05-17._

--- a/artifacts/feat-arch-review-marketing-associatewithprodu/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketing-associatewithprodu/impl/main.r1.md
@@ -1,0 +1,10 @@
+Named branch in a normal repo (`GIT_DIR == GIT_COMMON`). Three feature commits ready. Base branch is `main`.
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-marketing-associatewithprodu/spec.r1.md
+++ b/artifacts/feat-arch-review-marketing-associatewithprodu/spec.r1.md
@@ -1,0 +1,118 @@
+# Specification: Fix `MarketingAction.AssociateWithProduct` Duplicate Detection
+
+## Summary
+The domain method `MarketingAction.AssociateWithProduct` compares the raw input against stored values when checking for duplicates, but persists a normalized (trimmed, uppercased) value. This casing mismatch lets the guard pass when an equivalent association already exists, then trips the DB composite key constraint at save time. Normalize the input once, up front, and use the normalized value for both the guard and persistence.
+
+## Background
+`MarketingAction.AssociateWithProduct` (`backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:76–84`) is the intended boundary for adding product associations to a marketing action. Two handlers call it:
+
+- `UpdateMarketingActionHandler` — applies user-supplied product code lists from the UI/API.
+- `ImportFromOutlookHandler` — imports product codes parsed from Outlook content.
+
+Both call sites can supply product codes in mixed casing (e.g. `"abc"`, `"Abc"`, `" ABC "`). The current implementation:
+
+```csharp
+if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))   // raw, case-sensitive
+    return;
+
+ProductAssociations.Add(new MarketingActionProduct
+{
+    ProductCodePrefix = productCode.Trim().ToUpperInvariant(),            // stored uppercase
+    ...
+});
+```
+
+When `"abc"` is supplied while `"ABC"` is already stored, `"ABC" != "abc"` so the guard does not short-circuit, the entity adds a second `MarketingActionProduct` with `ProductCodePrefix = "ABC"`, and the DB composite primary key on `(MarketingActionId, ProductCodePrefix)` raises a `DbUpdateException` on `SaveChanges`. The domain guard is the intended defence; the DB constraint is meant to be a safety net, not the primary deduplication mechanism. Today, the safety net carries the load and a clean no-op turns into an unhandled exception that bubbles up through the handler.
+
+This was flagged by the daily arch-review routine on 2026-05-17.
+
+## Functional Requirements
+
+### FR-1: Normalize product code before duplicate check
+`AssociateWithProduct` MUST compute a single normalized form of the input — `Trim()` followed by `ToUpperInvariant()` — and use that normalized value for both the duplicate-detection comparison and the value persisted on the new `MarketingActionProduct`.
+
+**Acceptance criteria:**
+- Calling `AssociateWithProduct("abc")` when an association with `ProductCodePrefix == "ABC"` already exists returns without modifying `ProductAssociations` and without throwing.
+- Calling `AssociateWithProduct(" abc ")` when an association with `ProductCodePrefix == "ABC"` already exists returns without modifying `ProductAssociations` and without throwing.
+- Calling `AssociateWithProduct("xyz")` when no matching association exists adds exactly one `MarketingActionProduct` with `ProductCodePrefix == "XYZ"`.
+- A unit test asserts that two consecutive calls `AssociateWithProduct("abc")` then `AssociateWithProduct("ABC")` result in exactly one entry in `ProductAssociations`.
+
+### FR-2: Reject empty/whitespace input explicitly
+`AssociateWithProduct` MUST validate the input and throw `ArgumentException` for `null`, empty, or whitespace-only product codes, with `paramName = "productCode"`. This makes the contract explicit instead of silently storing an empty or whitespace string.
+
+**Acceptance criteria:**
+- `AssociateWithProduct(null)` throws `ArgumentException` with `ParamName == "productCode"`.
+- `AssociateWithProduct("")` throws `ArgumentException` with `ParamName == "productCode"`.
+- `AssociateWithProduct("   ")` throws `ArgumentException` with `ParamName == "productCode"`.
+- The existing handlers (`UpdateMarketingActionHandler`, `ImportFromOutlookHandler`) are reviewed to confirm they either pre-filter empty values or are acceptable to surface the `ArgumentException` (see Open Questions).
+
+### FR-3: Behaviour preserved for all other input
+For any input that is non-empty after trimming, the resulting `MarketingActionProduct` MUST have `ProductCodePrefix == productCode.Trim().ToUpperInvariant()`, `MarketingActionId == this.Id`, and `CreatedAt == DateTime.UtcNow` — matching today's stored shape. The only behavioural changes are (a) case-insensitive deduplication and (b) explicit rejection of empty input.
+
+**Acceptance criteria:**
+- All existing tests that exercise `AssociateWithProduct` continue to pass without modification (other than tests that intentionally relied on the buggy duplicate behaviour, if any exist).
+- No other public method on `MarketingAction` is modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change. The fix moves a single `Trim().ToUpperInvariant()` call earlier in the method; complexity remains O(n) over `ProductAssociations` which is small per marketing action.
+
+### NFR-2: Security
+None. No new external input surface, no authorization changes, no logging of sensitive data.
+
+### NFR-3: Backwards compatibility
+- Existing rows in `MarketingActionProducts` are already stored uppercase by the current code path, so no data migration is required.
+- The fix only changes the in-memory guard; the DB schema and constraints are unchanged.
+- Callers that previously triggered a `DbUpdateException` on duplicate will now see a silent no-op, matching the documented intent of the domain method. This is the desired behaviour change.
+
+## Data Model
+No schema changes.
+
+Affected types (unchanged shape):
+- `MarketingAction` (`backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs`) — owns `ProductAssociations`.
+- `MarketingActionProduct` — composite primary key `(MarketingActionId, ProductCodePrefix)`. The `ProductCodePrefix` invariant remains "trimmed, uppercase, non-empty".
+
+## API / Interface Design
+No public API, controller, MediatR request, or DTO changes. The fix is internal to the domain entity.
+
+Method signature (unchanged):
+```csharp
+public void AssociateWithProduct(string productCode)
+```
+
+Reference implementation (from the brief, accepted as the target):
+```csharp
+public void AssociateWithProduct(string productCode)
+{
+    if (string.IsNullOrWhiteSpace(productCode))
+        throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+    var normalized = productCode.Trim().ToUpperInvariant();
+
+    if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
+        return;
+
+    ProductAssociations.Add(new MarketingActionProduct
+    {
+        MarketingActionId = Id,
+        ProductCodePrefix = normalized,
+        CreatedAt = DateTime.UtcNow,
+    });
+}
+```
+
+## Dependencies
+None. Self-contained domain change. No external service, library, or feature flag involved.
+
+## Out of Scope
+- Refactoring `UpdateMarketingActionHandler` or `ImportFromOutlookHandler` beyond what FR-2 requires for handling `ArgumentException`.
+- Adding a corresponding `DisassociateFromProduct` normalization fix (file a follow-up if the same bug exists on the inverse path; not in scope here).
+- Changing the `MarketingActionProduct` composite key or adding a case-insensitive collation at the DB level.
+- Bulk-normalizing existing rows (already uppercase by construction).
+- Any UI/frontend changes — the API contract is unchanged.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketing-associatewithprodu/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketing-associatewithprodu/task-plan.r1.md
@@ -1,0 +1,349 @@
+# Fix `MarketingAction.AssociateWithProduct` Duplicate Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `MarketingAction.AssociateWithProduct` deduplicate against the same normalized value it persists, so mixed-case duplicate product codes no longer crash on `SaveChanges` with a primary-key violation.
+
+**Architecture:** Single-file domain-layer change inside the `MarketingAction` aggregate root. Compute `productCode.Trim().ToUpperInvariant()` once at the top of the method and use that value for both the `Any()` duplicate-check guard and the `ProductCodePrefix` field of the new `MarketingActionProduct`. No layer boundaries crossed, no contracts changed, no migration. A new xUnit + FluentAssertions test class — colocated with the existing `MarketingActionSyncTests` — covers the fixed behaviour and the empty-input contract.
+
+**Tech Stack:** .NET 8 / C# 12, xUnit, FluentAssertions. No mocks (pure domain logic, no dependencies).
+
+---
+
+## File Structure
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` (lines 71–85) — move the `Trim().ToUpperInvariant()` call out of the `Add` initializer to a local `normalized` variable computed before the duplicate-check guard; compare against `normalized` inside `Any()`.
+
+**Files to create:**
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs` — new xUnit test class colocated with `MarketingActionSyncTests.cs`, following the same conventions (xUnit + FluentAssertions, shared `CreateAction()` factory pattern, no mocks).
+
+**Files explicitly NOT touched:**
+- `MarketingActionProduct.cs` — schema and composite key unchanged.
+- `CreateMarketingActionHandler.cs`, `UpdateMarketingActionHandler.cs`, `ImportFromOutlookHandler.cs` — application-layer handlers do not need refactoring (out of scope per arch review).
+- Any EF Core configuration, migration, or DTO — schema-level fixes are explicitly out of scope.
+- Any frontend or controller code — the API contract does not change.
+- `LinkToFolder` sibling method — folder-key normalization is out of scope.
+
+---
+
+## Task 1: Document the bug with a failing TDD test
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`
+
+This task establishes the test scaffold and the **single failing test that proves the bug exists** before we touch production code. The test asserts the realistic in-loop scenario from the arch review: a single handler call passes both `"abc"` and `"ABC"` in sequence; today this crashes at `SaveChanges` because the entity adds two rows.
+
+- [ ] **Step 1: Create the test file with the bug-reproducer test only**
+
+Create `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`:
+
+```csharp
+using System;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionAssociateWithProductTests
+    {
+        private static MarketingAction CreateAction()
+        {
+            return new MarketingAction
+            {
+                Title = "Test Action",
+                StartDate = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                ModifiedAt = DateTime.UtcNow,
+                CreatedByUserId = "user-1",
+            };
+        }
+
+        [Fact]
+        public void AssociateWithProduct_DeduplicatesAcrossCase_WhenCalledTwiceWithMixedCasing()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.AssociateWithProduct("abc");
+            action.AssociateWithProduct("ABC");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the new test to verify it fails for the expected reason**
+
+Run from the worktree root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~MarketingActionAssociateWithProductTests" \
+    --nologo --verbosity minimal
+```
+
+Expected: FAIL with a FluentAssertions message similar to
+`Expected action.ProductAssociations to contain 1 item(s), but found 2`.
+
+If the test passes here, STOP — the production bug is not what we think it is and the plan needs re-validation against the actual code.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+git commit -m "test: add failing case-insensitive dedup test for AssociateWithProduct"
+```
+
+---
+
+## Task 2: Fix the duplicate-check guard
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:71-85`
+
+Replace the `AssociateWithProduct` body so a single `normalized` local drives both the duplicate-check `Any()` predicate and the `ProductCodePrefix` value of the new `MarketingActionProduct`. The empty-input guard already exists at lines 73–74 and stays untouched.
+
+- [ ] **Step 1: Apply the fix**
+
+Open `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs`. Replace the method body (lines 71–85) so the final shape is:
+
+```csharp
+public void AssociateWithProduct(string productCode)
+{
+    if (string.IsNullOrWhiteSpace(productCode))
+        throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+    var normalized = productCode.Trim().ToUpperInvariant();
+
+    if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
+        return;
+
+    ProductAssociations.Add(new MarketingActionProduct
+    {
+        MarketingActionId = Id,
+        ProductCodePrefix = normalized,
+        CreatedAt = DateTime.UtcNow,
+    });
+}
+```
+
+Diff summary (three changes):
+1. Insert `var normalized = productCode.Trim().ToUpperInvariant();` before the `Any()` guard.
+2. Change the `Any()` predicate from `pa => pa.ProductCodePrefix == productCode` to `pa => pa.ProductCodePrefix == normalized`.
+3. Change `ProductCodePrefix = productCode.Trim().ToUpperInvariant()` inside the `Add(...)` initializer to `ProductCodePrefix = normalized`.
+
+- [ ] **Step 2: Run the failing test again to verify it now passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~MarketingActionAssociateWithProductTests" \
+    --nologo --verbosity minimal
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Run the full Marketing domain test suite to confirm no regression**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Anela.Heblo.Tests.Domain.Marketing" \
+    --nologo --verbosity minimal
+```
+
+Expected: all tests pass (existing `MarketingActionSyncTests` cover `MarkOutlookSynced` / `ClearOutlookLink`; the fix does not affect them).
+
+- [ ] **Step 4: Commit the fix**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+git commit -m "fix(marketing): deduplicate AssociateWithProduct against normalized value"
+```
+
+---
+
+## Task 3: Add complete behavioural coverage for the fixed method
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`
+
+Expand the test class to cover every acceptance criterion from FR-1, FR-2, and FR-3 in `spec.r1.md`. Each test is small, behaviour-named, and uses Arrange-Act-Assert.
+
+- [ ] **Step 1: Append the remaining tests to the test class**
+
+Open `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs` and add the following methods inside the existing `MarketingActionAssociateWithProductTests` class (after `AssociateWithProduct_DeduplicatesAcrossCase_WhenCalledTwiceWithMixedCasing`, before the closing brace):
+
+```csharp
+        [Fact]
+        public void AssociateWithProduct_NoOps_WhenLowercaseDuplicateOfExistingUppercase()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+            var snapshotBefore = action.ProductAssociations.Single();
+
+            // Act
+            action.AssociateWithProduct("abc");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().Should().BeSameAs(snapshotBefore);
+        }
+
+        [Fact]
+        public void AssociateWithProduct_NoOps_WhenWhitespacePaddedLowercaseDuplicateOfExistingUppercase()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+            var snapshotBefore = action.ProductAssociations.Single();
+
+            // Act
+            action.AssociateWithProduct(" abc ");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().Should().BeSameAs(snapshotBefore);
+        }
+
+        [Fact]
+        public void AssociateWithProduct_AddsNormalizedRow_WhenInputIsNewCode()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 42;
+
+            // Act
+            action.AssociateWithProduct("xyz");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            var added = action.ProductAssociations.Single();
+            added.ProductCodePrefix.Should().Be("XYZ");
+            added.MarketingActionId.Should().Be(42);
+            added.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public void AssociateWithProduct_NormalizesPaddedMixedCaseInput_WhenNoExistingAssociation()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.AssociateWithProduct("  aBc  ");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AssociateWithProduct_Throws_WhenInputIsNullEmptyOrWhitespace(string? input)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () => action.AssociateWithProduct(input!);
+
+            // Assert
+            act.Should()
+                .Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("productCode");
+            action.ProductAssociations.Should().BeEmpty();
+        }
+```
+
+The final file has six test methods total (the original bug reproducer plus five appended here).
+
+- [ ] **Step 2: Run the new test class to confirm everything passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~MarketingActionAssociateWithProductTests" \
+    --nologo --verbosity minimal
+```
+
+Expected: 8 passed (1 `[Fact]` from Task 1 + 4 new `[Fact]`s + 3 cases of the `[Theory]`), 0 failed.
+
+- [ ] **Step 3: Commit the expanded coverage**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+git commit -m "test(marketing): cover empty input + add cases for AssociateWithProduct"
+```
+
+---
+
+## Task 4: Validation gates
+
+**Files:** None modified.
+
+Run the project-wide validation gates required by `CLAUDE.md` before declaring the task done. These confirm the fix integrates cleanly with the rest of the backend (build, format, all relevant tests).
+
+- [ ] **Step 1: Format C# files touched by the change**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+    backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs \
+    backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+```
+
+Expected: no errors. If `dotnet format` rewrites either file, re-run Task 3 step 2 to confirm tests still pass, then `git add` the formatted files and amend the most recent commit with `git commit --amend --no-edit`.
+
+- [ ] **Step 2: Build the whole backend**
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo --verbosity minimal
+```
+
+Expected: `Build succeeded. 0 Error(s)`. Warnings count must not increase compared to the baseline before this change.
+
+- [ ] **Step 3: Run the full Marketing application + domain test scope**
+
+The arch review identifies `CreateMarketingActionHandler` and `UpdateMarketingActionHandler` as the real callers. Run both their tests and the domain tests to confirm the behavioural change (silent no-op vs. previous `DbUpdateException`) does not break any existing handler test.
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Marketing" \
+    --nologo --verbosity minimal
+```
+
+Expected: all tests pass. If any test relied on duplicate codes raising an exception, treat that as evidence of a pre-existing test contract and surface it for review **before** modifying that test — do not silently rewrite assertions to fit the new behaviour.
+
+- [ ] **Step 4: Run the full backend test suite as the final gate**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --nologo --verbosity minimal
+```
+
+Expected: all tests pass. This catches any indirect coupling (Architecture tests, reflection-based tests, etc.) that might be affected.
+
+- [ ] **Step 5: Confirm the working tree is clean and commits are in order**
+
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: `git status` reports a clean tree; `git log` shows the three commits from Tasks 1–3 in chronological order at the top of the branch (plus the Task 4 amend if formatting required one).
+
+---
+
+## Out-of-Scope Follow-ups (DO NOT implement in this PR)
+
+Captured here so a future reviewer can see they were considered and deliberately deferred. Each is a separate, smaller PR if and when needed.
+
+1. **Switch handler-side `request.AssociatedProducts.Distinct()` to `Distinct(StringComparer.OrdinalIgnoreCase)`** in `CreateMarketingActionHandler` and `UpdateMarketingActionHandler`. Pure perf/clarity — correctness is now fully owned by the domain entity.
+2. **Apply the same normalize-then-compare fix to `MarketingAction.LinkToFolder`** if folder-key duplication ever surfaces. Today the spec is explicit about scope.
+3. **Refactor `UpdateMarketingActionHandler`'s `Clear()` + re-add pattern** to a diff-based merge if EF Core change-tracking or audit-trail behaviour becomes a concern.
+4. **Add a case-insensitive DB collation or EF value converter** for `ProductCodePrefix` if a future change ever bypasses the aggregate. Larger schema-surface change; not justified today.

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -73,13 +73,15 @@ namespace Anela.Heblo.Domain.Features.Marketing
             if (string.IsNullOrWhiteSpace(productCode))
                 throw new ArgumentException("Product code cannot be empty", nameof(productCode));
 
-            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))
+            var normalized = productCode.Trim().ToUpperInvariant();
+
+            if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
                 return;
 
             ProductAssociations.Add(new MarketingActionProduct
             {
                 MarketingActionId = Id,
-                ProductCodePrefix = productCode.Trim().ToUpperInvariant(),
+                ProductCodePrefix = normalized,
                 CreatedAt = DateTime.UtcNow,
             });
         }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionAssociateWithProductTests
+    {
+        private static MarketingAction CreateAction()
+        {
+            return new MarketingAction
+            {
+                Title = "Test Action",
+                StartDate = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                ModifiedAt = DateTime.UtcNow,
+                CreatedByUserId = "user-1",
+            };
+        }
+
+        [Fact]
+        public void AssociateWithProduct_DeduplicatesAcrossCase_WhenCalledTwiceWithMixedCasing()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.AssociateWithProduct("ABC");
+            action.AssociateWithProduct("abc");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
@@ -33,5 +33,84 @@ namespace Anela.Heblo.Tests.Domain.Marketing
             action.ProductAssociations.Should().HaveCount(1);
             action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
         }
+
+        [Fact]
+        public void AssociateWithProduct_NoOps_WhenLowercaseDuplicateOfExistingUppercase()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+
+            // Act
+            action.AssociateWithProduct("abc");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void AssociateWithProduct_NoOps_WhenWhitespacePaddedLowercaseDuplicateOfExistingUppercase()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+
+            // Act
+            action.AssociateWithProduct(" abc ");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void AssociateWithProduct_AddsNormalizedRow_WhenInputIsNewCode()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 42;
+
+            // Act
+            action.AssociateWithProduct("xyz");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            var added = action.ProductAssociations.Single();
+            added.ProductCodePrefix.Should().Be("XYZ");
+            added.MarketingActionId.Should().Be(42);
+            added.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public void AssociateWithProduct_NormalizesPaddedMixedCaseInput_WhenNoExistingAssociation()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.AssociateWithProduct("  aBc  ");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AssociateWithProduct_Throws_WhenInputIsNullEmptyOrWhitespace(string? input)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () => action.AssociateWithProduct(input!);
+
+            // Assert
+            act.Should()
+                .Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("productCode");
+            action.ProductAssociations.Should().BeEmpty();
+        }
     }
 }

--- a/docs/superpowers/plans/2026-05-18-fix-marketing-action-associate-with-product.md
+++ b/docs/superpowers/plans/2026-05-18-fix-marketing-action-associate-with-product.md
@@ -1,0 +1,349 @@
+# Fix `MarketingAction.AssociateWithProduct` Duplicate Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `MarketingAction.AssociateWithProduct` deduplicate against the same normalized value it persists, so mixed-case duplicate product codes no longer crash on `SaveChanges` with a primary-key violation.
+
+**Architecture:** Single-file domain-layer change inside the `MarketingAction` aggregate root. Compute `productCode.Trim().ToUpperInvariant()` once at the top of the method and use that value for both the `Any()` duplicate-check guard and the `ProductCodePrefix` field of the new `MarketingActionProduct`. No layer boundaries crossed, no contracts changed, no migration. A new xUnit + FluentAssertions test class — colocated with the existing `MarketingActionSyncTests` — covers the fixed behaviour and the empty-input contract.
+
+**Tech Stack:** .NET 8 / C# 12, xUnit, FluentAssertions. No mocks (pure domain logic, no dependencies).
+
+---
+
+## File Structure
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` (lines 71–85) — move the `Trim().ToUpperInvariant()` call out of the `Add` initializer to a local `normalized` variable computed before the duplicate-check guard; compare against `normalized` inside `Any()`.
+
+**Files to create:**
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs` — new xUnit test class colocated with `MarketingActionSyncTests.cs`, following the same conventions (xUnit + FluentAssertions, shared `CreateAction()` factory pattern, no mocks).
+
+**Files explicitly NOT touched:**
+- `MarketingActionProduct.cs` — schema and composite key unchanged.
+- `CreateMarketingActionHandler.cs`, `UpdateMarketingActionHandler.cs`, `ImportFromOutlookHandler.cs` — application-layer handlers do not need refactoring (out of scope per arch review).
+- Any EF Core configuration, migration, or DTO — schema-level fixes are explicitly out of scope.
+- Any frontend or controller code — the API contract does not change.
+- `LinkToFolder` sibling method — folder-key normalization is out of scope.
+
+---
+
+## Task 1: Document the bug with a failing TDD test
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`
+
+This task establishes the test scaffold and the **single failing test that proves the bug exists** before we touch production code. The test asserts the realistic in-loop scenario from the arch review: a single handler call passes both `"abc"` and `"ABC"` in sequence; today this crashes at `SaveChanges` because the entity adds two rows.
+
+- [ ] **Step 1: Create the test file with the bug-reproducer test only**
+
+Create `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`:
+
+```csharp
+using System;
+using System.Linq;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionAssociateWithProductTests
+    {
+        private static MarketingAction CreateAction()
+        {
+            return new MarketingAction
+            {
+                Title = "Test Action",
+                StartDate = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                ModifiedAt = DateTime.UtcNow,
+                CreatedByUserId = "user-1",
+            };
+        }
+
+        [Fact]
+        public void AssociateWithProduct_DeduplicatesAcrossCase_WhenCalledTwiceWithMixedCasing()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.AssociateWithProduct("abc");
+            action.AssociateWithProduct("ABC");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the new test to verify it fails for the expected reason**
+
+Run from the worktree root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~MarketingActionAssociateWithProductTests" \
+    --nologo --verbosity minimal
+```
+
+Expected: FAIL with a FluentAssertions message similar to
+`Expected action.ProductAssociations to contain 1 item(s), but found 2`.
+
+If the test passes here, STOP — the production bug is not what we think it is and the plan needs re-validation against the actual code.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+git commit -m "test: add failing case-insensitive dedup test for AssociateWithProduct"
+```
+
+---
+
+## Task 2: Fix the duplicate-check guard
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:71-85`
+
+Replace the `AssociateWithProduct` body so a single `normalized` local drives both the duplicate-check `Any()` predicate and the `ProductCodePrefix` value of the new `MarketingActionProduct`. The empty-input guard already exists at lines 73–74 and stays untouched.
+
+- [ ] **Step 1: Apply the fix**
+
+Open `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs`. Replace the method body (lines 71–85) so the final shape is:
+
+```csharp
+public void AssociateWithProduct(string productCode)
+{
+    if (string.IsNullOrWhiteSpace(productCode))
+        throw new ArgumentException("Product code cannot be empty", nameof(productCode));
+
+    var normalized = productCode.Trim().ToUpperInvariant();
+
+    if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
+        return;
+
+    ProductAssociations.Add(new MarketingActionProduct
+    {
+        MarketingActionId = Id,
+        ProductCodePrefix = normalized,
+        CreatedAt = DateTime.UtcNow,
+    });
+}
+```
+
+Diff summary (three changes):
+1. Insert `var normalized = productCode.Trim().ToUpperInvariant();` before the `Any()` guard.
+2. Change the `Any()` predicate from `pa => pa.ProductCodePrefix == productCode` to `pa => pa.ProductCodePrefix == normalized`.
+3. Change `ProductCodePrefix = productCode.Trim().ToUpperInvariant()` inside the `Add(...)` initializer to `ProductCodePrefix = normalized`.
+
+- [ ] **Step 2: Run the failing test again to verify it now passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~MarketingActionAssociateWithProductTests" \
+    --nologo --verbosity minimal
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Run the full Marketing domain test suite to confirm no regression**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Anela.Heblo.Tests.Domain.Marketing" \
+    --nologo --verbosity minimal
+```
+
+Expected: all tests pass (existing `MarketingActionSyncTests` cover `MarkOutlookSynced` / `ClearOutlookLink`; the fix does not affect them).
+
+- [ ] **Step 4: Commit the fix**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+git commit -m "fix(marketing): deduplicate AssociateWithProduct against normalized value"
+```
+
+---
+
+## Task 3: Add complete behavioural coverage for the fixed method
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`
+
+Expand the test class to cover every acceptance criterion from FR-1, FR-2, and FR-3 in `spec.r1.md`. Each test is small, behaviour-named, and uses Arrange-Act-Assert.
+
+- [ ] **Step 1: Append the remaining tests to the test class**
+
+Open `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs` and add the following methods inside the existing `MarketingActionAssociateWithProductTests` class (after `AssociateWithProduct_DeduplicatesAcrossCase_WhenCalledTwiceWithMixedCasing`, before the closing brace):
+
+```csharp
+        [Fact]
+        public void AssociateWithProduct_NoOps_WhenLowercaseDuplicateOfExistingUppercase()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+            var snapshotBefore = action.ProductAssociations.Single();
+
+            // Act
+            action.AssociateWithProduct("abc");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().Should().BeSameAs(snapshotBefore);
+        }
+
+        [Fact]
+        public void AssociateWithProduct_NoOps_WhenWhitespacePaddedLowercaseDuplicateOfExistingUppercase()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.AssociateWithProduct("ABC");
+            var snapshotBefore = action.ProductAssociations.Single();
+
+            // Act
+            action.AssociateWithProduct(" abc ");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().Should().BeSameAs(snapshotBefore);
+        }
+
+        [Fact]
+        public void AssociateWithProduct_AddsNormalizedRow_WhenInputIsNewCode()
+        {
+            // Arrange
+            var action = CreateAction();
+            action.Id = 42;
+
+            // Act
+            action.AssociateWithProduct("xyz");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            var added = action.ProductAssociations.Single();
+            added.ProductCodePrefix.Should().Be("XYZ");
+            added.MarketingActionId.Should().Be(42);
+            added.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        }
+
+        [Fact]
+        public void AssociateWithProduct_NormalizesPaddedMixedCaseInput_WhenNoExistingAssociation()
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            action.AssociateWithProduct("  aBc  ");
+
+            // Assert
+            action.ProductAssociations.Should().HaveCount(1);
+            action.ProductAssociations.Single().ProductCodePrefix.Should().Be("ABC");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AssociateWithProduct_Throws_WhenInputIsNullEmptyOrWhitespace(string? input)
+        {
+            // Arrange
+            var action = CreateAction();
+
+            // Act
+            Action act = () => action.AssociateWithProduct(input!);
+
+            // Assert
+            act.Should()
+                .Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("productCode");
+            action.ProductAssociations.Should().BeEmpty();
+        }
+```
+
+The final file has six test methods total (the original bug reproducer plus five appended here).
+
+- [ ] **Step 2: Run the new test class to confirm everything passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~MarketingActionAssociateWithProductTests" \
+    --nologo --verbosity minimal
+```
+
+Expected: 8 passed (1 `[Fact]` from Task 1 + 4 new `[Fact]`s + 3 cases of the `[Theory]`), 0 failed.
+
+- [ ] **Step 3: Commit the expanded coverage**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+git commit -m "test(marketing): cover empty input + add cases for AssociateWithProduct"
+```
+
+---
+
+## Task 4: Validation gates
+
+**Files:** None modified.
+
+Run the project-wide validation gates required by `CLAUDE.md` before declaring the task done. These confirm the fix integrates cleanly with the rest of the backend (build, format, all relevant tests).
+
+- [ ] **Step 1: Format C# files touched by the change**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+    backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs \
+    backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+```
+
+Expected: no errors. If `dotnet format` rewrites either file, re-run Task 3 step 2 to confirm tests still pass, then `git add` the formatted files and amend the most recent commit with `git commit --amend --no-edit`.
+
+- [ ] **Step 2: Build the whole backend**
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo --verbosity minimal
+```
+
+Expected: `Build succeeded. 0 Error(s)`. Warnings count must not increase compared to the baseline before this change.
+
+- [ ] **Step 3: Run the full Marketing application + domain test scope**
+
+The arch review identifies `CreateMarketingActionHandler` and `UpdateMarketingActionHandler` as the real callers. Run both their tests and the domain tests to confirm the behavioural change (silent no-op vs. previous `DbUpdateException`) does not break any existing handler test.
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Marketing" \
+    --nologo --verbosity minimal
+```
+
+Expected: all tests pass. If any test relied on duplicate codes raising an exception, treat that as evidence of a pre-existing test contract and surface it for review **before** modifying that test — do not silently rewrite assertions to fit the new behaviour.
+
+- [ ] **Step 4: Run the full backend test suite as the final gate**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --nologo --verbosity minimal
+```
+
+Expected: all tests pass. This catches any indirect coupling (Architecture tests, reflection-based tests, etc.) that might be affected.
+
+- [ ] **Step 5: Confirm the working tree is clean and commits are in order**
+
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: `git status` reports a clean tree; `git log` shows the three commits from Tasks 1–3 in chronological order at the top of the branch (plus the Task 4 amend if formatting required one).
+
+---
+
+## Out-of-Scope Follow-ups (DO NOT implement in this PR)
+
+Captured here so a future reviewer can see they were considered and deliberately deferred. Each is a separate, smaller PR if and when needed.
+
+1. **Switch handler-side `request.AssociatedProducts.Distinct()` to `Distinct(StringComparer.OrdinalIgnoreCase)`** in `CreateMarketingActionHandler` and `UpdateMarketingActionHandler`. Pure perf/clarity — correctness is now fully owned by the domain entity.
+2. **Apply the same normalize-then-compare fix to `MarketingAction.LinkToFolder`** if folder-key duplication ever surfaces. Today the spec is explicit about scope.
+3. **Refactor `UpdateMarketingActionHandler`'s `Clear()` + re-add pattern** to a diff-based merge if EF Core change-tracking or audit-trail behaviour becomes a concern.
+4. **Add a case-insensitive DB collation or EF value converter** for `ProductCodePrefix` if a future change ever bypasses the aggregate. Larger schema-surface change; not justified today.


### PR DESCRIPTION
Marketing

## Finding
`MarketingAction.AssociateWithProduct` checks for a duplicate using the raw (un-normalized) input, but stores the normalized value:

`backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs:76–84`
```csharp
if (ProductAssociations.Any(pa => pa.ProductCodePrefix == productCode))  // raw, case-sensitive
    return;

ProductAssociations.Add(new MarketingActionProduct
{
    ProductCodePrefix = productCode.Trim().ToUpperInvariant(),  // stored uppercase
    ...
});
```

Calling `AssociateWithProduct("abc")` when `"ABC"` is already stored passes the guard (`"ABC" != "abc"`) and attempts to insert a second row with `ProductCodePrefix = "ABC"`. The DB composite key then raises an exception at save time instead of the domain method silently deduplicating.

## Why it matters
The domain entity's guard is the intended defence; the DB constraint is a safety net. Relying on the constraint to catch what the entity method should handle means an unhandled DB exception surfaces instead of a clean no-op — affecting `UpdateMarketingActionHandler` and `ImportFromOutlookHandler` whenever product codes are passed with mixed casing.

## Suggested fix
Normalize before the dedup check:

```csharp
public void AssociateWithProduct(string productCode)
{
    if (string.IsNullOrWhiteSpace(productCode))
        throw new ArgumentException("Product code cannot be empty", nameof(productCode));

    var normalized = productCode.Trim().ToUpperInvariant();

    if (ProductAssociations.Any(pa => pa.ProductCodePrefix == normalized))
        return;

    ProductAssociations.Add(new MarketingActionProduct
    {
        MarketingActionId = Id,
        ProductCodePrefix = normalized,
        CreatedAt = DateTime.UtcNow,
    });
}
```

---
_Filed by daily arch-review routine on 2026-05-17._

---

Closes #1353

### Tokens used
11536078
