### PR TITLE
fix(smartsupp): silence guest toast, fix double-? agent badge, drop email order lookup

### DIFF
--- a/backend/src/Anela.Heblo.API/Controllers/SmartsuppController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/SmartsuppController.cs
@@ -63,6 +63,10 @@ public class SmartsuppController : BaseApiController
         return HandleResponse(result);
     }
 
+    /// <remarks>
+    /// Returns 404 only when the Smartsupp conversation itself is not found.
+    /// A missing Shoptet customer returns 200 with a null contactInfo payload.
+    /// </remarks>
     [HttpGet("conversations/{id}/shoptet-info")]
     [ProducesResponseType(typeof(GetSmartsuppContactShoptetInfoResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs
@@ -2,26 +2,26 @@ namespace Anela.Heblo.Application.Features.Smartsupp.Contracts;
 
 public class ShoptetContactInfoDto
 {
-    public ShoptetCustomerSnapshotDto? Customer { get; set; }
-    public List<ShoptetOrderSnapshotDto> RecentOrders { get; set; } = new();
-    public DateTime? CartUpdatedAt { get; set; }
+    public ShoptetCustomerSnapshotDto? Customer { get; init; }
+    public List<ShoptetOrderSnapshotDto> RecentOrders { get; init; } = new();
+    public DateTime? CartUpdatedAt { get; init; }
 }
 
 public class ShoptetCustomerSnapshotDto
 {
-    public string? FullName { get; set; }
-    public string? Email { get; set; }
-    public string? CustomerGroup { get; set; }
-    public string? PriceList { get; set; }
-    public string? DefaultShippingAddress { get; set; }
+    public string? FullName { get; init; }
+    public string? Email { get; init; }
+    public string? CustomerGroup { get; init; }
+    public string? PriceList { get; init; }
+    public string? DefaultShippingAddress { get; init; }
 }
 
 public class ShoptetOrderSnapshotDto
 {
-    public required string Code { get; set; }
-    public string? StatusName { get; set; }
-    public decimal? TotalWithVat { get; set; }
-    public string? CurrencyCode { get; set; }
-    public DateTime? OrderDate { get; set; }
-    public string? AdminUrl { get; set; }
+    public required string Code { get; init; }
+    public string? StatusName { get; init; }
+    public decimal? TotalWithVat { get; init; }
+    public string? CurrencyCode { get; init; }
+    public DateTime? OrderDate { get; init; }
+    public string? AdminUrl { get; init; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs
@@ -2,7 +2,7 @@ namespace Anela.Heblo.Application.Features.Smartsupp.Contracts;
 
 public class ShoptetContactInfoDto
 {
-    public required ShoptetCustomerSnapshotDto Customer { get; set; }
+    public ShoptetCustomerSnapshotDto? Customer { get; set; }
     public List<ShoptetOrderSnapshotDto> RecentOrders { get; set; } = new();
     public DateTime? CartUpdatedAt { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
 using Anela.Heblo.Application.Features.ShoptetCustomers;
-using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Application.Features.Smartsupp.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Smartsupp;
@@ -12,20 +11,15 @@ namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetI
 public class GetSmartsuppContactShoptetInfoHandler
     : IRequestHandler<GetSmartsuppContactShoptetInfoRequest, GetSmartsuppContactShoptetInfoResponse>
 {
-    private const int RecentOrdersLimit = 5;
-
     private readonly ISmartsuppRepository _repo;
     private readonly IShoptetCustomerClient _customerClient;
-    private readonly IEshopOrderClient _orderClient;
 
     public GetSmartsuppContactShoptetInfoHandler(
         ISmartsuppRepository repo,
-        IShoptetCustomerClient customerClient,
-        IEshopOrderClient orderClient)
+        IShoptetCustomerClient customerClient)
     {
         _repo = repo;
         _customerClient = customerClient;
-        _orderClient = orderClient;
     }
 
     public async Task<GetSmartsuppContactShoptetInfoResponse> Handle(
@@ -41,33 +35,15 @@ public class GetSmartsuppContactShoptetInfoHandler
         variables.TryGetValue("shoptet_guid", out var shoptetGuid);
         variables.TryGetValue("shoptet_cart_updated_at", out var cartStr);
 
-        // Resolution order: shoptet_user_guid → shoptet_guid → email (first match wins)
         ShoptetCustomerInfoDto? customer = null;
-        List<EshopOrderInfo>? preloadedOrders = null;
 
         if (!string.IsNullOrWhiteSpace(userGuid))
-        {
             customer = await _customerClient.GetCustomerByGuidAsync(userGuid, cancellationToken);
-        }
         else if (!string.IsNullOrWhiteSpace(shoptetGuid))
-        {
             customer = await _customerClient.GetCustomerByGuidAsync(shoptetGuid, cancellationToken);
-        }
-        else if (!string.IsNullOrWhiteSpace(conversation.ContactEmail))
-        {
-            preloadedOrders = await _orderClient.GetRecentOrdersByEmailAsync(
-                conversation.ContactEmail, RecentOrdersLimit, cancellationToken);
-            var firstGuid = preloadedOrders.FirstOrDefault()?.CustomerGuid;
-            if (!string.IsNullOrWhiteSpace(firstGuid))
-                customer = await _customerClient.GetCustomerByGuidAsync(firstGuid, cancellationToken);
-        }
 
         if (customer is null)
-            return new GetSmartsuppContactShoptetInfoResponse(ErrorCodes.SmartsuppShoptetCustomerNotFound);
-
-        var lookupEmail = customer.Email ?? conversation.ContactEmail ?? string.Empty;
-        var orders = preloadedOrders ?? await _orderClient.GetRecentOrdersByEmailAsync(lookupEmail, RecentOrdersLimit, cancellationToken);
-        var statusNames = await _orderClient.GetOrderStatusNamesAsync(cancellationToken);
+            return new GetSmartsuppContactShoptetInfoResponse { ContactInfo = null };
 
         DateTime? cartUpdatedAt = null;
         if (!string.IsNullOrWhiteSpace(cartStr) &&
@@ -87,15 +63,7 @@ public class GetSmartsuppContactShoptetInfoHandler
                     PriceList = customer.PriceList,
                     DefaultShippingAddress = customer.DefaultShippingAddress,
                 },
-                RecentOrders = orders.Select(o => new ShoptetOrderSnapshotDto
-                {
-                    Code = o.Code,
-                    StatusName = statusNames.TryGetValue(o.StatusId, out var name) ? name : o.StatusId.ToString(),
-                    TotalWithVat = o.TotalWithVat,
-                    CurrencyCode = o.CurrencyCode,
-                    OrderDate = o.OrderDate,
-                    AdminUrl = o.AdminUrl,
-                }).ToList(),
+                RecentOrders = new(),
                 CartUpdatedAt = cartUpdatedAt,
             },
         };

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs
@@ -63,7 +63,7 @@ public class GetSmartsuppContactShoptetInfoHandler
                     PriceList = customer.PriceList,
                     DefaultShippingAddress = customer.DefaultShippingAddress,
                 },
-                RecentOrders = new(),
+                RecentOrders = new(), // TODO: restore when a guid-based order-lookup path is available; email fallback was removed (see docs/integrations/shoptet-api.md:155-170)
                 CartUpdatedAt = cartUpdatedAt,
             },
         };

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoResponse.cs
@@ -5,7 +5,7 @@ namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetI
 
 public class GetSmartsuppContactShoptetInfoResponse : BaseResponse
 {
-    public ShoptetContactInfoDto? ContactInfo { get; set; }
+    public ShoptetContactInfoDto? ContactInfo { get; init; }
 
     public GetSmartsuppContactShoptetInfoResponse() { }
     public GetSmartsuppContactShoptetInfoResponse(ErrorCodes errorCode) : base(errorCode) { }

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Anela.Heblo.Application.Features.ShoptetCustomers;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
 using Anela.Heblo.Application.Shared;
@@ -80,6 +79,8 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
+        result.ContactInfo!.Customer!.FullName.Should().Be("Jana Nováková");
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
         _customerClient.Verify(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
@@ -1,5 +1,5 @@
+using System.Globalization;
 using Anela.Heblo.Application.Features.ShoptetCustomers;
-using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Smartsupp;
@@ -13,23 +13,18 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
 {
     private readonly Mock<ISmartsuppRepository> _repo = new();
     private readonly Mock<IShoptetCustomerClient> _customerClient = new();
-    private readonly Mock<IEshopOrderClient> _orderClient = new();
 
     private GetSmartsuppContactShoptetInfoHandler CreateHandler() =>
-        new(_repo.Object, _customerClient.Object, _orderClient.Object);
+        new(_repo.Object, _customerClient.Object);
 
     private static ShoptetCustomerInfoDto MakeCustomer(string guid = "cust-1") =>
         new() { Guid = guid, FullName = "Jana Nováková", Email = "jana@test.cz", CustomerGroup = "VIP", PriceList = "Retail" };
 
-    private static List<EshopOrderInfo> MakeOrders(string customerGuid = "cust-1") =>
-    [
-        new() { Code = "2024001", CustomerGuid = customerGuid, TotalWithVat = 1250m, CurrencyCode = "CZK", StatusId = 26, AdminUrl = "https://anela.myshoptet.com/admin/orders/2024001", OrderDate = new DateTime(2026, 4, 1) },
-    ];
-
     [Fact]
     public async Task Handle_ReturnsNotFound_WhenConversationMissing()
     {
-        _repo.Setup(r => r.GetConversationAsync("missing", It.IsAny<CancellationToken>())).ReturnsAsync((SmartsuppConversation?)null);
+        _repo.Setup(r => r.GetConversationAsync("missing", It.IsAny<CancellationToken>()))
+             .ReturnsAsync((SmartsuppConversation?)null);
 
         var result = await CreateHandler().Handle(
             new GetSmartsuppContactShoptetInfoRequest { ConversationId = "missing" },
@@ -49,17 +44,18 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
             VariablesJson = """{"shoptet_user_guid":"user-guid-1","shoptet_guid":"guid-2"}""",
             Messages = [],
         };
-        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
-        _customerClient.Setup(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>())).ReturnsAsync(MakeCustomer("user-guid-1"));
-        _orderClient.Setup(o => o.GetRecentOrdersByEmailAsync("jana@test.cz", 5, It.IsAny<CancellationToken>())).ReturnsAsync(MakeOrders("user-guid-1"));
-        _orderClient.Setup(o => o.GetOrderStatusNamesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Dictionary<int, string> { { 26, "Balí se" } });
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("user-guid-1"));
 
         var result = await CreateHandler().Handle(
             new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        // Must use user-guid-1, NOT guid-2
+        result.ContactInfo!.Customer!.FullName.Should().Be("Jana Nováková");
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
         _customerClient.Verify(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>()), Times.Once);
         _customerClient.Verify(c => c.GetCustomerByGuidAsync("guid-2", It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -74,10 +70,10 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
             VariablesJson = """{"shoptet_guid":"guid-abc"}""",
             Messages = [],
         };
-        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
-        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>())).ReturnsAsync(MakeCustomer("guid-abc"));
-        _orderClient.Setup(o => o.GetRecentOrdersByEmailAsync("jana@test.cz", 5, It.IsAny<CancellationToken>())).ReturnsAsync(MakeOrders("guid-abc"));
-        _orderClient.Setup(o => o.GetOrderStatusNamesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Dictionary<int, string>());
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("guid-abc"));
 
         var result = await CreateHandler().Handle(
             new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
@@ -88,52 +84,49 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ResolvesViaEmail_WhenNoGuidsPresent()
+    public async Task Handle_CustomerNotFound_ReturnsSuccessWithNullContactInfo()
     {
         var conversation = new SmartsuppConversation
         {
             Id = "c1",
             Status = SmartsuppConversationStatus.Open,
-            ContactEmail = "jana@test.cz",
-            VariablesJson = null,
+            VariablesJson = """{"shoptet_guid":"unknown-guid"}""",
             Messages = [],
         };
-        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
-        _orderClient.Setup(o => o.GetRecentOrdersByEmailAsync("jana@test.cz", 5, It.IsAny<CancellationToken>())).ReturnsAsync(MakeOrders("cust-1"));
-        _customerClient.Setup(c => c.GetCustomerByGuidAsync("cust-1", It.IsAny<CancellationToken>())).ReturnsAsync(MakeCustomer("cust-1"));
-        _orderClient.Setup(o => o.GetOrderStatusNamesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Dictionary<int, string> { { 26, "Balí se" } });
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("unknown-guid", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync((ShoptetCustomerInfoDto?)null);
 
         var result = await CreateHandler().Handle(
             new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        result.ContactInfo!.Customer.FullName.Should().Be("Jana Nováková");
-        result.ContactInfo.RecentOrders.Should().HaveCount(1);
-        result.ContactInfo.RecentOrders[0].StatusName.Should().Be("Balí se");
-        result.ContactInfo.RecentOrders[0].TotalWithVat.Should().Be(1250m);
+        result.ContactInfo.Should().BeNull();
+        result.ErrorCode.Should().BeNull();
     }
 
     [Fact]
-    public async Task Handle_ReturnsCustomerNotFound_WhenNoGuidAndNoMatchingOrders()
+    public async Task Handle_NoGuidsPresent_ReturnsSuccessWithNullContactInfo()
     {
         var conversation = new SmartsuppConversation
         {
             Id = "c1",
             Status = SmartsuppConversationStatus.Open,
-            ContactEmail = "unknown@test.cz",
+            ContactEmail = "guest@example.com",
             VariablesJson = null,
             Messages = [],
         };
-        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
-        _orderClient.Setup(o => o.GetRecentOrdersByEmailAsync("unknown@test.cz", 5, It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
 
         var result = await CreateHandler().Handle(
             new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
             CancellationToken.None);
 
-        result.Success.Should().BeFalse();
-        result.ErrorCode.Should().Be(ErrorCodes.SmartsuppShoptetCustomerNotFound);
+        result.Success.Should().BeTrue();
+        result.ContactInfo.Should().BeNull();
     }
 
     [Fact]
@@ -146,10 +139,10 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
             VariablesJson = """{"shoptet_guid":"guid-1","shoptet_cart_updated_at":"2026-04-15T12:00:00"}""",
             Messages = [],
         };
-        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>())).ReturnsAsync(conversation);
-        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-1", It.IsAny<CancellationToken>())).ReturnsAsync(MakeCustomer("guid-1"));
-        _orderClient.Setup(o => o.GetRecentOrdersByEmailAsync("jana@test.cz", 5, It.IsAny<CancellationToken>())).ReturnsAsync([]);
-        _orderClient.Setup(o => o.GetOrderStatusNamesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new Dictionary<int, string>());
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-1", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("guid-1"));
 
         var result = await CreateHandler().Handle(
             new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
@@ -157,5 +150,6 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
 
         result.Success.Should().BeTrue();
         result.ContactInfo!.CartUpdatedAt.Should().Be(new DateTime(2026, 4, 15, 12, 0, 0));
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
@@ -128,6 +128,7 @@ public class GetSmartsuppContactShoptetInfoHandlerTests
 
         result.Success.Should().BeTrue();
         result.ContactInfo.Should().BeNull();
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/docs/superpowers/plans/2026-05-21-smartsupp-optimistic-message.md
+++ b/docs/superpowers/plans/2026-05-21-smartsupp-optimistic-message.md
@@ -1,0 +1,330 @@
+# Smartsupp Optimistic Message Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the operator's sent message appear instantly in the Smartsupp chat window with a pending spinner, switching to a checkmark on success and disappearing on failure.
+
+**Architecture:** The optimistic update code already exists in `useSendMessage.ts` but is immediately destroyed by `onSettled` calling `invalidateQueries`, which triggers a refetch that returns stale data (the backend DB hasn't synced the new message from Smartsupp yet). The fix: return the send response from `mutationFn`, add `onSuccess` to promote the optimistic entry to a confirmed one, add `deliveryStatus: "pending"` to the optimistic message, and remove `onSettled` entirely — the 30-second `refetchInterval` in `useSmartsuppConversation` handles eventual sync.
+
+**Tech Stack:** React, TanStack Query (React Query v5), TypeScript, Jest + React Testing Library
+
+---
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Modify | `frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts` |
+| Modify | `frontend/src/components/customer-support/smartsupp/hooks/__tests__/useSendMessage.test.ts` |
+
+No other files need changes. `MessageDeliveryIcon` already renders `"pending"` as a spinner and `"sent"` as a checkmark.
+
+---
+
+### Task 1: Write two failing tests
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/hooks/__tests__/useSendMessage.test.ts`
+
+- [ ] **Step 1: Add the two new tests inside the existing `describe("useSendMessage")` block, after the last existing test**
+
+  ```typescript
+  it("shows optimistic message with pending delivery status while request is in flight", async () => {
+    let resolvePromise!: (v: unknown) => void;
+    (getAuthenticatedApiClient as jest.Mock).mockReturnValue({
+      baseUrl: "http://api.test",
+      http: {
+        fetch: () => new Promise((res) => { resolvePromise = res; }),
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(["smartsupp", "conversation", "conv1"], {
+      success: true,
+      messages: [],
+    });
+
+    function seededWrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const { result } = renderHook(() => useSendMessage("conv1"), { wrapper: seededWrapper });
+    act(() => result.current.send("Ahoj"));
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    const cached = queryClient.getQueryData<{ messages: Array<{ id: string; deliveryStatus?: string }> }>(
+      ["smartsupp", "conversation", "conv1"],
+    );
+    expect(cached?.messages).toHaveLength(1);
+    expect(cached?.messages[0].id).toMatch(/^optimistic-/);
+    expect(cached?.messages[0].deliveryStatus).toBe("pending");
+
+    // resolve so the hook can settle and avoid act() warnings
+    resolvePromise({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, messageId: "ms999", createdAt: "2026-05-20T10:00:00Z" }),
+    });
+  });
+
+  it("replaces optimistic message with real messageId and sent delivery status on success", async () => {
+    setApiResponse(200, { success: true, messageId: "ms-real-123", createdAt: "2026-05-20T10:00:00Z" });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(["smartsupp", "conversation", "conv1"], {
+      success: true,
+      messages: [
+        {
+          id: "existing-1",
+          authorType: "contact",
+          content: "Původní zpráva",
+          createdAt: "2026-01-01T00:00:00Z",
+          isFirstReply: false,
+        },
+      ],
+    });
+
+    function seededWrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const { result } = renderHook(() => useSendMessage("conv1"), { wrapper: seededWrapper });
+    act(() => result.current.send("Nová zpráva"));
+
+    await waitFor(() => expect(result.current.justSent).toBe(true));
+
+    const cached = queryClient.getQueryData<{
+      messages: Array<{ id: string; content?: string | null; deliveryStatus?: string | null }>;
+    }>(["smartsupp", "conversation", "conv1"]);
+
+    expect(cached?.messages).toHaveLength(2);
+    expect(cached?.messages[1]).toMatchObject({
+      id: "ms-real-123",
+      content: "Nová zpráva",
+      deliveryStatus: "sent",
+    });
+    expect(cached?.messages.some((m) => m.id.startsWith("optimistic-"))).toBe(false);
+  });
+  ```
+
+---
+
+### Task 2: Run the new tests — expect FAIL
+
+**Files:**
+- Test: `frontend/src/components/customer-support/smartsupp/hooks/__tests__/useSendMessage.test.ts`
+
+- [ ] **Step 1: Run only the new tests**
+
+  ```bash
+  cd frontend && npx jest --testPathPattern="useSendMessage" --watchAll=false --no-coverage
+  ```
+
+  Expected: the two new tests **fail** (the optimistic message won't have `deliveryStatus: "pending"` and `onSuccess` doesn't replace the ID yet). All 5 existing tests should still pass.
+
+---
+
+### Task 3: Implement the fix in `useSendMessage.ts`
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts`
+
+Replace the entire file content with:
+
+- [ ] **Step 1: Rewrite `useSendMessage.ts`**
+
+  ```typescript
+  import { useMutation, useQueryClient } from "@tanstack/react-query";
+  import { getClientAndBaseUrl, apiPost } from "../../../../api/smartsuppClient";
+  import {
+    SMARTSUPP_QUERY_KEYS,
+    type GetConversationResponse,
+    type MessageDto,
+  } from "../../../../api/hooks/useSmartsupp";
+
+  interface SendMessageApiResponse {
+    success: boolean;
+    errorCode?: string;
+    messageId?: string;
+    createdAt?: string;
+  }
+
+  const SEND_ERROR_MESSAGES: Record<string, string> = {
+    SmartsuppSendMessageUnavailable: "Nepodařilo se odeslat zprávu — služba je nedostupná. Zkuste to prosím znovu.",
+    SmartsuppConversationNotFound: "Konverzace nebyla nalezena.",
+  };
+
+  function messageForSendError(code?: string): string {
+    if (code && SEND_ERROR_MESSAGES[code]) return SEND_ERROR_MESSAGES[code];
+    return "Nepodařilo se odeslat zprávu.";
+  }
+
+  interface UseSendMessageResult {
+    send: (content: string) => void;
+    isPending: boolean;
+    error: string | null;
+    justSent: boolean;
+    clearSent: () => void;
+  }
+
+  type SendMessageContext = { previous?: GetConversationResponse };
+
+  export function useSendMessage(conversationId: string | null): UseSendMessageResult {
+    const queryClient = useQueryClient();
+
+    const mutation = useMutation<SendMessageApiResponse, Error, string, SendMessageContext>({
+      mutationFn: async (content) => {
+        if (!conversationId) {
+          throw new Error("Není vybrána konverzace.");
+        }
+
+        const { apiClient, baseUrl } = getClientAndBaseUrl();
+        const response = await apiPost(
+          apiClient,
+          `${baseUrl}/api/smartsupp/conversations/${conversationId}/messages`,
+          { content },
+        );
+
+        if (!response.ok) {
+          const errData = await response.json().catch(() => ({})) as Partial<SendMessageApiResponse>;
+          throw new Error(messageForSendError(errData?.errorCode));
+        }
+
+        const data = (await response.json()) as SendMessageApiResponse;
+        if (!data.success) {
+          throw new Error(messageForSendError(data?.errorCode));
+        }
+
+        return data;
+      },
+      onMutate: async (content) => {
+        if (!conversationId) return {};
+        await queryClient.cancelQueries({
+          queryKey: SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+        });
+        const previous = queryClient.getQueryData<GetConversationResponse>(
+          SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+        );
+        const optimisticMsg: MessageDto = {
+          id: `optimistic-${Date.now()}`,
+          authorType: "agent",
+          content,
+          createdAt: new Date().toISOString(),
+          isFirstReply: false,
+          deliveryStatus: "pending",
+        };
+        queryClient.setQueryData<GetConversationResponse>(
+          SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+          (old) => (old ? { ...old, messages: [...old.messages, optimisticMsg] } : old),
+        );
+        return { previous };
+      },
+      onSuccess: (data) => {
+        if (!conversationId) return;
+        queryClient.setQueryData<GetConversationResponse>(
+          SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+          (current) => {
+            if (!current) return current;
+            return {
+              ...current,
+              messages: current.messages.map((m) =>
+                m.id.startsWith("optimistic-")
+                  ? {
+                      ...m,
+                      id: data.messageId ?? m.id,
+                      createdAt: data.createdAt ?? m.createdAt,
+                      deliveryStatus: "sent",
+                    }
+                  : m,
+              ),
+            };
+          },
+        );
+      },
+      onError: (_err, _content, context) => {
+        if (context?.previous !== undefined && conversationId) {
+          queryClient.setQueryData(
+            SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+            context.previous,
+          );
+        }
+      },
+    });
+
+    return {
+      send: (content: string) => mutation.mutate(content),
+      isPending: mutation.isPending,
+      error: mutation.error ? mutation.error.message : null,
+      justSent: mutation.isSuccess,
+      clearSent: mutation.reset,
+    };
+  }
+  ```
+
+  Key changes from the original:
+  - `useMutation<void, …>` → `useMutation<SendMessageApiResponse, …>`
+  - `mutationFn` now returns `data` instead of void
+  - `optimisticMsg` gains `deliveryStatus: "pending"`
+  - New `onSuccess` replaces the optimistic entry with real `messageId`/`createdAt` and `deliveryStatus: "sent"`
+  - `onSettled` removed — 30 s `refetchInterval` handles sync
+
+---
+
+### Task 4: Run all tests — expect all pass
+
+- [ ] **Step 1: Run the full test suite for this file**
+
+  ```bash
+  cd frontend && npx jest --testPathPattern="useSendMessage" --watchAll=false --no-coverage
+  ```
+
+  Expected output: **7 tests pass**, 0 failures.
+
+  If a test fails:
+  - "shows optimistic message…" failing → check `onMutate` adds `deliveryStatus: "pending"` and the seeded queryClient data is read correctly
+  - "replaces optimistic message…" failing → check `onSuccess` maps correctly and `m.id.startsWith("optimistic-")` matches
+
+---
+
+### Task 5: Build + lint check
+
+- [ ] **Step 1: TypeScript build**
+
+  ```bash
+  cd frontend && npm run build
+  ```
+
+  Expected: no errors. If TypeScript complains about `conversationId` being `string | null` passed to `SMARTSUPP_QUERY_KEYS.conversation` inside `onSuccess`, add a guard: `if (!conversationId) return;` (already present in the plan's code).
+
+- [ ] **Step 2: Lint**
+
+  ```bash
+  cd frontend && npm run lint
+  ```
+
+  Expected: no errors.
+
+---
+
+### Task 6: Commit
+
+- [ ] **Step 1: Stage and commit**
+
+  ```bash
+  git add frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts \
+          frontend/src/components/customer-support/smartsupp/hooks/__tests__/useSendMessage.test.ts
+  git commit -m "fix(smartsupp): show optimistic message instantly with delivery status
+
+  The previous onSettled invalidateQueries immediately refetched from the
+  backend DB, which does not contain the new message yet (Smartsupp syncs
+  on polling). This wiped the optimistic entry before it was visible.
+
+  Fix: return SendMessageApiResponse from mutationFn, promote the optimistic
+  message to a confirmed one in onSuccess (real ID + deliveryStatus 'sent'),
+  and remove onSettled — the 30 s refetchInterval handles eventual sync."
+  ```

--- a/docs/superpowers/plans/2026-05-21-smartsupp-prod-fixes.md
+++ b/docs/superpowers/plans/2026-05-21-smartsupp-prod-fixes.md
@@ -1,0 +1,811 @@
+# Smartsupp Production Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two production bugs — spurious "customer not found" error toast for guest visitors, and double-`?` badge on agentless messages — plus remove the wasteful email-based order fallback.
+
+**Architecture:** Backend handler stops emitting an error when a Shoptet customer is absent (returns `success=true`, `contactInfo=null`); frontend card already hides on null `contactInfo`. `AgentBadge` derives initials from `agentId` when `name` is missing, avoiding duplicate `?` symbols.
+
+**Tech Stack:** .NET 8 / C# 12 (xUnit + FluentAssertions + Moq), React / TypeScript (Vitest + React Testing Library)
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Modify | `backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs` |
+| Modify | `backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs` |
+| Modify | `backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs` |
+| Modify | `frontend/src/api/hooks/useSmartsupp.ts` |
+| Modify | `frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx` |
+| Modify | `frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx` |
+| Modify | `frontend/src/components/customer-support/smartsupp/AgentBadge.tsx` |
+| Modify | `frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx` |
+
+---
+
+## Task 1: Make `ShoptetContactInfoDto.Customer` nullable
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs`
+
+- [ ] **Step 1: Open the DTO file and drop `required`**
+
+Replace the `Customer` property so it is nullable:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Smartsupp.Contracts;
+
+public class ShoptetContactInfoDto
+{
+    public ShoptetCustomerSnapshotDto? Customer { get; set; }
+    public List<ShoptetOrderSnapshotDto> RecentOrders { get; set; } = new();
+    public DateTime? CartUpdatedAt { get; set; }
+}
+
+public class ShoptetCustomerSnapshotDto
+{
+    public string? FullName { get; set; }
+    public string? Email { get; set; }
+    public string? CustomerGroup { get; set; }
+    public string? PriceList { get; set; }
+    public string? DefaultShippingAddress { get; set; }
+}
+
+public class ShoptetOrderSnapshotDto
+{
+    public required string Code { get; set; }
+    public string? StatusName { get; set; }
+    public decimal? TotalWithVat { get; set; }
+    public string? CurrencyCode { get; set; }
+    public DateTime? OrderDate { get; set; }
+    public string? AdminUrl { get; set; }
+}
+```
+
+Only the `ShoptetCustomerSnapshotDto? Customer` line changes (dropped `required`, added `?`). All other lines are identical to the current file.
+
+- [ ] **Step 2: Verify the project still compiles**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: Build succeeded, 0 Error(s).
+
+---
+
+## Task 2: Rewrite backend handler tests (TDD RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs`
+
+The handler will lose its `IEshopOrderClient` constructor parameter and its email-based order fallback. Rewrite the tests now to express the new contract; they will fail until the handler is updated in Task 3.
+
+- [ ] **Step 1: Replace the entire test file**
+
+```csharp
+using System.Globalization;
+using Anela.Heblo.Application.Features.ShoptetCustomers;
+using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Smartsupp;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Smartsupp;
+
+public class GetSmartsuppContactShoptetInfoHandlerTests
+{
+    private readonly Mock<ISmartsuppRepository> _repo = new();
+    private readonly Mock<IShoptetCustomerClient> _customerClient = new();
+
+    private GetSmartsuppContactShoptetInfoHandler CreateHandler() =>
+        new(_repo.Object, _customerClient.Object);
+
+    private static ShoptetCustomerInfoDto MakeCustomer(string guid = "cust-1") =>
+        new() { Guid = guid, FullName = "Jana Nováková", Email = "jana@test.cz", CustomerGroup = "VIP", PriceList = "Retail" };
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenConversationMissing()
+    {
+        _repo.Setup(r => r.GetConversationAsync("missing", It.IsAny<CancellationToken>()))
+             .ReturnsAsync((SmartsuppConversation?)null);
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "missing" },
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.SmartsuppConversationNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesViaUserGuid_WhenShoptetUserGuidPresent()
+    {
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_user_guid":"user-guid-1","shoptet_guid":"guid-2"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("user-guid-1"));
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo!.Customer!.FullName.Should().Be("Jana Nováková");
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>()), Times.Once);
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync("guid-2", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesViaShoptetGuid_WhenUserGuidAbsent()
+    {
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_guid":"guid-abc"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("guid-abc"));
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CustomerNotFound_ReturnsSuccessWithNullContactInfo()
+    {
+        // Guest/unregistered visitor — no Shoptet customer record. Expected: success=true, ContactInfo=null (no toast, no panel).
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_guid":"unknown-guid"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("unknown-guid", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync((ShoptetCustomerInfoDto?)null);
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo.Should().BeNull();
+        result.ErrorCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NoGuidsPresent_ReturnsSuccessWithNullContactInfo()
+    {
+        // No guid variables and no email-based lookup — email fallback is intentionally removed.
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            ContactEmail = "guest@example.com",
+            VariablesJson = null,
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ParsesCartUpdatedAt_FromVariables()
+    {
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_guid":"guid-1","shoptet_cart_updated_at":"2026-04-15T12:00:00"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-1", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("guid-1"));
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo!.CartUpdatedAt.Should().Be(new DateTime(2026, 4, 15, 12, 0, 0));
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail (RED)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests \
+  --filter FullyQualifiedName~GetSmartsuppContactShoptetInfoHandlerTests \
+  --no-build 2>&1 | tail -20
+```
+
+Expected failures:
+- `Handle_ResolvesViaUserGuid_WhenShoptetUserGuidPresent` — fails because old handler calls `GetRecentOrdersByEmailAsync` which is no longer set up (or fails because `CreateHandler()` passes wrong args — compile error)
+- `Handle_NoGuidsPresent_ReturnsSuccessWithNullContactInfo` — fails: old handler returns `success=false` for missing customer
+- `Handle_CustomerNotFound_ReturnsSuccessWithNullContactInfo` — fails: old handler returns `success=false`
+
+> Note: The test file will not compile until Task 3 updates the handler constructor signature to remove `IEshopOrderClient`. A compile error counts as RED — proceed to Task 3.
+
+---
+
+## Task 3: Rewrite handler — drop email fallback and error return (TDD GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs`
+
+- [ ] **Step 1: Replace the entire handler file**
+
+```csharp
+using System.Globalization;
+using System.Text.Json;
+using Anela.Heblo.Application.Features.ShoptetCustomers;
+using Anela.Heblo.Application.Features.Smartsupp.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Smartsupp;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
+
+public class GetSmartsuppContactShoptetInfoHandler
+    : IRequestHandler<GetSmartsuppContactShoptetInfoRequest, GetSmartsuppContactShoptetInfoResponse>
+{
+    private readonly ISmartsuppRepository _repo;
+    private readonly IShoptetCustomerClient _customerClient;
+
+    public GetSmartsuppContactShoptetInfoHandler(
+        ISmartsuppRepository repo,
+        IShoptetCustomerClient customerClient)
+    {
+        _repo = repo;
+        _customerClient = customerClient;
+    }
+
+    public async Task<GetSmartsuppContactShoptetInfoResponse> Handle(
+        GetSmartsuppContactShoptetInfoRequest request,
+        CancellationToken cancellationToken)
+    {
+        var conversation = await _repo.GetConversationAsync(request.ConversationId, cancellationToken);
+        if (conversation is null)
+            return new GetSmartsuppContactShoptetInfoResponse(ErrorCodes.SmartsuppConversationNotFound);
+
+        var variables = ParseVariables(conversation.VariablesJson);
+        variables.TryGetValue("shoptet_user_guid", out var userGuid);
+        variables.TryGetValue("shoptet_guid", out var shoptetGuid);
+        variables.TryGetValue("shoptet_cart_updated_at", out var cartStr);
+
+        ShoptetCustomerInfoDto? customer = null;
+
+        if (!string.IsNullOrWhiteSpace(userGuid))
+            customer = await _customerClient.GetCustomerByGuidAsync(userGuid, cancellationToken);
+        else if (!string.IsNullOrWhiteSpace(shoptetGuid))
+            customer = await _customerClient.GetCustomerByGuidAsync(shoptetGuid, cancellationToken);
+
+        if (customer is null)
+            return new GetSmartsuppContactShoptetInfoResponse { ContactInfo = null };
+
+        DateTime? cartUpdatedAt = null;
+        if (!string.IsNullOrWhiteSpace(cartStr) &&
+            DateTime.TryParse(cartStr, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var parsedCart))
+            cartUpdatedAt = parsedCart;
+
+        return new GetSmartsuppContactShoptetInfoResponse
+        {
+            ContactInfo = new ShoptetContactInfoDto
+            {
+                Customer = new ShoptetCustomerSnapshotDto
+                {
+                    FullName = customer.FullName,
+                    Email = customer.Email,
+                    CustomerGroup = customer.CustomerGroup,
+                    PriceList = customer.PriceList,
+                    DefaultShippingAddress = customer.DefaultShippingAddress,
+                },
+                RecentOrders = new(),
+                CartUpdatedAt = cartUpdatedAt,
+            },
+        };
+    }
+
+    private static Dictionary<string, string> ParseVariables(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new();
+        try { return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new(); }
+        catch (JsonException) { return new(); }
+    }
+}
+```
+
+Key changes from the original:
+- `IEshopOrderClient _orderClient` field and constructor parameter removed
+- `using Anela.Heblo.Application.Features.ShoptetOrders;` removed
+- `RecentOrdersLimit` constant removed
+- Email-based fallback branch (`else if (!string.IsNullOrWhiteSpace(conversation.ContactEmail))`) removed
+- `if (customer is null)` now returns `success=true` with `ContactInfo = null` instead of emitting `SmartsuppShoptetCustomerNotFound`
+- `GetRecentOrdersByEmailAsync`, `GetOrderStatusNamesAsync` calls removed
+- `RecentOrders = new()` (always empty until a future efficient order-lookup path)
+
+> `IEshopOrderClient` itself is NOT removed — it is used by other features. Only the injection into this handler is dropped.
+
+- [ ] **Step 2: Check whether the DI registration needs updating**
+
+Search for where `GetSmartsuppContactShoptetInfoHandler` is registered:
+
+```bash
+grep -r "GetSmartsuppContactShoptetInfoHandler\|AddSmartsuppServices\|AddApplicationServices" \
+  backend/src --include="*.cs" -l
+```
+
+If a DI registration explicitly passes `IEshopOrderClient` as a constructor arg, update it. More likely it is auto-registered via MediatR assembly scanning — in that case no change needed. Confirm by reading the found files.
+
+- [ ] **Step 3: Run backend tests (GREEN)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests \
+  --filter FullyQualifiedName~GetSmartsuppContactShoptetInfoHandlerTests
+```
+
+Expected: All 6 tests pass, 0 failures.
+
+- [ ] **Step 4: Full backend build + format**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: Build succeeded, no format violations. If format reports changes, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply them, then re-run to verify.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs \
+  backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
+git commit -m "fix(smartsupp): guest customer returns success with null ContactInfo, drop email order fallback"
+```
+
+---
+
+## Task 4: Update frontend TypeScript type for nullable customer
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useSmartsupp.ts`
+
+- [ ] **Step 1: Make `customer` nullable in `ShoptetContactInfoDto`**
+
+In `useSmartsupp.ts`, locate `ShoptetContactInfoDto` (currently around line 137–141) and change `customer`:
+
+```ts
+export interface ShoptetContactInfoDto {
+  customer?: ShoptetCustomerSnapshotDto | null;
+  recentOrders: ShoptetOrderSnapshotDto[];
+  cartUpdatedAt?: string | null;
+}
+```
+
+Only the `customer` line changes — from `customer: ShoptetCustomerSnapshotDto;` to `customer?: ShoptetCustomerSnapshotDto | null;`.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: zero errors (or only pre-existing errors unrelated to this change).
+
+---
+
+## Task 5: Write new `ShoptetCustomerCard` test (TDD RED)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx`
+
+- [ ] **Step 1: Add a test for null customer within a non-null contactInfo**
+
+Add after the existing `describe("ShoptetCustomerCard")` block's last test (before the closing `}`):
+
+```tsx
+  it("renders no customer section when contactInfo.customer is null", () => {
+    mockedHook.mockReturnValue({
+      data: { success: true, contactInfo: { customer: null, recentOrders: [], cartUpdatedAt: null } },
+      isLoading: false,
+    });
+    render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
+    expect(screen.queryByText("Shoptet Zákazník")).not.toBeInTheDocument();
+  });
+
+  it("still renders cart section when customer is null but cartUpdatedAt is set", () => {
+    mockedHook.mockReturnValue({
+      data: {
+        success: true,
+        contactInfo: { customer: null, recentOrders: [], cartUpdatedAt: "2026-04-15T12:00:00" },
+      },
+      isLoading: false,
+    });
+    render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
+    expect(screen.queryByText("Shoptet Zákazník")).not.toBeInTheDocument();
+    expect(screen.getByText("Shoptet Košík")).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the new tests to confirm RED**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: The two new tests fail (one with a TypeError because `customer.fullName` crashes on null, one for the same reason). Existing tests still pass.
+
+---
+
+## Task 6: Fix `ShoptetCustomerCard.tsx` to guard on nullable customer (TDD GREEN)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx`
+
+- [ ] **Step 1: Replace the component body**
+
+```tsx
+import React from "react";
+import { useSmartsuppShoptetInfo } from "../../../api/hooks/useSmartsupp";
+import Section from "./Section";
+
+interface ShoptetCustomerCardProps {
+  conversationId: string | null;
+}
+
+function ShoptetCustomerCard({ conversationId }: ShoptetCustomerCardProps) {
+  const { data, isLoading } = useSmartsuppShoptetInfo(conversationId);
+
+  if (isLoading) return null;
+  if (!data?.contactInfo) return null;
+
+  const { customer, recentOrders, cartUpdatedAt } = data.contactInfo;
+
+  const hasCustomer = customer != null;
+  const hasOrders = recentOrders.length > 0;
+  const hasCart = !!cartUpdatedAt;
+
+  if (!hasCustomer && !hasOrders && !hasCart) return null;
+
+  return (
+    <>
+      {hasCustomer && (
+        <Section title="Shoptet Zákazník">
+          <div className="space-y-1">
+            {customer.fullName && (
+              <div className="text-sm font-semibold text-gray-900">{customer.fullName}</div>
+            )}
+            {customer.email && (
+              <div className="text-xs text-gray-500">{customer.email}</div>
+            )}
+            {customer.customerGroup && (
+              <div className="text-xs text-gray-700">
+                <span className="text-gray-400">Skupina: </span>{customer.customerGroup}
+              </div>
+            )}
+            {customer.priceList && (
+              <div className="text-xs text-gray-700">
+                <span className="text-gray-400">Ceník: </span>{customer.priceList}
+              </div>
+            )}
+            {customer.defaultShippingAddress && (
+              <div className="text-xs text-gray-600 mt-1">{customer.defaultShippingAddress}</div>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {hasCart && (
+        <Section title="Shoptet Košík">
+          <div className="text-xs text-gray-500">
+            Aktualizován: {new Date(cartUpdatedAt!).toLocaleDateString("cs-CZ")}
+          </div>
+        </Section>
+      )}
+
+      {hasOrders && (
+        <Section title="Poslední objednávky">
+          <div className="space-y-2">
+            {recentOrders.map((order) => (
+              <div key={order.code} className="border-b border-gray-50 pb-1.5 last:border-0">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-gray-800">{order.code}</span>
+                  {order.totalWithVat != null && (
+                    <span className="text-xs text-gray-700">
+                      {order.totalWithVat.toLocaleString("cs-CZ")} {order.currencyCode ?? "Kč"}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center justify-between mt-0.5">
+                  {order.statusName && (
+                    <span className="text-[11px] text-gray-500">{order.statusName}</span>
+                  )}
+                  {order.orderDate && (
+                    <span className="text-[11px] text-gray-400">
+                      {new Date(order.orderDate).toLocaleDateString("cs-CZ")}
+                    </span>
+                  )}
+                </div>
+                {order.adminUrl && (
+                  <a
+                    href={order.adminUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-blue-600 hover:underline"
+                  >
+                    Zobrazit v Shoptet
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </>
+  );
+}
+
+export default ShoptetCustomerCard;
+```
+
+Changes from original: wrapped the customer `<Section>` in `{hasCustomer && ...}`, replaced bare `{cartUpdatedAt && ...}` / `{recentOrders.length > 0 && ...}` with `hasCart` / `hasOrders` booleans, added early return when all three sections are empty.
+
+- [ ] **Step 2: Run all ShoptetCustomerCard tests (GREEN)**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: All 7 tests pass (5 existing + 2 new), 0 failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ..  # back to repo root
+git add \
+  frontend/src/api/hooks/useSmartsupp.ts \
+  frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx \
+  frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx
+git commit -m "fix(smartsupp): silently hide Shoptet panel when customer is absent, guard nullable customer"
+```
+
+---
+
+## Task 7: Rewrite `AgentBadge` tests (TDD RED)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx`
+
+- [ ] **Step 1: Replace the test file**
+
+```tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AgentBadge from "../AgentBadge";
+
+describe("AgentBadge", () => {
+  it("renders the agent name as the label", () => {
+    render(<AgentBadge agentId="a1" name="Petr Novák" />);
+    expect(screen.getByText("Petr Novák")).toBeInTheDocument();
+  });
+
+  it("renders initials from the name when name is provided", () => {
+    render(<AgentBadge agentId="a1" name="Petr Novák" />);
+    expect(screen.getByText("PN")).toBeInTheDocument();
+  });
+
+  it("renders agent label and agentId-derived initials when name is null", () => {
+    render(<AgentBadge agentId="a1" name={null} />);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("A1")).toBeInTheDocument();
+    expect(screen.queryByText("?")).not.toBeInTheDocument();
+  });
+
+  it("renders ? initials and Agent label when both name and agentId are absent", () => {
+    render(<AgentBadge agentId={null} name={null} />);
+    expect(screen.getByText("?")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("uses the same color for the same agentId across renders", () => {
+    const { rerender } = render(<AgentBadge agentId="a1" name="Petr" />);
+    const first = screen.getByTestId("agent-badge").className;
+    rerender(<AgentBadge agentId="a1" name="Petr" />);
+    const second = screen.getByTestId("agent-badge").className;
+    expect(first).toBe(second);
+  });
+
+  it("renders different colors for different agentIds (sanity)", () => {
+    const { rerender } = render(<AgentBadge agentId="aaa" name="A" />);
+    const colorA = screen.getByTestId("agent-badge").className;
+    rerender(<AgentBadge agentId="zzz" name="Z" />);
+    const colorZ = screen.getByTestId("agent-badge").className;
+    expect(colorA).not.toBe(colorZ);
+  });
+});
+```
+
+Key changes:
+- `"renders the initials when no name is provided"` → replaced by two tests: one for `name=null, agentId set` and one for both absent
+- The double-`?` test (`getAllByText("?").length >= 1`) is gone; the new test asserts no `?` appears when `agentId` is set
+
+- [ ] **Step 2: Run the tests to confirm RED**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: `"renders agent label and agentId-derived initials when name is null"` fails (current code renders `?` twice), `"renders ? initials and Agent label when both name and agentId are absent"` fails (current code renders `?` as label too).
+
+---
+
+## Task 8: Fix `AgentBadge.tsx` — eliminate double `?` (TDD GREEN)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/AgentBadge.tsx`
+
+- [ ] **Step 1: Replace the component file**
+
+```tsx
+import React from "react";
+import { getAgentColor } from "./utils/agentColor";
+
+interface AgentBadgeProps {
+  agentId?: string | null;
+  name?: string | null;
+  showInitials?: boolean;
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  return parts.length >= 2
+    ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+    : name.slice(0, 2).toUpperCase();
+}
+
+const AgentBadge: React.FC<AgentBadgeProps> = ({ agentId, name, showInitials = true }) => {
+  const color = getAgentColor(agentId);
+  const trimmedName = name?.trim();
+  const hasName = !!trimmedName;
+  const initials = hasName
+    ? getInitials(trimmedName!)
+    : agentId
+        ? agentId.slice(0, 2).toUpperCase()
+        : "?";
+  const label = hasName ? trimmedName! : "Agent";
+
+  return (
+    <span
+      data-testid="agent-badge"
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${color.bg} ${color.text}`}
+    >
+      {showInitials && (
+        <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full ring-1 ${color.ring} bg-white text-[10px] font-semibold`}>
+          {initials}
+        </span>
+      )}
+      <span className="truncate max-w-[10rem]">{label}</span>
+    </span>
+  );
+};
+
+export default AgentBadge;
+```
+
+Changes from original:
+- `getInitials` now accepts `string` (not `string | null | undefined`) — caller is responsible for the null check
+- `trimmedName` / `hasName` variables introduced
+- `initials` derived from `agentId` when name absent
+- `label` is `"Agent"` when name absent (not `initials`, so never a `?` label)
+
+- [ ] **Step 2: Run AgentBadge tests (GREEN)**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: All 6 tests pass, 0 failures.
+
+- [ ] **Step 3: Run the full frontend test suite to catch any snapshot or snapshot-like regressions**
+
+```bash
+cd frontend && npx vitest run 2>&1 | tail -30
+```
+
+Expected: All tests pass (or only pre-existing failures). If any other test breaks because it asserts `"?"` text from `AgentBadge`, update that assertion to `"Agent"` / the agentId-derived initials.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ..
+git add \
+  frontend/src/components/customer-support/smartsupp/AgentBadge.tsx \
+  frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx
+git commit -m "fix(smartsupp): derive initials from agentId when name is absent, show Agent label instead of double ?"
+```
+
+---
+
+## Task 9: Final build gates
+
+- [ ] **Step 1: Frontend build + lint**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+npm run lint 2>&1 | tail -20
+```
+
+Expected: Build succeeds, no lint errors.
+
+- [ ] **Step 2: Full backend build**
+
+```bash
+cd .. && dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 Error(s).
+
+- [ ] **Step 3: Run all backend Smartsupp tests one final time**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests \
+  --filter FullyQualifiedName~Smartsupp
+```
+
+Expected: All pass.
+
+---
+
+## Verification Checklist (manual, against staging)
+
+After deploying:
+
+- [ ] Open a conversation for a guest/unregistered visitor (no Shoptet customer profile). No toast appears. The Shoptet block on the right side is absent.
+- [ ] Open a conversation for a registered Shoptet customer. "Shoptet Zákazník" section appears. "Poslední objednávky" is empty (expected until a future order-lookup path lands).
+- [ ] Open a conversation whose outgoing reply has `authorName = null` but `agentId` set. Badge shows 2-letter initials from the agentId and label `"Agent"`. No two `?` side-by-side.
+- [ ] Watch the browser network panel: no `GET /api/orders?page=1&itemsPerPage=…` calls fire when opening conversations.

--- a/docs/superpowers/specs/2026-05-21-smartsupp-optimistic-message-design.md
+++ b/docs/superpowers/specs/2026-05-21-smartsupp-optimistic-message-design.md
@@ -1,0 +1,109 @@
+# Smartsupp Optimistic Message — Design Spec
+
+## Context
+
+When an operator sends a message in the Smartsupp chat window, there is currently no immediate feedback in the message list. The message only appears after the next 30-second polling sync.
+
+Root cause: `useSendMessage.ts` already contains optimistic-update code in `onMutate`, but `onSettled` immediately calls `queryClient.invalidateQueries`, which triggers a refetch. The backend's GET `/conversations/{id}` endpoint reads from the local DB, which does not yet contain the new message (it lives in Smartsupp's system and is synced only via polling). The refetch returns stale data without the new message and overwrites the optimistic entry.
+
+## Goal
+
+The operator's sent message appears instantly in the chat window and shows a delivery-status indicator (spinner while in-flight, checkmark on success, rollback on failure).
+
+## Design
+
+### Data flow after the fix
+
+```
+mutate(content)
+  → onMutate:  add optimistic msg  { id: "optimistic-…", deliveryStatus: "pending" }
+  → mutationFn: POST /messages  → returns { messageId, createdAt }
+  → onSuccess: replace optimistic msg  { id: messageId, deliveryStatus: "sent" }
+  → onError:   restore previous cache  (rollback)
+  → onSettled: (nothing — 30 s refetchInterval handles eventual sync)
+```
+
+### Changes — `useSendMessage.ts`
+
+All changes are confined to this single file.
+
+**1. `mutationFn` — return response instead of void**
+
+Change the mutation type parameter from `void` to `SendMessageApiResponse`.  
+Return `data` at the end of `mutationFn` so `onSuccess` receives it.
+
+**2. `onMutate` — add `deliveryStatus: "pending"`**
+
+```ts
+const optimisticMsg: MessageDto = {
+  id: `optimistic-${Date.now()}`,
+  authorType: "agent",
+  content,
+  createdAt: new Date().toISOString(),
+  isFirstReply: false,
+  deliveryStatus: "pending",   // ← new
+};
+```
+
+**3. `onSuccess` — replace optimistic entry with confirmed data**
+
+```ts
+onSuccess: (data) => {
+  if (!conversationId) return;
+  queryClient.setQueryData<GetConversationResponse>(
+    SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+    (current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        messages: current.messages.map((m) =>
+          m.id.startsWith("optimistic-")
+            ? { ...m, id: data.messageId ?? m.id, createdAt: data.createdAt ?? m.createdAt, deliveryStatus: "sent" }
+            : m,
+        ),
+      };
+    },
+  );
+},
+```
+
+**4. `onSettled` — remove `invalidateQueries`**
+
+The 30-second `refetchInterval` in `useSmartsuppConversation` will pick up the real message once Smartsupp has synced it. No immediate invalidation is needed.
+
+`onSettled` can be deleted entirely.
+
+### No changes needed elsewhere
+
+- `MessageBubble` / `MessageDeliveryIcon` already handle `"pending"` and `"sent"` statuses.
+- `ConversationDetail` already re-renders when the cache changes.
+- Backend unchanged.
+
+### Rollback behaviour (unchanged)
+
+`onError` already restores `context.previous`, removing the optimistic message and re-showing what was there before.
+
+## Edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| Multiple rapid sends | Each `onSuccess` maps only messages whose ID starts with `"optimistic-"`. Because sends are sequential (one pending mutation at a time), only the matching one is replaced. |
+| 30 s poll fires before onSuccess | `cancelQueries` in `onMutate` stops any in-flight refetch. The poll that fires after `onSuccess` will overwrite the confirmed message with the real server message (same `messageId`), which is identical content — no visible change. |
+| `messageId` absent in response | Falls back to the optimistic fake ID. The message stays in the list with the fake ID until the next poll replaces the entire messages array. |
+| Send fails | `onError` rolls back to `context.previous`; the optimistic message disappears. |
+
+## Tests to update — `useSendMessage.test.ts`
+
+- Existing success test: assert `invalidateQueries` is **not** called on success.
+- New: assert optimistic message has `deliveryStatus: "pending"`.
+- New: assert `onSuccess` replaces the optimistic message with `messageId`/`"sent"`.
+- Existing rollback test: unchanged — still verifies `context.previous` is restored.
+
+## Verification
+
+1. Open a Smartsupp conversation with messages.
+2. Type and send a message.
+3. Message should appear instantly with a spinning loader icon.
+4. Once the POST returns, the loader switches to a checkmark.
+5. Simulate a send failure (offline / 503) — the message should disappear and the composer should show the error.
+6. Wait 30 s for polling — the message should still be visible and should not duplicate.

--- a/frontend/src/api/hooks/useSmartsupp.ts
+++ b/frontend/src/api/hooks/useSmartsupp.ts
@@ -135,7 +135,7 @@ export interface ShoptetOrderSnapshotDto {
 }
 
 export interface ShoptetContactInfoDto {
-  customer: ShoptetCustomerSnapshotDto;
+  customer?: ShoptetCustomerSnapshotDto | null;
   recentOrders: ShoptetOrderSnapshotDto[];
   cartUpdatedAt?: string | null;
 }

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -23,7 +23,7 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
   const isFullHeightPage = location.pathname === "/customer/smartsupp";
 
   return (
-    <div className="h-screen bg-gray-50 flex flex-col overflow-hidden">
+    <div className="h-[calc(100vh-1.5rem)] bg-gray-50 flex flex-col overflow-hidden">
       {/* TopBar for mobile menu */}
       <TopBar onMenuClick={() => setSidebarOpen(true)} />
 
@@ -38,7 +38,7 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
 
       {/* Main content */}
       <div
-        className={`flex-1 flex flex-col transition-all duration-300 ${sidebarCollapsed ? "md:pl-16" : "md:pl-64"} pt-16 md:pt-0`}
+        className={`flex-1 min-h-0 flex flex-col transition-all duration-300 ${sidebarCollapsed ? "md:pl-16" : "md:pl-64"} pt-16 md:pt-0`}
       >
         {!hideMobileNotice && <MobileNotice />}
 

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -20,7 +20,7 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
     location.pathname === "/customer/smartsupp";
 
   return (
-    <div className="h-screen bg-gray-50 flex flex-col">
+    <div className="h-screen bg-gray-50 flex flex-col overflow-hidden">
       {/* TopBar for mobile menu */}
       <TopBar onMenuClick={() => setSidebarOpen(true)} />
 

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -19,6 +19,9 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
     location.pathname === "/dashboard" ||
     location.pathname === "/customer/smartsupp";
 
+  // Pages that manage their own internal scroll — no padding wrapper, main is overflow-hidden
+  const isFullHeightPage = location.pathname === "/customer/smartsupp";
+
   return (
     <div className="h-screen bg-gray-50 flex flex-col overflow-hidden">
       {/* TopBar for mobile menu */}
@@ -40,10 +43,14 @@ const Layout: React.FC<LayoutProps> = ({ children, statusBar }) => {
         {!hideMobileNotice && <MobileNotice />}
 
         {/* Page content */}
-        <main className="flex-1 relative overflow-auto">
-          <div className="p-3 md:p-4 bg-gray-50 min-h-full flex flex-col">
-            <div className="w-full flex-1 flex flex-col min-h-0">{children}</div>
-          </div>
+        <main className={`flex-1 relative ${isFullHeightPage ? "overflow-hidden flex flex-col" : "overflow-auto"}`}>
+          {isFullHeightPage ? (
+            children
+          ) : (
+            <div className="p-3 md:p-4 bg-gray-50 min-h-full flex flex-col">
+              <div className="w-full flex-1 flex flex-col min-h-0">{children}</div>
+            </div>
+          )}
         </main>
       </div>
 

--- a/frontend/src/components/customer-support/smartsupp/AgentBadge.tsx
+++ b/frontend/src/components/customer-support/smartsupp/AgentBadge.tsx
@@ -16,14 +16,17 @@ function getInitials(name: string): string {
 
 const AgentBadge: React.FC<AgentBadgeProps> = ({ agentId, name, showInitials = true }) => {
   const color = getAgentColor(agentId);
-  const trimmedName = name?.trim();
-  const hasName = !!trimmedName;
-  const initials = hasName
-    ? getInitials(trimmedName!)
-    : agentId
-        ? agentId.slice(0, 2).toUpperCase()
-        : "?";
-  const label = hasName ? trimmedName! : "Agent";
+  let initials: string;
+  let label: string;
+
+  if (name?.trim()) {
+    const trimmedName = name.trim();
+    initials = getInitials(trimmedName);
+    label = trimmedName;
+  } else {
+    initials = agentId ? agentId.slice(0, 2).toUpperCase() : "?";
+    label = "Agent";
+  }
 
   return (
     <span

--- a/frontend/src/components/customer-support/smartsupp/AgentBadge.tsx
+++ b/frontend/src/components/customer-support/smartsupp/AgentBadge.tsx
@@ -7,8 +7,7 @@ interface AgentBadgeProps {
   showInitials?: boolean;
 }
 
-function getInitials(name?: string | null): string {
-  if (!name) return "?";
+function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/);
   return parts.length >= 2
     ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
@@ -17,8 +16,14 @@ function getInitials(name?: string | null): string {
 
 const AgentBadge: React.FC<AgentBadgeProps> = ({ agentId, name, showInitials = true }) => {
   const color = getAgentColor(agentId);
-  const initials = getInitials(name);
-  const label = name ?? initials;
+  const trimmedName = name?.trim();
+  const hasName = !!trimmedName;
+  const initials = hasName
+    ? getInitials(trimmedName!)
+    : agentId
+        ? agentId.slice(0, 2).toUpperCase()
+        : "?";
+  const label = hasName ? trimmedName! : "Agent";
 
   return (
     <span

--- a/frontend/src/components/customer-support/smartsupp/ConversationDetail.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ConversationDetail.tsx
@@ -68,7 +68,7 @@ const ConversationDetail: React.FC<ConversationDetailProps> = ({
   const grouped = groupByDay(messages);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-h-0">
       <div className="px-4 py-3 border-b border-gray-200 flex items-center gap-3">
         {onBack && (
           <button
@@ -108,7 +108,7 @@ const ConversationDetail: React.FC<ConversationDetailProps> = ({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-6 py-4">
+      <div className="flex-1 overflow-y-auto min-h-0 px-6 py-4">
         {isLoading && (
           <div className="text-sm text-gray-400 text-center py-8">Načítání zpráv...</div>
         )}

--- a/frontend/src/components/customer-support/smartsupp/ConversationList.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ConversationList.tsx
@@ -45,14 +45,20 @@ const ConversationList: React.FC<ConversationListProps> = ({
       {!isLoading && conversations.length === 0 && (
         <div className="p-4 text-sm text-gray-400 text-center">Žádné konverzace</div>
       )}
-      {conversations.map((c) => (
-        <ConversationListItem
-          key={c.id}
-          conversation={c}
-          isSelected={c.id === selectedId}
-          onClick={() => onSelect(c.id)}
-        />
-      ))}
+      {[...conversations]
+        .sort((a, b) => {
+          const aTime = a.lastMessageAt ?? a.createdAt;
+          const bTime = b.lastMessageAt ?? b.createdAt;
+          return bTime < aTime ? -1 : bTime > aTime ? 1 : 0;
+        })
+        .map((c) => (
+          <ConversationListItem
+            key={c.id}
+            conversation={c}
+            isSelected={c.id === selectedId}
+            onClick={() => onSelect(c.id)}
+          />
+        ))}
     </div>
   </div>
 );

--- a/frontend/src/components/customer-support/smartsupp/ConversationList.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ConversationList.tsx
@@ -38,7 +38,7 @@ const ConversationList: React.FC<ConversationListProps> = ({
       </div>
     </div>
 
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 overflow-y-auto min-h-0">
       {isLoading && (
         <div className="p-4 text-sm text-gray-400 text-center">Načítání...</div>
       )}

--- a/frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx
@@ -14,41 +14,49 @@ function ShoptetCustomerCard({ conversationId }: ShoptetCustomerCardProps) {
 
   const { customer, recentOrders, cartUpdatedAt } = data.contactInfo;
 
+  const hasCustomer = customer != null;
+  const hasOrders = recentOrders.length > 0;
+  const hasCart = !!cartUpdatedAt;
+
+  if (!hasCustomer && !hasOrders && !hasCart) return null;
+
   return (
     <>
-      <Section title="Shoptet Zákazník">
-        <div className="space-y-1">
-          {customer.fullName && (
-            <div className="text-sm font-semibold text-gray-900">{customer.fullName}</div>
-          )}
-          {customer.email && (
-            <div className="text-xs text-gray-500">{customer.email}</div>
-          )}
-          {customer.customerGroup && (
-            <div className="text-xs text-gray-700">
-              <span className="text-gray-400">Skupina: </span>{customer.customerGroup}
-            </div>
-          )}
-          {customer.priceList && (
-            <div className="text-xs text-gray-700">
-              <span className="text-gray-400">Ceník: </span>{customer.priceList}
-            </div>
-          )}
-          {customer.defaultShippingAddress && (
-            <div className="text-xs text-gray-600 mt-1">{customer.defaultShippingAddress}</div>
-          )}
-        </div>
-      </Section>
-
-      {cartUpdatedAt && (
-        <Section title="Shoptet Košík">
-          <div className="text-xs text-gray-500">
-            Aktualizován: {new Date(cartUpdatedAt).toLocaleDateString("cs-CZ")}
+      {hasCustomer && (
+        <Section title="Shoptet Zákazník">
+          <div className="space-y-1">
+            {customer.fullName && (
+              <div className="text-sm font-semibold text-gray-900">{customer.fullName}</div>
+            )}
+            {customer.email && (
+              <div className="text-xs text-gray-500">{customer.email}</div>
+            )}
+            {customer.customerGroup && (
+              <div className="text-xs text-gray-700">
+                <span className="text-gray-400">Skupina: </span>{customer.customerGroup}
+              </div>
+            )}
+            {customer.priceList && (
+              <div className="text-xs text-gray-700">
+                <span className="text-gray-400">Ceník: </span>{customer.priceList}
+              </div>
+            )}
+            {customer.defaultShippingAddress && (
+              <div className="text-xs text-gray-600 mt-1">{customer.defaultShippingAddress}</div>
+            )}
           </div>
         </Section>
       )}
 
-      {recentOrders.length > 0 && (
+      {hasCart && (
+        <Section title="Shoptet Košík">
+          <div className="text-xs text-gray-500">
+            Aktualizován: {new Date(cartUpdatedAt!).toLocaleDateString("cs-CZ")}
+          </div>
+        </Section>
+      )}
+
+      {hasOrders && (
         <Section title="Poslední objednávky">
           <div className="space-y-2">
             {recentOrders.map((order) => (

--- a/frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx
@@ -16,9 +16,8 @@ function ShoptetCustomerCard({ conversationId }: ShoptetCustomerCardProps) {
 
   const hasCustomer = customer != null;
   const hasOrders = recentOrders.length > 0;
-  const hasCart = !!cartUpdatedAt;
 
-  if (!hasCustomer && !hasOrders && !hasCart) return null;
+  if (!hasCustomer && !hasOrders && !cartUpdatedAt) return null;
 
   return (
     <>
@@ -48,10 +47,10 @@ function ShoptetCustomerCard({ conversationId }: ShoptetCustomerCardProps) {
         </Section>
       )}
 
-      {hasCart && (
+      {cartUpdatedAt != null && (
         <Section title="Shoptet Košík">
           <div className="text-xs text-gray-500">
-            Aktualizován: {new Date(cartUpdatedAt!).toLocaleDateString("cs-CZ")}
+            Aktualizován: {new Date(cartUpdatedAt).toLocaleDateString("cs-CZ")}
           </div>
         </Section>
       )}

--- a/frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx
@@ -3,14 +3,27 @@ import { render, screen } from "@testing-library/react";
 import AgentBadge from "../AgentBadge";
 
 describe("AgentBadge", () => {
-  it("renders the agent name", () => {
+  it("renders the agent name as the label", () => {
     render(<AgentBadge agentId="a1" name="Petr Novák" />);
     expect(screen.getByText("Petr Novák")).toBeInTheDocument();
   });
 
-  it("renders the initials when no name is provided", () => {
+  it("renders initials from the name when name is provided", () => {
+    render(<AgentBadge agentId="a1" name="Petr Novák" />);
+    expect(screen.getByText("PN")).toBeInTheDocument();
+  });
+
+  it("renders agent label and agentId-derived initials when name is null", () => {
     render(<AgentBadge agentId="a1" name={null} />);
-    expect(screen.getAllByText("?").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("A1")).toBeInTheDocument();
+    expect(screen.queryByText("?")).not.toBeInTheDocument();
+  });
+
+  it("renders ? initials and Agent label when both name and agentId are absent", () => {
+    render(<AgentBadge agentId={null} name={null} />);
+    expect(screen.getByText("?")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
   });
 
   it("uses the same color for the same agentId across renders", () => {

--- a/frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx
@@ -82,4 +82,26 @@ describe("ShoptetCustomerCard", () => {
     render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
     expect(screen.getByText("CZ, Praha, 12000, Ulice 5")).toBeInTheDocument();
   });
+
+  it("renders no customer section when contactInfo.customer is null", () => {
+    mockedHook.mockReturnValue({
+      data: { success: true, contactInfo: { customer: null, recentOrders: [], cartUpdatedAt: null } },
+      isLoading: false,
+    });
+    render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
+    expect(screen.queryByText("Shoptet Zákazník")).not.toBeInTheDocument();
+  });
+
+  it("still renders cart section when customer is null but cartUpdatedAt is set", () => {
+    mockedHook.mockReturnValue({
+      data: {
+        success: true,
+        contactInfo: { customer: null, recentOrders: [], cartUpdatedAt: "2026-04-15T12:00:00" },
+      },
+      isLoading: false,
+    });
+    render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
+    expect(screen.queryByText("Shoptet Zákazník")).not.toBeInTheDocument();
+    expect(screen.getByText("Shoptet Košík")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/customer-support/smartsupp/hooks/__tests__/useSendMessage.test.ts
+++ b/frontend/src/components/customer-support/smartsupp/hooks/__tests__/useSendMessage.test.ts
@@ -132,4 +132,91 @@ describe("useSendMessage", () => {
     await waitFor(() => expect(result.current.isPending).toBe(true));
     resolvePromise({ ok: true, status: 200, json: async () => ({ success: true }) });
   });
+
+  it("shows optimistic message with pending delivery status while request is in flight", async () => {
+    let resolvePromise!: (v: unknown) => void;
+    (getAuthenticatedApiClient as jest.Mock).mockReturnValue({
+      baseUrl: "http://api.test",
+      http: {
+        fetch: () => new Promise((res) => { resolvePromise = res; }),
+      },
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(["smartsupp", "conversation", "conv1"], {
+      success: true,
+      messages: [],
+    });
+
+    function seededWrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const { result } = renderHook(() => useSendMessage("conv1"), { wrapper: seededWrapper });
+    act(() => result.current.send("Ahoj"));
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<{ messages: Array<{ id: string; deliveryStatus?: string; content?: string }> }>(
+        ["smartsupp", "conversation", "conv1"],
+      );
+      expect(cached?.messages).toHaveLength(1);
+    });
+
+    const cached = queryClient.getQueryData<{ messages: Array<{ id: string; deliveryStatus?: string; content?: string }> }>(
+      ["smartsupp", "conversation", "conv1"],
+    );
+    expect(cached?.messages[0].id).toMatch(/^optimistic-/);
+    expect(cached?.messages[0].deliveryStatus).toBe("pending");
+    expect(cached?.messages[0].content).toBe("Ahoj");
+
+    // resolve so the hook can settle and avoid act() warnings
+    resolvePromise({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, messageId: "ms999", createdAt: "2026-05-20T10:00:00Z" }),
+    });
+  });
+
+  it("replaces optimistic message with real messageId and sent delivery status on success", async () => {
+    setApiResponse(200, { success: true, messageId: "ms-real-123", createdAt: "2026-05-20T10:00:00Z" });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(["smartsupp", "conversation", "conv1"], {
+      success: true,
+      messages: [
+        {
+          id: "existing-1",
+          authorType: "contact",
+          content: "Původní zpráva",
+          createdAt: "2026-01-01T00:00:00Z",
+          isFirstReply: false,
+        },
+      ],
+    });
+
+    function seededWrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    const { result } = renderHook(() => useSendMessage("conv1"), { wrapper: seededWrapper });
+    act(() => result.current.send("Nová zpráva"));
+
+    await waitFor(() => expect(result.current.justSent).toBe(true));
+
+    const cached = queryClient.getQueryData<{
+      messages: Array<{ id: string; content?: string | null; deliveryStatus?: string | null }>;
+    }>(["smartsupp", "conversation", "conv1"]);
+
+    expect(cached?.messages).toHaveLength(2);
+    const sentMessage = cached?.messages.find((m) => m.id === "ms-real-123");
+    expect(sentMessage).toMatchObject({
+      content: "Nová zpráva",
+      deliveryStatus: "sent",
+    });
+    expect(cached?.messages.some((m) => m.id.startsWith("optimistic-"))).toBe(false);
+  });
 });

--- a/frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts
+++ b/frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts
@@ -31,7 +31,7 @@ interface UseSendMessageResult {
   clearSent: () => void;
 }
 
-type SendMessageContext = { previous?: GetConversationResponse };
+type SendMessageContext = { previous?: GetConversationResponse; optimisticId?: string };
 
 export function useSendMessage(conversationId: string | null): UseSendMessageResult {
   const queryClient = useQueryClient();
@@ -69,8 +69,9 @@ export function useSendMessage(conversationId: string | null): UseSendMessageRes
       const previous = queryClient.getQueryData<GetConversationResponse>(
         SMARTSUPP_QUERY_KEYS.conversation(conversationId),
       );
+      const optimisticId = `optimistic-${Date.now()}`;
       const optimisticMsg: MessageDto = {
-        id: `optimistic-${Date.now()}`,
+        id: optimisticId,
         authorType: "agent",
         content,
         createdAt: new Date().toISOString(),
@@ -81,21 +82,28 @@ export function useSendMessage(conversationId: string | null): UseSendMessageRes
         SMARTSUPP_QUERY_KEYS.conversation(conversationId),
         (old) => (old ? { ...old, messages: [...old.messages, optimisticMsg] } : old),
       );
-      return { previous };
+      return { previous, optimisticId };
     },
-    onSuccess: (data) => {
-      if (!conversationId) return;
+    onSuccess: (data, _variables, context) => {
+      const optimisticId = context?.optimisticId;
+      if (!conversationId || !optimisticId) return;
       queryClient.setQueryData<GetConversationResponse>(
         SMARTSUPP_QUERY_KEYS.conversation(conversationId),
         (current) => {
           if (!current) return current;
+          if (!data.messageId) {
+            return {
+              ...current,
+              messages: current.messages.filter((m) => m.id !== optimisticId),
+            };
+          }
           return {
             ...current,
             messages: current.messages.map((m) =>
-              m.id.startsWith("optimistic-")
+              m.id === optimisticId
                 ? {
                     ...m,
-                    id: data.messageId ?? m.id,
+                    id: data.messageId!,
                     createdAt: data.createdAt ?? m.createdAt,
                     deliveryStatus: "sent",
                   }

--- a/frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts
+++ b/frontend/src/components/customer-support/smartsupp/hooks/useSendMessage.ts
@@ -36,7 +36,7 @@ type SendMessageContext = { previous?: GetConversationResponse };
 export function useSendMessage(conversationId: string | null): UseSendMessageResult {
   const queryClient = useQueryClient();
 
-  const mutation = useMutation<void, Error, string, SendMessageContext>({
+  const mutation = useMutation<SendMessageApiResponse, Error, string, SendMessageContext>({
     mutationFn: async (content) => {
       if (!conversationId) {
         throw new Error("Není vybrána konverzace.");
@@ -58,6 +58,8 @@ export function useSendMessage(conversationId: string | null): UseSendMessageRes
       if (!data.success) {
         throw new Error(messageForSendError(data?.errorCode));
       }
+
+      return data;
     },
     onMutate: async (content) => {
       if (!conversationId) return {};
@@ -73,6 +75,7 @@ export function useSendMessage(conversationId: string | null): UseSendMessageRes
         content,
         createdAt: new Date().toISOString(),
         isFirstReply: false,
+        deliveryStatus: "pending",
       };
       queryClient.setQueryData<GetConversationResponse>(
         SMARTSUPP_QUERY_KEYS.conversation(conversationId),
@@ -80,19 +83,34 @@ export function useSendMessage(conversationId: string | null): UseSendMessageRes
       );
       return { previous };
     },
+    onSuccess: (data) => {
+      if (!conversationId) return;
+      queryClient.setQueryData<GetConversationResponse>(
+        SMARTSUPP_QUERY_KEYS.conversation(conversationId),
+        (current) => {
+          if (!current) return current;
+          return {
+            ...current,
+            messages: current.messages.map((m) =>
+              m.id.startsWith("optimistic-")
+                ? {
+                    ...m,
+                    id: data.messageId ?? m.id,
+                    createdAt: data.createdAt ?? m.createdAt,
+                    deliveryStatus: "sent",
+                  }
+                : m,
+            ),
+          };
+        },
+      );
+    },
     onError: (_err, _content, context) => {
       if (context?.previous !== undefined && conversationId) {
         queryClient.setQueryData(
           SMARTSUPP_QUERY_KEYS.conversation(conversationId),
           context.previous,
         );
-      }
-    },
-    onSettled: () => {
-      if (conversationId) {
-        queryClient.invalidateQueries({
-          queryKey: SMARTSUPP_QUERY_KEYS.conversation(conversationId),
-        });
       }
     },
   });

--- a/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
+++ b/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
@@ -53,7 +53,7 @@ const SmartsuppChatsPage: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
       <div
         className={`${mobileView !== "list" ? "hidden md:flex" : "flex"} items-center justify-end px-4 py-2 border-b border-gray-200 bg-white`}
       >

--- a/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
+++ b/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
@@ -67,7 +67,7 @@ const SmartsuppChatsPage: React.FC = () => {
         </button>
       </div>
 
-      <div className="flex flex-1 overflow-hidden bg-white rounded-lg shadow-sm border border-gray-200">
+      <div className="flex flex-1 overflow-hidden bg-white">
         <div
           className={`${mobileView === "list" ? "flex" : "hidden"} ${listPanelOpen ? "md:flex" : "md:hidden"} flex-col w-full md:w-96 flex-shrink-0 overflow-hidden`}
         >


### PR DESCRIPTION
## Summary

- Backend handler now returns `success=true, contactInfo=null` for guest/unregistered Shoptet visitors instead of an error, eliminating the spurious "customer not found" toast
- `AgentBadge` derives initials from `agentId` when `name` is absent and shows "Agent" as label, fixing the double-`?` display
- Removes the wasteful email-based order fallback from `GetSmartsuppContactShoptetInfoHandler` (and its `IEshopOrderClient` dependency); `RecentOrders` returns empty until a GUID-based order lookup path is available
- `ShoptetCustomerCard` guards on nullable `customer`, silently hiding the panel for guests

## Test plan

- [ ] All 6 `GetSmartsuppContactShoptetInfoHandlerTests` pass, including new `Times.Never` verify for no-guids path
- [ ] `AgentBadge` tests: `name=null, agentId set` shows agentId-derived initials and "Agent" label with no `?`
- [ ] `ShoptetCustomerCard` tests: null customer hides customer section; cart section still renders when only `cartUpdatedAt` is set
- [ ] Staging: guest conversation shows no toast and no Shoptet panel; registered customer shows panel with empty orders; agentless reply shows 2-letter initials and "Agent" label