### PR TITLE
fix: run DB migrations on every startup, not just production

### DIFF
--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -274,8 +274,7 @@ public static class ApplicationBuilderExtensions
     }
 
     /// <summary>
-    /// Applies any pending EF Core migrations to the database.
-    /// Should only be called in Production; other environments use <c>dotnet ef database update</c>.
+    /// Applies any pending EF Core migrations to the database on every startup.
     /// Fails fast (rethrows) on error so the app does not start with an out-of-date schema.
     /// </summary>
     public static async Task MigrateDatabaseAsync(this WebApplication app)

--- a/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ApplicationBuilderExtensions.cs
@@ -287,6 +287,12 @@ public static class ApplicationBuilderExtensions
             using var scope = app.Services.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
+            if (!db.Database.IsRelational())
+            {
+                logger.LogInformation("Non-relational database provider — skipping migrations.");
+                return;
+            }
+
             var pending = (await db.Database.GetPendingMigrationsAsync()).ToList();
 
             if (pending.Count == 0)

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -125,12 +125,7 @@ public partial class Program
         // Initialize tile registry with all registered tiles
         app.InitializeTileRegistry();
 
-        // Apply pending EF Core migrations in Production only.
-        // Other environments (Dev/Test/Staging/Automation) keep the manual `dotnet ef database update` workflow.
-        if (app.Environment.IsProduction() || app.Environment.IsStaging())
-        {
-            await app.MigrateDatabaseAsync();
-        }
+        await app.MigrateDatabaseAsync();
 
         // Seed default recurring job configurations from discovered IRecurringJob implementations.
         // Runs before pipeline configuration and Hangfire startup to guarantee job configurations exist before recurring jobs start.


### PR DESCRIPTION
Removes the `IsProduction || IsStaging` guard in `Program.cs` so `MigrateDatabaseAsync()` runs unconditionally on every startup. Updates the XML doc comment on the method to reflect the new behavior.

This ensures local development and test environments also benefit from automatic schema updates instead of requiring a manual `dotnet ef database update`.