### PR TITLE
feat: Extract duplicated `GetConsumptionTypeText` helper in PackingMaterials module

### DIFF
--- a/artifacts/feat-arch-review-packingmaterials-getconsumpt/arch-review.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-getconsumpt/arch-review.r1.md
@@ -1,0 +1,153 @@
+I have enough context. The proposal aligns with existing patterns in this codebase. Now writing the architecture review.
+
+# Architecture Review: Extract duplicated `GetConsumptionTypeText` helper in PackingMaterials module
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure backend refactor confined to the `PackingMaterials` application layer slice. The proposal fits cleanly into existing conventions:
+
+- **Vertical-slice ownership**: The helper stays inside `Application/Features/PackingMaterials/`, respecting module isolation (`docs/architecture/development_guidelines.md` — "DTOs are never shared or global"; the same applies to formatting helpers).
+- **Precedent**: Per-feature static helpers already exist in this codebase — `Features/Smartsupp/SmartsuppNameHelper.cs`, `Features/Photobank/Validators/PhotobankValidationHelpers.cs`, `Features/Manufacture/ErrorFilters/Filters/ManufactureErrorParsingHelpers.cs`. A `PackingMaterialsTextHelper.cs` follows the established naming and placement convention.
+- **No cross-cutting impact**: `ConsumptionTypeText` is a presentation-layer string formatter, not domain logic. It belongs in `Application`, not `Domain` — consistent with the existing distribution where the `ConsumptionType` enum sits in `Domain/Features/PackingMaterials/Enums/` but its UI label is materialized at the application boundary into `PackingMaterialDto`.
+- **Internal visibility**: The helper is consumed only by handlers within the same assembly. `internal` is correct and matches the spec.
+
+The one minor deviation from filesystem.md is that `Contracts/` is documented as containing "Shared DTOs across use cases." The proposed file is a helper, not a DTO. See **Decision 1** below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Domain
+└── Features/PackingMaterials/Enums/
+    └── ConsumptionType.cs                  (unchanged — source enum)
+
+Anela.Heblo.Application
+└── Features/PackingMaterials/
+    ├── Contracts/
+    │   ├── PackingMaterialDto.cs           (unchanged — ConsumptionTypeText property)
+    │   └── PackingMaterialsTextHelper.cs   (NEW — internal static helper)
+    └── UseCases/
+        ├── CreatePackingMaterial/CreatePackingMaterialHandler.cs           (call site rewired)
+        ├── UpdatePackingMaterial/UpdatePackingMaterialHandler.cs           (call site rewired)
+        ├── UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs  (call site rewired)
+        ├── GetPackingMaterialsList/GetPackingMaterialsListHandler.cs       (call site rewired)
+        └── GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs         (call site rewired)
+```
+
+Each affected handler already imports `Anela.Heblo.Application.Features.PackingMaterials.Contracts` (for `PackingMaterialDto`) and `Anela.Heblo.Domain.Features.PackingMaterials.Enums` (for `ConsumptionType`), so no new `using` directives are required.
+
+### Key Design Decisions
+
+#### Decision 1: Place the helper in `Contracts/` rather than the module root or a new `Helpers/` folder
+**Options considered:**
+1. `Contracts/PackingMaterialsTextHelper.cs` — co-located with `PackingMaterialDto` whose `ConsumptionTypeText` property it populates.
+2. `PackingMaterials/PackingMaterialsTextHelper.cs` — at the module root, alongside `PackingMaterialsModule.cs`. Matches `Features/Smartsupp/SmartsuppNameHelper.cs`.
+3. New `Helpers/` subfolder under `PackingMaterials/`.
+
+**Chosen approach:** Option 1 (`Contracts/`), as specified in the spec and brief.
+
+**Rationale:** The helper exists exclusively to produce one field on `PackingMaterialDto`. Co-locating it with the DTO it serves makes the binding obvious and discoverable when the enum is extended. Option 2 is also defensible (and matches `SmartsuppNameHelper`), but the spec's choice is acceptable given the tight semantic coupling to the DTO. Option 3 introduces a new folder for a single file — premature structure.
+
+The minor naming friction (a non-DTO file under `Contracts/`) is acceptable for this single, surgical case. If a second helper appears later, promote both to `PackingMaterials/` root or a `Helpers/` folder at that point.
+
+#### Decision 2: Keep visibility `internal`, helper class `static`, method `public`
+**Options considered:**
+- `internal static class` with `public static` method (spec).
+- `public static class` (would expose the helper outside the assembly).
+
+**Chosen approach:** `internal static class PackingMaterialsTextHelper` with `public static string ConsumptionTypeText(ConsumptionType type)`.
+
+**Rationale:** No consumer outside `Anela.Heblo.Application` needs this formatter; the API project receives `ConsumptionTypeText` as a pre-formatted string on the DTO. `internal` enforces the module boundary documented in `development_guidelines.md`. The method must be `public` within the class so internal callers in other namespaces of the same assembly can reach it.
+
+#### Decision 3: Preserve the `_ => type.ToString()` fallback unchanged
+**Options considered:**
+- Keep the silent fallback (spec).
+- Throw `ArgumentOutOfRangeException` on unknown values to surface drift loudly.
+
+**Chosen approach:** Preserve the fallback. Explicitly out of scope per spec.
+
+**Rationale:** The whole point of consolidation is that a missing enum case now needs to be added in exactly one place, so the fallback's drift-hiding behavior is largely neutralized. Changing the fallback semantics in this PR would mix a behavior change with a mechanical refactor and risk altering API output for any data with unexpected enum values (e.g., legacy rows). Track as follow-up if desired.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create exactly one new file:
+
+```
+backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+```
+
+Modify exactly five existing files (delete the private method, rewire the single call site each):
+
+- `UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs` (lines 36, 50–56)
+- `UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs` (lines 37, 50–56)
+- `UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs` (lines 50, 63–69)
+- `UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs` (lines 39, 53–59)
+- `UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs` (lines 36, 63–69)
+
+No other files are touched. No `using` additions are required — the namespace `Anela.Heblo.Application.Features.PackingMaterials.Contracts` is already imported by every affected handler.
+
+### Interfaces and Contracts
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+internal static class PackingMaterialsTextHelper
+{
+    public static string ConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder   => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay     => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+Call-site rewrite pattern (each of the five DTO constructions):
+
+```csharp
+// before
+ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+
+// after
+ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+### Data Flow
+
+Unchanged. For each handler:
+
+1. Handler receives MediatR request.
+2. Handler loads `PackingMaterial` (with `ConsumptionType` enum value) from repository.
+3. Handler constructs `PackingMaterialDto`, calling `PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType)` (was: private `GetConsumptionTypeText`).
+4. Handler returns response containing the DTO.
+5. Controller serializes — the `ConsumptionTypeText` JSON field is byte-identical to the pre-refactor output for any current enum value.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missed call site or stale duplicate left behind | Low | After edit, run a repo-wide grep for `GetConsumptionTypeText` — must return zero hits. Spec FR-2 already lists this as acceptance criterion. |
+| Accidental behavior change (different label, lost diacritics) | Low | Copy the switch arms verbatim, including the Czech characters `á`, `ž`. Existing handler tests assert the strings indirectly via DTO snapshots/assertions; they must pass without modification. |
+| Helper placement under `Contracts/` may confuse future readers expecting only DTOs | Low | Documented in Decision 1. The file name `…TextHelper.cs` makes its purpose unambiguous. Revisit if a second helper appears. |
+| Encoding regression (file saved without UTF-8 BOM where the rest of the project uses BOM, or vice versa) | Low | Match the encoding of an existing sibling file in `Contracts/` (e.g., `PackingMaterialDto.cs`). Run `dotnet format` — spec NFR-4 requires a no-op diff. |
+| Other duplicated label helpers elsewhere in the codebase remain untouched | Low (out of scope) | Spec explicitly excludes touching other duplicates. The brief was filed by an automated arch-review routine; if it surfaces more, they will arrive as separate tickets. |
+
+## Specification Amendments
+
+None substantive. Two clarifications worth recording:
+
+1. **No new `using` statements are required.** Every target handler already imports both `Anela.Heblo.Application.Features.PackingMaterials.Contracts` and `Anela.Heblo.Domain.Features.PackingMaterials.Enums`. The spec doesn't say otherwise, but reviewers should not add a `using static` directive — call sites read `PackingMaterialsTextHelper.ConsumptionTypeText(...)` fully qualified by class name (matches `SmartsuppNameHelper` precedent).
+2. **Verification step:** After the edit, in addition to FR-2's grep for `GetConsumptionTypeText`, run `dotnet build` against `backend/Anela.Heblo.sln` and execute `dotnet test backend/test/Anela.Heblo.Tests` filtered to PackingMaterials. NFR-4 already implies this; making it explicit avoids ambiguity.
+
+## Prerequisites
+
+None. No migrations, no config changes, no infrastructure changes, no DI registration changes (helper is a static class, not injected). The work can begin immediately on the current branch.

--- a/artifacts/feat-arch-review-packingmaterials-getconsumpt/brief.md
+++ b/artifacts/feat-arch-review-packingmaterials-getconsumpt/brief.md
@@ -1,0 +1,47 @@
+## Module
+PackingMaterials
+
+## Finding
+The following private static method is copy-pasted identically into five separate handler files:
+
+```csharp
+private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+{
+    ConsumptionType.PerOrder => "za zakázku",
+    ConsumptionType.PerProduct => "za produkt",
+    ConsumptionType.PerDay => "za den",
+    _ => type.ToString()
+};
+```
+
+Locations:
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs:50-57`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs:50-56`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs:63-70`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs:53-59`
+- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs:63-69`
+
+## Why it matters
+Every time a new `ConsumptionType` enum value is added, all five files must be updated. Missing one produces a silently wrong label in the API response (falls through to `type.ToString()` which returns the raw enum name instead of the Czech UI string). This already happened once — the `_ => type.ToString()` fallback exists precisely because someone forgot to extend all copies.
+
+## Suggested fix
+Extract to a single static helper within the module. The natural home is a static class alongside the module's contracts or a `PackingMaterialsTextHelper` in the `Contracts/` folder:
+
+```csharp
+// Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+internal static class PackingMaterialsTextHelper
+{
+    public static string ConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder   => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay     => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+Replace all five private copies with a call to `PackingMaterialsTextHelper.ConsumptionTypeText(...)`. This is a purely mechanical, zero-risk change.
+
+---
+_Filed by daily arch-review routine on 2026-05-20._

--- a/artifacts/feat-arch-review-packingmaterials-getconsumpt/impl/main.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-getconsumpt/impl/main.r1.md
@@ -1,0 +1,12 @@
+Normal repo (GIT_DIR == GIT_COMMON), named branch. **Step 3: Base branch is `main`.**
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-packingmaterials-getconsumpt/spec.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-getconsumpt/spec.r1.md
@@ -1,0 +1,100 @@
+# Specification: Extract duplicated `GetConsumptionTypeText` helper in PackingMaterials module
+
+## Summary
+The private static method `GetConsumptionTypeText(ConsumptionType)` is copy-pasted verbatim across five handler files in the `PackingMaterials` module. Consolidate these five copies into a single internal static helper inside the module's `Contracts/` folder so that future enum additions only need to be edited in one place.
+
+## Background
+Each handler in `PackingMaterials/UseCases/*` formats `ConsumptionType` enum values into Czech UI strings (e.g. `PerOrder → "za zakázku"`). The same `switch` expression is duplicated five times. When a new `ConsumptionType` value is added, all five copies must be kept in sync; the existing fallback (`_ => type.ToString()`) silently emits the raw enum name when a copy is forgotten, masking the bug rather than surfacing it.
+
+This is a mechanical, zero-risk refactor that removes a known drift hazard without changing observable behavior.
+
+## Functional Requirements
+
+### FR-1: Introduce a single shared helper
+Create an `internal static` class `PackingMaterialsTextHelper` in `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs` exposing a single method `ConsumptionTypeText(ConsumptionType type)` that returns the Czech label string for each `ConsumptionType` value.
+
+**Acceptance criteria:**
+- File `PackingMaterialsTextHelper.cs` exists under `Application/Features/PackingMaterials/Contracts/`.
+- Class is declared `internal static`.
+- Method signature: `public static string ConsumptionTypeText(ConsumptionType type)`.
+- Switch expression preserves the exact same mappings as the current implementations:
+  - `ConsumptionType.PerOrder → "za zakázku"`
+  - `ConsumptionType.PerProduct → "za produkt"`
+  - `ConsumptionType.PerDay → "za den"`
+  - default → `type.ToString()`
+- No other public members are added.
+
+### FR-2: Remove all five duplicated private methods
+Delete the private static `GetConsumptionTypeText` method from each of the five handler files and replace every call site with `PackingMaterialsTextHelper.ConsumptionTypeText(...)`.
+
+**Acceptance criteria:**
+- The private method is removed from each of:
+  - `CreatePackingMaterial/CreatePackingMaterialHandler.cs`
+  - `UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`
+  - `UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`
+  - `GetPackingMaterialsList/GetPackingMaterialsListHandler.cs`
+  - `GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`
+- Every former call site now invokes `PackingMaterialsTextHelper.ConsumptionTypeText(...)`.
+- A repository-wide search for `GetConsumptionTypeText` returns zero results after the change.
+- No other code in these handlers is touched (surgical change only).
+
+### FR-3: Preserve behavior
+The refactor must not change any externally observable behavior. API responses returning consumption-type labels must produce byte-identical strings before and after the change.
+
+**Acceptance criteria:**
+- Existing unit/integration tests for the five handlers continue to pass with no modification.
+- No new enum values are introduced as part of this change.
+- No call site is removed or relocated; only the method invoked is renamed/redirected.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact. A static method call on a `switch` expression has identical runtime cost to the inline private method.
+
+### NFR-2: Security
+None — this change touches presentation-string formatting only. No new inputs, outputs, persistence, or trust boundaries.
+
+### NFR-3: Maintainability
+Single source of truth for `ConsumptionType` Czech labels eliminates drift between handlers. Future enum additions require updating exactly one switch arm.
+
+### NFR-4: Build & validation
+- `dotnet build` succeeds with zero warnings introduced by this change.
+- `dotnet format` produces no diff after the change.
+- All existing tests in `Anela.Heblo.Application.Tests` (or the relevant test project) pass.
+
+## Data Model
+No changes to the data model. The `ConsumptionType` enum itself is **not** modified.
+
+## API / Interface Design
+No external API changes. No new public types, no new endpoints, no DTO modifications. The new helper is `internal` to `Anela.Heblo.Application`.
+
+Internal-only addition:
+```csharp
+// Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+internal static class PackingMaterialsTextHelper
+{
+    public static string ConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder   => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay     => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+## Dependencies
+None. The change is confined to the `PackingMaterials` feature folder in `Anela.Heblo.Application`. The `ConsumptionType` enum is already referenced by every affected handler.
+
+## Out of Scope
+- Localization framework / resource-file based translation of `ConsumptionType` labels (still hard-coded Czech strings).
+- Removing the `_ => type.ToString()` fallback or replacing it with an exception.
+- Adding unit tests for the new helper (existing handler tests already exercise the mappings indirectly).
+- Touching any other duplicated helpers elsewhere in the codebase.
+- Frontend changes — none required; the API contract is unchanged.
+- Renaming, reordering, or modifying `ConsumptionType` enum values.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-packingmaterials-getconsumpt/task-plan.r1.md
+++ b/artifacts/feat-arch-review-packingmaterials-getconsumpt/task-plan.r1.md
@@ -1,0 +1,464 @@
+# Extract Duplicated `GetConsumptionTypeText` Helper in PackingMaterials Module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace five copy-pasted `private static string GetConsumptionTypeText(ConsumptionType)` methods in `Application/Features/PackingMaterials/UseCases/*` with a single shared `internal static` helper, so future enum additions only need to change one place.
+
+**Architecture:** Add `PackingMaterialsTextHelper` in `Application/Features/PackingMaterials/Contracts/`, co-located with `PackingMaterialDto` (whose `ConsumptionTypeText` property it populates). All five handlers already import the helper's namespace via the existing `Contracts` `using`, so the only changes per handler are: (a) replace the call-site identifier and (b) delete the private method. No DI, no public API, no behavior change.
+
+**Tech Stack:** .NET 8, C#, MediatR (already in place — handler shape unchanged).
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs` | New `internal static` helper; single switch expression mapping `ConsumptionType` → Czech UI string. |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs` | Replace call site (line 36); delete private method (lines 50–56). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs` | Replace call site (line 37); delete private method (lines 50–56). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs` | Replace call site (line 50); delete private method (lines 63–69). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs` | Replace call site (line 39); delete private method (lines 53–59). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs` | Replace call site (line 36); delete `GetConsumptionTypeText` (lines 63–69). **Keep** `GetLogTypeText` and the `Anela.Heblo.Domain.Features.PackingMaterials.Enums` using — both still needed for `LogEntryType`. |
+
+No other files are touched. No `using` directives are added or removed (the namespace `Anela.Heblo.Application.Features.PackingMaterials.Contracts` is already imported by every handler; `Anela.Heblo.Domain.Features.PackingMaterials.Enums` stays because it currently brings `ConsumptionType` and, in one handler, `LogEntryType` into source-level scope and any cleanup belongs to a separate change).
+
+**Why surgical:** Spec FR-2 requires "No other code in these handlers is touched." After removing the private method, the `Enums` `using` in four handlers becomes source-level unused, but the project has no `.editorconfig` / analyzer rule enforcing IDE0005, so `dotnet format` will not strip it. NFR-4 (`dotnet format` produces no diff) is satisfied by leaving them in place.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Confirm the worktree is clean and on the feature branch**
+
+Run:
+```bash
+git status
+git branch --show-current
+```
+
+Expected: clean working tree on branch `feat-arch-review-packingmaterials-getconsumpt`.
+
+- [ ] **Step 2: Confirm baseline build and test status before any change**
+
+Run:
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors.
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterials" --no-build
+```
+
+Expected: All tests pass (current PackingMaterials test files are `GetDailyConsumptionBreakdownHandlerTests`, `ConsumptionCalculationServiceTests`, `AllocationHandlerTests`; none exercise the text mapping, but they must pass to establish baseline).
+
+- [ ] **Step 3: Capture pre-refactor occurrence count of `GetConsumptionTypeText` for verification at the end**
+
+Run:
+```bash
+grep -rn "GetConsumptionTypeText" backend/src | wc -l
+```
+
+Expected: `10` (one method definition + one call site, in each of 5 handler files).
+
+---
+
+### Task 1: Add `PackingMaterialsTextHelper`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs`
+
+- [ ] **Step 1: Create the helper file**
+
+Write exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+internal static class PackingMaterialsTextHelper
+{
+    public static string ConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+**Encoding note:** Save as UTF-8 (without BOM) to match the existing sibling `PackingMaterialDto.cs` in the same folder. The Czech characters `á`, `ž` must round-trip byte-identical to the existing handler strings.
+
+- [ ] **Step 2: Verify the new file compiles (the helper is unreferenced at this point but the project must still build)**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+- [ ] **Step 3: Confirm the Czech strings round-tripped to disk correctly**
+
+Run:
+```bash
+grep -c "za zakázku" backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+grep -c "za produkt" backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+grep -c "za den" backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+```
+
+Expected: `1`, `1`, `1` (one match each). If any returns `0`, the file was saved with a wrong encoding — re-save as UTF-8 without BOM and re-check.
+
+---
+
+### Task 2: Rewire `CreatePackingMaterialHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 36**
+
+Find this line in `CreatePackingMaterialHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(createdMaterial.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(createdMaterial.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 50–56)**
+
+Remove this entire block (including the blank line that precedes it on line 49) from `CreatePackingMaterialHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+After removal, the closing `}` of the class must be the last non-empty line of the file. The `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive **stays** — do not delete it (surgical-change rule; `dotnet format` will not strip it).
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 3: Rewire `UpdatePackingMaterialHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 37**
+
+Find this line in `UpdatePackingMaterialHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 50–56)**
+
+Remove this entire block (including the preceding blank line) from `UpdatePackingMaterialHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+Keep the `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive in place.
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 4: Rewire `UpdatePackingMaterialQuantityHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 50**
+
+Find this line in `UpdatePackingMaterialQuantityHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 63–69)**
+
+Remove this entire block (including the preceding blank line) from `UpdatePackingMaterialQuantityHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+Keep the `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive (`LogEntryType` is referenced on line 33).
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 5: Rewire `GetPackingMaterialsListHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 39**
+
+Find this line in `GetPackingMaterialsListHandler.cs`:
+
+```csharp
+                ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+                ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 53–59)**
+
+Remove this entire block (including the preceding blank line) from `GetPackingMaterialsListHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+Keep the `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive.
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 6: Rewire `GetPackingMaterialLogsHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`
+
+This handler has **two** helpers (`GetConsumptionTypeText` and `GetLogTypeText`). Delete only the first; keep `GetLogTypeText` intact.
+
+- [ ] **Step 1: Replace the call site on line 36**
+
+Find this line in `GetPackingMaterialLogsHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete only the `GetConsumptionTypeText` private method (lines 63–69)**
+
+Remove this entire block (including the preceding blank line) from `GetPackingMaterialLogsHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+**Do not touch** the `GetLogTypeText` method below it — it is unrelated. After this edit, the file should end with `GetLogTypeText` followed by the closing brace.
+
+The `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive stays — `LogEntryType` is referenced on lines 50–51 and in the `GetLogTypeText` signature.
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 7: Verify zero residuals and run full validation
+
+- [ ] **Step 1: Confirm no `GetConsumptionTypeText` references remain anywhere in the repo**
+
+Run:
+```bash
+grep -rn "GetConsumptionTypeText" backend/src backend/test
+```
+
+Expected: no output (zero matches). If any match is printed, return to the corresponding task and fix.
+
+- [ ] **Step 2: Confirm exactly 5 call sites now invoke `PackingMaterialsTextHelper.ConsumptionTypeText`**
+
+Run:
+```bash
+grep -rn "PackingMaterialsTextHelper.ConsumptionTypeText" backend/src
+```
+
+Expected: 5 lines printed, one per handler file in `UseCases/`. (The helper definition itself does not call this fully-qualified path; it only declares the method.)
+
+- [ ] **Step 3: Full solution build**
+
+Run:
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` 0 errors. Warning count must equal the pre-refactor baseline (no new warnings).
+
+- [ ] **Step 4: Verify `dotnet format` produces no additional changes (NFR-4)**
+
+Run:
+```bash
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code 0 with no diff. If the tool exits non-zero, inspect the proposed changes with `git diff` after running `dotnet format Anela.Heblo.sln` without `--verify-no-changes`. Accept the formatting fixes and re-run verification; do not commit unverified formatting changes.
+
+- [ ] **Step 5: Run all backend tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests pass, with the same totals as the pre-refactor baseline.
+
+- [ ] **Step 6: Spot-check the diff before committing**
+
+Run:
+```bash
+git status
+git diff --stat
+```
+
+Expected `git status`:
+- `new file: backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs`
+- `modified: 5 handler files` listed under `UseCases/…`
+
+Expected `git diff --stat`: 6 files changed; the new helper file adds ~12 lines, each handler file loses ~7 lines net (call-site rename + 7-line private method removal).
+
+If the diff shows any other modified files, revert those edits — only the listed paths must change.
+
+- [ ] **Step 7: Commit**
+
+Run:
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs
+
+git commit -m "refactor(packing-materials): extract shared ConsumptionType text helper
+
+Consolidate five copy-pasted GetConsumptionTypeText methods in
+PackingMaterials handlers into a single internal static
+PackingMaterialsTextHelper.ConsumptionTypeText in Contracts/.
+No behavior change; API output is byte-identical."
+```
+
+Expected: commit succeeds; the next `git log -1 --stat` shows exactly the six files listed above.
+
+---
+
+## Acceptance Cross-Check
+
+| Spec requirement | Verified by |
+|---|---|
+| FR-1: helper exists, `internal static class`, single `public static` method, exact mappings, no other public members | Task 1 Step 1 + Step 3 (Czech-string round-trip) |
+| FR-2: private method deleted from all five handlers; all call sites rewired; repo-wide grep returns zero | Tasks 2–6 Step 2; Task 7 Step 1 |
+| FR-2: only the five listed handler files are modified | Task 7 Step 6 (`git diff --stat`) |
+| FR-3: existing tests still pass; no enum changes; only the invoked method name changes | Task 7 Step 5 + Step 6 |
+| NFR-1 / NFR-2: no perf or security impact | No change to call shape; static method on switch expression — verified inherently by FR-3 |
+| NFR-3: single source of truth for labels | Task 7 Step 2 (single helper, 5 callers) |
+| NFR-4: `dotnet build` succeeds with no new warnings; `dotnet format` produces no diff; tests pass | Task 7 Steps 3, 4, 5 |
+
+## Out-of-Scope Reminders
+
+Per spec, do **not** in this PR:
+- Add unit tests for `PackingMaterialsTextHelper` (existing handler tests provide indirect coverage and the spec excludes this).
+- Replace `_ => type.ToString()` with an exception.
+- Introduce a localization framework.
+- Touch other duplicated helpers elsewhere in the codebase.
+- Remove unused `using` directives that become dead due to the refactor (the project has no analyzer rule enforcing this; leaving them satisfies the surgical-change requirement and NFR-4).
+- Modify any frontend code — the API contract is unchanged.

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
@@ -1,0 +1,14 @@
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+internal static class PackingMaterialsTextHelper
+{
+    public static string ConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs
@@ -33,7 +33,7 @@ public class CreatePackingMaterialHandler : IRequestHandler<CreatePackingMateria
             Name = createdMaterial.Name,
             ConsumptionRate = createdMaterial.ConsumptionRate,
             ConsumptionType = createdMaterial.ConsumptionType,
-            ConsumptionTypeText = GetConsumptionTypeText(createdMaterial.ConsumptionType),
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(createdMaterial.ConsumptionType),
             CurrentQuantity = createdMaterial.CurrentQuantity,
             ForecastedDays = null, // New material, no history
             CreatedAt = createdMaterial.CreatedAt,
@@ -46,12 +46,4 @@ public class CreatePackingMaterialHandler : IRequestHandler<CreatePackingMateria
             Material = materialDto
         };
     }
-
-    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
-    {
-        ConsumptionType.PerOrder => "za zakázku",
-        ConsumptionType.PerProduct => "za produkt",
-        ConsumptionType.PerDay => "za den",
-        _ => type.ToString()
-    };
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs
@@ -33,7 +33,7 @@ public class GetPackingMaterialLogsHandler : IRequestHandler<GetPackingMaterialL
             Name = material.Name,
             ConsumptionRate = material.ConsumptionRate,
             ConsumptionType = material.ConsumptionType,
-            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
             CurrentQuantity = material.CurrentQuantity,
             CreatedAt = material.CreatedAt,
             UpdatedAt = material.UpdatedAt
@@ -59,14 +59,6 @@ public class GetPackingMaterialLogsHandler : IRequestHandler<GetPackingMaterialL
             Logs = logDtos
         };
     }
-
-    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
-    {
-        ConsumptionType.PerOrder => "za zakázku",
-        ConsumptionType.PerProduct => "za produkt",
-        ConsumptionType.PerDay => "za den",
-        _ => type.ToString()
-    };
 
     private static string GetLogTypeText(LogEntryType type) => type switch
     {

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs
@@ -36,7 +36,7 @@ public class GetPackingMaterialsListHandler : IRequestHandler<GetPackingMaterial
                 Name = material.Name,
                 ConsumptionRate = material.ConsumptionRate,
                 ConsumptionType = material.ConsumptionType,
-                ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+                ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
                 CurrentQuantity = material.CurrentQuantity,
                 ForecastedDays = displayForecast,
                 CreatedAt = material.CreatedAt,
@@ -49,12 +49,4 @@ public class GetPackingMaterialsListHandler : IRequestHandler<GetPackingMaterial
             Materials = materialDtos
         };
     }
-
-    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
-    {
-        ConsumptionType.PerOrder => "za zakázku",
-        ConsumptionType.PerProduct => "za produkt",
-        ConsumptionType.PerDay => "za den",
-        _ => type.ToString()
-    };
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs
@@ -34,7 +34,7 @@ public class UpdatePackingMaterialHandler : IRequestHandler<UpdatePackingMateria
             Name = material.Name,
             ConsumptionRate = material.ConsumptionRate,
             ConsumptionType = material.ConsumptionType,
-            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
             CurrentQuantity = material.CurrentQuantity,
             ForecastedDays = null, // Would need to recalculate
             CreatedAt = material.CreatedAt,
@@ -46,12 +46,4 @@ public class UpdatePackingMaterialHandler : IRequestHandler<UpdatePackingMateria
             Material = materialDto
         };
     }
-
-    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
-    {
-        ConsumptionType.PerOrder => "za zakázku",
-        ConsumptionType.PerProduct => "za produkt",
-        ConsumptionType.PerDay => "za den",
-        _ => type.ToString()
-    };
 }

--- a/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs
@@ -47,7 +47,7 @@ public class UpdatePackingMaterialQuantityHandler : IRequestHandler<UpdatePackin
             Name = material.Name,
             ConsumptionRate = material.ConsumptionRate,
             ConsumptionType = material.ConsumptionType,
-            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
             CurrentQuantity = material.CurrentQuantity,
             ForecastedDays = displayForecast,
             CreatedAt = material.CreatedAt,
@@ -59,12 +59,4 @@ public class UpdatePackingMaterialQuantityHandler : IRequestHandler<UpdatePackin
             Material = materialDto
         };
     }
-
-    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
-    {
-        ConsumptionType.PerOrder => "za zakázku",
-        ConsumptionType.PerProduct => "za produkt",
-        ConsumptionType.PerDay => "za den",
-        _ => type.ToString()
-    };
 }

--- a/docs/superpowers/plans/2026-05-21-packingmaterials-consumption-type-helper.md
+++ b/docs/superpowers/plans/2026-05-21-packingmaterials-consumption-type-helper.md
@@ -1,0 +1,464 @@
+# Extract Duplicated `GetConsumptionTypeText` Helper in PackingMaterials Module — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace five copy-pasted `private static string GetConsumptionTypeText(ConsumptionType)` methods in `Application/Features/PackingMaterials/UseCases/*` with a single shared `internal static` helper, so future enum additions only need to change one place.
+
+**Architecture:** Add `PackingMaterialsTextHelper` in `Application/Features/PackingMaterials/Contracts/`, co-located with `PackingMaterialDto` (whose `ConsumptionTypeText` property it populates). All five handlers already import the helper's namespace via the existing `Contracts` `using`, so the only changes per handler are: (a) replace the call-site identifier and (b) delete the private method. No DI, no public API, no behavior change.
+
+**Tech Stack:** .NET 8, C#, MediatR (already in place — handler shape unchanged).
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs` | New `internal static` helper; single switch expression mapping `ConsumptionType` → Czech UI string. |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs` | Replace call site (line 36); delete private method (lines 50–56). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs` | Replace call site (line 37); delete private method (lines 50–56). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs` | Replace call site (line 50); delete private method (lines 63–69). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs` | Replace call site (line 39); delete private method (lines 53–59). |
+| Modify | `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs` | Replace call site (line 36); delete `GetConsumptionTypeText` (lines 63–69). **Keep** `GetLogTypeText` and the `Anela.Heblo.Domain.Features.PackingMaterials.Enums` using — both still needed for `LogEntryType`. |
+
+No other files are touched. No `using` directives are added or removed (the namespace `Anela.Heblo.Application.Features.PackingMaterials.Contracts` is already imported by every handler; `Anela.Heblo.Domain.Features.PackingMaterials.Enums` stays because it currently brings `ConsumptionType` and, in one handler, `LogEntryType` into source-level scope and any cleanup belongs to a separate change).
+
+**Why surgical:** Spec FR-2 requires "No other code in these handlers is touched." After removing the private method, the `Enums` `using` in four handlers becomes source-level unused, but the project has no `.editorconfig` / analyzer rule enforcing IDE0005, so `dotnet format` will not strip it. NFR-4 (`dotnet format` produces no diff) is satisfied by leaving them in place.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Confirm the worktree is clean and on the feature branch**
+
+Run:
+```bash
+git status
+git branch --show-current
+```
+
+Expected: clean working tree on branch `feat-arch-review-packingmaterials-getconsumpt`.
+
+- [ ] **Step 2: Confirm baseline build and test status before any change**
+
+Run:
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors.
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PackingMaterials" --no-build
+```
+
+Expected: All tests pass (current PackingMaterials test files are `GetDailyConsumptionBreakdownHandlerTests`, `ConsumptionCalculationServiceTests`, `AllocationHandlerTests`; none exercise the text mapping, but they must pass to establish baseline).
+
+- [ ] **Step 3: Capture pre-refactor occurrence count of `GetConsumptionTypeText` for verification at the end**
+
+Run:
+```bash
+grep -rn "GetConsumptionTypeText" backend/src | wc -l
+```
+
+Expected: `10` (one method definition + one call site, in each of 5 handler files).
+
+---
+
+### Task 1: Add `PackingMaterialsTextHelper`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs`
+
+- [ ] **Step 1: Create the helper file**
+
+Write exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.PackingMaterials.Enums;
+
+namespace Anela.Heblo.Application.Features.PackingMaterials.Contracts;
+
+internal static class PackingMaterialsTextHelper
+{
+    public static string ConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+}
+```
+
+**Encoding note:** Save as UTF-8 (without BOM) to match the existing sibling `PackingMaterialDto.cs` in the same folder. The Czech characters `á`, `ž` must round-trip byte-identical to the existing handler strings.
+
+- [ ] **Step 2: Verify the new file compiles (the helper is unreferenced at this point but the project must still build)**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+- [ ] **Step 3: Confirm the Czech strings round-tripped to disk correctly**
+
+Run:
+```bash
+grep -c "za zakázku" backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+grep -c "za produkt" backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+grep -c "za den" backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
+```
+
+Expected: `1`, `1`, `1` (one match each). If any returns `0`, the file was saved with a wrong encoding — re-save as UTF-8 without BOM and re-check.
+
+---
+
+### Task 2: Rewire `CreatePackingMaterialHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 36**
+
+Find this line in `CreatePackingMaterialHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(createdMaterial.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(createdMaterial.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 50–56)**
+
+Remove this entire block (including the blank line that precedes it on line 49) from `CreatePackingMaterialHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+After removal, the closing `}` of the class must be the last non-empty line of the file. The `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive **stays** — do not delete it (surgical-change rule; `dotnet format` will not strip it).
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 3: Rewire `UpdatePackingMaterialHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 37**
+
+Find this line in `UpdatePackingMaterialHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 50–56)**
+
+Remove this entire block (including the preceding blank line) from `UpdatePackingMaterialHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+Keep the `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive in place.
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 4: Rewire `UpdatePackingMaterialQuantityHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 50**
+
+Find this line in `UpdatePackingMaterialQuantityHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 63–69)**
+
+Remove this entire block (including the preceding blank line) from `UpdatePackingMaterialQuantityHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+Keep the `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive (`LogEntryType` is referenced on line 33).
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 5: Rewire `GetPackingMaterialsListHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs`
+
+- [ ] **Step 1: Replace the call site on line 39**
+
+Find this line in `GetPackingMaterialsListHandler.cs`:
+
+```csharp
+                ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+                ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete the private method (lines 53–59)**
+
+Remove this entire block (including the preceding blank line) from `GetPackingMaterialsListHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+Keep the `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive.
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 6: Rewire `GetPackingMaterialLogsHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs`
+
+This handler has **two** helpers (`GetConsumptionTypeText` and `GetLogTypeText`). Delete only the first; keep `GetLogTypeText` intact.
+
+- [ ] **Step 1: Replace the call site on line 36**
+
+Find this line in `GetPackingMaterialLogsHandler.cs`:
+
+```csharp
+            ConsumptionTypeText = GetConsumptionTypeText(material.ConsumptionType),
+```
+
+Replace with:
+
+```csharp
+            ConsumptionTypeText = PackingMaterialsTextHelper.ConsumptionTypeText(material.ConsumptionType),
+```
+
+- [ ] **Step 2: Delete only the `GetConsumptionTypeText` private method (lines 63–69)**
+
+Remove this entire block (including the preceding blank line) from `GetPackingMaterialLogsHandler.cs`:
+
+```csharp
+
+    private static string GetConsumptionTypeText(ConsumptionType type) => type switch
+    {
+        ConsumptionType.PerOrder => "za zakázku",
+        ConsumptionType.PerProduct => "za produkt",
+        ConsumptionType.PerDay => "za den",
+        _ => type.ToString()
+    };
+```
+
+**Do not touch** the `GetLogTypeText` method below it — it is unrelated. After this edit, the file should end with `GetLogTypeText` followed by the closing brace.
+
+The `using Anela.Heblo.Domain.Features.PackingMaterials.Enums;` directive stays — `LogEntryType` is referenced on lines 50–51 and in the `GetLogTypeText` signature.
+
+- [ ] **Step 3: Verify the file compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` 0 errors, 0 new warnings.
+
+---
+
+### Task 7: Verify zero residuals and run full validation
+
+- [ ] **Step 1: Confirm no `GetConsumptionTypeText` references remain anywhere in the repo**
+
+Run:
+```bash
+grep -rn "GetConsumptionTypeText" backend/src backend/test
+```
+
+Expected: no output (zero matches). If any match is printed, return to the corresponding task and fix.
+
+- [ ] **Step 2: Confirm exactly 5 call sites now invoke `PackingMaterialsTextHelper.ConsumptionTypeText`**
+
+Run:
+```bash
+grep -rn "PackingMaterialsTextHelper.ConsumptionTypeText" backend/src
+```
+
+Expected: 5 lines printed, one per handler file in `UseCases/`. (The helper definition itself does not call this fully-qualified path; it only declares the method.)
+
+- [ ] **Step 3: Full solution build**
+
+Run:
+```bash
+dotnet build Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` 0 errors. Warning count must equal the pre-refactor baseline (no new warnings).
+
+- [ ] **Step 4: Verify `dotnet format` produces no additional changes (NFR-4)**
+
+Run:
+```bash
+dotnet format Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code 0 with no diff. If the tool exits non-zero, inspect the proposed changes with `git diff` after running `dotnet format Anela.Heblo.sln` without `--verify-no-changes`. Accept the formatting fixes and re-run verification; do not commit unverified formatting changes.
+
+- [ ] **Step 5: Run all backend tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests pass, with the same totals as the pre-refactor baseline.
+
+- [ ] **Step 6: Spot-check the diff before committing**
+
+Run:
+```bash
+git status
+git diff --stat
+```
+
+Expected `git status`:
+- `new file: backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs`
+- `modified: 5 handler files` listed under `UseCases/…`
+
+Expected `git diff --stat`: 6 files changed; the new helper file adds ~12 lines, each handler file loses ~7 lines net (call-site rename + 7-line private method removal).
+
+If the diff shows any other modified files, revert those edits — only the listed paths must change.
+
+- [ ] **Step 7: Commit**
+
+Run:
+```bash
+git add backend/src/Anela.Heblo.Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs
+
+git commit -m "refactor(packing-materials): extract shared ConsumptionType text helper
+
+Consolidate five copy-pasted GetConsumptionTypeText methods in
+PackingMaterials handlers into a single internal static
+PackingMaterialsTextHelper.ConsumptionTypeText in Contracts/.
+No behavior change; API output is byte-identical."
+```
+
+Expected: commit succeeds; the next `git log -1 --stat` shows exactly the six files listed above.
+
+---
+
+## Acceptance Cross-Check
+
+| Spec requirement | Verified by |
+|---|---|
+| FR-1: helper exists, `internal static class`, single `public static` method, exact mappings, no other public members | Task 1 Step 1 + Step 3 (Czech-string round-trip) |
+| FR-2: private method deleted from all five handlers; all call sites rewired; repo-wide grep returns zero | Tasks 2–6 Step 2; Task 7 Step 1 |
+| FR-2: only the five listed handler files are modified | Task 7 Step 6 (`git diff --stat`) |
+| FR-3: existing tests still pass; no enum changes; only the invoked method name changes | Task 7 Step 5 + Step 6 |
+| NFR-1 / NFR-2: no perf or security impact | No change to call shape; static method on switch expression — verified inherently by FR-3 |
+| NFR-3: single source of truth for labels | Task 7 Step 2 (single helper, 5 callers) |
+| NFR-4: `dotnet build` succeeds with no new warnings; `dotnet format` produces no diff; tests pass | Task 7 Steps 3, 4, 5 |
+
+## Out-of-Scope Reminders
+
+Per spec, do **not** in this PR:
+- Add unit tests for `PackingMaterialsTextHelper` (existing handler tests provide indirect coverage and the spec excludes this).
+- Replace `_ => type.ToString()` with an exception.
+- Introduce a localization framework.
+- Touch other duplicated helpers elsewhere in the codebase.
+- Remove unused `using` directives that become dead due to the refactor (the project has no analyzer rule enforcing this; leaving them satisfies the surgical-change requirement and NFR-4).
+- Modify any frontend code — the API contract is unchanged.


### PR DESCRIPTION
PackingMaterials

## Finding
The following private static method is copy-pasted identically into five separate handler files:

```csharp
private static string GetConsumptionTypeText(ConsumptionType type) => type switch
{
    ConsumptionType.PerOrder => "za zakázku",
    ConsumptionType.PerProduct => "za produkt",
    ConsumptionType.PerDay => "za den",
    _ => type.ToString()
};
```

Locations:
- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/CreatePackingMaterial/CreatePackingMaterialHandler.cs:50-57`
- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterial/UpdatePackingMaterialHandler.cs:50-56`
- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/UpdatePackingMaterialQuantity/UpdatePackingMaterialQuantityHandler.cs:63-70`
- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialsList/GetPackingMaterialsListHandler.cs:53-59`
- `backend/src/Anela.Heblo.Application/Features/PackingMaterials/UseCases/GetPackingMaterialLogs/GetPackingMaterialLogsHandler.cs:63-69`

## Why it matters
Every time a new `ConsumptionType` enum value is added, all five files must be updated. Missing one produces a silently wrong label in the API response (falls through to `type.ToString()` which returns the raw enum name instead of the Czech UI string). This already happened once — the `_ => type.ToString()` fallback exists precisely because someone forgot to extend all copies.

## Suggested fix
Extract to a single static helper within the module. The natural home is a static class alongside the module's contracts or a `PackingMaterialsTextHelper` in the `Contracts/` folder:

```csharp
// Application/Features/PackingMaterials/Contracts/PackingMaterialsTextHelper.cs
internal static class PackingMaterialsTextHelper
{
    public static string ConsumptionTypeText(ConsumptionType type) => type switch
    {
        ConsumptionType.PerOrder   => "za zakázku",
        ConsumptionType.PerProduct => "za produkt",
        ConsumptionType.PerDay     => "za den",
        _ => type.ToString()
    };
}
```

Replace all five private copies with a call to `PackingMaterialsTextHelper.ConsumptionTypeText(...)`. This is a purely mechanical, zero-risk change.

---
_Filed by daily arch-review routine on 2026-05-20._

---

Closes #1476

### Tokens used
9455139
