### PR TITLE
feat: Consistent Not-Found Error Handling in PackingMaterials Module

### DIFF
--- a/artifacts/feat-arch-review-packingmaterials-not-found-e/arch-review.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-not-found-e/arch-review.r1.md
@@ -1,0 +1,210 @@
+# Architecture Review: Consistent Not-Found Error Handling in PackingMaterials Module
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with patterns already proven in the same module. The allocation handlers (`GetAllocations`, `CreateAllocation`, `UpdateAllocation`, `DeleteAllocation`) are the de-facto reference implementation: they all return responses extending `Anela.Heblo.Application.Shared.BaseResponse`, which already exposes `Success` and `ErrorCode` plus a localization `Params` dictionary. Each response additionally defines its own `Error` string property. The PackingMaterials controller already encodes the inverse mapping for allocations at `PackingMaterialsController.cs:166-235` using `NotFound(new { error = response.Error })`. The proposed change applies that exact recipe to four more handlers — no new shared infrastructure required.
+
+Two integration points need closer attention than the spec implies:
+
+1. **`DeletePackingMaterialRequest` uses `IRequest` (Unit), not `IRequest<TResponse>`.** Its handler is `IRequestHandler<DeletePackingMaterialRequest>` returning bare `Task`, and there is no `DeletePackingMaterialResponse.cs` file. Switching to a structured return requires changing the request contract, the handler signature, and creating a new response type. The other three handlers already return typed responses extending `BaseResponse`, so only their bodies change.
+2. **The controller envelope for not-found is `NotFound(new { error = response.Error })`, not `NotFound(response)`.** The spec's FR-6 example is wrong; it must match the allocation pattern verbatim to keep wire-format uniform.
+
+`ErrorCodes.ResourceNotFound` is already attributed `[HttpStatusCode(HttpStatusCode.NotFound)]`, so the enum side requires no change.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ PackingMaterialsController (Anela.Heblo.API)                │
+│                                                             │
+│   PUT  /{id}                  POST /{id}/quantity           │
+│   DEL  /{id}                  GET  /{id}/logs               │
+│                                                             │
+│   ┌─ inspect response.Success ──┐                           │
+│   │  ErrorCode == ResourceNotFound → NotFound(new { error })│
+│   │  Success == true            → Ok / NoContent           │
+│   │  else                       → BadRequest(new { error })│
+│   └─────────────────────────────┘                           │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ MediatR
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Use-case handlers (Anela.Heblo.Application/...)             │
+│   UpdatePackingMaterialHandler                              │
+│   UpdatePackingMaterialQuantityHandler                      │
+│   DeletePackingMaterialHandler                              │
+│   GetPackingMaterialLogsHandler                             │
+│                                                             │
+│   material is null → return Response {                      │
+│     Success = false,                                        │
+│     ErrorCode = ErrorCodes.ResourceNotFound,                │
+│     Error = "Packing material {id} not found."              │
+│   }                                                         │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+                IPackingMaterialRepository
+```
+
+### Key Design Decisions
+
+#### Decision 1: Add `Error` property per response, reuse `Success`/`ErrorCode` from `BaseResponse`
+**Options considered:**
+- (A) Add `Error` to each affected response only (mirrors `GetAllocationsResponse`, `CreateAllocationResponse`).
+- (B) Lift `Error` into `BaseResponse` so every response in the codebase gets it.
+
+**Chosen approach:** A.
+**Rationale:** Option B is a cross-cutting change touching every response across all modules and is explicitly out of scope. The current convention — `Success`/`ErrorCode`/`Params` on `BaseResponse`, `Error` free-text on individual responses — is what the allocation handlers and the controller wiring already follow. Stay surgical.
+
+#### Decision 2: Convert `DeletePackingMaterialRequest` to `IRequest<DeletePackingMaterialResponse>`
+**Options considered:**
+- (A) Keep `IRequest` (Unit) and use a try/catch in the controller mapping the exception to 404.
+- (B) Promote to `IRequest<DeletePackingMaterialResponse>`, create the response DTO, change handler signature.
+
+**Chosen approach:** B.
+**Rationale:** A reintroduces the throw-and-catch pattern this spec exists to eliminate and is inconsistent with the three sibling handlers and the allocation handlers. B is one extra file (`DeletePackingMaterialResponse.cs`) plus a signature change — small, mechanical, and uniform.
+
+#### Decision 3: Controller error envelope is `NotFound(new { error = response.Error })`, not `NotFound(response)`
+**Options considered:**
+- (A) `NotFound(response)` — serializes the whole response DTO, including `Success`, `ErrorCode`, and any payload fields (which would be null/default on the not-found path).
+- (B) `NotFound(new { error = response.Error })` — mirrors the allocation endpoints.
+
+**Chosen approach:** B.
+**Rationale:** The four allocation endpoints in the same controller already use B. Uniformity beats theoretical merit. The spec's example must be overridden here.
+
+#### Decision 4: Do not add try/catch wrappers in the four handlers
+**Options considered:**
+- (A) Wrap the handler body in try/catch and translate unexpected exceptions to a structured `{ Success = false, Error = "..." }` response, mirroring `GetAllocationsHandler` and `CreateAllocationHandler`.
+- (B) Leave unexpected exceptions to propagate to the global error handler (HTTP 500); only the not-found path is structured.
+
+**Chosen approach:** B for this PR.
+**Rationale:** The spec explicitly scopes "not-found case only" and excludes other error conditions. Adding catch-all wrappers expands scope and starts a debate (logging level, what counts as "user-displayable error", etc.) better addressed module-wide in a separate ticket. Note this as a follow-up — see Specification Amendments.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Files to **edit** (no new directories):
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs` (contains `UpdatePackingMaterialResponse` inline — add `Error`)
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs` (add `Error`)
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs` (add `Error`)
+- `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (four endpoints)
+
+Files to **create**:
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs`
+
+Tests (add to existing test project, mirroring `AllocationHandlerTests.cs`):
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (or split per-handler — match existing style; the module currently uses a single per-area `*HandlerTests.cs` file).
+- Reuse `MockPackingMaterialRepository` already used by `AllocationHandlerTests.cs`.
+
+### Interfaces and Contracts
+
+**New response (delete):**
+```csharp
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialResponse : BaseResponse
+{
+    public string? Error { get; set; }
+}
+```
+
+**Request signature change (delete):**
+```csharp
+public class DeletePackingMaterialRequest : IRequest<DeletePackingMaterialResponse>
+{
+    public int Id { get; set; }
+}
+```
+
+**Existing response extensions (additive — `Success`, `ErrorCode`, `Params` already come from `BaseResponse`):**
+
+```csharp
+// UpdatePackingMaterialResponse, UpdatePackingMaterialQuantityResponse,
+// GetPackingMaterialLogsResponse — each gains:
+public string? Error { get; set; }
+```
+
+The payload properties (`Material`, `Logs`) must remain. On the not-found path the handler returns a response with `Success = false`, the `Error` string set, and the payload property left as default (`null!` for `Material`, default for `Logs`). Callers MUST inspect `Success` before reading payload properties — controller does this; frontend currently throws on non-OK status before touching the body, so it is safe.
+
+**Handler return pattern (uniform across all four):**
+```csharp
+if (material == null)
+{
+    return new TResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = $"Packing material with ID {request.Id} not found."
+    };
+}
+```
+
+Use the exact message template `$"Packing material with ID {id} not found."` — this matches the existing allocation handler messages (`GetAllocationsHandler.cs:32`, `CreateAllocationHandler.cs:38`). This resolves FR-7 in favor of the existing convention rather than the spec's variant `"Packing material {id} not found."`.
+
+**Controller mapping pattern (uniform across all four endpoints):**
+```csharp
+var response = await _mediator.Send(request, cancellationToken);
+if (response.Success) return Ok(response);        // or NoContent() for Delete
+if (response.ErrorCode == ErrorCodes.ResourceNotFound)
+    return NotFound(new { error = response.Error });
+return BadRequest(new { error = response.Error });
+```
+
+For `DELETE /{id}`, the success branch is `NoContent()`. For `PUT /{id}`, `POST /{id}/quantity`, `GET /{id}/logs`, the success branch is `Ok(response)`.
+
+Add `[ProducesResponseType]` attributes to mirror the allocation endpoints (e.g. `200`, `404`).
+
+### Data Flow
+
+**Not-found path (e.g. `PUT /api/packing-materials/99` where 99 does not exist):**
+1. Controller dispatches `UpdatePackingMaterialRequest { Id = 99 }` via MediatR.
+2. `UpdatePackingMaterialHandler` calls `_repository.GetByIdAsync(99, ct)` → returns `null`.
+3. Handler returns `UpdatePackingMaterialResponse { Success = false, ErrorCode = ResourceNotFound, Error = "Packing material with ID 99 not found." }`.
+4. Controller inspects `response.Success == false`, checks `ErrorCode == ResourceNotFound`, returns `NotFound(new { error = response.Error })`.
+5. Client receives HTTP 404 with body `{ "error": "Packing material with ID 99 not found." }`.
+
+**Happy path:** unchanged. Handler sets `Success` implicitly via `BaseResponse` default (`true` in the parameterless constructor). Controller returns `Ok(response)` / `NoContent()`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Frontend hand-rolled `PackingMaterialsApiClient` (`frontend/src/api/hooks/usePackingMaterials.ts`) throws `new Error("API request failed: ${statusText}")` on any non-OK status. The behavior is identical for 404 and 500 — UI shows a generic error. | Low | No code change required. Document the audit result in the PR description per FR-9. If product wants distinct UX for "material not found", that is a separate ticket. |
+| `DeletePackingMaterialResponse` is a new type — OpenAPI client regeneration introduces a new generated TS type. | Low | Run `dotnet build` then `npm run build` to regenerate the client. Verify the generated client compiles (`api-client.ts` will gain the new type). Frontend currently invokes `deletePackingMaterial` via the hand-rolled `makeRequest<void>` and ignores the body — additive type does not break call sites. |
+| The four handlers under change do **not** have try/catch wrappers; unexpected exceptions still hit the global handler as HTTP 500. Mixed pattern with allocation handlers (which do wrap) remains. | Low | Out of scope. File a follow-up to align all PackingMaterials handlers' unexpected-exception treatment. Do not expand scope here. |
+| Tests for the four handlers do not exist today (only `AllocationHandlerTests.cs` exists for this module). FR-8 mandates new tests, and existing happy-path coverage for these handlers is also missing. | Medium | Add tests for both the not-found path (the FR) AND the happy path (so we don't merge untested code). Use `MockPackingMaterialRepository` from the existing test file. |
+| `UpdatePackingMaterialResponse` is declared inline in `UpdatePackingMaterialRequest.cs` (lines 15-18), unlike the others which are in separate files. Editing requires modifying that combined file. | Low | Edit in place. Do not move to a separate file in this PR (out of surgical scope). |
+| Empty `Material`/`Logs` payload fields on not-found responses serialize as `null` / default. If a future consumer assumes payload presence, it crashes. | Low | Mitigated by `Success` flag — controller redirects to 404 before the body is consumed for the success path. Frontend throws before reading. |
+| The `Params` localization dictionary on `BaseResponse` is unused by the allocation pattern (uses free-text `Error` instead). This PR continues that convention; if future i18n work requires `Params`, it will need to be reconciled module-wide. | Low | Acknowledge in PR description; do not introduce in this change. |
+
+## Specification Amendments
+
+1. **FR-6, controller envelope:** Override the spec's `NotFound(response)` with `NotFound(new { error = response.Error })`. The allocation controller uses the latter (see `PackingMaterialsController.cs:168, 191, 218, 233`). The non-success-non-not-found fallback is `BadRequest(new { error = response.Error })`, matching the same convention.
+
+2. **FR-7, message template:** The spec proposes `"Packing material {id} not found."`. The existing allocation handlers use `"Packing material with ID {id} not found."` (see `GetAllocationsHandler.cs:32`, `CreateAllocationHandler.cs:38`). Adopt the existing wording verbatim across all six handlers — uniformity over the spec's alternative phrasing.
+
+3. **FR-3, Delete contract change:** The spec implicitly assumes `DeletePackingMaterialResponse` exists. It does not. The PR must:
+   - Create `DeletePackingMaterialResponse.cs` (extending `BaseResponse`, with `Error` string).
+   - Change `DeletePackingMaterialRequest` from `IRequest` to `IRequest<DeletePackingMaterialResponse>`.
+   - Change `DeletePackingMaterialHandler` to `IRequestHandler<DeletePackingMaterialRequest, DeletePackingMaterialResponse>` returning `Task<DeletePackingMaterialResponse>`.
+   - Change the controller's `DeletePackingMaterial` action to capture the response, branch on `Success`, and return `NoContent()` on success.
+
+4. **NFR-5, observability:** The four handlers currently have no logger. Continue without injecting one in this PR — the spec lists this as acceptable, and the 404 response itself is observable in HTTP request logs. Do not add `ILogger` injection just for the not-found path; it would be a different change from the reference pattern (the four allocation handlers inject `ILogger` only because they have try/catch wrappers).
+
+5. **FR-9, frontend audit:** Confirmed audit result (record in PR description): the only call sites are in `frontend/src/api/hooks/usePackingMaterials.ts`, which throws a generic `Error` on any non-OK response. No call site distinguishes 404 from 500. No frontend code change is required. Generated client regeneration is automatic on backend build.
+
+6. **Happy-path success flag:** Affected handlers do not currently set `Success`. `BaseResponse`'s parameterless constructor sets it to `true`, so the happy path is correct by default. Do not add explicit `Success = true` assignments — they would be noise and inconsistent with the allocation success returns.
+
+## Prerequisites
+
+None. No migrations, no infrastructure, no new packages, no new shared types. All required building blocks (`BaseResponse`, `ErrorCodes.ResourceNotFound`, `[HttpStatusCode]` attribute mapping, controller-side envelope convention, MediatR dispatch) already exist. The OpenAPI TypeScript client regenerates automatically on `dotnet build`.

--- a/artifacts/feat-arch-review-packingmaterials-not-found-e/brief.md
+++ b/artifacts/feat-arch-review-packingmaterials-not-found-e/brief.md
@@ -1,0 +1,37 @@
+## Module
+PackingMaterials
+
+## Finding
+The module has two incompatible error-handling patterns for entity-not-found across its handlers:
+
+**Handlers that throw (→ unhandled exception → HTTP 500):**
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs:24` — `throw new ArgumentException($"PackingMaterial with ID {request.Id} not found")`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs:29-31` — `throw new ArgumentException(...)`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs:21` — `throw new InvalidOperationException(...)`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs:24` — `throw new InvalidOperationException(...)`
+
+**Handlers that return structured errors (→ controller maps → HTTP 404):**
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetAllocations/GetAllocationsHandler.cs:27-34` — returns `{ Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "..." }`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreateAllocation/CreateAllocationHandler.cs:38` — same pattern
+
+The controllers for `PUT /{id}`, `POST /{id}/quantity`, and `DELETE /{id}` do not have try/catch blocks for not-found, so the thrown exceptions will propagate to the global error handler and surface as HTTP 500 instead of 404.
+
+## Why it matters
+- Callers receive HTTP 500 when they pass a non-existent ID to update or delete endpoints — incorrect HTTP semantics, harder to debug, potentially misleading.
+- Two different patterns for the same scenario within the same module makes the codebase inconsistent and harder to maintain.
+- The allocation handlers' pattern (structured response with `ErrorCode`) is the one the controllers are designed to consume; the other pattern bypasses this entirely.
+
+## Suggested fix
+Align CRUD handlers with the allocation pattern. For each handler that currently throws on not-found, replace the `throw` with a structured return:
+
+```csharp
+// UpdatePackingMaterialHandler.cs:23-25 — replace:
+throw new ArgumentException($"PackingMaterial with ID {request.Id} not found");
+// with:
+return new UpdatePackingMaterialResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = $"Packing material {request.Id} not found." };
+```
+
+Then update the controllers to check `response.Success` and return `NotFound()` when `ErrorCode == ErrorCodes.ResourceNotFound`, matching the allocation endpoints.
+
+---
+_Filed by daily arch-review routine on 2026-05-20._

--- a/artifacts/feat-arch-review-packingmaterials-not-found-e/impl/main.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-not-found-e/impl/main.r1.md
@@ -1,0 +1,75 @@
+Here is the implementation output:
+
+---
+
+# Implementation: Consistent Not-Found Error Handling in PackingMaterials Module
+
+## What was implemented
+
+Replaced exception-throwing not-found behavior in four PackingMaterials CRUD handlers with the existing structured-return pattern used by the allocation handlers. `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, and `GET /api/packing-materials/{id}/logs` now return HTTP 404 instead of HTTP 500 for missing IDs.
+
+## Files created/modified
+
+### Application layer (handlers + DTOs)
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs` — added `string? Error` to inline `UpdatePackingMaterialResponse`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs` — added `string? Error`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs` — added `string? Error`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs` — **new file**, response DTO extending `BaseResponse`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs` — replaced `ArgumentException` throw with structured return
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs` — replaced `ArgumentException` throw with structured return
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs` — replaced `InvalidOperationException` throw with structured return
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs` — promoted from `IRequest` to `IRequest<DeletePackingMaterialResponse>`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs` — new typed handler returning `Task<DeletePackingMaterialResponse>`
+
+### API layer (controller)
+- `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` — four actions updated to inspect `response.Success`/`response.ErrorCode` and return 204/404/400
+
+### Tests
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` — **new file**, 8 handler tests (2 per handler)
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` — **new file**, 5 controller tests (1×404 per endpoint + 1×204 for Delete)
+
+## Tests
+
+**Handler tests** (`PackingMaterialCrudHandlerTests.cs`) — per handler:
+- `*_ReturnsNotFoundResponse_WhenMaterialDoesNotExist` — verifies `Success=false`, `ErrorCode=ResourceNotFound`, ID in error message
+- `*_UpdatesMaterial/DeletesAndReturnsSuccess_WhenMaterialExists` — verifies happy path still works
+
+**Controller tests** (`PackingMaterialsControllerNotFoundTests.cs`) — per endpoint:
+- `*_Returns404_WhenHandlerReturnsResourceNotFound` — mocks handler response, asserts HTTP 404
+- `DeletePackingMaterial_Returns204_WhenHandlerReturnsSuccess` — asserts HTTP 204
+
+## How to verify
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.PackingMaterials" --no-build
+```
+
+All 42 PackingMaterials tests pass. Full suite: 4,084/4,085 pass (1 pre-existing Shoptet integration failure unrelated to this change).
+
+## Notes
+
+- **Error message format**: `"Packing material with ID {id} not found."` — matches existing allocation handlers
+- **Controller envelope**: `NotFound(new { error = response.Error })` — matches allocation endpoints in the same controller
+- **`DeletePackingMaterialRequest` contract change**: promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>` — required because the not-found case needs a return channel
+- **No try/catch wrappers added**: allocation handlers have `try/catch` + logger because they predate this convention; the four CRUD handlers follow the simpler no-catch pattern per spec amendment
+- **Frontend audit (FR-9)**: All four affected endpoints are consumed in `usePackingMaterials.ts` via React Query hooks with generic error handlers that don't branch on HTTP status codes. No frontend code change required. Generated OpenAPI client regenerated automatically on build.
+- **Pre-existing lint issues**: 135 pre-existing frontend lint errors unrelated to this change
+
+## PR Summary
+
+Replace exception-throwing not-found behavior in four PackingMaterials CRUD handlers with the structured-return pattern already used by the allocation handlers in the same module. Requests to `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, and `GET /api/packing-materials/{id}/logs` with a non-existent ID now correctly return HTTP 404 instead of HTTP 500.
+
+The `DeletePackingMaterial` endpoint required the most change: `DeletePackingMaterialRequest` was promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>` so the handler has a return channel for the structured error. The other three handlers were simpler — a single line swap from `throw new ArgumentException/InvalidOperationException` to `return new Response { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "..." }`. All four affected controller actions were updated to inspect `response.Success` and map `ResourceNotFound` → `NotFound(new { error })`, matching the existing allocation endpoints verbatim.
+
+### Changes
+- `DeletePackingMaterialResponse.cs` — new response DTO (required for the contract promotion)
+- `DeletePackingMaterialRequest.cs` — promoted to `IRequest<DeletePackingMaterialResponse>`
+- `DeletePackingMaterialHandler.cs` — new typed handler signature + structured return
+- `UpdatePackingMaterialHandler.cs`, `UpdatePackingMaterialQuantityHandler.cs`, `GetPackingMaterialLogsHandler.cs` — throw replaced with structured return
+- `UpdatePackingMaterialRequest.cs`, `UpdatePackingMaterialQuantityResponse.cs`, `GetPackingMaterialLogsResponse.cs` — `string? Error` property added (additive)
+- `PackingMaterialsController.cs` — four actions updated with response inspection + `[ProducesResponseType]` attributes
+- `PackingMaterialCrudHandlerTests.cs` + `PackingMaterialsControllerNotFoundTests.cs` — new test files, 13 tests total
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-packingmaterials-not-found-e/spec.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-not-found-e/spec.r1.md
@@ -1,0 +1,188 @@
+# Specification: Consistent Not-Found Error Handling in PackingMaterials Module
+
+## Summary
+Align all PackingMaterials CRUD handlers with the existing allocation-handler pattern: return a structured response with `Success = false` and `ErrorCode = ErrorCodes.ResourceNotFound` instead of throwing exceptions, and update the corresponding controllers to map this to HTTP 404. This eliminates incorrect HTTP 500 responses on missing IDs and unifies error handling within the module.
+
+## Background
+The `PackingMaterials` module currently mixes two incompatible error-handling patterns for the "entity not found" case:
+
+1. **Throwing handlers** (`UpdatePackingMaterial`, `UpdatePackingMaterialQuantity`, `DeletePackingMaterial`, `GetPackingMaterialLogs`) throw `ArgumentException` or `InvalidOperationException`. Their controllers do not catch these, so the global error handler converts them to **HTTP 500**.
+2. **Structured-return handlers** (`GetAllocations`, `CreateAllocation`) return `{ Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "..." }`. Their controllers inspect `response.Success` and return **HTTP 404**.
+
+The structured pattern is the one the controllers are designed to consume; the throwing pattern bypasses it and produces incorrect HTTP semantics. Callers attempting `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, or `GET /api/packing-materials/{id}/logs` with a non-existent ID currently receive HTTP 500 instead of HTTP 404, which is misleading for clients and obscures the actual problem in logs and monitoring.
+
+The fix is small in scope, isolated to the `PackingMaterials` module, and follows an already-established convention used by the allocation endpoints in the same module.
+
+## Functional Requirements
+
+### FR-1: UpdatePackingMaterial returns structured not-found
+Replace the `throw new ArgumentException(...)` in `UpdatePackingMaterialHandler` with a structured response indicating the resource was not found, matching the allocation-handler pattern.
+
+**Acceptance criteria:**
+- `UpdatePackingMaterialHandler.cs:24` no longer throws when the material does not exist.
+- The handler returns `UpdatePackingMaterialResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "Packing material {id} not found." }`.
+- The error message includes the requested ID.
+- The handler signature, return type, and happy-path behavior are unchanged.
+
+### FR-2: UpdatePackingMaterialQuantity returns structured not-found
+Replace the `throw new ArgumentException(...)` in `UpdatePackingMaterialQuantityHandler` with a structured response.
+
+**Acceptance criteria:**
+- `UpdatePackingMaterialQuantityHandler.cs:29-31` no longer throws when the material does not exist.
+- The handler returns `UpdatePackingMaterialQuantityResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "Packing material {id} not found." }`.
+- Happy-path behavior is unchanged.
+
+### FR-3: DeletePackingMaterial returns structured not-found
+Replace the `throw new InvalidOperationException(...)` in `DeletePackingMaterialHandler` with a structured response.
+
+**Acceptance criteria:**
+- `DeletePackingMaterialHandler.cs:21` no longer throws when the material does not exist.
+- The handler returns `DeletePackingMaterialResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "Packing material {id} not found." }`.
+- Happy-path behavior (successful delete) is unchanged.
+
+### FR-4: GetPackingMaterialLogs returns structured not-found
+Replace the `throw new InvalidOperationException(...)` in `GetPackingMaterialLogsHandler` with a structured response.
+
+**Acceptance criteria:**
+- `GetPackingMaterialLogsHandler.cs:24` no longer throws when the material does not exist.
+- The handler returns `GetPackingMaterialLogsResponse { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "Packing material {id} not found." }`.
+- Happy-path behavior is unchanged.
+
+### FR-5: Response DTOs support structured error fields
+The four affected response DTOs (`UpdatePackingMaterialResponse`, `UpdatePackingMaterialQuantityResponse`, `DeletePackingMaterialResponse`, `GetPackingMaterialLogsResponse`) must expose the same error-shape contract as the allocation responses: `Success`, `ErrorCode`, and `Error` properties.
+
+**Acceptance criteria:**
+- Each affected response DTO has `bool Success { get; set; }`, `ErrorCodes? ErrorCode { get; set; }` (or the existing project convention used by allocation responses), and `string? Error { get; set; }` properties.
+- DTOs remain plain classes (not records), per the project's OpenAPI-client-generation rule in `CLAUDE.md`.
+- Existing consumers (frontend, other handlers) of these DTOs are not broken — `Success` defaults to `true` for happy-path returns, or the handler explicitly sets it.
+- The exact property naming, nullability, and type for `ErrorCode` matches the convention already used by `GetAllocationsResponse` / `CreateAllocationResponse` so the controller-side mapping is uniform.
+
+### FR-6: Controllers map structured not-found to HTTP 404
+The PackingMaterials controller endpoints for `PUT /{id}`, `POST /{id}/quantity`, `DELETE /{id}`, and `GET /{id}/logs` must inspect the handler response and return `NotFound()` when `Success == false && ErrorCode == ErrorCodes.ResourceNotFound`, matching the existing allocation controller logic.
+
+**Acceptance criteria:**
+- Each affected controller action checks `response.Success` after dispatching the MediatR request.
+- When `ErrorCode == ErrorCodes.ResourceNotFound`, the action returns `NotFound(response)` (or the existing project convention used by allocation endpoints — e.g. `NotFound(new { response.Error })`).
+- When `Success == true`, the action returns the existing success result (`Ok(response)`, `NoContent()`, etc.) unchanged.
+- Other error codes, if any are returned by these handlers in the future, fall through to a sensible default (e.g. `BadRequest(response)`) consistent with the allocation controller.
+- A request to `PUT /api/packing-materials/{nonexistent-id}` returns HTTP 404 (verified end-to-end).
+- The same applies to `POST /api/packing-materials/{nonexistent-id}/quantity`, `DELETE /api/packing-materials/{nonexistent-id}`, and `GET /api/packing-materials/{nonexistent-id}/logs`.
+
+### FR-7: Consistent error-message format
+The not-found error message string emitted by all four affected handlers uses a single, consistent format that includes the entity name and the requested ID.
+
+**Acceptance criteria:**
+- All four handlers emit the same message template (e.g. `"Packing material {id} not found."`).
+- The template matches the casing and punctuation already used by the allocation handlers' not-found messages, or, if those differ, a single project-wide convention is chosen and applied to all six handlers (four CRUD + two allocation). If the allocation messages are kept as-is, the new messages should at minimum follow the same template style.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance change is required or expected. Replacing exception-throwing with structured returns is, if anything, marginally faster on the not-found path because exception construction and stack-unwinding are avoided.
+
+### NFR-2: Security
+No security-sensitive surface area is touched. The error message format should not leak any data beyond the ID the caller already supplied. No authentication, authorization, or input-validation logic changes.
+
+### NFR-3: Backwards compatibility
+- The HTTP contract for the happy path (200/204) is unchanged.
+- The HTTP contract for the not-found path changes from **500 → 404**. This is an intentional and correcting break; any client currently relying on HTTP 500 for missing IDs is broken and should be fixed.
+- The shape of the success response body is unchanged. The error response body now contains `{ Success, ErrorCode, Error }` rather than the global error-handler's 500 payload — this is the intended new contract.
+- Frontend code that consumes these endpoints must be reviewed; if any code path catches HTTP 500 to detect not-found, it must be updated to handle HTTP 404. This is captured in FR-9 below.
+
+### NFR-4: Testability
+Each handler's not-found path must be unit-testable without provoking an exception. Each controller's 404 mapping must be testable via integration test or controller-level unit test.
+
+### NFR-5: Observability
+Removing the thrown exceptions removes the corresponding stack traces from the global error handler's logs. The handler's existing logger (if any) should log the not-found event at an appropriate level (e.g. `Information` or `Warning`) so the event remains visible. If no logger is used today on the throw path, none is required — the HTTP 404 response is itself observable in request logs.
+
+## Data Model
+
+No schema changes. The affected entities are:
+
+- `PackingMaterial` (existing) — looked up by `Id`. No changes.
+- `ErrorCodes` enum (existing, shared) — uses the existing `ResourceNotFound` value. No new enum members required.
+
+DTOs are extended (not redefined) to carry the structured-error fields per FR-5; this is purely additive and does not change database schemas or migrations.
+
+## API / Interface Design
+
+### Affected HTTP endpoints
+All paths are under the existing PackingMaterials controller (canonical base path: `/api/packing-materials`, confirmed during implementation).
+
+| Method | Path | Current not-found response | New not-found response |
+|---|---|---|---|
+| `PUT` | `/{id}` | 500 | 404 with `{ Success: false, ErrorCode: "ResourceNotFound", Error: "..." }` |
+| `POST` | `/{id}/quantity` | 500 | 404 with same body shape |
+| `DELETE` | `/{id}` | 500 | 404 with same body shape |
+| `GET` | `/{id}/logs` | 500 | 404 with same body shape |
+| `GET` | `/{id}/allocations` | 404 (already correct) | unchanged |
+| `POST` | `/{id}/allocations` | 404 (already correct) | unchanged |
+
+### Handler-level pattern (example)
+```csharp
+// UpdatePackingMaterialHandler — replace the throw with:
+var packingMaterial = await _repository.GetByIdAsync(request.Id, cancellationToken);
+if (packingMaterial is null)
+{
+    return new UpdatePackingMaterialResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = $"Packing material {request.Id} not found."
+    };
+}
+```
+
+### Controller-level pattern (example)
+```csharp
+var response = await _mediator.Send(request, cancellationToken);
+if (!response.Success && response.ErrorCode == ErrorCodes.ResourceNotFound)
+    return NotFound(response);
+return Ok(response);
+```
+The exact controller helper used (`NotFound(response)` vs. `NotFound(new { response.Error })`) must match the convention already in place for the allocation endpoints in the same controller — the implementer should copy that pattern verbatim.
+
+### OpenAPI / generated client impact
+- The OpenAPI TypeScript client is auto-generated on build. Adding `Success`, `ErrorCode`, and `Error` fields to the four response DTOs will regenerate the client types. Frontend consumers that destructure the response body should compile-check cleanly because the new fields are additive and optional on the success path.
+- DTOs must remain plain classes (not records), per the project rule documented in `CLAUDE.md` and `docs/architecture/development_guidelines.md`.
+
+### FR-8: Tests for the changed behavior
+Each affected handler and controller must have tests covering the not-found path with the new contract.
+
+**Acceptance criteria:**
+- Unit test per handler: given a non-existent ID, the handler returns a response with `Success == false` and `ErrorCode == ErrorCodes.ResourceNotFound` and does not throw.
+- Unit or integration test per controller endpoint: given a non-existent ID, the endpoint returns HTTP 404.
+- Existing happy-path tests for these handlers/endpoints continue to pass.
+- Overall project test coverage does not regress below the existing baseline.
+
+### FR-9: Frontend usage audit
+Audit the frontend for any code that consumes the four affected endpoints and verify it handles HTTP 404 correctly.
+
+**Acceptance criteria:**
+- All `fetch`/`apiClient` call sites for `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, and `GET /api/packing-materials/{id}/logs` are reviewed.
+- Any call site that currently catches HTTP 500 to infer not-found is updated to catch HTTP 404 instead. (Expected to be zero, since the prior behavior was incorrect.)
+- Any call site that displays the server error message to the user continues to work — the new 404 body still contains `Error` text suitable for display.
+- If no consumers need changes, this is documented in the PR description rather than skipped silently.
+
+## Dependencies
+
+- **Internal:** `ErrorCodes` enum (existing, shared across the application). No new shared types.
+- **Internal:** Existing allocation-handler pattern in the same module — used as the reference implementation. Do not modify it.
+- **External libraries:** None. MediatR, ASP.NET Core MVC, and the existing repository abstraction are sufficient.
+- **Build pipeline:** OpenAPI TypeScript client regeneration on `dotnet build` — runs automatically; no manual step required, but the frontend build must be re-run after the backend changes to pick up the new DTO fields.
+
+## Out of Scope
+
+- **Other modules.** Only `PackingMaterials` handlers are touched. Any similar inconsistency in `Catalog`, `Manufacturing`, `Inventory`, or other modules is explicitly out of scope and should be tracked as separate findings.
+- **The allocation handlers themselves.** `GetAllocationsHandler` and `CreateAllocationHandler` are the reference pattern and are not modified.
+- **Global error-handler refactor.** The global exception-to-HTTP-status mapping is not changed. We are removing the exceptions that incorrectly reached it, not redefining its behavior.
+- **New `ErrorCode` values.** Only the existing `ResourceNotFound` is used.
+- **Validation errors, conflict errors, or other non-success cases.** Only the not-found case is in scope. Any other handler-level error condition currently encoded as a thrown exception is left as-is for this PR.
+- **API versioning.** The HTTP contract for these endpoints changes (500 → 404), but no formal API version bump is introduced, on the basis that the prior 500 was a bug rather than a documented contract.
+- **Database migrations.** None required.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-packingmaterials-not-found-e/task-plan.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-not-found-e/task-plan.r1.md
@@ -1,0 +1,1243 @@
+# Consistent Not-Found Error Handling in PackingMaterials Module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace exception-throwing not-found behavior in four PackingMaterials CRUD handlers with the existing structured-return pattern used by the allocation handlers, so `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, and `GET /api/packing-materials/{id}/logs` return HTTP 404 instead of HTTP 500 for missing IDs.
+
+**Architecture:** Each affected handler returns a response inheriting from `BaseResponse` (which provides `Success` and `ErrorCode`) plus a free-text `Error` string — exactly mirroring `GetAllocationsHandler` / `CreateAllocationHandler`. The controller inspects `response.Success` and `response.ErrorCode == ErrorCodes.ResourceNotFound` to return `NotFound(new { error = response.Error })`, matching the existing allocation endpoints in the same controller. `DeletePackingMaterialRequest` is promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>` so it can carry the structured result.
+
+**Tech Stack:** .NET 8, MediatR, ASP.NET Core MVC, xUnit + FluentAssertions + Moq, OpenAPI TypeScript client (auto-regenerated on `dotnet build`).
+
+---
+
+## File Map
+
+**Modify (backend, application layer):**
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs` — add `Error` to inline `UpdatePackingMaterialResponse` class.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs` — add `Error` property.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs` — add `Error` property.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs` — replace throw with structured return.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs` — replace throw with structured return.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs` — replace throw with structured return.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs` — change to `IRequest<DeletePackingMaterialResponse>`.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs` — change signature to `IRequestHandler<DeletePackingMaterialRequest, DeletePackingMaterialResponse>` and return structured response.
+
+**Modify (backend, API layer):**
+- `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` — four endpoints (`UpdatePackingMaterial`, `UpdatePackingMaterialQuantity`, `DeletePackingMaterial`, `GetPackingMaterialLogs`) inspect response and map `ResourceNotFound` → 404.
+
+**Create (backend):**
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs` — new response DTO extending `BaseResponse` with `Error` property.
+
+**Create (tests):**
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` — handler tests for the four affected use cases.
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` — controller unit tests (Moq IMediator) verifying 404 on not-found responses.
+
+**Frontend / generated artifacts (no source changes expected, only regeneration):**
+- `frontend/src/api/generated/api-client.ts` — regenerates automatically on `dotnet build`. No frontend source edits expected per arch-review §FR-9.
+
+---
+
+## Task 1: Add structured-error scaffolding to response DTOs
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs`
+
+This task is pure scaffolding (no behavior change). It compiles cleanly because `Error` is an additive optional property and `DeletePackingMaterialResponse` is a new type not yet referenced.
+
+- [ ] **Step 1: Add `Error` property to `UpdatePackingMaterialResponse`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs` so the inline response class becomes:
+
+```csharp
+public class UpdatePackingMaterialResponse : BaseResponse
+{
+    public PackingMaterialDto Material { get; set; } = null!;
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 2: Add `Error` property to `UpdatePackingMaterialQuantityResponse`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class UpdatePackingMaterialQuantityResponse : BaseResponse
+{
+    public PackingMaterialDto Material { get; set; } = null!;
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 3: Add `Error` property to `GetPackingMaterialLogsResponse`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
+
+public class GetPackingMaterialLogsResponse : BaseResponse
+{
+    public PackingMaterialDto Material { get; set; } = null!;
+    public IEnumerable<PackingMaterialLogDto> Logs { get; set; } = new List<PackingMaterialLogDto>();
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `DeletePackingMaterialResponse`**
+
+Create `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialResponse : BaseResponse
+{
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 5: Build to verify everything compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds. The handlers and controller still reference the old contracts unchanged at this point; we have only added new optional members and one new type.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs
+git commit -m "feat: scaffold structured error fields on PackingMaterials response DTOs"
+```
+
+---
+
+## Task 2: UpdatePackingMaterial — TDD handler + controller 404 mapping
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`UpdatePackingMaterial` action)
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` with this content (we will append cases for the other three handlers in later tasks):
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using System.Reflection;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class PackingMaterialCrudHandlerTests
+{
+    private static PackingMaterial MakeMaterial(int id, string name = "TestMaterial")
+    {
+        var material = new PackingMaterial(name, 1m, ConsumptionType.PerOrder, 100m);
+        typeof(PackingMaterial)
+            .GetProperty("Id")!
+            .SetValue(material, id);
+        return material;
+    }
+
+    private static MockPackingMaterialRepository BuildRepo(params PackingMaterial[] materials)
+    {
+        var repo = new MockPackingMaterialRepository();
+        repo.SetMaterials(materials);
+        return repo;
+    }
+
+    // ---- UpdatePackingMaterial ----
+
+    [Fact]
+    public async Task UpdatePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+    {
+        // Arrange
+        var repo = BuildRepo();
+        var handler = new UpdatePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialRequest
+        {
+            Id = 99,
+            Name = "Anything",
+            ConsumptionRate = 1m,
+            ConsumptionType = ConsumptionType.PerOrder
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+        Assert.NotNull(response.Error);
+        Assert.Contains("99", response.Error!);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterial_UpdatesMaterialAndReturnsSuccess_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1, "Old");
+        var repo = BuildRepo(material);
+        var handler = new UpdatePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialRequest
+        {
+            Id = 1,
+            Name = "New",
+            ConsumptionRate = 2m,
+            ConsumptionType = ConsumptionType.PerProduct
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorCode);
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Material);
+        Assert.Equal(1, response.Material.Id);
+        Assert.Equal("New", response.Material.Name);
+        Assert.Equal(2m, response.Material.ConsumptionRate);
+        Assert.Single(repo.UpdatedMaterials);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests, expect the not-found case to fail with a thrown exception**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests"`
+Expected:
+- `UpdatePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist` FAILS because the handler currently throws `ArgumentException`.
+- `UpdatePackingMaterial_UpdatesMaterialAndReturnsSuccess_WhenMaterialExists` PASSES (current happy-path behavior is correct).
+
+- [ ] **Step 3: Replace the throw in `UpdatePackingMaterialHandler` with a structured return**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`. Add `using Anela.Heblo.Application.Shared;` at the top, then replace the not-found branch:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
+
+public class UpdatePackingMaterialHandler : IRequestHandler<UpdatePackingMaterialRequest, UpdatePackingMaterialResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+
+    public UpdatePackingMaterialHandler(IPackingMaterialRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<UpdatePackingMaterialResponse> Handle(
+        UpdatePackingMaterialRequest request,
+        CancellationToken cancellationToken)
+    {
+        var material = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (material == null)
+        {
+            return new UpdatePackingMaterialResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
+        }
+
+        material.UpdateMaterial(request.Name, request.ConsumptionRate, request.ConsumptionType);
+        await _repository.UpdateAsync(material, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        var materialDto = new PackingMaterialDto
+        {
+            Id = material.Id,
+            Name = material.Name,
+            ConsumptionRate = material.ConsumptionRate,
+            ConsumptionType = material.ConsumptionType,
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            CurrentQuantity = material.CurrentQuantity,
+            ForecastedDays = null,
+            CreatedAt = material.CreatedAt,
+            UpdatedAt = material.UpdatedAt
+        };
+
+        return new UpdatePackingMaterialResponse
+        {
+            Material = materialDto
+        };
+    }
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+- [ ] **Step 4: Re-run the handler tests, expect both to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests"`
+Expected: both `UpdatePackingMaterial_*` tests PASS.
+
+- [ ] **Step 5: Write the failing controller test for the 404 mapping**
+
+Create `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs`:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class PackingMaterialsControllerNotFoundTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly PackingMaterialsController _controller;
+
+    public PackingMaterialsControllerNotFoundTests()
+    {
+        _controller = new PackingMaterialsController(_mediator.Object);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterial_Returns404_WhenHandlerReturnsResourceNotFound()
+    {
+        // Arrange
+        var notFound = new UpdatePackingMaterialResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.ResourceNotFound,
+            Error = "Packing material with ID 99 not found."
+        };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<UpdatePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notFound);
+
+        var request = new UpdatePackingMaterialRequest
+        {
+            Id = 99,
+            Name = "Anything",
+            ConsumptionRate = 1m,
+            ConsumptionType = ConsumptionType.PerOrder
+        };
+
+        // Act
+        var result = await _controller.UpdatePackingMaterial(99, request, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+}
+```
+
+- [ ] **Step 6: Run the controller test, expect it to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterial_Returns404"`
+Expected: FAIL. The current controller returns `Ok(response)` regardless of `response.Success`, so the assertion `BeOfType<NotFoundObjectResult>()` fails.
+
+- [ ] **Step 7: Update the `UpdatePackingMaterial` controller action to map the structured response**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `UpdatePackingMaterial` action body (lines around 58-76) with:
+
+```csharp
+[HttpPut("{id}")]
+[ProducesResponseType(typeof(UpdatePackingMaterialResponse), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult<UpdatePackingMaterialResponse>> UpdatePackingMaterial(
+    int id,
+    [FromBody] UpdatePackingMaterialRequest request,
+    CancellationToken cancellationToken = default)
+{
+    if (id != request.Id)
+    {
+        return BadRequest("ID mismatch");
+    }
+
+    if (!ModelState.IsValid)
+    {
+        return BadRequest(ModelState);
+    }
+
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success) return Ok(response);
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 8: Re-run the controller test, expect it to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterial_Returns404"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for UpdatePackingMaterial when material is missing"
+```
+
+---
+
+## Task 3: UpdatePackingMaterialQuantity — TDD handler + controller 404 mapping
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (append cases)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` (append case)
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`UpdatePackingMaterialQuantity` action)
+
+The `UpdatePackingMaterialQuantityHandler` depends on `ICurrentUserService` — we need a stub for tests. The simplest approach is a tiny in-file stub; if the test base already has a mock for it elsewhere we can reuse, but the simplest self-contained approach is a local stub.
+
+- [ ] **Step 1: Add a local stub `ICurrentUserService` for tests**
+
+Append this stub to `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (above the existing `PackingMaterialCrudHandlerTests` class, inside the same file, in the same namespace):
+
+```csharp
+internal sealed class StubCurrentUserService : Anela.Heblo.Domain.Features.Users.ICurrentUserService
+{
+    private readonly Anela.Heblo.Domain.Features.Users.CurrentUser? _user;
+
+    public StubCurrentUserService(Anela.Heblo.Domain.Features.Users.CurrentUser? user = null)
+    {
+        _user = user;
+    }
+
+    public Anela.Heblo.Domain.Features.Users.CurrentUser GetCurrentUser()
+        => _user ?? new Anela.Heblo.Domain.Features.Users.CurrentUser("test-user-id", "Test User", "test@example.com", true);
+}
+```
+
+> **Note for executor:** if the `CurrentUser` constructor signature differs in this codebase, adapt the construction above to match the existing type. Discover by reading `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs` (or wherever the type is defined) and use the existing happy-path constructor. The point of the stub is only that `GetCurrentUser()` returns a non-null value with an `Id`; nothing else is asserted.
+
+- [ ] **Step 2: Append failing handler tests for `UpdatePackingMaterialQuantityHandler`**
+
+Append these `[Fact]` methods inside the `PackingMaterialCrudHandlerTests` class (after the `UpdatePackingMaterial_*` tests). Add the needed `using` at the top of the file if missing: `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;`.
+
+```csharp
+// ---- UpdatePackingMaterialQuantity ----
+
+[Fact]
+public async Task UpdatePackingMaterialQuantity_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+{
+    // Arrange
+    var repo = BuildRepo();
+    var handler = new UpdatePackingMaterialQuantityHandler(repo, new StubCurrentUserService());
+
+    // Act
+    var response = await handler.Handle(new UpdatePackingMaterialQuantityRequest
+    {
+        Id = 99,
+        NewQuantity = 5m,
+        Date = DateOnly.FromDateTime(DateTime.UtcNow)
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.False(response.Success);
+    Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+    Assert.NotNull(response.Error);
+    Assert.Contains("99", response.Error!);
+}
+
+[Fact]
+public async Task UpdatePackingMaterialQuantity_UpdatesAndReturnsSuccess_WhenMaterialExists()
+{
+    // Arrange
+    var material = MakeMaterial(1);
+    var repo = BuildRepo(material);
+    var handler = new UpdatePackingMaterialQuantityHandler(repo, new StubCurrentUserService());
+
+    // Act
+    var response = await handler.Handle(new UpdatePackingMaterialQuantityRequest
+    {
+        Id = 1,
+        NewQuantity = 42m,
+        Date = DateOnly.FromDateTime(DateTime.UtcNow)
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.True(response.Success);
+    Assert.Null(response.ErrorCode);
+    Assert.Null(response.Error);
+    Assert.NotNull(response.Material);
+    Assert.Equal(1, response.Material.Id);
+    Assert.Single(repo.UpdatedMaterials);
+}
+```
+
+- [ ] **Step 3: Run the new tests, expect not-found to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.UpdatePackingMaterialQuantity"`
+Expected: `UpdatePackingMaterialQuantity_ReturnsNotFoundResponse_WhenMaterialDoesNotExist` FAILS (handler throws). Happy-path PASSES.
+
+- [ ] **Step 4: Replace the throw in `UpdatePackingMaterialQuantityHandler`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`. Add `using Anela.Heblo.Application.Shared;` at the top, then replace the not-found branch:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
+
+public class UpdatePackingMaterialQuantityHandler : IRequestHandler<UpdatePackingMaterialQuantityRequest, UpdatePackingMaterialQuantityResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public UpdatePackingMaterialQuantityHandler(
+        IPackingMaterialRepository repository,
+        ICurrentUserService currentUserService)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<UpdatePackingMaterialQuantityResponse> Handle(
+        UpdatePackingMaterialQuantityRequest request,
+        CancellationToken cancellationToken)
+    {
+        var material = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (material == null)
+        {
+            return new UpdatePackingMaterialQuantityResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
+        }
+
+        var currentUser = _currentUserService.GetCurrentUser();
+        material.UpdateQuantity(request.NewQuantity, request.Date, LogEntryType.Manual, currentUser?.Id);
+
+        await _repository.UpdateAsync(material, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        var oneMonthAgo = DateTime.UtcNow.AddMonths(-1);
+        var recentLogs = await _repository.GetRecentLogsAsync(material.Id, oneMonthAgo, cancellationToken);
+        var forecastedDays = material.CalculateForecastedDays(recentLogs.ToList());
+        var displayForecast = forecastedDays == decimal.MaxValue ? null : (decimal?)Math.Round(forecastedDays, 1);
+
+        var materialDto = new PackingMaterialDto
+        {
+            Id = material.Id,
+            Name = material.Name,
+            ConsumptionRate = material.ConsumptionRate,
+            ConsumptionType = material.ConsumptionType,
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            CurrentQuantity = material.CurrentQuantity,
+            ForecastedDays = displayForecast,
+            CreatedAt = material.CreatedAt,
+            UpdatedAt = material.UpdatedAt
+        };
+
+        return new UpdatePackingMaterialQuantityResponse
+        {
+            Material = materialDto
+        };
+    }
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+- [ ] **Step 5: Re-run handler tests, expect both to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.UpdatePackingMaterialQuantity"`
+Expected: PASS.
+
+- [ ] **Step 6: Append failing controller test**
+
+Append this `[Fact]` to `PackingMaterialsControllerNotFoundTests` (add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;` at the top if needed):
+
+```csharp
+[Fact]
+public async Task UpdatePackingMaterialQuantity_Returns404_WhenHandlerReturnsResourceNotFound()
+{
+    // Arrange
+    var notFound = new UpdatePackingMaterialQuantityResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = "Packing material with ID 99 not found."
+    };
+    _mediator
+        .Setup(m => m.Send(It.IsAny<UpdatePackingMaterialQuantityRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(notFound);
+
+    var body = new UpdateQuantityRequest
+    {
+        NewQuantity = 5m,
+        Date = DateOnly.FromDateTime(DateTime.UtcNow)
+    };
+
+    // Act
+    var result = await _controller.UpdatePackingMaterialQuantity(99, body, CancellationToken.None);
+
+    // Assert
+    var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+    notFoundResult.StatusCode.Should().Be(404);
+}
+```
+
+- [ ] **Step 7: Run the controller test, expect it to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterialQuantity_Returns404"`
+Expected: FAIL — controller currently returns `Ok(response)` regardless of `response.Success`.
+
+- [ ] **Step 8: Update the `UpdatePackingMaterialQuantity` controller action**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `UpdatePackingMaterialQuantity` action with:
+
+```csharp
+[HttpPost("{id}/quantity")]
+[ProducesResponseType(typeof(UpdatePackingMaterialQuantityResponse), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult<UpdatePackingMaterialQuantityResponse>> UpdatePackingMaterialQuantity(
+    int id,
+    [FromBody] UpdateQuantityRequest request,
+    CancellationToken cancellationToken = default)
+{
+    if (!ModelState.IsValid)
+    {
+        return BadRequest(ModelState);
+    }
+
+    var quantityRequest = new UpdatePackingMaterialQuantityRequest
+    {
+        Id = id,
+        NewQuantity = request.NewQuantity,
+        Date = request.Date
+    };
+
+    var response = await _mediator.Send(quantityRequest, cancellationToken);
+    if (response.Success) return Ok(response);
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 9: Re-run controller test, expect PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterialQuantity_Returns404"`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for UpdatePackingMaterialQuantity when material is missing"
+```
+
+---
+
+## Task 4: GetPackingMaterialLogs — TDD handler + controller 404 mapping
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (append)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` (append)
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`GetPackingMaterialLogs` action)
+
+- [ ] **Step 1: Append failing handler tests**
+
+Add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;` at the top of `PackingMaterialCrudHandlerTests.cs` if missing, then append inside the test class:
+
+```csharp
+// ---- GetPackingMaterialLogs ----
+
+[Fact]
+public async Task GetPackingMaterialLogs_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+{
+    // Arrange
+    var repo = BuildRepo();
+    var handler = new GetPackingMaterialLogsHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new GetPackingMaterialLogsRequest
+    {
+        PackingMaterialId = 99,
+        Days = 30
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.False(response.Success);
+    Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+    Assert.NotNull(response.Error);
+    Assert.Contains("99", response.Error!);
+}
+
+[Fact]
+public async Task GetPackingMaterialLogs_ReturnsSuccess_WhenMaterialExists()
+{
+    // Arrange
+    var material = MakeMaterial(1);
+    var repo = BuildRepo(material);
+    var handler = new GetPackingMaterialLogsHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new GetPackingMaterialLogsRequest
+    {
+        PackingMaterialId = 1,
+        Days = 30
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.True(response.Success);
+    Assert.Null(response.ErrorCode);
+    Assert.Null(response.Error);
+    Assert.NotNull(response.Material);
+    Assert.Equal(1, response.Material.Id);
+    Assert.Empty(response.Logs);
+}
+```
+
+- [ ] **Step 2: Run the new tests, expect not-found to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.GetPackingMaterialLogs"`
+Expected: not-found case FAILS (handler throws `InvalidOperationException`). Happy-path PASSES.
+
+- [ ] **Step 3: Replace the throw in `GetPackingMaterialLogsHandler`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`. Add `using Anela.Heblo.Application.Shared;` and replace the not-found branch:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
+
+public class GetPackingMaterialLogsHandler : IRequestHandler<GetPackingMaterialLogsRequest, GetPackingMaterialLogsResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+
+    public GetPackingMaterialLogsHandler(IPackingMaterialRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetPackingMaterialLogsResponse> Handle(
+        GetPackingMaterialLogsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var material = await _repository.GetByIdWithLogsAsync(request.PackingMaterialId, cancellationToken);
+        if (material == null)
+        {
+            return new GetPackingMaterialLogsResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.PackingMaterialId} not found."
+            };
+        }
+
+        var fromDate = DateTime.UtcNow.AddDays(-request.Days);
+        var recentLogs = await _repository.GetRecentLogsAsync(request.PackingMaterialId, fromDate, cancellationToken);
+
+        var materialDto = new PackingMaterialDto
+        {
+            Id = material.Id,
+            Name = material.Name,
+            ConsumptionRate = material.ConsumptionRate,
+            ConsumptionType = material.ConsumptionType,
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            CurrentQuantity = material.CurrentQuantity,
+            CreatedAt = material.CreatedAt,
+            UpdatedAt = material.UpdatedAt
+        };
+
+        var logDtos = recentLogs.Select(log => new PackingMaterialLogDto
+        {
+            Id = log.Id,
+            PackingMaterialId = log.PackingMaterialId,
+            Date = log.Date,
+            OldQuantity = log.OldQuantity,
+            NewQuantity = log.NewQuantity,
+            ChangeAmount = log.ChangeAmount,
+            LogType = log.LogType,
+            LogTypeText = GetLogTypeText(log.LogType),
+            UserId = log.UserId,
+            CreatedAt = log.CreatedAt
+        }).OrderByDescending(log => log.Date).ThenByDescending(log => log.CreatedAt).ToList();
+
+        return new GetPackingMaterialLogsResponse
+        {
+            Material = materialDto,
+            Logs = logDtos
+        };
+    }
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+
+    private static string GetLogTypeText(LogEntryType type) => type switch
+    {
+        LogEntryType.Manual => "Ruční",
+        LogEntryType.AutomaticConsumption => "Automatická spotřeba",
+        _ => type.ToString()
+    };
+}
+```
+
+- [ ] **Step 4: Re-run handler tests, expect both to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.GetPackingMaterialLogs"`
+Expected: PASS.
+
+- [ ] **Step 5: Append failing controller test**
+
+Append this `[Fact]` to `PackingMaterialsControllerNotFoundTests` (add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;` at the top if missing):
+
+```csharp
+[Fact]
+public async Task GetPackingMaterialLogs_Returns404_WhenHandlerReturnsResourceNotFound()
+{
+    // Arrange
+    var notFound = new GetPackingMaterialLogsResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = "Packing material with ID 99 not found."
+    };
+    _mediator
+        .Setup(m => m.Send(It.IsAny<GetPackingMaterialLogsRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(notFound);
+
+    // Act
+    var result = await _controller.GetPackingMaterialLogs(99, 60, CancellationToken.None);
+
+    // Assert
+    var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+    notFoundResult.StatusCode.Should().Be(404);
+}
+```
+
+- [ ] **Step 6: Run controller test, expect fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.GetPackingMaterialLogs_Returns404"`
+Expected: FAIL.
+
+- [ ] **Step 7: Update the `GetPackingMaterialLogs` controller action**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `GetPackingMaterialLogs` action with:
+
+```csharp
+[HttpGet("{id}/logs")]
+[ProducesResponseType(typeof(GetPackingMaterialLogsResponse), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult<GetPackingMaterialLogsResponse>> GetPackingMaterialLogs(
+    int id,
+    [FromQuery] int days = 60,
+    CancellationToken cancellationToken = default)
+{
+    var request = new GetPackingMaterialLogsRequest
+    {
+        PackingMaterialId = id,
+        Days = days
+    };
+
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success) return Ok(response);
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 8: Re-run controller test, expect PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.GetPackingMaterialLogs_Returns404"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for GetPackingMaterialLogs when material is missing"
+```
+
+---
+
+## Task 5: DeletePackingMaterial — contract change + TDD handler + controller 204/404 mapping
+
+This task is larger than the previous three because `DeletePackingMaterialRequest` must be promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>`, the handler signature changes, and the controller action moves from awaiting `Unit` to mapping a typed response.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`DeletePackingMaterial` action)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (append)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` (append)
+
+- [ ] **Step 1: Append failing handler tests**
+
+Add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;` at the top of `PackingMaterialCrudHandlerTests.cs` if missing, then append inside the test class:
+
+```csharp
+// ---- DeletePackingMaterial ----
+
+[Fact]
+public async Task DeletePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+{
+    // Arrange
+    var repo = BuildRepo();
+    var handler = new DeletePackingMaterialHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new DeletePackingMaterialRequest { Id = 99 }, CancellationToken.None);
+
+    // Assert
+    Assert.False(response.Success);
+    Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+    Assert.NotNull(response.Error);
+    Assert.Contains("99", response.Error!);
+    Assert.Single(repo.Materials);
+}
+
+[Fact]
+public async Task DeletePackingMaterial_DeletesAndReturnsSuccess_WhenMaterialExists()
+{
+    // Arrange
+    var material = MakeMaterial(1);
+    var repo = BuildRepo(material);
+    var handler = new DeletePackingMaterialHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new DeletePackingMaterialRequest { Id = 1 }, CancellationToken.None);
+
+    // Assert
+    Assert.True(response.Success);
+    Assert.Null(response.ErrorCode);
+    Assert.Null(response.Error);
+    Assert.Empty(repo.Materials);
+}
+```
+
+- [ ] **Step 2: Run, expect compile errors (return type changed)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.DeletePackingMaterial"`
+Expected: COMPILE ERROR. The new tests treat `handler.Handle(...)` as returning a `DeletePackingMaterialResponse`, but the current handler returns `Task` (Unit). The tests cannot even compile until the contract is changed in Step 3.
+
+- [ ] **Step 3: Change `DeletePackingMaterialRequest` to typed request**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialRequest : IRequest<DeletePackingMaterialResponse>
+{
+    public int Id { get; set; }
+}
+```
+
+- [ ] **Step 4: Change `DeletePackingMaterialHandler` signature and body**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialHandler : IRequestHandler<DeletePackingMaterialRequest, DeletePackingMaterialResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+
+    public DeletePackingMaterialHandler(IPackingMaterialRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<DeletePackingMaterialResponse> Handle(DeletePackingMaterialRequest request, CancellationToken cancellationToken)
+    {
+        var packingMaterial = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (packingMaterial == null)
+        {
+            return new DeletePackingMaterialResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
+        }
+
+        await _repository.DeleteAsync(packingMaterial, cancellationToken);
+        return new DeletePackingMaterialResponse();
+    }
+}
+```
+
+- [ ] **Step 5: Update the `DeletePackingMaterial` controller action**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `DeletePackingMaterial` action with:
+
+```csharp
+[HttpDelete("{id}")]
+[ProducesResponseType(StatusCodes.Status204NoContent)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult> DeletePackingMaterial(
+    int id,
+    CancellationToken cancellationToken = default)
+{
+    var request = new DeletePackingMaterialRequest { Id = id };
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success) return NoContent();
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 6: Build to confirm everything compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 7: Re-run handler tests, expect both DeletePackingMaterial cases to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.DeletePackingMaterial"`
+Expected: PASS.
+
+- [ ] **Step 8: Append failing controller test**
+
+Append these `[Fact]` methods to `PackingMaterialsControllerNotFoundTests` (add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;` at the top if missing):
+
+```csharp
+[Fact]
+public async Task DeletePackingMaterial_Returns404_WhenHandlerReturnsResourceNotFound()
+{
+    // Arrange
+    var notFound = new DeletePackingMaterialResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = "Packing material with ID 99 not found."
+    };
+    _mediator
+        .Setup(m => m.Send(It.IsAny<DeletePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(notFound);
+
+    // Act
+    var result = await _controller.DeletePackingMaterial(99, CancellationToken.None);
+
+    // Assert
+    var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+    notFoundResult.StatusCode.Should().Be(404);
+}
+
+[Fact]
+public async Task DeletePackingMaterial_Returns204_WhenHandlerReturnsSuccess()
+{
+    // Arrange
+    var ok = new DeletePackingMaterialResponse();
+    _mediator
+        .Setup(m => m.Send(It.IsAny<DeletePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(ok);
+
+    // Act
+    var result = await _controller.DeletePackingMaterial(1, CancellationToken.None);
+
+    // Assert
+    result.Should().BeOfType<NoContentResult>();
+}
+```
+
+- [ ] **Step 9: Run the controller tests, expect PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.DeletePackingMaterial"`
+Expected: PASS (Step 5 already updated the controller to inspect the typed response).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for DeletePackingMaterial when material is missing"
+```
+
+---
+
+## Task 6: Backend-wide validation
+
+This task confirms nothing else regressed (the PackingMaterials module shares the `PackingMaterialsController` with the allocation endpoints, and the global build must remain clean).
+
+**Files:** none changed; verification only. If `dotnet format` reports formatting drift in the files this PR touched, accept those edits in a follow-up commit.
+
+- [ ] **Step 1: Run `dotnet build` on the whole solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: zero errors, zero warnings introduced by this PR.
+
+- [ ] **Step 2: Run the full PackingMaterials test suite**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.PackingMaterials"`
+Expected: all PackingMaterials tests pass, including the existing `AllocationHandlerTests`, `ConsumptionCalculationServiceTests`, and `GetDailyConsumptionBreakdownHandlerTests`.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: total test count is at least equal to the count before this PR plus the new tests added in Tasks 2–5; zero failures.
+
+- [ ] **Step 4: Run `dotnet format` on the modified projects**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes` (or `dotnet format backend/Anela.Heblo.sln` if drift is found, then re-run with `--verify-no-changes`)
+Expected: no formatting violations remain.
+
+- [ ] **Step 5: Commit any formatting fixes (only if Step 4 reformatted files)**
+
+```bash
+git add -A
+git commit -m "chore: apply dotnet format"
+```
+
+Skip this step entirely if `dotnet format --verify-no-changes` reported nothing.
+
+---
+
+## Task 7: Frontend regeneration + verification + audit notes
+
+The OpenAPI TypeScript client is regenerated automatically by `dotnet build`. We verify the frontend still builds, lints, and that the frontend audit (FR-9) finds no required source changes.
+
+**Files:** no frontend source edits expected. Audit findings are recorded in the eventual PR description, not in any source file.
+
+- [ ] **Step 1: Ensure backend builds (so the TS client regenerates)**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: succeeds. The build target regenerates `frontend/src/api/generated/api-client.ts`. The regenerated client will gain a new TypeScript type for `DeletePackingMaterialResponse` and additional optional fields on the three existing types — purely additive.
+
+- [ ] **Step 2: Frontend build**
+
+Run: `npm --prefix frontend run build`
+Expected: succeeds with no new TS errors. The hand-rolled `frontend/src/api/hooks/usePackingMaterials.ts` does not consume the new fields and is unaffected.
+
+- [ ] **Step 3: Frontend lint**
+
+Run: `npm --prefix frontend run lint`
+Expected: succeeds with no new lint errors.
+
+- [ ] **Step 4: Audit frontend call sites for the four affected endpoints**
+
+Use Grep to find every call site that targets the four affected endpoints. Run from the worktree root:
+
+```
+Grep pattern: packing-materials/\$\{|packing-materials\?|/quantity|/logs
+Glob:        frontend/src/**/*.ts*
+```
+
+Specifically inspect `frontend/src/api/hooks/usePackingMaterials.ts`. Verify that:
+- It currently throws a generic `Error` for any non-OK HTTP status. (Confirmed by arch-review §FR-9.)
+- No call site distinguishes HTTP 500 from HTTP 404 by status code.
+- No call site reads `response.body.Error` for a special UX on not-found.
+
+The expected outcome is **zero source-code changes**. Record this confirmation as a one-line note for the eventual PR description, e.g.:
+
+> *Frontend audit: only call site is `frontend/src/api/hooks/usePackingMaterials.ts`, which throws a generic `Error` on any non-OK status. No 500-vs-404 differentiation. No source changes required. (FR-9.)*
+
+If the audit unexpectedly finds a call site that branches on 500, **stop and flag it** — that case is beyond the spec's scope and needs a separate discussion before proceeding.
+
+- [ ] **Step 5: Commit (only if Step 1 produced regenerated client edits to commit)**
+
+If the regenerated `frontend/src/api/generated/api-client.ts` has uncommitted diffs from the build, stage and commit them:
+
+```bash
+git status --short frontend/src/api/generated
+# if changes are listed:
+git add frontend/src/api/generated/api-client.ts
+git commit -m "chore: regenerate openapi client for PackingMaterials response DTOs"
+```
+
+If the file is gitignored or otherwise not tracked (some projects exclude generated artifacts), skip this step.
+
+---
+
+## Self-Review (executed before declaring the plan complete)
+
+**Spec coverage:**
+- FR-1 (UpdatePackingMaterial structured not-found) → Task 2.
+- FR-2 (UpdatePackingMaterialQuantity structured not-found) → Task 3.
+- FR-3 (DeletePackingMaterial structured not-found) → Task 5.
+- FR-4 (GetPackingMaterialLogs structured not-found) → Task 4.
+- FR-5 (response DTOs carry `Success`/`ErrorCode`/`Error`) → Task 1 (scaffolding) + arch-review override (`Error` per response, not on `BaseResponse`).
+- FR-6 (controllers map ResourceNotFound to 404) → Tasks 2, 3, 4, 5 (controller edits + tests). Envelope is `NotFound(new { error = response.Error })` per arch-review override.
+- FR-7 (consistent message template) → All four handlers emit `"Packing material with ID {id} not found."` matching `GetAllocationsHandler.cs:32`.
+- FR-8 (tests for changed behavior) → Tasks 2–5 add both not-found and happy-path tests per handler, plus controller-level 404 mapping tests.
+- FR-9 (frontend audit) → Task 7 Step 4 documents the audit result with no source changes.
+- NFR-1 (performance) → no concern; structured returns replace throws, marginally faster on the not-found path.
+- NFR-2 (security) → unchanged; messages echo only the caller-supplied ID.
+- NFR-3 (backwards compat) → 404 replaces 500 on not-found path; happy path unchanged. Stated intentionally in this plan and in the spec.
+- NFR-4 (testability) → handler not-found path tested without throws.
+- NFR-5 (observability) → no logger injected (matches the spec NFR-5 amendment in arch-review).
+
+**Placeholder scan:** none — every step has either concrete code or a concrete command + expected outcome. The one judgment call (`CurrentUser` constructor signature in Task 3 Step 1) is explicitly framed as "read the existing type and match it"; no other step contains "TBD" / "as appropriate" / "etc."
+
+**Type consistency:** the four response DTOs all gain the same `string? Error { get; set; }` member. The four handler not-found return paths all emit the identical message template `"Packing material with ID {id} not found."`. The four controller actions all use the identical mapping `if (response.Success) return Ok/NoContent; if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error }); return BadRequest(new { error = response.Error });`. `DeletePackingMaterialResponse` is referenced consistently between Task 1 (creation) and Task 5 (use).

--- a/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
@@ -109,13 +109,18 @@ public class PackingMaterialsController : BaseApiController
     }
 
     [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeletePackingMaterial(
         int id,
         CancellationToken cancellationToken = default)
     {
         var request = new DeletePackingMaterialRequest { Id = id };
-        await _mediator.Send(request, cancellationToken);
-        return NoContent();
+        var response = await _mediator.Send(request, cancellationToken);
+        if (response.Success) return NoContent();
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
     }
 
     [HttpPost("process-daily-consumption")]

--- a/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
@@ -8,6 +8,7 @@ using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetDailyConsump
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.ProcessDailyConsumption;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdateAllocation;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
 using Anela.Heblo.API.Infrastructure;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -81,6 +82,9 @@ public class PackingMaterialsController : BaseApiController
     }
 
     [HttpPost("{id}/quantity")]
+    [ProducesResponseType(typeof(UpdatePackingMaterialQuantityResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<UpdatePackingMaterialQuantityResponse>> UpdatePackingMaterialQuantity(
         int id,
         [FromBody] UpdateQuantityRequest request,
@@ -99,7 +103,9 @@ public class PackingMaterialsController : BaseApiController
         };
 
         var response = await _mediator.Send(quantityRequest, cancellationToken);
-        return Ok(response);
+        if (response.Success) return Ok(response);
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
     }
 
     [HttpDelete("{id}")]

--- a/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
@@ -151,6 +151,9 @@ public class PackingMaterialsController : BaseApiController
     }
 
     [HttpGet("{id}/logs")]
+    [ProducesResponseType(typeof(GetPackingMaterialLogsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<GetPackingMaterialLogsResponse>> GetPackingMaterialLogs(
         int id,
         [FromQuery] int days = 60,
@@ -163,7 +166,9 @@ public class PackingMaterialsController : BaseApiController
         };
 
         var response = await _mediator.Send(request, cancellationToken);
-        return Ok(response);
+        if (response.Success) return Ok(response);
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
     }
 
     [HttpGet("{id}/allocations")]

--- a/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs
@@ -56,6 +56,9 @@ public class PackingMaterialsController : BaseApiController
     }
 
     [HttpPut("{id}")]
+    [ProducesResponseType(typeof(UpdatePackingMaterialResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<UpdatePackingMaterialResponse>> UpdatePackingMaterial(
         int id,
         [FromBody] UpdatePackingMaterialRequest request,
@@ -72,7 +75,9 @@ public class PackingMaterialsController : BaseApiController
         }
 
         var response = await _mediator.Send(request, cancellationToken);
-        return Ok(response);
+        if (response.Success) return Ok(response);
+        if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+        return BadRequest(new { error = response.Error });
     }
 
     [HttpPost("{id}/quantity")]

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs
@@ -5,4 +5,5 @@ namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
 public class UpdatePackingMaterialQuantityResponse : BaseResponse
 {
     public PackingMaterialDto Material { get; set; } = null!;
+    public string? Error { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs
@@ -15,4 +15,5 @@ public class UpdatePackingMaterialRequest : IRequest<UpdatePackingMaterialRespon
 public class UpdatePackingMaterialResponse : BaseResponse
 {
     public PackingMaterialDto Material { get; set; } = null!;
+    public string? Error { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs
@@ -1,9 +1,10 @@
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using MediatR;
 
 namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
 
-public class DeletePackingMaterialHandler : IRequestHandler<DeletePackingMaterialRequest>
+public class DeletePackingMaterialHandler : IRequestHandler<DeletePackingMaterialRequest, DeletePackingMaterialResponse>
 {
     private readonly IPackingMaterialRepository _repository;
 
@@ -12,14 +13,20 @@ public class DeletePackingMaterialHandler : IRequestHandler<DeletePackingMateria
         _repository = repository;
     }
 
-    public async Task Handle(DeletePackingMaterialRequest request, CancellationToken cancellationToken)
+    public async Task<DeletePackingMaterialResponse> Handle(DeletePackingMaterialRequest request, CancellationToken cancellationToken)
     {
         var packingMaterial = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (packingMaterial == null)
         {
-            throw new InvalidOperationException($"Packing material with ID {request.Id} not found.");
+            return new DeletePackingMaterialResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
         }
 
         await _repository.DeleteAsync(packingMaterial, cancellationToken);
+        return new DeletePackingMaterialResponse();
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs
@@ -2,7 +2,7 @@ using MediatR;
 
 namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
 
-public class DeletePackingMaterialRequest : IRequest
+public class DeletePackingMaterialRequest : IRequest<DeletePackingMaterialResponse>
 {
     public int Id { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs
@@ -1,0 +1,8 @@
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialResponse : BaseResponse
+{
+    public string? Error { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
 using MediatR;
@@ -21,7 +22,12 @@ public class GetPackingMaterialLogsHandler : IRequestHandler<GetPackingMaterialL
         var material = await _repository.GetByIdWithLogsAsync(request.PackingMaterialId, cancellationToken);
         if (material == null)
         {
-            throw new InvalidOperationException($"Packing material with ID {request.PackingMaterialId} not found.");
+            return new GetPackingMaterialLogsResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.PackingMaterialId} not found."
+            };
         }
 
         var fromDate = DateTime.UtcNow.AddDays(-request.Days);

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs
@@ -7,4 +7,5 @@ public class GetPackingMaterialLogsResponse : BaseResponse
 {
     public PackingMaterialDto Material { get; set; } = null!;
     public IEnumerable<PackingMaterialLogDto> Logs { get; set; } = new List<PackingMaterialLogDto>();
+    public string? Error { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
 using MediatR;
@@ -21,7 +22,12 @@ public class UpdatePackingMaterialHandler : IRequestHandler<UpdatePackingMateria
         var material = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (material == null)
         {
-            throw new ArgumentException($"PackingMaterial with ID {request.Id} not found");
+            return new UpdatePackingMaterialResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
         }
 
         material.UpdateMaterial(request.Name, request.ConsumptionRate, request.ConsumptionType);
@@ -36,7 +42,7 @@ public class UpdatePackingMaterialHandler : IRequestHandler<UpdatePackingMateria
             ConsumptionType = material.ConsumptionType,
             ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
             CurrentQuantity = material.CurrentQuantity,
-            ForecastedDays = null, // Would need to recalculate
+            ForecastedDays = null,
             CreatedAt = material.CreatedAt,
             UpdatedAt = material.UpdatedAt
         };

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
 using Anela.Heblo.Domain.Features.Users;
@@ -26,7 +27,12 @@ public class UpdatePackingMaterialQuantityHandler : IRequestHandler<UpdatePackin
         var material = await _repository.GetByIdAsync(request.Id, cancellationToken);
         if (material == null)
         {
-            throw new ArgumentException($"PackingMaterial with ID {request.Id} not found");
+            return new UpdatePackingMaterialQuantityResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
         }
 
         var currentUser = _currentUserService.GetCurrentUser();
@@ -35,7 +41,6 @@ public class UpdatePackingMaterialQuantityHandler : IRequestHandler<UpdatePackin
         await _repository.UpdateAsync(material, cancellationToken);
         await _repository.SaveChangesAsync(cancellationToken);
 
-        // Recalculate forecast with updated data
         var oneMonthAgo = DateTime.UtcNow.AddMonths(-1);
         var recentLogs = await _repository.GetRecentLogsAsync(material.Id, oneMonthAgo, cancellationToken);
         var forecastedDays = material.CalculateForecastedDays(recentLogs.ToList());

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
 using Anela.Heblo.Application.Shared;
@@ -134,5 +135,52 @@ public class PackingMaterialCrudHandlerTests
         Assert.NotNull(response.Material);
         Assert.Equal(1, response.Material.Id);
         Assert.Single(repo.UpdatedMaterials);
+    }
+
+    // ---- GetPackingMaterialLogs ----
+
+    [Fact]
+    public async Task GetPackingMaterialLogs_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+    {
+        // Arrange
+        var repo = BuildRepo();
+        var handler = new GetPackingMaterialLogsHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new GetPackingMaterialLogsRequest
+        {
+            PackingMaterialId = 99,
+            Days = 30
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+        Assert.NotNull(response.Error);
+        Assert.Contains("99", response.Error!);
+    }
+
+    [Fact]
+    public async Task GetPackingMaterialLogs_ReturnsSuccess_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var repo = BuildRepo(material);
+        var handler = new GetPackingMaterialLogsHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new GetPackingMaterialLogsRequest
+        {
+            PackingMaterialId = 1,
+            Days = 30
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorCode);
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Material);
+        Assert.Equal(1, response.Material.Id);
+        Assert.Empty(response.Logs);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
@@ -7,6 +8,14 @@ using System.Reflection;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+internal sealed class StubCurrentUserService : Anela.Heblo.Domain.Features.Users.ICurrentUserService
+{
+    public Anela.Heblo.Domain.Features.Users.CurrentUser GetCurrentUser()
+        => new Anela.Heblo.Domain.Features.Users.CurrentUser("test-user-id", "Test User", "test@example.com", true);
+
+    public bool IsInRole(string role) => false;
+}
 
 public class PackingMaterialCrudHandlerTests
 {
@@ -75,6 +84,55 @@ public class PackingMaterialCrudHandlerTests
         Assert.NotNull(response.Material);
         Assert.Equal(1, response.Material.Id);
         Assert.Equal("New", response.Material.Name);
+        Assert.Single(repo.UpdatedMaterials);
+    }
+
+    // ---- UpdatePackingMaterialQuantity ----
+
+    [Fact]
+    public async Task UpdatePackingMaterialQuantity_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+    {
+        // Arrange
+        var repo = BuildRepo();
+        var handler = new UpdatePackingMaterialQuantityHandler(repo, new StubCurrentUserService());
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialQuantityRequest
+        {
+            Id = 99,
+            NewQuantity = 5m,
+            Date = DateOnly.FromDateTime(DateTime.UtcNow)
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+        Assert.NotNull(response.Error);
+        Assert.Contains("99", response.Error!);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterialQuantity_UpdatesAndReturnsSuccess_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var repo = BuildRepo(material);
+        var handler = new UpdatePackingMaterialQuantityHandler(repo, new StubCurrentUserService());
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialQuantityRequest
+        {
+            Id = 1,
+            NewQuantity = 42m,
+            Date = DateOnly.FromDateTime(DateTime.UtcNow)
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorCode);
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Material);
+        Assert.Equal(1, response.Material.Id);
         Assert.Single(repo.UpdatedMaterials);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
@@ -1,0 +1,80 @@
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using System.Reflection;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class PackingMaterialCrudHandlerTests
+{
+    private static PackingMaterial MakeMaterial(int id, string name = "TestMaterial")
+    {
+        var material = new PackingMaterial(name, 1m, ConsumptionType.PerOrder, 100m);
+        typeof(PackingMaterial)
+            .GetProperty("Id")!
+            .SetValue(material, id);
+        return material;
+    }
+
+    private static MockPackingMaterialRepository BuildRepo(params PackingMaterial[] materials)
+    {
+        var repo = new MockPackingMaterialRepository();
+        repo.SetMaterials(materials);
+        return repo;
+    }
+
+    // ---- UpdatePackingMaterial ----
+
+    [Fact]
+    public async Task UpdatePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+    {
+        // Arrange
+        var repo = BuildRepo();
+        var handler = new UpdatePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialRequest
+        {
+            Id = 99,
+            Name = "Anything",
+            ConsumptionRate = 1m,
+            ConsumptionType = ConsumptionType.PerOrder
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+        Assert.NotNull(response.Error);
+        Assert.Contains("99", response.Error!);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterial_UpdatesMaterialAndReturnsSuccess_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1, "Old");
+        var repo = BuildRepo(material);
+        var handler = new UpdatePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialRequest
+        {
+            Id = 1,
+            Name = "New",
+            ConsumptionRate = 2m,
+            ConsumptionType = ConsumptionType.PerProduct
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorCode);
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Material);
+        Assert.Equal(1, response.Material.Id);
+        Assert.Equal("New", response.Material.Name);
+        Assert.Single(repo.UpdatedMaterials);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
@@ -182,5 +183,42 @@ public class PackingMaterialCrudHandlerTests
         Assert.NotNull(response.Material);
         Assert.Equal(1, response.Material.Id);
         Assert.Empty(response.Logs);
+    }
+
+    // ---- DeletePackingMaterial ----
+
+    [Fact]
+    public async Task DeletePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+    {
+        // Arrange
+        var repo = BuildRepo();
+        var handler = new DeletePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new DeletePackingMaterialRequest { Id = 99 }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+        Assert.NotNull(response.Error);
+        Assert.Contains("99", response.Error!);
+    }
+
+    [Fact]
+    public async Task DeletePackingMaterial_DeletesAndReturnsSuccess_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1);
+        var repo = BuildRepo(material);
+        var handler = new DeletePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new DeletePackingMaterialRequest { Id = 1 }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorCode);
+        Assert.Null(response.Error);
+        Assert.Empty(repo.Materials);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.API.Controllers;
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
 using FluentAssertions;
@@ -44,6 +45,34 @@ public class PackingMaterialsControllerNotFoundTests
 
         // Act
         var result = await _controller.UpdatePackingMaterial(99, request, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterialQuantity_Returns404_WhenHandlerReturnsResourceNotFound()
+    {
+        // Arrange
+        var notFound = new UpdatePackingMaterialQuantityResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.ResourceNotFound,
+            Error = "Packing material with ID 99 not found."
+        };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<UpdatePackingMaterialQuantityRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notFound);
+
+        var body = new UpdateQuantityRequest
+        {
+            NewQuantity = 5m,
+            Date = DateOnly.FromDateTime(DateTime.UtcNow)
+        };
+
+        // Act
+        var result = await _controller.UpdatePackingMaterialQuantity(99, body, CancellationToken.None);
 
         // Assert
         var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.API.Controllers;
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
 using Anela.Heblo.Application.Shared;
@@ -100,5 +101,43 @@ public class PackingMaterialsControllerNotFoundTests
         // Assert
         var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
         notFoundResult.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task DeletePackingMaterial_Returns404_WhenHandlerReturnsResourceNotFound()
+    {
+        // Arrange
+        var notFound = new DeletePackingMaterialResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.ResourceNotFound,
+            Error = "Packing material with ID 99 not found."
+        };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<DeletePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notFound);
+
+        // Act
+        var result = await _controller.DeletePackingMaterial(99, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task DeletePackingMaterial_Returns204_WhenHandlerReturnsSuccess()
+    {
+        // Arrange
+        var ok = new DeletePackingMaterialResponse();
+        _mediator
+            .Setup(m => m.Send(It.IsAny<DeletePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ok);
+
+        // Act
+        var result = await _controller.DeletePackingMaterial(1, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.API.Controllers;
 using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
 using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
@@ -73,6 +74,28 @@ public class PackingMaterialsControllerNotFoundTests
 
         // Act
         var result = await _controller.UpdatePackingMaterialQuantity(99, body, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task GetPackingMaterialLogs_Returns404_WhenHandlerReturnsResourceNotFound()
+    {
+        // Arrange
+        var notFound = new GetPackingMaterialLogsResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.ResourceNotFound,
+            Error = "Packing material with ID 99 not found."
+        };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<GetPackingMaterialLogsRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notFound);
+
+        // Act
+        var result = await _controller.GetPackingMaterialLogs(99, 60, CancellationToken.None);
 
         // Assert
         var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;

--- a/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
@@ -1,0 +1,52 @@
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class PackingMaterialsControllerNotFoundTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly PackingMaterialsController _controller;
+
+    public PackingMaterialsControllerNotFoundTests()
+    {
+        _controller = new PackingMaterialsController(_mediator.Object);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterial_Returns404_WhenHandlerReturnsResourceNotFound()
+    {
+        // Arrange
+        var notFound = new UpdatePackingMaterialResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.ResourceNotFound,
+            Error = "Packing material with ID 99 not found."
+        };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<UpdatePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notFound);
+
+        var request = new UpdatePackingMaterialRequest
+        {
+            Id = 99,
+            Name = "Anything",
+            ConsumptionRate = 1m,
+            ConsumptionType = ConsumptionType.PerOrder
+        };
+
+        // Act
+        var result = await _controller.UpdatePackingMaterial(99, request, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+}

--- a/docs/superpowers/plans/2026-05-21-packing-materials-not-found-error-handling.md
+++ b/docs/superpowers/plans/2026-05-21-packing-materials-not-found-error-handling.md
@@ -1,0 +1,1243 @@
+# Consistent Not-Found Error Handling in PackingMaterials Module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace exception-throwing not-found behavior in four PackingMaterials CRUD handlers with the existing structured-return pattern used by the allocation handlers, so `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, and `GET /api/packing-materials/{id}/logs` return HTTP 404 instead of HTTP 500 for missing IDs.
+
+**Architecture:** Each affected handler returns a response inheriting from `BaseResponse` (which provides `Success` and `ErrorCode`) plus a free-text `Error` string — exactly mirroring `GetAllocationsHandler` / `CreateAllocationHandler`. The controller inspects `response.Success` and `response.ErrorCode == ErrorCodes.ResourceNotFound` to return `NotFound(new { error = response.Error })`, matching the existing allocation endpoints in the same controller. `DeletePackingMaterialRequest` is promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>` so it can carry the structured result.
+
+**Tech Stack:** .NET 8, MediatR, ASP.NET Core MVC, xUnit + FluentAssertions + Moq, OpenAPI TypeScript client (auto-regenerated on `dotnet build`).
+
+---
+
+## File Map
+
+**Modify (backend, application layer):**
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs` — add `Error` to inline `UpdatePackingMaterialResponse` class.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs` — add `Error` property.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs` — add `Error` property.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs` — replace throw with structured return.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs` — replace throw with structured return.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs` — replace throw with structured return.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs` — change to `IRequest<DeletePackingMaterialResponse>`.
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs` — change signature to `IRequestHandler<DeletePackingMaterialRequest, DeletePackingMaterialResponse>` and return structured response.
+
+**Modify (backend, API layer):**
+- `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` — four endpoints (`UpdatePackingMaterial`, `UpdatePackingMaterialQuantity`, `DeletePackingMaterial`, `GetPackingMaterialLogs`) inspect response and map `ResourceNotFound` → 404.
+
+**Create (backend):**
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs` — new response DTO extending `BaseResponse` with `Error` property.
+
+**Create (tests):**
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` — handler tests for the four affected use cases.
+- `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` — controller unit tests (Moq IMediator) verifying 404 on not-found responses.
+
+**Frontend / generated artifacts (no source changes expected, only regeneration):**
+- `frontend/src/api/generated/api-client.ts` — regenerates automatically on `dotnet build`. No frontend source edits expected per arch-review §FR-9.
+
+---
+
+## Task 1: Add structured-error scaffolding to response DTOs
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs`
+
+This task is pure scaffolding (no behavior change). It compiles cleanly because `Error` is an additive optional property and `DeletePackingMaterialResponse` is a new type not yet referenced.
+
+- [ ] **Step 1: Add `Error` property to `UpdatePackingMaterialResponse`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs` so the inline response class becomes:
+
+```csharp
+public class UpdatePackingMaterialResponse : BaseResponse
+{
+    public PackingMaterialDto Material { get; set; } = null!;
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 2: Add `Error` property to `UpdatePackingMaterialQuantityResponse`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+public class UpdatePackingMaterialQuantityResponse : BaseResponse
+{
+    public PackingMaterialDto Material { get; set; } = null!;
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 3: Add `Error` property to `GetPackingMaterialLogsResponse`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
+
+public class GetPackingMaterialLogsResponse : BaseResponse
+{
+    public PackingMaterialDto Material { get; set; } = null!;
+    public IEnumerable<PackingMaterialLogDto> Logs { get; set; } = new List<PackingMaterialLogDto>();
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 4: Create `DeletePackingMaterialResponse`**
+
+Create `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialResponse : BaseResponse
+{
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 5: Build to verify everything compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds. The handlers and controller still reference the old contracts unchanged at this point; we have only added new optional members and one new type.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/UpdatePackingMaterialQuantityResponse.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsResponse.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialResponse.cs
+git commit -m "feat: scaffold structured error fields on PackingMaterials response DTOs"
+```
+
+---
+
+## Task 2: UpdatePackingMaterial — TDD handler + controller 404 mapping
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs`
+- Create: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`UpdatePackingMaterial` action)
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` with this content (we will append cases for the other three handlers in later tasks):
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using System.Reflection;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class PackingMaterialCrudHandlerTests
+{
+    private static PackingMaterial MakeMaterial(int id, string name = "TestMaterial")
+    {
+        var material = new PackingMaterial(name, 1m, ConsumptionType.PerOrder, 100m);
+        typeof(PackingMaterial)
+            .GetProperty("Id")!
+            .SetValue(material, id);
+        return material;
+    }
+
+    private static MockPackingMaterialRepository BuildRepo(params PackingMaterial[] materials)
+    {
+        var repo = new MockPackingMaterialRepository();
+        repo.SetMaterials(materials);
+        return repo;
+    }
+
+    // ---- UpdatePackingMaterial ----
+
+    [Fact]
+    public async Task UpdatePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+    {
+        // Arrange
+        var repo = BuildRepo();
+        var handler = new UpdatePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialRequest
+        {
+            Id = 99,
+            Name = "Anything",
+            ConsumptionRate = 1m,
+            ConsumptionType = ConsumptionType.PerOrder
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+        Assert.NotNull(response.Error);
+        Assert.Contains("99", response.Error!);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterial_UpdatesMaterialAndReturnsSuccess_WhenMaterialExists()
+    {
+        // Arrange
+        var material = MakeMaterial(1, "Old");
+        var repo = BuildRepo(material);
+        var handler = new UpdatePackingMaterialHandler(repo);
+
+        // Act
+        var response = await handler.Handle(new UpdatePackingMaterialRequest
+        {
+            Id = 1,
+            Name = "New",
+            ConsumptionRate = 2m,
+            ConsumptionType = ConsumptionType.PerProduct
+        }, CancellationToken.None);
+
+        // Assert
+        Assert.True(response.Success);
+        Assert.Null(response.ErrorCode);
+        Assert.Null(response.Error);
+        Assert.NotNull(response.Material);
+        Assert.Equal(1, response.Material.Id);
+        Assert.Equal("New", response.Material.Name);
+        Assert.Equal(2m, response.Material.ConsumptionRate);
+        Assert.Single(repo.UpdatedMaterials);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests, expect the not-found case to fail with a thrown exception**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests"`
+Expected:
+- `UpdatePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist` FAILS because the handler currently throws `ArgumentException`.
+- `UpdatePackingMaterial_UpdatesMaterialAndReturnsSuccess_WhenMaterialExists` PASSES (current happy-path behavior is correct).
+
+- [ ] **Step 3: Replace the throw in `UpdatePackingMaterialHandler` with a structured return**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`. Add `using Anela.Heblo.Application.Shared;` at the top, then replace the not-found branch:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterial;
+
+public class UpdatePackingMaterialHandler : IRequestHandler<UpdatePackingMaterialRequest, UpdatePackingMaterialResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+
+    public UpdatePackingMaterialHandler(IPackingMaterialRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<UpdatePackingMaterialResponse> Handle(
+        UpdatePackingMaterialRequest request,
+        CancellationToken cancellationToken)
+    {
+        var material = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (material == null)
+        {
+            return new UpdatePackingMaterialResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
+        }
+
+        material.UpdateMaterial(request.Name, request.ConsumptionRate, request.ConsumptionType);
+        await _repository.UpdateAsync(material, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        var materialDto = new PackingMaterialDto
+        {
+            Id = material.Id,
+            Name = material.Name,
+            ConsumptionRate = material.ConsumptionRate,
+            ConsumptionType = material.ConsumptionType,
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            CurrentQuantity = material.CurrentQuantity,
+            ForecastedDays = null,
+            CreatedAt = material.CreatedAt,
+            UpdatedAt = material.UpdatedAt
+        };
+
+        return new UpdatePackingMaterialResponse
+        {
+            Material = materialDto
+        };
+    }
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+- [ ] **Step 4: Re-run the handler tests, expect both to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests"`
+Expected: both `UpdatePackingMaterial_*` tests PASS.
+
+- [ ] **Step 5: Write the failing controller test for the 404 mapping**
+
+Create `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs`:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.PackingMaterials;
+
+public class PackingMaterialsControllerNotFoundTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly PackingMaterialsController _controller;
+
+    public PackingMaterialsControllerNotFoundTests()
+    {
+        _controller = new PackingMaterialsController(_mediator.Object);
+    }
+
+    [Fact]
+    public async Task UpdatePackingMaterial_Returns404_WhenHandlerReturnsResourceNotFound()
+    {
+        // Arrange
+        var notFound = new UpdatePackingMaterialResponse
+        {
+            Success = false,
+            ErrorCode = ErrorCodes.ResourceNotFound,
+            Error = "Packing material with ID 99 not found."
+        };
+        _mediator
+            .Setup(m => m.Send(It.IsAny<UpdatePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(notFound);
+
+        var request = new UpdatePackingMaterialRequest
+        {
+            Id = 99,
+            Name = "Anything",
+            ConsumptionRate = 1m,
+            ConsumptionType = ConsumptionType.PerOrder
+        };
+
+        // Act
+        var result = await _controller.UpdatePackingMaterial(99, request, CancellationToken.None);
+
+        // Assert
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.StatusCode.Should().Be(404);
+    }
+}
+```
+
+- [ ] **Step 6: Run the controller test, expect it to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterial_Returns404"`
+Expected: FAIL. The current controller returns `Ok(response)` regardless of `response.Success`, so the assertion `BeOfType<NotFoundObjectResult>()` fails.
+
+- [ ] **Step 7: Update the `UpdatePackingMaterial` controller action to map the structured response**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `UpdatePackingMaterial` action body (lines around 58-76) with:
+
+```csharp
+[HttpPut("{id}")]
+[ProducesResponseType(typeof(UpdatePackingMaterialResponse), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult<UpdatePackingMaterialResponse>> UpdatePackingMaterial(
+    int id,
+    [FromBody] UpdatePackingMaterialRequest request,
+    CancellationToken cancellationToken = default)
+{
+    if (id != request.Id)
+    {
+        return BadRequest("ID mismatch");
+    }
+
+    if (!ModelState.IsValid)
+    {
+        return BadRequest(ModelState);
+    }
+
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success) return Ok(response);
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 8: Re-run the controller test, expect it to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterial_Returns404"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for UpdatePackingMaterial when material is missing"
+```
+
+---
+
+## Task 3: UpdatePackingMaterialQuantity — TDD handler + controller 404 mapping
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (append cases)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` (append case)
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`UpdatePackingMaterialQuantity` action)
+
+The `UpdatePackingMaterialQuantityHandler` depends on `ICurrentUserService` — we need a stub for tests. The simplest approach is a tiny in-file stub; if the test base already has a mock for it elsewhere we can reuse, but the simplest self-contained approach is a local stub.
+
+- [ ] **Step 1: Add a local stub `ICurrentUserService` for tests**
+
+Append this stub to `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (above the existing `PackingMaterialCrudHandlerTests` class, inside the same file, in the same namespace):
+
+```csharp
+internal sealed class StubCurrentUserService : Anela.Heblo.Domain.Features.Users.ICurrentUserService
+{
+    private readonly Anela.Heblo.Domain.Features.Users.CurrentUser? _user;
+
+    public StubCurrentUserService(Anela.Heblo.Domain.Features.Users.CurrentUser? user = null)
+    {
+        _user = user;
+    }
+
+    public Anela.Heblo.Domain.Features.Users.CurrentUser GetCurrentUser()
+        => _user ?? new Anela.Heblo.Domain.Features.Users.CurrentUser("test-user-id", "Test User", "test@example.com", true);
+}
+```
+
+> **Note for executor:** if the `CurrentUser` constructor signature differs in this codebase, adapt the construction above to match the existing type. Discover by reading `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs` (or wherever the type is defined) and use the existing happy-path constructor. The point of the stub is only that `GetCurrentUser()` returns a non-null value with an `Id`; nothing else is asserted.
+
+- [ ] **Step 2: Append failing handler tests for `UpdatePackingMaterialQuantityHandler`**
+
+Append these `[Fact]` methods inside the `PackingMaterialCrudHandlerTests` class (after the `UpdatePackingMaterial_*` tests). Add the needed `using` at the top of the file if missing: `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;`.
+
+```csharp
+// ---- UpdatePackingMaterialQuantity ----
+
+[Fact]
+public async Task UpdatePackingMaterialQuantity_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+{
+    // Arrange
+    var repo = BuildRepo();
+    var handler = new UpdatePackingMaterialQuantityHandler(repo, new StubCurrentUserService());
+
+    // Act
+    var response = await handler.Handle(new UpdatePackingMaterialQuantityRequest
+    {
+        Id = 99,
+        NewQuantity = 5m,
+        Date = DateOnly.FromDateTime(DateTime.UtcNow)
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.False(response.Success);
+    Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+    Assert.NotNull(response.Error);
+    Assert.Contains("99", response.Error!);
+}
+
+[Fact]
+public async Task UpdatePackingMaterialQuantity_UpdatesAndReturnsSuccess_WhenMaterialExists()
+{
+    // Arrange
+    var material = MakeMaterial(1);
+    var repo = BuildRepo(material);
+    var handler = new UpdatePackingMaterialQuantityHandler(repo, new StubCurrentUserService());
+
+    // Act
+    var response = await handler.Handle(new UpdatePackingMaterialQuantityRequest
+    {
+        Id = 1,
+        NewQuantity = 42m,
+        Date = DateOnly.FromDateTime(DateTime.UtcNow)
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.True(response.Success);
+    Assert.Null(response.ErrorCode);
+    Assert.Null(response.Error);
+    Assert.NotNull(response.Material);
+    Assert.Equal(1, response.Material.Id);
+    Assert.Single(repo.UpdatedMaterials);
+}
+```
+
+- [ ] **Step 3: Run the new tests, expect not-found to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.UpdatePackingMaterialQuantity"`
+Expected: `UpdatePackingMaterialQuantity_ReturnsNotFoundResponse_WhenMaterialDoesNotExist` FAILS (handler throws). Happy-path PASSES.
+
+- [ ] **Step 4: Replace the throw in `UpdatePackingMaterialQuantityHandler`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`. Add `using Anela.Heblo.Application.Shared;` at the top, then replace the not-found branch:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;
+
+public class UpdatePackingMaterialQuantityHandler : IRequestHandler<UpdatePackingMaterialQuantityRequest, UpdatePackingMaterialQuantityResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public UpdatePackingMaterialQuantityHandler(
+        IPackingMaterialRepository repository,
+        ICurrentUserService currentUserService)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<UpdatePackingMaterialQuantityResponse> Handle(
+        UpdatePackingMaterialQuantityRequest request,
+        CancellationToken cancellationToken)
+    {
+        var material = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (material == null)
+        {
+            return new UpdatePackingMaterialQuantityResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
+        }
+
+        var currentUser = _currentUserService.GetCurrentUser();
+        material.UpdateQuantity(request.NewQuantity, request.Date, LogEntryType.Manual, currentUser?.Id);
+
+        await _repository.UpdateAsync(material, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        var oneMonthAgo = DateTime.UtcNow.AddMonths(-1);
+        var recentLogs = await _repository.GetRecentLogsAsync(material.Id, oneMonthAgo, cancellationToken);
+        var forecastedDays = material.CalculateForecastedDays(recentLogs.ToList());
+        var displayForecast = forecastedDays == decimal.MaxValue ? null : (decimal?)Math.Round(forecastedDays, 1);
+
+        var materialDto = new PackingMaterialDto
+        {
+            Id = material.Id,
+            Name = material.Name,
+            ConsumptionRate = material.ConsumptionRate,
+            ConsumptionType = material.ConsumptionType,
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            CurrentQuantity = material.CurrentQuantity,
+            ForecastedDays = displayForecast,
+            CreatedAt = material.CreatedAt,
+            UpdatedAt = material.UpdatedAt
+        };
+
+        return new UpdatePackingMaterialQuantityResponse
+        {
+            Material = materialDto
+        };
+    }
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+- [ ] **Step 5: Re-run handler tests, expect both to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.UpdatePackingMaterialQuantity"`
+Expected: PASS.
+
+- [ ] **Step 6: Append failing controller test**
+
+Append this `[Fact]` to `PackingMaterialsControllerNotFoundTests` (add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.UpdatePackingMaterialQuantity;` at the top if needed):
+
+```csharp
+[Fact]
+public async Task UpdatePackingMaterialQuantity_Returns404_WhenHandlerReturnsResourceNotFound()
+{
+    // Arrange
+    var notFound = new UpdatePackingMaterialQuantityResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = "Packing material with ID 99 not found."
+    };
+    _mediator
+        .Setup(m => m.Send(It.IsAny<UpdatePackingMaterialQuantityRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(notFound);
+
+    var body = new UpdateQuantityRequest
+    {
+        NewQuantity = 5m,
+        Date = DateOnly.FromDateTime(DateTime.UtcNow)
+    };
+
+    // Act
+    var result = await _controller.UpdatePackingMaterialQuantity(99, body, CancellationToken.None);
+
+    // Assert
+    var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+    notFoundResult.StatusCode.Should().Be(404);
+}
+```
+
+- [ ] **Step 7: Run the controller test, expect it to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterialQuantity_Returns404"`
+Expected: FAIL — controller currently returns `Ok(response)` regardless of `response.Success`.
+
+- [ ] **Step 8: Update the `UpdatePackingMaterialQuantity` controller action**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `UpdatePackingMaterialQuantity` action with:
+
+```csharp
+[HttpPost("{id}/quantity")]
+[ProducesResponseType(typeof(UpdatePackingMaterialQuantityResponse), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult<UpdatePackingMaterialQuantityResponse>> UpdatePackingMaterialQuantity(
+    int id,
+    [FromBody] UpdateQuantityRequest request,
+    CancellationToken cancellationToken = default)
+{
+    if (!ModelState.IsValid)
+    {
+        return BadRequest(ModelState);
+    }
+
+    var quantityRequest = new UpdatePackingMaterialQuantityRequest
+    {
+        Id = id,
+        NewQuantity = request.NewQuantity,
+        Date = request.Date
+    };
+
+    var response = await _mediator.Send(quantityRequest, cancellationToken);
+    if (response.Success) return Ok(response);
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 9: Re-run controller test, expect PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.UpdatePackingMaterialQuantity_Returns404"`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for UpdatePackingMaterialQuantity when material is missing"
+```
+
+---
+
+## Task 4: GetPackingMaterialLogs — TDD handler + controller 404 mapping
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (append)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` (append)
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`GetPackingMaterialLogs` action)
+
+- [ ] **Step 1: Append failing handler tests**
+
+Add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;` at the top of `PackingMaterialCrudHandlerTests.cs` if missing, then append inside the test class:
+
+```csharp
+// ---- GetPackingMaterialLogs ----
+
+[Fact]
+public async Task GetPackingMaterialLogs_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+{
+    // Arrange
+    var repo = BuildRepo();
+    var handler = new GetPackingMaterialLogsHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new GetPackingMaterialLogsRequest
+    {
+        PackingMaterialId = 99,
+        Days = 30
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.False(response.Success);
+    Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+    Assert.NotNull(response.Error);
+    Assert.Contains("99", response.Error!);
+}
+
+[Fact]
+public async Task GetPackingMaterialLogs_ReturnsSuccess_WhenMaterialExists()
+{
+    // Arrange
+    var material = MakeMaterial(1);
+    var repo = BuildRepo(material);
+    var handler = new GetPackingMaterialLogsHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new GetPackingMaterialLogsRequest
+    {
+        PackingMaterialId = 1,
+        Days = 30
+    }, CancellationToken.None);
+
+    // Assert
+    Assert.True(response.Success);
+    Assert.Null(response.ErrorCode);
+    Assert.Null(response.Error);
+    Assert.NotNull(response.Material);
+    Assert.Equal(1, response.Material.Id);
+    Assert.Empty(response.Logs);
+}
+```
+
+- [ ] **Step 2: Run the new tests, expect not-found to fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.GetPackingMaterialLogs"`
+Expected: not-found case FAILS (handler throws `InvalidOperationException`). Happy-path PASSES.
+
+- [ ] **Step 3: Replace the throw in `GetPackingMaterialLogsHandler`**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`. Add `using Anela.Heblo.Application.Shared;` and replace the not-found branch:
+
+```csharp
+using Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;
+
+public class GetPackingMaterialLogsHandler : IRequestHandler<GetPackingMaterialLogsRequest, GetPackingMaterialLogsResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+
+    public GetPackingMaterialLogsHandler(IPackingMaterialRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetPackingMaterialLogsResponse> Handle(
+        GetPackingMaterialLogsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var material = await _repository.GetByIdWithLogsAsync(request.PackingMaterialId, cancellationToken);
+        if (material == null)
+        {
+            return new GetPackingMaterialLogsResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.PackingMaterialId} not found."
+            };
+        }
+
+        var fromDate = DateTime.UtcNow.AddDays(-request.Days);
+        var recentLogs = await _repository.GetRecentLogsAsync(request.PackingMaterialId, fromDate, cancellationToken);
+
+        var materialDto = new PackingMaterialDto
+        {
+            Id = material.Id,
+            Name = material.Name,
+            ConsumptionRate = material.ConsumptionRate,
+            ConsumptionType = material.ConsumptionType,
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            CurrentQuantity = material.CurrentQuantity,
+            CreatedAt = material.CreatedAt,
+            UpdatedAt = material.UpdatedAt
+        };
+
+        var logDtos = recentLogs.Select(log => new PackingMaterialLogDto
+        {
+            Id = log.Id,
+            PackingMaterialId = log.PackingMaterialId,
+            Date = log.Date,
+            OldQuantity = log.OldQuantity,
+            NewQuantity = log.NewQuantity,
+            ChangeAmount = log.ChangeAmount,
+            LogType = log.LogType,
+            LogTypeText = GetLogTypeText(log.LogType),
+            UserId = log.UserId,
+            CreatedAt = log.CreatedAt
+        }).OrderByDescending(log => log.Date).ThenByDescending(log => log.CreatedAt).ToList();
+
+        return new GetPackingMaterialLogsResponse
+        {
+            Material = materialDto,
+            Logs = logDtos
+        };
+    }
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+
+    private static string GetLogTypeText(LogEntryType type) => type switch
+    {
+        LogEntryType.Manual => "Ruční",
+        LogEntryType.AutomaticConsumption => "Automatická spotřeba",
+        _ => type.ToString()
+    };
+}
+```
+
+- [ ] **Step 4: Re-run handler tests, expect both to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.GetPackingMaterialLogs"`
+Expected: PASS.
+
+- [ ] **Step 5: Append failing controller test**
+
+Append this `[Fact]` to `PackingMaterialsControllerNotFoundTests` (add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.GetPackingMaterialLogs;` at the top if missing):
+
+```csharp
+[Fact]
+public async Task GetPackingMaterialLogs_Returns404_WhenHandlerReturnsResourceNotFound()
+{
+    // Arrange
+    var notFound = new GetPackingMaterialLogsResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = "Packing material with ID 99 not found."
+    };
+    _mediator
+        .Setup(m => m.Send(It.IsAny<GetPackingMaterialLogsRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(notFound);
+
+    // Act
+    var result = await _controller.GetPackingMaterialLogs(99, 60, CancellationToken.None);
+
+    // Assert
+    var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+    notFoundResult.StatusCode.Should().Be(404);
+}
+```
+
+- [ ] **Step 6: Run controller test, expect fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.GetPackingMaterialLogs_Returns404"`
+Expected: FAIL.
+
+- [ ] **Step 7: Update the `GetPackingMaterialLogs` controller action**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `GetPackingMaterialLogs` action with:
+
+```csharp
+[HttpGet("{id}/logs")]
+[ProducesResponseType(typeof(GetPackingMaterialLogsResponse), StatusCodes.Status200OK)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult<GetPackingMaterialLogsResponse>> GetPackingMaterialLogs(
+    int id,
+    [FromQuery] int days = 60,
+    CancellationToken cancellationToken = default)
+{
+    var request = new GetPackingMaterialLogsRequest
+    {
+        PackingMaterialId = id,
+        Days = days
+    };
+
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success) return Ok(response);
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 8: Re-run controller test, expect PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.GetPackingMaterialLogs_Returns404"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for GetPackingMaterialLogs when material is missing"
+```
+
+---
+
+## Task 5: DeletePackingMaterial — contract change + TDD handler + controller 204/404 mapping
+
+This task is larger than the previous three because `DeletePackingMaterialRequest` must be promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>`, the handler signature changes, and the controller action moves from awaiting `Unit` to mapping a typed response.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs` (`DeletePackingMaterial` action)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs` (append)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs` (append)
+
+- [ ] **Step 1: Append failing handler tests**
+
+Add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;` at the top of `PackingMaterialCrudHandlerTests.cs` if missing, then append inside the test class:
+
+```csharp
+// ---- DeletePackingMaterial ----
+
+[Fact]
+public async Task DeletePackingMaterial_ReturnsNotFoundResponse_WhenMaterialDoesNotExist()
+{
+    // Arrange
+    var repo = BuildRepo();
+    var handler = new DeletePackingMaterialHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new DeletePackingMaterialRequest { Id = 99 }, CancellationToken.None);
+
+    // Assert
+    Assert.False(response.Success);
+    Assert.Equal(ErrorCodes.ResourceNotFound, response.ErrorCode);
+    Assert.NotNull(response.Error);
+    Assert.Contains("99", response.Error!);
+    Assert.Single(repo.Materials);
+}
+
+[Fact]
+public async Task DeletePackingMaterial_DeletesAndReturnsSuccess_WhenMaterialExists()
+{
+    // Arrange
+    var material = MakeMaterial(1);
+    var repo = BuildRepo(material);
+    var handler = new DeletePackingMaterialHandler(repo);
+
+    // Act
+    var response = await handler.Handle(new DeletePackingMaterialRequest { Id = 1 }, CancellationToken.None);
+
+    // Assert
+    Assert.True(response.Success);
+    Assert.Null(response.ErrorCode);
+    Assert.Null(response.Error);
+    Assert.Empty(repo.Materials);
+}
+```
+
+- [ ] **Step 2: Run, expect compile errors (return type changed)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.DeletePackingMaterial"`
+Expected: COMPILE ERROR. The new tests treat `handler.Handle(...)` as returning a `DeletePackingMaterialResponse`, but the current handler returns `Task` (Unit). The tests cannot even compile until the contract is changed in Step 3.
+
+- [ ] **Step 3: Change `DeletePackingMaterialRequest` to typed request**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs`:
+
+```csharp
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialRequest : IRequest<DeletePackingMaterialResponse>
+{
+    public int Id { get; set; }
+}
+```
+
+- [ ] **Step 4: Change `DeletePackingMaterialHandler` signature and body**
+
+Edit `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs`:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.PackingMaterials;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;
+
+public class DeletePackingMaterialHandler : IRequestHandler<DeletePackingMaterialRequest, DeletePackingMaterialResponse>
+{
+    private readonly IPackingMaterialRepository _repository;
+
+    public DeletePackingMaterialHandler(IPackingMaterialRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<DeletePackingMaterialResponse> Handle(DeletePackingMaterialRequest request, CancellationToken cancellationToken)
+    {
+        var packingMaterial = await _repository.GetByIdAsync(request.Id, cancellationToken);
+        if (packingMaterial == null)
+        {
+            return new DeletePackingMaterialResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.ResourceNotFound,
+                Error = $"Packing material with ID {request.Id} not found."
+            };
+        }
+
+        await _repository.DeleteAsync(packingMaterial, cancellationToken);
+        return new DeletePackingMaterialResponse();
+    }
+}
+```
+
+- [ ] **Step 5: Update the `DeletePackingMaterial` controller action**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs`, replace the `DeletePackingMaterial` action with:
+
+```csharp
+[HttpDelete("{id}")]
+[ProducesResponseType(StatusCodes.Status204NoContent)]
+[ProducesResponseType(StatusCodes.Status400BadRequest)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+public async Task<ActionResult> DeletePackingMaterial(
+    int id,
+    CancellationToken cancellationToken = default)
+{
+    var request = new DeletePackingMaterialRequest { Id = id };
+    var response = await _mediator.Send(request, cancellationToken);
+    if (response.Success) return NoContent();
+    if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error });
+    return BadRequest(new { error = response.Error });
+}
+```
+
+- [ ] **Step 6: Build to confirm everything compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 7: Re-run handler tests, expect both DeletePackingMaterial cases to pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialCrudHandlerTests.DeletePackingMaterial"`
+Expected: PASS.
+
+- [ ] **Step 8: Append failing controller test**
+
+Append these `[Fact]` methods to `PackingMaterialsControllerNotFoundTests` (add `using Anela.Heblo.Application.Features.PackingMaterials.UseCases.DeletePackingMaterial;` at the top if missing):
+
+```csharp
+[Fact]
+public async Task DeletePackingMaterial_Returns404_WhenHandlerReturnsResourceNotFound()
+{
+    // Arrange
+    var notFound = new DeletePackingMaterialResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.ResourceNotFound,
+        Error = "Packing material with ID 99 not found."
+    };
+    _mediator
+        .Setup(m => m.Send(It.IsAny<DeletePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(notFound);
+
+    // Act
+    var result = await _controller.DeletePackingMaterial(99, CancellationToken.None);
+
+    // Assert
+    var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+    notFoundResult.StatusCode.Should().Be(404);
+}
+
+[Fact]
+public async Task DeletePackingMaterial_Returns204_WhenHandlerReturnsSuccess()
+{
+    // Arrange
+    var ok = new DeletePackingMaterialResponse();
+    _mediator
+        .Setup(m => m.Send(It.IsAny<DeletePackingMaterialRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(ok);
+
+    // Act
+    var result = await _controller.DeletePackingMaterial(1, CancellationToken.None);
+
+    // Assert
+    result.Should().BeOfType<NoContentResult>();
+}
+```
+
+- [ ] **Step 9: Run the controller tests, expect PASS**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterialsControllerNotFoundTests.DeletePackingMaterial"`
+Expected: PASS (Step 5 already updated the controller to inspect the typed response).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialRequest.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/DeletePackingMaterial/DeletePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.API/Controllers/PackingMaterialsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialCrudHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/PackingMaterials/PackingMaterialsControllerNotFoundTests.cs
+git commit -m "fix(packing-materials): return 404 for DeletePackingMaterial when material is missing"
+```
+
+---
+
+## Task 6: Backend-wide validation
+
+This task confirms nothing else regressed (the PackingMaterials module shares the `PackingMaterialsController` with the allocation endpoints, and the global build must remain clean).
+
+**Files:** none changed; verification only. If `dotnet format` reports formatting drift in the files this PR touched, accept those edits in a follow-up commit.
+
+- [ ] **Step 1: Run `dotnet build` on the whole solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: zero errors, zero warnings introduced by this PR.
+
+- [ ] **Step 2: Run the full PackingMaterials test suite**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Features.PackingMaterials"`
+Expected: all PackingMaterials tests pass, including the existing `AllocationHandlerTests`, `ConsumptionCalculationServiceTests`, and `GetDailyConsumptionBreakdownHandlerTests`.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: total test count is at least equal to the count before this PR plus the new tests added in Tasks 2–5; zero failures.
+
+- [ ] **Step 4: Run `dotnet format` on the modified projects**
+
+Run: `dotnet format backend/Anela.Heblo.sln --verify-no-changes` (or `dotnet format backend/Anela.Heblo.sln` if drift is found, then re-run with `--verify-no-changes`)
+Expected: no formatting violations remain.
+
+- [ ] **Step 5: Commit any formatting fixes (only if Step 4 reformatted files)**
+
+```bash
+git add -A
+git commit -m "chore: apply dotnet format"
+```
+
+Skip this step entirely if `dotnet format --verify-no-changes` reported nothing.
+
+---
+
+## Task 7: Frontend regeneration + verification + audit notes
+
+The OpenAPI TypeScript client is regenerated automatically by `dotnet build`. We verify the frontend still builds, lints, and that the frontend audit (FR-9) finds no required source changes.
+
+**Files:** no frontend source edits expected. Audit findings are recorded in the eventual PR description, not in any source file.
+
+- [ ] **Step 1: Ensure backend builds (so the TS client regenerates)**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: succeeds. The build target regenerates `frontend/src/api/generated/api-client.ts`. The regenerated client will gain a new TypeScript type for `DeletePackingMaterialResponse` and additional optional fields on the three existing types — purely additive.
+
+- [ ] **Step 2: Frontend build**
+
+Run: `npm --prefix frontend run build`
+Expected: succeeds with no new TS errors. The hand-rolled `frontend/src/api/hooks/usePackingMaterials.ts` does not consume the new fields and is unaffected.
+
+- [ ] **Step 3: Frontend lint**
+
+Run: `npm --prefix frontend run lint`
+Expected: succeeds with no new lint errors.
+
+- [ ] **Step 4: Audit frontend call sites for the four affected endpoints**
+
+Use Grep to find every call site that targets the four affected endpoints. Run from the worktree root:
+
+```
+Grep pattern: packing-materials/\$\{|packing-materials\?|/quantity|/logs
+Glob:        frontend/src/**/*.ts*
+```
+
+Specifically inspect `frontend/src/api/hooks/usePackingMaterials.ts`. Verify that:
+- It currently throws a generic `Error` for any non-OK HTTP status. (Confirmed by arch-review §FR-9.)
+- No call site distinguishes HTTP 500 from HTTP 404 by status code.
+- No call site reads `response.body.Error` for a special UX on not-found.
+
+The expected outcome is **zero source-code changes**. Record this confirmation as a one-line note for the eventual PR description, e.g.:
+
+> *Frontend audit: only call site is `frontend/src/api/hooks/usePackingMaterials.ts`, which throws a generic `Error` on any non-OK status. No 500-vs-404 differentiation. No source changes required. (FR-9.)*
+
+If the audit unexpectedly finds a call site that branches on 500, **stop and flag it** — that case is beyond the spec's scope and needs a separate discussion before proceeding.
+
+- [ ] **Step 5: Commit (only if Step 1 produced regenerated client edits to commit)**
+
+If the regenerated `frontend/src/api/generated/api-client.ts` has uncommitted diffs from the build, stage and commit them:
+
+```bash
+git status --short frontend/src/api/generated
+# if changes are listed:
+git add frontend/src/api/generated/api-client.ts
+git commit -m "chore: regenerate openapi client for PackingMaterials response DTOs"
+```
+
+If the file is gitignored or otherwise not tracked (some projects exclude generated artifacts), skip this step.
+
+---
+
+## Self-Review (executed before declaring the plan complete)
+
+**Spec coverage:**
+- FR-1 (UpdatePackingMaterial structured not-found) → Task 2.
+- FR-2 (UpdatePackingMaterialQuantity structured not-found) → Task 3.
+- FR-3 (DeletePackingMaterial structured not-found) → Task 5.
+- FR-4 (GetPackingMaterialLogs structured not-found) → Task 4.
+- FR-5 (response DTOs carry `Success`/`ErrorCode`/`Error`) → Task 1 (scaffolding) + arch-review override (`Error` per response, not on `BaseResponse`).
+- FR-6 (controllers map ResourceNotFound to 404) → Tasks 2, 3, 4, 5 (controller edits + tests). Envelope is `NotFound(new { error = response.Error })` per arch-review override.
+- FR-7 (consistent message template) → All four handlers emit `"Packing material with ID {id} not found."` matching `GetAllocationsHandler.cs:32`.
+- FR-8 (tests for changed behavior) → Tasks 2–5 add both not-found and happy-path tests per handler, plus controller-level 404 mapping tests.
+- FR-9 (frontend audit) → Task 7 Step 4 documents the audit result with no source changes.
+- NFR-1 (performance) → no concern; structured returns replace throws, marginally faster on the not-found path.
+- NFR-2 (security) → unchanged; messages echo only the caller-supplied ID.
+- NFR-3 (backwards compat) → 404 replaces 500 on not-found path; happy path unchanged. Stated intentionally in this plan and in the spec.
+- NFR-4 (testability) → handler not-found path tested without throws.
+- NFR-5 (observability) → no logger injected (matches the spec NFR-5 amendment in arch-review).
+
+**Placeholder scan:** none — every step has either concrete code or a concrete command + expected outcome. The one judgment call (`CurrentUser` constructor signature in Task 3 Step 1) is explicitly framed as "read the existing type and match it"; no other step contains "TBD" / "as appropriate" / "etc."
+
+**Type consistency:** the four response DTOs all gain the same `string? Error { get; set; }` member. The four handler not-found return paths all emit the identical message template `"Packing material with ID {id} not found."`. The four controller actions all use the identical mapping `if (response.Success) return Ok/NoContent; if (response.ErrorCode == ErrorCodes.ResourceNotFound) return NotFound(new { error = response.Error }); return BadRequest(new { error = response.Error });`. `DeletePackingMaterialResponse` is referenced consistently between Task 1 (creation) and Task 5 (use).


### PR DESCRIPTION

Replace exception-throwing not-found behavior in four PackingMaterials CRUD handlers with the structured-return pattern already used by the allocation handlers in the same module. Requests to `PUT /api/packing-materials/{id}`, `POST /api/packing-materials/{id}/quantity`, `DELETE /api/packing-materials/{id}`, and `GET /api/packing-materials/{id}/logs` with a non-existent ID now correctly return HTTP 404 instead of HTTP 500.

The `DeletePackingMaterial` endpoint required the most change: `DeletePackingMaterialRequest` was promoted from `IRequest` (Unit) to `IRequest<DeletePackingMaterialResponse>` so the handler has a return channel for the structured error. The other three handlers were simpler — a single line swap from `throw new ArgumentException/InvalidOperationException` to `return new Response { Success = false, ErrorCode = ErrorCodes.ResourceNotFound, Error = "..." }`. All four affected controller actions were updated to inspect `response.Success` and map `ResourceNotFound` → `NotFound(new { error })`, matching the existing allocation endpoints verbatim.

### Changes
- `DeletePackingMaterialResponse.cs` — new response DTO (required for the contract promotion)
- `DeletePackingMaterialRequest.cs` — promoted to `IRequest<DeletePackingMaterialResponse>`
- `DeletePackingMaterialHandler.cs` — new typed handler signature + structured return
- `UpdatePackingMaterialHandler.cs`, `UpdatePackingMaterialQuantityHandler.cs`, `GetPackingMaterialLogsHandler.cs` — throw replaced with structured return
- `UpdatePackingMaterialRequest.cs`, `UpdatePackingMaterialQuantityResponse.cs`, `GetPackingMaterialLogsResponse.cs` — `string? Error` property added (additive)
- `PackingMaterialsController.cs` — four actions updated with response inspection + `[ProducesResponseType]` attributes
- `PackingMaterialCrudHandlerTests.cs` + `PackingMaterialsControllerNotFoundTests.cs` — new test files, 13 tests total

---

Closes #1473

### Tokens used
50807039
