### PR TITLE
feat: Relocate Photobank request-body DTOs to the Application project

### DIFF
--- a/artifacts/feat-arch-review-photobank-request-body-dtos-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-photobank-request-body-dtos-/arch-review.r1.md
@@ -1,0 +1,127 @@
+I now have everything I need. The refactor is well-understood and grounded in the actual code.
+
+```markdown
+# Architecture Review: Relocate Photobank request-body DTOs to the Application project
+
+## Skip Design: true
+
+This is a backend-only structural refactor — relocating four C# class declarations between projects. No UI components, screens, or visual decisions are involved. The generated TypeScript client output is required to remain byte-for-byte identical, so even the frontend surface is untouched.
+
+## Architectural Fit Assessment
+
+The proposal does not introduce architecture — it **removes a deviation from existing architecture**. I verified the following against the codebase:
+
+- `PhotobankController.cs:425–446` declares the four `…Body` classes as siblings of the controller inside the `Anela.Heblo.API.Controllers` namespace. They are referenced unqualified by the action signatures at lines 99, 129, 166, 190.
+- The Photobank `Contracts/` folder already exists and already holds the module's other transport types: `IndexRootDto.cs`, `PhotoDto.cs`, `TagDto.cs` (which contains `TagDto` + `TagWithCountDto`), and `TagRuleDto.cs`. All use namespace `Anela.Heblo.Application.Features.Photobank.Contracts` with **block-scoped** namespace syntax and are declared as `class` with mutable `{ get; set; }` (or `init`) properties.
+- The controller already imports many `Anela.Heblo.Application.Features.Photobank.*` namespaces (UseCases, Services), confirming the API→Application reference exists. The relocated types are reachable with one added `using`.
+
+The four body classes are the lone exception to the documented rule (*"API project never defines or owns DTOs — it only uses them."*). The change makes the module 100% consistent with its own established convention. Integration points: the controller's four action signatures and the NSwag OpenAPI client generator.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.API (Controllers)                Anela.Heblo.Application (Features/Photobank/Contracts)
+┌──────────────────────────────┐             ┌────────────────────────────────────────┐
+│ PhotobankController           │             │ AddPhotoTagBody.cs        (new)         │
+│  + using ...Photobank.Contracts│──uses──────▶│ CreateTagBody.cs          (new)         │
+│  [FromBody] CreateTagBody      │             │ BulkAddPhotoTagBody.cs    (new)         │
+│  [FromBody] AddPhotoTagBody    │             │ BulkAddPhotoTagByIdsBody.cs (new)       │
+│  [FromBody] BulkAddPhotoTagBody│             │ (existing) PhotoDto, TagDto, TagRuleDto,│
+│  [FromBody] BulkAddPhotoTagByIds│            │            IndexRootDto                 │
+│  (class declarations DELETED)  │             └────────────────────────────────────────┘
+└──────────────────────────────┘
+            │
+            │ maps onto (unchanged)
+            ▼
+   MediatR requests: CreateTagRequest, AddPhotoTagRequest,
+   BulkAddPhotoTagRequest, BulkAddPhotoTagByIdsRequest
+```
+
+Dependency direction is preserved: API → Application. No new project references; no inversion.
+
+### Key Design Decisions
+
+#### Decision 1: One type per file vs. grouping in a single file
+**Options considered:** (a) one file per class (`AddPhotoTagBody.cs`, etc.); (b) a single `PhotobankRequestBodies.cs` holding all four; (c) follow the local `TagDto.cs` precedent of grouping closely related types.
+**Chosen approach:** One file per class, four files total — matching FR-1's acceptance criteria.
+**Rationale:** The spec mandates four named files. While `TagDto.cs` groups `TagDto`+`TagWithCountDto`, those are a value/projection pair of one concept; the four bodies are independent request contracts for distinct endpoints. One-file-per-type is the dominant convention in the folder (`PhotoDto`, `IndexRootDto`, `TagRuleDto` are each standalone) and the global C# style rule ("keep files aligned with the primary type they define"). Follow it.
+
+#### Decision 2: Namespace syntax — block-scoped vs. file-scoped
+**Options considered:** file-scoped (`namespace X;`) or block-scoped (`namespace X { }`).
+**Chosen approach:** Block-scoped, matching every existing file in the `Contracts/` folder.
+**Rationale:** Consistency within the module trumps personal preference. All four sibling files (`TagDto.cs` etc.) use block-scoped. Match them exactly so the diff reads as a clean relocation. This is a surgical change — do not modernize syntax.
+
+#### Decision 3: Keep `class` (not `record`), keep mutable setters
+**Chosen approach:** Verbatim move — `public class`, `{ get; set; }`, identical default initializers (`= null!`, `= string.Empty`, `= []`).
+**Rationale:** Hard project rule (DTOs are classes for OpenAPI generator compatibility) and FR-3's byte-identical-client requirement. The model binder needs settable properties. Do not "improve" to records or `init`-only setters — that would risk the NSwag output and violate the rule.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Create four files under `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/`:
+
+```
+Contracts/
+  AddPhotoTagBody.cs           (new)
+  CreateTagBody.cs             (new)
+  BulkAddPhotoTagBody.cs       (new)
+  BulkAddPhotoTagByIdsBody.cs  (new)
+```
+
+Delete lines 425–446 from `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` (the four `public class …Body` blocks), leaving the namespace's closing brace intact.
+
+### Interfaces and Contracts
+
+Each new file follows the established `Contracts/` template (block-scoped namespace, `class`, public auto-properties). Example:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagBody
+    {
+        public List<string>? Tags { get; set; }
+        public string? Search { get; set; }
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+`List<>` resolves via the `Application` project's `ImplicitUsings` (verify it is enabled in `Anela.Heblo.Application.csproj`; if not, add `using System.Collections.Generic;`). The existing `Contracts` files don't include collection usings, which indicates `ImplicitUsings` is on for the project — but confirm before relying on it.
+
+Controller change: add **one** import alongside the existing Photobank usings (alphabetical placement, after the `…Photobank.Contracts` would sort before `…Photobank.Services` at line 5):
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+```
+
+The `[FromBody]` parameters at lines 99, 129, 166, 190 then resolve to the relocated types with **no signature change**.
+
+### Data Flow
+
+Unchanged. HTTP request body → ASP.NET model binder → `…Body` DTO (now in Application) → controller maps onto the corresponding MediatR `…Request` → handler. Only the *declaration location* of the DTO type moves; the runtime path is identical.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| NSwag/OpenAPI TS client output changes after relocation | LOW | NSwag derives TS interface names from the C# **type name**, not its CLR namespace. Names are unchanged. Validate per FR-3: regenerate and `git diff frontend/src/api/generated/api-client.ts` must be empty. |
+| Type-name collision in `Contracts` namespace after import | LOW | Confirmed via grep: no other `CreateTagBody`/`AddPhotoTagBody`/`BulkAddPhotoTagBody`/`BulkAddPhotoTagByIdsBody` exists. The added `using` introduces no ambiguity. |
+| `List<>` fails to compile if `ImplicitUsings` is off in Application project | LOW | Existing `Contracts` files use no collection usings, implying it's on. If `dotnet build` fails, add `using System.Collections.Generic;` to the two affected files. |
+| Stale `using System.Collections.Generic;` left in controller becomes unused | LOW | After removing the body classes, the controller may no longer need its line-1 `using System.Collections.Generic;`. Let `dotnet format`/analyzer flag it; remove only if genuinely unused, otherwise leave untouched (surgical scope). |
+
+## Specification Amendments
+
+None required. The spec is complete, correct, and matches the verified code state (line numbers, property shapes, namespace, and the API→Application reference all confirmed). One clarification to fold into implementation, not a spec change: prefer relying on the project's `ImplicitUsings` for `List<>` (consistent with sibling files) rather than adding an explicit `using`, unless the build proves otherwise.
+
+## Prerequisites
+
+None. No migrations, config, or infrastructure changes. The API project already references the Application project. Validation gate after implementation:
+
+1. `dotnet build` (backend compiles, client regenerates on build).
+2. `dotnet format` (formatting/analyzer pass).
+3. `git diff frontend/src/api/generated/api-client.ts` → **must be empty** (FR-3 proof).
+4. Run any existing Photobank controller/integration tests touched by the four endpoints.
+```

--- a/artifacts/feat-arch-review-photobank-request-body-dtos-/brief.md
+++ b/artifacts/feat-arch-review-photobank-request-body-dtos-/brief.md
@@ -1,0 +1,43 @@
+## Module
+Photobank
+
+## Finding
+Four request-body DTO classes are defined at the bottom of `PhotobankController.cs` inside the `Anela.Heblo.API` project:
+
+- `AddPhotoTagBody` (line 425)
+- `CreateTagBody` (line 429)
+- `BulkAddPhotoTagBody` (line 434)
+- `BulkAddPhotoTagByIdsBody` (line 441)
+
+File: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`, lines 425–447.
+
+```csharp
+public class AddPhotoTagBody
+{
+    public string TagName { get; set; } = null!;
+}
+// ... three more body classes follow
+```
+
+The project rule is explicit: *"API project never defines or owns DTOs — it only uses them."* All request/response DTOs must live in `Application/Features/<Module>/Contracts/`.
+
+## Why it matters
+- Violates the documented DTO ownership rule from `docs/architecture/development_guidelines.md`.
+- The generated TypeScript client reflects this mis-placement: NSwag picks these types up from the API project and emits them in `api-client.ts` under names like `CreateTagBody` — if they were moved to the Application project they would still be generated correctly, but ownership would be correct and they could be shared/reused by validators without a project-level dependency inversion.
+- Establishes a precedent that makes it harder to enforce the boundary for future contributors.
+
+## Suggested fix
+Move all four classes to `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/`:
+
+```
+Contracts/
+  AddPhotoTagBody.cs
+  CreateTagBody.cs
+  BulkAddPhotoTagBody.cs
+  BulkAddPhotoTagByIdsBody.cs
+```
+
+Add a `using Anela.Heblo.Application.Features.Photobank.Contracts;` to the controller. No logic changes required.
+
+---
+_Filed by daily arch-review routine on 2026-05-21._

--- a/artifacts/feat-arch-review-photobank-request-body-dtos-/impl.r1.md
+++ b/artifacts/feat-arch-review-photobank-request-body-dtos-/impl.r1.md
@@ -1,0 +1,48 @@
+# Implementation: Relocate Photobank request-body DTOs to the Application project
+
+## What was implemented
+
+Pure structural refactor: four request-body DTO classes (`AddPhotoTagBody`, `CreateTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`) were moved verbatim from inline declarations at the bottom of `PhotobankController.cs` (API project) into four individual files under `Application/Features/Photobank/Contracts/`. The controller gained one `using` directive to resolve the relocated types. No behavioral changes.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs` — request body for `POST /api/photobank/photos/{id}/tags`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs` — request body for `POST /api/photobank/tags`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs` — request body for `POST /api/photobank/photos/bulk-tag`
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs` — request body for `POST /api/photobank/photos/tag-by-ids`
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — added `using Anela.Heblo.Application.Features.Photobank.Contracts;`, removed the four inline class declarations (23 lines)
+
+## Tests
+
+No new tests written — this is a pure structural relocation with no new behavior. Existing suite verified:
+- `dotnet test` — 3,764 tests pass (includes PhotobankControllerThumbnailTests, PhotobankTagsCacheTests, PhotobankRepositoryGetTagsTests, and 7 other Photobank-scoped test classes)
+
+## How to verify
+
+```bash
+dotnet build                                                       # 0 errors
+dotnet format --verify-no-changes                                  # clean
+git diff --exit-code frontend/src/api/generated/api-client.ts     # empty (FR-3)
+dotnet test --filter "FullyQualifiedName~Photobank"               # all pass
+```
+
+## Notes
+
+- The code quality reviewer initially flagged `string.Empty`, `List<string>?` without initializer, and `= []` as inconsistent with sibling files. These suggestions were rejected: the spec requires verbatim copy of the original properties including their default initializers, and changing them (e.g., `string.Empty` → `null!`) would alter runtime behavior and violate FR-3's byte-identical client requirement.
+- `= []` (collection expression) is valid C# 12 / .NET 8 syntax, consistent with the original source.
+
+## PR Summary
+
+Moves four Photobank request-body DTO classes (`AddPhotoTagBody`, `CreateTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`) from inline declarations in `PhotobankController.cs` (API project) into dedicated files in `Application/Features/Photobank/Contracts/`, restoring the documented "API project never owns DTOs" architectural boundary.
+
+The classes are relocated verbatim — identical names, properties, types, and default initializers. The controller gains one `using` directive. The regenerated TypeScript client is byte-for-byte identical (NSwag names types by C# class name, not CLR namespace). All 3,764 backend tests pass.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs` — new DTO file
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs` — new DTO file
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs` — new DTO file
+- `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs` — new DTO file
+- `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` — added Contracts using, removed inline class declarations
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-photobank-request-body-dtos-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-photobank-request-body-dtos-/impl/main.r1.md
@@ -1,0 +1,8 @@
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-photobank-request-body-dtos-/spec.r1.md
+++ b/artifacts/feat-arch-review-photobank-request-body-dtos-/spec.r1.md
@@ -1,0 +1,91 @@
+# Specification: Relocate Photobank request-body DTOs to the Application project
+
+## Summary
+Four request-body DTO classes (`AddPhotoTagBody`, `CreateTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`) are currently declared at the bottom of `PhotobankController.cs` inside the `Anela.Heblo.API` project. This violates the documented rule that the API project never owns DTOs. Move all four into `Anela.Heblo.Application/Features/Photobank/Contracts/` with no behavioral changes, restoring the architectural boundary while keeping the generated API clients identical.
+
+## Background
+The project follows Clean Architecture with a Vertical Slice organization. Per `docs/architecture/development_guidelines.md`, the rule is explicit: *"API project never defines or owns DTOs — it only uses them."* All request/response DTOs must live in `Application/Features/<Module>/Contracts/`.
+
+The Photobank module already honors this convention for its other contracts — `IndexRootDto`, `PhotoDto`, `TagDto`/`TagWithCountDto`, and `TagRuleDto` all live under `Anela.Heblo.Application/Features/Photobank/Contracts/`. The four request-body classes are the lone exception: they were declared inline in the controller file.
+
+Because NSwag generates the TypeScript client from the API surface, these types are currently emitted into `frontend/src/api/generated/api-client.ts` (e.g. `CreateTagBody`). Moving the classes to the Application project does not change their public shape or namespace-independent serialization, so the generated client output remains byte-for-byte identical — but ownership becomes correct and the contracts become reusable (e.g. by FluentValidation validators) without inverting the project dependency direction.
+
+This is a pure structural refactor surfaced by the daily arch-review routine on 2026-05-21. No new functionality is introduced.
+
+## Functional Requirements
+
+### FR-1: Move the four request-body DTOs into the Contracts folder
+Each of the four classes is moved verbatim (same name, same properties, same default initializers, same nullability) from `PhotobankController.cs` into its own file under `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/`:
+
+| Class | Properties (unchanged) |
+|-------|------------------------|
+| `AddPhotoTagBody` | `string TagName { get; set; } = null!;` |
+| `CreateTagBody` | `string Name { get; set; } = string.Empty;` |
+| `BulkAddPhotoTagBody` | `List<string>? Tags`, `string? Search`, `string TagName = null!` |
+| `BulkAddPhotoTagByIdsBody` | `List<int> PhotoIds = []`, `string TagName = null!` |
+
+Each class is placed in the `Anela.Heblo.Application.Features.Photobank.Contracts` namespace, matching the existing files in that folder.
+
+**Acceptance criteria:**
+- Four new files exist: `Contracts/AddPhotoTagBody.cs`, `Contracts/CreateTagBody.cs`, `Contracts/BulkAddPhotoTagBody.cs`, `Contracts/BulkAddPhotoTagByIdsBody.cs`.
+- Each file declares exactly one of the four classes in namespace `Anela.Heblo.Application.Features.Photobank.Contracts`.
+- Property names, types, accessors, and default initializers are identical to the originals at `PhotobankController.cs:425–446`.
+- The classes are declared as `class` (not `record`), per the project rule that DTOs are classes for OpenAPI generator compatibility.
+- `List<>` usages compile (file uses a `using System.Collections.Generic;` directive or the project enables `ImplicitUsings`).
+
+### FR-2: Remove the inline class declarations from the controller file
+The four class definitions at `PhotobankController.cs:425–446` are deleted. The controller adds `using Anela.Heblo.Application.Features.Photobank.Contracts;` so the action signatures (`CreateTag`, `AddPhotoTag`, `BulkAddPhotoTag`, `BulkAddPhotoTagByIds`) continue to resolve the body types.
+
+**Acceptance criteria:**
+- `PhotobankController.cs` no longer contains any of the four `public class …Body` declarations.
+- The controller imports the `Contracts` namespace.
+- All four endpoint signatures still bind their `[FromBody]` parameters to the relocated types with no signature change.
+- No controller logic, attributes, routes, or status-code declarations are modified.
+
+### FR-3: Preserve API and generated-client compatibility
+The HTTP contract (route, verb, request body shape, response shape) is unchanged. The regenerated TypeScript client must continue to expose the same type names with the same members.
+
+**Acceptance criteria:**
+- The four request bodies serialize/deserialize identically (same JSON property names, same optional/required semantics).
+- After client regeneration, `frontend/src/api/generated/api-client.ts` contains the same `CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, and `BulkAddPhotoTagByIdsBody` definitions as before the change (no consumer code edits required).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact. This is a compile-time relocation of type declarations with no change to request handling.
+
+### NFR-2: Security
+No security impact. Authorization attributes, roles (`SuperUser`, `MarketingWriter`), and validation behavior are untouched. No secrets, auth, or input-validation logic is involved.
+
+### NFR-3: Maintainability
+The change restores conformance to the documented DTO ownership boundary, removing a precedent that would otherwise make the boundary harder to enforce for future contributors. File organization follows the one-type-per-file convention used by the surrounding Contracts files.
+
+### NFR-4: Backward compatibility
+Zero breaking changes to the public HTTP API or to frontend consumers. The refactor is internal to the backend project layout.
+
+## Data Model
+No data-model changes. The relocated classes are transport DTOs only; they are mapped onto the existing MediatR request types (`CreateTagRequest`, `AddPhotoTagRequest`, `BulkAddPhotoTagRequest`, `BulkAddPhotoTagByIdsRequest`) by the controller exactly as today. No entities, persistence, or migrations are affected.
+
+## API / Interface Design
+No interface design changes. Affected endpoints (unchanged):
+
+- `POST /api/photobank/tags` — body `CreateTagBody`
+- `POST /api/photobank/photos/{id}/tags` — body `AddPhotoTagBody`
+- `POST /api/photobank/photos/bulk-tag` — body `BulkAddPhotoTagBody`
+- `POST /api/photobank/photos/tag-by-ids` — body `BulkAddPhotoTagByIdsBody`
+
+## Dependencies
+- `Anela.Heblo.API` already references `Anela.Heblo.Application` (it imports the Photobank UseCases and Contracts namespaces), so the relocated types are reachable from the controller with no new project reference.
+- NSwag / OpenAPI TypeScript client generation runs on build; the client must be regenerated as part of validation to confirm FR-3.
+
+## Out of Scope
+- Adding FluentValidation validators or any input-validation logic to the relocated DTOs.
+- Renaming the classes (e.g. dropping the `Body` suffix) or changing their property names/shapes.
+- Converting the DTOs to records (explicitly prohibited by the project rule).
+- Moving or refactoring any other DTOs, request types, or controller logic.
+- Any change to the `RetagPhotos`, `AddRoot`, `AddRule`, or `UpdateRule` endpoints, which bind MediatR request types directly rather than dedicated body classes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-photobank-request-body-dtos-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-photobank-request-body-dtos-/task-plan.r1.md
@@ -1,0 +1,248 @@
+# Relocate Photobank Request-Body DTOs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move four request-body DTO classes out of `PhotobankController.cs` (in the API project) into the Application project's Photobank `Contracts/` folder, restoring the documented "API project never owns DTOs" boundary with zero behavioral change.
+
+**Architecture:** This is a pure structural relocation. The four `…Body` classes are cut verbatim from the bottom of the controller file and pasted into four new one-type-per-file `.cs` files under `Application/Features/Photobank/Contracts/`, each using the existing `Anela.Heblo.Application.Features.Photobank.Contracts` namespace (block-scoped, `class`, mutable setters). The controller gains a single `using` so its `[FromBody]` parameters still resolve. The API project already references the Application project, so dependency direction (API → Application) is preserved. NSwag derives TypeScript type names from the C# **type name**, not its CLR namespace, so the generated client output stays byte-for-byte identical.
+
+**Tech Stack:** .NET 8, ASP.NET Core MVC controllers, NSwag OpenAPI client generation, xUnit (existing tests).
+
+---
+
+## Context an engineer needs before starting
+
+- **Verified source:** The four classes live at `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs:425–446`, inside the controller's namespace but as siblings of the controller class (after the controller's closing brace at line 423). Line 447 is the namespace's closing brace.
+- **Target folder:** `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/` already exists and holds `IndexRootDto.cs`, `PhotoDto.cs`, `TagDto.cs`, `TagRuleDto.cs`. All use **block-scoped** namespace `Anela.Heblo.Application.Features.Photobank.Contracts`, declare `public class`, and use no collection `using` directives.
+- **`ImplicitUsings` is `enable`d** in `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — confirmed. So `List<string>` / `List<int>` compile without an explicit `using System.Collections.Generic;`. Do **not** add one (it would diverge from the sibling files).
+- **No name collisions:** grep confirms no other `CreateTagBody` / `AddPhotoTagBody` / `BulkAddPhotoTagBody` / `BulkAddPhotoTagByIdsBody` class exists anywhere in `backend/src`.
+- **Controller usings (lines 1–15):** Line 5 is `using Anela.Heblo.Application.Features.Photobank.Services;`. The new `…Photobank.Contracts` using sorts alphabetically **before** `…Photobank.Services`, so insert it immediately before line 5.
+- **The four classes, exactly as they exist today (copy verbatim — same names, properties, accessors, initializers):**
+
+```csharp
+public class AddPhotoTagBody
+{
+    public string TagName { get; set; } = null!;
+}
+
+public class CreateTagBody
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+public class BulkAddPhotoTagBody
+{
+    public List<string>? Tags { get; set; }
+    public string? Search { get; set; }
+    public string TagName { get; set; } = null!;
+}
+
+public class BulkAddPhotoTagByIdsBody
+{
+    public List<int> PhotoIds { get; set; } = [];
+    public string TagName { get; set; } = null!;
+}
+```
+
+- **Why no TDD test-first cycle here:** This task introduces no new behavior — it relocates type declarations. The verification gate is "the project still compiles, the formatter is clean, the existing tests still pass, and the regenerated TypeScript client diff is empty." Each task below ends with the relevant verification command and its expected output. Do not invent new unit tests for moved types; that is explicitly out of scope per the spec.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs` | Request body for `POST /api/photobank/photos/{id}/tags` | Create |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs` | Request body for `POST /api/photobank/tags` | Create |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs` | Request body for `POST /api/photobank/photos/bulk-tag` | Create |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs` | Request body for `POST /api/photobank/photos/tag-by-ids` | Create |
+| `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` | Photobank HTTP endpoints | Modify: add 1 `using`, delete lines 425–446 |
+
+---
+
+## Task 1: Create the four Contracts files
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs`
+
+- [ ] **Step 1: Create `AddPhotoTagBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddPhotoTagBody
+    {
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 2: Create `CreateTagBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class CreateTagBody
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}
+```
+
+- [ ] **Step 3: Create `BulkAddPhotoTagBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagBody
+    {
+        public List<string>? Tags { get; set; }
+        public string? Search { get; set; }
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Create `BulkAddPhotoTagByIdsBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagByIdsBody
+    {
+        public List<int> PhotoIds { get; set; } = [];
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 5: Verify the Application project compiles with the new files**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors. (Confirms `List<>` resolves via `ImplicitUsings` and the namespace/class declarations are valid. At this point the four classes exist in BOTH the Application project and the controller — that is expected and still compiles because they are in different namespaces; the duplicate is removed in Task 2.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs \
+        backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs \
+        backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs \
+        backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs
+git commit -m "refactor: add Photobank request-body DTOs to Application Contracts"
+```
+
+---
+
+## Task 2: Remove the inline classes from the controller and import the Contracts namespace
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` (add `using` near line 5; delete lines 425–446)
+
+- [ ] **Step 1: Add the Contracts using directive**
+
+Insert this line immediately **before** the existing `using Anela.Heblo.Application.Features.Photobank.Services;` (currently line 5), so the Photobank usings stay alphabetically ordered:
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+```
+
+The top of the usings block should then read:
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Features.Photobank.Services;
+```
+
+- [ ] **Step 2: Delete the four inline class declarations**
+
+Remove the entire block at lines 425–446 (the four `public class …Body { … }` declarations that sit between the controller's closing brace at line 423 and the namespace's closing brace at line 447). After deletion, the bottom of the file is the controller's closing brace followed directly by the namespace's closing brace:
+
+```csharp
+            return new FileStreamResult(rawThumbnail.Content, rawThumbnail.ContentType);
+        }
+    }
+}
+```
+
+Do not touch any controller logic, attributes, routes, action signatures, or status-code declarations. The `[FromBody]` parameters (`CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`) now resolve via the new `using`.
+
+- [ ] **Step 3: Verify the full backend solution compiles**
+
+Run: `dotnet build`
+Expected: Build succeeded, 0 errors. (Confirms the controller resolves the relocated types and there is no longer a duplicate definition.)
+
+- [ ] **Step 4: Check whether the controller's `using System.Collections.Generic;` (line 1) became unused**
+
+Run: `dotnet format --verify-no-changes backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+
+- If it reports the line-1 `using System.Collections.Generic;` (or any other) as an unused/unsorted import in `PhotobankController.cs`, run `dotnet format` to let the analyzer remove/reorder it, then re-run the verify command until clean. Removing a genuinely-unused using is in scope (it is a direct consequence of this change).
+- If it reports no changes, leave the file as-is. Do not manually delete the using on a guess — only act on what the analyzer flags. Keep the change surgical.
+
+Expected (after any format pass): `dotnet format --verify-no-changes` reports no remaining changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+git commit -m "refactor: move Photobank request-body DTOs out of controller"
+```
+
+---
+
+## Task 3: Verify API and generated-client compatibility (FR-3)
+
+**Files:**
+- Verify only: `frontend/src/api/generated/api-client.ts` (auto-generated on build — do not hand-edit)
+
+- [ ] **Step 1: Confirm the working tree is clean before regenerating**
+
+Run: `git status --porcelain`
+Expected: empty output (Tasks 1 and 2 are committed). A clean tree makes the next diff check unambiguous.
+
+- [ ] **Step 2: Regenerate the OpenAPI clients via a build**
+
+The TypeScript client is regenerated as part of the backend/build pipeline (NSwag runs on build). Run the project's standard build so generation runs:
+
+Run: `dotnet build`
+Expected: Build succeeded, 0 errors.
+
+> If `dotnet build` alone does not trigger client regeneration in this repo, consult `docs/development/api-client-generation.md` for the exact regeneration command and run that instead. The goal of this task is: the generator has run against the new code state.
+
+- [ ] **Step 3: Confirm the generated client is byte-for-byte unchanged**
+
+Run: `git diff --exit-code frontend/src/api/generated/api-client.ts`
+Expected: **empty diff**, command exits 0. This is the FR-3 proof — NSwag names types by C# type name, not namespace, so `CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, and `BulkAddPhotoTagByIdsBody` must emit identically to before the move.
+
+> If the diff is NOT empty: STOP. Inspect what changed. A non-empty diff means a property name, nullability, or type ordering drifted during the move — re-check the four Contracts files against the verbatim source in the Context section above. Do not commit a changed client as "expected."
+
+- [ ] **Step 4: Run the existing Photobank backend tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~Photobank"`
+Expected: All tests pass. (Covers `PhotobankControllerThumbnailTests` and any other Photobank-scoped tests; confirms no regression in the controller's behavior.)
+
+- [ ] **Step 5: Commit (only if the build produced any legitimately-regenerated, intentional client output)**
+
+In the expected case Step 3's diff is empty and there is nothing new to commit. If the build produced unrelated generated-artifact churn that the repo normally commits, review it carefully first; otherwise there is no commit for this task.
+
+```bash
+git status   # expect clean; only commit if there is intended, reviewed output
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- FR-1 (move four DTOs into Contracts, verbatim, as `class`, block-scoped namespace, one file each) → Task 1, Steps 1–4. ✓
+- FR-2 (delete inline declarations, add `using`, signatures unchanged) → Task 2, Steps 1–2. ✓
+- FR-3 (HTTP contract + generated client identical) → Task 3, Steps 2–3. ✓
+- NFR-3 (one-type-per-file, follows convention) → Task 1 creates four separate files. ✓
+- NFR-4 (zero breaking changes) → Task 3 git-diff-empty gate. ✓
+- Out-of-scope items (no validators, no renames, no record conversion, no other endpoints) → plan touches only the four classes + one `using` + one deletion. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N" placeholders. Every code step shows complete code; every verification step shows the exact command and expected output. ✓
+
+**3. Type consistency:** Class names, property names, types, accessors, and initializers in Task 1 match the verbatim source in the Context section and are referenced consistently in Tasks 2–3 (`CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`). The namespace `Anela.Heblo.Application.Features.Photobank.Contracts` is identical across all four files and the controller `using`. ✓

--- a/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Photobank.Contracts;
 using Anela.Heblo.Application.Features.Photobank.Services;
 using Microsoft.Identity.Client;
 using Anela.Heblo.Application.Features.Photobank.UseCases.AddPhotoTag;
@@ -420,28 +421,5 @@ namespace Anela.Heblo.API.Controllers
 
             return new FileStreamResult(rawThumbnail.Content, rawThumbnail.ContentType);
         }
-    }
-
-    public class AddPhotoTagBody
-    {
-        public string TagName { get; set; } = null!;
-    }
-
-    public class CreateTagBody
-    {
-        public string Name { get; set; } = string.Empty;
-    }
-
-    public class BulkAddPhotoTagBody
-    {
-        public List<string>? Tags { get; set; }
-        public string? Search { get; set; }
-        public string TagName { get; set; } = null!;
-    }
-
-    public class BulkAddPhotoTagByIdsBody
-    {
-        public List<int> PhotoIds { get; set; } = [];
-        public string TagName { get; set; } = null!;
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddPhotoTagBody
+    {
+        public string TagName { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagBody
+    {
+        public List<string>? Tags { get; set; }
+        public string? Search { get; set; }
+        public string TagName { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs
@@ -1,0 +1,8 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagByIdsBody
+    {
+        public List<int> PhotoIds { get; set; } = [];
+        public string TagName { get; set; } = null!;
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class CreateTagBody
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/docs/superpowers/plans/2026-05-22-photobank-request-body-dtos.md
+++ b/docs/superpowers/plans/2026-05-22-photobank-request-body-dtos.md
@@ -1,0 +1,248 @@
+# Relocate Photobank Request-Body DTOs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move four request-body DTO classes out of `PhotobankController.cs` (in the API project) into the Application project's Photobank `Contracts/` folder, restoring the documented "API project never owns DTOs" boundary with zero behavioral change.
+
+**Architecture:** This is a pure structural relocation. The four `…Body` classes are cut verbatim from the bottom of the controller file and pasted into four new one-type-per-file `.cs` files under `Application/Features/Photobank/Contracts/`, each using the existing `Anela.Heblo.Application.Features.Photobank.Contracts` namespace (block-scoped, `class`, mutable setters). The controller gains a single `using` so its `[FromBody]` parameters still resolve. The API project already references the Application project, so dependency direction (API → Application) is preserved. NSwag derives TypeScript type names from the C# **type name**, not its CLR namespace, so the generated client output stays byte-for-byte identical.
+
+**Tech Stack:** .NET 8, ASP.NET Core MVC controllers, NSwag OpenAPI client generation, xUnit (existing tests).
+
+---
+
+## Context an engineer needs before starting
+
+- **Verified source:** The four classes live at `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs:425–446`, inside the controller's namespace but as siblings of the controller class (after the controller's closing brace at line 423). Line 447 is the namespace's closing brace.
+- **Target folder:** `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/` already exists and holds `IndexRootDto.cs`, `PhotoDto.cs`, `TagDto.cs`, `TagRuleDto.cs`. All use **block-scoped** namespace `Anela.Heblo.Application.Features.Photobank.Contracts`, declare `public class`, and use no collection `using` directives.
+- **`ImplicitUsings` is `enable`d** in `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — confirmed. So `List<string>` / `List<int>` compile without an explicit `using System.Collections.Generic;`. Do **not** add one (it would diverge from the sibling files).
+- **No name collisions:** grep confirms no other `CreateTagBody` / `AddPhotoTagBody` / `BulkAddPhotoTagBody` / `BulkAddPhotoTagByIdsBody` class exists anywhere in `backend/src`.
+- **Controller usings (lines 1–15):** Line 5 is `using Anela.Heblo.Application.Features.Photobank.Services;`. The new `…Photobank.Contracts` using sorts alphabetically **before** `…Photobank.Services`, so insert it immediately before line 5.
+- **The four classes, exactly as they exist today (copy verbatim — same names, properties, accessors, initializers):**
+
+```csharp
+public class AddPhotoTagBody
+{
+    public string TagName { get; set; } = null!;
+}
+
+public class CreateTagBody
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+public class BulkAddPhotoTagBody
+{
+    public List<string>? Tags { get; set; }
+    public string? Search { get; set; }
+    public string TagName { get; set; } = null!;
+}
+
+public class BulkAddPhotoTagByIdsBody
+{
+    public List<int> PhotoIds { get; set; } = [];
+    public string TagName { get; set; } = null!;
+}
+```
+
+- **Why no TDD test-first cycle here:** This task introduces no new behavior — it relocates type declarations. The verification gate is "the project still compiles, the formatter is clean, the existing tests still pass, and the regenerated TypeScript client diff is empty." Each task below ends with the relevant verification command and its expected output. Do not invent new unit tests for moved types; that is explicitly out of scope per the spec.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs` | Request body for `POST /api/photobank/photos/{id}/tags` | Create |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs` | Request body for `POST /api/photobank/tags` | Create |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs` | Request body for `POST /api/photobank/photos/bulk-tag` | Create |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs` | Request body for `POST /api/photobank/photos/tag-by-ids` | Create |
+| `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` | Photobank HTTP endpoints | Modify: add 1 `using`, delete lines 425–446 |
+
+---
+
+## Task 1: Create the four Contracts files
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs`
+
+- [ ] **Step 1: Create `AddPhotoTagBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class AddPhotoTagBody
+    {
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 2: Create `CreateTagBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class CreateTagBody
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}
+```
+
+- [ ] **Step 3: Create `BulkAddPhotoTagBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagBody
+    {
+        public List<string>? Tags { get; set; }
+        public string? Search { get; set; }
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 4: Create `BulkAddPhotoTagByIdsBody.cs`**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Photobank.Contracts
+{
+    public class BulkAddPhotoTagByIdsBody
+    {
+        public List<int> PhotoIds { get; set; } = [];
+        public string TagName { get; set; } = null!;
+    }
+}
+```
+
+- [ ] **Step 5: Verify the Application project compiles with the new files**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors. (Confirms `List<>` resolves via `ImplicitUsings` and the namespace/class declarations are valid. At this point the four classes exist in BOTH the Application project and the controller — that is expected and still compiles because they are in different namespaces; the duplicate is removed in Task 2.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/AddPhotoTagBody.cs \
+        backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/CreateTagBody.cs \
+        backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagBody.cs \
+        backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/BulkAddPhotoTagByIdsBody.cs
+git commit -m "refactor: add Photobank request-body DTOs to Application Contracts"
+```
+
+---
+
+## Task 2: Remove the inline classes from the controller and import the Contracts namespace
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` (add `using` near line 5; delete lines 425–446)
+
+- [ ] **Step 1: Add the Contracts using directive**
+
+Insert this line immediately **before** the existing `using Anela.Heblo.Application.Features.Photobank.Services;` (currently line 5), so the Photobank usings stay alphabetically ordered:
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+```
+
+The top of the usings block should then read:
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Contracts;
+using Anela.Heblo.Application.Features.Photobank.Services;
+```
+
+- [ ] **Step 2: Delete the four inline class declarations**
+
+Remove the entire block at lines 425–446 (the four `public class …Body { … }` declarations that sit between the controller's closing brace at line 423 and the namespace's closing brace at line 447). After deletion, the bottom of the file is the controller's closing brace followed directly by the namespace's closing brace:
+
+```csharp
+            return new FileStreamResult(rawThumbnail.Content, rawThumbnail.ContentType);
+        }
+    }
+}
+```
+
+Do not touch any controller logic, attributes, routes, action signatures, or status-code declarations. The `[FromBody]` parameters (`CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`) now resolve via the new `using`.
+
+- [ ] **Step 3: Verify the full backend solution compiles**
+
+Run: `dotnet build`
+Expected: Build succeeded, 0 errors. (Confirms the controller resolves the relocated types and there is no longer a duplicate definition.)
+
+- [ ] **Step 4: Check whether the controller's `using System.Collections.Generic;` (line 1) became unused**
+
+Run: `dotnet format --verify-no-changes backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj`
+
+- If it reports the line-1 `using System.Collections.Generic;` (or any other) as an unused/unsorted import in `PhotobankController.cs`, run `dotnet format` to let the analyzer remove/reorder it, then re-run the verify command until clean. Removing a genuinely-unused using is in scope (it is a direct consequence of this change).
+- If it reports no changes, leave the file as-is. Do not manually delete the using on a guess — only act on what the analyzer flags. Keep the change surgical.
+
+Expected (after any format pass): `dotnet format --verify-no-changes` reports no remaining changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs
+git commit -m "refactor: move Photobank request-body DTOs out of controller"
+```
+
+---
+
+## Task 3: Verify API and generated-client compatibility (FR-3)
+
+**Files:**
+- Verify only: `frontend/src/api/generated/api-client.ts` (auto-generated on build — do not hand-edit)
+
+- [ ] **Step 1: Confirm the working tree is clean before regenerating**
+
+Run: `git status --porcelain`
+Expected: empty output (Tasks 1 and 2 are committed). A clean tree makes the next diff check unambiguous.
+
+- [ ] **Step 2: Regenerate the OpenAPI clients via a build**
+
+The TypeScript client is regenerated as part of the backend/build pipeline (NSwag runs on build). Run the project's standard build so generation runs:
+
+Run: `dotnet build`
+Expected: Build succeeded, 0 errors.
+
+> If `dotnet build` alone does not trigger client regeneration in this repo, consult `docs/development/api-client-generation.md` for the exact regeneration command and run that instead. The goal of this task is: the generator has run against the new code state.
+
+- [ ] **Step 3: Confirm the generated client is byte-for-byte unchanged**
+
+Run: `git diff --exit-code frontend/src/api/generated/api-client.ts`
+Expected: **empty diff**, command exits 0. This is the FR-3 proof — NSwag names types by C# type name, not namespace, so `CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, and `BulkAddPhotoTagByIdsBody` must emit identically to before the move.
+
+> If the diff is NOT empty: STOP. Inspect what changed. A non-empty diff means a property name, nullability, or type ordering drifted during the move — re-check the four Contracts files against the verbatim source in the Context section above. Do not commit a changed client as "expected."
+
+- [ ] **Step 4: Run the existing Photobank backend tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~Photobank"`
+Expected: All tests pass. (Covers `PhotobankControllerThumbnailTests` and any other Photobank-scoped tests; confirms no regression in the controller's behavior.)
+
+- [ ] **Step 5: Commit (only if the build produced any legitimately-regenerated, intentional client output)**
+
+In the expected case Step 3's diff is empty and there is nothing new to commit. If the build produced unrelated generated-artifact churn that the repo normally commits, review it carefully first; otherwise there is no commit for this task.
+
+```bash
+git status   # expect clean; only commit if there is intended, reviewed output
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- FR-1 (move four DTOs into Contracts, verbatim, as `class`, block-scoped namespace, one file each) → Task 1, Steps 1–4. ✓
+- FR-2 (delete inline declarations, add `using`, signatures unchanged) → Task 2, Steps 1–2. ✓
+- FR-3 (HTTP contract + generated client identical) → Task 3, Steps 2–3. ✓
+- NFR-3 (one-type-per-file, follows convention) → Task 1 creates four separate files. ✓
+- NFR-4 (zero breaking changes) → Task 3 git-diff-empty gate. ✓
+- Out-of-scope items (no validators, no renames, no record conversion, no other endpoints) → plan touches only the four classes + one `using` + one deletion. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N" placeholders. Every code step shows complete code; every verification step shows the exact command and expected output. ✓
+
+**3. Type consistency:** Class names, property names, types, accessors, and initializers in Task 1 match the verbatim source in the Context section and are referenced consistently in Tasks 2–3 (`CreateTagBody`, `AddPhotoTagBody`, `BulkAddPhotoTagBody`, `BulkAddPhotoTagByIdsBody`). The namespace `Anela.Heblo.Application.Features.Photobank.Contracts` is identical across all four files and the controller `using`. ✓


### PR DESCRIPTION
Photobank

## Finding
Four request-body DTO classes are defined at the bottom of `PhotobankController.cs` inside the `Anela.Heblo.API` project:

- `AddPhotoTagBody` (line 425)
- `CreateTagBody` (line 429)
- `BulkAddPhotoTagBody` (line 434)
- `BulkAddPhotoTagByIdsBody` (line 441)

File: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`, lines 425–447.

```csharp
public class AddPhotoTagBody
{
    public string TagName { get; set; } = null!;
}
// ... three more body classes follow
```

The project rule is explicit: *"API project never defines or owns DTOs — it only uses them."* All request/response DTOs must live in `Application/Features/<Module>/Contracts/`.

## Why it matters
- Violates the documented DTO ownership rule from `docs/architecture/development_guidelines.md`.
- The generated TypeScript client reflects this mis-placement: NSwag picks these types up from the API project and emits them in `api-client.ts` under names like `CreateTagBody` — if they were moved to the Application project they would still be generated correctly, but ownership would be correct and they could be shared/reused by validators without a project-level dependency inversion.
- Establishes a precedent that makes it harder to enforce the boundary for future contributors.

## Suggested fix
Move all four classes to `backend/src/Anela.Heblo.Application/Features/Photobank/Contracts/`:

```
Contracts/
  AddPhotoTagBody.cs
  CreateTagBody.cs
  BulkAddPhotoTagBody.cs
  BulkAddPhotoTagByIdsBody.cs
```

Add a `using Anela.Heblo.Application.Features.Photobank.Contracts;` to the controller. No logic changes required.

---
_Filed by daily arch-review routine on 2026-05-21._

---

Closes #1519

### Tokens used
11434209
