### PR TITLE
feat: Runtime Hot-Reload for Marketing `PushEnabled` Kill-Switch

### DIFF
--- a/artifacts/feat-arch-review-marketing-pushenabled-flag-r/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketing-pushenabled-flag-r/arch-review.r1.md
@@ -1,0 +1,206 @@
+```markdown
+# Architecture Review: Runtime Hot-Reload for Marketing `PushEnabled` Kill-Switch
+
+## Skip Design: true
+
+Backend-only DI-mechanism change. No UI surface, no new visual components, no design decisions required.
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with the existing Marketing module conventions:
+
+- `MarketingCategoryMapper` already consumes `IOptionsMonitor<MarketingCalendarOptions>` (file: `backend/src/Anela.Heblo.Application/Features/Marketing/Services/MarketingCategoryMapper.cs:17`), establishing the hot-reload pattern as **intentional module policy**, not an isolated outlier.
+- `MarketingModule.AddMarketingModule` registers options via `services.AddOptions<MarketingCalendarOptions>().Bind(...).Validate(...).ValidateOnStart()` (file: `backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs:17-27`). This registration makes both `IOptions<T>` and `IOptionsMonitor<T>` available automatically — **no DI changes required**.
+- The global `csharp-patterns.md` Options Pattern guidance favors strongly-typed options; switching the access pattern from `Value` to `CurrentValue` is a localized refinement, not a structural change.
+
+**Integration points:** two MediatR command handlers in the Application layer, plus the test doubles that construct them. No persistence, no API contract, no module boundaries crossed.
+
+**Critical scope gap found:** `DeleteMarketingActionHandler` (file: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs:20,54`) **also** reads `_options.Value.PushEnabled` to gate an outbound Graph `DeleteEventAsync` call. The brief and spec list only Create and Update. Leaving Delete on a startup snapshot defeats the stated operational goal ("operators can disable outbound Graph traffic immediately during an incident"): an operator flipping `PushEnabled = false` would still see DELETE calls to Graph as long as users perform soft-deletes. This is the same class of write handler making the same outbound call — it must be in scope, or the rationale for excluding it must be explicitly documented.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+        MediatR pipeline
+              │
+   ┌──────────┴──────────┬──────────────────────┐
+   ▼                     ▼                      ▼
+CreateMarketingAction UpdateMarketingAction DeleteMarketingAction
+   Handler              Handler              Handler
+   │ │                    │ │                    │ │
+   │ └─ IOptionsMonitor<MarketingCalendarOptions> ─┘ │       ← change: was IOptions<T>
+   │                                                  │
+   └────────── IOutlookCalendarSync ─────────────────┘
+                       │
+                       ▼
+               Microsoft Graph API
+                       ▲
+                       │
+       (separate path — already correct)
+                       │
+              MarketingCategoryMapper
+                       │
+                       └─ IOptionsMonitor<MarketingCalendarOptions>
+                          + OnChange subscription + Snapshot fallback
+
+Configuration source (appsettings + Azure App Config)
+   └─ services.AddOptions<MarketingCalendarOptions>().Bind(...).ValidateOnStart()
+      └─ provides both IOptions<T> and IOptionsMonitor<T> to DI
+```
+
+### Key Design Decisions
+
+#### Decision 1: Direct `CurrentValue` read vs. subscription with cached projection
+**Options considered:**
+- A. Read `_options.CurrentValue.PushEnabled` directly at the check site.
+- B. Mirror `MarketingCategoryMapper`: subscribe via `OnChange`, cache a `volatile bool` field, fall back on failure.
+
+**Chosen approach:** A — direct `CurrentValue` read.
+
+**Rationale:** The mapper subscribes because it builds a derived structure (case-insensitive dictionaries) whose **construction can fail** on malformed input; a snapshot-on-failure strategy is meaningful there. `PushEnabled` is a primitive boolean — there is no projection to cache, no construction to fail, and no measurable read cost (`CurrentValue` is a cached field updated by change tokens). Adding a subscription would import the mapper's complexity without any benefit and re-introduce a separate cached state that could drift. FR-3 explicitly endorses this asymmetry.
+
+#### Decision 2: Treat `IOptionsMonitor<T>` as available-by-default; no DI changes
+**Options considered:**
+- A. Rely on existing `AddOptions<T>().Bind(...)` registration; `IOptionsMonitor<T>` is automatically resolvable.
+- B. Add explicit registration in `MarketingModule`.
+
+**Chosen approach:** A.
+
+**Rationale:** The .NET options abstraction guarantees `IOptionsMonitor<T>` whenever `Configure`/`Bind` has been called on the same type. The Marketing module already uses this for the mapper — confirmed in `MarketingModule.cs:17-27`. No new registration is needed and adding one would be misleading.
+
+#### Decision 3: Do **not** add defensive `try/catch` around `CurrentValue`
+**Options considered:**
+- A. Read `CurrentValue.PushEnabled` directly; let any (improbable) exception bubble up.
+- B. Wrap in `try/catch` and "fail closed" (treat as `false`) per NFR-4.
+
+**Chosen approach:** A — no defensive wrapping.
+
+**Rationale:** `CurrentValue` returns a cached, already-bound value; in practice it does not throw for a successfully-bound options class. Startup binding/validation is already enforced by `.ValidateOnStart()` (`MarketingModule.cs:27`) — that is where binding failure must surface, loudly, at the correct layer. Wrapping the read in `try/catch` would (1) hide the *next* class of bugs (e.g., a future `IValidateOptions` rejection during reload) behind a silent kill-switch, and (2) introduce a second failure path with no symmetry to the mapper's design (which keeps the prior snapshot — equivalent to **fail-open** for the prior value, not fail-closed). The spec's NFR-4 should be reworded; see Specification Amendments.
+
+#### Decision 4: Promote `TestOptionsMonitor<T>` to a shared test helper
+**Options considered:**
+- A. Re-implement `TestOptionsMonitor<T>` inline in each handler test file.
+- B. Lift the existing private class from `MarketingCategoryMapperTests.cs:20-68` to a shared test-utility namespace.
+
+**Chosen approach:** B.
+
+**Rationale:** Three test files (`Application/Marketing/CreateMarketingActionHandlerTests.cs`, `Application/Marketing/UpdateMarketingActionHandlerTests.cs`, and the older duplicate `Features/Marketing/CreateMarketingActionHandlerTests.cs` plus `Features/Marketing/MarketingActionHandlerSyncTests.cs`) will need to construct an `IOptionsMonitor<MarketingCalendarOptions>` with mutation support. DRY (per global `coding-style.md`) and the spec's FR-5 acceptance criterion ("standard test-double approach … or introduce a minimal helper") favor extraction.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Modified source files (handlers — three, not two):**
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs` *(new — see Specification Amendments)*
+
+**New test helper:**
+- `backend/test/Anela.Heblo.Tests/TestHelpers/TestOptionsMonitor.cs` — lifted verbatim from `MarketingCategoryMapperTests.TestOptionsMonitor<T>`, made `public` (or `internal` with `InternalsVisibleTo`-free positioning under the test project).
+
+**Modified test files:**
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs` — replace `Options.Create(...)` (line 49) with `new TestOptionsMonitor<MarketingCalendarOptions>(...)`; add the two new hot-reload tests required by FR-5.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` — same substitution at line 69; add FR-5 tests.
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs` — older duplicate, replace `Mock<IOptions<MarketingCalendarOptions>>` (line 35). **Flag to maintainer:** this duplicate test class exists alongside the canonical one in `Application/Marketing/`; mention but don't delete (per project rule: don't touch unrelated code, surface dead/duplicate code instead).
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — replace `Mock<IOptions<MarketingCalendarOptions>>` at lines 54, 68, 82.
+
+**Not modified:**
+- `MarketingCalendarOptions.cs` — no fields added or changed.
+- `MarketingModule.cs` — no DI changes.
+- `OutlookCalendarSyncService.cs` — out of scope per spec; its `_options.Value` snapshot of `GroupId` at construction (line 43) is acceptable because it is scoped per-request and `GroupId` is not the kill-switch.
+
+### Interfaces and Contracts
+
+No public contracts change. The MediatR request/response types for Create/Update/Delete are unchanged.
+
+The only contract change is internal-to-DI: handler constructors swap one type parameter.
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+```csharp
+// Before
+if (_options.Value.PushEnabled)
+
+// After
+if (_options.CurrentValue.PushEnabled)
+```
+
+Field name `_options` is retained — it matches the mapper's pattern of holding the monitor and reading via `.CurrentValue` at the use site.
+
+### Data Flow
+
+For the create path with hot-reload (representative; update/delete are symmetric):
+
+```
+1. Request arrives → MediatR dispatches → CreateMarketingActionHandler.Handle
+2. Authentication check (unchanged)
+3. Build MarketingAction (unchanged)
+4. Read _options.CurrentValue.PushEnabled        ← was _options.Value.PushEnabled
+   │
+   ├─ true  → call IOutlookCalendarSync.CreateEventAsync
+   │         (Graph API call; reflects the *current* config snapshot
+   │          at handler invocation time, not startup)
+   │
+   └─ false → skip Graph call
+5. Persist via repository (unchanged)
+6. Return response (unchanged)
+```
+
+Runtime sequence when an operator flips the kill-switch:
+
+```
+T0: PushEnabled = true; handler call N performs Graph push.
+T1: Operator changes Azure App Configuration: PushEnabled = false.
+T2: Refresh interval elapses (configured by the Azure App Config provider,
+    same wiring already used by MarketingCategoryMapper).
+T3: IOptionsMonitor<MarketingCalendarOptions>.CurrentValue now reports
+    PushEnabled = false (change-token cache updated).
+T4: Handler call N+1 reads CurrentValue → skips Graph push. No restart.
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec excludes `DeleteMarketingActionHandler`, leaving the kill-switch incomplete: deletes continue to call Graph after operator flips the flag | **HIGH** | Amend spec to include Delete (preferred). If explicitly out of scope, document the rationale — but the brief's "kill-switch for Outlook calendar sync" framing makes exclusion hard to justify. |
+| NFR-4's "fail closed if `IOptionsMonitor` throws" risks the implementer wrapping `CurrentValue` in `try/catch`, silently turning a binding/validation bug into a silent "push disabled" state | MEDIUM | Reword NFR-4 (see Specification Amendments). Rely on `.ValidateOnStart()` for boot-time validation; let any unexpected runtime exception propagate so it surfaces in logs as a real bug. |
+| Two duplicate handler-test classes (`Application/Marketing/...` and `Features/Marketing/...`) — easy to update one and leave the other failing the build | MEDIUM | Update both. Flag the duplication in the PR description; do not silently delete the older file (not in scope). |
+| `Options.Create(...)` calls in current tests return `IOptions<T>` and will break compile after the constructor change | LOW | Search-and-replace via the new `TestOptionsMonitor<T>` helper. Compile error surfaces immediately — low risk of silent regression. |
+| `MarketingCalendarOptions.CategoryMappings` lacks a setter (it's `init`), so a `TestOptionsMonitor<T>.Set(new MarketingCalendarOptions { ... })` is required between toggles | LOW | The existing helper already supports `.Set(next)`; no extra work. |
+| Performance regression from `CurrentValue` property access | NEGLIGIBLE | `CurrentValue` is a cached field read backed by `OptionsCache<T>`; equivalent cost to `IOptions<T>.Value`. NFR-1 already states this; no mitigation needed. |
+| Hot-reload depends on whatever Azure App Configuration / change-token wiring already powers the mapper — if that wiring is broken globally, the kill-switch is broken too | LOW (existing risk) | Out of scope to fix; smoke-test by toggling a `CategoryMappings` value in a staging environment and confirming the mapper picks it up. If the mapper hot-reloads, this fix hot-reloads. |
+
+## Specification Amendments
+
+1. **Extend FR scope to include `DeleteMarketingActionHandler`.**
+   Add an `FR-1b` (or extend FR-1/FR-2 to "all three write handlers") covering Delete. The acceptance criteria mirror FR-1 verbatim: constructor injects `IOptionsMonitor<MarketingCalendarOptions>`, the check at line 54 reads `_options.CurrentValue.PushEnabled`, runtime toggle is honored.
+   If the implementer/owner decides to defer Delete, the spec must explicitly justify why the kill-switch is acceptable to be partial (e.g., delete frequency, idempotency-at-Graph). The brief's framing — "the only kill-switch for Outlook calendar sync" — argues against deferral.
+
+2. **Rewrite NFR-4.**
+   Current text says the handler "should fail closed — i.e., behave as if `PushEnabled = false` and skip the push — rather than throwing". Replace with:
+   > `IOptionsMonitor<MarketingCalendarOptions>.CurrentValue` is a cached read and is not expected to throw under normal operation. No defensive wrapping is added at the call site. Configuration binding and validation errors are caught at application startup by `.ValidateOnStart()` in `MarketingModule`. Any unexpected runtime exception is allowed to propagate and surface in standard error logging.
+
+3. **Extend FR-5 to cover Delete** (if amendment 1 is accepted): add a symmetric hot-reload test for `DeleteMarketingActionHandler` covering `true → false` and `false → true` transitions across two invocations on the same handler instance.
+
+4. **Acknowledge the shared test helper.**
+   Add a note to FR-5 that the existing `TestOptionsMonitor<T>` from `MarketingCategoryMapperTests` is to be promoted to a shared test-utility class under `backend/test/Anela.Heblo.Tests/TestHelpers/` and reused — not re-implemented per test file.
+
+5. **Acknowledge duplicate test files.**
+   Note that `Features/Marketing/CreateMarketingActionHandlerTests.cs` and `Features/Marketing/MarketingActionHandlerSyncTests.cs` (older duplicates of the canonical `Application/Marketing/` tests) must also be updated to compile against the new constructor signature. Do not delete them in this change; surface the duplication for separate cleanup.
+
+## Prerequisites
+
+None.
+
+- `Microsoft.Extensions.Options` is already referenced (the mapper uses it).
+- `IOptionsMonitor<MarketingCalendarOptions>` is already resolvable via the existing `AddOptions<MarketingCalendarOptions>().Bind(...)` registration in `MarketingModule.cs`.
+- The Azure App Configuration / change-token plumbing is already in production for `MarketingCategoryMapper`; this work depends on it being functional but does not modify it.
+- No database migration, no infrastructure change, no new package, no config-schema change.
+```

--- a/artifacts/feat-arch-review-marketing-pushenabled-flag-r/brief.md
+++ b/artifacts/feat-arch-review-marketing-pushenabled-flag-r/brief.md
@@ -1,0 +1,40 @@
+## Module
+Marketing
+
+## Finding
+Both write handlers check `PushEnabled` via `IOptions<MarketingCalendarOptions>`, which is a startup snapshot and does not update at runtime:
+
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs:25,70`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs:25,70`
+
+```csharp
+private readonly IOptions<MarketingCalendarOptions> _options;
+...
+if (_options.Value.PushEnabled)   // ← always the startup snapshot
+```
+
+By contrast, `MarketingCategoryMapper` is registered as a singleton and explicitly uses `IOptionsMonitor<MarketingCalendarOptions>` with a snapshot-on-failure strategy, documenting that runtime config updates (e.g., via Azure App Config) are an intentional design goal for this module.
+
+## Why it matters
+`PushEnabled` is the only kill-switch for Outlook calendar sync. In an incident where outbound Graph calls need to be disabled without a restart (e.g., Graph API degradation, token issues), flipping `PushEnabled = false` in config has no effect because the handlers read the startup value. The `CategoryMappings` hot-reload pattern establishes intent — its absence on `PushEnabled` is the higher-impact omission.
+
+## Suggested fix
+Change both handlers to inject `IOptionsMonitor<MarketingCalendarOptions>` and access `_options.CurrentValue.PushEnabled`:
+
+```csharp
+// Constructor
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+
+public CreateMarketingActionHandler(..., IOptionsMonitor<MarketingCalendarOptions> options, ...)
+{
+    _options = options;
+}
+
+// Usage
+if (_options.CurrentValue.PushEnabled)
+```
+
+Same change in `UpdateMarketingActionHandler`. `OutlookCalendarSyncService` also stores `options.Value` at construction (line 43), but since it is scoped and `GroupId`/`PushEnabled` are unlikely to change at runtime independently of the service lifetime, that is lower priority.
+
+---
+_Filed by daily arch-review routine on 2026-05-17._

--- a/artifacts/feat-arch-review-marketing-pushenabled-flag-r/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketing-pushenabled-flag-r/impl/main.r1.md
@@ -1,0 +1,72 @@
+All committed. Here is the output artifact:
+
+---
+
+# Implementation: Marketing PushEnabled Runtime Hot-Reload
+
+## What was implemented
+
+Converted all three Marketing write handlers (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`, `DeleteMarketingActionHandler`) from `IOptions<MarketingCalendarOptions>` to `IOptionsMonitor<MarketingCalendarOptions>`. The kill-switch (`PushEnabled`) is now read via `.CurrentValue` at handler execution time, so Azure App Configuration changes are honored without an application restart. A shared `TestOptionsMonitor<T>` test helper was extracted from `MarketingCategoryMapperTests` to a common location.
+
+## Files created/modified
+
+### New
+- `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs` — shared IOptionsMonitor<T> test double with `.Set()` for runtime toggle testing
+
+### Modified (handlers)
+- `backend/src/.../CreateMarketingAction/CreateMarketingActionHandler.cs` — `IOptions` → `IOptionsMonitor`, `.Value` → `.CurrentValue`
+- `backend/src/.../UpdateMarketingAction/UpdateMarketingActionHandler.cs` — same
+- `backend/src/.../DeleteMarketingAction/DeleteMarketingActionHandler.cs` — same
+
+### Modified (canonical tests)
+- `backend/test/.../Application/Marketing/CreateMarketingActionHandlerTests.cs` — `TestOptionsMonitor` factory + 2 hot-reload tests
+- `backend/test/.../Application/Marketing/UpdateMarketingActionHandlerTests.cs` — same
+- `backend/test/.../Application/Marketing/DeleteMarketingActionHandlerTests.cs` — same
+
+### Modified (legacy tests)
+- `backend/test/.../Features/Marketing/CreateMarketingActionHandlerTests.cs` — updated constructor to use `TestOptionsMonitor`
+- `backend/test/.../Features/Marketing/MarketingActionHandlerSyncTests.cs` — all three `BuildXxxHandler` methods updated
+- `backend/test/.../Features/Marketing/Services/MarketingCategoryMapperTests.cs` — removed inline `TestOptionsMonitor<T>` nested class, added shared using
+
+## Tests
+
+- **96 marketing tests pass** — all original tests plus 6 new hot-reload tests (2 per handler: true→false and false→true)
+- **3375 other unit tests pass** — no regressions
+- 22 pre-existing Docker/Testcontainers failures in Photobank and KnowledgeBase (unrelated, require running Docker)
+
+## How to verify
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Marketing"
+# Expected: 96 passed
+```
+
+## Notes
+
+Two duplicate test files exist alongside the canonical ones — they were updated to compile against the new `IOptionsMonitor<T>` constructor but were intentionally **not** deleted:
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`
+
+Recommend follow-up to consolidate or remove these duplicates.
+
+`OutlookCalendarSyncService.cs` and `MarketingModule.cs` are **untouched** — out of scope per spec.
+
+## PR Summary
+
+Switch all three Marketing write handlers off `IOptions<T>` so the `PushEnabled` kill-switch responds to runtime configuration changes (e.g., Azure App Configuration) without an application restart. Previously, toggling `PushEnabled = false` during an incident had no effect on running handlers — a restart was required. Now all three handlers (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`, `DeleteMarketingActionHandler`) read `.CurrentValue.PushEnabled` at invocation time.
+
+A shared `TestOptionsMonitor<T>` test helper was extracted from `MarketingCategoryMapperTests` (the existing hot-reload reference implementation) so all handler test suites can drive runtime toggle transitions. Six new unit tests cover the true→false and false→true transitions for each handler.
+
+**Note:** Two duplicate Marketing handler test files in `Features/Marketing/` were updated to compile against the new constructor signature but were intentionally not deleted. Recommend a separate cleanup PR.
+
+### Changes
+- `backend/src/.../CreateMarketingAction/CreateMarketingActionHandler.cs` — `IOptions` → `IOptionsMonitor`, `.Value` → `.CurrentValue`
+- `backend/src/.../UpdateMarketingAction/UpdateMarketingActionHandler.cs` — same
+- `backend/src/.../DeleteMarketingAction/DeleteMarketingActionHandler.cs` — same
+- `backend/test/.../Helpers/TestOptionsMonitor.cs` — new shared test double (promoted from `MarketingCategoryMapperTests`)
+- `backend/test/.../Application/Marketing/*HandlerTests.cs` — use shared helper; add hot-reload tests
+- `backend/test/.../Features/Marketing/*Tests.cs` — updated to compile; duplicates flagged for cleanup
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-marketing-pushenabled-flag-r/spec.r1.md
+++ b/artifacts/feat-arch-review-marketing-pushenabled-flag-r/spec.r1.md
@@ -1,0 +1,119 @@
+# Specification: Runtime Hot-Reload for Marketing `PushEnabled` Kill-Switch
+
+## Summary
+Convert the marketing action write handlers to read `PushEnabled` via `IOptionsMonitor<MarketingCalendarOptions>` so the Outlook calendar sync kill-switch responds to runtime configuration changes (e.g., Azure App Configuration) without requiring an application restart. This aligns the handlers with the existing `MarketingCategoryMapper` hot-reload pattern already established in the module.
+
+## Background
+The Marketing module integrates with Microsoft Graph to push marketing actions into an Outlook calendar. The `PushEnabled` flag in `MarketingCalendarOptions` is the single kill-switch that disables these outbound Graph calls. Today, two write handlers — `CreateMarketingActionHandler` and `UpdateMarketingActionHandler` — inject `IOptions<MarketingCalendarOptions>`, which captures a startup snapshot. As a result, toggling `PushEnabled` at runtime via Azure App Configuration (or any other dynamic config source) has no effect on the handlers; an application restart is required to honor the change.
+
+This is operationally unsafe. During an incident — Graph API degradation, expired/rotated credentials, runaway sync producing duplicate calendar entries, or any need to halt outbound calls quickly — the operator cannot stop the sync without a deployment-equivalent action (restart). The `MarketingCategoryMapper` singleton in the same module already uses `IOptionsMonitor<MarketingCalendarOptions>` with a documented snapshot-on-failure strategy, demonstrating that runtime config refresh is an intentional design goal for this module. The handlers' continued use of `IOptions<T>` is an inconsistency, and because `PushEnabled` is a kill-switch (not a tunable), it is the higher-impact omission.
+
+Affected code:
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs` (lines 25, 70)
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs` (lines 25, 70)
+
+## Functional Requirements
+
+### FR-1: `CreateMarketingActionHandler` reads `PushEnabled` at runtime
+The `CreateMarketingActionHandler` must evaluate the current value of `MarketingCalendarOptions.PushEnabled` at the time the handler executes, not at the time it (or the host) was constructed.
+
+**Acceptance criteria:**
+- The handler's constructor injects `IOptionsMonitor<MarketingCalendarOptions>` in place of `IOptions<MarketingCalendarOptions>`.
+- The kill-switch check at line 70 reads `_options.CurrentValue.PushEnabled` (or equivalent live access) rather than `_options.Value.PushEnabled`.
+- After the application is running, setting `PushEnabled = false` in the configuration source causes the next invocation of the handler to skip the Outlook push, without restart.
+- After the application is running, setting `PushEnabled = true` causes the next invocation to perform the Outlook push, without restart.
+- No behavioral change occurs when `PushEnabled` is unchanged.
+
+### FR-2: `UpdateMarketingActionHandler` reads `PushEnabled` at runtime
+The `UpdateMarketingActionHandler` must evaluate `PushEnabled` at handler execution time, mirroring FR-1.
+
+**Acceptance criteria:**
+- The handler's constructor injects `IOptionsMonitor<MarketingCalendarOptions>` in place of `IOptions<MarketingCalendarOptions>`.
+- The kill-switch check at line 70 reads `_options.CurrentValue.PushEnabled`.
+- Runtime toggling of `PushEnabled` is honored on the next handler invocation, without restart.
+
+### FR-3: Consistent pattern with existing hot-reload usage
+The implementation must match the conventions already established by `MarketingCategoryMapper`, so that future readers see a single, consistent pattern within the Marketing module.
+
+**Acceptance criteria:**
+- The field name and access pattern follow the conventions used in `MarketingCategoryMapper` (e.g., field type `IOptionsMonitor<MarketingCalendarOptions>`, access via `.CurrentValue`).
+- No additional caching of `PushEnabled` is introduced at the handler level that would re-establish the snapshot problem.
+- If `MarketingCategoryMapper` uses a specific failure/fallback strategy when reading options, this is intentionally **not** copied for the simple boolean `PushEnabled` — the snapshot-on-failure strategy is specific to mapping data, not to a primitive flag.
+
+### FR-4: No regression in non-push code paths
+All existing functionality of both handlers — request validation, persistence, response shape, error handling — must remain identical. The change is strictly an option-access mechanism.
+
+**Acceptance criteria:**
+- All existing unit/integration tests for `CreateMarketingActionHandler` and `UpdateMarketingActionHandler` pass without modification, except where they construct the handler and must be updated to supply an `IOptionsMonitor<T>` test double.
+- Behavior when `PushEnabled = true` and when `PushEnabled = false` is observationally identical to current behavior at the moment of handler invocation.
+
+### FR-5: Test coverage for runtime toggling
+The hot-reload behavior must be covered by automated tests so the kill-switch cannot silently regress to a snapshot read.
+
+**Acceptance criteria:**
+- A unit test exists for each handler that:
+  1. Constructs the handler with an `IOptionsMonitor<MarketingCalendarOptions>` test double initialized with `PushEnabled = true`.
+  2. Invokes the handler and asserts the push path executed.
+  3. Mutates the monitor's current value to `PushEnabled = false`.
+  4. Invokes the handler again with the same instance and asserts the push path did **not** execute.
+- A symmetric test covers the `false → true` transition.
+- Tests use the standard test-double approach already used elsewhere in the codebase for `IOptionsMonitor<T>` (or introduce a minimal helper if none exists).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+`IOptionsMonitor<T>.CurrentValue` is a fast property read backed by a cached value updated by change tokens. The overhead per handler invocation must remain negligible (sub-microsecond) and must not introduce any measurable latency vs. the current `IOptions<T>.Value` access.
+
+### NFR-2: Security
+No change to authentication, authorization, or data sensitivity. The kill-switch itself becomes more responsive, which is a security/operations improvement: operators can disable outbound Graph traffic immediately during an incident without a deployment.
+
+### NFR-3: Operability
+After deployment, an operator must be able to toggle `PushEnabled` via the configured runtime configuration source (e.g., Azure App Configuration) and observe the change taking effect on subsequent handler invocations within the refresh interval already configured for that source. No new configuration source, polling mechanism, or refresh wiring is introduced by this change — it relies on whatever is already in place for `MarketingCategoryMapper`.
+
+### NFR-4: Reliability
+Reading `CurrentValue` must not throw under normal operation. If the underlying `IOptionsMonitor<T>` ever fails to produce a value, the handler should fail closed — i.e., behave as if `PushEnabled = false` and skip the push — rather than throwing and failing the whole create/update operation. (See Open Questions if this contradicts existing module conventions.)
+
+### NFR-5: Backwards compatibility
+The public contract of `CreateMarketingActionHandler` and `UpdateMarketingActionHandler` (their MediatR request/response types) does not change. Only the DI signature changes, which is internal to composition.
+
+## Data Model
+No data model changes. `MarketingCalendarOptions` remains as-is. The only entities involved are:
+
+- `MarketingCalendarOptions` — existing options class containing `PushEnabled` (bool), `GroupId`, and other Graph/calendar settings.
+- `CreateMarketingActionHandler` / `UpdateMarketingActionHandler` — MediatR handlers whose constructor signatures change.
+
+## API / Interface Design
+No external API surface changes. The change is confined to:
+
+1. **Constructor parameter type change** in both handlers:
+   - Before: `IOptions<MarketingCalendarOptions> options`
+   - After: `IOptionsMonitor<MarketingCalendarOptions> options`
+
+2. **Field type change** in both handlers:
+   - Before: `private readonly IOptions<MarketingCalendarOptions> _options;`
+   - After: `private readonly IOptionsMonitor<MarketingCalendarOptions> _options;`
+
+3. **Access expression change** at the `PushEnabled` check site (line 70 in both files):
+   - Before: `if (_options.Value.PushEnabled)`
+   - After: `if (_options.CurrentValue.PushEnabled)`
+
+DI registration of `MarketingCalendarOptions` does not change — `IOptionsMonitor<T>` is available automatically whenever `IOptions<T>` is registered via `services.Configure<T>(...)`.
+
+## Dependencies
+- **Microsoft.Extensions.Options** — `IOptionsMonitor<T>` is part of the standard options abstraction; no new package is required.
+- **Existing Azure App Configuration / change-token plumbing** — whatever already powers `MarketingCategoryMapper`'s hot-reload is reused as-is. This work depends on that infrastructure being functional but does not modify it.
+- **Existing test infrastructure** — `Moq`/`NSubstitute`/manual stub patterns already used in the handler test suites.
+
+## Out of Scope
+- **`OutlookCalendarSyncService`** (`options.Value` cached at construction, line 43). The brief explicitly deprioritizes this: it is scoped, and its options (`GroupId`, `PushEnabled`) are unlikely to change independently of its lifetime. Not touched in this work.
+- **`MarketingCategoryMapper`** — already correct; no changes.
+- **Changes to `MarketingCalendarOptions`** itself (no new fields, no defaults changed).
+- **Changes to Azure App Configuration wiring, refresh intervals, or sentinel keys.**
+- **A general audit of `IOptions<T>` vs. `IOptionsMonitor<T>` across the rest of the codebase.** That is worthwhile but separate from this kill-switch fix.
+- **Adding telemetry, alerting, or audit logging around `PushEnabled` transitions.** Worth considering but out of scope here.
+- **UI or admin endpoint for toggling `PushEnabled`.** The toggle remains a configuration-source concern.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketing-pushenabled-flag-r/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketing-pushenabled-flag-r/task-plan.r1.md
@@ -1,0 +1,850 @@
+# Marketing `PushEnabled` Runtime Hot-Reload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the three Marketing write handlers (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`, `DeleteMarketingActionHandler`) to read `MarketingCalendarOptions.PushEnabled` via `IOptionsMonitor<T>.CurrentValue` so the Outlook calendar-sync kill-switch responds to runtime configuration changes without an application restart.
+
+**Architecture:** Pure DI-mechanism refactor inside the Application layer. Each handler swaps `IOptions<MarketingCalendarOptions>` for `IOptionsMonitor<MarketingCalendarOptions>` and reads the boolean directly at the call site (no caching, no `OnChange` subscription, no defensive `try/catch` — the read is a cached field access and `.ValidateOnStart()` already enforces binding at boot). The `TestOptionsMonitor<T>` test double currently nested inside `MarketingCategoryMapperTests` is promoted to a shared test helper so all three handler test suites can drive runtime toggles.
+
+**Tech Stack:** .NET 8, C#, MediatR, `Microsoft.Extensions.Options`, xUnit, FluentAssertions, Moq, `Microsoft.Extensions.Logging.Abstractions`.
+
+---
+
+## File Structure
+
+**Modified production files:**
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs`
+
+Each handler changes in exactly three places: field type, constructor parameter type, and the `PushEnabled` access expression. The field name `_options` is retained.
+
+**New test helper (shared):**
+- `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs` — lifted verbatim from the private nested class in `MarketingCategoryMapperTests.cs:20-68`, made `public` so all test files in the assembly can use it. Placed under the existing `Helpers/` directory next to `FakeHttpMessageHandler.cs`.
+
+**Modified test files:**
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs` — delete the inline nested `TestOptionsMonitor<T>` and use the shared helper.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs` — replace `Options.Create(...)` factory with `TestOptionsMonitor<MarketingCalendarOptions>`; add hot-reload tests required by FR-5.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` — same.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — same.
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs` — older duplicate; constructor signature must compile against `IOptionsMonitor<T>`.
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — older duplicate covering all three handlers; three `BuildXxxHandler` methods must each take `IOptionsMonitor<T>`.
+
+**Not modified:**
+- `MarketingCalendarOptions.cs` — no schema change.
+- `MarketingModule.cs` — DI registration unchanged; `IOptionsMonitor<T>` is auto-resolvable from `AddOptions<T>().Bind(...)`.
+- `MarketingCategoryMapper.cs` — already correct.
+- `OutlookCalendarSyncService.cs` — out of scope per spec; scoped lifetime, `GroupId` is not the kill-switch.
+
+---
+
+## Task 1: Promote `TestOptionsMonitor<T>` to a shared test helper
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs:20-68` (delete the nested class) and `:81-93` (use the shared helper)
+
+- [ ] **Step 1: Create the shared test helper file**
+
+Write `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Tests.Helpers;
+
+/// <summary>
+/// Minimal <see cref="IOptionsMonitor{T}"/> implementation for tests.
+/// Lifted from MarketingCategoryMapperTests so all handler tests can drive
+/// runtime option changes (PushEnabled toggling, category mapping reloads).
+/// </summary>
+public sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+{
+    private T _current;
+    private readonly List<Action<T, string?>> _listeners = new();
+
+    public TestOptionsMonitor(T initial)
+    {
+        _current = initial;
+    }
+
+    public T CurrentValue => _current;
+
+    public T Get(string? name) => _current;
+
+    public IDisposable OnChange(Action<T, string?> listener)
+    {
+        _listeners.Add(listener);
+        return new Subscription(() => _listeners.Remove(listener));
+    }
+
+    public void Set(T next)
+    {
+        _current = next;
+        foreach (var l in _listeners.ToArray())
+        {
+            l(next, null);
+        }
+    }
+
+    public void SetNull()
+    {
+        foreach (var l in _listeners.ToArray())
+        {
+            l(default(T)!, null);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _dispose;
+
+        public Subscription(Action d)
+        {
+            _dispose = d;
+        }
+
+        public void Dispose() => _dispose();
+    }
+}
+```
+
+- [ ] **Step 2: Remove the inline nested class from `MarketingCategoryMapperTests.cs`**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs`, delete the entire nested helper block (lines 16-68 inclusive — the comment header and the `private sealed class TestOptionsMonitor<T>` definition through its closing brace). Add a `using` directive at the top of the file:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+The remaining file content (factories at line ~74 onward and the tests) is unchanged — `TestOptionsMonitor<MarketingCalendarOptions>` now resolves to the shared type because the local nested class is gone.
+
+- [ ] **Step 3: Run the mapper tests to confirm parity**
+
+Run from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingCategoryMapperTests"
+```
+
+Expected: all 11 mapper tests pass. If any fail, the helper extraction is wrong — diff against the original nested class and fix before moving on.
+
+- [ ] **Step 4: Run a full backend build to confirm no other consumers broke**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs
+git commit -m "refactor: extract TestOptionsMonitor to shared test helper"
+```
+
+---
+
+## Task 2: Switch `CreateMarketingActionHandler` to `IOptionsMonitor`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs:20,25-27,33,72`
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs:11,43-49,143-151` (replace `Options.Create` factory; add hot-reload tests)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs:13,34-43` (legacy duplicate — compile against new constructor)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs:16,51-63` (`BuildCreateHandler` only)
+
+- [ ] **Step 1: Write the failing hot-reload test for Create**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs`, add the following `using` directive near the existing imports:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Then append the following two tests inside the class (after the existing `Handle_ReturnsUnauthorized_WhenUserNotAuthenticated` test, before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+{
+    // Arrange
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+    var handler = new CreateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = true
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook called exactly once (for the first invocation only)
+    _outlookSync.Verify(
+        x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+{
+    // Arrange
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+    var handler = new CreateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = false
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook called exactly once (for the second invocation only)
+    _outlookSync.Verify(
+        x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Application.Marketing.CreateMarketingActionHandlerTests"
+```
+
+Expected: build FAILS with `CS1503` or similar — the `CreateMarketingActionHandler` constructor's fifth parameter is `IOptions<MarketingCalendarOptions>`, not `IOptionsMonitor<MarketingCalendarOptions>`. This is the red state.
+
+- [ ] **Step 3: Update the handler to take `IOptionsMonitor<T>`**
+
+In `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs`:
+
+Change line 20:
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+Change line 27 (constructor signature, last parameter):
+
+```csharp
+// Before
+IOptions<MarketingCalendarOptions> options)
+
+// After
+IOptionsMonitor<MarketingCalendarOptions> options)
+```
+
+Change line 72 (the `PushEnabled` check):
+
+```csharp
+// Before
+if (_options.Value.PushEnabled)
+
+// After
+if (_options.CurrentValue.PushEnabled)
+```
+
+The existing `using Microsoft.Extensions.Options;` on line 10 already imports `IOptionsMonitor<T>`; no using change is required.
+
+- [ ] **Step 4: Update the existing `BuildHandler` factory in the canonical Create test class**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs`, replace lines 43-49 (the `BuildHandler` method) with:
+
+```csharp
+private CreateMarketingActionHandler BuildHandler(bool pushEnabled = true) =>
+    new(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+```
+
+Remove the now-unused `using Microsoft.Extensions.Options;` directive at line 11 (the test file no longer references `Options.Create` or `IOptions<T>` directly).
+
+- [ ] **Step 5: Update the legacy duplicate Create test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs`, add the helper using directive at the top:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Replace the constructor body's Options setup (lines 34-43, the block that builds `mockOptions` via `Mock<IOptions<MarketingCalendarOptions>>` and constructs `_handler`):
+
+```csharp
+// Before
+var options = new MarketingCalendarOptions { PushEnabled = false, GroupId = "test@example.com" };
+var mockOptions = new Mock<IOptions<MarketingCalendarOptions>>();
+mockOptions.Setup(o => o.Value).Returns(options);
+
+_handler = new CreateMarketingActionHandler(
+    _repositoryMock.Object,
+    _currentUserServiceMock.Object,
+    _loggerMock.Object,
+    _outlookSyncMock.Object,
+    mockOptions.Object);
+
+// After
+var options = new MarketingCalendarOptions { PushEnabled = false, GroupId = "test@example.com" };
+var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+_handler = new CreateMarketingActionHandler(
+    _repositoryMock.Object,
+    _currentUserServiceMock.Object,
+    _loggerMock.Object,
+    _outlookSyncMock.Object,
+    monitor);
+```
+
+Then remove the unused `using Microsoft.Extensions.Options;` directive at line 13.
+
+- [ ] **Step 6: Update `BuildCreateHandler` in the legacy combined-sync test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`, add the helper using directive at the top:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Replace lines 51-63 (`BuildCreateHandler` method) with:
+
+```csharp
+private CreateMarketingActionHandler BuildCreateHandler(bool pushEnabled)
+{
+    var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+    return new CreateMarketingActionHandler(
+        _repositoryMock.Object,
+        _currentUserServiceMock.Object,
+        NullLogger<CreateMarketingActionHandler>.Instance,
+        _outlookSyncMock.Object,
+        monitor);
+}
+```
+
+Do **not** touch `BuildUpdateHandler` or `BuildDeleteHandler` in this step — they are wired in Tasks 3 and 4 respectively. Leave the `using Microsoft.Extensions.Options;` directive in place for now (it is still needed by the other two builders).
+
+- [ ] **Step 7: Run the Create handler tests and verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~CreateMarketingActionHandlerTests"
+```
+
+Expected: all Create handler tests pass — the original 7 in `Application/Marketing/`, the 2 new hot-reload tests, and the 2 in `Features/Marketing/`. Confirm the two new `Handle_HonorsRuntimePushEnabledFlip_*` tests are present in the output and green.
+
+- [ ] **Step 8: Run the full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds. `MarketingActionHandlerSyncTests.cs`'s `BuildUpdateHandler` and `BuildDeleteHandler` still compile because the Update and Delete handlers haven't been changed yet.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs \
+        backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "feat(marketing): hot-reload PushEnabled in CreateMarketingActionHandler"
+```
+
+---
+
+## Task 3: Switch `UpdateMarketingActionHandler` to `IOptionsMonitor`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs:25,32,70`
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs:11,63-69` (replace `Options.Create` factory; add hot-reload tests)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs:65-77` (`BuildUpdateHandler` only)
+
+- [ ] **Step 1: Write the failing hot-reload test for Update**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`, add the helper using directive near the existing imports:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Then append the following two tests inside the class (after the existing `Handle_UpdatesProductsAndFolderLinks_WhenProvided` test, before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+{
+    // Arrange — fresh repository setup so two invocations both find the action
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+    var handler = new UpdateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = true (existing event → UpdateEventAsync)
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook called exactly once (first invocation only)
+    _outlookSync.Verify(
+        x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+    _outlookSync.Verify(
+        x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+{
+    // Arrange
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+    var handler = new UpdateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = false
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook UpdateEventAsync called exactly once (second invocation only,
+    // because BuildExistingAction has an OutlookEventId so Update path is taken).
+    _outlookSync.Verify(
+        x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Application.Marketing.UpdateMarketingActionHandlerTests"
+```
+
+Expected: build FAILS with `CS1503` — the `UpdateMarketingActionHandler` constructor still takes `IOptions<MarketingCalendarOptions>`.
+
+- [ ] **Step 3: Update the handler to take `IOptionsMonitor<T>`**
+
+In `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`:
+
+Change line 25:
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+Change line 32 (constructor signature, last parameter):
+
+```csharp
+// Before
+IOptions<MarketingCalendarOptions> options)
+
+// After
+IOptionsMonitor<MarketingCalendarOptions> options)
+```
+
+Change line 70 (the `PushEnabled` check):
+
+```csharp
+// Before
+if (_options.Value.PushEnabled)
+
+// After
+if (_options.CurrentValue.PushEnabled)
+```
+
+- [ ] **Step 4: Update the existing `BuildHandler` factory in the canonical Update test class**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`, replace lines 63-69 (the `BuildHandler` method) with:
+
+```csharp
+private UpdateMarketingActionHandler BuildHandler(bool pushEnabled = true) =>
+    new(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+```
+
+Remove the now-unused `using Microsoft.Extensions.Options;` directive at line 11.
+
+- [ ] **Step 5: Update `BuildUpdateHandler` in the legacy combined-sync test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`, replace lines 65-77 (the `BuildUpdateHandler` method) with:
+
+```csharp
+private UpdateMarketingActionHandler BuildUpdateHandler(bool pushEnabled)
+{
+    var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+    return new UpdateMarketingActionHandler(
+        _repositoryMock.Object,
+        _currentUserServiceMock.Object,
+        NullLogger<UpdateMarketingActionHandler>.Instance,
+        _outlookSyncMock.Object,
+        monitor);
+}
+```
+
+Leave `BuildDeleteHandler` and the existing `using Microsoft.Extensions.Options;` directive in place — both are still needed for Task 4.
+
+- [ ] **Step 6: Run the Update handler tests and verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdateMarketingActionHandlerTests"
+```
+
+Expected: all Update handler tests pass — the original 8 plus the 2 new hot-reload tests. Also re-run the cross-cutting sync tests to confirm the Update path inside `MarketingActionHandlerSyncTests` still passes:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingActionHandlerSyncTests"
+```
+
+Expected: all 7 sync tests pass.
+
+- [ ] **Step 7: Run the full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds. `BuildDeleteHandler` in the sync test file still compiles because the Delete handler hasn't been changed yet.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs \
+        backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "feat(marketing): hot-reload PushEnabled in UpdateMarketingActionHandler"
+```
+
+---
+
+## Task 4: Switch `DeleteMarketingActionHandler` to `IOptionsMonitor`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs:20,27,54`
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs:11,53-59` (replace `Options.Create` factory; add hot-reload tests)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs:79-91` (`BuildDeleteHandler` only)
+
+- [ ] **Step 1: Write the failing hot-reload test for Delete**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs`, add the helper using directive near the existing imports:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Then append the following two tests inside the class (after the existing `Handle_ReturnsNotFound_WhenActionDoesNotExist` test, before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+{
+    // Arrange — return a fresh action with an OutlookEventId on every call
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+    var handler = new DeleteMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = true
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook DeleteEventAsync called exactly once (first invocation only)
+    _outlookSync.Verify(
+        x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+{
+    // Arrange
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+    var handler = new DeleteMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = false
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook DeleteEventAsync called exactly once (second invocation only)
+    _outlookSync.Verify(
+        x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Application.Marketing.DeleteMarketingActionHandlerTests"
+```
+
+Expected: build FAILS with `CS1503` — the `DeleteMarketingActionHandler` constructor still takes `IOptions<MarketingCalendarOptions>`.
+
+- [ ] **Step 3: Update the handler to take `IOptionsMonitor<T>`**
+
+In `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs`:
+
+Change line 20:
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+Change line 27 (constructor signature, last parameter):
+
+```csharp
+// Before
+IOptions<MarketingCalendarOptions> options)
+
+// After
+IOptionsMonitor<MarketingCalendarOptions> options)
+```
+
+Change line 54 (the `PushEnabled` check):
+
+```csharp
+// Before
+if (_options.Value.PushEnabled && !string.IsNullOrEmpty(action.OutlookEventId))
+
+// After
+if (_options.CurrentValue.PushEnabled && !string.IsNullOrEmpty(action.OutlookEventId))
+```
+
+- [ ] **Step 4: Update the existing `BuildHandler` factory in the canonical Delete test class**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs`, replace lines 53-59 (the `BuildHandler` method) with:
+
+```csharp
+private DeleteMarketingActionHandler BuildHandler(bool pushEnabled = true) =>
+    new(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+```
+
+Remove the now-unused `using Microsoft.Extensions.Options;` directive at line 11.
+
+- [ ] **Step 5: Update `BuildDeleteHandler` in the legacy combined-sync test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`, replace lines 79-91 (the `BuildDeleteHandler` method) with:
+
+```csharp
+private DeleteMarketingActionHandler BuildDeleteHandler(bool pushEnabled)
+{
+    var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+    return new DeleteMarketingActionHandler(
+        _repositoryMock.Object,
+        _currentUserServiceMock.Object,
+        NullLogger<DeleteMarketingActionHandler>.Instance,
+        _outlookSyncMock.Object,
+        monitor);
+}
+```
+
+Now that none of the three `BuildXxxHandler` methods reference `IOptions<T>` or `Mock<IOptions<...>>` anywhere in the file, remove the unused `using Microsoft.Extensions.Options;` directive at line 16.
+
+- [ ] **Step 6: Run the Delete handler tests and verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~DeleteMarketingActionHandlerTests"
+```
+
+Expected: all Delete handler tests pass — the original 7 plus the 2 new hot-reload tests.
+
+- [ ] **Step 7: Run the full marketing test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Marketing"
+```
+
+Expected: all marketing-namespace tests pass — mapper tests, all three handler test classes (canonical), the two legacy duplicate handler test files, and any other marketing tests in the project.
+
+- [ ] **Step 8: Run the full backend build and the full test suite**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds; all tests in the suite pass with no regressions outside marketing.
+
+- [ ] **Step 9: Run `dotnet format` and commit**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs \
+        backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "feat(marketing): hot-reload PushEnabled in DeleteMarketingActionHandler"
+```
+
+If `dotnet format` produces additional whitespace-only changes in unrelated files, stage and commit those separately with `chore: dotnet format` rather than bundling them into the feature commit.
+
+---
+
+## Task 5: Final verification
+
+**Files:** none modified — this task only verifies the end state.
+
+- [ ] **Step 1: Confirm no remaining `IOptions<MarketingCalendarOptions>` references in the three handlers**
+
+```bash
+grep -nE "IOptions<MarketingCalendarOptions>" \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+```
+
+Expected: each file shows only `IOptionsMonitor<MarketingCalendarOptions>` matches (because `IOptionsMonitor` contains the substring `IOptions`). To check there is no exact `IOptions<...>` (without `Monitor`):
+
+```bash
+grep -nE "IOptions<MarketingCalendarOptions>" \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/*/*Handler.cs \
+  | grep -v IOptionsMonitor
+```
+
+Expected: empty output (no matches).
+
+- [ ] **Step 2: Confirm `OutlookCalendarSyncService` is untouched (out of scope per spec)**
+
+```bash
+git diff main -- backend/src/Anela.Heblo.Application/Features/Marketing/Services/OutlookCalendarSyncService.cs
+```
+
+Expected: empty diff. This service was intentionally left on `IOptions<T>` because it is scoped per request and `GroupId` is not the kill-switch.
+
+- [ ] **Step 3: Confirm `MarketingModule` DI registration is untouched**
+
+```bash
+git diff main -- backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+```
+
+Expected: empty diff. `IOptionsMonitor<MarketingCalendarOptions>` is auto-resolvable from the existing `AddOptions<T>().Bind(...)` call; no new registration is needed.
+
+- [ ] **Step 4: Run the full test suite and full backend build one more time as a final gate**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: both succeed.
+
+- [ ] **Step 5: Manually confirm the PR description should call out the duplicate test files**
+
+When opening the PR, include a note in the description (do not modify any code for this step):
+
+> Two duplicate Marketing handler test classes exist alongside the canonical ones in `Application/Marketing/`:
+> - `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs`
+> - `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`
+>
+> Both were updated to compile against the new `IOptionsMonitor<T>` constructor signature but were intentionally **not** deleted as part of this change. Recommend follow-up to consolidate or remove these duplicates.
+
+No commit produced by this step — it is a PR-description reminder, not a code change.

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
@@ -17,14 +17,14 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAct
         private readonly ICurrentUserService _currentUserService;
         private readonly ILogger<CreateMarketingActionHandler> _logger;
         private readonly IOutlookCalendarSync _outlookSync;
-        private readonly IOptions<MarketingCalendarOptions> _options;
+        private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
 
         public CreateMarketingActionHandler(
             IMarketingActionRepository repository,
             ICurrentUserService currentUserService,
             ILogger<CreateMarketingActionHandler> logger,
             IOutlookCalendarSync outlookSync,
-            IOptions<MarketingCalendarOptions> options)
+            IOptionsMonitor<MarketingCalendarOptions> options)
         {
             _repository = repository;
             _currentUserService = currentUserService;
@@ -69,7 +69,7 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAct
 
             string? outlookEventId = null;
 
-            if (_options.Value.PushEnabled)
+            if (_options.CurrentValue.PushEnabled)
             {
                 try
                 {

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
@@ -17,14 +17,14 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAct
         private readonly ICurrentUserService _currentUserService;
         private readonly ILogger<DeleteMarketingActionHandler> _logger;
         private readonly IOutlookCalendarSync _outlookSync;
-        private readonly IOptions<MarketingCalendarOptions> _options;
+        private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
 
         public DeleteMarketingActionHandler(
             IMarketingActionRepository repository,
             ICurrentUserService currentUserService,
             ILogger<DeleteMarketingActionHandler> logger,
             IOutlookCalendarSync outlookSync,
-            IOptions<MarketingCalendarOptions> options)
+            IOptionsMonitor<MarketingCalendarOptions> options)
         {
             _repository = repository;
             _currentUserService = currentUserService;
@@ -51,7 +51,7 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAct
                     new Dictionary<string, string> { { "actionId", request.Id.ToString() } });
             }
 
-            if (_options.Value.PushEnabled && !string.IsNullOrEmpty(action.OutlookEventId))
+            if (_options.CurrentValue.PushEnabled && !string.IsNullOrEmpty(action.OutlookEventId))
             {
                 try
                 {

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
@@ -22,14 +22,14 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAct
         private readonly ICurrentUserService _currentUserService;
         private readonly ILogger<UpdateMarketingActionHandler> _logger;
         private readonly IOutlookCalendarSync _outlookSync;
-        private readonly IOptions<MarketingCalendarOptions> _options;
+        private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
 
         public UpdateMarketingActionHandler(
             IMarketingActionRepository repository,
             ICurrentUserService currentUserService,
             ILogger<UpdateMarketingActionHandler> logger,
             IOutlookCalendarSync outlookSync,
-            IOptions<MarketingCalendarOptions> options)
+            IOptionsMonitor<MarketingCalendarOptions> options)
         {
             _repository = repository;
             _currentUserService = currentUserService;
@@ -67,7 +67,7 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAct
             action.ModifiedByUserId = currentUser.Id;
             action.ModifiedByUsername = currentUser.Name ?? "Unknown User";
 
-            if (_options.Value.PushEnabled)
+            if (_options.CurrentValue.PushEnabled)
             {
                 try
                 {

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs
@@ -6,9 +6,9 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Anela.Heblo.Tests.Application.Marketing;
@@ -46,7 +46,8 @@ public class CreateMarketingActionHandlerTests
             _currentUserService.Object,
             _logger.Object,
             _outlookSync.Object,
-            Options.Create(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+            new TestOptionsMonitor<MarketingCalendarOptions>(
+                new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
 
     private static CreateMarketingActionRequest BuildRequest() => new()
     {
@@ -164,5 +165,51 @@ public class CreateMarketingActionHandlerTests
         _outlookSync.Verify(
             x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+    {
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+        var handler = new CreateMarketingActionHandler(
+            _repository.Object,
+            _currentUserService.Object,
+            _logger.Object,
+            _outlookSync.Object,
+            monitor);
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        _outlookSync.Verify(
+            x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+    {
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+        var handler = new CreateMarketingActionHandler(
+            _repository.Object,
+            _currentUserService.Object,
+            _logger.Object,
+            _outlookSync.Object,
+            monitor);
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        _outlookSync.Verify(
+            x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
@@ -6,9 +6,9 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Anela.Heblo.Tests.Application.Marketing;
@@ -56,7 +56,8 @@ public class DeleteMarketingActionHandlerTests
             _currentUserService.Object,
             _logger.Object,
             _outlookSync.Object,
-            Options.Create(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+            new TestOptionsMonitor<MarketingCalendarOptions>(
+                new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
 
     [Fact]
     public async Task Handle_CallsOutlookDeleteBeforeSoftDelete_WhenPushEnabled()
@@ -166,5 +167,59 @@ public class DeleteMarketingActionHandlerTests
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.MarketingActionNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => BuildExistingAction());
+
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+        var handler = new DeleteMarketingActionHandler(
+            _repository.Object,
+            _currentUserService.Object,
+            _logger.Object,
+            _outlookSync.Object,
+            monitor);
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        _outlookSync.Verify(
+            x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => BuildExistingAction());
+
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+        var handler = new DeleteMarketingActionHandler(
+            _repository.Object,
+            _currentUserService.Object,
+            _logger.Object,
+            _outlookSync.Object,
+            monitor);
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        _outlookSync.Verify(
+            x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
@@ -6,9 +6,9 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Anela.Heblo.Tests.Application.Marketing;
@@ -66,7 +66,8 @@ public class UpdateMarketingActionHandlerTests
             _currentUserService.Object,
             _logger.Object,
             _outlookSync.Object,
-            Options.Create(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+            new TestOptionsMonitor<MarketingCalendarOptions>(
+                new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
 
     [Fact]
     public async Task Handle_CallsOutlookBeforeDb_WhenPushEnabled()
@@ -198,5 +199,62 @@ public class UpdateMarketingActionHandlerTests
                 a.ProductAssociations.Count == 2 &&
                 a.FolderLinks.Count == 1),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => BuildExistingAction());
+
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+        var handler = new UpdateMarketingActionHandler(
+            _repository.Object,
+            _currentUserService.Object,
+            _logger.Object,
+            _outlookSync.Object,
+            monitor);
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        _outlookSync.Verify(
+            x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _outlookSync.Verify(
+            x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+    {
+        _repository
+            .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => BuildExistingAction());
+
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+        var handler = new UpdateMarketingActionHandler(
+            _repository.Object,
+            _currentUserService.Object,
+            _logger.Object,
+            _outlookSync.Object,
+            monitor);
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+        await handler.Handle(BuildRequest(), CancellationToken.None);
+
+        _outlookSync.Verify(
+            x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
@@ -8,9 +8,9 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -32,15 +32,14 @@ public class CreateMarketingActionHandlerTests
         _outlookSyncMock = new Mock<IOutlookCalendarSync>();
 
         var options = new MarketingCalendarOptions { PushEnabled = false, GroupId = "test@example.com" };
-        var mockOptions = new Mock<IOptions<MarketingCalendarOptions>>();
-        mockOptions.Setup(o => o.Value).Returns(options);
+        var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
 
         _handler = new CreateMarketingActionHandler(
             _repositoryMock.Object,
             _currentUserServiceMock.Object,
             _loggerMock.Object,
             _outlookSyncMock.Object,
-            mockOptions.Object);
+            monitor);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
@@ -11,9 +11,9 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -51,43 +51,40 @@ namespace Anela.Heblo.Tests.Features.Marketing
         private CreateMarketingActionHandler BuildCreateHandler(bool pushEnabled)
         {
             var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
-            var mockOptions = new Mock<IOptions<MarketingCalendarOptions>>();
-            mockOptions.Setup(o => o.Value).Returns(options);
+            var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
 
             return new CreateMarketingActionHandler(
                 _repositoryMock.Object,
                 _currentUserServiceMock.Object,
                 NullLogger<CreateMarketingActionHandler>.Instance,
                 _outlookSyncMock.Object,
-                mockOptions.Object);
+                monitor);
         }
 
         private UpdateMarketingActionHandler BuildUpdateHandler(bool pushEnabled)
         {
             var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
-            var mockOptions = new Mock<IOptions<MarketingCalendarOptions>>();
-            mockOptions.Setup(o => o.Value).Returns(options);
+            var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
 
             return new UpdateMarketingActionHandler(
                 _repositoryMock.Object,
                 _currentUserServiceMock.Object,
                 NullLogger<UpdateMarketingActionHandler>.Instance,
                 _outlookSyncMock.Object,
-                mockOptions.Object);
+                monitor);
         }
 
         private DeleteMarketingActionHandler BuildDeleteHandler(bool pushEnabled)
         {
             var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
-            var mockOptions = new Mock<IOptions<MarketingCalendarOptions>>();
-            mockOptions.Setup(o => o.Value).Returns(options);
+            var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
 
             return new DeleteMarketingActionHandler(
                 _repositoryMock.Object,
                 _currentUserServiceMock.Object,
                 NullLogger<DeleteMarketingActionHandler>.Instance,
                 _outlookSyncMock.Object,
-                mockOptions.Object);
+                monitor);
         }
 
         private static MarketingAction BuildAction(string? outlookEventId = null)

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,60 +14,6 @@ namespace Anela.Heblo.Tests.Features.Marketing.Services;
 
 public sealed class MarketingCategoryMapperTests
 {
-    // ---------------------------------------------------------------------------
-    // Helper: minimal IOptionsMonitor<T> implementation for tests
-    // ---------------------------------------------------------------------------
-
-    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
-    {
-        private T _current;
-        private readonly List<Action<T, string?>> _listeners = new();
-
-        public TestOptionsMonitor(T initial)
-        {
-            _current = initial;
-        }
-
-        public T CurrentValue => _current;
-
-        public T Get(string? name) => _current;
-
-        public IDisposable OnChange(Action<T, string?> listener)
-        {
-            _listeners.Add(listener);
-            return new Subscription(() => _listeners.Remove(listener));
-        }
-
-        public void Set(T next)
-        {
-            _current = next;
-            foreach (var l in _listeners.ToArray())
-            {
-                l(next, null);
-            }
-        }
-
-        public void SetNull()
-        {
-            foreach (var l in _listeners.ToArray())
-            {
-                l(default(T)!, null);
-            }
-        }
-
-        private sealed class Subscription : IDisposable
-        {
-            private readonly Action _dispose;
-
-            public Subscription(Action d)
-            {
-                _dispose = d;
-            }
-
-            public void Dispose() => _dispose();
-        }
-    }
-
     // ---------------------------------------------------------------------------
     // Factory helpers
     // ---------------------------------------------------------------------------

--- a/backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs
+++ b/backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Tests.Helpers;
+
+public sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+{
+    private T _current;
+    private readonly List<Action<T, string?>> _listeners = new();
+
+    public TestOptionsMonitor(T initial)
+    {
+        _current = initial;
+    }
+
+    public T CurrentValue => _current;
+
+    public T Get(string? name) => _current;
+
+    public IDisposable OnChange(Action<T, string?> listener)
+    {
+        _listeners.Add(listener);
+        return new Subscription(() => _listeners.Remove(listener));
+    }
+
+    public void Set(T next)
+    {
+        _current = next;
+        foreach (var l in _listeners.ToArray())
+        {
+            l(next, null);
+        }
+    }
+
+    public void SetNull()
+    {
+        foreach (var l in _listeners.ToArray())
+        {
+            l(default(T)!, null);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _dispose;
+
+        public Subscription(Action d)
+        {
+            _dispose = d;
+        }
+
+        public void Dispose() => _dispose();
+    }
+}

--- a/docs/superpowers/plans/2026-05-18-marketing-pushenabled-hot-reload.md
+++ b/docs/superpowers/plans/2026-05-18-marketing-pushenabled-hot-reload.md
@@ -1,0 +1,850 @@
+# Marketing `PushEnabled` Runtime Hot-Reload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the three Marketing write handlers (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`, `DeleteMarketingActionHandler`) to read `MarketingCalendarOptions.PushEnabled` via `IOptionsMonitor<T>.CurrentValue` so the Outlook calendar-sync kill-switch responds to runtime configuration changes without an application restart.
+
+**Architecture:** Pure DI-mechanism refactor inside the Application layer. Each handler swaps `IOptions<MarketingCalendarOptions>` for `IOptionsMonitor<MarketingCalendarOptions>` and reads the boolean directly at the call site (no caching, no `OnChange` subscription, no defensive `try/catch` — the read is a cached field access and `.ValidateOnStart()` already enforces binding at boot). The `TestOptionsMonitor<T>` test double currently nested inside `MarketingCategoryMapperTests` is promoted to a shared test helper so all three handler test suites can drive runtime toggles.
+
+**Tech Stack:** .NET 8, C#, MediatR, `Microsoft.Extensions.Options`, xUnit, FluentAssertions, Moq, `Microsoft.Extensions.Logging.Abstractions`.
+
+---
+
+## File Structure
+
+**Modified production files:**
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs`
+
+Each handler changes in exactly three places: field type, constructor parameter type, and the `PushEnabled` access expression. The field name `_options` is retained.
+
+**New test helper (shared):**
+- `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs` — lifted verbatim from the private nested class in `MarketingCategoryMapperTests.cs:20-68`, made `public` so all test files in the assembly can use it. Placed under the existing `Helpers/` directory next to `FakeHttpMessageHandler.cs`.
+
+**Modified test files:**
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs` — delete the inline nested `TestOptionsMonitor<T>` and use the shared helper.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs` — replace `Options.Create(...)` factory with `TestOptionsMonitor<MarketingCalendarOptions>`; add hot-reload tests required by FR-5.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs` — same.
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs` — same.
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs` — older duplicate; constructor signature must compile against `IOptionsMonitor<T>`.
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs` — older duplicate covering all three handlers; three `BuildXxxHandler` methods must each take `IOptionsMonitor<T>`.
+
+**Not modified:**
+- `MarketingCalendarOptions.cs` — no schema change.
+- `MarketingModule.cs` — DI registration unchanged; `IOptionsMonitor<T>` is auto-resolvable from `AddOptions<T>().Bind(...)`.
+- `MarketingCategoryMapper.cs` — already correct.
+- `OutlookCalendarSyncService.cs` — out of scope per spec; scoped lifetime, `GroupId` is not the kill-switch.
+
+---
+
+## Task 1: Promote `TestOptionsMonitor<T>` to a shared test helper
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs:20-68` (delete the nested class) and `:81-93` (use the shared helper)
+
+- [ ] **Step 1: Create the shared test helper file**
+
+Write `backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Tests.Helpers;
+
+/// <summary>
+/// Minimal <see cref="IOptionsMonitor{T}"/> implementation for tests.
+/// Lifted from MarketingCategoryMapperTests so all handler tests can drive
+/// runtime option changes (PushEnabled toggling, category mapping reloads).
+/// </summary>
+public sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+{
+    private T _current;
+    private readonly List<Action<T, string?>> _listeners = new();
+
+    public TestOptionsMonitor(T initial)
+    {
+        _current = initial;
+    }
+
+    public T CurrentValue => _current;
+
+    public T Get(string? name) => _current;
+
+    public IDisposable OnChange(Action<T, string?> listener)
+    {
+        _listeners.Add(listener);
+        return new Subscription(() => _listeners.Remove(listener));
+    }
+
+    public void Set(T next)
+    {
+        _current = next;
+        foreach (var l in _listeners.ToArray())
+        {
+            l(next, null);
+        }
+    }
+
+    public void SetNull()
+    {
+        foreach (var l in _listeners.ToArray())
+        {
+            l(default(T)!, null);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _dispose;
+
+        public Subscription(Action d)
+        {
+            _dispose = d;
+        }
+
+        public void Dispose() => _dispose();
+    }
+}
+```
+
+- [ ] **Step 2: Remove the inline nested class from `MarketingCategoryMapperTests.cs`**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs`, delete the entire nested helper block (lines 16-68 inclusive — the comment header and the `private sealed class TestOptionsMonitor<T>` definition through its closing brace). Add a `using` directive at the top of the file:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+The remaining file content (factories at line ~74 onward and the tests) is unchanged — `TestOptionsMonitor<MarketingCalendarOptions>` now resolves to the shared type because the local nested class is gone.
+
+- [ ] **Step 3: Run the mapper tests to confirm parity**
+
+Run from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingCategoryMapperTests"
+```
+
+Expected: all 11 mapper tests pass. If any fail, the helper extraction is wrong — diff against the original nested class and fix before moving on.
+
+- [ ] **Step 4: Run a full backend build to confirm no other consumers broke**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Helpers/TestOptionsMonitor.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/Services/MarketingCategoryMapperTests.cs
+git commit -m "refactor: extract TestOptionsMonitor to shared test helper"
+```
+
+---
+
+## Task 2: Switch `CreateMarketingActionHandler` to `IOptionsMonitor`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs:20,25-27,33,72`
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs:11,43-49,143-151` (replace `Options.Create` factory; add hot-reload tests)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs:13,34-43` (legacy duplicate — compile against new constructor)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs:16,51-63` (`BuildCreateHandler` only)
+
+- [ ] **Step 1: Write the failing hot-reload test for Create**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs`, add the following `using` directive near the existing imports:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Then append the following two tests inside the class (after the existing `Handle_ReturnsUnauthorized_WhenUserNotAuthenticated` test, before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+{
+    // Arrange
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+    var handler = new CreateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = true
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook called exactly once (for the first invocation only)
+    _outlookSync.Verify(
+        x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+{
+    // Arrange
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+    var handler = new CreateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = false
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook called exactly once (for the second invocation only)
+    _outlookSync.Verify(
+        x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Application.Marketing.CreateMarketingActionHandlerTests"
+```
+
+Expected: build FAILS with `CS1503` or similar — the `CreateMarketingActionHandler` constructor's fifth parameter is `IOptions<MarketingCalendarOptions>`, not `IOptionsMonitor<MarketingCalendarOptions>`. This is the red state.
+
+- [ ] **Step 3: Update the handler to take `IOptionsMonitor<T>`**
+
+In `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs`:
+
+Change line 20:
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+Change line 27 (constructor signature, last parameter):
+
+```csharp
+// Before
+IOptions<MarketingCalendarOptions> options)
+
+// After
+IOptionsMonitor<MarketingCalendarOptions> options)
+```
+
+Change line 72 (the `PushEnabled` check):
+
+```csharp
+// Before
+if (_options.Value.PushEnabled)
+
+// After
+if (_options.CurrentValue.PushEnabled)
+```
+
+The existing `using Microsoft.Extensions.Options;` on line 10 already imports `IOptionsMonitor<T>`; no using change is required.
+
+- [ ] **Step 4: Update the existing `BuildHandler` factory in the canonical Create test class**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs`, replace lines 43-49 (the `BuildHandler` method) with:
+
+```csharp
+private CreateMarketingActionHandler BuildHandler(bool pushEnabled = true) =>
+    new(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+```
+
+Remove the now-unused `using Microsoft.Extensions.Options;` directive at line 11 (the test file no longer references `Options.Create` or `IOptions<T>` directly).
+
+- [ ] **Step 5: Update the legacy duplicate Create test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs`, add the helper using directive at the top:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Replace the constructor body's Options setup (lines 34-43, the block that builds `mockOptions` via `Mock<IOptions<MarketingCalendarOptions>>` and constructs `_handler`):
+
+```csharp
+// Before
+var options = new MarketingCalendarOptions { PushEnabled = false, GroupId = "test@example.com" };
+var mockOptions = new Mock<IOptions<MarketingCalendarOptions>>();
+mockOptions.Setup(o => o.Value).Returns(options);
+
+_handler = new CreateMarketingActionHandler(
+    _repositoryMock.Object,
+    _currentUserServiceMock.Object,
+    _loggerMock.Object,
+    _outlookSyncMock.Object,
+    mockOptions.Object);
+
+// After
+var options = new MarketingCalendarOptions { PushEnabled = false, GroupId = "test@example.com" };
+var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+_handler = new CreateMarketingActionHandler(
+    _repositoryMock.Object,
+    _currentUserServiceMock.Object,
+    _loggerMock.Object,
+    _outlookSyncMock.Object,
+    monitor);
+```
+
+Then remove the unused `using Microsoft.Extensions.Options;` directive at line 13.
+
+- [ ] **Step 6: Update `BuildCreateHandler` in the legacy combined-sync test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`, add the helper using directive at the top:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Replace lines 51-63 (`BuildCreateHandler` method) with:
+
+```csharp
+private CreateMarketingActionHandler BuildCreateHandler(bool pushEnabled)
+{
+    var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+    return new CreateMarketingActionHandler(
+        _repositoryMock.Object,
+        _currentUserServiceMock.Object,
+        NullLogger<CreateMarketingActionHandler>.Instance,
+        _outlookSyncMock.Object,
+        monitor);
+}
+```
+
+Do **not** touch `BuildUpdateHandler` or `BuildDeleteHandler` in this step — they are wired in Tasks 3 and 4 respectively. Leave the `using Microsoft.Extensions.Options;` directive in place for now (it is still needed by the other two builders).
+
+- [ ] **Step 7: Run the Create handler tests and verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~CreateMarketingActionHandlerTests"
+```
+
+Expected: all Create handler tests pass — the original 7 in `Application/Marketing/`, the 2 new hot-reload tests, and the 2 in `Features/Marketing/`. Confirm the two new `Handle_HonorsRuntimePushEnabledFlip_*` tests are present in the output and green.
+
+- [ ] **Step 8: Run the full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds. `MarketingActionHandlerSyncTests.cs`'s `BuildUpdateHandler` and `BuildDeleteHandler` still compile because the Update and Delete handlers haven't been changed yet.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs \
+        backend/test/Anela.Heblo.Tests/Application/Marketing/CreateMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "feat(marketing): hot-reload PushEnabled in CreateMarketingActionHandler"
+```
+
+---
+
+## Task 3: Switch `UpdateMarketingActionHandler` to `IOptionsMonitor`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs:25,32,70`
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs:11,63-69` (replace `Options.Create` factory; add hot-reload tests)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs:65-77` (`BuildUpdateHandler` only)
+
+- [ ] **Step 1: Write the failing hot-reload test for Update**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`, add the helper using directive near the existing imports:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Then append the following two tests inside the class (after the existing `Handle_UpdatesProductsAndFolderLinks_WhenProvided` test, before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+{
+    // Arrange — fresh repository setup so two invocations both find the action
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+    var handler = new UpdateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = true (existing event → UpdateEventAsync)
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook called exactly once (first invocation only)
+    _outlookSync.Verify(
+        x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+    _outlookSync.Verify(
+        x => x.CreateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+{
+    // Arrange
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+    var handler = new UpdateMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = false
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook UpdateEventAsync called exactly once (second invocation only,
+    // because BuildExistingAction has an OutlookEventId so Update path is taken).
+    _outlookSync.Verify(
+        x => x.UpdateEventAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Application.Marketing.UpdateMarketingActionHandlerTests"
+```
+
+Expected: build FAILS with `CS1503` — the `UpdateMarketingActionHandler` constructor still takes `IOptions<MarketingCalendarOptions>`.
+
+- [ ] **Step 3: Update the handler to take `IOptionsMonitor<T>`**
+
+In `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs`:
+
+Change line 25:
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+Change line 32 (constructor signature, last parameter):
+
+```csharp
+// Before
+IOptions<MarketingCalendarOptions> options)
+
+// After
+IOptionsMonitor<MarketingCalendarOptions> options)
+```
+
+Change line 70 (the `PushEnabled` check):
+
+```csharp
+// Before
+if (_options.Value.PushEnabled)
+
+// After
+if (_options.CurrentValue.PushEnabled)
+```
+
+- [ ] **Step 4: Update the existing `BuildHandler` factory in the canonical Update test class**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs`, replace lines 63-69 (the `BuildHandler` method) with:
+
+```csharp
+private UpdateMarketingActionHandler BuildHandler(bool pushEnabled = true) =>
+    new(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+```
+
+Remove the now-unused `using Microsoft.Extensions.Options;` directive at line 11.
+
+- [ ] **Step 5: Update `BuildUpdateHandler` in the legacy combined-sync test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`, replace lines 65-77 (the `BuildUpdateHandler` method) with:
+
+```csharp
+private UpdateMarketingActionHandler BuildUpdateHandler(bool pushEnabled)
+{
+    var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+    return new UpdateMarketingActionHandler(
+        _repositoryMock.Object,
+        _currentUserServiceMock.Object,
+        NullLogger<UpdateMarketingActionHandler>.Instance,
+        _outlookSyncMock.Object,
+        monitor);
+}
+```
+
+Leave `BuildDeleteHandler` and the existing `using Microsoft.Extensions.Options;` directive in place — both are still needed for Task 4.
+
+- [ ] **Step 6: Run the Update handler tests and verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdateMarketingActionHandlerTests"
+```
+
+Expected: all Update handler tests pass — the original 8 plus the 2 new hot-reload tests. Also re-run the cross-cutting sync tests to confirm the Update path inside `MarketingActionHandlerSyncTests` still passes:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingActionHandlerSyncTests"
+```
+
+Expected: all 7 sync tests pass.
+
+- [ ] **Step 7: Run the full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds. `BuildDeleteHandler` in the sync test file still compiles because the Delete handler hasn't been changed yet.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs \
+        backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "feat(marketing): hot-reload PushEnabled in UpdateMarketingActionHandler"
+```
+
+---
+
+## Task 4: Switch `DeleteMarketingActionHandler` to `IOptionsMonitor`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs:20,27,54`
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs:11,53-59` (replace `Options.Create` factory; add hot-reload tests)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs:79-91` (`BuildDeleteHandler` only)
+
+- [ ] **Step 1: Write the failing hot-reload test for Delete**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs`, add the helper using directive near the existing imports:
+
+```csharp
+using Anela.Heblo.Tests.Helpers;
+```
+
+Then append the following two tests inside the class (after the existing `Handle_ReturnsNotFound_WhenActionDoesNotExist` test, before the closing `}`):
+
+```csharp
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_TrueToFalse()
+{
+    // Arrange — return a fresh action with an OutlookEventId on every call
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+    var handler = new DeleteMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = true
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook DeleteEventAsync called exactly once (first invocation only)
+    _outlookSync.Verify(
+        x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+
+[Fact]
+public async Task Handle_HonorsRuntimePushEnabledFlip_FalseToTrue()
+{
+    // Arrange
+    _repository
+        .Setup(x => x.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(() => BuildExistingAction());
+
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(
+        new MarketingCalendarOptions { GroupId = "grp", PushEnabled = false });
+    var handler = new DeleteMarketingActionHandler(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        monitor);
+
+    // Act — first invocation with PushEnabled = false
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Flip the kill-switch at runtime
+    monitor.Set(new MarketingCalendarOptions { GroupId = "grp", PushEnabled = true });
+
+    // Act — second invocation on the same handler instance
+    await handler.Handle(BuildRequest(), CancellationToken.None);
+
+    // Assert — Outlook DeleteEventAsync called exactly once (second invocation only)
+    _outlookSync.Verify(
+        x => x.DeleteEventAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Application.Marketing.DeleteMarketingActionHandlerTests"
+```
+
+Expected: build FAILS with `CS1503` — the `DeleteMarketingActionHandler` constructor still takes `IOptions<MarketingCalendarOptions>`.
+
+- [ ] **Step 3: Update the handler to take `IOptionsMonitor<T>`**
+
+In `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs`:
+
+Change line 20:
+
+```csharp
+// Before
+private readonly IOptions<MarketingCalendarOptions> _options;
+
+// After
+private readonly IOptionsMonitor<MarketingCalendarOptions> _options;
+```
+
+Change line 27 (constructor signature, last parameter):
+
+```csharp
+// Before
+IOptions<MarketingCalendarOptions> options)
+
+// After
+IOptionsMonitor<MarketingCalendarOptions> options)
+```
+
+Change line 54 (the `PushEnabled` check):
+
+```csharp
+// Before
+if (_options.Value.PushEnabled && !string.IsNullOrEmpty(action.OutlookEventId))
+
+// After
+if (_options.CurrentValue.PushEnabled && !string.IsNullOrEmpty(action.OutlookEventId))
+```
+
+- [ ] **Step 4: Update the existing `BuildHandler` factory in the canonical Delete test class**
+
+In `backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs`, replace lines 53-59 (the `BuildHandler` method) with:
+
+```csharp
+private DeleteMarketingActionHandler BuildHandler(bool pushEnabled = true) =>
+    new(
+        _repository.Object,
+        _currentUserService.Object,
+        _logger.Object,
+        _outlookSync.Object,
+        new TestOptionsMonitor<MarketingCalendarOptions>(
+            new MarketingCalendarOptions { GroupId = "grp", PushEnabled = pushEnabled }));
+```
+
+Remove the now-unused `using Microsoft.Extensions.Options;` directive at line 11.
+
+- [ ] **Step 5: Update `BuildDeleteHandler` in the legacy combined-sync test file**
+
+In `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`, replace lines 79-91 (the `BuildDeleteHandler` method) with:
+
+```csharp
+private DeleteMarketingActionHandler BuildDeleteHandler(bool pushEnabled)
+{
+    var options = new MarketingCalendarOptions { PushEnabled = pushEnabled, GroupId = "cal@example.com" };
+    var monitor = new TestOptionsMonitor<MarketingCalendarOptions>(options);
+
+    return new DeleteMarketingActionHandler(
+        _repositoryMock.Object,
+        _currentUserServiceMock.Object,
+        NullLogger<DeleteMarketingActionHandler>.Instance,
+        _outlookSyncMock.Object,
+        monitor);
+}
+```
+
+Now that none of the three `BuildXxxHandler` methods reference `IOptions<T>` or `Mock<IOptions<...>>` anywhere in the file, remove the unused `using Microsoft.Extensions.Options;` directive at line 16.
+
+- [ ] **Step 6: Run the Delete handler tests and verify all pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~DeleteMarketingActionHandlerTests"
+```
+
+Expected: all Delete handler tests pass — the original 7 plus the 2 new hot-reload tests.
+
+- [ ] **Step 7: Run the full marketing test suite**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Marketing"
+```
+
+Expected: all marketing-namespace tests pass — mapper tests, all three handler test classes (canonical), the two legacy duplicate handler test files, and any other marketing tests in the project.
+
+- [ ] **Step 8: Run the full backend build and the full test suite**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds; all tests in the suite pass with no regressions outside marketing.
+
+- [ ] **Step 9: Run `dotnet format` and commit**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+git add backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs \
+        backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+git commit -m "feat(marketing): hot-reload PushEnabled in DeleteMarketingActionHandler"
+```
+
+If `dotnet format` produces additional whitespace-only changes in unrelated files, stage and commit those separately with `chore: dotnet format` rather than bundling them into the feature commit.
+
+---
+
+## Task 5: Final verification
+
+**Files:** none modified — this task only verifies the end state.
+
+- [ ] **Step 1: Confirm no remaining `IOptions<MarketingCalendarOptions>` references in the three handlers**
+
+```bash
+grep -nE "IOptions<MarketingCalendarOptions>" \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/DeleteMarketingAction/DeleteMarketingActionHandler.cs
+```
+
+Expected: each file shows only `IOptionsMonitor<MarketingCalendarOptions>` matches (because `IOptionsMonitor` contains the substring `IOptions`). To check there is no exact `IOptions<...>` (without `Monitor`):
+
+```bash
+grep -nE "IOptions<MarketingCalendarOptions>" \
+  backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/*/*Handler.cs \
+  | grep -v IOptionsMonitor
+```
+
+Expected: empty output (no matches).
+
+- [ ] **Step 2: Confirm `OutlookCalendarSyncService` is untouched (out of scope per spec)**
+
+```bash
+git diff main -- backend/src/Anela.Heblo.Application/Features/Marketing/Services/OutlookCalendarSyncService.cs
+```
+
+Expected: empty diff. This service was intentionally left on `IOptions<T>` because it is scoped per request and `GroupId` is not the kill-switch.
+
+- [ ] **Step 3: Confirm `MarketingModule` DI registration is untouched**
+
+```bash
+git diff main -- backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+```
+
+Expected: empty diff. `IOptionsMonitor<MarketingCalendarOptions>` is auto-resolvable from the existing `AddOptions<T>().Bind(...)` call; no new registration is needed.
+
+- [ ] **Step 4: Run the full test suite and full backend build one more time as a final gate**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: both succeed.
+
+- [ ] **Step 5: Manually confirm the PR description should call out the duplicate test files**
+
+When opening the PR, include a note in the description (do not modify any code for this step):
+
+> Two duplicate Marketing handler test classes exist alongside the canonical ones in `Application/Marketing/`:
+> - `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs`
+> - `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`
+>
+> Both were updated to compile against the new `IOptionsMonitor<T>` constructor signature but were intentionally **not** deleted as part of this change. Recommend follow-up to consolidate or remove these duplicates.
+
+No commit produced by this step — it is a PR-description reminder, not a code change.


### PR DESCRIPTION

Switch all three Marketing write handlers off `IOptions<T>` so the `PushEnabled` kill-switch responds to runtime configuration changes (e.g., Azure App Configuration) without an application restart. Previously, toggling `PushEnabled = false` during an incident had no effect on running handlers — a restart was required. Now all three handlers (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`, `DeleteMarketingActionHandler`) read `.CurrentValue.PushEnabled` at invocation time.

A shared `TestOptionsMonitor<T>` test helper was extracted from `MarketingCategoryMapperTests` (the existing hot-reload reference implementation) so all handler test suites can drive runtime toggle transitions. Six new unit tests cover the true→false and false→true transitions for each handler.

**Note:** Two duplicate Marketing handler test files in `Features/Marketing/` were updated to compile against the new constructor signature but were intentionally not deleted. Recommend a separate cleanup PR.

### Changes
- `backend/src/.../CreateMarketingAction/CreateMarketingActionHandler.cs` — `IOptions` → `IOptionsMonitor`, `.Value` → `.CurrentValue`
- `backend/src/.../UpdateMarketingAction/UpdateMarketingActionHandler.cs` — same
- `backend/src/.../DeleteMarketingAction/DeleteMarketingActionHandler.cs` — same
- `backend/test/.../Helpers/TestOptionsMonitor.cs` — new shared test double (promoted from `MarketingCategoryMapperTests`)
- `backend/test/.../Application/Marketing/*HandlerTests.cs` — use shared helper; add hot-reload tests
- `backend/test/.../Features/Marketing/*Tests.cs` — updated to compile; duplicates flagged for cleanup

---

Closes #1355

### Tokens used
16462221
