### PR TITLE
feat: Remove Redundant Try-Catch in GetOrganizationStructureHandler

### DIFF
--- a/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/arch-review.r1.md
+++ b/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/arch-review.r1.md
@@ -1,0 +1,140 @@
+# Architecture Review: Remove Redundant Try-Catch in GetOrganizationStructureHandler
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposed change strongly aligns with existing patterns in this codebase. The reference handler `GetJournalEntriesHandler` (`backend/src/Anela.Heblo.Application/Features/Journal/UseCases/GetJournalEntries/GetJournalEntriesHandler.cs`) — and all other handlers I sampled — contain **no try-catch wrappers around their happy path**. The OrgChart handler is the outlier; removing its catch block brings it into conformance with the convention, not away from it.
+
+Integration points are minimal and well-bounded:
+- **MediatR pipeline** — already designed to propagate exceptions; no behavior change.
+- **`OrgChartController` catch block** (lines 40–53) — already the single, authoritative point that logs the failure and shapes the 500 response.
+- **Logger contract** — `ILogger<GetOrganizationStructureHandler>` is still used for the informational entry log, so the DI registration and constructor signature are unchanged.
+
+One observation from reading `OrgChartController.cs:51`: the 500 response body currently returns `ex.Message` to the client (`new { error = "...", message = ex.Message }`). This is a pre-existing concern about leaking exception detail to API consumers — it's **out of scope** for this spec, but worth flagging for a follow-up arch review of the controller's error handling.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP Client
+    │
+    ▼
+OrgChartController.GetOrganizationStructure       ◄── single try-catch
+    │   (logs request, sends MediatR request,
+    │    catches + logs + maps to 500)
+    ▼
+IMediator.Send
+    │
+    ▼
+GetOrganizationStructureHandler.Handle             ◄── happy-path only after change
+    │   (logs "Handling request...", calls service)
+    ▼
+IOrgChartService.GetOrganizationStructureAsync
+```
+
+After the change, exceptions thrown by `IOrgChartService` propagate unmodified through the handler and MediatR pipeline back to the controller, which performs the single log + 500 mapping.
+
+### Key Design Decisions
+
+#### Decision 1: Remove the catch entirely vs. keep it for "defensive" logging
+**Options considered:**
+- (a) Delete the try-catch — handler returns to happy-path-only.
+- (b) Keep the catch but downgrade to `LogDebug` to avoid duplicate ERROR entries.
+- (c) Replace with a MediatR pipeline behavior that logs all handler exceptions globally.
+
+**Chosen approach:** (a) — delete the try-catch entirely.
+
+**Rationale:** Option (b) leaves dead-but-noisy code in place and still violates KISS. Option (c) is the long-term direction (pipeline behavior or exception middleware) but is explicitly out of scope per the spec and would touch every handler. Option (a) is the surgical fix called for by the brief and matches every other handler in the codebase (`GetJournalEntriesHandler` and siblings have no top-level try-catch).
+
+#### Decision 2: What to do about missing handler tests
+**Options considered:**
+- (a) Add a minimal xUnit test class for `GetOrganizationStructureHandler` covering happy path + exception propagation.
+- (b) Skip tests entirely on the grounds that the handler is a one-liner.
+
+**Chosen approach:** (a) — add a small test class.
+
+**Rationale:** No tests currently exist for `OrgChart` in `backend/test/Anela.Heblo.Tests` (confirmed via search). FR-4 in the spec requires "a test exists (new or existing) verifying that an exception thrown by `_orgChartService` propagates out of `Handle` unchanged." Since there is no existing test file, one must be created — see Specification Amendments below for the resulting clarification.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new directories. Files affected:
+
+```
+backend/
+├── src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/
+│   └── GetOrganizationStructureHandler.cs        ← EDIT: remove try-catch
+└── test/Anela.Heblo.Tests/Features/
+    └── OrgChart/                                  ← NEW directory
+        └── GetOrganizationStructureHandlerTests.cs  ← NEW file
+```
+
+The new test directory mirrors `src/Anela.Heblo.Application/Features/OrgChart/` per the C# testing convention (`Mirror src/ structure under tests/`).
+
+### Interfaces and Contracts
+
+No interface or contract changes:
+- `IRequestHandler<GetOrganizationStructureRequest, OrgChartResponse>` — unchanged.
+- `GetOrganizationStructureRequest` (empty marker request) — unchanged.
+- `OrgChartResponse` — unchanged.
+- `IOrgChartService.GetOrganizationStructureAsync(CancellationToken)` — unchanged.
+- `OrgChartController.GetOrganizationStructure` route + response shape — unchanged.
+
+After the edit, the handler body must be exactly:
+
+```csharp
+public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
+{
+    _logger.LogInformation("Handling request to fetch organizational structure");
+    return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
+}
+```
+
+Remove the now-unused `result` local. No `using` directives need to change — `Microsoft.Extensions.Logging` is still required for `LogInformation`, and the rest are still in use.
+
+### Data Flow
+
+**Success path** (unchanged client-visible behavior):
+1. Controller logs `"Fetching organizational structure"` (Information).
+2. Controller sends `GetOrganizationStructureRequest` via MediatR.
+3. Handler logs `"Handling request to fetch organizational structure"` (Information).
+4. Handler awaits `_orgChartService.GetOrganizationStructureAsync` and returns its result.
+5. Controller wraps the result in `Ok(...)` → HTTP 200 + `OrgChartResponse`.
+
+**Failure path** (one fewer log entry, otherwise identical):
+1. Controller logs `"Fetching organizational structure"` (Information).
+2. Handler logs `"Handling request..."` (Information) and calls the service.
+3. Service throws.
+4. Exception propagates **unmodified** through the handler (no log) and MediatR.
+5. Controller's catch logs `"Error fetching organizational structure"` (Error) **once**, returns HTTP 500.
+
+Net effect: one ERROR log per failed request instead of two; all other log lines unchanged.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| An observability dashboard/alert is keyed on the handler's `"Error fetching organizational structure"` log line emitted from the `Application` assembly's logger category (`GetOrganizationStructureHandler`). | Low | The controller emits the identical message text under a different category (`OrgChartController`). Search log/alert configs (`appsettings*.json`, Azure Monitor / Application Insights queries, Grafana) for the logger category `…GetOrganizationStructureHandler` before merge. Note: the spec says this is a solo-developer project, so the risk surface is small. |
+| A future MediatR pipeline behavior or exception middleware is added that assumes handlers self-log on failure. | Low | Document in the commit/PR that handlers in this codebase do not self-log exceptions — the controller (or, later, a global filter) owns that responsibility. |
+| Removing the catch changes the stack trace shape in the single remaining error log (slightly shallower, no `Handler.Handle` frame above the `await`). | Low | Acceptable — the controller's `LogError(ex, …)` still captures the full inner stack from the service throw site. |
+| New test file is placed in a path that doesn't match the existing `Anela.Heblo.Tests` project convention. | Low | Place under `backend/test/Anela.Heblo.Tests/Features/OrgChart/` to mirror `src/Anela.Heblo.Application/Features/OrgChart/`, matching `Features/Journal/`, `Features/Catalog/`, etc. The xUnit project will auto-include it. |
+
+## Specification Amendments
+
+1. **FR-4 clarification — no existing handler tests.** A search of `backend/test/` returns zero files referencing `OrgChart`. The spec's "Any existing handler tests asserting on the redundant catch behavior must be updated" is vacuously satisfied. The spec's positive requirement — "A test exists (new or existing) verifying that an exception thrown by `_orgChartService` propagates out of `Handle` unchanged" — therefore requires **creating** a new test file. Implementation must produce:
+   - `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` with at minimum:
+     - `Handle_ReturnsServiceResponse_WhenServiceSucceeds`
+     - `Handle_PropagatesException_WhenServiceThrows` (asserts `await Assert.ThrowsAsync<…>(() => handler.Handle(...))` and verifies the exception instance/type is unchanged).
+   - Use xUnit + FluentAssertions + NSubstitute or Moq per the existing test project's conventions (inspect a peer test class such as one under `Features/Journal/` to match exact mock framework choice).
+   - No assertion on any handler-emitted `LogError` (such an assertion would be wrong post-change).
+
+2. **NFR-4 observability — clarification of "at least as rich".** The pre-change handler log was `LogError(ex, "Error fetching organizational structure")`. The controller log is `LogError(ex, "Error fetching organizational structure")` — verbatim identical message text plus the same exception object. Information content is **equal**, satisfying "at least as rich." No controller change required. Record this verification in the PR description rather than re-opening it as an Open Question.
+
+3. **Note on controller `ex.Message` exposure (not in scope, but worth recording).** `OrgChartController.cs:51` returns `ex.Message` in the 500 response body. This pre-dates the current change and is explicitly out of scope per the spec, but should be tracked as a separate finding for a future arch review (potentially together with a move to a global exception middleware as outlined in "Out of Scope").
+
+## Prerequisites
+
+None. The change is purely an in-place edit of one file plus the addition of one test file. No migrations, no config changes, no infrastructure changes, no new dependencies. The existing `dotnet build` + `dotnet format` + `dotnet test` validation gates from `CLAUDE.md` are sufficient to verify the change before commit.

--- a/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/brief.md
+++ b/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/brief.md
@@ -1,0 +1,32 @@
+## Module
+OrgChart
+
+## Finding
+`GetOrganizationStructureHandler.cs` lines 29–35 wraps the single service call in a try-catch that only logs and rethrows:
+
+```csharp
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Error fetching organizational structure");
+    throw;
+}
+```
+
+`OrgChartController.cs` lines 40–53 has an identical catch block that also logs and converts the exception into a 500 response. The result is that every error is logged twice with nearly identical messages before the client ever sees the response.
+
+## Why it matters
+The handler's catch adds zero behaviour — it neither recovers, transforms, nor enriches the exception. It just adds a redundant log line, making error traces harder to read and inflating log volume. This violates KISS: every line of code should earn its place.
+
+## Suggested fix
+Delete the try-catch from `GetOrganizationStructureHandler.Handle` entirely. The controller is the right place to catch, log, and shape the HTTP error response. The handler should contain only the happy path:
+
+```csharp
+public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
+{
+    _logger.LogInformation("Handling request to fetch organizational structure");
+    return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
+}
+```
+
+---
+_Filed by daily arch-review routine on 2026-05-19._

--- a/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/impl.r1.md
+++ b/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/impl.r1.md
@@ -1,0 +1,45 @@
+# Implementation: Remove Redundant Try-Catch in GetOrganizationStructureHandler
+
+## What was implemented
+Removed the dead `try { ... } catch { log; throw; }` wrapper from `GetOrganizationStructureHandler.Handle` so failure paths log exactly once (from the controller). Added missing unit-test coverage verifying the new propagation behavior. The handler now matches every other handler in the codebase (happy-path-only, no self-logging on failure).
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — removed try-catch block and intermediate `result` variable; `Handle` now logs informational entry then directly `return await`s the service call
+- `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` — new file; two xUnit tests using Moq + FluentAssertions
+
+## Tests
+`backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs`
+- `Handle_ReturnsServiceResponse_WhenServiceSucceeds` — happy path: verifies the service response object is returned unchanged (BeSameAs)
+- `Handle_PropagatesException_WhenServiceThrows` — exception path: verifies the exception propagates unchanged (BeSameAs) and that the handler emits NO LogError (Times.Never)
+
+All 3623 existing tests in the test suite continue to pass.
+
+## How to verify
+```bash
+# Run only the new handler tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetOrganizationStructureHandlerTests" --nologo
+
+# Run full suite
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --nologo
+```
+
+Both handler tests pass. No regressions.
+
+## Notes
+- The controller's catch block (`OrgChartController.cs` lines 40–53) is unchanged — it remains the single authoritative point for logging failures and returning 500.
+- Per the arch-review amendment: the controller log message and exception attachment are verbatim identical to what the handler was logging, so NFR-4 (observability richness) is satisfied without any controller change.
+- Pre-existing concern noted in arch review: `OrgChartController.cs:51` returns `ex.Message` in the 500 body. This is out of scope for this change but flagged for a future arch review.
+- Commits: `16454b0c` (test file, RED phase) and `048d3ecd` (handler edit, GREEN phase).
+
+## PR Summary
+Removes the redundant try-catch wrapper from `GetOrganizationStructureHandler.Handle` that logged and rethrew without adding any behavior. The controller already owns failure logging for this endpoint, so the handler-level catch was producing a duplicate ERROR log entry on every failure. After this change each org-chart failure produces exactly one error log (from the controller).
+
+Also adds the first unit tests for this handler — a happy-path test and an exception-propagation test that explicitly asserts the handler does not emit its own LogError, enforcing the single-responsibility boundary.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — removed try-catch; `Handle` is now a two-liner (log + return await)
+- `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` — new file; two tests covering happy path and exception propagation
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/impl/main.r1.md
+++ b/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/impl/main.r1.md
@@ -1,0 +1,9 @@
+Implementation complete. Here's a summary of what was done:
+
+**Task 1 — Tests (RED phase, commit `16454b0c`):**
+Created `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` with two xUnit/Moq/FluentAssertions tests. The exception-propagation test failed as expected (the current handler was calling `LogError` before rethrowing), confirming the RED state.
+
+**Task 2 — Refactor (GREEN phase, commit `048d3ecd`):**
+Removed the `try { var result = ...; return result; } catch (Exception ex) { _logger.LogError(...); throw; }` block from `GetOrganizationStructureHandler.Handle`. The method is now a two-liner: `LogInformation` + `return await _orgChartService.GetOrganizationStructureAsync(cancellationToken)`.
+
+Both new tests now pass, and all 3623 existing tests continue to pass. Each org-chart failure now produces exactly one ERROR log entry (from the controller) instead of two.

--- a/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/spec.r1.md
+++ b/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/spec.r1.md
@@ -1,0 +1,85 @@
+# Specification: Remove Redundant Try-Catch in GetOrganizationStructureHandler
+
+## Summary
+Remove the redundant try-catch block in `GetOrganizationStructureHandler.Handle` that only logs and rethrows. Error handling and HTTP response shaping remain centralized in `OrgChartController`, eliminating duplicate log entries for every failure path.
+
+## Background
+Daily architecture review (2026-05-19) flagged that `GetOrganizationStructureHandler.cs` (lines 29–35) wraps a single service call in a try-catch that adds no behavior — it logs the exception and rethrows. `OrgChartController.cs` (lines 40–53) already has an identical catch block that logs and converts the exception into a 500 response. The result is duplicate log entries for every error, increased log volume, and harder-to-read traces. The handler-level catch violates KISS: code that does not earn its place should be removed.
+
+## Functional Requirements
+
+### FR-1: Remove handler-level exception handling
+The `Handle` method in `GetOrganizationStructureHandler` must contain only the happy path: a single `LogInformation` call followed by the service invocation. The try-catch must be removed entirely so that exceptions propagate unmodified to the MediatR pipeline and ultimately to the controller.
+
+**Acceptance criteria:**
+- `GetOrganizationStructureHandler.Handle` contains no try-catch block.
+- The method body is exactly: log informational message, then `return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);`.
+- No `using` directives become unused after removal; if any do, remove them.
+- The handler still logs the informational "Handling request..." line at entry.
+
+### FR-2: Preserve controller-level error handling
+The existing try-catch in `OrgChartController` (lines 40–53) must remain unchanged. It is the authoritative point for logging the failure and translating it into a 500 response for the client.
+
+**Acceptance criteria:**
+- `OrgChartController` continues to catch exceptions from the MediatR send call.
+- The 500 response shape returned to the client is unchanged.
+- Error log message and log level in the controller are unchanged.
+
+### FR-3: Preserve client-observable behavior
+The change is a pure refactor. Clients calling the org-chart endpoint must observe identical responses for both success and failure paths (status codes, response bodies, headers).
+
+**Acceptance criteria:**
+- Successful requests return the same `OrgChartResponse` payload and 200 status code as before.
+- Failed requests (when `_orgChartService.GetOrganizationStructureAsync` throws) return the same 500 response shape as before.
+- No new exception types are introduced or swallowed.
+
+### FR-4: Update or add tests
+Any existing handler tests asserting on the redundant catch behavior must be updated. If tests verify that the handler logs an error on failure, they must be removed or rewritten to verify that exceptions now propagate. Controller tests must continue to verify the 500 response on exception.
+
+**Acceptance criteria:**
+- All existing tests for `GetOrganizationStructureHandler` pass.
+- No test asserts on a handler-level error log entry.
+- A test exists (new or existing) verifying that an exception thrown by `_orgChartService` propagates out of `Handle` unchanged.
+- Controller tests verifying 500 response on exception continue to pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact expected. Removing one try-catch frame is negligible. Log volume on error paths decreases by roughly 50% for the org-chart endpoint.
+
+### NFR-2: Security
+No security implications. Exception messages were already being logged at the controller layer; no new information is exposed to clients.
+
+### NFR-3: Maintainability
+The change improves maintainability by removing dead code and consolidating error-handling responsibility at a single layer (controller).
+
+### NFR-4: Observability
+Each org-chart request failure must produce exactly one error log entry (from the controller). The information content of that single log line must be at least as rich as the previous handler log line (exception + contextual message). Verify that the controller log already includes the exception object; if not, this spec does not extend the controller log — note it in Open Questions instead.
+
+## Data Model
+No data model changes.
+
+## API / Interface Design
+No public API changes. The MediatR request/response contracts (`GetOrganizationStructureRequest`, `OrgChartResponse`) and the controller endpoint signature remain identical.
+
+**Files affected:**
+- `GetOrganizationStructureHandler.cs` — remove try-catch in `Handle`.
+- `OrgChartController.cs` — unchanged.
+- Handler unit tests — update assertions if any reference the removed log line.
+
+## Dependencies
+- MediatR (existing) — exceptions thrown from `Handle` propagate through the pipeline unchanged.
+- `ILogger<GetOrganizationStructureHandler>` (existing) — still used for the informational log.
+- `_orgChartService` (existing) — no change to its contract.
+
+## Out of Scope
+- Refactoring the controller's error handling (e.g., moving to a global exception filter / middleware).
+- Auditing other handlers in the codebase for the same anti-pattern. (May be addressed in a follow-up arch review.)
+- Changing the 500 response shape or error message format.
+- Adding new structured-logging fields or correlation IDs.
+- Renaming or relocating files.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/task-plan.r1.md
+++ b/artifacts/feat-arch-review-orgchart-dead-catch-log-reth/task-plan.r1.md
@@ -1,0 +1,290 @@
+# Remove Redundant Try-Catch in GetOrganizationStructureHandler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead `try { ... } catch { log; throw; }` wrapper from `GetOrganizationStructureHandler.Handle` so failure paths log exactly once (from the controller), and add the missing unit-test coverage that asserts the new propagation behavior.
+
+**Architecture:** Pure refactor in a single MediatR handler — the controller already owns failure logging and the 500 mapping; the handler returns to a happy-path-only shape that matches every other handler in the codebase (e.g., `GetJournalEntriesHandler`). No interface, contract, route, or response-shape changes. Adds a new xUnit test class mirroring `src/Anela.Heblo.Application/Features/OrgChart/` under `backend/test/Anela.Heblo.Tests/Features/OrgChart/` to satisfy spec FR-4.
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, FluentAssertions, Moq (matches `Features/Journal/GetJournalEntryHandlerTests.cs` peer conventions). Build/format/test gates: `dotnet build`, `dotnet format`, `dotnet test`.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` | Remove try-catch in `Handle`; keep the entry `LogInformation` and the single `await` to `IOrgChartService`. |
+| Create | `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` | Unit tests: happy path returns service response unchanged; exception from service propagates out of `Handle` unchanged. |
+
+No other files change. `OrgChartController.cs` stays exactly as-is (verified in arch review — the controller log line is verbatim identical to the handler log line and already attaches the exception object).
+
+---
+
+## Task 1: Add unit tests for the handler (RED phase)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs`
+
+> Why first: there are zero existing tests for `OrgChart` in `backend/test/Anela.Heblo.Tests/`. Per spec FR-4 and the arch-review amendment, we need (a) a happy-path test and (b) an exception-propagation test that would FAIL today (because the current handler catches, logs, then rethrows — which still propagates, BUT we additionally assert *no* `LogError` is emitted by the handler logger; that assertion fails today and passes after Task 2). This gives us a true RED → GREEN cycle.
+
+- [ ] **Step 1: Create the test file with both tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` with exactly this content:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Anela.Heblo.Application.Features.OrgChart.UseCases.GetOrganizationStructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.OrgChart;
+
+public class GetOrganizationStructureHandlerTests
+{
+    private readonly Mock<IOrgChartService> _orgChartServiceMock;
+    private readonly Mock<ILogger<GetOrganizationStructureHandler>> _loggerMock;
+    private readonly GetOrganizationStructureHandler _handler;
+
+    public GetOrganizationStructureHandlerTests()
+    {
+        _orgChartServiceMock = new Mock<IOrgChartService>();
+        _loggerMock = new Mock<ILogger<GetOrganizationStructureHandler>>();
+        _handler = new GetOrganizationStructureHandler(_orgChartServiceMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsServiceResponse_WhenServiceSucceeds()
+    {
+        // Arrange
+        var request = new GetOrganizationStructureRequest();
+        var expected = new OrgChartResponse
+        {
+            Organization = new OrganizationDto { Name = "Anela" }
+        };
+
+        _orgChartServiceMock
+            .Setup(x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSameAs(expected);
+        _orgChartServiceMock.Verify(
+            x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesException_WhenServiceThrows()
+    {
+        // Arrange
+        var request = new GetOrganizationStructureRequest();
+        var thrown = new InvalidOperationException("boom");
+
+        _orgChartServiceMock
+            .Setup(x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        // Act
+        var act = async () => await _handler.Handle(request, CancellationToken.None);
+
+        // Assert: the exception propagates UNMODIFIED (same instance, same type, same message).
+        var caught = await act.Should().ThrowAsync<InvalidOperationException>();
+        caught.Which.Should().BeSameAs(thrown);
+
+        // Assert: the handler does NOT emit its own LogError — the controller owns failure logging.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+}
+```
+
+Notes on the test code (do not deviate):
+- `OrganizationDto` is in `Anela.Heblo.Application.Features.OrgChart.Contracts` and has a `Name` property — the only thing the happy-path test needs is *some* response object identity (`BeSameAs`), so the DTO contents are not asserted; the field is only set to make the construction explicit.
+- `BeSameAs(thrown)` is critical — spec FR-3/FR-4 requires the exception instance/type be unchanged (no wrapping, no swallowing).
+- The `_loggerMock.Verify(...)` block uses the canonical `ILogger.Log<TState>(LogLevel, EventId, TState, Exception?, Func<TState, Exception?, string>)` overload with `It.IsAnyType` because that is how `ILogger` extension methods (`LogError`, `LogInformation`, etc.) bottom out at the abstraction level Moq can intercept. This is the same pattern that other test classes in this repo use to assert on logger calls; do not switch to `LogError(...)` directly — Moq cannot intercept extension methods.
+- `OrgChartResponse` derives from `BaseResponse`; the parameterless constructor sets `Success = true`. No need to set anything else.
+
+- [ ] **Step 2: Run the new tests and verify the failure-propagation test FAILS**
+
+Run from the worktree root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetOrganizationStructureHandlerTests" \
+  --nologo
+```
+
+Expected result:
+- `Handle_ReturnsServiceResponse_WhenServiceSucceeds` → **PASS** (current handler returns the service response on the happy path).
+- `Handle_PropagatesException_WhenServiceThrows` → **FAIL** with a Moq verification message like `Expected invocation on the mock should never have been performed, but was 1 times: x => x.Log<...>(Error, ...)`. The exception itself still propagates today (the current catch rethrows), so the `ThrowAsync` assertion will pass — but the `LogError` assertion will fail because the current handler logs at error level before rethrowing.
+
+If both tests pass at this point, **stop** — that means the handler edit was already applied or the logger verification is malformed. Re-check the file you just wrote.
+
+- [ ] **Step 3: Commit the RED test file**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+git commit -m "test(orgchart): add handler tests asserting exception propagation without self-log"
+```
+
+---
+
+## Task 2: Remove the redundant try-catch in the handler (GREEN phase)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs:24-38`
+
+- [ ] **Step 1: Replace the `Handle` method body**
+
+Open `GetOrganizationStructureHandler.cs`. Replace lines 24–38 (the entire `Handle` method) with:
+
+```csharp
+    public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling request to fetch organizational structure");
+        return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
+    }
+```
+
+The full post-edit file must read exactly:
+
+```csharp
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Anela.Heblo.Application.Features.OrgChart.Services;
+
+namespace Anela.Heblo.Application.Features.OrgChart.UseCases.GetOrganizationStructure;
+
+/// <summary>
+/// Handler for retrieving the complete organizational structure
+/// </summary>
+public class GetOrganizationStructureHandler : IRequestHandler<GetOrganizationStructureRequest, OrgChartResponse>
+{
+    private readonly IOrgChartService _orgChartService;
+    private readonly ILogger<GetOrganizationStructureHandler> _logger;
+
+    public GetOrganizationStructureHandler(
+        IOrgChartService orgChartService,
+        ILogger<GetOrganizationStructureHandler> logger)
+    {
+        _orgChartService = orgChartService;
+        _logger = logger;
+    }
+
+    public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling request to fetch organizational structure");
+        return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
+    }
+}
+```
+
+Verification checklist before moving on:
+- No `try`, `catch`, or `throw` keywords appear anywhere in the file.
+- The intermediate `var result = ...; return result;` is gone — single-expression return.
+- `using Microsoft.Extensions.Logging;` is still present (still needed for `LogInformation`).
+- The other two `using` directives (`MediatR`, `Anela.Heblo.Application.Features.OrgChart.Contracts`, `Anela.Heblo.Application.Features.OrgChart.Services`) all remain — each is still referenced.
+- Class name, namespace, constructor signature, interface implementation — all unchanged.
+
+- [ ] **Step 2: Re-run the handler tests and verify both PASS**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetOrganizationStructureHandlerTests" \
+  --nologo
+```
+
+Expected: both tests PASS. `Handle_PropagatesException_WhenServiceThrows` flips from FAIL to PASS because the handler no longer calls `LogError`.
+
+- [ ] **Step 3: Run `dotnet format` on the changed files**
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs \
+            backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+```
+
+Expected: command exits 0 with no further changes (or with whitespace-only fixups that you then re-commit). If `dotnet format` reports it cannot find the solution file, fall back to `dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` and `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`.
+
+- [ ] **Step 4: Run a full backend build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --nologo
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --nologo
+```
+
+Expected: both `Build succeeded.` with `0 Error(s)`. Warnings about unused `using` directives in the handler file would indicate Step 1 of this task was applied incorrectly — re-check.
+
+- [ ] **Step 5: Run the full backend test suite to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --nologo
+```
+
+Expected: all tests pass. Spec FR-3 (client-observable behavior unchanged) is implicitly verified by the absence of failures in any controller-level or integration test that exercises the org-chart endpoint. If a previously-passing test now fails *and* its assertion references a handler-emitted `LogError` for the org-chart path, update that test to drop the assertion (it was wrong per the new design) and note the change in the commit. If a failing test references *anything else*, stop and investigate — the change may have unintended side effects.
+
+- [ ] **Step 6: Commit the handler change**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs
+git commit -m "refactor(orgchart): remove redundant try-catch in handler; controller owns failure log"
+```
+
+If `dotnet format` modified the test file in step 3 (whitespace only), include those changes in this commit:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+git commit --amend --no-edit
+```
+
+(Only amend if the only delta in the test file is `dotnet format` whitespace. Otherwise — i.e., if the test logic itself changed — investigate before amending.)
+
+---
+
+## Self-Review
+
+**Spec coverage check** — every requirement from `spec.r1.md` mapped to a task:
+
+| Spec item | Where addressed |
+|---|---|
+| FR-1: Remove handler-level try-catch | Task 2, Step 1 |
+| FR-1: Body is `LogInformation` + single `return await` | Task 2, Step 1 (exact code shown) |
+| FR-1: No unused `using` directives remain | Task 2, Step 1 verification checklist + Step 4 build check |
+| FR-2: Controller try-catch unchanged | No task touches `OrgChartController.cs`; verified by Task 2, Step 5 (full suite still green). |
+| FR-3: Success path returns same `OrgChartResponse` / 200 | Task 1 happy-path test + Task 2, Step 5 |
+| FR-3: Failure path returns same 500 shape | Controller is untouched; Task 2, Step 5 full suite |
+| FR-3: No new exception types introduced or swallowed | Task 1 `Handle_PropagatesException_WhenServiceThrows` asserts `BeSameAs(thrown)` |
+| FR-4: Existing handler tests updated | Vacuous — none exist; the arch-review amendment documented this. |
+| FR-4: A test verifying propagation exists | Task 1, `Handle_PropagatesException_WhenServiceThrows` |
+| FR-4: No test asserts on handler-level error log | Task 1 explicitly asserts `LogError` is NOT called |
+| FR-4: Controller 500 tests continue to pass | Task 2, Step 5 full suite |
+| NFR-1: Performance — negligible | No-op (no perf-targeted tasks needed) |
+| NFR-2: Security — no new info exposed to clients | Controller body untouched; arch-review flagged `ex.Message` exposure as pre-existing out-of-scope |
+| NFR-3: Maintainability — dead code removed | Task 2 |
+| NFR-4: Exactly one error log per failure, content "at least as rich" | Arch-review amendment 2 verifies the controller log text/exception are verbatim identical to the removed handler log; no controller edits required. |
+
+**Placeholder scan:** searched the plan for "TBD", "TODO", "implement later", "fill in details", "add appropriate", "similar to Task" — none present. Every code block is complete. Every command has an expected outcome.
+
+**Type consistency check:**
+- `GetOrganizationStructureHandler` — same class name in Task 1 (test) and Task 2 (edit).
+- `IOrgChartService.GetOrganizationStructureAsync(CancellationToken)` — same signature referenced in both tasks; matches the actual interface.
+- `GetOrganizationStructureRequest` — empty marker class with parameterless constructor in both tasks; matches the actual source.
+- `OrgChartResponse` — class with `Organization` property (`OrganizationDto`) in Task 1; matches the actual source. `BaseResponse` parameterless ctor sets `Success = true` (default).
+- `OrganizationDto.Name` — verified via the `OrgChart/Contracts/OrganizationDto.cs` file in the codebase.
+- Logger verification uses `ILogger.Log<TState>(LogLevel, EventId, TState, Exception?, Func<TState, Exception?, string>)` — the only signature Moq can intercept, because `LogError`/`LogInformation` are extension methods.
+
+No gaps, no inconsistencies, no placeholders.

--- a/backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs
@@ -24,16 +24,6 @@ public class GetOrganizationStructureHandler : IRequestHandler<GetOrganizationSt
     public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Handling request to fetch organizational structure");
-
-        try
-        {
-            var result = await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error fetching organizational structure");
-            throw;
-        }
+        return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
@@ -1,0 +1,76 @@
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Anela.Heblo.Application.Features.OrgChart.UseCases.GetOrganizationStructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.OrgChart;
+
+public class GetOrganizationStructureHandlerTests
+{
+    private readonly Mock<IOrgChartService> _orgChartServiceMock;
+    private readonly Mock<ILogger<GetOrganizationStructureHandler>> _loggerMock;
+    private readonly GetOrganizationStructureHandler _handler;
+
+    public GetOrganizationStructureHandlerTests()
+    {
+        _orgChartServiceMock = new Mock<IOrgChartService>();
+        _loggerMock = new Mock<ILogger<GetOrganizationStructureHandler>>();
+        _handler = new GetOrganizationStructureHandler(_orgChartServiceMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsServiceResponse_WhenServiceSucceeds()
+    {
+        // Arrange
+        var request = new GetOrganizationStructureRequest();
+        var expected = new OrgChartResponse
+        {
+            Organization = new OrganizationDto { Name = "Anela" }
+        };
+
+        _orgChartServiceMock
+            .Setup(x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSameAs(expected);
+        _orgChartServiceMock.Verify(
+            x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesException_WhenServiceThrows()
+    {
+        // Arrange
+        var request = new GetOrganizationStructureRequest();
+        var thrown = new InvalidOperationException("boom");
+
+        _orgChartServiceMock
+            .Setup(x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        // Act
+        var act = async () => await _handler.Handle(request, CancellationToken.None);
+
+        // Assert: the exception propagates UNMODIFIED (same instance, same type, same message).
+        var caught = await act.Should().ThrowAsync<InvalidOperationException>();
+        caught.Which.Should().BeSameAs(thrown);
+
+        // Assert: the handler does NOT emit its own LogError — the controller owns failure logging.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+}

--- a/docs/superpowers/plans/2026-05-20-orgchart-dead-catch-log-rethrow.md
+++ b/docs/superpowers/plans/2026-05-20-orgchart-dead-catch-log-rethrow.md
@@ -1,0 +1,290 @@
+# Remove Redundant Try-Catch in GetOrganizationStructureHandler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead `try { ... } catch { log; throw; }` wrapper from `GetOrganizationStructureHandler.Handle` so failure paths log exactly once (from the controller), and add the missing unit-test coverage that asserts the new propagation behavior.
+
+**Architecture:** Pure refactor in a single MediatR handler — the controller already owns failure logging and the 500 mapping; the handler returns to a happy-path-only shape that matches every other handler in the codebase (e.g., `GetJournalEntriesHandler`). No interface, contract, route, or response-shape changes. Adds a new xUnit test class mirroring `src/Anela.Heblo.Application/Features/OrgChart/` under `backend/test/Anela.Heblo.Tests/Features/OrgChart/` to satisfy spec FR-4.
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, FluentAssertions, Moq (matches `Features/Journal/GetJournalEntryHandlerTests.cs` peer conventions). Build/format/test gates: `dotnet build`, `dotnet format`, `dotnet test`.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` | Remove try-catch in `Handle`; keep the entry `LogInformation` and the single `await` to `IOrgChartService`. |
+| Create | `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` | Unit tests: happy path returns service response unchanged; exception from service propagates out of `Handle` unchanged. |
+
+No other files change. `OrgChartController.cs` stays exactly as-is (verified in arch review — the controller log line is verbatim identical to the handler log line and already attaches the exception object).
+
+---
+
+## Task 1: Add unit tests for the handler (RED phase)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs`
+
+> Why first: there are zero existing tests for `OrgChart` in `backend/test/Anela.Heblo.Tests/`. Per spec FR-4 and the arch-review amendment, we need (a) a happy-path test and (b) an exception-propagation test that would FAIL today (because the current handler catches, logs, then rethrows — which still propagates, BUT we additionally assert *no* `LogError` is emitted by the handler logger; that assertion fails today and passes after Task 2). This gives us a true RED → GREEN cycle.
+
+- [ ] **Step 1: Create the test file with both tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs` with exactly this content:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Anela.Heblo.Application.Features.OrgChart.UseCases.GetOrganizationStructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.OrgChart;
+
+public class GetOrganizationStructureHandlerTests
+{
+    private readonly Mock<IOrgChartService> _orgChartServiceMock;
+    private readonly Mock<ILogger<GetOrganizationStructureHandler>> _loggerMock;
+    private readonly GetOrganizationStructureHandler _handler;
+
+    public GetOrganizationStructureHandlerTests()
+    {
+        _orgChartServiceMock = new Mock<IOrgChartService>();
+        _loggerMock = new Mock<ILogger<GetOrganizationStructureHandler>>();
+        _handler = new GetOrganizationStructureHandler(_orgChartServiceMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsServiceResponse_WhenServiceSucceeds()
+    {
+        // Arrange
+        var request = new GetOrganizationStructureRequest();
+        var expected = new OrgChartResponse
+        {
+            Organization = new OrganizationDto { Name = "Anela" }
+        };
+
+        _orgChartServiceMock
+            .Setup(x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeSameAs(expected);
+        _orgChartServiceMock.Verify(
+            x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesException_WhenServiceThrows()
+    {
+        // Arrange
+        var request = new GetOrganizationStructureRequest();
+        var thrown = new InvalidOperationException("boom");
+
+        _orgChartServiceMock
+            .Setup(x => x.GetOrganizationStructureAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        // Act
+        var act = async () => await _handler.Handle(request, CancellationToken.None);
+
+        // Assert: the exception propagates UNMODIFIED (same instance, same type, same message).
+        var caught = await act.Should().ThrowAsync<InvalidOperationException>();
+        caught.Which.Should().BeSameAs(thrown);
+
+        // Assert: the handler does NOT emit its own LogError — the controller owns failure logging.
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+}
+```
+
+Notes on the test code (do not deviate):
+- `OrganizationDto` is in `Anela.Heblo.Application.Features.OrgChart.Contracts` and has a `Name` property — the only thing the happy-path test needs is *some* response object identity (`BeSameAs`), so the DTO contents are not asserted; the field is only set to make the construction explicit.
+- `BeSameAs(thrown)` is critical — spec FR-3/FR-4 requires the exception instance/type be unchanged (no wrapping, no swallowing).
+- The `_loggerMock.Verify(...)` block uses the canonical `ILogger.Log<TState>(LogLevel, EventId, TState, Exception?, Func<TState, Exception?, string>)` overload with `It.IsAnyType` because that is how `ILogger` extension methods (`LogError`, `LogInformation`, etc.) bottom out at the abstraction level Moq can intercept. This is the same pattern that other test classes in this repo use to assert on logger calls; do not switch to `LogError(...)` directly — Moq cannot intercept extension methods.
+- `OrgChartResponse` derives from `BaseResponse`; the parameterless constructor sets `Success = true`. No need to set anything else.
+
+- [ ] **Step 2: Run the new tests and verify the failure-propagation test FAILS**
+
+Run from the worktree root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetOrganizationStructureHandlerTests" \
+  --nologo
+```
+
+Expected result:
+- `Handle_ReturnsServiceResponse_WhenServiceSucceeds` → **PASS** (current handler returns the service response on the happy path).
+- `Handle_PropagatesException_WhenServiceThrows` → **FAIL** with a Moq verification message like `Expected invocation on the mock should never have been performed, but was 1 times: x => x.Log<...>(Error, ...)`. The exception itself still propagates today (the current catch rethrows), so the `ThrowAsync` assertion will pass — but the `LogError` assertion will fail because the current handler logs at error level before rethrowing.
+
+If both tests pass at this point, **stop** — that means the handler edit was already applied or the logger verification is malformed. Re-check the file you just wrote.
+
+- [ ] **Step 3: Commit the RED test file**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+git commit -m "test(orgchart): add handler tests asserting exception propagation without self-log"
+```
+
+---
+
+## Task 2: Remove the redundant try-catch in the handler (GREEN phase)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs:24-38`
+
+- [ ] **Step 1: Replace the `Handle` method body**
+
+Open `GetOrganizationStructureHandler.cs`. Replace lines 24–38 (the entire `Handle` method) with:
+
+```csharp
+    public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling request to fetch organizational structure");
+        return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
+    }
+```
+
+The full post-edit file must read exactly:
+
+```csharp
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Anela.Heblo.Application.Features.OrgChart.Services;
+
+namespace Anela.Heblo.Application.Features.OrgChart.UseCases.GetOrganizationStructure;
+
+/// <summary>
+/// Handler for retrieving the complete organizational structure
+/// </summary>
+public class GetOrganizationStructureHandler : IRequestHandler<GetOrganizationStructureRequest, OrgChartResponse>
+{
+    private readonly IOrgChartService _orgChartService;
+    private readonly ILogger<GetOrganizationStructureHandler> _logger;
+
+    public GetOrganizationStructureHandler(
+        IOrgChartService orgChartService,
+        ILogger<GetOrganizationStructureHandler> logger)
+    {
+        _orgChartService = orgChartService;
+        _logger = logger;
+    }
+
+    public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling request to fetch organizational structure");
+        return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
+    }
+}
+```
+
+Verification checklist before moving on:
+- No `try`, `catch`, or `throw` keywords appear anywhere in the file.
+- The intermediate `var result = ...; return result;` is gone — single-expression return.
+- `using Microsoft.Extensions.Logging;` is still present (still needed for `LogInformation`).
+- The other two `using` directives (`MediatR`, `Anela.Heblo.Application.Features.OrgChart.Contracts`, `Anela.Heblo.Application.Features.OrgChart.Services`) all remain — each is still referenced.
+- Class name, namespace, constructor signature, interface implementation — all unchanged.
+
+- [ ] **Step 2: Re-run the handler tests and verify both PASS**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetOrganizationStructureHandlerTests" \
+  --nologo
+```
+
+Expected: both tests PASS. `Handle_PropagatesException_WhenServiceThrows` flips from FAIL to PASS because the handler no longer calls `LogError`.
+
+- [ ] **Step 3: Run `dotnet format` on the changed files**
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs \
+            backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+```
+
+Expected: command exits 0 with no further changes (or with whitespace-only fixups that you then re-commit). If `dotnet format` reports it cannot find the solution file, fall back to `dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` and `dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`.
+
+- [ ] **Step 4: Run a full backend build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --nologo
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --nologo
+```
+
+Expected: both `Build succeeded.` with `0 Error(s)`. Warnings about unused `using` directives in the handler file would indicate Step 1 of this task was applied incorrectly — re-check.
+
+- [ ] **Step 5: Run the full backend test suite to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --nologo
+```
+
+Expected: all tests pass. Spec FR-3 (client-observable behavior unchanged) is implicitly verified by the absence of failures in any controller-level or integration test that exercises the org-chart endpoint. If a previously-passing test now fails *and* its assertion references a handler-emitted `LogError` for the org-chart path, update that test to drop the assertion (it was wrong per the new design) and note the change in the commit. If a failing test references *anything else*, stop and investigate — the change may have unintended side effects.
+
+- [ ] **Step 6: Commit the handler change**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs
+git commit -m "refactor(orgchart): remove redundant try-catch in handler; controller owns failure log"
+```
+
+If `dotnet format` modified the test file in step 3 (whitespace only), include those changes in this commit:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/OrgChart/GetOrganizationStructureHandlerTests.cs
+git commit --amend --no-edit
+```
+
+(Only amend if the only delta in the test file is `dotnet format` whitespace. Otherwise — i.e., if the test logic itself changed — investigate before amending.)
+
+---
+
+## Self-Review
+
+**Spec coverage check** — every requirement from `spec.r1.md` mapped to a task:
+
+| Spec item | Where addressed |
+|---|---|
+| FR-1: Remove handler-level try-catch | Task 2, Step 1 |
+| FR-1: Body is `LogInformation` + single `return await` | Task 2, Step 1 (exact code shown) |
+| FR-1: No unused `using` directives remain | Task 2, Step 1 verification checklist + Step 4 build check |
+| FR-2: Controller try-catch unchanged | No task touches `OrgChartController.cs`; verified by Task 2, Step 5 (full suite still green). |
+| FR-3: Success path returns same `OrgChartResponse` / 200 | Task 1 happy-path test + Task 2, Step 5 |
+| FR-3: Failure path returns same 500 shape | Controller is untouched; Task 2, Step 5 full suite |
+| FR-3: No new exception types introduced or swallowed | Task 1 `Handle_PropagatesException_WhenServiceThrows` asserts `BeSameAs(thrown)` |
+| FR-4: Existing handler tests updated | Vacuous — none exist; the arch-review amendment documented this. |
+| FR-4: A test verifying propagation exists | Task 1, `Handle_PropagatesException_WhenServiceThrows` |
+| FR-4: No test asserts on handler-level error log | Task 1 explicitly asserts `LogError` is NOT called |
+| FR-4: Controller 500 tests continue to pass | Task 2, Step 5 full suite |
+| NFR-1: Performance — negligible | No-op (no perf-targeted tasks needed) |
+| NFR-2: Security — no new info exposed to clients | Controller body untouched; arch-review flagged `ex.Message` exposure as pre-existing out-of-scope |
+| NFR-3: Maintainability — dead code removed | Task 2 |
+| NFR-4: Exactly one error log per failure, content "at least as rich" | Arch-review amendment 2 verifies the controller log text/exception are verbatim identical to the removed handler log; no controller edits required. |
+
+**Placeholder scan:** searched the plan for "TBD", "TODO", "implement later", "fill in details", "add appropriate", "similar to Task" — none present. Every code block is complete. Every command has an expected outcome.
+
+**Type consistency check:**
+- `GetOrganizationStructureHandler` — same class name in Task 1 (test) and Task 2 (edit).
+- `IOrgChartService.GetOrganizationStructureAsync(CancellationToken)` — same signature referenced in both tasks; matches the actual interface.
+- `GetOrganizationStructureRequest` — empty marker class with parameterless constructor in both tasks; matches the actual source.
+- `OrgChartResponse` — class with `Organization` property (`OrganizationDto`) in Task 1; matches the actual source. `BaseResponse` parameterless ctor sets `Success = true` (default).
+- `OrganizationDto.Name` — verified via the `OrgChart/Contracts/OrganizationDto.cs` file in the codebase.
+- Logger verification uses `ILogger.Log<TState>(LogLevel, EventId, TState, Exception?, Func<TState, Exception?, string>)` — the only signature Moq can intercept, because `LogError`/`LogInformation` are extension methods.
+
+No gaps, no inconsistencies, no placeholders.


### PR DESCRIPTION
OrgChart

## Finding
`GetOrganizationStructureHandler.cs` lines 29–35 wraps the single service call in a try-catch that only logs and rethrows:

```csharp
catch (Exception ex)
{
    _logger.LogError(ex, "Error fetching organizational structure");
    throw;
}
```

`OrgChartController.cs` lines 40–53 has an identical catch block that also logs and converts the exception into a 500 response. The result is that every error is logged twice with nearly identical messages before the client ever sees the response.

## Why it matters
The handler's catch adds zero behaviour — it neither recovers, transforms, nor enriches the exception. It just adds a redundant log line, making error traces harder to read and inflating log volume. This violates KISS: every line of code should earn its place.

## Suggested fix
Delete the try-catch from `GetOrganizationStructureHandler.Handle` entirely. The controller is the right place to catch, log, and shape the HTTP error response. The handler should contain only the happy path:

```csharp
public async Task<OrgChartResponse> Handle(GetOrganizationStructureRequest request, CancellationToken cancellationToken)
{
    _logger.LogInformation("Handling request to fetch organizational structure");
    return await _orgChartService.GetOrganizationStructureAsync(cancellationToken);
}
```

---
_Filed by daily arch-review routine on 2026-05-19._

---

Closes #1429

### Tokens used
6646911
