### PR TITLE
fix(smartsupp): null ContactId when referenced contact is missing to prevent FK violation

### DIFF
--- a/backend/src/Anela.Heblo.Persistence/Smartsupp/SmartsuppRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Smartsupp/SmartsuppRepository.cs
@@ -76,6 +76,14 @@ public sealed class SmartsuppRepository : ISmartsuppRepository
         SmartsuppConversation conversation,
         CancellationToken cancellationToken)
     {
+        if (conversation.ContactId is not null)
+        {
+            var contactExists = await _db.SmartsuppContacts
+                .AnyAsync(c => c.Id == conversation.ContactId, cancellationToken);
+            if (!contactExists)
+                conversation.ContactId = null;
+        }
+
         var existing = await _db.SmartsuppConversations
             .FirstOrDefaultAsync(c => c.Id == conversation.Id, cancellationToken);
 


### PR DESCRIPTION
When a `conversation.opened` (or any conversation event) arrives before the referenced contact exists in `SmartsuppContacts`, inserting the conversation fails with PostgreSQL error 23503 (FK violation on `FK_SmartsuppConversations_SmartsuppContacts_ContactId`).

`UpsertConversationAsync` now checks whether the referenced contact exists and sets `ContactId` to `null` if it does not. The FK is already optional (`IsRequired(false)`, `OnDelete = SetNull`), so the conversation is saved cleanly and linked once the contact arrives via a later event.

`ContactName` and `ContactEmail` stored directly on the conversation row are unaffected and remain available for display.