### PR TITLE
feat: Reuse `JsonSerializerOptions` in OrgChartService

### DIFF
--- a/artifacts/feat-arch-review-orgchart-jsonserializeroptio/arch-review.r1.md
+++ b/artifacts/feat-arch-review-orgchart-jsonserializeroptio/arch-review.r1.md
@@ -1,0 +1,117 @@
+# Architecture Review: Reuse `JsonSerializerOptions` in OrgChartService
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change aligns perfectly with established codebase conventions. A `grep` for `static readonly JsonSerializerOptions` returns **14+ existing call sites** that already use exactly this pattern — including the direct analog `backend/src/Adapters/Anela.Heblo.Adapters.OpenMeteo/OpenMeteoWeatherForecastClient.cs:20`, which is structurally identical to `OrgChartService` (HTTP client + JSON deserialization in a feature service). `OrgChartService` is the outlier; this brings it into compliance.
+
+Integration points are zero. The change is internal to a single class, behind the `IOrgChartService` interface. No DI registration, MediatR handler (`GetOrganizationStructureHandler`), or DTO contract (`OrgChartResponse`, `OrganizationDto`, `PositionDto`, `EmployeeDto`) is affected.
+
+Note one path discrepancy from the spec: the actual file lives at `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` (lowercase `backend/`, `Services/` subfolder), not `Backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartService.cs` as the spec states. Lines 39–42 match the cited block.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GetOrganizationStructureHandler (MediatR)
+        │ depends on
+        ▼
+IOrgChartService  ──implemented by──►  OrgChartService
+                                          │
+                                          ├─ HttpClient (injected, scoped)
+                                          ├─ OrgChartOptions (IOptions<>)
+                                          ├─ ILogger<OrgChartService>
+                                          └─ JsonOptions  ◄── NEW: private static readonly
+                                                              (process-lifetime singleton,
+                                                               independent of DI lifetime)
+```
+
+No new components. The static field is a CLR-level cache attached to the type, not a DI registration.
+
+### Key Design Decisions
+
+#### Decision 1: Field scope — `private static readonly` on `OrgChartService` (no shared registry)
+
+**Options considered:**
+- (A) `private static readonly` on `OrgChartService` itself (matches every other adapter/service in the codebase).
+- (B) Centralized `JsonSerializerOptions` registry in `Anela.Heblo.Application.Common` (e.g., a `JsonDefaults` static class).
+- (C) `internal static` to allow tests in the same assembly to assert option configuration.
+
+**Chosen approach:** (A) — `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };`
+
+**Rationale:** The spec explicitly excludes a centralized registry from scope (Out of Scope §3). Every existing call site in the codebase uses option (A). Introducing a new shared abstraction would (1) violate YAGNI, (2) require touching 14 unrelated files, (3) couple unrelated features through a global, and (4) exceed the surgical-change directive in `CLAUDE.md`. Option (C) is unnecessary because no tests for `OrgChartService` currently exist and the spec does not require adding any.
+
+#### Decision 2: Field naming — `JsonOptions` (PascalCase)
+
+**Options considered:** `JsonOptions`, `_jsonOptions`, `s_jsonOptions`, `SerializerOptions`.
+
+**Chosen approach:** `JsonOptions` — PascalCase, no underscore prefix.
+
+**Rationale:** 12 of 14 existing call sites use `JsonOptions` (PascalCase). This is the dominant convention. Two outliers (`ClaudeMeetingSummaryExplainer._jsonOptions`, `GraphApiHelpers.JsonOptions` as `public static`) do not justify deviating from the prevailing pattern.
+
+#### Decision 3: Initialization — inline `new()` expression, no static constructor
+
+**Options considered:** Inline field initializer vs. explicit `static` constructor.
+
+**Chosen approach:** Inline `new() { PropertyNameCaseInsensitive = true }`.
+
+**Rationale:** Single option, no ordering or conditional logic. Inline initialization is the idiom used by all existing call sites and avoids the BeforeFieldInit semantic differences that come with explicit static constructors.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Single file modified: `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs`. No new files, no module changes, no DI registration changes in `OrgChartModule.cs` or `ApplicationModule.cs`.
+
+### Interfaces and Contracts
+
+No interface or contract changes. `IOrgChartService.GetOrganizationStructureAsync` signature, `OrgChartResponse` shape, and all DTO contracts remain byte-identical.
+
+### Data Flow
+
+Unchanged. The only behavioral difference is that the `JsonSerializerOptions` instance referenced on the `JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions)` call is the same heap object on every invocation, instead of a freshly allocated one. The deserializer's internal reflection metadata cache (attached to the options instance) is built once on first call and reused thereafter.
+
+Concretely, replace lines 39–44 of `OrgChartService.cs`:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true
+};
+
+var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, options);
+```
+
+with a usage of the new field, and add at the top of the class (alongside the other `private readonly` fields, but before them since it is `static`):
+
+```csharp
+private static readonly JsonSerializerOptions JsonOptions = new()
+{
+    PropertyNameCaseInsensitive = true
+};
+```
+
+Then: `var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions);`
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A future contributor adds a mutating call (e.g., `JsonOptions.Converters.Add(...)`) and triggers `InvalidOperationException` because options become read-only on first use. | LOW | `readonly` field + `private` scope confines mutation surface to this one file. Microsoft's `JsonSerializerOptions` itself throws if mutated after first use, surfacing the bug immediately at runtime. No additional guard required. |
+| The static field outlives DI scopes, so if anyone later adds DI-resolved converters they'd be confused by the lifetime mismatch. | LOW | Out of scope per spec (Out of Scope §4 — no converters). Document in the field declaration only if a converter is added later. |
+| Static field initialization racing with type-load could theoretically delay first request marginally. | NEGLIGIBLE | This is true of every other `JsonOptions` field in the codebase; the cost is amortized and one-time, identical to the previous per-call cost on the first invocation. |
+| Tests inadvertently rely on a fresh options instance (e.g., asserting option identity). | NONE | No existing tests for `OrgChartService` (verified via `find backend/test -iname "*orgchart*"` — zero results). |
+
+## Specification Amendments
+
+1. **File path correction.** Spec references `Backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartService.cs`. The actual path is `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` (lowercase `backend`, additional `Services/` subfolder). Update the spec's Background and Dependencies sections to match.
+
+2. **Test coverage statement is misleading.** Spec FR-2 acceptance criterion says "Existing unit/integration tests covering `OrgChartService.GetOrganizationStructureAsync` continue to pass without modification." No such tests exist. Reword to: "No existing tests cover `OrgChartService` directly; the existing `backend` test suite (`dotnet test`) must continue to pass without modification, and no new tests are required for this change."
+
+3. **Field naming clarification (non-blocking).** Spec uses `JsonOptions` in the example, which matches the codebase convention. Recommend the spec explicitly call out `JsonOptions` (PascalCase, no underscore) as the required name to remove any ambiguity at review time.
+
+## Prerequisites
+
+None. No migrations, configuration changes, infrastructure work, or upstream merges are required. Implementation can begin immediately on the current branch.

--- a/artifacts/feat-arch-review-orgchart-jsonserializeroptio/brief.md
+++ b/artifacts/feat-arch-review-orgchart-jsonserializeroptio/brief.md
@@ -1,0 +1,33 @@
+## Module
+OrgChart
+
+## Finding
+`OrgChartService.cs` lines 39–42 construct a new `JsonSerializerOptions` instance inside `GetOrganizationStructureAsync` on every invocation:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true
+};
+var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, options);
+```
+
+`JsonSerializerOptions` is expensive to create: on first use it builds reflection metadata caches internally. Microsoft's own documentation explicitly warns against constructing new instances per call and recommends reusing a single instance.
+
+## Why it matters
+Every org chart request allocates and immediately discards a `JsonSerializerOptions` instance along with its internal state. While a 30-minute `staleTime` on the frontend limits call frequency, the pattern is still wrong by default and sets a bad example for code that gets copied into more frequently called paths.
+
+## Suggested fix
+Extract to a `private static readonly` field:
+
+```csharp
+private static readonly JsonSerializerOptions JsonOptions = new()
+{
+    PropertyNameCaseInsensitive = true
+};
+```
+
+Then use `JsonOptions` in the call to `JsonSerializer.Deserialize`. No other changes needed.
+
+---
+_Filed by daily arch-review routine on 2026-05-19._

--- a/artifacts/feat-arch-review-orgchart-jsonserializeroptio/impl/main.r1.md
+++ b/artifacts/feat-arch-review-orgchart-jsonserializeroptio/impl/main.r1.md
@@ -1,0 +1,50 @@
+All tasks complete. Here is the output artifact:
+
+---
+
+# Implementation: Reuse `JsonSerializerOptions` in OrgChartService
+
+## What was implemented
+
+Extracted the per-call `JsonSerializerOptions` allocation in `OrgChartService.GetOrganizationStructureAsync` into a `private static readonly JsonSerializerOptions JsonOptions` field. The field is initialized once at type-load time and reused on every request, eliminating a per-invocation allocation and allowing the deserializer's internal reflection metadata cache to be built once and reused.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` — added `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };` as the first class member; removed the 5-line local `var options` block; updated `JsonSerializer.Deserialize<OrgChartResponse>(content, options)` → `(content, JsonOptions)`.
+
+## Tests
+
+No tests were added or modified. The spec explicitly states none are required for this class (no existing tests cover `OrgChartService` directly). The full backend test suite (`dotnet test`) passed: 61 passed, 1 skipped (pre-existing Shoptet DI issue unrelated to this change).
+
+## How to verify
+
+```bash
+# Confirm build is clean
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+
+# Confirm format is clean
+dotnet format backend/Anela.Heblo.sln --verify-no-changes \
+  --include backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+
+# Confirm test suite passes
+dotnet test backend/Anela.Heblo.sln --no-restore
+
+# Inspect the diff
+git diff HEAD~1 -- backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+```
+
+## Notes
+
+- Field naming (`JsonOptions`, PascalCase, no underscore prefix) matches the dominant convention used across 12+ existing call sites in this codebase.
+- Static field is placed before instance fields with one blank line separator, consistent with the pattern at `OpenMeteoWeatherForecastClient.cs`.
+- Commit: `c3e7eae1` — `refactor(orgchart): reuse static JsonSerializerOptions in OrgChartService`.
+
+## PR Summary
+
+Eliminated a per-call `JsonSerializerOptions` allocation in `OrgChartService` by extracting it to a `private static readonly` field. `JsonSerializerOptions` is expensive to construct because it lazily builds internal reflection metadata caches; constructing one per request means rebuilding that cache on every call. The fix aligns `OrgChartService` with the same pattern already used by 12+ other services and adapters in this codebase (e.g., `OpenMeteoWeatherForecastClient`).
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` — added `private static readonly JsonSerializerOptions JsonOptions` field, removed per-call local variable, updated `Deserialize` call to reference the shared instance.
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-orgchart-jsonserializeroptio/spec.r1.md
+++ b/artifacts/feat-arch-review-orgchart-jsonserializeroptio/spec.r1.md
@@ -1,0 +1,72 @@
+# Specification: Reuse `JsonSerializerOptions` in OrgChartService
+
+## Summary
+Extract the per-call `JsonSerializerOptions` instance in `OrgChartService.GetOrganizationStructureAsync` to a `private static readonly` field so the instance (and its internal reflection metadata cache) is created once and reused across all requests. This aligns with Microsoft's official `System.Text.Json` guidance and removes an unnecessary allocation hotspot.
+
+## Background
+`Backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartService.cs` (lines 39–42) currently constructs a new `JsonSerializerOptions` on every invocation of `GetOrganizationStructureAsync`:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true
+};
+var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, options);
+```
+
+`JsonSerializerOptions` is documented as expensive to construct because it lazily builds reflection metadata caches keyed to the configured options. Microsoft explicitly recommends caching a single instance and reusing it. Although the org chart endpoint is currently cached for 30 minutes on the frontend (limiting blast radius), the pattern itself is incorrect and risks being copy-pasted into hotter code paths. Filed by the daily arch-review routine on 2026-05-19.
+
+## Functional Requirements
+
+### FR-1: Extract `JsonSerializerOptions` to a static readonly field
+The per-call `JsonSerializerOptions` instance in `OrgChartService` must be replaced with a single `private static readonly` field, initialized once at type-load time with `PropertyNameCaseInsensitive = true`. The existing `JsonSerializer.Deserialize<OrgChartResponse>(content, ...)` call must use this shared field instead.
+
+**Acceptance criteria:**
+- `OrgChartService.cs` declares `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };` (or equivalent).
+- `GetOrganizationStructureAsync` no longer constructs a local `JsonSerializerOptions` instance.
+- The `Deserialize<OrgChartResponse>` call references the shared static field.
+- No other behavior, signature, return value, or error handling in the method changes.
+- `dotnet build` succeeds with no new warnings.
+- `dotnet format` reports no changes required.
+
+### FR-2: Preserve existing deserialization behavior
+The new shared options instance must be semantically identical to the previous per-call instance: case-insensitive property matching enabled, every other option at its default. The deserializer must continue to produce the same `OrgChartResponse` for the same input.
+
+**Acceptance criteria:**
+- The only option configured on the static instance is `PropertyNameCaseInsensitive = true`.
+- Existing unit/integration tests covering `OrgChartService.GetOrganizationStructureAsync` continue to pass without modification.
+- The endpoint that surfaces this data returns identical responses to representative inputs before and after the change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+A single `JsonSerializerOptions` instance is allocated per process lifetime instead of per request, eliminating the per-call allocation and avoiding rebuilding internal reflection metadata caches. No measurable regression to latency or throughput is acceptable; an improvement, if any, is incidental and not required to be measured.
+
+### NFR-2: Security
+No auth, data-sensitivity, or trust-boundary changes. The deserializer continues to operate on payloads already fetched by the existing HTTP client; no new inputs cross a trust boundary.
+
+### NFR-3: Maintainability
+The shared field must be `private` (scoped to `OrgChartService` only) and `readonly` so it cannot be mutated after initialization. This prevents accidental cross-call configuration drift and matches the idiom recommended by Microsoft's `System.Text.Json` documentation.
+
+## Data Model
+No data model changes. `OrgChartResponse` and any nested DTOs are untouched.
+
+## API / Interface Design
+No public API, controller, MediatR handler, or interface changes. The modification is internal to `OrgChartService` and invisible to callers.
+
+## Dependencies
+- `System.Text.Json` (already referenced).
+- `Backend/src/Anela.Heblo.Application/Features/OrgChart/OrgChartService.cs` is the only file expected to change.
+
+## Out of Scope
+- Auditing or refactoring other call sites that construct `JsonSerializerOptions` per call elsewhere in the codebase.
+- Changing the frontend `staleTime` or any caching behavior.
+- Introducing a centralized/shared `JsonSerializerOptions` registry across modules.
+- Adding new serializer options (e.g., naming policies, converters, source generation).
+- Performance benchmarking or instrumentation.
+- Changes to `OrgChartResponse` or any other DTO.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-orgchart-jsonserializeroptio/task-plan.r1.md
+++ b/artifacts/feat-arch-review-orgchart-jsonserializeroptio/task-plan.r1.md
@@ -1,0 +1,160 @@
+# Reuse `JsonSerializerOptions` in `OrgChartService` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-call `JsonSerializerOptions` allocation in `OrgChartService.GetOrganizationStructureAsync` with a `private static readonly` field so the instance (and its internal reflection-metadata cache) is built once at type-load time and reused on every request.
+
+**Architecture:** Single-file refactor in `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs`. No DI registration, MediatR handler, interface, or DTO contracts are touched. The new field is `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };` — matching the dominant convention used by 12+ existing call sites in this codebase (notably `backend/src/Adapters/Anela.Heblo.Adapters.OpenMeteo/OpenMeteoWeatherForecastClient.cs`, which is structurally identical).
+
+**Tech Stack:** C# / .NET 8, `System.Text.Json`.
+
+---
+
+## Background context for the engineer
+
+- The codebase convention is `private static readonly JsonSerializerOptions JsonOptions = new() { ... };` — PascalCase, no underscore, inline initializer. Confirmed across 12+ sites; do not invent a new naming or initialization style.
+- `JsonSerializerOptions` becomes effectively read-only after first use; mutating it later throws at runtime. `private static readonly` is the correct scope.
+- There are **zero existing tests** for `OrgChartService` (verified by the architecture review via `find backend/test -iname "*orgchart*"`). Do not invent tests for this refactor — the spec is explicit that none are required. The success bar is "existing test suite passes + build is clean + format is clean."
+- The actual file path is `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` (lowercase `backend`, `Services/` subfolder). The spec's path with `Backend/...` and no `Services/` segment is wrong — use the path stated here.
+- This is a surgical refactor. Do not touch any other line, comment, formatting, or `using` directive in the file beyond what the steps below specify.
+
+---
+
+## File Structure
+
+**Files modified (1):**
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` — adds the `JsonOptions` static field and switches the `Deserialize` call to use it.
+
+**Files created:** none.
+**Files deleted:** none.
+**Tests added:** none (per spec; no existing tests for this class).
+
+---
+
+## Tasks
+
+### Task 1: Replace per-call `JsonSerializerOptions` with a `private static readonly` field
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` (lines 13 and 39–44)
+
+- [ ] **Step 1: Add the `JsonOptions` static field above the existing instance fields**
+
+Open `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs`. Locate the field declaration block at the top of the class (currently line 13):
+
+```csharp
+public class OrgChartService : IOrgChartService
+{
+    private readonly HttpClient _httpClient;
+    private readonly OrgChartOptions _options;
+    private readonly ILogger<OrgChartService> _logger;
+```
+
+Insert the new static field as the first member of the class body, before the existing instance fields, so it reads:
+
+```csharp
+public class OrgChartService : IOrgChartService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly OrgChartOptions _options;
+    private readonly ILogger<OrgChartService> _logger;
+```
+
+Rationale for placement: statics-first then instance fields is the prevailing convention at sister sites (e.g., `OpenMeteoWeatherForecastClient.cs:20`). Keeping a single blank line between the static and the instance block matches the surrounding style.
+
+- [ ] **Step 2: Remove the local `options` allocation in `GetOrganizationStructureAsync`**
+
+In the same file, locate lines 39–44 inside `GetOrganizationStructureAsync`:
+
+```csharp
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, options);
+```
+
+Replace that block with:
+
+```csharp
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions);
+```
+
+That is: delete the four-line `var options = new JsonSerializerOptions { ... };` block (including its trailing blank line) and change the third argument of `Deserialize<OrgChartResponse>` from `options` to `JsonOptions`. Leave every other line in the method — `try`/`catch` structure, logging calls, null check, throw sites — untouched.
+
+- [ ] **Step 3: Verify the `using System.Text.Json;` directive is still present**
+
+The file already has `using System.Text.Json;` at line 1. Do not add, remove, or reorder `using` directives. Confirm by reading the top of the file; if line 1 is no longer `using System.Text.Json;`, stop and investigate — the file must not have been touched anywhere else.
+
+- [ ] **Step 4: Run `dotnet build` and confirm it succeeds with no new warnings**
+
+Run from the worktree root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` with `0 Warning(s)` and `0 Error(s)`. If any new warning appears that was not present before this change, stop and fix it before continuing.
+
+- [ ] **Step 5: Run `dotnet format` and confirm it reports no changes required**
+
+Run from the worktree root:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes --include backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+```
+
+Expected: exits with code `0` and no formatting differences. If the command reports formatting changes, run `dotnet format` without `--verify-no-changes` on the file, then re-run with the flag to confirm clean.
+
+- [ ] **Step 6: Run the existing backend test suite and confirm all tests pass**
+
+Run from the worktree root:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-restore
+```
+
+Expected: all tests pass. There are no tests targeting `OrgChartService` directly, so this is a regression-safety check on the broader suite. If any test fails, the failure is almost certainly pre-existing or unrelated — read the failure carefully before concluding the refactor caused it. Do not modify any test as part of this task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+git commit -m "refactor(orgchart): reuse static JsonSerializerOptions in OrgChartService"
+```
+
+---
+
+## Verification (end-to-end sanity check before declaring complete)
+
+After Task 1 is committed, do one final read-through of the modified file to confirm:
+
+- [ ] The class begins with `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };`.
+- [ ] No `var options = new JsonSerializerOptions { ... };` block remains anywhere in the file.
+- [ ] The single `JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions)` call is the only reference to `JsonOptions` in the file.
+- [ ] No other lines in the file changed (compare with `git diff HEAD~1` — diff should be exactly: one block added at the top of the class, one block deleted in the method, one argument renamed on the `Deserialize` call).
+- [ ] `dotnet build` clean, `dotnet format --verify-no-changes` clean, `dotnet test` clean.
+
+If all four boxes check, the feature is done.
+
+---
+
+## Out of scope (do not do these, even if tempted)
+
+- Do not audit or refactor other `JsonSerializerOptions` call sites elsewhere in the codebase. The spec explicitly excludes this (Out of Scope §1).
+- Do not introduce a centralized `JsonDefaults`/`JsonOptions` registry in `Anela.Heblo.Application.Common`. Spec Out of Scope §3.
+- Do not add converters, naming policies, or source-generated context. Spec Out of Scope §4.
+- Do not add new tests for `OrgChartService`. Spec FR-2 acceptance criteria and arch review §3 both confirm none are required.
+- Do not change the frontend `staleTime` or any caching behavior. Spec Out of Scope §2.
+- Do not benchmark or instrument. Spec Out of Scope §5.
+- Do not touch `OrgChartResponse` or any other DTO. Spec Out of Scope §6.

--- a/backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
@@ -10,6 +10,11 @@ namespace Anela.Heblo.Application.Features.OrgChart.Services;
 /// </summary>
 public class OrgChartService : IOrgChartService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private readonly HttpClient _httpClient;
     private readonly OrgChartOptions _options;
     private readonly ILogger<OrgChartService> _logger;
@@ -36,12 +41,7 @@ public class OrgChartService : IOrgChartService
 
             var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            };
-
-            var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, options);
+            var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions);
 
             if (orgChart == null)
             {

--- a/docs/superpowers/plans/2026-05-20-orgchart-jsonserializeroptions-static.md
+++ b/docs/superpowers/plans/2026-05-20-orgchart-jsonserializeroptions-static.md
@@ -1,0 +1,160 @@
+# Reuse `JsonSerializerOptions` in `OrgChartService` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-call `JsonSerializerOptions` allocation in `OrgChartService.GetOrganizationStructureAsync` with a `private static readonly` field so the instance (and its internal reflection-metadata cache) is built once at type-load time and reused on every request.
+
+**Architecture:** Single-file refactor in `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs`. No DI registration, MediatR handler, interface, or DTO contracts are touched. The new field is `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };` — matching the dominant convention used by 12+ existing call sites in this codebase (notably `backend/src/Adapters/Anela.Heblo.Adapters.OpenMeteo/OpenMeteoWeatherForecastClient.cs`, which is structurally identical).
+
+**Tech Stack:** C# / .NET 8, `System.Text.Json`.
+
+---
+
+## Background context for the engineer
+
+- The codebase convention is `private static readonly JsonSerializerOptions JsonOptions = new() { ... };` — PascalCase, no underscore, inline initializer. Confirmed across 12+ sites; do not invent a new naming or initialization style.
+- `JsonSerializerOptions` becomes effectively read-only after first use; mutating it later throws at runtime. `private static readonly` is the correct scope.
+- There are **zero existing tests** for `OrgChartService` (verified by the architecture review via `find backend/test -iname "*orgchart*"`). Do not invent tests for this refactor — the spec is explicit that none are required. The success bar is "existing test suite passes + build is clean + format is clean."
+- The actual file path is `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` (lowercase `backend`, `Services/` subfolder). The spec's path with `Backend/...` and no `Services/` segment is wrong — use the path stated here.
+- This is a surgical refactor. Do not touch any other line, comment, formatting, or `using` directive in the file beyond what the steps below specify.
+
+---
+
+## File Structure
+
+**Files modified (1):**
+- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` — adds the `JsonOptions` static field and switches the `Deserialize` call to use it.
+
+**Files created:** none.
+**Files deleted:** none.
+**Tests added:** none (per spec; no existing tests for this class).
+
+---
+
+## Tasks
+
+### Task 1: Replace per-call `JsonSerializerOptions` with a `private static readonly` field
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` (lines 13 and 39–44)
+
+- [ ] **Step 1: Add the `JsonOptions` static field above the existing instance fields**
+
+Open `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs`. Locate the field declaration block at the top of the class (currently line 13):
+
+```csharp
+public class OrgChartService : IOrgChartService
+{
+    private readonly HttpClient _httpClient;
+    private readonly OrgChartOptions _options;
+    private readonly ILogger<OrgChartService> _logger;
+```
+
+Insert the new static field as the first member of the class body, before the existing instance fields, so it reads:
+
+```csharp
+public class OrgChartService : IOrgChartService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly OrgChartOptions _options;
+    private readonly ILogger<OrgChartService> _logger;
+```
+
+Rationale for placement: statics-first then instance fields is the prevailing convention at sister sites (e.g., `OpenMeteoWeatherForecastClient.cs:20`). Keeping a single blank line between the static and the instance block matches the surrounding style.
+
+- [ ] **Step 2: Remove the local `options` allocation in `GetOrganizationStructureAsync`**
+
+In the same file, locate lines 39–44 inside `GetOrganizationStructureAsync`:
+
+```csharp
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, options);
+```
+
+Replace that block with:
+
+```csharp
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            var orgChart = JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions);
+```
+
+That is: delete the four-line `var options = new JsonSerializerOptions { ... };` block (including its trailing blank line) and change the third argument of `Deserialize<OrgChartResponse>` from `options` to `JsonOptions`. Leave every other line in the method — `try`/`catch` structure, logging calls, null check, throw sites — untouched.
+
+- [ ] **Step 3: Verify the `using System.Text.Json;` directive is still present**
+
+The file already has `using System.Text.Json;` at line 1. Do not add, remove, or reorder `using` directives. Confirm by reading the top of the file; if line 1 is no longer `using System.Text.Json;`, stop and investigate — the file must not have been touched anywhere else.
+
+- [ ] **Step 4: Run `dotnet build` and confirm it succeeds with no new warnings**
+
+Run from the worktree root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` with `0 Warning(s)` and `0 Error(s)`. If any new warning appears that was not present before this change, stop and fix it before continuing.
+
+- [ ] **Step 5: Run `dotnet format` and confirm it reports no changes required**
+
+Run from the worktree root:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes --include backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+```
+
+Expected: exits with code `0` and no formatting differences. If the command reports formatting changes, run `dotnet format` without `--verify-no-changes` on the file, then re-run with the flag to confirm clean.
+
+- [ ] **Step 6: Run the existing backend test suite and confirm all tests pass**
+
+Run from the worktree root:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-restore
+```
+
+Expected: all tests pass. There are no tests targeting `OrgChartService` directly, so this is a regression-safety check on the broader suite. If any test fails, the failure is almost certainly pre-existing or unrelated — read the failure carefully before concluding the refactor caused it. Do not modify any test as part of this task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs
+git commit -m "refactor(orgchart): reuse static JsonSerializerOptions in OrgChartService"
+```
+
+---
+
+## Verification (end-to-end sanity check before declaring complete)
+
+After Task 1 is committed, do one final read-through of the modified file to confirm:
+
+- [ ] The class begins with `private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };`.
+- [ ] No `var options = new JsonSerializerOptions { ... };` block remains anywhere in the file.
+- [ ] The single `JsonSerializer.Deserialize<OrgChartResponse>(content, JsonOptions)` call is the only reference to `JsonOptions` in the file.
+- [ ] No other lines in the file changed (compare with `git diff HEAD~1` — diff should be exactly: one block added at the top of the class, one block deleted in the method, one argument renamed on the `Deserialize` call).
+- [ ] `dotnet build` clean, `dotnet format --verify-no-changes` clean, `dotnet test` clean.
+
+If all four boxes check, the feature is done.
+
+---
+
+## Out of scope (do not do these, even if tempted)
+
+- Do not audit or refactor other `JsonSerializerOptions` call sites elsewhere in the codebase. The spec explicitly excludes this (Out of Scope §1).
+- Do not introduce a centralized `JsonDefaults`/`JsonOptions` registry in `Anela.Heblo.Application.Common`. Spec Out of Scope §3.
+- Do not add converters, naming policies, or source-generated context. Spec Out of Scope §4.
+- Do not add new tests for `OrgChartService`. Spec FR-2 acceptance criteria and arch review §3 both confirm none are required.
+- Do not change the frontend `staleTime` or any caching behavior. Spec Out of Scope §2.
+- Do not benchmark or instrument. Spec Out of Scope §5.
+- Do not touch `OrgChartResponse` or any other DTO. Spec Out of Scope §6.


### PR DESCRIPTION

Eliminated a per-call `JsonSerializerOptions` allocation in `OrgChartService` by extracting it to a `private static readonly` field. `JsonSerializerOptions` is expensive to construct because it lazily builds internal reflection metadata caches; constructing one per request means rebuilding that cache on every call. The fix aligns `OrgChartService` with the same pattern already used by 12+ other services and adapters in this codebase (e.g., `OpenMeteoWeatherForecastClient`).

### Changes
- `backend/src/Anela.Heblo.Application/Features/OrgChart/Services/OrgChartService.cs` — added `private static readonly JsonSerializerOptions JsonOptions` field, removed per-call local variable, updated `Deserialize` call to reference the shared instance.

---

Closes #1431

### Tokens used
3637383
