### PR TITLE
feat(dashboard): add weather forecast tile

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
@@ -1,0 +1,61 @@
+using Anela.Heblo.Domain.Features.Logistics.Weather;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.WeatherForecast.DashboardTiles;
+
+public class WeatherForecastTile : ITile
+{
+    private readonly IWeatherForecastClient _weatherClient;
+    private readonly ILogger<WeatherForecastTile> _logger;
+
+    public string Title => "Předpověď počasí";
+    public string Description => "5denní předpověď počasí — nejteplejší místo v ČR";
+    public TileSize Size => TileSize.Large;
+    public TileCategory Category => TileCategory.Manufacture;
+    public bool DefaultEnabled => false;
+    public bool AutoShow => true;
+    public Type ComponentType => typeof(object);
+    public string[] RequiredPermissions => Array.Empty<string>();
+
+    public WeatherForecastTile(IWeatherForecastClient weatherClient, ILogger<WeatherForecastTile> logger)
+    {
+        _weatherClient = weatherClient;
+        _logger = logger;
+    }
+
+    public async Task<object> LoadDataAsync(
+        Dictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var forecasts = await _weatherClient.GetForecastAsync(cancellationToken);
+
+            var days = forecasts
+                .SelectMany(city => city.Days.Select(day => (CityName: city.CityName, Day: day)))
+                .GroupBy(x => x.Day.Date)
+                .OrderBy(g => g.Key)
+                .Select(g =>
+                {
+                    var hottest = g.MaxBy(x => x.Day.MaxTemperatureCelsius)!;
+                    return new
+                    {
+                        date = hottest.Day.Date.ToString("yyyy-MM-dd"),
+                        cityName = hottest.CityName,
+                        minTemperatureCelsius = hottest.Day.MinTemperatureCelsius,
+                        maxTemperatureCelsius = hottest.Day.MaxTemperatureCelsius,
+                        weatherCode = hottest.Day.WeatherCode,
+                    };
+                })
+                .ToList();
+
+            return new { status = "success", data = new { days } };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to load weather forecast for dashboard tile");
+            return new { status = "error", error = "Předpověď počasí není dostupná." };
+        }
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
@@ -38,7 +38,7 @@ public class WeatherForecastTile : ITile
                 .OrderBy(g => g.Key)
                 .Select(g =>
                 {
-                    var hottest = g.MaxBy(x => x.Day.MaxTemperatureCelsius);
+                    var hottest = g.MaxBy(x => x.Day.MaxTemperatureCelsius)!;
                     return new
                     {
                         date = hottest.Day.Date.ToString("yyyy-MM-dd"),

--- a/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
@@ -14,7 +14,7 @@ public class WeatherForecastTile : ITile
     public TileSize Size => TileSize.Large;
     public TileCategory Category => TileCategory.Manufacture;
     public bool DefaultEnabled => false;
-    public bool AutoShow => true;
+    public bool AutoShow => false;
     public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
@@ -38,7 +38,7 @@ public class WeatherForecastTile : ITile
                 .OrderBy(g => g.Key)
                 .Select(g =>
                 {
-                    var hottest = g.MaxBy(x => x.Day.MaxTemperatureCelsius)!;
+                    var hottest = g.MaxBy(x => x.Day.MaxTemperatureCelsius);
                     return new
                     {
                         date = hottest.Day.Date.ToString("yyyy-MM-dd"),

--- a/backend/src/Anela.Heblo.Application/Features/WeatherForecast/WeatherForecastModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/WeatherForecast/WeatherForecastModule.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Application.Features.WeatherForecast.DashboardTiles;
+using Anela.Heblo.Xcc.Services.Dashboard;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Anela.Heblo.Application.Features.WeatherForecast;
@@ -6,6 +8,7 @@ public static class WeatherForecastModule
 {
     public static IServiceCollection AddWeatherForecastModule(this IServiceCollection services)
     {
+        services.RegisterTile<WeatherForecastTile>();
         return services;
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using Anela.Heblo.Application.Features.WeatherForecast.DashboardTiles;
+using Anela.Heblo.Domain.Features.Logistics.Weather;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.WeatherForecast.DashboardTiles;
+
+public class WeatherForecastTileTests
+{
+    private readonly Mock<IWeatherForecastClient> _clientMock;
+    private readonly Mock<ILogger<WeatherForecastTile>> _loggerMock;
+    private readonly WeatherForecastTile _tile;
+
+    public WeatherForecastTileTests()
+    {
+        _clientMock = new Mock<IWeatherForecastClient>();
+        _loggerMock = new Mock<ILogger<WeatherForecastTile>>();
+        _tile = new WeatherForecastTile(_clientMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public void Metadata_HasCorrectValues()
+    {
+        _tile.Title.Should().Be("Předpověď počasí");
+        _tile.Description.Should().Be("5denní předpověď počasí — nejteplejší místo v ČR");
+        _tile.Size.Should().Be(TileSize.Large);
+        _tile.Category.Should().Be(TileCategory.Manufacture);
+        _tile.DefaultEnabled.Should().BeFalse();
+        _tile.AutoShow.Should().BeTrue();
+        _tile.ComponentType.Should().Be(typeof(object));
+        _tile.RequiredPermissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TileId_IsWeatherForecast()
+    {
+        TileExtensions.GetTileId<WeatherForecastTile>().Should().Be("weatherforecast");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WithMultipleCities_ReturnsHottestCityPerDay()
+    {
+        var forecasts = new List<CityForecast>
+        {
+            new("Praha", new[]
+            {
+                new CityForecastDay(new DateOnly(2026, 5, 19), 14.0, 22.0, 1),
+            }),
+            new("Brno", new[]
+            {
+                new CityForecastDay(new DateOnly(2026, 5, 19), 16.0, 28.0, 0),
+            }),
+        };
+
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(forecasts);
+
+        var result = await _tile.LoadDataAsync();
+
+        var json = JsonSerializer.SerializeToElement(result);
+        json.GetProperty("status").GetString().Should().Be("success");
+        var days = json.GetProperty("data").GetProperty("days");
+        days.GetArrayLength().Should().Be(1);
+        var day = days[0];
+        day.GetProperty("cityName").GetString().Should().Be("Brno");
+        day.GetProperty("maxTemperatureCelsius").GetDouble().Should().Be(28.0);
+        day.GetProperty("minTemperatureCelsius").GetDouble().Should().Be(16.0);
+        day.GetProperty("date").GetString().Should().Be("2026-05-19");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WithEmptyForecast_ReturnsSuccessWithEmptyDays()
+    {
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CityForecast>());
+
+        var result = await _tile.LoadDataAsync();
+
+        var json = JsonSerializer.SerializeToElement(result);
+        json.GetProperty("status").GetString().Should().Be("success");
+        json.GetProperty("data").GetProperty("days").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WhenClientThrows_ReturnsErrorStatus()
+    {
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Open-Meteo unreachable"));
+
+        var result = await _tile.LoadDataAsync();
+
+        var json = JsonSerializer.SerializeToElement(result);
+        json.GetProperty("status").GetString().Should().Be("error");
+        json.GetProperty("error").GetString().Should().Be("Předpověď počasí není dostupná.");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WhenCancelled_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            _tile.LoadDataAsync(cancellationToken: cts.Token));
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
@@ -8,7 +8,7 @@ using Moq;
 
 namespace Anela.Heblo.Tests.Features.WeatherForecast.DashboardTiles;
 
-public class WeatherForecastTileTests
+public sealed class WeatherForecastTileTests
 {
     private readonly Mock<IWeatherForecastClient> _clientMock;
     private readonly Mock<ILogger<WeatherForecastTile>> _loggerMock;
@@ -29,7 +29,7 @@ public class WeatherForecastTileTests
         _tile.Size.Should().Be(TileSize.Large);
         _tile.Category.Should().Be(TileCategory.Manufacture);
         _tile.DefaultEnabled.Should().BeFalse();
-        _tile.AutoShow.Should().BeTrue();
+        _tile.AutoShow.Should().BeFalse();
         _tile.ComponentType.Should().Be(typeof(object));
         _tile.RequiredPermissions.Should().BeEmpty();
     }
@@ -103,7 +103,8 @@ public class WeatherForecastTileTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+        _clientMock
+            .Setup(x => x.GetForecastAsync(It.Is<CancellationToken>(t => t.IsCancellationRequested)))
             .ThrowsAsync(new OperationCanceledException());
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>

--- a/docs/superpowers/plans/2026-05-19-weather-forecast-dashboard-tile.md
+++ b/docs/superpowers/plans/2026-05-19-weather-forecast-dashboard-tile.md
@@ -1,0 +1,611 @@
+# Weather Forecast Dashboard Tile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dashboard tile that displays the 5-day weather forecast (hottest city in CZ per day) with temperature color bars, reusing existing backend and frontend forecast utilities.
+
+**Architecture:** A new `WeatherForecastTile` C# class implements `ITile`, delegates to the existing `IWeatherForecastClient`, and returns a JSON-serializable object. On the frontend, a new `WeatherForecastTile.tsx` receives the tile data as a prop and renders rows identical to the cooling-tab `WeatherForecastReport` component. The tile is registered in `WeatherForecastModule` (backend) and `TileContent` (frontend).
+
+**Tech Stack:** .NET 8 / C# (xUnit, FluentAssertions, Moq), React 18 / TypeScript (Vitest, @testing-library/react), Tailwind CSS
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| **Create** | `backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs` |
+| **Create** | `backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs` |
+| **Modify** | `backend/src/Anela.Heblo.Application/Features/WeatherForecast/WeatherForecastModule.cs` |
+| **Create** | `frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx` |
+| **Create** | `frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx` |
+| **Modify** | `frontend/src/components/dashboard/tiles/TileContent.tsx` |
+
+---
+
+### Task 1: Backend — WeatherForecastTile class
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.WeatherForecast.DashboardTiles;
+using Anela.Heblo.Domain.Features.Logistics.Weather;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.WeatherForecast.DashboardTiles;
+
+public class WeatherForecastTileTests
+{
+    private readonly Mock<IWeatherForecastClient> _clientMock;
+    private readonly Mock<ILogger<WeatherForecastTile>> _loggerMock;
+    private readonly WeatherForecastTile _tile;
+
+    public WeatherForecastTileTests()
+    {
+        _clientMock = new Mock<IWeatherForecastClient>();
+        _loggerMock = new Mock<ILogger<WeatherForecastTile>>();
+        _tile = new WeatherForecastTile(_clientMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public void Metadata_HasCorrectValues()
+    {
+        _tile.Title.Should().Be("Předpověď počasí");
+        _tile.Description.Should().Be("5denní předpověď počasí — nejteplejší místo v ČR");
+        _tile.Size.Should().Be(TileSize.Large);
+        _tile.Category.Should().Be(TileCategory.Manufacture);
+        _tile.DefaultEnabled.Should().BeFalse();
+        _tile.AutoShow.Should().BeTrue();
+        _tile.ComponentType.Should().Be(typeof(object));
+        _tile.RequiredPermissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TileId_IsWeatherForecast()
+    {
+        TileExtensions.GetTileId<WeatherForecastTile>().Should().Be("weatherforecast");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WithMultipleCities_ReturnsHottestCityPerDay()
+    {
+        // Arrange — two cities, same date; Brno is hotter
+        var forecasts = new List<CityForecast>
+        {
+            new("Praha", new[]
+            {
+                new CityForecastDay(new DateOnly(2026, 5, 19), 14.0, 22.0, 1),
+            }),
+            new("Brno", new[]
+            {
+                new CityForecastDay(new DateOnly(2026, 5, 19), 16.0, 28.0, 0),
+            }),
+        };
+
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(forecasts);
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.SerializeToElement(result);
+        json.GetProperty("status").GetString().Should().Be("success");
+        var days = json.GetProperty("data").GetProperty("days");
+        days.GetArrayLength().Should().Be(1);
+        var day = days[0];
+        day.GetProperty("cityName").GetString().Should().Be("Brno");
+        day.GetProperty("maxTemperatureCelsius").GetDouble().Should().Be(28.0);
+        day.GetProperty("minTemperatureCelsius").GetDouble().Should().Be(16.0);
+        day.GetProperty("date").GetString().Should().Be("2026-05-19");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WithEmptyForecast_ReturnsSuccessWithEmptyDays()
+    {
+        // Arrange
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CityForecast>());
+
+        // Act
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.SerializeToElement(result);
+        json.GetProperty("status").GetString().Should().Be("success");
+        json.GetProperty("data").GetProperty("days").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WhenClientThrows_ReturnsErrorStatus()
+    {
+        // Arrange
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Open-Meteo unreachable"));
+
+        // Act — must not throw
+        var result = await _tile.LoadDataAsync();
+
+        // Assert
+        var json = JsonSerializer.SerializeToElement(result);
+        json.GetProperty("status").GetString().Should().Be("error");
+        json.GetProperty("error").GetString().Should().Be("Předpověď počasí není dostupná.");
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_WhenCancelled_PropagatesCancellation()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _clientMock.Setup(x => x.GetForecastAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            _tile.LoadDataAsync(cancellationToken: cts.Token));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~WeatherForecastTileTests" -v minimal 2>&1 | tail -20
+```
+
+Expected: build error — `WeatherForecastTile` does not exist yet.
+
+- [ ] **Step 3: Create the tile implementation**
+
+Create `backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.Logistics.Weather;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.WeatherForecast.DashboardTiles;
+
+public class WeatherForecastTile : ITile
+{
+    private readonly IWeatherForecastClient _weatherClient;
+    private readonly ILogger<WeatherForecastTile> _logger;
+
+    public string Title => "Předpověď počasí";
+    public string Description => "5denní předpověď počasí — nejteplejší místo v ČR";
+    public TileSize Size => TileSize.Large;
+    public TileCategory Category => TileCategory.Manufacture;
+    public bool DefaultEnabled => false;
+    public bool AutoShow => true;
+    public Type ComponentType => typeof(object);
+    public string[] RequiredPermissions => Array.Empty<string>();
+
+    public WeatherForecastTile(IWeatherForecastClient weatherClient, ILogger<WeatherForecastTile> logger)
+    {
+        _weatherClient = weatherClient;
+        _logger = logger;
+    }
+
+    public async Task<object> LoadDataAsync(
+        Dictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var forecasts = await _weatherClient.GetForecastAsync(cancellationToken);
+
+            var days = forecasts
+                .SelectMany(city => city.Days.Select(day => (CityName: city.CityName, Day: day)))
+                .GroupBy(x => x.Day.Date)
+                .OrderBy(g => g.Key)
+                .Select(g =>
+                {
+                    var hottest = g.MaxBy(x => x.Day.MaxTemperatureCelsius)!;
+                    return new
+                    {
+                        date = hottest.Day.Date.ToString("yyyy-MM-dd"),
+                        cityName = hottest.CityName,
+                        minTemperatureCelsius = hottest.Day.MinTemperatureCelsius,
+                        maxTemperatureCelsius = hottest.Day.MaxTemperatureCelsius,
+                        weatherCode = hottest.Day.WeatherCode,
+                    };
+                })
+                .ToList();
+
+            return new { status = "success", data = new { days } };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to load weather forecast for dashboard tile");
+            return new { status = "error", error = "Předpověď počasí není dostupná." };
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~WeatherForecastTileTests" -v minimal 2>&1 | tail -20
+```
+
+Expected: 5 tests pass, 0 failures.
+
+- [ ] **Step 5: Verify build is clean**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/backend
+dotnet build --no-incremental -v minimal 2>&1 | tail -10
+```
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs \
+  backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
+git commit -m "feat(dashboard): add WeatherForecastTile backend implementation"
+```
+
+---
+
+### Task 2: Backend — Register tile
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/WeatherForecast/WeatherForecastModule.cs`
+
+- [ ] **Step 1: Register the tile in the module**
+
+Current content of `WeatherForecastModule.cs`:
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.WeatherForecast;
+
+public static class WeatherForecastModule
+{
+    public static IServiceCollection AddWeatherForecastModule(this IServiceCollection services)
+    {
+        return services;
+    }
+}
+```
+
+Replace with:
+```csharp
+using Anela.Heblo.Application.Features.WeatherForecast.DashboardTiles;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.WeatherForecast;
+
+public static class WeatherForecastModule
+{
+    public static IServiceCollection AddWeatherForecastModule(this IServiceCollection services)
+    {
+        services.RegisterTile<WeatherForecastTile>();
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Verify build is clean**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/backend
+dotnet build --no-incremental -v minimal 2>&1 | tail -10
+```
+
+Expected: `Build succeeded. 0 Warning(s). 0 Error(s).`
+
+- [ ] **Step 3: Run full backend test suite**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/backend
+dotnet test -v minimal 2>&1 | tail -15
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/WeatherForecast/WeatherForecastModule.cs
+git commit -m "feat(dashboard): register WeatherForecastTile in DI"
+```
+
+---
+
+### Task 3: Frontend — WeatherForecastTile component
+
+**Files:**
+- Create: `frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx`
+- Create: `frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { WeatherForecastTile } from '../WeatherForecastTile';
+
+const fiveDays = {
+  status: 'success',
+  data: {
+    days: [
+      { date: '2026-05-19', cityName: 'Brno', minTemperatureCelsius: 14, maxTemperatureCelsius: 18, weatherCode: 2 },
+      { date: '2026-05-20', cityName: 'Praha', minTemperatureCelsius: 19, maxTemperatureCelsius: 26, weatherCode: 0 },
+      { date: '2026-05-21', cityName: 'Brno', minTemperatureCelsius: 9, maxTemperatureCelsius: 11, weatherCode: 95 },
+      { date: '2026-05-22', cityName: 'Praha', minTemperatureCelsius: 16, maxTemperatureCelsius: 23, weatherCode: 3 },
+      { date: '2026-05-23', cityName: 'Brno', minTemperatureCelsius: 22, maxTemperatureCelsius: 31, weatherCode: 0 },
+    ],
+  },
+};
+
+function renderTile(data: object) {
+  return render(
+    <MemoryRouter>
+      <WeatherForecastTile data={data} />
+    </MemoryRouter>,
+  );
+}
+
+describe('WeatherForecastTile', () => {
+  it('renders five forecast rows', () => {
+    renderTile(fiveDays);
+    // Each row shows city name
+    expect(screen.getAllByText('Brno').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getAllByText('Praha').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders min and max temperature for each row', () => {
+    renderTile(fiveDays);
+    // First row: 14° and 18°C
+    expect(screen.getByText('14°')).toBeInTheDocument();
+    expect(screen.getByText('18°C')).toBeInTheDocument();
+  });
+
+  it('applies red color class for max temp >= 26°C', () => {
+    renderTile(fiveDays);
+    const bars = screen.getAllByTestId('temp-bar');
+    // Day 2: max 26°C → bg-red-500
+    const redBar = bars.find(b => b.className.includes('bg-red-500'));
+    expect(redBar).toBeDefined();
+  });
+
+  it('applies amber color class for max temp 21–25°C', () => {
+    renderTile(fiveDays);
+    const bars = screen.getAllByTestId('temp-bar');
+    // Day 4: max 23°C → bg-orange-500 (21–25 range is actually orange-500, not amber)
+    // Day 1: max 18°C → bg-amber-400
+    const amberBar = bars.find(b => b.className.includes('bg-amber-400'));
+    expect(amberBar).toBeDefined();
+  });
+
+  it('renders a link to the cooling page', () => {
+    renderTile(fiveDays);
+    const link = screen.getByRole('link', { name: /chlaz/i });
+    expect(link).toHaveAttribute('href', '/customer/cooling');
+  });
+
+  it('shows error message when status is error', () => {
+    renderTile({ status: 'error', error: 'Předpověď počasí není dostupná.' });
+    expect(screen.getByText('Předpověď počasí není dostupná.')).toBeInTheDocument();
+  });
+
+  it('shows empty state message when days array is empty', () => {
+    renderTile({ status: 'success', data: { days: [] } });
+    expect(screen.getByText('Žádná data')).toBeInTheDocument();
+  });
+
+  it('renders nothing when data.data is undefined', () => {
+    const { container } = renderTile({ status: 'success' });
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/frontend
+npx vitest run src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx 2>&1 | tail -20
+```
+
+Expected: error — `WeatherForecastTile` module not found.
+
+- [ ] **Step 3: Create the tile component**
+
+Create `frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx`:
+
+```tsx
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { getWeatherIcon } from '../../customer/cooling/weatherIcons';
+import { getTemperatureColor, getTemperatureRangeBar } from '../../customer/cooling/temperatureScale';
+
+interface ForecastDay {
+  date: string;
+  cityName: string;
+  minTemperatureCelsius: number;
+  maxTemperatureCelsius: number;
+  weatherCode: number;
+}
+
+interface WeatherForecastTileProps {
+  data: {
+    status?: string;
+    error?: string;
+    data?: {
+      days: ForecastDay[];
+    };
+  };
+}
+
+export function WeatherForecastTile({ data }: WeatherForecastTileProps) {
+  if (!data.data) return null;
+
+  if (data.status === 'error') {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-sm text-red-600">
+        {data.error ?? 'Předpověď počasí není dostupná.'}
+      </div>
+    );
+  }
+
+  const { days } = data.data;
+
+  return (
+    <div className="flex h-full flex-col p-4">
+      <div className="flex-1 space-y-2">
+        {days.length === 0 ? (
+          <p className="text-sm text-gray-400">Žádná data</p>
+        ) : (
+          days.map((day) => {
+            const icon = getWeatherIcon(day.weatherCode);
+            const [year, month, dayNum] = day.date.split('-').map(Number);
+            const dateObj = new Date(year, month - 1, dayNum);
+            const label = dateObj.toLocaleDateString('cs-CZ', {
+              weekday: 'short',
+              day: 'numeric',
+              month: 'numeric',
+            });
+            const { left, width } = getTemperatureRangeBar(
+              day.minTemperatureCelsius,
+              day.maxTemperatureCelsius,
+            );
+
+            return (
+              <div key={day.date} className="flex items-center gap-3 text-sm">
+                <span className="w-14 shrink-0 text-gray-500">{label}</span>
+                <span className="shrink-0 text-base leading-none">{icon}</span>
+                <span className="w-8 shrink-0 text-right text-gray-600">
+                  {Math.round(day.minTemperatureCelsius)}°
+                </span>
+                <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    data-testid="temp-bar"
+                    className={`absolute h-2 ${getTemperatureColor(day.maxTemperatureCelsius)}`}
+                    style={{ left: `${left}%`, width: `${width}%` }}
+                  />
+                </div>
+                <span className="w-8 shrink-0 text-left font-medium text-gray-900">
+                  {Math.round(day.maxTemperatureCelsius)}°C
+                </span>
+                <span className="w-12 shrink-0 text-right text-xs text-gray-400">
+                  {day.cityName}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <div className="mt-3 border-t border-gray-100 pt-2 text-right">
+        <Link
+          to="/customer/cooling"
+          className="text-xs text-gray-400 hover:text-gray-600"
+        >
+          → Zásilky s chlazením
+        </Link>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/frontend
+npx vitest run src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx 2>&1 | tail -20
+```
+
+Expected: 8 tests pass, 0 failures.
+
+- [ ] **Step 5: Run frontend lint and build**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/frontend
+npm run lint 2>&1 | tail -10
+npm run build 2>&1 | tail -10
+```
+
+Expected: no lint errors, build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx \
+  frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx
+git commit -m "feat(dashboard): add WeatherForecastTile frontend component"
+```
+
+---
+
+### Task 4: Frontend — Register tile in TileContent
+
+**Files:**
+- Modify: `frontend/src/components/dashboard/tiles/TileContent.tsx`
+
+- [ ] **Step 1: Add import and case**
+
+In `frontend/src/components/dashboard/tiles/TileContent.tsx`:
+
+Add the import after the existing tile imports (around line 14, before the `DefaultTile` import line):
+```tsx
+import { WeatherForecastTile } from './WeatherForecastTile';
+```
+
+Add the case inside the `switch (tile.tileId)` block, before the `default:` case (around line 78):
+```tsx
+case 'weatherforecast':
+  return <WeatherForecastTile data={tile.data} />;
+```
+
+- [ ] **Step 2: Run frontend lint and build**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/frontend
+npm run lint 2>&1 | tail -10
+npm run build 2>&1 | tail -10
+```
+
+Expected: no errors, build succeeds.
+
+- [ ] **Step 3: Run full frontend test suite**
+
+```bash
+cd /Users/pajgrtondrej/conductor/workspaces/Anela.Heblo/dallas/frontend
+npx vitest run 2>&1 | tail -15
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/dashboard/tiles/TileContent.tsx
+git commit -m "feat(dashboard): register weatherforecast tile in TileContent"
+```

--- a/docs/superpowers/specs/2026-05-19-weather-forecast-dashboard-tile-design.md
+++ b/docs/superpowers/specs/2026-05-19-weather-forecast-dashboard-tile-design.md
@@ -1,0 +1,123 @@
+# Weather Forecast Dashboard Tile — Design Spec
+
+**Date:** 2026-05-19
+**Status:** Approved
+
+---
+
+## Overview
+
+Add a dashboard tile that surfaces the 5-day weather forecast (hottest place in CZ per day) already displayed in the Cooling tab. The tile reuses existing backend logic (`IWeatherForecastClient`) and existing frontend utilities (`temperatureScale.ts`, `weatherIcons.ts`). No new API surface is needed.
+
+---
+
+## Tile Metadata
+
+| Property | Value |
+|---|---|
+| Tile ID | `weatherforecast` (derived from class name `WeatherForecastTile`) |
+| Title | `Předpověď počasí` |
+| Description | `5denní předpověď počasí — nejteplejší místo v ČR` |
+| Size | `Large` |
+| Category | `Manufacture` |
+| DefaultEnabled | `false` (opt-in) |
+| AutoShow | `true` |
+| RequiredPermissions | none |
+
+---
+
+## Backend
+
+### New file: `WeatherForecastTile.cs`
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs`
+
+Implements `ITile`. Injects `IWeatherForecastClient`. In `LoadDataAsync`, calls the client, applies the same grouping/hottest-day logic as `GetWeatherForecastHandler`, and returns:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "days": [
+      {
+        "date": "2026-05-19",
+        "cityName": "Brno",
+        "minTemperatureCelsius": 14.2,
+        "maxTemperatureCelsius": 26.0,
+        "weatherCode": 1
+      }
+    ]
+  }
+}
+```
+
+On exception (non-cancellation): log warning, return `{ "status": "error", "error": "Předpověď počasí není dostupná." }`.
+
+### Registration
+
+Add `services.RegisterTile<WeatherForecastTile>();` to `WeatherForecastModule.AddWeatherForecastModule()`.
+
+---
+
+## Frontend
+
+### New file: `WeatherForecastTile.tsx`
+
+**Location:** `frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx`
+
+Receives `data` prop (standard tile data shape). Renders five forecast rows identical in layout to `WeatherForecastReport.tsx`:
+
+```
+[date label]  [icon]  [min°]  [color bar]  [max°]  [city]
+```
+
+- Uses `getTemperatureColor(maxTemp)` from `temperatureScale.ts` for bar color
+- Uses `getTemperatureRangeBar(min, max)` for bar position/width
+- Uses `getWeatherIcon(weatherCode)` from `weatherIcons.ts`
+- Renders a footer link `→ Zásilky s chlazením` that navigates to `/customer/cooling`
+- Error state: standard error message in tile body
+- Data shape: `data.data.days` — array of `HottestDayDto`-shaped objects
+
+**Note:** Does not call `useWeatherForecast()` hook directly — data arrives via the dashboard tile data system (fetched by `useTileData()` every 30 s).
+
+### Registration in `TileContent.tsx`
+
+Add a case to the switch statement:
+
+```tsx
+case 'weatherforecast':
+  return <WeatherForecastTile data={tile.data} />;
+```
+
+---
+
+## Data Flow
+
+```
+Dashboard auto-refresh (30 s)
+  → GET /api/dashboard/data
+  → DashboardService (parallel tile load)
+  → WeatherForecastTile.LoadDataAsync()
+  → IWeatherForecastClient.GetForecastAsync()
+  → Returns { status, data: { days: [...] } }
+  → Frontend WeatherForecastTile renders rows
+```
+
+---
+
+## Error Handling
+
+| Scenario | Backend | Frontend |
+|---|---|---|
+| Client throws | Log warning, return `status: error` | Show error message in tile body |
+| Cancellation | Re-throw (let framework handle) | — |
+| Empty days list | Return `status: success`, `days: []` | Render empty state (no rows, subtitle "Žádná data") |
+
+---
+
+## Out of Scope
+
+- No new API endpoint — tile data goes through the existing `/api/dashboard/data` route
+- No changes to `WeatherForecastReport.tsx` in the cooling tab
+- No new permissions
+- No E2E test for this tile (E2E suite targets critical user flows; a dashboard tile is low-risk)

--- a/frontend/src/components/dashboard/tiles/TileContent.tsx
+++ b/frontend/src/components/dashboard/tiles/TileContent.tsx
@@ -11,6 +11,7 @@ import { PurchaseOrdersInTransitTile } from './PurchaseOrdersInTransitTile';
 import { LowStockAlertTile } from './LowStockAlertTile';
 import { DataQualityTile } from './DataQualityTile';
 import { DqtYesterdayStatusTile } from './DqtYesterdayStatusTile';
+import { WeatherForecastTile } from './WeatherForecastTile';
 import { DefaultTile } from './DefaultTile';
 import { Truck, PackageCheck, Package, FileText, Landmark, ClipboardList, Beaker, AlertTriangle, Gift } from 'lucide-react';
 
@@ -75,6 +76,8 @@ export const TileContent: React.FC<TileContentProps> = ({ tile }) => {
       return <DataQualityTile data={tile.data} />;
     case 'dqtyesterdaystatus':
       return <DqtYesterdayStatusTile data={tile.data} />;
+    case 'weatherforecast':
+      return <WeatherForecastTile data={tile.data} />;
     default:
       return <DefaultTile data={tile.data} />;
   }

--- a/frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx
+++ b/frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { getWeatherIcon } from '../../customer/cooling/weatherIcons';
+import { getTemperatureColor, getTemperatureRangeBar } from '../../customer/cooling/temperatureScale';
+
+interface ForecastDay {
+  date: string;
+  cityName: string;
+  minTemperatureCelsius: number;
+  maxTemperatureCelsius: number;
+  weatherCode: number;
+}
+
+interface WeatherForecastTileProps {
+  data: {
+    status?: string;
+    error?: string;
+    data?: {
+      days: ForecastDay[];
+    };
+  };
+}
+
+export function WeatherForecastTile({ data }: WeatherForecastTileProps) {
+  if (data.status === 'error') {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-sm text-red-600">
+        {data.error ?? 'Předpověď počasí není dostupná.'}
+      </div>
+    );
+  }
+
+  if (!data.data) return null;
+
+  const { days } = data.data;
+
+  return (
+    <div className="flex h-full flex-col p-4">
+      <div className="flex-1 space-y-2">
+        {days.length === 0 ? (
+          <p className="text-sm text-gray-400">Žádná data</p>
+        ) : (
+          days.map((day) => {
+            const icon = getWeatherIcon(day.weatherCode);
+            const [year, month, dayNum] = day.date.split('-').map(Number);
+            const dateObj = new Date(year, month - 1, dayNum);
+            const label = dateObj.toLocaleDateString('cs-CZ', {
+              weekday: 'short',
+              day: 'numeric',
+              month: 'numeric',
+            });
+            const { left, width } = getTemperatureRangeBar(
+              day.minTemperatureCelsius,
+              day.maxTemperatureCelsius,
+            );
+
+            return (
+              <div key={day.date} className="flex items-center gap-3 text-sm">
+                <span className="w-14 shrink-0 text-gray-500">{label}</span>
+                <span className="shrink-0 text-base leading-none">{icon}</span>
+                <span className="w-8 shrink-0 text-right text-gray-600">
+                  {Math.round(day.minTemperatureCelsius)}°
+                </span>
+                <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    data-testid="temp-bar"
+                    className={`absolute h-2 ${getTemperatureColor(day.maxTemperatureCelsius)}`}
+                    style={{ left: `${left}%`, width: `${width}%` }}
+                  />
+                </div>
+                <span className="w-8 shrink-0 text-left font-medium text-gray-900">
+                  {Math.round(day.maxTemperatureCelsius)}°C
+                </span>
+                <span className="w-12 shrink-0 text-right text-xs text-gray-400">
+                  {day.cityName}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <div className="mt-3 border-t border-gray-100 pt-2 text-right">
+        <Link
+          to="/customer/cooling"
+          className="text-xs text-gray-400 hover:text-gray-600"
+        >
+          → Zásilky s chlazením
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx
+++ b/frontend/src/components/dashboard/tiles/WeatherForecastTile.tsx
@@ -11,7 +11,7 @@ interface ForecastDay {
   weatherCode: number;
 }
 
-interface WeatherForecastTileProps {
+export interface WeatherForecastTileProps {
   data: {
     status?: string;
     error?: string;
@@ -42,6 +42,8 @@ export function WeatherForecastTile({ data }: WeatherForecastTileProps) {
         ) : (
           days.map((day) => {
             const icon = getWeatherIcon(day.weatherCode);
+            // new Date('YYYY-MM-DD') parses as UTC, shifting to the previous day in
+            // negative-offset timezones. Construct in local time instead.
             const [year, month, dayNum] = day.date.split('-').map(Number);
             const dateObj = new Date(year, month - 1, dayNum);
             const label = dateObj.toLocaleDateString('cs-CZ', {

--- a/frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx
+++ b/frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { WeatherForecastTile } from '../WeatherForecastTile';
+
+const fiveDays = {
+  status: 'success',
+  data: {
+    days: [
+      { date: '2026-05-19', cityName: 'Brno', minTemperatureCelsius: 14, maxTemperatureCelsius: 18, weatherCode: 2 },
+      { date: '2026-05-20', cityName: 'Praha', minTemperatureCelsius: 19, maxTemperatureCelsius: 26, weatherCode: 0 },
+      { date: '2026-05-21', cityName: 'Brno', minTemperatureCelsius: 9, maxTemperatureCelsius: 11, weatherCode: 95 },
+      { date: '2026-05-22', cityName: 'Praha', minTemperatureCelsius: 16, maxTemperatureCelsius: 23, weatherCode: 3 },
+      { date: '2026-05-23', cityName: 'Brno', minTemperatureCelsius: 22, maxTemperatureCelsius: 31, weatherCode: 0 },
+    ],
+  },
+};
+
+function renderTile(data: object) {
+  return render(
+    <MemoryRouter>
+      <WeatherForecastTile data={data} />
+    </MemoryRouter>,
+  );
+}
+
+describe('WeatherForecastTile', () => {
+  it('renders five forecast rows', () => {
+    renderTile(fiveDays);
+    expect(screen.getAllByText('Brno').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getAllByText('Praha').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders min and max temperature for each row', () => {
+    renderTile(fiveDays);
+    expect(screen.getByText('14°')).toBeInTheDocument();
+    expect(screen.getByText('18°C')).toBeInTheDocument();
+  });
+
+  it('applies red color class for max temp >= 26°C', () => {
+    renderTile(fiveDays);
+    const bars = screen.getAllByTestId('temp-bar');
+    const redBar = bars.find(b => b.className.includes('bg-red-500'));
+    expect(redBar).toBeDefined();
+  });
+
+  it('applies amber color class for max temp in 16–20°C range', () => {
+    renderTile(fiveDays);
+    const bars = screen.getAllByTestId('temp-bar');
+    // Day 1: max 18°C → bg-amber-400
+    const amberBar = bars.find(b => b.className.includes('bg-amber-400'));
+    expect(amberBar).toBeDefined();
+  });
+
+  it('renders a link to the cooling page', () => {
+    renderTile(fiveDays);
+    const link = screen.getByRole('link', { name: /chlaz/i });
+    expect(link).toHaveAttribute('href', '/customer/cooling');
+  });
+
+  it('shows error message when status is error', () => {
+    renderTile({ status: 'error', error: 'Předpověď počasí není dostupná.' });
+    expect(screen.getByText('Předpověď počasí není dostupná.')).toBeInTheDocument();
+  });
+
+  it('shows empty state message when days array is empty', () => {
+    renderTile({ status: 'success', data: { days: [] } });
+    expect(screen.getByText('Žádná data')).toBeInTheDocument();
+  });
+
+  it('renders nothing when data.data is undefined', () => {
+    const { container } = renderTile({ status: 'success' });
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx
+++ b/frontend/src/components/dashboard/tiles/__tests__/WeatherForecastTile.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { WeatherForecastTile } from '../WeatherForecastTile';
+import { WeatherForecastTile, type WeatherForecastTileProps } from '../WeatherForecastTile';
 
 const fiveDays = {
   status: 'success',
@@ -16,7 +16,7 @@ const fiveDays = {
   },
 };
 
-function renderTile(data: object) {
+function renderTile(data: WeatherForecastTileProps['data']) {
   return render(
     <MemoryRouter>
       <WeatherForecastTile data={data} />


### PR DESCRIPTION
## Summary

- Adds `WeatherForecastTile` backend class implementing `ITile` — fetches the 5-day forecast via `IWeatherForecastClient`, picks the hottest city per day, and returns structured JSON to the dashboard data endpoint
- Registers the tile in `WeatherForecastModule` (DI) as an opt-in Large tile in the Manufacture category
- Adds `WeatherForecastTile.tsx` frontend component rendering 5 forecast rows with date, weather icon, min/max temperatures, and color-coded range bars using the existing `temperatureScale.ts` scale; includes a drill-down link to `/customer/cooling`
- Wires the new component into `TileContent.tsx` via the `'weatherforecast'` switch case

## Test Plan

- [ ] Backend: `dotnet test --filter WeatherForecastTileTests` — 5 tests covering metadata, hottest-city selection, empty input, error handling, and cancellation propagation
- [ ] Frontend: `react-scripts test WeatherForecastTile` — 8 tests covering all render states (5-day rows, temperatures, color classes, error, empty, null data)
- [ ] Enable the tile in dashboard settings and verify the 5-day forecast renders with correct color bars
- [ ] Verify the "→ Zásilky s chlazením" footer link navigates to the cooling page