### PR TITLE
fix(meeting-tasks): surface Planner submit failures instead of closing modal silently

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/GraphPlannerService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/Services/GraphPlannerService.cs
@@ -18,6 +18,10 @@ public class GraphPlannerService : IMeetingTaskExporter
     private readonly string _planId;
     private readonly string? _bucketId;
 
+    // Single-flight delegated-token cache, scoped to one /submit request (service is Scoped).
+    // Prevents MSAL's internal retry loop from firing once per approved task when consent is missing.
+    private Task<string>? _delegatedTokenTask;
+
     public GraphPlannerService(
         ITokenAcquisition tokenAcquisition,
         IHttpClientFactory httpClientFactory,
@@ -144,7 +148,12 @@ public class GraphPlannerService : IMeetingTaskExporter
         }
     }
 
-    private async Task<string> GetDelegatedTokenAsync()
+    private Task<string> GetDelegatedTokenAsync()
+    {
+        return _delegatedTokenTask ??= AcquireDelegatedTokenAsync();
+    }
+
+    private async Task<string> AcquireDelegatedTokenAsync()
     {
         try
         {

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/SubmitToTodo/SubmitToTodoHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/UseCases/SubmitToTodo/SubmitToTodoHandler.cs
@@ -101,9 +101,20 @@ public class SubmitToTodoHandler : IRequestHandler<SubmitToTodoRequest, SubmitTo
 
         await _repository.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Exported {SuccessCount} Planner tasks for transcript {Id}, {FailedCount} failed",
-            response.SuccessCount, transcript.Id, response.FailedCount);
+        // Warning when anything failed — Information is dropped by CostOptimizedTelemetryProcessor
+        // in Production, which previously hid silent consent failures from telemetry.
+        if (response.FailedCount > 0)
+        {
+            _logger.LogWarning(
+                "Exported {SuccessCount} Planner tasks for transcript {Id}, {FailedCount} failed",
+                response.SuccessCount, transcript.Id, response.FailedCount);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Exported {SuccessCount} Planner tasks for transcript {Id}, {FailedCount} failed",
+                response.SuccessCount, transcript.Id, response.FailedCount);
+        }
 
         return response;
     }

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/GraphPlannerServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/GraphPlannerServiceTests.cs
@@ -7,6 +7,7 @@ using Anela.Heblo.Application.Features.MeetingTasks.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Web;
 using Moq;
 using Xunit;
@@ -350,6 +351,81 @@ public class GraphPlannerServiceTests
         result.Success.Should().BeTrue("task was already created before the patch failed");
         result.ExternalTaskId.Should().Be("t1");
         result.Error.Should().BeNull();
+    }
+
+    // ─── Delegated-token caching ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExportTaskAsync_DelegatedToken_AcquiredOncePerService()
+    {
+        // Service is registered Scoped — one instance per /submit request handles N tasks.
+        // The delegated OBO token must be reused, not re-acquired for each ExportTaskAsync call.
+        var tokenAcquisition = new Mock<ITokenAcquisition>();
+        tokenAcquisition
+            .Setup(t => t.GetAccessTokenForUserAsync(
+                It.IsAny<IEnumerable<string>>(), null, null, null, null))
+            .ReturnsAsync("delegated-token");
+
+        var recordingHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent("""{"id":"t1"}""", Encoding.UTF8, "application/json")
+        });
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("MicrosoftGraph")).Returns(new HttpClient(recordingHandler));
+
+        var service = new GraphPlannerService(
+            tokenAcquisition.Object,
+            factory.Object,
+            Options.Create(new MeetingTasksOptions { PlannerPlanId = "plan-1" }),
+            NullLogger<GraphPlannerService>.Instance);
+
+        await service.ExportTaskAsync("user-a", "T1", "", null);
+        await service.ExportTaskAsync("user-b", "T2", "", null);
+        await service.ExportTaskAsync("user-c", "T3", "", null);
+
+        tokenAcquisition.Verify(
+            t => t.GetAccessTokenForUserAsync(
+                It.IsAny<IEnumerable<string>>(), null, null, null, null),
+            Times.Once,
+            "delegated token must be cached across ExportTaskAsync calls within one request");
+    }
+
+    [Fact]
+    public async Task ExportTaskAsync_DelegatedTokenUiRequired_CachedAndDoesNotRetry()
+    {
+        // When MSAL throws MsalUiRequiredException (e.g. AADSTS65001 consent missing),
+        // subsequent ExportTaskAsync calls in the same request must short-circuit
+        // without calling MSAL again — preventing N×6 MSAL retry traces.
+        var tokenAcquisition = new Mock<ITokenAcquisition>();
+        tokenAcquisition
+            .Setup(t => t.GetAccessTokenForUserAsync(
+                It.IsAny<IEnumerable<string>>(), null, null, null, null))
+            .ThrowsAsync(new MsalUiRequiredException("invalid_grant", "consent required"));
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("MicrosoftGraph")).Returns(new HttpClient(new RecordingHandler(_ =>
+            throw new InvalidOperationException("Graph must not be called when token acquisition failed"))));
+
+        var service = new GraphPlannerService(
+            tokenAcquisition.Object,
+            factory.Object,
+            Options.Create(new MeetingTasksOptions { PlannerPlanId = "plan-1" }),
+            NullLogger<GraphPlannerService>.Instance);
+
+        var first = await service.ExportTaskAsync("user-a", "T1", "", null);
+        var second = await service.ExportTaskAsync("user-b", "T2", "", null);
+        var third = await service.ExportTaskAsync("user-c", "T3", "", null);
+
+        first.Success.Should().BeFalse();
+        second.Success.Should().BeFalse();
+        third.Success.Should().BeFalse();
+        first.Error.Should().Contain("Microsoft 365 consent required");
+
+        tokenAcquisition.Verify(
+            t => t.GetAccessTokenForUserAsync(
+                It.IsAny<IEnumerable<string>>(), null, null, null, null),
+            Times.Once,
+            "MSAL must be called once; cached exception is rethrown for subsequent tasks");
     }
 
     // ─── Recording infrastructure ─────────────────────────────────────────────

--- a/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/SubmitToTodoHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MeetingTasks/SubmitToTodoHandlerTests.cs
@@ -3,6 +3,7 @@ using Anela.Heblo.Application.Features.MeetingTasks.UseCases.SubmitToTodo;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.MeetingTasks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -355,5 +356,65 @@ public class SubmitToTodoHandlerTests
 
         result.SuccessCount.Should().Be(1);
         result.FailedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_LogsWarning_WhenAnyTaskFailed()
+    {
+        // Information traces are dropped in PROD by CostOptimizedTelemetryProcessor — failures
+        // must escalate to Warning so they remain visible in App Insights.
+        var task = NewTask(ProposedTaskStatus.Approved, assigneeEmail: "ghost@anela.cz", title: "Spook");
+        var transcript = NewTranscript(task);
+
+        _repo.Setup(r => r.GetByIdAsync(transcript.Id, It.IsAny<CancellationToken>())).ReturnsAsync(transcript);
+        _taskExporter.Setup(t => t.ResolveUserIdByEmailAsync("ghost@anela.cz", It.IsAny<CancellationToken>())).ReturnsAsync((string?)null);
+
+        var logger = new Mock<ILogger<SubmitToTodoHandler>>();
+        var handler = new SubmitToTodoHandler(_repo.Object, _taskExporter.Object, _guard.Object, logger.Object);
+
+        await handler.Handle(new SubmitToTodoRequest { TranscriptId = transcript.Id }, CancellationToken.None);
+
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Exported") && v.ToString()!.Contains("failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_LogsInformation_WhenAllTasksSucceeded()
+    {
+        var task = NewTask(ProposedTaskStatus.Approved, assigneeEmail: "ok@anela.cz", title: "OK");
+        var transcript = NewTranscript(task);
+
+        _repo.Setup(r => r.GetByIdAsync(transcript.Id, It.IsAny<CancellationToken>())).ReturnsAsync(transcript);
+        _taskExporter.Setup(t => t.ResolveUserIdByEmailAsync("ok@anela.cz", It.IsAny<CancellationToken>())).ReturnsAsync("u");
+        _taskExporter.Setup(t => t.ExportTaskAsync("u", "OK", "desc", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MeetingTaskExportResult(true, "ext-1", null));
+
+        var logger = new Mock<ILogger<SubmitToTodoHandler>>();
+        var handler = new SubmitToTodoHandler(_repo.Object, _taskExporter.Object, _guard.Object, logger.Object);
+
+        await handler.Handle(new SubmitToTodoRequest { TranscriptId = transcript.Id }, CancellationToken.None);
+
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Exported") && v.ToString()!.Contains("failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Exported") && v.ToString()!.Contains("failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
     }
 }

--- a/frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx
+++ b/frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx
@@ -196,7 +196,16 @@ const MeetingTaskDetailPage: React.FC = () => {
   };
 
   const confirmSubmit = async () => {
-    await submitToTodo.mutateAsync(id);
+    const result = await submitToTodo.mutateAsync(id);
+    if (result.failedCount === 0) {
+      submitToTodo.reset();
+      setSubmitOpen(false);
+    }
+    // Failures: keep modal open so the user can read the error list rendered below.
+  };
+
+  const closeSubmitModal = () => {
+    submitToTodo.reset();
     setSubmitOpen(false);
   };
 
@@ -533,10 +542,29 @@ const MeetingTaskDetailPage: React.FC = () => {
                 Odeslani selhalo: {submitToTodo.error instanceof Error ? submitToTodo.error.message : String(submitToTodo.error)}
               </p>
             )}
+            {submitToTodo.data && submitToTodo.data.failedCount > 0 && (
+              <div className="mt-3 p-3 rounded border border-red-200 bg-red-50">
+                <p className="text-sm font-medium text-red-800">
+                  Odeslání selhalo: {submitToTodo.data.failedCount} z {submitToTodo.data.successCount + submitToTodo.data.failedCount} úloh.
+                </p>
+                {submitToTodo.data.errors.length > 0 && (
+                  <ul className="mt-2 list-disc list-inside text-sm text-red-700 space-y-1">
+                    {submitToTodo.data.errors.map((err, i) => (
+                      <li key={i}>{err}</li>
+                    ))}
+                  </ul>
+                )}
+                {submitToTodo.data.errors.some(e => e.includes('consent required') || e.includes('Tasks.ReadWrite')) && (
+                  <p className="mt-2 text-sm text-red-700">
+                    Microsoft 365 vyžaduje souhlas administrátora pro práci s úkoly v Planneru. Odhlaste se a znovu se přihlaste po udělení souhlasu.
+                  </p>
+                )}
+              </div>
+            )}
             <div className="flex justify-end gap-2 mt-4">
               <button
                 type="button"
-                onClick={() => setSubmitOpen(false)}
+                onClick={closeSubmitModal}
                 disabled={submitToTodo.isPending}
                 className="px-3 py-1.5 rounded-md text-sm text-gray-700 hover:bg-gray-100"
               >


### PR DESCRIPTION
## Summary

Root-caused via App Insights: `POST /meeting-tasks/{id}/submit` returns 200 OK but every per-task export fails with `MsalClaimsChallengeException` (AADSTS65001) on the delegated `Tasks.ReadWrite` OBO call introduced by #1471's follow-up. The handler swallows each per-task error, the FE ignores `failedCount`/`errors`, and PROD telemetry drops the Information-level summary — so the user sees a "success" modal while zero Planner tasks are created.

## Changes

- **BE** `GraphPlannerService` caches the delegated OBO token per request (single-flight), turning N×6 MSAL retry storms into a single attempt that's reused or rethrown for the rest of the batch.
- **BE** `SubmitToTodoHandler` escalates the final summary log to `Warning` when `FailedCount > 0` so it survives `CostOptimizedTelemetryProcessor` in PROD.
- **FE** `MeetingTaskDetailPage` reads `failedCount`/`errors`, keeps the modal open on failure with a per-task error list, and shows a Czech hint pointing at the MS365 admin-consent fix when the message matches.
- Adds 4 unit tests (log-severity branch, token-cache success + UiRequired paths).

## Test plan

- [x] `dotnet test` — 3733 passed, 0 failed
- [x] `npm run build` — clean
- [x] `dotnet format --verify-no-changes` on touched paths — clean
- [ ] Manual PROD smoke after Azure admin grants `Tasks.ReadWrite` delegated consent: expect Planner task created and modal closed
- [ ] Manual failure path: temporarily break an `AssigneeEmail` and confirm modal stays open with the error list