### PR TITLE
fix(meeting-tasks): raise Anthropic HTTP timeout to 180s and warn on empty extraction

### DIFF
--- a/backend/src/Anela.Heblo.API/appsettings.json
+++ b/backend/src/Anela.Heblo.API/appsettings.json
@@ -160,7 +160,8 @@
     "Organization": ""
   },
   "Anthropic": {
-    "ApiKey": ""
+    "ApiKey": "",
+    "HttpTimeoutSeconds": 180
   },
   "Plaud": {
     "CliExecutablePath": "plaud",

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/ClaudeMeetingTaskExtractor.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/ClaudeMeetingTaskExtractor.cs
@@ -60,9 +60,14 @@ public sealed class ClaudeMeetingTaskExtractor : IMeetingTaskExtractor
 
             try
             {
-                var result = JsonSerializer.Deserialize<List<ExtractedTask>>(text, JsonOptions);
+                var result = JsonSerializer.Deserialize<List<ExtractedTask>>(text, JsonOptions) ?? [];
 
-                return result ?? [];
+                if (result.Count == 0)
+                {
+                    _logger.LogWarning("Meeting task extraction completed with no tasks — Claude returned an empty array");
+                }
+
+                return result;
             }
             catch (JsonException ex)
             {

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/ClaudeMeetingTaskExtractorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/ClaudeMeetingTaskExtractorTests.cs
@@ -142,6 +142,24 @@ public sealed class ClaudeMeetingTaskExtractorTests
     }
 
     [Fact]
+    public async Task ExtractAsync_WhenResponseIsEmptyArray_LogsWarningAndReturnsEmpty()
+    {
+        SetupResponse("[]");
+
+        var result = await _extractor.ExtractAsync("summary", "transcript", CancellationToken.None);
+
+        result.Should().BeEmpty();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("no tasks")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ExtractAsync_WhenApiThrows_LogsErrorAndReturnsEmpty()
     {
         _mockChatClient


### PR DESCRIPTION
## Summary

Production Claude calls for meeting transcript extraction were hitting the default 60s `HttpClient.Timeout`, causing `ClaudeMeetingTaskExtractor` to silently swallow the `TaskCanceledException` and persist zero proposed tasks (App Insights confirmed this on transcript `7b69b83f-…` via a real timeout exception). This PR raises `Anthropic:HttpTimeoutSeconds` to 180s and adds a `LogWarning` when the extractor returns an empty array, so the legitimate "Claude returned `[]`" case is visible under the prod Warning-level App Insights filter. After deploy, hitting Reimport on affected transcripts will repopulate Pending tasks (Approved/Rejected survive).

## Test plan

- [x] `dotnet test` — all 128 MeetingTasks + Anthropic tests pass, including new `ExtractAsync_WhenResponseIsEmptyArray_LogsWarningAndReturnsEmpty`
- [x] `dotnet format --verify-no-changes` clean
- [ ] After deploy: hit Reimport on transcript `7b69b83f-6447-472f-9004-111229a2e861` and confirm proposed tasks appear
- [ ] After deploy: verify next legitimately-empty extraction emits the new Warning trace in App Insights