### PR TITLE
feat: Batch SaveChangesAsync in MarketingInvoiceImportService

### DIFF
--- a/artifacts/feat-arch-review-marketinginvoices-savechange/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-savechange/arch-review.r1.md
@@ -1,0 +1,168 @@
+# Architecture Review: Batch SaveChangesAsync in MarketingInvoiceImportService
+
+## Skip Design: true
+
+Backend-only refactor of a job-invoked service. No UI components, screens, or visual design decisions.
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with existing conventions. `IImportedMarketingTransactionRepository.SaveChangesAsync` delegates to `ApplicationDbContext.SaveChangesAsync` (via `BaseRepository`), which is a unit-of-work flush — calling it per record is indeed a misuse. `AddAsync` calls `DbSet.AddAsync`, which only stages the entity in EF Core change tracking, so deferring the flush is correct.
+
+Integration points are narrow and well-contained:
+- **Single caller surface:** `MarketingInvoiceImportService` is constructed directly inside `GoogleAdsInvoiceImportJob` and `MetaAdsInvoiceImportJob` (`new MarketingInvoiceImportService(...)`, not DI-resolved). Both jobs only read `MarketingImportResult` counts for logging — no caller depends on per-record commit timing. The contract that must hold is the count semantics, exactly as the spec states.
+- **Scoped lifetime:** `IImportedMarketingTransactionRepository` is registered `AddScoped`. Each job execution resolves a fresh `ApplicationDbContext`, so the change tracker is per-run and does not leak staged entities across runs even on flush failure.
+- **EF transactionality:** A single `SaveChangesAsync` over N `Added` entities is already wrapped in an implicit database transaction by EF Core. The spec's "all-or-nothing" goal is therefore satisfied **without** an explicit `IDbContextTransaction` — correctly listed as out of scope.
+
+The spec is sound, but it **misses one genuine behavior regression** — see Decision 1 and Risks.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GoogleAdsInvoiceImportJob / MetaAdsInvoiceImportJob   (twice-daily cron)
+        │  new MarketingInvoiceImportService(source, repository, logger)
+        ▼
+MarketingInvoiceImportService.ImportAsync(from, to, ct)
+        │
+        ├─ source.GetTransactionsAsync(from, to, ct)
+        │
+        ├─ foreach transaction:                       ◄── per-record try/catch (unchanged)
+        │     ├─ repository.ExistsAsync(...)           ── SQL query, sees DB only
+        │     ├─ [NEW] in-batch dedup check            ── sees entities staged this run
+        │     ├─ repository.AddAsync(entity, ct)       ── stages in change tracker only
+        │     └─ stagedCount++
+        │
+        └─ if stagedCount > 0:                         ◄── single flush, NEW try/catch
+              repository.SaveChangesAsync(ct)          ── one INSERT batch + COMMIT
+              └─ on failure: move stagedCount → Failed, Imported = 0
+```
+
+### Key Design Decisions
+
+#### Decision 1: Guard against intra-batch duplicate TransactionIds
+
+**Options considered:**
+- (A) Implement the spec as written — rely solely on `ExistsAsync` for duplicate detection.
+- (B) Add an in-memory `HashSet<string>` of `TransactionId`s staged in the current run, and skip a transaction when it is in the set, alongside the existing `ExistsAsync` check.
+
+**Chosen approach:** (B).
+
+**Rationale:** This is the one real defect in the spec. `ExistsAsync` runs `DbSet.AnyAsync` — a SQL query against the database — so it **cannot see entities staged via `AddAsync` but not yet flushed**. Under the *current* per-record save, if the source returns the same `(Platform, TransactionId)` twice in one run, the first record is committed immediately and the second's `ExistsAsync` returns `true` → `Skipped++`. After batching, the first record is only staged; the second's `ExistsAsync` returns `false` → both are staged → the final `SaveChangesAsync` violates the unique index `IX_ImportedMarketingTransactions_Platform_TransactionId` → **the entire batch flush fails** and FR-3 reports *every* record as `Failed`.
+
+So a previously survivable, low-cost event (one duplicate → one skip) becomes a catastrophic one (whole run lost). Whether ad-platform billing APIs ever return a transaction twice within a 7-day lookback is uncertain — but the failure mode is severe enough that the architecture must not depend on the assumption. A `HashSet<string>` checked next to `ExistsAsync` restores the prior intra-batch dedup behavior at negligible cost and keeps the change inside the service with no contract change.
+
+#### Decision 2: Use a local `stagedCount`, not `result.Imported`, as the flush guard
+
+**Options considered:**
+- (A) Spec's wording: guard the flush with `result.Imported > 0` and, on flush failure, set `result.Imported = 0` / `result.Failed += <old Imported>`.
+- (B) Track a local `int stagedCount` incremented after `AddAsync`; set `result.Imported = stagedCount` only after a successful flush; on failure set `result.Failed += stagedCount`.
+
+**Chosen approach:** (B).
+
+**Rationale:** `result.Imported` is a *reporting* field. Reusing it as loop-control state and then mutating it back to `0` conflates "what happened" with "what to do next" and makes the FR-3 correction read as a fix-up rather than the intended semantics. With a local `stagedCount`, `result.Imported` only ever holds a true value: it stays `0` until the flush succeeds. This is functionally equivalent to the spec and produces identical counts for every acceptance criterion — it is purely a clarity improvement. Treat this as the recommended implementation of FR-1/FR-3 (see Specification Amendments).
+
+#### Decision 3: Keep error isolation asymmetric — per-record catch + one flush catch
+
+**Chosen approach:** Retain the existing per-transaction `try/catch` inside the loop and add a separate `try/catch` around the single post-loop `SaveChangesAsync`, neither rethrowing.
+
+**Rationale:** Matches the spec and the established "error-isolation" style of this service and both import jobs (which log-and-continue). The flush `catch` should catch `Exception` for consistency with the loop, accepting that a cancellation mid-flush would be logged as an error — acceptable and pre-existing in spirit (low severity).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Two files change:
+
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — the refactor.
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — updated and new tests.
+
+No changes to `IImportedMarketingTransactionRepository`, the repository implementation, `MarketingImportResult`, the entity, the EF configuration, or `MarketingInvoicesModule`.
+
+### Interfaces and Contracts
+
+All public contracts are unchanged: `ImportAsync(DateTime, DateTime, CancellationToken)` signature, `MarketingImportResult`, and the repository interface. The change is entirely inside the `ImportAsync` method body.
+
+Implementation shape inside `ImportAsync`:
+
+```csharp
+var result = new MarketingImportResult();
+var stagedCount = 0;
+var stagedIds = new HashSet<string>();   // intra-batch dedup (Decision 1)
+
+foreach (var transaction in transactions)
+{
+    try
+    {
+        // duplicate: already in DB, OR already staged in this run
+        if (stagedIds.Contains(transaction.TransactionId) ||
+            await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct))
+        {
+            _logger.LogDebug("Transaction {TransactionId} for {Platform} already imported — skipping",
+                transaction.TransactionId, _source.Platform);
+            result.Skipped++;
+            continue;
+        }
+
+        var entity = new ImportedMarketingTransaction { /* unchanged mapping */ };
+        await _repository.AddAsync(entity, ct);
+        stagedIds.Add(transaction.TransactionId);
+        stagedCount++;
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to import transaction {TransactionId} for {Platform}",
+            transaction.TransactionId, _source.Platform);
+        result.Failed++;
+    }
+}
+
+if (stagedCount > 0)
+{
+    try
+    {
+        await _repository.SaveChangesAsync(ct);
+        result.Imported = stagedCount;
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex,
+            "Failed to persist {Count} marketing transactions for {Platform}",
+            stagedCount, _source.Platform);
+        result.Failed += stagedCount;
+        // result.Imported stays 0
+    }
+}
+// final completion log uses corrected result counts (unchanged log line)
+```
+
+### Data Flow
+
+1. **Happy path (N new, no intra-batch dupes):** N `AddAsync` calls stage N entities; one `SaveChangesAsync` issues one batched `INSERT` + `COMMIT`. `Imported = N`, `Skipped = 0`, `Failed = 0`.
+2. **Mixed new/duplicate:** DB duplicates and intra-batch duplicates both hit the skip path → `Skipped`. New records → staged. One flush. Counts reflect true outcome.
+3. **Per-transaction error:** Exception in `ExistsAsync`/`AddAsync` is caught → `Failed++`; loop continues; already-staged entities remain tracked and are flushed at the end.
+4. **Flush failure (FR-3):** `SaveChangesAsync` throws → logged with platform + count; `Failed += stagedCount`; `Imported` remains `0`. Method returns normally. The scoped `DbContext` is disposed with the job scope, discarding the orphaned `Added` entities.
+5. **Empty / all-skipped:** `stagedCount == 0` → `SaveChangesAsync` is never called.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Intra-batch duplicate `TransactionId` poisons the whole batch via unique-index violation on the single flush (regression vs. per-record save) | HIGH | Add in-run `HashSet<string>` dedup check alongside `ExistsAsync` (Decision 1). Add a test covering two source rows with the same `TransactionId` → one `Imported`, one `Skipped`. |
+| A single bad record (e.g. constraint/data error not caught earlier) now fails the entire batch instead of one record | MEDIUM | Inherent and accepted trade-off of batching, explicitly desired by the brief ("all-or-nothing"). FR-3 ensures counts stay truthful; structured `LogError` keeps it observable. No further mitigation. |
+| Reusing `result.Imported` as control-flow state obscures intent and risks an off-by-one during the FR-3 correction | LOW | Use a local `stagedCount`; set `result.Imported` only after a successful flush (Decision 2). |
+| `OperationCanceledException` during the flush is caught and logged as an error rather than surfaced as cancellation | LOW | Acceptable — consistent with the existing catch-all loop style; out of scope to change. |
+
+## Specification Amendments
+
+1. **New requirement — intra-batch duplicate handling (insert as FR-1a or extend FR-2).** The service must skip a transaction whose `(Platform, TransactionId)` was already staged earlier in the *same* run, not only those already in the database. Rationale: `ExistsAsync` queries the DB and cannot see un-flushed staged entities; without this, a duplicated source row triggers a unique-index violation that fails the entire batched flush. Acceptance: given two source transactions with identical `TransactionId`, exactly one is staged and counted `Imported`, the other is counted `Skipped`, and the run does not fail.
+
+2. **FR-4 — add a test for amendment 1.** Add a test: source returns the same `TransactionId` twice → `AddAsync` invoked `Times.Once`, `SaveChangesAsync` `Times.Once`, `Imported == 1`, `Skipped == 1`, `Failed == 0`.
+
+3. **FR-1 / FR-3 wording refinement.** Replace the `result.Imported > 0` flush guard and the "move `Imported` to `Failed`" correction with a local `stagedCount`: guard the flush on `stagedCount > 0`; set `result.Imported = stagedCount` only after a successful flush; on flush failure set `result.Failed += stagedCount` and leave `result.Imported` at `0`. Functionally identical to the current wording for every stated acceptance criterion; clearer intent.
+
+4. **Note on atomicity (informational).** State explicitly that the all-or-nothing guarantee comes from EF Core wrapping the single `SaveChangesAsync` in an implicit transaction — no explicit `IDbContextTransaction` is needed (consistent with Out of Scope).
+
+## Prerequisites
+
+None. No migration, configuration, or infrastructure change. The unique index `IX_ImportedMarketingTransactions_Platform_TransactionId` already exists and is unchanged. Validation per `CLAUDE.md`: `dotnet build`, `dotnet format`, and the `MarketingInvoiceImportServiceTests` suite must pass.

--- a/artifacts/feat-arch-review-marketinginvoices-savechange/brief.md
+++ b/artifacts/feat-arch-review-marketinginvoices-savechange/brief.md
@@ -1,0 +1,48 @@
+## Module
+MarketingInvoices
+
+## Finding
+`MarketingInvoiceImportService.ImportAsync` calls `SaveChangesAsync` after every individual `AddAsync` inside the transaction loop:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs, lines 56–57
+await _repository.AddAsync(entity, ct);
+await _repository.SaveChangesAsync(ct);   // ← one round-trip to DB per transaction
+```
+
+For a 7-day lookback import, this issues N separate `INSERT + COMMIT` round-trips instead of one. The `AddAsync` accumulates the entity into EF change tracking; a single `SaveChangesAsync` after the loop is sufficient and correct.
+
+## Why it matters
+- **Performance:** Each call to `SaveChangesAsync` is a separate database round-trip. With dozens or hundreds of transactions over a 7-day window, this is unnecessary I/O at every job execution (twice daily).
+- **Atomicity mismatch:** The current loop saves each record individually. If the process is interrupted mid-batch, the DB is left in a partially-imported state with no way to distinguish which records came from the current run. Batching the save makes all-or-nothing reasoning easier and better matches the intent of the domain operation.
+- **The `IImportedMarketingTransactionRepository` interface exposes `SaveChangesAsync`** — calling it once per item is not what that method is designed for; it is a unit-of-work flush operation.
+
+## Suggested fix
+Move `SaveChangesAsync` outside the loop, and update the `result.Imported` count to reflect what was tracked before the final save:
+
+```csharp
+foreach (var transaction in transactions)
+{
+    try
+    {
+        var exists = await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct);
+        if (exists) { result.Skipped++; continue; }
+
+        await _repository.AddAsync(new ImportedMarketingTransaction { ... }, ct);
+        result.Imported++;
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, ...);
+        result.Failed++;
+    }
+}
+
+if (result.Imported > 0)
+    await _repository.SaveChangesAsync(ct);
+```
+
+If per-record error isolation is required, the save can still happen per-record, but that should be a deliberate choice noted in the code, not an accidental pattern.
+
+---
+_Filed by daily arch-review routine on 2026-05-18._

--- a/artifacts/feat-arch-review-marketinginvoices-savechange/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-savechange/impl/main.r1.md
@@ -1,0 +1,8 @@
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-marketinginvoices-savechange/spec.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-savechange/spec.r1.md
@@ -1,0 +1,97 @@
+# Specification: Batch SaveChangesAsync in MarketingInvoiceImportService
+
+## Summary
+`MarketingInvoiceImportService.ImportAsync` currently calls `SaveChangesAsync` once per imported transaction inside its loop, producing one database round-trip per record. This change moves the flush outside the loop so a single `SaveChangesAsync` persists the whole batch, cutting unnecessary I/O on a job that runs twice daily and making the import behave as an all-or-nothing unit of work.
+
+## Background
+The MarketingInvoices module imports marketing-spend transactions (e.g. ad platform charges) into the `ImportedMarketingTransaction` table for later sync. A scheduled job invokes `ImportAsync(from, to)` with a 7-day lookback window, twice per day.
+
+Inside the per-transaction loop, the service does:
+
+```csharp
+await _repository.AddAsync(entity, ct);
+await _repository.SaveChangesAsync(ct);   // one INSERT + COMMIT per transaction
+```
+
+`AddAsync` already stages the entity in EF Core change tracking. Calling `SaveChangesAsync` after every `AddAsync` issues N separate `INSERT + COMMIT` round-trips for N new transactions instead of one. `SaveChangesAsync` on `IImportedMarketingTransactionRepository` is a unit-of-work flush; the intended usage is one call per logical batch.
+
+Beyond the I/O cost, per-record commit leaves the table in a partially-imported state if the process is interrupted mid-loop, with no marker distinguishing records from the current run. A single batched flush gives clean all-or-nothing semantics for the import.
+
+This was filed by the daily arch-review routine on 2026-05-18. It is a targeted refactor: behavior visible to callers (the `MarketingImportResult` counts) must remain correct.
+
+## Functional Requirements
+
+### FR-1: Single batched flush per import run
+`SaveChangesAsync` must be called at most once per `ImportAsync` invocation, after the transaction loop completes, instead of once per imported record.
+
+**Acceptance criteria:**
+- The `await _repository.SaveChangesAsync(ct)` call is removed from inside the `foreach` loop.
+- After the loop, `SaveChangesAsync(ct)` is called exactly once when at least one entity was staged via `AddAsync` (i.e. `result.Imported > 0` before the final save).
+- When no new entities were staged (all transactions skipped/failed before `AddAsync`, or the source returned an empty list), `SaveChangesAsync` is not called.
+- `ExistsAsync`, `AddAsync`, duplicate-skip logic, and per-transaction `try/catch` remain inside the loop and behave as today.
+
+### FR-2: Preserve `MarketingImportResult` count semantics
+The `Imported`, `Skipped`, and `Failed` counts returned to callers must continue to reflect the true outcome of the run.
+
+**Detailed description:** `result.Imported` is incremented inside the loop after a successful `AddAsync` (records staged in change tracking). `result.Skipped` increments for duplicates detected by `ExistsAsync`. `result.Failed` increments when a per-transaction operation throws. The final batched `SaveChangesAsync` must not silently leave `Imported` reporting records that were never persisted.
+
+**Acceptance criteria:**
+- For an import where all transactions are new and the flush succeeds, `Imported` equals the number of new transactions, `Skipped == 0`, `Failed == 0`.
+- For a mix of new and duplicate transactions, `Imported` counts only new records and `Skipped` counts duplicates.
+- A per-transaction exception (e.g. inside `ExistsAsync` or `AddAsync`) increments `Failed`, does not abort the run, and the remaining transactions are still processed.
+
+### FR-3: Handle failure of the final batched flush
+If the single post-loop `SaveChangesAsync` throws, the batch was not persisted; the result must not report those records as imported.
+
+**Detailed description:** With per-record save, a failure affected only one record. With a batched save, a flush failure means none of the staged records were committed. Assumption (see Open Questions — resolved): the post-loop `SaveChangesAsync` is wrapped in a `try/catch`. On exception the error is logged with structured context, and the staged count is moved from `Imported` to `Failed` so the returned `MarketingImportResult` reflects that nothing was persisted.
+
+**Acceptance criteria:**
+- The post-loop `SaveChangesAsync` is wrapped in `try/catch`.
+- On a flush exception: the exception is logged via `_logger.LogError` with the platform and the affected record count; `result.Failed` is increased by the previously-staged `Imported` count and `result.Imported` is set to `0`.
+- The exception is not rethrown; `ImportAsync` returns the corrected `MarketingImportResult` normally (consistent with the existing per-transaction error-isolation style).
+- The final completion log line reports the corrected counts.
+
+### FR-4: Update affected unit tests
+Existing tests in `MarketingInvoiceImportServiceTests` assume per-record `SaveChangesAsync` and must be updated to the batched contract.
+
+**Acceptance criteria:**
+- `ImportAsync_NewTransactions_ArePersistedAndCounted` changes its verification from `SaveChangesAsync ... Times.Exactly(2)` to `Times.Once`; `Imported == 2` assertion is unchanged.
+- `ImportAsync_DuplicateTransaction_IsSkipped` continues to pass; add verification that `SaveChangesAsync` is `Times.Never` when nothing is staged.
+- `ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun` continues to pass (`Imported == 1`, `Failed == 1`).
+- A new test covers FR-3: when the post-loop `SaveChangesAsync` throws, `Imported == 0` and `Failed` equals the number of staged records, and `ImportAsync` does not throw.
+- A new test covers the empty-input / all-skipped case: `SaveChangesAsync` is `Times.Never`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+For an import run with N new transactions, the number of `SaveChangesAsync` round-trips drops from N to 1 (or 0 when nothing is new). `ExistsAsync` continues to be one query per source transaction — unchanged by this work. No regression in the import job's wall-clock time; expected improvement proportional to N.
+
+### NFR-2: Security
+No change to the security posture. No new inputs, endpoints, secrets, or auth surface. The service remains an internal job-invoked component. Exception logging must not include raw connection strings or SQL text (existing `LogError` calls already pass only structured properties).
+
+## Data Model
+Unchanged. The affected entity is `ImportedMarketingTransaction` (`Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`): `Id` (int identity), `TransactionId`, `Platform`, `Amount`, `TransactionDate`, `ImportedAt`, `IsSynced`, `ErrorMessage`. No schema change, no migration.
+
+## API / Interface Design
+No public API or contract change.
+- `IImportedMarketingTransactionRepository` (`ExistsAsync`, `AddAsync`, `GetUnsyncedAsync`, `SaveChangesAsync`) is unchanged.
+- `MarketingInvoiceImportService.ImportAsync(DateTime from, DateTime to, CancellationToken ct)` signature and return type (`MarketingImportResult`) are unchanged.
+- The only changes are internal to `ImportAsync`: loop body removes the inline `SaveChangesAsync`; a guarded single `SaveChangesAsync` is added after the loop.
+
+## Dependencies
+- EF Core change tracking via `ApplicationDbContext` / `BaseRepository<ImportedMarketingTransaction, int>` — already in place.
+- xUnit + Moq test stack for `MarketingInvoiceImportServiceTests` — already in place.
+- No new external services or libraries.
+
+## Out of Scope
+- Introducing an explicit database transaction / `IDbContextTransaction` wrapper around the import.
+- Adding a run-id or batch marker column to distinguish records by import run.
+- Changing duplicate-detection (`ExistsAsync`) into a batched/bulk lookup.
+- Bulk-insert libraries (e.g. `EFCore.BulkExtensions`).
+- Changes to the import scheduling job, lookback window, or the sync (`GetUnsyncedAsync`) path.
+- Reworking the `MarketingTransaction` source contract.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketinginvoices-savechange/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-savechange/task-plan.r1.md
@@ -1,0 +1,447 @@
+# Batch SaveChangesAsync in MarketingInvoiceImportService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the `SaveChangesAsync` flush out of the per-transaction loop in `MarketingInvoiceImportService.ImportAsync` so a single batched flush persists the whole import run, with truthful `MarketingImportResult` counts and a guard against intra-batch duplicate `TransactionId`s.
+
+**Architecture:** The change is entirely inside the body of `ImportAsync`. The per-transaction `try/catch` and skip logic stay in the loop; `AddAsync` only stages entities. After the loop, a single `SaveChangesAsync` (wrapped in its own `try/catch`) flushes everything. A local `stagedCount` tracks how many entities were staged so `result.Imported` only ever holds a true value — it is set after a successful flush, and on flush failure the staged count moves to `result.Failed` instead. A run-scoped `HashSet<string>` of staged `TransactionId`s detects source rows duplicated *within the same run* (which `ExistsAsync`, a SQL query, cannot see) — without it a duplicated source row would violate the unique index and fail the entire batched flush.
+
+**Tech Stack:** .NET 8, EF Core (change tracking + implicit transaction on a single `SaveChangesAsync`), xUnit + Moq for tests.
+
+---
+
+## Background & Context
+
+`MarketingInvoiceImportService` is constructed directly (`new MarketingInvoiceImportService(...)`) inside `GoogleAdsInvoiceImportJob` and `MetaAdsInvoiceImportJob`, which run twice daily. Callers only read `MarketingImportResult` counts for logging — no caller depends on per-record commit timing. The repository is registered `AddScoped`, so each job run gets a fresh `ApplicationDbContext`; on a flush failure the orphaned `Added` entities are discarded when the job scope disposes.
+
+The all-or-nothing guarantee comes from EF Core wrapping the single `SaveChangesAsync` over N `Added` entities in an implicit database transaction — **no explicit `IDbContextTransaction` is needed** (it is out of scope).
+
+**Files in scope (only two change):**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — the refactor (only the `ImportAsync` method body changes).
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — update 2 existing tests, add 3 new tests.
+
+**Explicitly NOT touched:** `IImportedMarketingTransactionRepository`, the repository implementation, `MarketingImportResult`, `ImportedMarketingTransaction`, the EF configuration, `MarketingInvoicesModule`, the import jobs, and the database schema. No migration.
+
+---
+
+## Task 1: Update and extend the test suite to the batched contract (RED)
+
+This task rewrites the test file to encode the batched-flush contract. After this task the test project compiles but tests fail against the current per-record code — that is expected and proves the tests exercise the new behavior.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+- [ ] **Step 1: Replace the entire test file with the batched-contract version**
+
+Overwrite `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` with the following. Changes from the current file: (1) `ImportAsync_NewTransactions_ArePersistedAndCounted` verifies `SaveChangesAsync` `Times.Once` instead of `Times.Exactly(2)`; (2) `ImportAsync_DuplicateTransaction_IsSkipped` adds a `SaveChangesAsync` `Times.Never` verification; (3) `ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun` is unchanged in assertions; (4) three new tests are added. The `Assert.*` (xUnit) style is kept to match the existing file — do not switch to FluentAssertions.
+
+```csharp
+using Anela.Heblo.Application.Features.MarketingInvoices.Services;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.MarketingInvoices;
+
+public class MarketingInvoiceImportServiceTests
+{
+    private readonly Mock<IMarketingTransactionSource> _mockSource;
+    private readonly Mock<IImportedMarketingTransactionRepository> _mockRepository;
+    private readonly Mock<ILogger<MarketingInvoiceImportService>> _mockLogger;
+    private readonly MarketingInvoiceImportService _service;
+
+    public MarketingInvoiceImportServiceTests()
+    {
+        _mockSource = new Mock<IMarketingTransactionSource>();
+        _mockRepository = new Mock<IImportedMarketingTransactionRepository>();
+        _mockLogger = new Mock<ILogger<MarketingInvoiceImportService>>();
+
+        _mockSource.Setup(x => x.Platform).Returns("TestPlatform");
+
+        _service = new MarketingInvoiceImportService(
+            _mockSource.Object,
+            _mockRepository.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ImportAsync_NewTransactions_ArePersistedAndCounted()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(2, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DuplicateTransaction_IsSkipped()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Already exists in DB
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", "TX-001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(1, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // First transaction succeeds
+        _mockRepository.Setup(x => x.AddAsync(It.Is<ImportedMarketingTransaction>(t => t.TransactionId == "TX-001"), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Second transaction throws on AddAsync
+        _mockRepository.Setup(x => x.AddAsync(It.Is<ImportedMarketingTransaction>(t => t.TransactionId == "TX-002"), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB write failed"));
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(1, result.Failed);
+    }
+
+    [Fact]
+    public async Task ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // The single post-loop flush fails — none of the staged records are persisted
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(2, result.Failed);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_EmptyInput_DoesNotCallSaveChanges()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingTransaction>());
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        // Same TransactionId returned twice by the source in one run
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Not present in the DB — ExistsAsync cannot see un-flushed staged entities
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project to confirm it compiles**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: Build succeeds (the new tests reference only existing public APIs — `ImportAsync`, `MarketingImportResult`, the repository interface, `MarketingTransaction`).
+
+- [ ] **Step 3: Run the test class to confirm the expected failures**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"`
+Expected: FAIL. Against the current per-record code:
+- `ImportAsync_NewTransactions_ArePersistedAndCounted` fails — `SaveChangesAsync` is called twice (per record), not once.
+- `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce` fails — current code calls `AddAsync` twice (no intra-batch dedup) and `SaveChangesAsync` once per record.
+- `ImportAsync_FinalSaveChangesThrows_...` fails — current per-record code catches the throw inside the loop, so it would report `Failed == 2` only if both records' saves throw, but `Imported` handling differs; the count expectations will not match the per-record behavior.
+- `ImportAsync_DuplicateTransaction_IsSkipped` and `ImportAsync_EmptyInput_...` and `ImportAsync_PerTransactionError_...` may pass already — that is fine.
+
+This RED state confirms the tests pin the new contract. Do not commit yet — the commit happens in Task 2 with the implementation.
+
+---
+
+## Task 2: Refactor `ImportAsync` to a single batched flush (GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+- [ ] **Step 1: Replace the `ImportAsync` method body**
+
+In `MarketingInvoiceImportService.cs`, replace the entire `ImportAsync` method (currently lines 22-76) with the version below. Constructor, fields, `using` directives, and namespace stay exactly as they are. Changes: a local `stagedCount` and a `stagedIds` `HashSet<string>` are introduced; the inline `await _repository.SaveChangesAsync(ct)` and the inline `result.Imported++` are removed from the loop; the skip condition also checks `stagedIds`; a single guarded `SaveChangesAsync` runs after the loop.
+
+```csharp
+    public async Task<MarketingImportResult> ImportAsync(DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        _logger.LogInformation(
+            "Starting marketing invoice import for platform {Platform} from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
+            _source.Platform, from, to);
+
+        var transactions = await _source.GetTransactionsAsync(from, to, ct);
+
+        var result = new MarketingImportResult();
+        var stagedCount = 0;
+        var stagedIds = new HashSet<string>();
+
+        foreach (var transaction in transactions)
+        {
+            try
+            {
+                // Duplicate: already persisted in the DB, OR already staged earlier in this run.
+                // ExistsAsync runs a SQL query and cannot see entities staged via AddAsync but not yet flushed.
+                if (stagedIds.Contains(transaction.TransactionId) ||
+                    await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct))
+                {
+                    _logger.LogDebug(
+                        "Transaction {TransactionId} for {Platform} already imported — skipping",
+                        transaction.TransactionId, _source.Platform);
+                    result.Skipped++;
+                    continue;
+                }
+
+                var entity = new ImportedMarketingTransaction
+                {
+                    TransactionId = transaction.TransactionId,
+                    Platform = _source.Platform,
+                    Amount = transaction.Amount,
+                    TransactionDate = transaction.TransactionDate,
+                    ImportedAt = DateTime.UtcNow,
+                    IsSynced = false,
+                };
+
+                await _repository.AddAsync(entity, ct);
+                stagedIds.Add(transaction.TransactionId);
+                stagedCount++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to import transaction {TransactionId} for {Platform}",
+                    transaction.TransactionId, _source.Platform);
+                result.Failed++;
+            }
+        }
+
+        if (stagedCount > 0)
+        {
+            try
+            {
+                await _repository.SaveChangesAsync(ct);
+                result.Imported = stagedCount;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to persist {Count} marketing transactions for {Platform}",
+                    stagedCount, _source.Platform);
+                result.Failed += stagedCount;
+                // result.Imported intentionally stays 0 — nothing was committed.
+            }
+        }
+
+        _logger.LogInformation(
+            "Marketing invoice import complete for {Platform}: Imported={Imported}, Skipped={Skipped}, Failed={Failed}",
+            _source.Platform, result.Imported, result.Skipped, result.Failed);
+
+        return result;
+    }
+```
+
+- [ ] **Step 2: Build the application project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeds with no warnings introduced by the change.
+
+- [ ] **Step 3: Run the test class to verify all tests pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"`
+Expected: PASS — all 6 tests green:
+- `ImportAsync_NewTransactions_ArePersistedAndCounted` — `Imported == 2`, `SaveChangesAsync` once.
+- `ImportAsync_DuplicateTransaction_IsSkipped` — `Skipped == 1`, `SaveChangesAsync` never.
+- `ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun` — `Imported == 1`, `Failed == 1` (TX-001 staged then flushed once, TX-002 throws on `AddAsync`).
+- `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` — `Imported == 0`, `Failed == 2`, no exception.
+- `ImportAsync_EmptyInput_DoesNotCallSaveChanges` — all counts 0, `SaveChangesAsync` never.
+- `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce` — `Imported == 1`, `Skipped == 1`, `AddAsync` once, `SaveChangesAsync` once.
+
+- [ ] **Step 4: Run `dotnet format` on the changed files**
+
+Run: `dotnet format Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+Expected: Completes with no remaining formatting changes (or applies whitespace fixes only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+git commit -m "refactor: batch SaveChangesAsync in MarketingInvoiceImportService
+
+Move the EF Core flush out of the per-transaction loop so a single
+SaveChangesAsync persists the whole import run as one unit of work.
+Add a run-scoped HashSet to skip source rows duplicated within the
+same run (ExistsAsync cannot see un-flushed staged entities). Track a
+local stagedCount so result.Imported only reports records after a
+successful flush; on flush failure the staged count moves to Failed."
+```
+
+---
+
+## Task 3: Full validation
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Build the whole solution**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Run the full test project**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: All tests pass. The change is confined to `MarketingInvoiceImportService`; no other test should be affected. If an unrelated test fails, confirm it is pre-existing (run it on `origin/main`) before proceeding.
+
+- [ ] **Step 3: Confirm `dotnet format` reports no outstanding changes**
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes --include backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+Expected: Exit code 0 — no formatting changes needed.
+
+If any step fails, fix the cause and re-run that step before declaring the task complete.
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Implemented by |
+|---|---|
+| FR-1: single batched flush per run | Task 2 Step 1 — inline `SaveChangesAsync` removed from loop; guarded single `SaveChangesAsync` after loop on `stagedCount > 0` |
+| FR-2: preserve `Imported`/`Skipped`/`Failed` semantics | Task 2 Step 1 — `Skipped++`/`Failed++` unchanged in loop; `result.Imported = stagedCount` after successful flush; Task 1 tests pin counts |
+| FR-3: handle final flush failure | Task 2 Step 1 — `try/catch` around `SaveChangesAsync`, `LogError` with platform + count, `Failed += stagedCount`, `Imported` stays 0, no rethrow; Task 1 `ImportAsync_FinalSaveChangesThrows_...` test |
+| FR-4: update affected unit tests | Task 1 — `NewTransactions` → `Times.Once`; `DuplicateTransaction` → `Times.Never`; `PerTransactionError` unchanged; new flush-failure + empty-input tests |
+| Arch amendment 1+2: intra-batch duplicate `TransactionId` handling + test | Task 2 Step 1 — `stagedIds` `HashSet` check; Task 1 `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce` test |
+| Arch Decision 2: local `stagedCount`, not `result.Imported`, as flush guard | Task 2 Step 1 — `stagedCount` declared and incremented; `result.Imported` set only after successful flush |
+| NFR-1: performance (N round-trips → 1) | Task 2 Step 1 — flush moved outside loop |
+| NFR-2: security unchanged | No new inputs/endpoints/secrets; `LogError` passes only structured properties (platform, count) |
+| Data model / API unchanged | No files other than the service and its test are modified (Task 1 + Task 2 file lists) |

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
@@ -28,13 +28,16 @@ public class MarketingInvoiceImportService
         var transactions = await _source.GetTransactionsAsync(from, to, ct);
 
         var result = new MarketingImportResult();
+        var stagedCount = 0;
+        var stagedIds = new HashSet<string>();
 
         foreach (var transaction in transactions)
         {
             try
             {
-                var exists = await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct);
-                if (exists)
+                // ExistsAsync queries the DB and cannot see entities staged via AddAsync but not yet flushed.
+                if (stagedIds.Contains(transaction.TransactionId) ||
+                    await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct))
                 {
                     _logger.LogDebug(
                         "Transaction {TransactionId} for {Platform} already imported — skipping",
@@ -54,9 +57,8 @@ public class MarketingInvoiceImportService
                 };
 
                 await _repository.AddAsync(entity, ct);
-                await _repository.SaveChangesAsync(ct);
-
-                result.Imported++;
+                stagedIds.Add(transaction.TransactionId);
+                stagedCount++;
             }
             catch (Exception ex)
             {
@@ -65,6 +67,24 @@ public class MarketingInvoiceImportService
                     "Failed to import transaction {TransactionId} for {Platform}",
                     transaction.TransactionId, _source.Platform);
                 result.Failed++;
+            }
+        }
+
+        if (stagedCount > 0)
+        {
+            try
+            {
+                await _repository.SaveChangesAsync(ct);
+                result.Imported = stagedCount;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to persist {Count} marketing transactions for {Platform}",
+                    stagedCount, _source.Platform);
+                result.Failed += stagedCount;
+                // result.Imported intentionally stays 0 — nothing was committed.
             }
         }
 

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -60,7 +60,7 @@ public class MarketingInvoiceImportServiceTests
         Assert.Equal(0, result.Skipped);
         Assert.Equal(0, result.Failed);
         _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
-        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -90,6 +90,7 @@ public class MarketingInvoiceImportServiceTests
         Assert.Equal(1, result.Skipped);
         Assert.Equal(0, result.Failed);
         _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -128,5 +129,100 @@ public class MarketingInvoiceImportServiceTests
         Assert.Equal(1, result.Imported);
         Assert.Equal(0, result.Skipped);
         Assert.Equal(1, result.Failed);
+    }
+
+    [Fact]
+    public async Task ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // The single post-loop flush fails — none of the staged records are persisted
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(2, result.Failed);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_EmptyInput_DoesNotCallSaveChanges()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingTransaction>());
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        // Same TransactionId returned twice by the source in one run
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Not present in the DB — ExistsAsync cannot see un-flushed staged entities
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/docs/superpowers/plans/2026-05-19-batch-savechanges-marketing-invoice-import.md
+++ b/docs/superpowers/plans/2026-05-19-batch-savechanges-marketing-invoice-import.md
@@ -1,0 +1,447 @@
+# Batch SaveChangesAsync in MarketingInvoiceImportService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the `SaveChangesAsync` flush out of the per-transaction loop in `MarketingInvoiceImportService.ImportAsync` so a single batched flush persists the whole import run, with truthful `MarketingImportResult` counts and a guard against intra-batch duplicate `TransactionId`s.
+
+**Architecture:** The change is entirely inside the body of `ImportAsync`. The per-transaction `try/catch` and skip logic stay in the loop; `AddAsync` only stages entities. After the loop, a single `SaveChangesAsync` (wrapped in its own `try/catch`) flushes everything. A local `stagedCount` tracks how many entities were staged so `result.Imported` only ever holds a true value — it is set after a successful flush, and on flush failure the staged count moves to `result.Failed` instead. A run-scoped `HashSet<string>` of staged `TransactionId`s detects source rows duplicated *within the same run* (which `ExistsAsync`, a SQL query, cannot see) — without it a duplicated source row would violate the unique index and fail the entire batched flush.
+
+**Tech Stack:** .NET 8, EF Core (change tracking + implicit transaction on a single `SaveChangesAsync`), xUnit + Moq for tests.
+
+---
+
+## Background & Context
+
+`MarketingInvoiceImportService` is constructed directly (`new MarketingInvoiceImportService(...)`) inside `GoogleAdsInvoiceImportJob` and `MetaAdsInvoiceImportJob`, which run twice daily. Callers only read `MarketingImportResult` counts for logging — no caller depends on per-record commit timing. The repository is registered `AddScoped`, so each job run gets a fresh `ApplicationDbContext`; on a flush failure the orphaned `Added` entities are discarded when the job scope disposes.
+
+The all-or-nothing guarantee comes from EF Core wrapping the single `SaveChangesAsync` over N `Added` entities in an implicit database transaction — **no explicit `IDbContextTransaction` is needed** (it is out of scope).
+
+**Files in scope (only two change):**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — the refactor (only the `ImportAsync` method body changes).
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — update 2 existing tests, add 3 new tests.
+
+**Explicitly NOT touched:** `IImportedMarketingTransactionRepository`, the repository implementation, `MarketingImportResult`, `ImportedMarketingTransaction`, the EF configuration, `MarketingInvoicesModule`, the import jobs, and the database schema. No migration.
+
+---
+
+## Task 1: Update and extend the test suite to the batched contract (RED)
+
+This task rewrites the test file to encode the batched-flush contract. After this task the test project compiles but tests fail against the current per-record code — that is expected and proves the tests exercise the new behavior.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+- [ ] **Step 1: Replace the entire test file with the batched-contract version**
+
+Overwrite `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` with the following. Changes from the current file: (1) `ImportAsync_NewTransactions_ArePersistedAndCounted` verifies `SaveChangesAsync` `Times.Once` instead of `Times.Exactly(2)`; (2) `ImportAsync_DuplicateTransaction_IsSkipped` adds a `SaveChangesAsync` `Times.Never` verification; (3) `ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun` is unchanged in assertions; (4) three new tests are added. The `Assert.*` (xUnit) style is kept to match the existing file — do not switch to FluentAssertions.
+
+```csharp
+using Anela.Heblo.Application.Features.MarketingInvoices.Services;
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.MarketingInvoices;
+
+public class MarketingInvoiceImportServiceTests
+{
+    private readonly Mock<IMarketingTransactionSource> _mockSource;
+    private readonly Mock<IImportedMarketingTransactionRepository> _mockRepository;
+    private readonly Mock<ILogger<MarketingInvoiceImportService>> _mockLogger;
+    private readonly MarketingInvoiceImportService _service;
+
+    public MarketingInvoiceImportServiceTests()
+    {
+        _mockSource = new Mock<IMarketingTransactionSource>();
+        _mockRepository = new Mock<IImportedMarketingTransactionRepository>();
+        _mockLogger = new Mock<ILogger<MarketingInvoiceImportService>>();
+
+        _mockSource.Setup(x => x.Platform).Returns("TestPlatform");
+
+        _service = new MarketingInvoiceImportService(
+            _mockSource.Object,
+            _mockRepository.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ImportAsync_NewTransactions_ArePersistedAndCounted()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(2, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DuplicateTransaction_IsSkipped()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Already exists in DB
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", "TX-001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(1, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // First transaction succeeds
+        _mockRepository.Setup(x => x.AddAsync(It.Is<ImportedMarketingTransaction>(t => t.TransactionId == "TX-001"), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Second transaction throws on AddAsync
+        _mockRepository.Setup(x => x.AddAsync(It.Is<ImportedMarketingTransaction>(t => t.TransactionId == "TX-002"), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB write failed"));
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(1, result.Failed);
+    }
+
+    [Fact]
+    public async Task ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // The single post-loop flush fails — none of the staged records are persisted
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("flush failed"));
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(2, result.Failed);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_EmptyInput_DoesNotCallSaveChanges()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingTransaction>());
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        // Same TransactionId returned twice by the source in one run
+        var transactions = new List<MarketingTransaction>
+        {
+            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+        };
+
+        _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Not present in the DB — ExistsAsync cannot see un-flushed staged entities
+        _mockRepository.Setup(x => x.ExistsAsync("TestPlatform", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _mockRepository.Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mockRepository.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _service.ImportAsync(from, to);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project to confirm it compiles**
+
+Run: `dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: Build succeeds (the new tests reference only existing public APIs — `ImportAsync`, `MarketingImportResult`, the repository interface, `MarketingTransaction`).
+
+- [ ] **Step 3: Run the test class to confirm the expected failures**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"`
+Expected: FAIL. Against the current per-record code:
+- `ImportAsync_NewTransactions_ArePersistedAndCounted` fails — `SaveChangesAsync` is called twice (per record), not once.
+- `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce` fails — current code calls `AddAsync` twice (no intra-batch dedup) and `SaveChangesAsync` once per record.
+- `ImportAsync_FinalSaveChangesThrows_...` fails — current per-record code catches the throw inside the loop, so it would report `Failed == 2` only if both records' saves throw, but `Imported` handling differs; the count expectations will not match the per-record behavior.
+- `ImportAsync_DuplicateTransaction_IsSkipped` and `ImportAsync_EmptyInput_...` and `ImportAsync_PerTransactionError_...` may pass already — that is fine.
+
+This RED state confirms the tests pin the new contract. Do not commit yet — the commit happens in Task 2 with the implementation.
+
+---
+
+## Task 2: Refactor `ImportAsync` to a single batched flush (GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+- [ ] **Step 1: Replace the `ImportAsync` method body**
+
+In `MarketingInvoiceImportService.cs`, replace the entire `ImportAsync` method (currently lines 22-76) with the version below. Constructor, fields, `using` directives, and namespace stay exactly as they are. Changes: a local `stagedCount` and a `stagedIds` `HashSet<string>` are introduced; the inline `await _repository.SaveChangesAsync(ct)` and the inline `result.Imported++` are removed from the loop; the skip condition also checks `stagedIds`; a single guarded `SaveChangesAsync` runs after the loop.
+
+```csharp
+    public async Task<MarketingImportResult> ImportAsync(DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        _logger.LogInformation(
+            "Starting marketing invoice import for platform {Platform} from {From:yyyy-MM-dd} to {To:yyyy-MM-dd}",
+            _source.Platform, from, to);
+
+        var transactions = await _source.GetTransactionsAsync(from, to, ct);
+
+        var result = new MarketingImportResult();
+        var stagedCount = 0;
+        var stagedIds = new HashSet<string>();
+
+        foreach (var transaction in transactions)
+        {
+            try
+            {
+                // Duplicate: already persisted in the DB, OR already staged earlier in this run.
+                // ExistsAsync runs a SQL query and cannot see entities staged via AddAsync but not yet flushed.
+                if (stagedIds.Contains(transaction.TransactionId) ||
+                    await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct))
+                {
+                    _logger.LogDebug(
+                        "Transaction {TransactionId} for {Platform} already imported — skipping",
+                        transaction.TransactionId, _source.Platform);
+                    result.Skipped++;
+                    continue;
+                }
+
+                var entity = new ImportedMarketingTransaction
+                {
+                    TransactionId = transaction.TransactionId,
+                    Platform = _source.Platform,
+                    Amount = transaction.Amount,
+                    TransactionDate = transaction.TransactionDate,
+                    ImportedAt = DateTime.UtcNow,
+                    IsSynced = false,
+                };
+
+                await _repository.AddAsync(entity, ct);
+                stagedIds.Add(transaction.TransactionId);
+                stagedCount++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to import transaction {TransactionId} for {Platform}",
+                    transaction.TransactionId, _source.Platform);
+                result.Failed++;
+            }
+        }
+
+        if (stagedCount > 0)
+        {
+            try
+            {
+                await _repository.SaveChangesAsync(ct);
+                result.Imported = stagedCount;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to persist {Count} marketing transactions for {Platform}",
+                    stagedCount, _source.Platform);
+                result.Failed += stagedCount;
+                // result.Imported intentionally stays 0 — nothing was committed.
+            }
+        }
+
+        _logger.LogInformation(
+            "Marketing invoice import complete for {Platform}: Imported={Imported}, Skipped={Skipped}, Failed={Failed}",
+            _source.Platform, result.Imported, result.Skipped, result.Failed);
+
+        return result;
+    }
+```
+
+- [ ] **Step 2: Build the application project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeds with no warnings introduced by the change.
+
+- [ ] **Step 3: Run the test class to verify all tests pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"`
+Expected: PASS — all 6 tests green:
+- `ImportAsync_NewTransactions_ArePersistedAndCounted` — `Imported == 2`, `SaveChangesAsync` once.
+- `ImportAsync_DuplicateTransaction_IsSkipped` — `Skipped == 1`, `SaveChangesAsync` never.
+- `ImportAsync_PerTransactionError_CountsAsFailed_DoesNotAbortRun` — `Imported == 1`, `Failed == 1` (TX-001 staged then flushed once, TX-002 throws on `AddAsync`).
+- `ImportAsync_FinalSaveChangesThrows_ReportsAllStagedAsFailed_DoesNotThrow` — `Imported == 0`, `Failed == 2`, no exception.
+- `ImportAsync_EmptyInput_DoesNotCallSaveChanges` — all counts 0, `SaveChangesAsync` never.
+- `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce` — `Imported == 1`, `Skipped == 1`, `AddAsync` once, `SaveChangesAsync` once.
+
+- [ ] **Step 4: Run `dotnet format` on the changed files**
+
+Run: `dotnet format Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+Expected: Completes with no remaining formatting changes (or applies whitespace fixes only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+git commit -m "refactor: batch SaveChangesAsync in MarketingInvoiceImportService
+
+Move the EF Core flush out of the per-transaction loop so a single
+SaveChangesAsync persists the whole import run as one unit of work.
+Add a run-scoped HashSet to skip source rows duplicated within the
+same run (ExistsAsync cannot see un-flushed staged entities). Track a
+local stagedCount so result.Imported only reports records after a
+successful flush; on flush failure the staged count moves to Failed."
+```
+
+---
+
+## Task 3: Full validation
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Build the whole solution**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Run the full test project**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: All tests pass. The change is confined to `MarketingInvoiceImportService`; no other test should be affected. If an unrelated test fails, confirm it is pre-existing (run it on `origin/main`) before proceeding.
+
+- [ ] **Step 3: Confirm `dotnet format` reports no outstanding changes**
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes --include backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+Expected: Exit code 0 — no formatting changes needed.
+
+If any step fails, fix the cause and re-run that step before declaring the task complete.
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Implemented by |
+|---|---|
+| FR-1: single batched flush per run | Task 2 Step 1 — inline `SaveChangesAsync` removed from loop; guarded single `SaveChangesAsync` after loop on `stagedCount > 0` |
+| FR-2: preserve `Imported`/`Skipped`/`Failed` semantics | Task 2 Step 1 — `Skipped++`/`Failed++` unchanged in loop; `result.Imported = stagedCount` after successful flush; Task 1 tests pin counts |
+| FR-3: handle final flush failure | Task 2 Step 1 — `try/catch` around `SaveChangesAsync`, `LogError` with platform + count, `Failed += stagedCount`, `Imported` stays 0, no rethrow; Task 1 `ImportAsync_FinalSaveChangesThrows_...` test |
+| FR-4: update affected unit tests | Task 1 — `NewTransactions` → `Times.Once`; `DuplicateTransaction` → `Times.Never`; `PerTransactionError` unchanged; new flush-failure + empty-input tests |
+| Arch amendment 1+2: intra-batch duplicate `TransactionId` handling + test | Task 2 Step 1 — `stagedIds` `HashSet` check; Task 1 `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce` test |
+| Arch Decision 2: local `stagedCount`, not `result.Imported`, as flush guard | Task 2 Step 1 — `stagedCount` declared and incremented; `result.Imported` set only after successful flush |
+| NFR-1: performance (N round-trips → 1) | Task 2 Step 1 — flush moved outside loop |
+| NFR-2: security unchanged | No new inputs/endpoints/secrets; `LogError` passes only structured properties (platform, count) |
+| Data model / API unchanged | No files other than the service and its test are modified (Task 1 + Task 2 file lists) |


### PR DESCRIPTION
MarketingInvoices

## Finding
`MarketingInvoiceImportService.ImportAsync` calls `SaveChangesAsync` after every individual `AddAsync` inside the transaction loop:

```csharp
// backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs, lines 56–57
await _repository.AddAsync(entity, ct);
await _repository.SaveChangesAsync(ct);   // ← one round-trip to DB per transaction
```

For a 7-day lookback import, this issues N separate `INSERT + COMMIT` round-trips instead of one. The `AddAsync` accumulates the entity into EF change tracking; a single `SaveChangesAsync` after the loop is sufficient and correct.

## Why it matters
- **Performance:** Each call to `SaveChangesAsync` is a separate database round-trip. With dozens or hundreds of transactions over a 7-day window, this is unnecessary I/O at every job execution (twice daily).
- **Atomicity mismatch:** The current loop saves each record individually. If the process is interrupted mid-batch, the DB is left in a partially-imported state with no way to distinguish which records came from the current run. Batching the save makes all-or-nothing reasoning easier and better matches the intent of the domain operation.
- **The `IImportedMarketingTransactionRepository` interface exposes `SaveChangesAsync`** — calling it once per item is not what that method is designed for; it is a unit-of-work flush operation.

## Suggested fix
Move `SaveChangesAsync` outside the loop, and update the `result.Imported` count to reflect what was tracked before the final save:

```csharp
foreach (var transaction in transactions)
{
    try
    {
        var exists = await _repository.ExistsAsync(_source.Platform, transaction.TransactionId, ct);
        if (exists) { result.Skipped++; continue; }

        await _repository.AddAsync(new ImportedMarketingTransaction { ... }, ct);
        result.Imported++;
    }
    catch (Exception ex)
    {
        _logger.LogError(ex, ...);
        result.Failed++;
    }
}

if (result.Imported > 0)
    await _repository.SaveChangesAsync(ct);
```

If per-record error isolation is required, the save can still happen per-record, but that should be a deliberate choice noted in the code, not an accidental pattern.

---
_Filed by daily arch-review routine on 2026-05-18._

---

Closes #1400

### Tokens used
8251617
