### PR TITLE
fix(cooling): lower weather forecast color thresholds so ≥26 °C is red

### DIFF
--- a/frontend/src/components/customer/cooling/__tests__/WeatherForecastReport.test.tsx
+++ b/frontend/src/components/customer/cooling/__tests__/WeatherForecastReport.test.tsx
@@ -72,6 +72,6 @@ describe('WeatherForecastReport', () => {
     });
     // Day 1: min=18°C → left=45% (non-zero confirms it's a range bar, not 0→max)
     expect(bars[0].getAttribute('style')).toMatch(/left:\s*4[0-9]/);
-    expect(bars[0]).toHaveClass('bg-orange-500'); // 28.5°C → [28, 34) → orange
+    expect(bars[0]).toHaveClass('bg-red-500'); // 28.5°C → ≥26 → red
   });
 });

--- a/frontend/src/components/customer/cooling/__tests__/temperatureScale.test.ts
+++ b/frontend/src/components/customer/cooling/__tests__/temperatureScale.test.ts
@@ -32,35 +32,35 @@ describe('getTemperatureBarPercent', () => {
 });
 
 describe('getTemperatureColor', () => {
-  it('returns a cool class for temperatures below 15 °C', () => {
-    expect(getTemperatureColor(10)).toBe('bg-sky-400');
+  it('returns a cool class for temperatures below 10 °C', () => {
+    expect(getTemperatureColor(9)).toBe('bg-sky-400');
     expect(getTemperatureColor(0)).toBe('bg-sky-400');
   });
 
-  it('returns a hot class for temperatures above 34 °C', () => {
+  it('returns a hot class for temperatures at or above 26 °C', () => {
+    expect(getTemperatureColor(26)).toBe('bg-red-500');
     expect(getTemperatureColor(35)).toBe('bg-red-500');
-    expect(getTemperatureColor(40)).toBe('bg-red-500');
   });
 
   it('returns different classes for cool vs hot temperatures', () => {
     const cool = getTemperatureColor(5);
-    const hot = getTemperatureColor(38);
+    const hot = getTemperatureColor(30);
     expect(cool).not.toBe(hot);
   });
 
-  it('returns emerald for temperatures in [15, 22)', () => {
+  it('returns emerald for temperatures in [10, 16)', () => {
+    expect(getTemperatureColor(10)).toBe('bg-emerald-400');
     expect(getTemperatureColor(15)).toBe('bg-emerald-400');
-    expect(getTemperatureColor(21)).toBe('bg-emerald-400');
   });
 
-  it('returns amber for temperatures in [22, 28)', () => {
-    expect(getTemperatureColor(22)).toBe('bg-amber-400');
-    expect(getTemperatureColor(27)).toBe('bg-amber-400');
+  it('returns amber for temperatures in [16, 21)', () => {
+    expect(getTemperatureColor(16)).toBe('bg-amber-400');
+    expect(getTemperatureColor(20)).toBe('bg-amber-400');
   });
 
-  it('returns orange for temperatures in [28, 34)', () => {
-    expect(getTemperatureColor(28)).toBe('bg-orange-500');
-    expect(getTemperatureColor(33)).toBe('bg-orange-500');
+  it('returns orange for temperatures in [21, 26)', () => {
+    expect(getTemperatureColor(21)).toBe('bg-orange-500');
+    expect(getTemperatureColor(25)).toBe('bg-orange-500');
   });
 });
 

--- a/frontend/src/components/customer/cooling/temperatureScale.ts
+++ b/frontend/src/components/customer/cooling/temperatureScale.ts
@@ -1,10 +1,10 @@
 export const TEMP_SCALE_MIN = 0;
 export const TEMP_SCALE_MAX = 40;
 
-export const COOL_THRESHOLD = 15;
-export const WARM_THRESHOLD = 22;
-export const HOT_THRESHOLD = 28;
-export const VERY_HOT_THRESHOLD = 34;
+export const COOL_THRESHOLD = 10;
+export const WARM_THRESHOLD = 16;
+export const HOT_THRESHOLD = 21;
+export const VERY_HOT_THRESHOLD = 26;
 
 export function getTemperatureBarPercent(temp: number): number {
   const clamped = Math.max(TEMP_SCALE_MIN, Math.min(TEMP_SCALE_MAX, temp));


### PR DESCRIPTION
Adjusts the temperature color scale in the weather forecast widget to better reflect the cosmetics cooling use case, where 26 °C is considered high. All five color bands (blue → green → yellow → orange → red) are redistributed proportionally within the 0–26 °C range, with red now starting at 26 °C instead of 34 °C. Tests are updated to match the new thresholds.