### PR TITLE
feat: Relocate OrgChartService HTTP adapter to Infrastructure

### DIFF
--- a/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/arch-review.r1.md
+++ b/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/arch-review.r1.md
@@ -1,0 +1,164 @@
+Now I have enough verified context to write the architecture review.
+
+```markdown
+# Architecture Review: Relocate OrgChartService HTTP adapter to Infrastructure
+
+## Skip Design: true
+
+Backend-only structural refactor. No UI components, screens, or visual changes — only folder/namespace relocation of one C# class.
+
+## Architectural Fit Assessment
+
+The proposal aligns precisely with the project's documented Clean Architecture / Vertical Slice convention. `docs/architecture/filesystem.md` (lines 32–33) explicitly defines:
+
+- `Features/{Feature}/Services/` — *"Domain services and business logic"*
+- `Features/{Feature}/Infrastructure/` — *"Feature infrastructure"*
+
+Verified facts from the codebase:
+
+1. **OrgChartService.cs is unambiguously infrastructure.** It does nothing but `HttpClient.GetAsync` → `JsonSerializer.Deserialize` → wrap exceptions. Zero domain rules or policy.
+2. **OrgChart is the only feature module without an `Infrastructure/` folder.** All other modules I sampled (`Bank`, `Catalog`, `ExpeditionList`, `FileStorage`, `Invoices`, `Leaflet`, `MeetingTasks`) have one.
+3. **Reference surface is tiny.** Grep confirms only 5 files reference `OrgChartService` / `OrgChart.Services`: the three OrgChart files themselves, `GetOrganizationStructureHandler.cs` (depends on the interface — unaffected by moving the concrete class), and `ApplicationModule.cs` (uses the `AddOrgChartServices` extension — unaffected). No backend tests reference `OrgChartService`.
+4. **The codebase already shows mild convention drift.** `MeetingTasks/Services/` contains `GraphPlannerService` and `ClaudeMeetingTaskExtractor` (clearly external adapters), and `ExpeditionList/Services/` contains `FileSystemPrintQueueSink`. Fixing OrgChart is correct, but the broader inconsistency should be acknowledged (see Risks).
+
+Integration points the move touches: nothing runtime. Only namespace resolution at compile time in `OrgChartModule.cs`.
+
+The spec is correct, minimal, and faithful to the documented rule. The architectural decision worth being explicit about is **where the interface lives**.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Features/OrgChart/
+├── Contracts/                                 (unchanged)
+│   └── OrgChartResponse, *Dto.cs
+├── Services/                                  (domain boundary)
+│   └── IOrgChartService.cs                    ← interface STAYS here
+├── Infrastructure/                            (new folder)
+│   └── OrgChartService.cs                     ← concrete adapter MOVED here
+├── UseCases/
+│   └── GetOrganizationStructure/
+│       └── GetOrganizationStructureHandler.cs (depends on Services.IOrgChartService)
+├── OrgChartOptions.cs                         (unchanged)
+└── OrgChartModule.cs                          (gains one using directive)
+
+Dependency direction (compile-time):
+   UseCases ──depends on──▶ Services (interface)
+   Infrastructure ──implements──▶ Services (interface)
+   Module ──wires──▶ Services + Infrastructure
+```
+
+### Key Design Decisions
+
+#### Decision 1: Interface placement — `Services/` vs `Infrastructure/`
+**Options considered:**
+- (A) Move both `IOrgChartService` and `OrgChartService` into `Infrastructure/`.
+- (B) Keep `IOrgChartService` in `Services/`; move only the concrete class to `Infrastructure/` (the spec's choice).
+- (C) Promote `IOrgChartService` to `Contracts/` since it is a feature-facing contract.
+
+**Chosen approach:** (B). The interface remains in `Services/`; only the concrete `OrgChartService` moves.
+
+**Rationale:** `IOrgChartService` is the **abstraction the use-case handler depends on**. It belongs on the domain side of the boundary so the application layer doesn't depend on infrastructure namespaces. This matches the well-known Dependency Inversion convention (the consumer owns the interface). Option (A) would force handlers to `using ...Infrastructure;`, defeating the purpose of the split. Option (C) is plausible but `Contracts/` in this codebase holds DTOs, not service abstractions — keeping it as-is preserves the project's existing semantic.
+
+#### Decision 2: Preserve git history via `git mv`
+**Options considered:** plain delete-and-create vs `git mv`.
+**Chosen approach:** `git mv` (or an equivalent rename detected by git).
+**Rationale:** `git log --follow` and `git blame` continuity matter for forensic work on adapter quirks. The spec already mandates this in NFR-4.
+
+#### Decision 3: Do not refactor while moving
+**Chosen approach:** Byte-identical contents except the `namespace` line.
+**Rationale:** This refactor's value is the boundary correction. Mixing logic changes (retry, Polly, logging cleanup, JSON options consolidation) would obscure the diff, defeat history detection, and expand the test surface. Note these as follow-ups (see Specification Amendments).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly one new directory and move one file:
+
+```
++ backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/
++ backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs   (from Services/)
+- backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+~ backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs                   (one using added)
+```
+
+Execution sequence:
+1. `git mv backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs`
+2. Edit the `namespace` line to `Anela.Heblo.Application.Features.OrgChart.Infrastructure;`
+3. Add `using Anela.Heblo.Application.Features.OrgChart.Infrastructure;` to `OrgChartModule.cs` (keep existing `using ...Services;` line).
+4. `dotnet build` then `dotnet format` then `dotnet test`.
+
+### Interfaces and Contracts
+
+No interface changes. The contract `IOrgChartService` continues to live at:
+
+```csharp
+// Features/OrgChart/Services/IOrgChartService.cs
+namespace Anela.Heblo.Application.Features.OrgChart.Services;
+
+public interface IOrgChartService
+{
+    Task<OrgChartResponse> GetOrganizationStructureAsync(CancellationToken cancellationToken = default);
+}
+```
+
+`OrgChartModule.cs` after the change must contain exactly these two using directives for the wiring line:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;        // for IOrgChartService
+using Anela.Heblo.Application.Features.OrgChart.Infrastructure;  // for OrgChartService
+// ...
+services.AddHttpClient<IOrgChartService, OrgChartService>();
+```
+
+### Data Flow
+
+Unchanged at runtime. Compile-time only:
+
+```
+GetOrganizationStructureHandler
+       │ depends on
+       ▼
+IOrgChartService                       (Services namespace)
+       ▲
+       │ implemented by
+OrgChartService                        (Infrastructure namespace — NEW)
+       │ uses
+       ▼
+HttpClient + OrgChartOptions ──► external DataSourceUrl ──► OrgChartResponse JSON
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Build breaks because `OrgChartModule.cs` can't resolve `OrgChartService` after the namespace change | LOW | Spec FR-4 mandates adding the new `using` line; `dotnet build` catches it immediately. |
+| Git rename detection fails (file appears as delete + add), losing `--follow` history | LOW | Use `git mv`; verify with `git log --follow --oneline Infrastructure/OrgChartService.cs` before commit. Default rename threshold (50%) is safe because contents are byte-identical apart from the namespace line. |
+| Hidden reflection / DI scanning relies on the old namespace | VERY LOW | DI is explicit (`AddHttpClient<IOrgChartService, OrgChartService>()`); no reflection-based scanners in the OrgChart module. Verified by reading `OrgChartModule.cs`. |
+| Convention drift elsewhere (e.g. `MeetingTasks/Services/GraphPlannerService.cs`, `ExpeditionList/Services/FileSystemPrintQueueSink.cs`) makes future readers think OrgChart is now the outlier in the opposite direction | MEDIUM | Out of scope here per the spec. Track as a follow-up to migrate other adapters and then add a NetArchTest rule to prevent regression (see Specification Amendments). |
+| Stale references in docs/comments still say `OrgChart.Services.OrgChartService` | LOW | Grep `docs/` and code comments for the fully qualified name after the move; update any hits. None found in current grep, but re-verify post-move. |
+
+## Specification Amendments
+
+The spec is already tight and correct. Three small additions worth incorporating:
+
+1. **Verification step in FR-6:** Add `git log --follow backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` as an explicit acceptance check that history continuity survived the move. (Currently NFR-4 mandates the outcome but does not specify a verification command.)
+
+2. **Sanity grep after the move:** Add to acceptance criteria a repository-wide grep for `OrgChart.Services.OrgChartService` (fully-qualified) and for any stale comments/docs referencing the old location, ensuring zero hits other than `IOrgChartService` (which legitimately remains in `Services`).
+
+3. **Follow-up tracker (not in this PR):** The spec correctly lists "introducing an architecture-test (e.g. NetArchTest)" and "auditing other potentially-misplaced files" as out of scope. Recommend filing those as separate tickets immediately after merge so the boundary becomes enforceable, not just documented. Candidates spotted while exploring: `MeetingTasks/Services/GraphPlannerService.cs`, `MeetingTasks/Services/ClaudeMeetingTaskExtractor.cs`, `MeetingTasks/Services/IPlaudClient.cs` and related Plaud files, `ExpeditionList/Services/FileSystemPrintQueueSink.cs`, `Invoices/Services/InvoiceImportService.cs` (review whether it is domain logic or import plumbing).
+
+## Prerequisites
+
+None. The change requires:
+
+- No migrations.
+- No configuration changes (`OrgChartOptions.SectionName` and the `DataSourceUrl` key are unchanged).
+- No infrastructure changes.
+- No new NuGet packages.
+- No coordination with frontend or with the OpenAPI client generator (no contract change).
+- No feature flag.
+
+The branch can be implemented, built, tested, and merged in a single small PR.
+```

--- a/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/brief.md
+++ b/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/brief.md
@@ -1,0 +1,23 @@
+## Module
+OrgChart
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` is an HTTP client adapter — it calls an external URL, receives raw JSON, and deserializes it. It contains zero domain or business logic. Yet it lives in `Services/`, a folder that `docs/architecture/filesystem.md` defines as holding **"Domain services and business logic"**.
+
+The same filesystem doc defines `Features/{Feature}/Infrastructure/` as the home for **"Feature infrastructure"**, which is exactly what an external-API adapter is.
+
+## Why it matters
+Misplacing infrastructure code in the `Services/` layer blurs the distinction between domain logic and I/O concerns. A future developer looking for "where HTTP calls happen" will not find it in `Infrastructure/`, and a developer scanning `Services/` for business rules will wade through HTTP plumbing. The naming mismatch also makes it harder to enforce Clean Architecture boundaries via static analysis.
+
+## Suggested fix
+Move the file (and nothing else — no logic changes needed):
+
+```
+Before: Application/Features/OrgChart/Services/OrgChartService.cs
+After:  Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+`IOrgChartService` stays in `Services/` (it is the domain-facing contract); only the concrete implementation moves to `Infrastructure/`. Update the namespace accordingly.
+
+---
+_Filed by daily arch-review routine on 2026-05-19._

--- a/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/impl/main.r1.md
+++ b/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/impl/main.r1.md
@@ -1,0 +1,10 @@
+This is a normal repo (GIT_DIR == GIT_COMMON) on branch `feat-arch-review-orgchart-http-adapter-orgcha`, based off `main`.
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/spec.r1.md
+++ b/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/spec.r1.md
@@ -1,0 +1,156 @@
+# Specification: Relocate OrgChartService HTTP adapter to Infrastructure
+
+## Summary
+Move the concrete `OrgChartService` HTTP-client adapter from `Features/OrgChart/Services/` to `Features/OrgChart/Infrastructure/` and update its namespace accordingly. The `IOrgChartService` interface stays in `Services/` as the domain-facing contract. This is a structural refactor only — no behavior, no logic, no API contract changes.
+
+## Background
+`docs/architecture/filesystem.md` defines two distinct folders inside a feature module:
+
+- `Features/{Feature}/Services/` — **Domain services and business logic**
+- `Features/{Feature}/Infrastructure/` — **Feature infrastructure**
+
+`backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` is a pure HTTP-client adapter: it issues `HttpClient.GetAsync` against `OrgChartOptions.DataSourceUrl`, deserializes JSON into `OrgChartResponse`, and logs/translates HTTP and JSON failures. It contains no domain rules, calculations, or policy. It is, by the project's own definition, feature infrastructure misfiled under the domain-services folder.
+
+This violates the conventions documented in `docs/architecture/filesystem.md` and blurs the Clean-Architecture boundary the codebase otherwise maintains. Every other feature module in the application (e.g. `ExpeditionList`, `MeetingTasks`, `Invoices`, `Bank`, `Catalog`, `FileStorage`, `PackingMaterials`, `Leaflet`, `KnowledgeBase`, `DataQuality`) already has an `Infrastructure/` folder for exactly this kind of adapter — `OrgChart` is the outlier.
+
+Filed by daily arch-review routine on 2026-05-19.
+
+## Functional Requirements
+
+### FR-1: Move OrgChartService.cs to the Infrastructure folder
+The concrete class `OrgChartService` (the `IOrgChartService` implementation) must be relocated from the `Services/` folder to a new `Infrastructure/` folder inside the OrgChart feature module.
+
+**Acceptance criteria:**
+- File `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` no longer exists.
+- File `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` exists.
+- File contents are byte-identical to the original except for the `namespace` declaration (see FR-2).
+- The `Features/OrgChart/Infrastructure/` directory exists and contains the moved file.
+- The move is performed with `git mv` (or equivalent) so git history is preserved.
+
+### FR-2: Update the concrete class's namespace
+The relocated class's namespace must match its new physical folder.
+
+**Acceptance criteria:**
+- The `namespace` declaration in `Infrastructure/OrgChartService.cs` reads exactly:
+  ```csharp
+  namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+  ```
+- No other `namespace` declaration in the file.
+- The `using Anela.Heblo.Application.Features.OrgChart.Contracts;` directive is preserved (the class still depends on `OrgChartResponse`).
+
+### FR-3: Keep IOrgChartService in Services/
+The `IOrgChartService` interface is the domain-facing contract consumed by `GetOrganizationStructureHandler`. It must remain where it is — in `Features/OrgChart/Services/` — and keep its current namespace `Anela.Heblo.Application.Features.OrgChart.Services`.
+
+**Acceptance criteria:**
+- File `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/IOrgChartService.cs` is unchanged (path, content, namespace).
+- `GetOrganizationStructureHandler.cs` continues to compile without modifying its `using Anela.Heblo.Application.Features.OrgChart.Services;` directive.
+
+### FR-4: Update OrgChartModule.cs to reference both namespaces
+`OrgChartModule.cs` references both `IOrgChartService` (interface, in `Services`) and the concrete `OrgChartService` (class, now in `Infrastructure`) via `services.AddHttpClient<IOrgChartService, OrgChartService>();`. It currently has a single `using Anela.Heblo.Application.Features.OrgChart.Services;` directive that covers both. After the move, it needs both namespaces in scope.
+
+**Acceptance criteria:**
+- `OrgChartModule.cs` contains both:
+  ```csharp
+  using Anela.Heblo.Application.Features.OrgChart.Services;
+  using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+  ```
+- The `AddHttpClient<IOrgChartService, OrgChartService>()` registration line is unchanged.
+- No other code in `OrgChartModule.cs` is modified.
+
+### FR-5: No other source files require changes
+A repository-wide search confirms the only other references to `OrgChartService` / `OrgChart.Services` are:
+- `Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — references `IOrgChartService` (interface, unchanged).
+- `Anela.Heblo.Application/ApplicationModule.cs` — calls `services.AddOrgChartServices(configuration)` (extension method, unchanged).
+
+**Acceptance criteria:**
+- `GetOrganizationStructureHandler.cs` is not modified.
+- `ApplicationModule.cs` is not modified.
+- No other `.cs` file in the repository is modified.
+
+### FR-6: Build and behavior must remain green
+The refactor must not break the build, change runtime behavior, or alter the public API.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with zero new errors or warnings attributable to this change.
+- `dotnet format` reports no formatting drift on the moved file.
+- The `GET /api/orgchart/structure` endpoint (or whichever route `GetOrganizationStructureHandler` powers) returns the same payload before and after the change, given the same upstream response.
+- DI resolution of `IOrgChartService` continues to yield a configured `HttpClient`-backed `OrgChartService` instance.
+- Any existing tests touching `OrgChart*` continue to pass (currently none — see Dependencies).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact. This is a compile-time relocation; runtime behavior is identical.
+
+### NFR-2: Security
+No security impact. No new code paths, no new I/O, no new configuration.
+
+### NFR-3: Maintainability
+After the change, the OrgChart feature must match the layout convention used by all other feature modules (e.g. `Catalog`, `Invoices`, `MeetingTasks`), with `Services/` reserved for domain logic and `Infrastructure/` reserved for adapters. This makes future static-analysis or architecture-test rules (e.g. NetArchTest) able to enforce the boundary uniformly.
+
+### NFR-4: Git history
+The move must preserve `OrgChartService.cs`'s history — use `git mv` so `git log --follow` still works on the relocated file.
+
+## Data Model
+No changes. `OrgChartResponse`, `OrganizationDto`, `PositionDto`, `EmployeeDto` (in `Features/OrgChart/Contracts/`) and `OrgChartOptions` are untouched.
+
+## API / Interface Design
+
+### Internal interface (unchanged)
+```csharp
+// Features/OrgChart/Services/IOrgChartService.cs  (stays here)
+namespace Anela.Heblo.Application.Features.OrgChart.Services;
+
+public interface IOrgChartService
+{
+    Task<OrgChartResponse> GetOrganizationStructureAsync(CancellationToken cancellationToken = default);
+}
+```
+
+### Concrete adapter (relocated)
+```csharp
+// Features/OrgChart/Infrastructure/OrgChartService.cs  (moved here, namespace updated)
+namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+
+public class OrgChartService : IOrgChartService
+{
+    // body unchanged
+}
+```
+
+### Module registration (one using directive added)
+```csharp
+// Features/OrgChart/OrgChartModule.cs
+using Anela.Heblo.Application.Features.OrgChart.Services;        // existing
+using Anela.Heblo.Application.Features.OrgChart.Infrastructure;  // added
+// ...
+services.AddHttpClient<IOrgChartService, OrgChartService>();      // unchanged
+```
+
+### Public HTTP API
+No change. The route, request shape, response shape, and status codes exposed by `GetOrganizationStructureHandler` are not affected.
+
+## Dependencies
+- **No external service dependencies.** Pure source-tree refactor.
+- **No NuGet changes.** No package added, removed, or upgraded.
+- **No database changes.**
+- **No existing tests reference `OrgChartService` or `IOrgChartService` directly.** Repository-wide grep found zero test files referencing these symbols. The change therefore needs no test updates, but should be verified with the full backend test suite (`dotnet test`) to confirm no indirect breakage.
+- Affected source files (3 total):
+  1. `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` — deleted (moved).
+  2. `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` — created (moved-to target).
+  3. `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` — one `using` directive added.
+
+## Out of Scope
+- Renaming `OrgChartService` (the class name stays — only its folder/namespace changes).
+- Renaming or relocating `IOrgChartService`.
+- Refactoring `OrgChartService` internals (logging, error handling, retry/timeout/circuit-breaker policies, JSON options).
+- Adding unit or integration tests for `OrgChartService` (a separate concern; this spec is scoped to the relocation only).
+- Introducing an architecture-test (e.g. NetArchTest, ArchUnitNET) to enforce the Services-vs-Infrastructure boundary across all features.
+- Auditing or relocating any other potentially-misplaced files in other feature modules.
+- Frontend changes (none required).
+- Documentation updates beyond what is required by the change itself (none — `docs/architecture/filesystem.md` already documents the correct convention).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/task-plan.r1.md
+++ b/artifacts/feat-arch-review-orgchart-http-adapter-orgcha/task-plan.r1.md
@@ -1,0 +1,530 @@
+# Relocate OrgChartService HTTP Adapter to Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the concrete `OrgChartService` HTTP-client adapter from `Features/OrgChart/Services/` to `Features/OrgChart/Infrastructure/` (with matching namespace update) so the OrgChart module obeys the documented Services-vs-Infrastructure boundary used by every other feature module.
+
+**Architecture:** Pure source-tree refactor of one file plus one using-directive addition. The `IOrgChartService` interface (the abstraction the use-case handler depends on) stays in `Services/`; only the concrete adapter moves into a new `Infrastructure/` folder. No behavior, no API, no DI registration line, and no tests change. Git history is preserved via `git mv`.
+
+**Tech Stack:** .NET 8, C#, MediatR, Microsoft.Extensions.Http, Microsoft.Extensions.Options, xUnit (existing test suite — no new tests).
+
+---
+
+## File Structure
+
+**Modified files (3 total — exactly matches spec FR-5 / arch-review):**
+
+| Action  | Path | Responsibility |
+|---------|------|----------------|
+| Move (delete) | `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` | Concrete HTTP adapter — old location |
+| Move (create) | `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` | Concrete HTTP adapter — new location (byte-identical body, only namespace differs) |
+| Edit | `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` | DI registration — gain one `using` for the new namespace |
+
+**Unchanged files (do NOT touch):**
+
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/IOrgChartService.cs` — interface stays in `Services/` (consumer owns the abstraction).
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — already `using ...Services;` for `IOrgChartService`.
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — calls extension method by name, namespace-agnostic.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Contracts/*` — DTOs untouched.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartOptions.cs` — config class untouched.
+
+---
+
+## Task 1: Move OrgChartService.cs to Infrastructure via `git mv`
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` → `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs`
+
+- [ ] **Step 1: Pre-flight — confirm starting state**
+
+Run from the worktree root:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/
+```
+
+Expected output (no `Infrastructure/` yet):
+
+```
+Contracts
+OrgChartModule.cs
+OrgChartOptions.cs
+Services
+UseCases
+```
+
+And confirm the source file exists:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/Services/
+```
+
+Expected output includes both:
+
+```
+IOrgChartService.cs
+OrgChartService.cs
+```
+
+- [ ] **Step 2: Perform the move with `git mv` (auto-creates `Infrastructure/`)**
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+`git mv` creates the destination directory automatically. No `mkdir` step is needed.
+
+- [ ] **Step 3: Verify the move and that git detected a rename (not a delete+add)**
+
+```bash
+git status
+```
+
+Expected output contains exactly one `renamed:` line for this file (and nothing else under `Changes to be committed`):
+
+```
+On branch feat-arch-review-orgchart-http-adapter-orgcha
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+	renamed:    backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs -> backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+If git shows `deleted:` + `new file:` instead of `renamed:` — **stop**. That means rename detection failed and `git log --follow` will not work. Run `git diff --staged --find-renames=40` to inspect, then redo with `git mv` from a clean state. Default threshold (50%) should detect the rename since contents are byte-identical at this point.
+
+- [ ] **Step 4: Verify directory layout post-move**
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/
+```
+
+Expected (now includes `Infrastructure/`):
+
+```
+Contracts
+Infrastructure
+OrgChartModule.cs
+OrgChartOptions.cs
+Services
+UseCases
+```
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/Services/
+```
+
+Expected:
+
+```
+# Infrastructure/
+OrgChartService.cs
+
+# Services/
+IOrgChartService.cs
+```
+
+Do **not** commit yet — the file still has the old namespace and the build is broken.
+
+---
+
+## Task 2: Update the namespace in the moved file
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` (line 6 only)
+
+- [ ] **Step 1: Inspect line 6 of the moved file**
+
+```bash
+sed -n '1,8p' backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected output (note line 6 still says `.Services`):
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.OrgChart.Services;
+
+/// <summary>
+```
+
+- [ ] **Step 2: Replace the namespace line in-place**
+
+Edit the file so the namespace declaration at line 6 reads:
+
+```csharp
+namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+```
+
+Replace exactly this one line. The four `using` directives (lines 1–4), the blank line (5), and everything from line 7 onward must remain byte-identical to the original. Do NOT reorder usings, do NOT remove comments, do NOT touch the body of the class. The using `Anela.Heblo.Application.Features.OrgChart.Contracts;` (line 2) must be preserved — the class still depends on `OrgChartResponse`.
+
+- [ ] **Step 3: Verify the diff is exactly one line**
+
+```bash
+git diff --staged --no-color backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Note: after `git mv` followed by an edit, the file shows as `renamed:` plus modified content. To see just the content diff vs the original location, use:
+
+```bash
+git diff HEAD --no-color -- backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected: exactly one removed line and one added line in the diff hunks (ignoring rename header):
+
+```
+-namespace Anela.Heblo.Application.Features.OrgChart.Services;
++namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+```
+
+If the diff shows more than this one-for-one change, revert the file (`git restore --source=HEAD --staged --worktree <path>` then redo `git mv` and re-edit only that one line).
+
+- [ ] **Step 4: Verify there is no second `namespace` declaration**
+
+```bash
+grep -n '^namespace ' backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected: exactly one line:
+
+```
+6:namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+```
+
+If grep finds zero or more than one match, fix the file before continuing.
+
+- [ ] **Step 5: Verify the `Contracts` using directive is still present (spec FR-2 acceptance)**
+
+```bash
+grep -n 'using Anela.Heblo.Application.Features.OrgChart.Contracts;' \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected: one match on line 2.
+
+```
+2:using Anela.Heblo.Application.Features.OrgChart.Contracts;
+```
+
+Do **not** build yet — `OrgChartModule.cs` still can't resolve the concrete class.
+
+---
+
+## Task 3: Add the `Infrastructure` using directive to `OrgChartModule.cs`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` (insert one using directive)
+
+- [ ] **Step 1: Read the current state of `OrgChartModule.cs`**
+
+```bash
+cat backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+```
+
+Current top-of-file (lines 1–3):
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+```
+
+- [ ] **Step 2: Insert the new using directive**
+
+Add `using Anela.Heblo.Application.Features.OrgChart.Infrastructure;` immediately after the existing `using Anela.Heblo.Application.Features.OrgChart.Services;` line. The top of the file must read exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+```
+
+Note: the `Services` line stays — it is needed for `IOrgChartService` (interface lives in `Services`). The new `Infrastructure` line resolves the concrete `OrgChartService`.
+
+Do **not** touch anything else in the file. In particular, line 21 must remain exactly:
+
+```csharp
+services.AddHttpClient<IOrgChartService, OrgChartService>();
+```
+
+- [ ] **Step 3: Verify the diff is exactly one added line**
+
+```bash
+git diff --no-color backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+```
+
+Expected hunk:
+
+```
+@@ -1,3 +1,4 @@
+ using Anela.Heblo.Application.Features.OrgChart.Services;
++using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+ using Microsoft.Extensions.Configuration;
+ using Microsoft.Extensions.DependencyInjection;
+```
+
+If the diff shows anything more than this single added line, revert (`git checkout -- backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs`) and redo Step 2.
+
+---
+
+## Task 4: Build verification (`dotnet build`)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Restore + build the backend solution**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded.` with **0 Error(s)**. Any non-zero error count attributable to OrgChart symbols (e.g. `CS0246: The type or namespace name 'OrgChartService' could not be found`) means the namespace update or the using directive is wrong — recheck Tasks 2 and 3.
+
+Existing pre-refactor warnings unrelated to OrgChart may persist — that is acceptable provided no **new** warnings reference OrgChart. To isolate, search the build output:
+
+```bash
+cd backend && dotnet build 2>&1 | grep -iE 'orgchart|OrgChart' || echo "no OrgChart-related build messages"
+```
+
+Expected output: `no OrgChart-related build messages`.
+
+- [ ] **Step 2: Return to worktree root for the rest of the verification**
+
+```bash
+cd ..
+pwd
+```
+
+Expected: the worktree root (path ending in `feat-arch-review-orgchart-http-adapter-orgcha`).
+
+---
+
+## Task 5: Format verification (`dotnet format`)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Run `dotnet format` in verify-only mode against the moved file**
+
+```bash
+cd backend && dotnet format --include \
+  src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs \
+  src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs \
+  --verify-no-changes
+```
+
+Expected: exit code 0 with no output, or a message like `Format complete in <duration>. No files formatted.`
+
+If `dotnet format` reports drift (exit code 2), re-run **without** `--verify-no-changes` to apply fixes, then re-stage and re-verify. Common drift is whitespace at end of the inserted `using` line — applying `dotnet format` resolves it.
+
+- [ ] **Step 2: Re-stage any files `dotnet format` touched**
+
+```bash
+cd ..
+git add -u backend/src/Anela.Heblo.Application/Features/OrgChart/
+git status
+```
+
+Expected: still only the same `renamed:` + `modified:` files staged — nothing else.
+
+---
+
+## Task 6: Test verification (full backend suite)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Run the entire backend test suite**
+
+```bash
+cd backend && dotnet test --no-build
+```
+
+Expected: `Passed: <N>, Failed: 0, Skipped: <M>`.
+
+The spec confirms **zero existing tests reference `OrgChartService` or `IOrgChartService`** directly, so this run validates that no indirect breakage occurred (DI scanning, ApplicationModule wiring, etc.). If any test fails:
+
+1. Check whether the failure mentions OrgChart symbols.
+2. If yes → recheck Tasks 2 and 3 (namespace/using directive).
+3. If no → the failure is pre-existing and unrelated; capture the test name and report it but do not let it block this refactor. Cross-check by running the same command on `main` to confirm the baseline.
+
+- [ ] **Step 2: Return to worktree root**
+
+```bash
+cd ..
+```
+
+---
+
+## Task 7: History continuity check (arch-review amendment #1)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Verify `git log --follow` works on the relocated file**
+
+```bash
+git log --follow --oneline \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs | head -20
+```
+
+Expected: more than one commit, including historical commits from the file's life at `Features/OrgChart/Services/OrgChartService.cs`. If the output contains only one or two recent commits (i.e. only this refactor's commit when it lands), git did not detect the rename — go back to Task 1 Step 3 and diagnose.
+
+- [ ] **Step 2: Spot-check rename detection on the staged change**
+
+```bash
+git diff --staged --find-renames=50 --stat
+```
+
+Expected: the line for `OrgChartService.cs` shows `100% similarity` rename detection (or `99%` accounting for the one namespace line change):
+
+```
+.../Services/OrgChartService.cs => .../Infrastructure/OrgChartService.cs   (99%)
+```
+
+If it shows less than ~95%, contents drifted beyond the namespace line — diff against `HEAD` and revert any unintended edits.
+
+---
+
+## Task 8: Stale reference grep (arch-review amendment #2)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Grep the entire repository for the old fully-qualified concrete-class reference**
+
+```bash
+git grep -nE 'Anela\.Heblo\.Application\.Features\.OrgChart\.Services\.OrgChartService\b' || \
+  echo "no stale fully-qualified references"
+```
+
+Expected: `no stale fully-qualified references`. The only legitimate hit would be on the moved file itself if the namespace edit was botched — none should remain anywhere.
+
+- [ ] **Step 2: Grep for any remaining references to `OrgChart.Services` and confirm each one points only to `IOrgChartService`**
+
+```bash
+git grep -nE 'OrgChart\.Services' -- \
+  ':!docs/superpowers/plans/' \
+  ':!artifacts/'
+```
+
+Expected matches (and nothing else):
+
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/IOrgChartService.cs` — interface itself.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — `using Anela.Heblo.Application.Features.OrgChart.Services;` to resolve the interface.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` — the same `using` (now alongside the new `Infrastructure` using).
+
+If any other file references `OrgChart.Services` (e.g. a stale doc or comment that points at the old concrete class location), update it. Cross-reference the arch-review's note: there should be zero hits in `docs/` for the old path — verify:
+
+```bash
+git grep -nE 'OrgChart/Services/OrgChartService|OrgChart\.Services\.OrgChartService' -- docs/ || \
+  echo "no stale doc references"
+```
+
+Expected: `no stale doc references`.
+
+- [ ] **Step 3: Confirm `GetOrganizationStructureHandler.cs` and `ApplicationModule.cs` were not modified (spec FR-5)**
+
+```bash
+git diff --staged --name-only
+```
+
+Expected: exactly these three paths, in any order:
+
+```
+backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+```
+
+The third path appears because of the rename — that's expected. If any other file appears in `--name-only`, revert it (`git restore --staged <path>` then `git checkout -- <path>`).
+
+---
+
+## Task 9: Final commit
+
+**Files:** all three staged files from prior tasks.
+
+- [ ] **Step 1: Final `git status` sanity check**
+
+```bash
+git status
+```
+
+Expected exactly:
+
+```
+On branch feat-arch-review-orgchart-http-adapter-orgcha
+Changes to be committed:
+	renamed:    backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs -> backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+	modified:   backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+	modified:   backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+```
+
+(Some git versions consolidate the `renamed:` + `modified:` lines for the moved file into a single line. Either form is acceptable as long as the rename was detected.)
+
+If you see any `Untracked files:` for the OrgChart folder, or any unstaged modifications, resolve them before committing.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "refactor(orgchart): relocate HTTP adapter to Infrastructure folder
+
+Move OrgChartService concrete class from Features/OrgChart/Services/
+to Features/OrgChart/Infrastructure/ to match the Services-vs-Infrastructure
+boundary documented in docs/architecture/filesystem.md and used by every
+other feature module. IOrgChartService interface stays in Services/ as
+the abstraction the use-case handler depends on. Module gains one using
+directive to resolve the relocated concrete class for the existing
+AddHttpClient<IOrgChartService, OrgChartService>() registration.
+
+No behavior change, no API change, no test change."
+```
+
+- [ ] **Step 3: Verify the commit landed and rename survived**
+
+```bash
+git show --stat HEAD
+```
+
+Expected: the commit summary lists the rename (with `99%` or `100%` similarity), the modified `OrgChartService.cs` at the new path, and the one-line `OrgChartModule.cs` change. Nothing else.
+
+```bash
+git log --follow --oneline \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs | head -5
+```
+
+Expected: this commit at the top, followed by historical commits from before the move. If `--follow` produces only this commit, rename detection failed when the commit was created — `git commit --amend` after re-running `git mv` from a clean staging area can recover, but if the commit has already been pushed, prefer leaving it and noting it as a known git artifact.
+
+---
+
+## Acceptance Criteria Mapping (cross-check vs spec FRs)
+
+| Spec FR | Covered by |
+|---------|-----------|
+| FR-1 (file moved to Infrastructure with `git mv`) | Task 1 Steps 2–4 |
+| FR-2 (namespace updated to `...Infrastructure`, `Contracts` using preserved) | Task 2 Steps 2–5 |
+| FR-3 (`IOrgChartService` stays in `Services/`) | Task 8 Step 3 (file does not appear in diff) |
+| FR-4 (both usings present in `OrgChartModule.cs`, registration line unchanged) | Task 3 Steps 2–3 |
+| FR-5 (no other source files modified) | Task 8 Step 3 |
+| FR-6 (build green, format clean, behavior unchanged, tests pass) | Tasks 4, 5, 6 |
+| NFR-3 (matches convention of other feature modules) | Achieved by FR-1; verified visually in Task 1 Step 4 |
+| NFR-4 (git history preserved) | Task 7 Steps 1–2; final check in Task 9 Step 3 |
+| Arch-review amendment #1 (`git log --follow` verification) | Task 7 Step 1; reconfirmed Task 9 Step 3 |
+| Arch-review amendment #2 (stale reference grep) | Task 8 Steps 1–2 |
+| Arch-review amendment #3 (follow-up tracker) | Out of scope per spec — not a code task; raise as a separate ticket post-merge |
+
+---
+
+## Notes for the Executing Engineer
+
+- **Surgical changes only.** The diff for this PR is exactly: one rename, one line changed in the moved file (the namespace), one line added to `OrgChartModule.cs`. If your diff shows anything else (reordered usings, reformatted braces, "while I was in there" cleanups, refactored exception handling), revert and start over. The value of this PR is the byte-identical move — preserving it lets `git blame` and `git log --follow` keep working on every line of `OrgChartService.cs`.
+
+- **Do not refactor logic.** Retry/timeout/Polly/JSON-options improvements were explicitly listed as out-of-scope in the spec. Note them as follow-ups if you spot something, do not mix them in.
+
+- **Do not change the interface location.** Moving `IOrgChartService` into `Infrastructure/` would force the use-case handler to `using ...Infrastructure;`, defeating the boundary. The arch-review's Decision 1 explains why (consumer owns the abstraction / dependency inversion).
+
+- **Do not relocate other features' adapters.** The arch-review identified `MeetingTasks/Services/GraphPlannerService.cs`, `ExpeditionList/Services/FileSystemPrintQueueSink.cs`, etc. as similarly misfiled. Those are out of scope. File separate tickets after merge.
+
+- **Frontend / OpenAPI client / migrations / config.** None of these need changes. There is no contract change, no DB change, no env change.

--- a/backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
@@ -1,9 +1,10 @@
 using System.Text.Json;
 using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Anela.Heblo.Application.Features.OrgChart.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Anela.Heblo.Application.Features.OrgChart.Services;
+namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
 
 /// <summary>
 /// Service for retrieving organizational chart data from external source

--- a/backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.OrgChart.Services;
+using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/docs/superpowers/plans/2026-05-20-relocate-orgchart-http-adapter-to-infrastructure.md
+++ b/docs/superpowers/plans/2026-05-20-relocate-orgchart-http-adapter-to-infrastructure.md
@@ -1,0 +1,530 @@
+# Relocate OrgChartService HTTP Adapter to Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the concrete `OrgChartService` HTTP-client adapter from `Features/OrgChart/Services/` to `Features/OrgChart/Infrastructure/` (with matching namespace update) so the OrgChart module obeys the documented Services-vs-Infrastructure boundary used by every other feature module.
+
+**Architecture:** Pure source-tree refactor of one file plus one using-directive addition. The `IOrgChartService` interface (the abstraction the use-case handler depends on) stays in `Services/`; only the concrete adapter moves into a new `Infrastructure/` folder. No behavior, no API, no DI registration line, and no tests change. Git history is preserved via `git mv`.
+
+**Tech Stack:** .NET 8, C#, MediatR, Microsoft.Extensions.Http, Microsoft.Extensions.Options, xUnit (existing test suite — no new tests).
+
+---
+
+## File Structure
+
+**Modified files (3 total — exactly matches spec FR-5 / arch-review):**
+
+| Action  | Path | Responsibility |
+|---------|------|----------------|
+| Move (delete) | `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` | Concrete HTTP adapter — old location |
+| Move (create) | `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` | Concrete HTTP adapter — new location (byte-identical body, only namespace differs) |
+| Edit | `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` | DI registration — gain one `using` for the new namespace |
+
+**Unchanged files (do NOT touch):**
+
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/IOrgChartService.cs` — interface stays in `Services/` (consumer owns the abstraction).
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — already `using ...Services;` for `IOrgChartService`.
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — calls extension method by name, namespace-agnostic.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Contracts/*` — DTOs untouched.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartOptions.cs` — config class untouched.
+
+---
+
+## Task 1: Move OrgChartService.cs to Infrastructure via `git mv`
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` → `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs`
+
+- [ ] **Step 1: Pre-flight — confirm starting state**
+
+Run from the worktree root:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/
+```
+
+Expected output (no `Infrastructure/` yet):
+
+```
+Contracts
+OrgChartModule.cs
+OrgChartOptions.cs
+Services
+UseCases
+```
+
+And confirm the source file exists:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/Services/
+```
+
+Expected output includes both:
+
+```
+IOrgChartService.cs
+OrgChartService.cs
+```
+
+- [ ] **Step 2: Perform the move with `git mv` (auto-creates `Infrastructure/`)**
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+`git mv` creates the destination directory automatically. No `mkdir` step is needed.
+
+- [ ] **Step 3: Verify the move and that git detected a rename (not a delete+add)**
+
+```bash
+git status
+```
+
+Expected output contains exactly one `renamed:` line for this file (and nothing else under `Changes to be committed`):
+
+```
+On branch feat-arch-review-orgchart-http-adapter-orgcha
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+	renamed:    backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs -> backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+If git shows `deleted:` + `new file:` instead of `renamed:` — **stop**. That means rename detection failed and `git log --follow` will not work. Run `git diff --staged --find-renames=40` to inspect, then redo with `git mv` from a clean state. Default threshold (50%) should detect the rename since contents are byte-identical at this point.
+
+- [ ] **Step 4: Verify directory layout post-move**
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/
+```
+
+Expected (now includes `Infrastructure/`):
+
+```
+Contracts
+Infrastructure
+OrgChartModule.cs
+OrgChartOptions.cs
+Services
+UseCases
+```
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/
+ls backend/src/Anela.Heblo.Application/Features/OrgChart/Services/
+```
+
+Expected:
+
+```
+# Infrastructure/
+OrgChartService.cs
+
+# Services/
+IOrgChartService.cs
+```
+
+Do **not** commit yet — the file still has the old namespace and the build is broken.
+
+---
+
+## Task 2: Update the namespace in the moved file
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs` (line 6 only)
+
+- [ ] **Step 1: Inspect line 6 of the moved file**
+
+```bash
+sed -n '1,8p' backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected output (note line 6 still says `.Services`):
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.OrgChart.Contracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Anela.Heblo.Application.Features.OrgChart.Services;
+
+/// <summary>
+```
+
+- [ ] **Step 2: Replace the namespace line in-place**
+
+Edit the file so the namespace declaration at line 6 reads:
+
+```csharp
+namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+```
+
+Replace exactly this one line. The four `using` directives (lines 1–4), the blank line (5), and everything from line 7 onward must remain byte-identical to the original. Do NOT reorder usings, do NOT remove comments, do NOT touch the body of the class. The using `Anela.Heblo.Application.Features.OrgChart.Contracts;` (line 2) must be preserved — the class still depends on `OrgChartResponse`.
+
+- [ ] **Step 3: Verify the diff is exactly one line**
+
+```bash
+git diff --staged --no-color backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Note: after `git mv` followed by an edit, the file shows as `renamed:` plus modified content. To see just the content diff vs the original location, use:
+
+```bash
+git diff HEAD --no-color -- backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected: exactly one removed line and one added line in the diff hunks (ignoring rename header):
+
+```
+-namespace Anela.Heblo.Application.Features.OrgChart.Services;
++namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+```
+
+If the diff shows more than this one-for-one change, revert the file (`git restore --source=HEAD --staged --worktree <path>` then redo `git mv` and re-edit only that one line).
+
+- [ ] **Step 4: Verify there is no second `namespace` declaration**
+
+```bash
+grep -n '^namespace ' backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected: exactly one line:
+
+```
+6:namespace Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+```
+
+If grep finds zero or more than one match, fix the file before continuing.
+
+- [ ] **Step 5: Verify the `Contracts` using directive is still present (spec FR-2 acceptance)**
+
+```bash
+grep -n 'using Anela.Heblo.Application.Features.OrgChart.Contracts;' \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+```
+
+Expected: one match on line 2.
+
+```
+2:using Anela.Heblo.Application.Features.OrgChart.Contracts;
+```
+
+Do **not** build yet — `OrgChartModule.cs` still can't resolve the concrete class.
+
+---
+
+## Task 3: Add the `Infrastructure` using directive to `OrgChartModule.cs`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` (insert one using directive)
+
+- [ ] **Step 1: Read the current state of `OrgChartModule.cs`**
+
+```bash
+cat backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+```
+
+Current top-of-file (lines 1–3):
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+```
+
+- [ ] **Step 2: Insert the new using directive**
+
+Add `using Anela.Heblo.Application.Features.OrgChart.Infrastructure;` immediately after the existing `using Anela.Heblo.Application.Features.OrgChart.Services;` line. The top of the file must read exactly:
+
+```csharp
+using Anela.Heblo.Application.Features.OrgChart.Services;
+using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+```
+
+Note: the `Services` line stays — it is needed for `IOrgChartService` (interface lives in `Services`). The new `Infrastructure` line resolves the concrete `OrgChartService`.
+
+Do **not** touch anything else in the file. In particular, line 21 must remain exactly:
+
+```csharp
+services.AddHttpClient<IOrgChartService, OrgChartService>();
+```
+
+- [ ] **Step 3: Verify the diff is exactly one added line**
+
+```bash
+git diff --no-color backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+```
+
+Expected hunk:
+
+```
+@@ -1,3 +1,4 @@
+ using Anela.Heblo.Application.Features.OrgChart.Services;
++using Anela.Heblo.Application.Features.OrgChart.Infrastructure;
+ using Microsoft.Extensions.Configuration;
+ using Microsoft.Extensions.DependencyInjection;
+```
+
+If the diff shows anything more than this single added line, revert (`git checkout -- backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs`) and redo Step 2.
+
+---
+
+## Task 4: Build verification (`dotnet build`)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Restore + build the backend solution**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded.` with **0 Error(s)**. Any non-zero error count attributable to OrgChart symbols (e.g. `CS0246: The type or namespace name 'OrgChartService' could not be found`) means the namespace update or the using directive is wrong — recheck Tasks 2 and 3.
+
+Existing pre-refactor warnings unrelated to OrgChart may persist — that is acceptable provided no **new** warnings reference OrgChart. To isolate, search the build output:
+
+```bash
+cd backend && dotnet build 2>&1 | grep -iE 'orgchart|OrgChart' || echo "no OrgChart-related build messages"
+```
+
+Expected output: `no OrgChart-related build messages`.
+
+- [ ] **Step 2: Return to worktree root for the rest of the verification**
+
+```bash
+cd ..
+pwd
+```
+
+Expected: the worktree root (path ending in `feat-arch-review-orgchart-http-adapter-orgcha`).
+
+---
+
+## Task 5: Format verification (`dotnet format`)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Run `dotnet format` in verify-only mode against the moved file**
+
+```bash
+cd backend && dotnet format --include \
+  src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs \
+  src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs \
+  --verify-no-changes
+```
+
+Expected: exit code 0 with no output, or a message like `Format complete in <duration>. No files formatted.`
+
+If `dotnet format` reports drift (exit code 2), re-run **without** `--verify-no-changes` to apply fixes, then re-stage and re-verify. Common drift is whitespace at end of the inserted `using` line — applying `dotnet format` resolves it.
+
+- [ ] **Step 2: Re-stage any files `dotnet format` touched**
+
+```bash
+cd ..
+git add -u backend/src/Anela.Heblo.Application/Features/OrgChart/
+git status
+```
+
+Expected: still only the same `renamed:` + `modified:` files staged — nothing else.
+
+---
+
+## Task 6: Test verification (full backend suite)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Run the entire backend test suite**
+
+```bash
+cd backend && dotnet test --no-build
+```
+
+Expected: `Passed: <N>, Failed: 0, Skipped: <M>`.
+
+The spec confirms **zero existing tests reference `OrgChartService` or `IOrgChartService`** directly, so this run validates that no indirect breakage occurred (DI scanning, ApplicationModule wiring, etc.). If any test fails:
+
+1. Check whether the failure mentions OrgChart symbols.
+2. If yes → recheck Tasks 2 and 3 (namespace/using directive).
+3. If no → the failure is pre-existing and unrelated; capture the test name and report it but do not let it block this refactor. Cross-check by running the same command on `main` to confirm the baseline.
+
+- [ ] **Step 2: Return to worktree root**
+
+```bash
+cd ..
+```
+
+---
+
+## Task 7: History continuity check (arch-review amendment #1)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Verify `git log --follow` works on the relocated file**
+
+```bash
+git log --follow --oneline \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs | head -20
+```
+
+Expected: more than one commit, including historical commits from the file's life at `Features/OrgChart/Services/OrgChartService.cs`. If the output contains only one or two recent commits (i.e. only this refactor's commit when it lands), git did not detect the rename — go back to Task 1 Step 3 and diagnose.
+
+- [ ] **Step 2: Spot-check rename detection on the staged change**
+
+```bash
+git diff --staged --find-renames=50 --stat
+```
+
+Expected: the line for `OrgChartService.cs` shows `100% similarity` rename detection (or `99%` accounting for the one namespace line change):
+
+```
+.../Services/OrgChartService.cs => .../Infrastructure/OrgChartService.cs   (99%)
+```
+
+If it shows less than ~95%, contents drifted beyond the namespace line — diff against `HEAD` and revert any unintended edits.
+
+---
+
+## Task 8: Stale reference grep (arch-review amendment #2)
+
+**Files:** (none directly — verification only)
+
+- [ ] **Step 1: Grep the entire repository for the old fully-qualified concrete-class reference**
+
+```bash
+git grep -nE 'Anela\.Heblo\.Application\.Features\.OrgChart\.Services\.OrgChartService\b' || \
+  echo "no stale fully-qualified references"
+```
+
+Expected: `no stale fully-qualified references`. The only legitimate hit would be on the moved file itself if the namespace edit was botched — none should remain anywhere.
+
+- [ ] **Step 2: Grep for any remaining references to `OrgChart.Services` and confirm each one points only to `IOrgChartService`**
+
+```bash
+git grep -nE 'OrgChart\.Services' -- \
+  ':!docs/superpowers/plans/' \
+  ':!artifacts/'
+```
+
+Expected matches (and nothing else):
+
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/IOrgChartService.cs` — interface itself.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/UseCases/GetOrganizationStructure/GetOrganizationStructureHandler.cs` — `using Anela.Heblo.Application.Features.OrgChart.Services;` to resolve the interface.
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs` — the same `using` (now alongside the new `Infrastructure` using).
+
+If any other file references `OrgChart.Services` (e.g. a stale doc or comment that points at the old concrete class location), update it. Cross-reference the arch-review's note: there should be zero hits in `docs/` for the old path — verify:
+
+```bash
+git grep -nE 'OrgChart/Services/OrgChartService|OrgChart\.Services\.OrgChartService' -- docs/ || \
+  echo "no stale doc references"
+```
+
+Expected: `no stale doc references`.
+
+- [ ] **Step 3: Confirm `GetOrganizationStructureHandler.cs` and `ApplicationModule.cs` were not modified (spec FR-5)**
+
+```bash
+git diff --staged --name-only
+```
+
+Expected: exactly these three paths, in any order:
+
+```
+backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+```
+
+The third path appears because of the rename — that's expected. If any other file appears in `--name-only`, revert it (`git restore --staged <path>` then `git checkout -- <path>`).
+
+---
+
+## Task 9: Final commit
+
+**Files:** all three staged files from prior tasks.
+
+- [ ] **Step 1: Final `git status` sanity check**
+
+```bash
+git status
+```
+
+Expected exactly:
+
+```
+On branch feat-arch-review-orgchart-http-adapter-orgcha
+Changes to be committed:
+	renamed:    backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs -> backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+	modified:   backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs
+	modified:   backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartModule.cs
+```
+
+(Some git versions consolidate the `renamed:` + `modified:` lines for the moved file into a single line. Either form is acceptable as long as the rename was detected.)
+
+If you see any `Untracked files:` for the OrgChart folder, or any unstaged modifications, resolve them before committing.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "refactor(orgchart): relocate HTTP adapter to Infrastructure folder
+
+Move OrgChartService concrete class from Features/OrgChart/Services/
+to Features/OrgChart/Infrastructure/ to match the Services-vs-Infrastructure
+boundary documented in docs/architecture/filesystem.md and used by every
+other feature module. IOrgChartService interface stays in Services/ as
+the abstraction the use-case handler depends on. Module gains one using
+directive to resolve the relocated concrete class for the existing
+AddHttpClient<IOrgChartService, OrgChartService>() registration.
+
+No behavior change, no API change, no test change."
+```
+
+- [ ] **Step 3: Verify the commit landed and rename survived**
+
+```bash
+git show --stat HEAD
+```
+
+Expected: the commit summary lists the rename (with `99%` or `100%` similarity), the modified `OrgChartService.cs` at the new path, and the one-line `OrgChartModule.cs` change. Nothing else.
+
+```bash
+git log --follow --oneline \
+  backend/src/Anela.Heblo.Application/Features/OrgChart/Infrastructure/OrgChartService.cs | head -5
+```
+
+Expected: this commit at the top, followed by historical commits from before the move. If `--follow` produces only this commit, rename detection failed when the commit was created — `git commit --amend` after re-running `git mv` from a clean staging area can recover, but if the commit has already been pushed, prefer leaving it and noting it as a known git artifact.
+
+---
+
+## Acceptance Criteria Mapping (cross-check vs spec FRs)
+
+| Spec FR | Covered by |
+|---------|-----------|
+| FR-1 (file moved to Infrastructure with `git mv`) | Task 1 Steps 2–4 |
+| FR-2 (namespace updated to `...Infrastructure`, `Contracts` using preserved) | Task 2 Steps 2–5 |
+| FR-3 (`IOrgChartService` stays in `Services/`) | Task 8 Step 3 (file does not appear in diff) |
+| FR-4 (both usings present in `OrgChartModule.cs`, registration line unchanged) | Task 3 Steps 2–3 |
+| FR-5 (no other source files modified) | Task 8 Step 3 |
+| FR-6 (build green, format clean, behavior unchanged, tests pass) | Tasks 4, 5, 6 |
+| NFR-3 (matches convention of other feature modules) | Achieved by FR-1; verified visually in Task 1 Step 4 |
+| NFR-4 (git history preserved) | Task 7 Steps 1–2; final check in Task 9 Step 3 |
+| Arch-review amendment #1 (`git log --follow` verification) | Task 7 Step 1; reconfirmed Task 9 Step 3 |
+| Arch-review amendment #2 (stale reference grep) | Task 8 Steps 1–2 |
+| Arch-review amendment #3 (follow-up tracker) | Out of scope per spec — not a code task; raise as a separate ticket post-merge |
+
+---
+
+## Notes for the Executing Engineer
+
+- **Surgical changes only.** The diff for this PR is exactly: one rename, one line changed in the moved file (the namespace), one line added to `OrgChartModule.cs`. If your diff shows anything else (reordered usings, reformatted braces, "while I was in there" cleanups, refactored exception handling), revert and start over. The value of this PR is the byte-identical move — preserving it lets `git blame` and `git log --follow` keep working on every line of `OrgChartService.cs`.
+
+- **Do not refactor logic.** Retry/timeout/Polly/JSON-options improvements were explicitly listed as out-of-scope in the spec. Note them as follow-ups if you spot something, do not mix them in.
+
+- **Do not change the interface location.** Moving `IOrgChartService` into `Infrastructure/` would force the use-case handler to `using ...Infrastructure;`, defeating the boundary. The arch-review's Decision 1 explains why (consumer owns the abstraction / dependency inversion).
+
+- **Do not relocate other features' adapters.** The arch-review identified `MeetingTasks/Services/GraphPlannerService.cs`, `ExpeditionList/Services/FileSystemPrintQueueSink.cs`, etc. as similarly misfiled. Those are out of scope. File separate tickets after merge.
+
+- **Frontend / OpenAPI client / migrations / config.** None of these need changes. There is no contract change, no DB change, no env change.


### PR DESCRIPTION
OrgChart

## Finding
`backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` is an HTTP client adapter — it calls an external URL, receives raw JSON, and deserializes it. It contains zero domain or business logic. Yet it lives in `Services/`, a folder that `docs/architecture/filesystem.md` defines as holding **"Domain services and business logic"**.

The same filesystem doc defines `Features/{Feature}/Infrastructure/` as the home for **"Feature infrastructure"**, which is exactly what an external-API adapter is.

## Why it matters
Misplacing infrastructure code in the `Services/` layer blurs the distinction between domain logic and I/O concerns. A future developer looking for "where HTTP calls happen" will not find it in `Infrastructure/`, and a developer scanning `Services/` for business rules will wade through HTTP plumbing. The naming mismatch also makes it harder to enforce Clean Architecture boundaries via static analysis.

## Suggested fix
Move the file (and nothing else — no logic changes needed):

```
Before: Application/Features/OrgChart/Services/OrgChartService.cs
After:  Application/Features/OrgChart/Infrastructure/OrgChartService.cs
```

`IOrgChartService` stays in `Services/` (it is the domain-facing contract); only the concrete implementation moves to `Infrastructure/`. Update the namespace accordingly.

---
_Filed by daily arch-review routine on 2026-05-19._

---

Closes #1430

### Tokens used
13057481
