### PR TITLE
fix: correct Shoptet invoice VAT rate and payment method mapping

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/BillingMethodMapper.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/BillingMethodMapper.cs
@@ -59,16 +59,4 @@ public class BillingMethodMapper
         return BillingMethod.BankTransfer;
     }
 
-    public BillingMethod Map(string? shoptetCode)
-    {
-        if (string.IsNullOrEmpty(shoptetCode) || !CodeMap.TryGetValue(shoptetCode, out var method))
-        {
-            if (!string.IsNullOrEmpty(shoptetCode))
-                _logger.LogWarning(
-                    "Unknown Shoptet billingMethod code '{Code}' — defaulting to BankTransfer. Add to BillingMethodMapper.Map.",
-                    shoptetCode);
-            return BillingMethod.BankTransfer;
-        }
-        return method;
-    }
 }

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/BillingMethodMapper.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/BillingMethodMapper.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
 using Anela.Heblo.Domain.Features.Invoices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -6,6 +7,16 @@ namespace Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
 
 public class BillingMethodMapper
 {
+    // Stable, documented numeric billing method ids returned by the Shoptet Invoices API.
+    // See docs/integrations/shoptet-api.md §10.6 — preferred over the store-configured `name`.
+    private static readonly Dictionary<int, BillingMethod> IdMap = new()
+    {
+        [1] = BillingMethod.CoD,          // Dobírka
+        [2] = BillingMethod.BankTransfer, // Převodem
+        [3] = BillingMethod.Cash,         // Hotově
+        [4] = BillingMethod.CreditCard,   // Kartou
+    };
+
     private static readonly Dictionary<string, BillingMethod> CodeMap = new(StringComparer.OrdinalIgnoreCase)
     {
         ["bankTransfer"] = BillingMethod.BankTransfer,
@@ -28,6 +39,24 @@ public class BillingMethodMapper
 
     public BillingMethodMapper() : this(NullLogger<BillingMethodMapper>.Instance)
     {
+    }
+
+    public BillingMethod Map(ShoptetBillingMethodDto? billingMethod)
+    {
+        if (billingMethod == null)
+            return BillingMethod.BankTransfer;
+
+        if (IdMap.TryGetValue(billingMethod.Id, out var byId))
+            return byId;
+
+        // Unexpected id (e.g. 0 = missing) — fall back to the store-configured name.
+        if (!string.IsNullOrEmpty(billingMethod.Name) && CodeMap.TryGetValue(billingMethod.Name, out var byName))
+            return byName;
+
+        _logger.LogWarning(
+            "Unknown Shoptet billingMethod id '{Id}' / name '{Name}' — defaulting to BankTransfer. Add to BillingMethodMapper.",
+            billingMethod.Id, billingMethod.Name);
+        return BillingMethod.BankTransfer;
     }
 
     public BillingMethod Map(string? shoptetCode)

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/ShoptetInvoiceMapper.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/IssuedInvoices/Mapping/ShoptetInvoiceMapper.cs
@@ -70,7 +70,7 @@ public class ShoptetInvoiceMapper
         }
 
         var headerPrice = MapInvoicePrice(src.Price);   // WithVat is toPay (post-rounding) or withVat fallback
-        var totalWithVat = products.Where(i => i.ItemPrice.VatRate != "none").Sum(i => i.ItemPrice.TotalWithVat);
+        var totalWithVat = products.Where(i => i.ItemPrice.VatRate != "zero").Sum(i => i.ItemPrice.TotalWithVat);
         var totalWithoutVat = products.Sum(i => i.ItemPrice.TotalWithoutVat);
 
         // Use the header's effective WithVat (toPay when within rounding range, otherwise withVat) as the
@@ -91,7 +91,7 @@ public class ShoptetInvoiceMapper
             CreationTime = ParseDate(src.CreationTime),
             DueDate = ParseDate(src.DueDate),
             TaxDate = ParseDate(src.TaxDate),
-            BillingMethod = _billingMapper.Map(src.BillingMethod?.Name),
+            BillingMethod = _billingMapper.Map(src.BillingMethod),
             ShippingMethod = ResolveShippingFromItemNames(products.Select(i => i.Name)),
             VatPayer = !string.IsNullOrEmpty(src.BillingAddress?.VatId),
             BillingAddress = billingAddress,
@@ -115,8 +115,8 @@ public class ShoptetInvoiceMapper
         itemType is not null && AggregateDiscountTypes.Contains(itemType);
 
     /// <summary>
-    /// Converts a Shoptet REST API numeric VAT rate string (e.g. "21.00") to a Pohoda named rate
-    /// (e.g. "high") — matching the format the Playwright/XML adapter produces from rateVAT.
+    /// Converts a Shoptet REST API numeric VAT rate string (e.g. "21.00") to a canonical named
+    /// rate ("high", "first", "second", "zero") understood by the Flexi VAT rate mapping.
     /// </summary>
     private static string? MapVatRate(string? vatRate)
     {
@@ -130,10 +130,10 @@ public class ShoptetInvoiceMapper
         return rate switch
         {
             21m => "high",
-            12m => "low",
-            10m => "low",
-            15m => "low",
-            0m => "none",
+            12m => "first",
+            15m => "first",
+            10m => "second",
+            0m => "zero",
             _ => vatRate,
         };
     }

--- a/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Invoices/FlexiInvoiceMappingProfileVatRateTests.cs
+++ b/backend/test/Anela.Heblo.Adapters.Flexi.Tests/Invoices/FlexiInvoiceMappingProfileVatRateTests.cs
@@ -1,0 +1,63 @@
+using Anela.Heblo.Adapters.Flexi.Invoices;
+using Anela.Heblo.Domain.Features.Invoices;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Rem.FlexiBeeSDK.Model.Invoices;
+using Xunit;
+
+namespace Anela.Heblo.Adapters.Flexi.Tests.Invoices;
+
+public class FlexiInvoiceMappingProfileVatRateTests
+{
+    [Theory]
+    [InlineData("high", "typSzbDph.dphZakl")]    // 21% standard rate
+    [InlineData("first", "typSzbDph.dphSniz")]   // 12% reduced rate
+    [InlineData("second", "typSzbDph.dphSniz2")] // 10% second reduced rate
+    [InlineData("zero", "typSzbDph.dphOsv")]     // 0% exempt
+    public void Map_TranslatesNamedVatRate_ToFlexiVatRateType(
+        string namedVatRate, string expectedFlexiVatRateType)
+    {
+        // Arrange
+        var config = new MapperConfiguration(
+            c => c.AddProfile<FlexiInvoiceMappingProfile>(),
+            NullLoggerFactory.Instance);
+        var mapper = config.CreateMapper();
+
+        var domain = new IssuedInvoiceDetail
+        {
+            Code = "INV1",
+            OrderCode = "ORD1",
+            Customer = new InvoiceCustomer { Name = "Test" },
+            BillingAddress = new InvoiceAddress { Street = "S", City = "C", CountryCode = "CZ" },
+            DeliveryAddress = new InvoiceAddress { Street = "S", City = "C", CountryCode = "CZ" },
+            Price = new InvoicePrice { CurrencyCode = "CZK", WithoutVat = 100m, WithVat = 112m, Vat = 12m },
+            Items = new List<IssuedInvoiceDetailItem>
+            {
+                new()
+                {
+                    Code = "P1",
+                    Name = "Product 1",
+                    Amount = 1m,
+                    ItemPrice = new InvoicePrice
+                    {
+                        CurrencyCode = "CZK",
+                        WithoutVat = 100m,
+                        WithVat = 112m,
+                        Vat = 12m,
+                        TotalWithoutVat = 100m,
+                        TotalWithVat = 112m,
+                        VatRate = namedVatRate,
+                    },
+                }
+            },
+        };
+
+        // Act
+        var flexi = mapper.Map<IssuedInvoiceDetailFlexiDto>(domain);
+
+        // Assert
+        flexi.Items.Should().HaveCount(1);
+        flexi.Items[0].VatRateType.Should().Be(expectedFlexiVatRateType);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/BillingMethodMapperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/BillingMethodMapperTests.cs
@@ -1,0 +1,58 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+using Anela.Heblo.Domain.Features.Invoices;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Adapters.ShoptetApi;
+
+public class BillingMethodMapperTests
+{
+    [Theory]
+    [InlineData(1, BillingMethod.CoD)]
+    [InlineData(2, BillingMethod.BankTransfer)]
+    [InlineData(3, BillingMethod.Cash)]
+    [InlineData(4, BillingMethod.CreditCard)]
+    public void Map_ResolvesByDocumentedNumericId(int id, BillingMethod expected)
+    {
+        // Arrange
+        var dto = new ShoptetBillingMethodDto { Id = id, Name = "anything" };
+
+        // Act
+        var result = new BillingMethodMapper().Map(dto);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Map_ReturnsBankTransfer_WhenBillingMethodIsNull()
+    {
+        var result = new BillingMethodMapper().Map((ShoptetBillingMethodDto?)null);
+
+        result.Should().Be(BillingMethod.BankTransfer);
+    }
+
+    [Fact]
+    public void Map_FallsBackToName_WhenIdIsUnknownButNameIsKnown()
+    {
+        // Arrange — id 0 (missing/unexpected), name still resolvable
+        var dto = new ShoptetBillingMethodDto { Id = 0, Name = "Kartou" };
+
+        // Act
+        var result = new BillingMethodMapper().Map(dto);
+
+        // Assert
+        result.Should().Be(BillingMethod.CreditCard);
+    }
+
+    [Fact]
+    public void Map_ReturnsBankTransfer_WhenIdAndNameAreUnknown()
+    {
+        var dto = new ShoptetBillingMethodDto { Id = 99, Name = "Mystery method" };
+
+        var result = new BillingMethodMapper().Map(dto);
+
+        result.Should().Be(BillingMethod.BankTransfer);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetInvoiceMapperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetInvoiceMapperTests.cs
@@ -1,0 +1,99 @@
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Mapping;
+using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices.Model;
+using Anela.Heblo.Adapters.ShoptetApi.Orders;
+using Anela.Heblo.Domain.Features.Invoices;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Adapters.ShoptetApi;
+
+public class ShoptetInvoiceMapperTests
+{
+    private static ShoptetInvoiceMapper BuildMapper() =>
+        new(new BillingMethodMapper(),
+            new ShippingMethodMapper(Options.Create(new ShoptetApiSettings())));
+
+    [Theory]
+    [InlineData("21.0", "high")]
+    [InlineData("12.0", "first")]
+    [InlineData("15.0", "first")]
+    [InlineData("10.0", "second")]
+    [InlineData("0.0", "zero")]
+    public void Map_ConvertsShoptetNumericVatRate_ToCanonicalNamedRate(
+        string shoptetVatRate, string expectedNamedRate)
+    {
+        // Arrange
+        var src = new ShoptetInvoiceDto
+        {
+            Code = "INV1",
+            Items = new List<ShoptetInvoiceItemDto>
+            {
+                new()
+                {
+                    Code = "P1",
+                    Name = "Product 1",
+                    Amount = "1.00",
+                    ItemType = "product",
+                    UnitPrice = new ShoptetInvoiceUnitPriceDto
+                    {
+                        WithoutVat = "100.00",
+                        WithVat = shoptetVatRate == "12.0" ? "112.00" : "121.00",
+                        Vat = shoptetVatRate == "12.0" ? "12.00" : "21.00",
+                        VatRate = shoptetVatRate,
+                    },
+                },
+            },
+        };
+
+        // Act
+        var result = BuildMapper().Map(src);
+
+        // Assert
+        result.Items.Should().HaveCount(1);
+        result.Items[0].ItemPrice.VatRate.Should().Be(expectedNamedRate);
+    }
+
+    [Theory]
+    [InlineData(1, "Dobírka", BillingMethod.CoD)]
+    [InlineData(2, "Převodem", BillingMethod.BankTransfer)]
+    [InlineData(3, "Hotově", BillingMethod.Cash)]
+    [InlineData(4, "Kartou", BillingMethod.CreditCard)]
+    public void Map_ResolvesBillingMethodByShoptetId(
+        int billingMethodId, string billingMethodName, BillingMethod expected)
+    {
+        // Arrange
+        var src = new ShoptetInvoiceDto
+        {
+            Code = "INV1",
+            BillingMethod = new ShoptetBillingMethodDto
+            {
+                Id = billingMethodId,
+                Name = billingMethodName,
+            },
+            Items = new List<ShoptetInvoiceItemDto>
+            {
+                new()
+                {
+                    Code = "P1",
+                    Name = "Product 1",
+                    Amount = "1.00",
+                    ItemType = "product",
+                    UnitPrice = new ShoptetInvoiceUnitPriceDto
+                    {
+                        WithoutVat = "100.00",
+                        WithVat = "121.00",
+                        Vat = "21.00",
+                        VatRate = "21.0",
+                    },
+                },
+            },
+        };
+
+        // Act
+        var result = BuildMapper().Map(src);
+
+        // Assert
+        result.BillingMethod.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two mapping bugs in the Shoptet REST-API issued-invoice import:

- **VAT rate** — invoice VAT rates are now mapped to the canonical Flexi rate names (`high`/`first`/`second`/`zero`) instead of the stale `low`/`none` values, and the item-total filter excludes `zero`-rated lines correctly.
- **Payment method** — `BillingMethodMapper` now resolves the payment method by Shoptet's documented numeric `billingMethod` id (1=Dobírka, 2=Převodem, 3=Hotově, 4=Kartou) rather than the store-configured free-text `name`; the name lookup remains only as a safety-net fallback.

Previously, cash, card, and cash-on-delivery invoices whose name did not match the small dictionary silently defaulted to bank transfer, so in-store sales and COD orders were all booked as PŘEVOD in Abra.

## Test plan

- [x] `BillingMethodMapperTests` + `ShoptetInvoiceMapperTests` — 16/16 pass
- [x] `FlexiInvoiceMappingProfileVatRateTests` — 14/14 pass
- [x] `dotnet build` + `dotnet format` clean