### PR TITLE
fix(auth): resolve currentUser.Email from preferred_username/upn claims

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs
@@ -27,8 +27,14 @@ public class CurrentUserService : ICurrentUserService
                  ?? user?.FindFirst("sub")?.Value
                  ?? user?.FindFirst("oid")?.Value;
 
+        // Entra ID access tokens omit the `email` claim by default; the user's
+        // email/UPN lives in `preferred_username` (and sometimes `upn`).
+        // ClaimTypes.Upn covers the legacy JwtSecurityTokenHandler claim remap.
         var email = user?.FindFirst(ClaimTypes.Email)?.Value
-                    ?? user?.FindFirst("email")?.Value;
+                    ?? user?.FindFirst("email")?.Value
+                    ?? user?.FindFirst("preferred_username")?.Value
+                    ?? user?.FindFirst(ClaimTypes.Upn)?.Value
+                    ?? user?.FindFirst("upn")?.Value;
 
         return new CurrentUser(
             Id: id,

--- a/backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs
@@ -70,6 +70,44 @@ public class CurrentUserServiceTests
     }
 
     [Fact]
+    public void GetCurrentUser_WhenOnlyPreferredUsername_ReturnsItAsEmail()
+    {
+        // Entra ID access tokens omit the `email` claim by default and put the
+        // user's email/UPN in `preferred_username`. Without this fallback,
+        // production code reading currentUser.Email gets null.
+        var principal = Authenticated(new Claim("preferred_username", "ondra@anela.cz"));
+        var service = CreateService(principal);
+
+        var user = service.GetCurrentUser();
+
+        Assert.Equal("ondra@anela.cz", user.Email);
+    }
+
+    [Fact]
+    public void GetCurrentUser_WhenOnlyUpn_ReturnsItAsEmail()
+    {
+        var principal = Authenticated(new Claim("upn", "ondra@anela.cz"));
+        var service = CreateService(principal);
+
+        var user = service.GetCurrentUser();
+
+        Assert.Equal("ondra@anela.cz", user.Email);
+    }
+
+    [Fact]
+    public void GetCurrentUser_PrefersEmailOverPreferredUsername()
+    {
+        var principal = Authenticated(
+            new Claim(ClaimTypes.Email, "real@anela.cz"),
+            new Claim("preferred_username", "upn@anela.cz"));
+        var service = CreateService(principal);
+
+        var user = service.GetCurrentUser();
+
+        Assert.Equal("real@anela.cz", user.Email);
+    }
+
+    [Fact]
     public void GetCurrentUser_WhenUnauthenticated_ReturnsAnonymous()
     {
         var principal = new ClaimsPrincipal(new ClaimsIdentity());


### PR DESCRIPTION
## Summary

Entra ID access tokens do not emit the `email` claim by default — the user's email/UPN lives in `preferred_username` (and sometimes `upn`). `CurrentUserService` only inspected `ClaimTypes.Email`/`email`, so `currentUser.Email` was `null` in production, which broke Smartsupp **SendMessage** (returned `SmartsuppAgentMappingNotFound` despite #1487 shipping the correct `AgentMap` entry for the signed-in user) and silently degraded `MeetingAccessGuard`, `UpdateMeetingAccessHandler`, and `GetTranscriptListHandler`. Mock and E2E sessions injected both `ClaimTypes.Email` and `preferred_username`, which is why the bug was invisible locally.

Adds `preferred_username` → `ClaimTypes.Upn` → `upn` fallbacks after the existing email lookups (so a real `email` claim still wins if Entra's optional email claim is enabled later), plus three xUnit cases covering each fallback and the precedence rule.

## Test plan

- [x] `dotnet build src/Anela.Heblo.Application` — 0 warnings, 0 errors
- [x] `dotnet test --filter CurrentUserServiceTests|SendMessageHandlerTests` — 15/15 pass (was 6/8 before the fix, with the two new claim fallbacks failing)
- [x] `dotnet format --verify-no-changes` on the changed file — clean
- [ ] Post-deploy smoke: send a Smartsupp message as a mapped user → expect `200 OK` instead of `SmartsuppAgentMappingNotFound`