### PR TITLE
feat(expedition): frost badge on cooled orders in expedition PDF

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Domain.Features.Catalog;
+
 namespace Anela.Heblo.Adapters.ShoptetApi.Expedition;
 
 public class ExpeditionProtocolData
@@ -15,6 +17,8 @@ public class ExpeditionOrder
     public string? CustomerRemark { get; set; }
     public string? EshopRemark { get; set; }
     public List<ExpeditionOrderItem> Items { get; set; } = new();
+
+    public bool IsCooled => Items.Any(i => i.Cooling != Cooling.None);
 }
 
 public class ExpeditionOrderItem
@@ -30,4 +34,5 @@ public class ExpeditionOrderItem
     public string Unit { get; set; } = string.Empty;
     public bool IsFromSet { get; set; }
     public string? SetName { get; set; }
+    public Cooling Cooling { get; set; } = Cooling.None;
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
@@ -24,6 +24,13 @@ public class ExpeditionProtocolDocument : IDocument
     private const float CenaCol = 2f;
     private const float StavCol = 2f;
 
+    // Frost badge layout constants
+    private const float FrostIconSize = 12f;
+    private const float FrostBadgePadding = 3f;
+    private const float FrostBadgeBorderThickness = 0.5f;
+
+    private static readonly byte[] FrostIconBytes = GenerateFrostIcon();
+
     private readonly ExpeditionProtocolData _data;
     public ExpeditionProtocolDocument(ExpeditionProtocolData data)
     {
@@ -82,6 +89,24 @@ public class ExpeditionProtocolDocument : IDocument
                 t.Span("Objednávka ").FontSize(10);
                 t.Span(order.Code).Bold().FontSize(10);
             });
+
+            // Frost badge — shown only for orders containing at least one cooled product
+            if (order.IsCooled)
+            {
+                orderCol.Item().PaddingTop(3).PaddingBottom(3).Element(pill =>
+                    pill
+                        .Border(FrostBadgeBorderThickness)
+                        .BorderColor(Colors.Blue.Medium)
+                        .Background(Colors.Blue.Lighten4)
+                        .Padding(FrostBadgePadding)
+                        .Row(row =>
+                        {
+                            row.AutoItem().Width(FrostIconSize).Height(FrostIconSize).Image(FrostIconBytes).FitArea();
+                            row.AutoItem().PaddingLeft(3).AlignMiddle()
+                                .Text("CHLAZENÁ ZÁSILKA")
+                                .Bold().FontSize(10).FontColor(Colors.Blue.Darken2);
+                        }));
+            }
 
             // Barcode — 60% of full width
             var barcodeBytes = GenerateBarcode(order.Code);
@@ -291,6 +316,52 @@ public class ExpeditionProtocolDocument : IDocument
         };
 
         using var bitmap = writer.Write(text);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    private static byte[] GenerateFrostIcon()
+    {
+        const int size = 64;
+        using var bitmap = new SKBitmap(size, size);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Transparent);
+
+        using var paint = new SKPaint
+        {
+            Color = new SKColor(0x1E, 0x88, 0xE5), // blue
+            StrokeWidth = 4f,
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeCap = SKStrokeCap.Round,
+        };
+
+        var cx = size / 2f;
+        var cy = size / 2f;
+        var spokeLen = size * 0.42f;
+        var branchLen = size * 0.18f;
+        var branchOffset = size * 0.20f;
+
+        for (var i = 0; i < 6; i++)
+        {
+            var angle = i * 60.0 * Math.PI / 180.0;
+            var ex = cx + (float)(Math.Cos(angle) * spokeLen);
+            var ey = cy + (float)(Math.Sin(angle) * spokeLen);
+            canvas.DrawLine(cx, cy, ex, ey, paint);
+
+            // Two branch pairs along the spoke
+            foreach (var offsetFraction in new[] { branchOffset, spokeLen - branchLen })
+            {
+                var bx = cx + (float)(Math.Cos(angle) * offsetFraction);
+                var by = cy + (float)(Math.Sin(angle) * offsetFraction);
+                var leftAngle = angle + 60.0 * Math.PI / 180.0;
+                var rightAngle = angle - 60.0 * Math.PI / 180.0;
+                canvas.DrawLine(bx, by, bx + (float)(Math.Cos(leftAngle) * branchLen), by + (float)(Math.Sin(leftAngle) * branchLen), paint);
+                canvas.DrawLine(bx, by, bx + (float)(Math.Cos(rightAngle) * branchLen), by + (float)(Math.Sin(rightAngle) * branchLen), paint);
+            }
+        }
+
         using var image = SKImage.FromBitmap(bitmap);
         using var data = image.Encode(SKEncodedImageFormat.Png, 100);
         return data.ToArray();

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
@@ -136,15 +136,11 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
                         coolingByCode[productCode] = entry.Properties.Cooling;
                     }
                 }
-                foreach (var item in batch.SelectMany(o => o.Items))
-                {
-                    if (stockByCode.TryGetValue(item.ProductCode, out var stock))
-                        item.StockCount = stock;
-                    if (string.IsNullOrEmpty(item.WarehousePosition) && locationByCode.TryGetValue(item.ProductCode, out var location))
-                        item.WarehousePosition = location;
-                    if (coolingByCode.TryGetValue(item.ProductCode, out var cooling))
-                        item.Cooling = cooling;
-                }
+                ApplyEnrichment(
+                    batch.SelectMany(o => o.Items),
+                    stockByCode,
+                    locationByCode,
+                    coolingByCode);
 
                 var data = new ExpeditionProtocolData
                 {
@@ -242,6 +238,23 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
             EshopRemark = detail.Notes?.EshopRemark,
             Items = MapOrderItems(detail),
         };
+    }
+
+    internal static void ApplyEnrichment(
+        IEnumerable<ExpeditionOrderItem> items,
+        Dictionary<string, decimal> stockByCode,
+        Dictionary<string, string> locationByCode,
+        Dictionary<string, Cooling> coolingByCode)
+    {
+        foreach (var item in items)
+        {
+            if (stockByCode.TryGetValue(item.ProductCode, out var stock))
+                item.StockCount = stock;
+            if (string.IsNullOrEmpty(item.WarehousePosition) && locationByCode.TryGetValue(item.ProductCode, out var location))
+                item.WarehousePosition = location;
+            if (coolingByCode.TryGetValue(item.ProductCode, out var cooling))
+                item.Cooling = cooling;
+        }
     }
 
     internal static List<ExpeditionOrderItem> MapOrderItems(Model.ExpeditionOrderDetail detail)

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
@@ -119,11 +119,12 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
 
             async Task FlushBatchAsync(List<ExpeditionOrder> batch)
             {
-                // Enrich with stock counts and warehouse positions from catalog.
+                // Enrich with stock counts, warehouse positions, and cooling from catalog.
                 // Positions are only applied where the Shoptet API left them blank (set components).
                 var productCodes = batch.SelectMany(o => o.Items).Select(i => i.ProductCode).Distinct();
                 var stockByCode = new Dictionary<string, decimal>();
                 var locationByCode = new Dictionary<string, string>();
+                var coolingByCode = new Dictionary<string, Cooling>();
                 foreach (var productCode in productCodes)
                 {
                     var entry = await _catalog.GetByIdAsync(productCode, cancellationToken);
@@ -132,6 +133,7 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
                         stockByCode[productCode] = entry.Stock.Eshop;
                         if (!string.IsNullOrEmpty(entry.Location))
                             locationByCode[productCode] = entry.Location;
+                        coolingByCode[productCode] = entry.Properties.Cooling;
                     }
                 }
                 foreach (var item in batch.SelectMany(o => o.Items))
@@ -140,6 +142,8 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
                         item.StockCount = stock;
                     if (string.IsNullOrEmpty(item.WarehousePosition) && locationByCode.TryGetValue(item.ProductCode, out var location))
                         item.WarehousePosition = location;
+                    if (coolingByCode.TryGetValue(item.ProductCode, out var cooling))
+                        item.Cooling = cooling;
                 }
 
                 var data = new ExpeditionProtocolData

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Adapters.ShoptetApi.Expedition;
+using Anela.Heblo.Domain.Features.Catalog;
 using FluentAssertions;
 using QuestPDF.Infrastructure;
 
@@ -518,5 +519,117 @@ public class ExpeditionProtocolDocumentTests
         var act = () => ExpeditionProtocolDocument.Generate(data);
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Generate_WithCooledOrder_DoesNotThrow()
+    {
+        // Arrange — order with one L2 cooled item; frost badge must render without exception
+        var data = new ExpeditionProtocolData
+        {
+            CarrierDisplayName = "PPL",
+            Orders = new List<ExpeditionOrder>
+            {
+                new()
+                {
+                    Code = "COOL001",
+                    CustomerName = "Test Cooled",
+                    Address = "Chladná 1, 100 00 Praha",
+                    Phone = "+420 600000001",
+                    Items = new List<ExpeditionOrderItem>
+                    {
+                        new()
+                        {
+                            ProductCode = "CHLAD001",
+                            Name = "Chlazená Krémová Maska",
+                            Variant = "Obsah: 50 ml",
+                            WarehousePosition = "C01-1",
+                            Quantity = 1,
+                            StockCount = 20,
+                            StockDemand = 1,
+                            UnitPrice = 590.00m,
+                            Unit = "ks",
+                            Cooling = Cooling.L2,
+                        },
+                    },
+                },
+            },
+        };
+
+        // Act
+        var act = () => ExpeditionProtocolDocument.Generate(data);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Generate_CooledOrder_SavesToDiskForVisualInspection()
+    {
+        // Generates a PDF for manual visual verification of the frost badge.
+        // Output: <temp>/ExpeditionList_CooledOrder.pdf
+        var data = new ExpeditionProtocolData
+        {
+            CarrierDisplayName = "Zásilkovna",
+            Orders = new List<ExpeditionOrder>
+            {
+                new()
+                {
+                    Code = "COOL001",
+                    CustomerName = "Jana Mrazíková",
+                    Address = "Ledová 42, 100 00 Praha 1",
+                    Phone = "+420 725 191 660",
+                    Items = new List<ExpeditionOrderItem>
+                    {
+                        new()
+                        {
+                            ProductCode = "CHLAD001",
+                            Name = "Chlazená Krémová Maska",
+                            Variant = "Obsah: 50 ml",
+                            WarehousePosition = "C01-1",
+                            Quantity = 2,
+                            StockCount = 20,
+                            StockDemand = 2,
+                            UnitPrice = 590.00m,
+                            Unit = "ks",
+                            Cooling = Cooling.L2,
+                        },
+                    },
+                },
+                new()
+                {
+                    Code = "NORM001",
+                    CustomerName = "Petr Normální",
+                    Address = "Běžná 5, 110 00 Praha",
+                    Phone = "+420 600 000 002",
+                    Items = new List<ExpeditionOrderItem>
+                    {
+                        new()
+                        {
+                            ProductCode = "P001",
+                            Name = "Standardní produkt",
+                            Variant = string.Empty,
+                            WarehousePosition = "A01-1",
+                            Quantity = 1,
+                            StockCount = 50,
+                            StockDemand = 1,
+                            UnitPrice = 299.00m,
+                            Unit = "ks",
+                            Cooling = Cooling.None,
+                        },
+                    },
+                },
+            },
+        };
+
+        var pdfBytes = ExpeditionProtocolDocument.Generate(data);
+
+        var outputPath = Path.Combine(Path.GetTempPath(), "ExpeditionList_CooledOrder.pdf");
+        File.WriteAllBytes(outputPath, pdfBytes);
+
+        pdfBytes.Should().NotBeNullOrEmpty();
+        File.Exists(outputPath).Should().BeTrue();
+
+        Console.WriteLine($"PDF saved to: {outputPath}");
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
@@ -488,6 +488,68 @@ public class ShoptetApiExpeditionListSourceTests
         foreach (var file in result.ExportedFiles.Where(File.Exists))
             File.Delete(file);
     }
+
+    [Fact]
+    public void ExpeditionOrder_IsCooled_False_WhenAllItemsHaveCoolingNone()
+    {
+        // Arrange
+        var order = new ExpeditionOrder
+        {
+            Code = "ORD001",
+            CustomerName = "Test",
+            Address = "Praha",
+            Phone = "123",
+            Items = new List<ExpeditionOrderItem>
+            {
+                new() { ProductCode = "P001", Name = "A", Variant = string.Empty, WarehousePosition = "A1", Quantity = 1, Cooling = Cooling.None },
+                new() { ProductCode = "P002", Name = "B", Variant = string.Empty, WarehousePosition = "A2", Quantity = 1, Cooling = Cooling.None },
+            },
+        };
+
+        // Act + Assert
+        order.IsCooled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExpeditionOrder_IsCooled_True_WhenAnyItemHasCoolingL1()
+    {
+        // Arrange
+        var order = new ExpeditionOrder
+        {
+            Code = "ORD002",
+            CustomerName = "Test",
+            Address = "Praha",
+            Phone = "123",
+            Items = new List<ExpeditionOrderItem>
+            {
+                new() { ProductCode = "P001", Name = "A", Variant = string.Empty, WarehousePosition = "A1", Quantity = 1, Cooling = Cooling.None },
+                new() { ProductCode = "P002", Name = "B", Variant = string.Empty, WarehousePosition = "A2", Quantity = 1, Cooling = Cooling.L1 },
+            },
+        };
+
+        // Act + Assert
+        order.IsCooled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ExpeditionOrder_IsCooled_True_WhenAnyItemHasCoolingL2()
+    {
+        // Arrange
+        var order = new ExpeditionOrder
+        {
+            Code = "ORD003",
+            CustomerName = "Test",
+            Address = "Praha",
+            Phone = "123",
+            Items = new List<ExpeditionOrderItem>
+            {
+                new() { ProductCode = "P001", Name = "A", Variant = string.Empty, WarehousePosition = "A1", Quantity = 1, Cooling = Cooling.L2 },
+            },
+        };
+
+        // Act + Assert
+        order.IsCooled.Should().BeTrue();
+    }
 }
 
 /// <summary>

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
@@ -576,19 +576,14 @@ public class ShoptetApiExpeditionListSourceTests
         var source = new ShoptetApiExpeditionListSource(client, TimeProvider.System, catalogMock.Object);
 
         // Act
-        var act = async () => await source.CreatePickingList(DefaultRequest(), null);
+        var result = await source.CreatePickingList(DefaultRequest(), null);
 
         // Assert
-        await act.Should().NotThrowAsync();
-
-        // Catalog must have been called for the product code
         catalogMock.Verify(c => c.GetByIdAsync("P001", It.IsAny<CancellationToken>()), Times.Once);
 
         // Cleanup
-        foreach (var file in Directory.GetFiles(Path.GetTempPath(), "*.pdf").Where(File.Exists))
-        {
-            try { File.Delete(file); } catch { /* best effort */ }
-        }
+        foreach (var file in result.ExportedFiles.Where(File.Exists))
+            File.Delete(file);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
@@ -550,6 +550,46 @@ public class ShoptetApiExpeditionListSourceTests
         // Act + Assert
         order.IsCooled.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task CreatePickingList_EnrichesCooling_FromCatalog()
+    {
+        // Arrange — one Zasilkovna order with product P001; catalog returns Cooling=L1 for P001
+        var listResp = SinglePageList(("Z001", ZasilkovnaDoRukyGuid));
+
+        var client = BuildClient(req =>
+        {
+            if (req.RequestUri!.PathAndQuery.StartsWith("/api/orders?"))
+                return Json(listResp);
+            return Json(DetailFor(req.RequestUri.Segments.Last()));  // P001 item
+        });
+
+        var catalogMock = new Mock<ICatalogRepository>();
+        catalogMock
+            .Setup(c => c.GetByIdAsync("P001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CatalogAggregate
+            {
+                ProductCode = "P001",
+                Properties = new CatalogProperties { Cooling = Cooling.L1 },
+            });
+
+        var source = new ShoptetApiExpeditionListSource(client, TimeProvider.System, catalogMock.Object);
+
+        // Act
+        var act = async () => await source.CreatePickingList(DefaultRequest(), null);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+
+        // Catalog must have been called for the product code
+        catalogMock.Verify(c => c.GetByIdAsync("P001", It.IsAny<CancellationToken>()), Times.Once);
+
+        // Cleanup
+        foreach (var file in Directory.GetFiles(Path.GetTempPath(), "*.pdf").Where(File.Exists))
+        {
+            try { File.Delete(file); } catch { /* best effort */ }
+        }
+    }
 }
 
 /// <summary>

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
@@ -590,6 +590,55 @@ public class ShoptetApiExpeditionListSourceTests
             try { File.Delete(file); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void ApplyEnrichment_SetsCooling_FromDictionary()
+    {
+        // Arrange
+        var item = new ExpeditionOrderItem
+        {
+            ProductCode = "P001",
+            Name = "Test",
+            Variant = string.Empty,
+            WarehousePosition = "A1",
+            Quantity = 1,
+        };
+        var coolingByCode = new Dictionary<string, Cooling> { ["P001"] = Cooling.L1 };
+
+        // Act
+        ShoptetApiExpeditionListSource.ApplyEnrichment(
+            new[] { item },
+            stockByCode: new Dictionary<string, decimal>(),
+            locationByCode: new Dictionary<string, string>(),
+            coolingByCode: coolingByCode);
+
+        // Assert
+        item.Cooling.Should().Be(Cooling.L1);
+    }
+
+    [Fact]
+    public void ApplyEnrichment_LeavesDefaultCooling_WhenProductNotInCoolingDictionary()
+    {
+        // Arrange
+        var item = new ExpeditionOrderItem
+        {
+            ProductCode = "P999",
+            Name = "Unknown",
+            Variant = string.Empty,
+            WarehousePosition = "A1",
+            Quantity = 1,
+        };
+
+        // Act
+        ShoptetApiExpeditionListSource.ApplyEnrichment(
+            new[] { item },
+            stockByCode: new Dictionary<string, decimal>(),
+            locationByCode: new Dictionary<string, string>(),
+            coolingByCode: new Dictionary<string, Cooling>());
+
+        // Assert
+        item.Cooling.Should().Be(Cooling.None);
+    }
 }
 
 /// <summary>

--- a/docs/superpowers/plans/2026-05-18-expedition-frost-badge.md
+++ b/docs/superpowers/plans/2026-05-18-expedition-frost-badge.md
@@ -1,0 +1,692 @@
+# Expedition Frost Badge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a visible frost badge on cooled orders in the expedition list PDF so warehouse staff can identify cold-chain orders at a glance.
+
+**Architecture:** The `Cooling` enum (`None | L1 | L2`) lives on `CatalogAggregate.Properties.Cooling`. The enrichment loop in `FlushBatchAsync` already fetches a `CatalogAggregate` per product code to read stock/location — we piggyback on that same lookup to capture `Cooling` and store it on `ExpeditionOrderItem`. `ExpeditionOrder` gains a computed `IsCooled` property. The PDF document renders a snowflake-icon + text pill badge above the barcode for any cooled order; the icon is drawn vectorially with SkiaSharp so it is font-independent.
+
+**Tech Stack:** .NET 8, C#, QuestPDF (PDF rendering), SkiaSharp (vector icon), xUnit, FluentAssertions, Moq
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs` | Add `Cooling` property to `ExpeditionOrderItem`; add `IsCooled` computed property to `ExpeditionOrder` |
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs` | Capture `Cooling` per product in `FlushBatchAsync`; apply to items |
+| `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs` | Add frost badge constants, `GenerateFrostIcon()`, and badge rendering in `ComposeOrderBlock` |
+| `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs` | Add cooled-order smoke test and visual inspection test |
+| `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs` | Add enrichment test for `Cooling` mapping and `IsCooled` unit tests |
+
+---
+
+## Task 1: Add `Cooling` to the data model
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs`
+
+- [ ] **Step 1: Write the failing tests for `IsCooled` logic**
+
+Add these tests to `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs` (inside the `ShoptetApiExpeditionListSourceTests` class, after the existing tests):
+
+```csharp
+[Fact]
+public void ExpeditionOrder_IsCooled_False_WhenAllItemsHaveCoolingNone()
+{
+    // Arrange
+    var order = new ExpeditionOrder
+    {
+        Code = "ORD001",
+        CustomerName = "Test",
+        Address = "Praha",
+        Phone = "123",
+        Items = new List<ExpeditionOrderItem>
+        {
+            new() { ProductCode = "P001", Name = "A", Variant = string.Empty, WarehousePosition = "A1", Quantity = 1, Cooling = Cooling.None },
+            new() { ProductCode = "P002", Name = "B", Variant = string.Empty, WarehousePosition = "A2", Quantity = 1, Cooling = Cooling.None },
+        },
+    };
+
+    // Act + Assert
+    order.IsCooled.Should().BeFalse();
+}
+
+[Fact]
+public void ExpeditionOrder_IsCooled_True_WhenAnyItemHasCoolingL1()
+{
+    // Arrange
+    var order = new ExpeditionOrder
+    {
+        Code = "ORD002",
+        CustomerName = "Test",
+        Address = "Praha",
+        Phone = "123",
+        Items = new List<ExpeditionOrderItem>
+        {
+            new() { ProductCode = "P001", Name = "A", Variant = string.Empty, WarehousePosition = "A1", Quantity = 1, Cooling = Cooling.None },
+            new() { ProductCode = "P002", Name = "B", Variant = string.Empty, WarehousePosition = "A2", Quantity = 1, Cooling = Cooling.L1 },
+        },
+    };
+
+    // Act + Assert
+    order.IsCooled.Should().BeTrue();
+}
+
+[Fact]
+public void ExpeditionOrder_IsCooled_True_WhenAnyItemHasCoolingL2()
+{
+    // Arrange
+    var order = new ExpeditionOrder
+    {
+        Code = "ORD003",
+        CustomerName = "Test",
+        Address = "Praha",
+        Phone = "123",
+        Items = new List<ExpeditionOrderItem>
+        {
+            new() { ProductCode = "P001", Name = "A", Variant = string.Empty, WarehousePosition = "A1", Quantity = 1, Cooling = Cooling.L2 },
+        },
+    };
+
+    // Act + Assert
+    order.IsCooled.Should().BeTrue();
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "ExpeditionOrder_IsCooled" --no-build 2>&1 | tail -20
+```
+
+Expected: compilation error — `Cooling` property does not exist on `ExpeditionOrderItem`, and `IsCooled` does not exist on `ExpeditionOrder`.
+
+- [ ] **Step 3: Update `ExpeditionProtocolData.cs`**
+
+Replace the entire file content:
+
+```csharp
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Adapters.ShoptetApi.Expedition;
+
+public class ExpeditionProtocolData
+{
+    public string CarrierDisplayName { get; set; } = null!;
+    public List<ExpeditionOrder> Orders { get; set; } = new();
+}
+
+public class ExpeditionOrder
+{
+    public string Code { get; set; } = null!;
+    public string CustomerName { get; set; } = null!;
+    public string Address { get; set; } = null!;
+    public string Phone { get; set; } = null!;
+    public string? CustomerRemark { get; set; }
+    public string? EshopRemark { get; set; }
+    public List<ExpeditionOrderItem> Items { get; set; } = new();
+
+    public bool IsCooled => Items.Any(i => i.Cooling != Cooling.None);
+}
+
+public class ExpeditionOrderItem
+{
+    public string ProductCode { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public string Variant { get; set; } = null!;
+    public string WarehousePosition { get; set; } = null!;
+    public int Quantity { get; set; }
+    public decimal StockCount { get; set; }
+    public decimal StockDemand { get; set; }
+    public decimal UnitPrice { get; set; }
+    public string Unit { get; set; } = string.Empty;
+    public bool IsFromSet { get; set; }
+    public string? SetName { get; set; }
+    public Cooling Cooling { get; set; } = Cooling.None;
+}
+```
+
+- [ ] **Step 4: Run the `IsCooled` tests to confirm they pass**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "ExpeditionOrder_IsCooled"
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Build to confirm no regressions**
+
+```
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs
+git add backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+git commit -m "feat(expedition): add Cooling field to ExpeditionOrderItem and IsCooled to ExpeditionOrder"
+```
+
+---
+
+## Task 2: Enrich `Cooling` during batch processing
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs`
+
+- [ ] **Step 1: Write the failing enrichment test**
+
+Add this test to `ShoptetApiExpeditionListSourceTests` (after the `IsCooled` tests added in Task 1):
+
+```csharp
+[Fact]
+public async Task CreatePickingList_EnrichesCooling_FromCatalog()
+{
+    // Arrange — one Zasilkovna order with product P001; catalog returns Cooling=L1 for P001
+    var listResp = SinglePageList(("Z001", ZasilkovnaDoRukyGuid));
+
+    var client = BuildClient(req =>
+    {
+        if (req.RequestUri!.PathAndQuery.StartsWith("/api/orders?"))
+            return Json(listResp);
+        return Json(DetailFor(req.RequestUri.Segments.Last()));  // P001 item
+    });
+
+    var catalogMock = new Mock<ICatalogRepository>();
+    catalogMock
+        .Setup(c => c.GetByIdAsync("P001", It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new CatalogAggregate
+        {
+            ProductCode = "P001",
+            Properties = new CatalogProperties { Cooling = Cooling.L1 },
+        });
+
+    var source = new ShoptetApiExpeditionListSource(client, TimeProvider.System, catalogMock.Object);
+
+    // Act — capture items via a batch callback
+    List<ExpeditionOrder>? capturedBatch = null;
+    // We can't directly inspect batch internals, so verify indirectly:
+    // the generated PDF must not throw (IsCooled path exercised).
+    var act = async () => await source.CreatePickingList(DefaultRequest(), null);
+
+    // Assert
+    await act.Should().NotThrowAsync();
+
+    // Catalog must have been called for the product code
+    catalogMock.Verify(c => c.GetByIdAsync("P001", It.IsAny<CancellationToken>()), Times.Once);
+
+    // Cleanup
+    foreach (var file in Directory.GetFiles(Path.GetTempPath(), "*.pdf").Where(File.Exists))
+    {
+        try { File.Delete(file); } catch { /* best effort */ }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails (or passes trivially)**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "CreatePickingList_EnrichesCooling_FromCatalog"
+```
+
+This test will pass trivially at the assertion level but catalog.Verify will fail because BuildSource uses `new Mock<ICatalogRepository>().Object` which doesn't set up anything — the test uses an explicit mock. Expected: verify fails with "Expected invocation on the mock exactly 1 time, but was 0 times".
+
+Actually wait — let me re-examine. The `BuildSource` helper uses `new Mock<ICatalogRepository>().Object`. The new test constructs its own `ShoptetApiExpeditionListSource` with `catalogMock.Object`. The setup returns a `CatalogAggregate` for "P001", so `GetByIdAsync` will be called. The Verify should pass once enrichment is implemented. Currently the enrichment doesn't capture Cooling, but the call still happens (stock/location enrichment). So the Verify might already pass but the behavior isn't complete yet. Let's check:
+
+Looking at `FlushBatchAsync` (lines 122–143 of `ShoptetApiExpeditionListSource.cs`), `_catalog.GetByIdAsync` IS already called for every product. So the `Verify(Times.Once)` assertion will already pass. The test as written doesn't verify `Cooling` is set on the item. That's OK — the catalog call verification is the right scope here, and the document test in Task 3 will verify the badge rendering path.
+
+- [ ] **Step 3: Update `FlushBatchAsync` in `ShoptetApiExpeditionListSource.cs`**
+
+Locate the `FlushBatchAsync` local function (lines 120–159). Replace the enrichment section (lines 122–143) with:
+
+```csharp
+async Task FlushBatchAsync(List<ExpeditionOrder> batch)
+{
+    // Enrich with stock counts, warehouse positions, and cooling from catalog.
+    // Positions are only applied where the Shoptet API left them blank (set components).
+    var productCodes = batch.SelectMany(o => o.Items).Select(i => i.ProductCode).Distinct();
+    var stockByCode = new Dictionary<string, decimal>();
+    var locationByCode = new Dictionary<string, string>();
+    var coolingByCode = new Dictionary<string, Cooling>();
+    foreach (var productCode in productCodes)
+    {
+        var entry = await _catalog.GetByIdAsync(productCode, cancellationToken);
+        if (entry != null)
+        {
+            stockByCode[productCode] = entry.Stock.Eshop;
+            if (!string.IsNullOrEmpty(entry.Location))
+                locationByCode[productCode] = entry.Location;
+            coolingByCode[productCode] = entry.Properties.Cooling;
+        }
+    }
+    foreach (var item in batch.SelectMany(o => o.Items))
+    {
+        if (stockByCode.TryGetValue(item.ProductCode, out var stock))
+            item.StockCount = stock;
+        if (string.IsNullOrEmpty(item.WarehousePosition) && locationByCode.TryGetValue(item.ProductCode, out var location))
+            item.WarehousePosition = location;
+        if (coolingByCode.TryGetValue(item.ProductCode, out var cooling))
+            item.Cooling = cooling;
+    }
+
+    var data = new ExpeditionProtocolData
+    {
+        CarrierDisplayName = carrierDisplayName,
+        Orders = batch,
+    };
+
+    var pdfBytes = ExpeditionProtocolDocument.Generate(data);
+    var fileName = $"{timestamp}_{carrier}_{batchIndex}.pdf";
+    var filePath = Path.Combine(Path.GetTempPath(), fileName);
+    await File.WriteAllBytesAsync(filePath, pdfBytes, cancellationToken);
+    exportedFiles.Add(filePath);
+
+    if (onBatchFilesReady != null)
+        await onBatchFilesReady(new List<string> { filePath });
+}
+```
+
+Note: `Cooling` is already in scope via the existing `using Anela.Heblo.Domain.Features.Catalog;` at the top of the file. No new using is needed.
+
+- [ ] **Step 4: Run enrichment test and existing tests**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "ShoptetApiExpeditionListSourceTests"
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Build**
+
+```
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+git add backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiExpeditionListSourceTests.cs
+git commit -m "feat(expedition): capture Cooling from catalog aggregate during batch enrichment"
+```
+
+---
+
+## Task 3: Render the frost badge in the PDF
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs`
+
+- [ ] **Step 1: Write the failing smoke test for cooled order**
+
+Add to `ExpeditionProtocolDocumentTests` (after the last existing `[Fact]`):
+
+```csharp
+[Fact]
+public void Generate_WithCooledOrder_DoesNotThrow()
+{
+    // Arrange — order with one L2 cooled item; frost badge must render without exception
+    var data = new ExpeditionProtocolData
+    {
+        CarrierDisplayName = "PPL",
+        Orders = new List<ExpeditionOrder>
+        {
+            new()
+            {
+                Code = "COOL001",
+                CustomerName = "Test Cooled",
+                Address = "Chladná 1, 100 00 Praha",
+                Phone = "+420 600000001",
+                Items = new List<ExpeditionOrderItem>
+                {
+                    new()
+                    {
+                        ProductCode = "CHLAD001",
+                        Name = "Chlazená Krémová Maska",
+                        Variant = "Obsah: 50 ml",
+                        WarehousePosition = "C01-1",
+                        Quantity = 1,
+                        StockCount = 20,
+                        StockDemand = 1,
+                        UnitPrice = 590.00m,
+                        Unit = "ks",
+                        Cooling = Cooling.L2,
+                    },
+                },
+            },
+        },
+    };
+
+    // Act
+    var act = () => ExpeditionProtocolDocument.Generate(data);
+
+    // Assert
+    act.Should().NotThrow();
+}
+
+[Fact]
+public void Generate_CooledOrder_SavesToDiskForVisualInspection()
+{
+    // Generates a PDF for manual visual verification of the frost badge.
+    // Output: <temp>/ExpeditionList_CooledOrder.pdf
+    var data = new ExpeditionProtocolData
+    {
+        CarrierDisplayName = "Zásilkovna",
+        Orders = new List<ExpeditionOrder>
+        {
+            new()
+            {
+                Code = "COOL001",
+                CustomerName = "Jana Mrazíková",
+                Address = "Ledová 42, 100 00 Praha 1",
+                Phone = "+420 725 191 660",
+                Items = new List<ExpeditionOrderItem>
+                {
+                    new()
+                    {
+                        ProductCode = "CHLAD001",
+                        Name = "Chlazená Krémová Maska",
+                        Variant = "Obsah: 50 ml",
+                        WarehousePosition = "C01-1",
+                        Quantity = 2,
+                        StockCount = 20,
+                        StockDemand = 2,
+                        UnitPrice = 590.00m,
+                        Unit = "ks",
+                        Cooling = Cooling.L2,
+                    },
+                },
+            },
+            new()
+            {
+                Code = "NORM001",
+                CustomerName = "Petr Normální",
+                Address = "Běžná 5, 110 00 Praha",
+                Phone = "+420 600 000 002",
+                Items = new List<ExpeditionOrderItem>
+                {
+                    new()
+                    {
+                        ProductCode = "P001",
+                        Name = "Standardní produkt",
+                        Variant = string.Empty,
+                        WarehousePosition = "A01-1",
+                        Quantity = 1,
+                        StockCount = 50,
+                        StockDemand = 1,
+                        UnitPrice = 299.00m,
+                        Unit = "ks",
+                        Cooling = Cooling.None,
+                    },
+                },
+            },
+        },
+    };
+
+    var pdfBytes = ExpeditionProtocolDocument.Generate(data);
+
+    var outputPath = Path.Combine(Path.GetTempPath(), "ExpeditionList_CooledOrder.pdf");
+    File.WriteAllBytes(outputPath, pdfBytes);
+
+    pdfBytes.Should().NotBeNullOrEmpty();
+    File.Exists(outputPath).Should().BeTrue();
+
+    Console.WriteLine($"PDF saved to: {outputPath}");
+}
+```
+
+Also add the `using` at the top of the test file if not already present:
+
+```csharp
+using Anela.Heblo.Domain.Features.Catalog;
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "Generate_WithCooledOrder_DoesNotThrow|Generate_CooledOrder_SavesToDiskForVisualInspection"
+```
+
+Expected: `Generate_WithCooledOrder_DoesNotThrow` fails because the badge rendering code doesn't exist yet (the PDF generation will succeed — no exception — but after implementation it should exercise the badge code path). Actually this test might pass trivially since `IsCooled` exists and `ComposeOrderBlock` won't crash without badge code. So the test verifying correctness needs visual inspection. The visual test will fail until we add the badge. Let's verify: yes, both tests will pass trivially because `ExpeditionProtocolDocument` doesn't crash on cooled orders. That's expected — the test becomes meaningful after Step 3 implementation by ensuring the badge code doesn't introduce crashes.
+
+- [ ] **Step 3: Add frost badge constants to `ExpeditionProtocolDocument.cs`**
+
+Inside `ExpeditionProtocolDocument`, add these constants after the existing layout constants block (after line 24, `private const float StavCol = 2f;`):
+
+```csharp
+// Frost badge layout constants
+private const float FrostIconSize = 12f;
+private const float FrostBadgePadding = 3f;
+private const float FrostBadgeBorderThickness = 0.5f;
+```
+
+- [ ] **Step 4: Add the cached frost icon field**
+
+Add this field immediately before the `_data` field declaration in `ExpeditionProtocolDocument`:
+
+```csharp
+private static readonly byte[] FrostIconBytes = GenerateFrostIcon();
+```
+
+- [ ] **Step 5: Add the `GenerateFrostIcon()` method**
+
+Add this method after the existing `GenerateBarcode()` method (after line 297):
+
+```csharp
+private static byte[] GenerateFrostIcon()
+{
+    const int size = 64;
+    using var bitmap = new SKBitmap(size, size);
+    using var canvas = new SKCanvas(bitmap);
+    canvas.Clear(SKColors.Transparent);
+
+    using var paint = new SKPaint
+    {
+        Color = new SKColor(0x1E, 0x88, 0xE5), // blue
+        StrokeWidth = 4f,
+        IsAntialias = true,
+        Style = SKPaintStyle.Stroke,
+        StrokeCap = SKStrokeCap.Round,
+    };
+
+    var cx = size / 2f;
+    var cy = size / 2f;
+    var spokeLen = size * 0.42f;
+    var branchLen = size * 0.18f;
+    var branchOffset = size * 0.20f;
+
+    for (var i = 0; i < 6; i++)
+    {
+        var angle = i * 60.0 * Math.PI / 180.0;
+        var ex = cx + (float)(Math.Cos(angle) * spokeLen);
+        var ey = cy + (float)(Math.Sin(angle) * spokeLen);
+        canvas.DrawLine(cx, cy, ex, ey, paint);
+
+        // Two branch pairs along the spoke
+        foreach (var offsetFraction in new[] { branchOffset, spokeLen - branchLen })
+        {
+            var bx = cx + (float)(Math.Cos(angle) * offsetFraction);
+            var by = cy + (float)(Math.Sin(angle) * offsetFraction);
+            var leftAngle = angle + 60.0 * Math.PI / 180.0;
+            var rightAngle = angle - 60.0 * Math.PI / 180.0;
+            canvas.DrawLine(bx, by, bx + (float)(Math.Cos(leftAngle) * branchLen), by + (float)(Math.Sin(leftAngle) * branchLen), paint);
+            canvas.DrawLine(bx, by, bx + (float)(Math.Cos(rightAngle) * branchLen), by + (float)(Math.Sin(rightAngle) * branchLen), paint);
+        }
+    }
+
+    using var image = SKImage.FromBitmap(bitmap);
+    using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+    return data.ToArray();
+}
+```
+
+- [ ] **Step 6: Render the frost badge in `ComposeOrderBlock`**
+
+In `ComposeOrderBlock`, add the frost badge block between the order heading (`orderCol.Item().Text(...)`) and the barcode line. The existing `ComposeOrderBlock` body starts at line 78. Insert after the closing `});` of the heading Text block and before the barcode line:
+
+```csharp
+// Frost badge — shown only for orders containing at least one cooled product
+if (order.IsCooled)
+{
+    orderCol.Item().PaddingTop(3).PaddingBottom(3).Element(pill =>
+        pill
+            .Border(FrostBadgeBorderThickness)
+            .BorderColor(Colors.Blue.Medium)
+            .Background(Colors.Blue.Lighten4)
+            .Padding(FrostBadgePadding)
+            .Row(row =>
+            {
+                row.AutoItem().Width(FrostIconSize).Height(FrostIconSize).Image(FrostIconBytes).FitArea();
+                row.AutoItem().PaddingLeft(3).AlignMiddle()
+                    .Text("CHLAZENÁ ZÁSILKA")
+                    .Bold().FontSize(10).FontColor(Colors.Blue.Darken2);
+            }));
+}
+```
+
+The full updated `ComposeOrderBlock` method should look like this (showing the relevant section; keep all other code unchanged):
+
+```csharp
+private void ComposeOrderBlock(IContainer container, ExpeditionOrder order)
+{
+    container
+        .PaddingBottom(OrderGap)
+        .Border(BorderThickness)
+        .BorderColor(Colors.Grey.Darken2)
+        .Padding(BorderPadding)
+        .Column(orderCol =>
+    {
+        // Order heading: "Objednávka " + bold code — 30% larger than body (9 * 1.3 ≈ 12)
+        orderCol.Item().Text(t =>
+        {
+            t.Span("Objednávka ").FontSize(10);
+            t.Span(order.Code).Bold().FontSize(10);
+        });
+
+        // Frost badge — shown only for orders containing at least one cooled product
+        if (order.IsCooled)
+        {
+            orderCol.Item().PaddingTop(3).PaddingBottom(3).Element(pill =>
+                pill
+                    .Border(FrostBadgeBorderThickness)
+                    .BorderColor(Colors.Blue.Medium)
+                    .Background(Colors.Blue.Lighten4)
+                    .Padding(FrostBadgePadding)
+                    .Row(row =>
+                    {
+                        row.AutoItem().Width(FrostIconSize).Height(FrostIconSize).Image(FrostIconBytes).FitArea();
+                        row.AutoItem().PaddingLeft(3).AlignMiddle()
+                            .Text("CHLAZENÁ ZÁSILKA")
+                            .Bold().FontSize(10).FontColor(Colors.Blue.Darken2);
+                    }));
+        }
+
+        // Barcode — 60% of full width
+        var barcodeBytes = GenerateBarcode(order.Code);
+        orderCol.Item().Height(20).MaxWidth(200).Image(barcodeBytes).FitHeight();
+
+        // Customer info — single right-aligned line
+        orderCol.Item().AlignRight().Text(
+            $"{order.CustomerName}, {order.Address} {order.Phone}".Trim())
+            .FontSize(8);
+
+        // Items table
+        BuildItemsTable(orderCol.Item(), order.Items);
+
+        // Notes — shown only when at least one remark is present
+        var hasCustomerRemark = !string.IsNullOrWhiteSpace(order.CustomerRemark);
+        var hasEshopRemark = !string.IsNullOrWhiteSpace(order.EshopRemark);
+        if (hasCustomerRemark || hasEshopRemark)
+        {
+            orderCol.Item().PaddingTop(2).Column(notesCol =>
+            {
+                if (hasCustomerRemark)
+                    notesCol.Item().Text($"Poznámka zákazníka: {order.CustomerRemark}")
+                        .FontSize(8).Italic().Bold();
+                if (hasEshopRemark)
+                    notesCol.Item().Text($"Interní poznámka: {order.EshopRemark}")
+                        .FontSize(8).Italic().Bold();
+            });
+        }
+    });
+}
+```
+
+- [ ] **Step 7: Run all PDF document tests**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "ExpeditionProtocolDocumentTests"
+```
+
+Expected: all tests pass including the two new cooled-order tests.
+
+- [ ] **Step 8: Run all source tests**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "ShoptetApiExpeditionListSourceTests"
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Build and format**
+
+```
+dotnet build backend/Anela.Heblo.sln && dotnet format backend/Anela.Heblo.sln
+```
+
+Expected: 0 errors; format makes no changes (or only whitespace).
+
+- [ ] **Step 10: Run visual inspection test and verify PDF**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests --filter "Generate_CooledOrder_SavesToDiskForVisualInspection" -v normal 2>&1 | grep "PDF saved"
+```
+
+Open the printed path (e.g. `/tmp/ExpeditionList_CooledOrder.pdf`) and confirm:
+- Order `COOL001` (Jana Mrazíková) shows the blue frost badge with snowflake icon and "CHLAZENÁ ZÁSILKA" text above the barcode.
+- Order `NORM001` (Petr Normální) has no badge.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
+git add backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs
+git commit -m "feat(expedition): render frost badge on cooled orders in expedition PDF"
+```
+
+---
+
+## Task 4: Final verification
+
+- [ ] **Step 1: Run full test suite for touched projects**
+
+```
+dotnet test backend/test/Anela.Heblo.Tests
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run adapter tests if they exist**
+
+```
+dotnet test backend/test/Anela.Heblo.Adapters.Shoptet.Tests 2>/dev/null || echo "No such project"
+```
+
+Expected: pass (or project does not exist).
+
+- [ ] **Step 3: Final build + format**
+
+```
+dotnet build backend/Anela.Heblo.sln && dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: build succeeds, format reports no changes.


### PR DESCRIPTION
Adds a visual frost badge to cooled orders in the expedition list PDF so warehouse staff can identify cold-chain orders at a glance.

- `ExpeditionOrderItem` gains a `Cooling` field; `ExpeditionOrder` gains a computed `IsCooled` property
- `FlushBatchAsync` captures `Cooling` from the existing `CatalogAggregate` lookup during batch enrichment
- `ExpeditionProtocolDocument` renders a blue pill badge (SkiaSharp snowflake icon + "CHLAZENÁ ZÁSILKA" text) above the barcode for any cooled order
- Tests cover `IsCooled` unit logic, enrichment path, and PDF smoke + visual inspection