### PR TITLE
feat: Remove Npgsql dependency from Photobank Application layer

### DIFF
--- a/artifacts/feat-arch-review-photobank-application-layer-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-photobank-application-layer-/arch-review.r1.md
@@ -1,0 +1,108 @@
+I have enough grounding. Key facts verified:
+- `PhotobankRepository` lives in **Application** but references EF Core + `Persistence` (the real layering compromise).
+- `Domain` has zero infra refs — `MediatR` + DI/logging abstractions only; matches the `IssuedInvoiceClientException` precedent.
+- `Npgsql` reaches Application transitively via `Persistence` → `Npgsql.EntityFrameworkCore.PostgreSQL`; no package change needed.
+- `ErrorCodes` is in `Application/Shared/`.
+- `GetPhotosHandlerTests` already exists (mock-based) — the new case slots straight in.
+- The `PostgresException 2201B` surfaces during query *materialization* (`CountAsync`/`ToListAsync`), not in `BuildFilterQuery`.
+
+One contract subtlety to flag: the handler currently echoes `request.Search` (untrimmed) into `Params["pattern"]`, while `BuildFilterQuery` trims before matching. That drives a specification amendment.
+
+# Architecture Review: Remove Npgsql dependency from Photobank Application layer
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposed fix is well-aligned with this codebase. The exception-translation-at-the-seam pattern already has precedent in `Domain/Features/Invoices/IssuedInvoiceClientException.cs` — a plain `Exception` subclass carrying contextual data, defined in Domain with no infra dependencies. The spec's `InvalidPhotoSearchPatternException` follows this convention exactly.
+
+The integration points are clean and minimal:
+- **Domain** (`IPhotobankRepository.cs` already lives here) gains a sibling exception type. No new package references — Domain currently depends only on `MediatR` and Microsoft abstractions, so the rule "no infra leak in Domain" is upheld.
+- **Application repository** (`PhotobankRepository.GetPhotosAsync`) becomes the single translation point. It already legitimately imports `Npgsql` territory via EF Core + `Persistence`, so the `PostgresException` catch belongs here.
+- **Application handler** (`GetPhotosHandler`) drops `using Npgsql;` and catches the domain exception instead.
+
+**Important caveat (scoped out, correctly):** the deeper Clean Architecture smell is that `PhotobankRepository` — a data-access adapter referencing EF Core and `Persistence` — physically resides in the **Application** project rather than a dedicated Infrastructure project. This fix does *not* fully purify the Application layer; `Npgsql` types remain reachable inside `PhotobankRepository`. What it *does* achieve is removing the leak from the **use-case handler** (the pure orchestration layer) and making the error path **unit-testable without a database**. That is the correct, surgical win. Relocating the repository is a larger refactor and rightly out of scope.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────── Domain ───────────────────────────┐
+│  IPhotobankRepository                                          │
+│  InvalidPhotoSearchPatternException : Exception   ← NEW        │
+│      + Pattern : string                                        │
+│  (no Npgsql, no EF Core)                                       │
+└───────────────────────────────────────────────────────────────┘
+              ▲ throws                       ▲ implements
+              │                              │
+┌────────────┴──────────────── Application ─┴───────────────────┐
+│  GetPhotosHandler                                              │
+│    catch (InvalidPhotoSearchPatternException)  ← was Postgres  │
+│    → GetPhotosResponse { Success=false, PhotobankInvalidRegex }│
+│                                                                │
+│  PhotobankRepository.GetPhotosAsync                            │
+│    try { Count + ToList }                                      │
+│    catch (PostgresException) when (useRegex && 2201B)          │
+│      → throw new InvalidPhotoSearchPatternException(...)  ← NEW │
+│    (Npgsql visible transitively via Persistence)               │
+└───────────────────────────────────────────────────────────────┘
+              │ EF Core query (Regex.IsMatch → '~*')
+              ▼
+┌──────────── Persistence (Npgsql.EntityFrameworkCore.PostgreSQL) ┐
+│  ApplicationDbContext → PostgreSQL (raises 2201B at execution)  │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Translate in `GetPhotosAsync`, not `BuildFilterQuery`
+**Options considered:** (a) wrap the `Regex.IsMatch` predicate construction inside `BuildFilterQuery`; (b) wrap query *materialization* (`CountAsync` + `ToListAsync`) inside `GetPhotosAsync`.
+**Chosen approach:** (b) — wrap the execution block in `GetPhotosAsync`.
+**Rationale:** `BuildFilterQuery` only composes an `IQueryable`; it does not execute. The `PostgresException 2201B` is raised by PostgreSQL only when the `~*` regex operator actually runs — i.e. during `CountAsync`/`ToListAsync`. Wrapping `BuildFilterQuery` would catch nothing. Critically, the `try` must cover **both** `await` calls (count and list), since either can be the first to trigger evaluation. The other three `BuildFilterQuery` callers (`CountFilteredPhotosAsync`, `GetFilteredPhotoIdsMissingTagAsync` — both pass `useRegex: false`) stay untouched, so the blast radius is exactly one method.
+
+#### Decision 2: Domain exception carries `Pattern`, but the response param keeps sourcing from `request.Search`
+**Options considered:** (a) handler reads `ex.Pattern` for `Params["pattern"]`; (b) handler keeps `request.Search ?? string.Empty`.
+**Chosen approach:** (b) for the response, with `Pattern` retained on the exception for diagnostics/logging.
+**Rationale:** preserving the *exact* client-facing contract is the stated goal. `BuildFilterQuery` trims the search (`pattern = search.Trim()`), so an exception populated from the trimmed value would diverge from today's untrimmed `request.Search`. See the Specification Amendment below — this is the one place the spec's wording ("carrying `Pattern`") could silently change behavior if the handler switched to `ex.Pattern`.
+
+#### Decision 3: No `PrivateAssets` change; rely on existing transitive flow
+**Chosen approach:** leave project references as-is.
+**Rationale:** `PostgresException` resolves through `Persistence`'s `Npgsql.EntityFrameworkCore.PostgreSQL` package, whose `Npgsql` dependency flows transitively to Application by default. The repository already compiles against this surface. No `.csproj` edits required.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+- **New:** `backend/src/Anela.Heblo.Domain/Features/Photobank/InvalidPhotoSearchPatternException.cs`
+- **Edit:** `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs` (`GetPhotosAsync` only)
+- **Edit:** `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs` (remove `using Npgsql;`, swap catch)
+- **Edit:** `backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs` (add the new case to the existing file — do **not** create a new test class; the spec's "New `GetPhotosHandlerTests`" should read "new test case in the existing `GetPhotosHandlerTests`").
+
+### Interfaces and Contracts
+- `InvalidPhotoSearchPatternException` — match the `IssuedInvoiceClientException` shape: `public class`, public `string Pattern { get; }`, single constructor `(string pattern)` calling `base($"Invalid search pattern: {pattern}")`. Place it in namespace `Anela.Heblo.Domain.Features.Photobank` (the folder uses block-scoped namespaces today; the new file may use either — match the file you're nearest to, prefer file-scoped per the global C# style, but Domain currently mixes both, so block-scoped here is acceptable for consistency with `IPhotobankRepository`).
+- `IPhotobankRepository` — **no signature change.** `GetPhotosAsync` already receives `useRegex` and `search`, which is everything the translation needs. The exception is a documented runtime contract, not a method signature.
+- `GetPhotosResponse` contract — **unchanged.** `Success=false`, `ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern`, `Params["pattern"]`.
+
+### Data Flow
+1. `GetPhotosHandler.Handle` → `_repository.GetPhotosAsync(..., useRegex: true, ...)`.
+2. `GetPhotosAsync` builds the query (`Regex.IsMatch` → `~*`) and awaits `CountAsync`/`ToListAsync`.
+3. PostgreSQL rejects the bad pattern → `Npgsql` raises `PostgresException` (SqlState `2201B`).
+4. `catch (PostgresException ex) when (useRegex && ex.SqlState == "2201B")` → `throw new InvalidPhotoSearchPatternException(search ?? string.Empty)`.
+5. Handler `catch (InvalidPhotoSearchPatternException)` → returns the structured `GetPhotosResponse` with `Params["pattern"] = request.Search ?? string.Empty`.
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `try` wraps only one of the two `await` calls, missing the exception | Medium | Wrap the entire execution block (both `CountAsync` and `ToListAsync`) in one `try`. |
+| Switching the response param to `ex.Pattern` silently trims the echoed pattern, changing the client contract | Medium | Keep `Params["pattern"] = request.Search ?? string.Empty` in the handler; use `ex.Pattern` only for logs. |
+| `PostgresException` arriving wrapped (e.g. inside another EF exception) escaping the catch | Low | Reads/queries surface `PostgresException` directly today (the current handler catches it directly), so direct catch preserves existing behavior. No change in wrapping behavior is introduced. |
+| Future relocation of `PhotobankRepository` to an Infra project assumed by reviewers | Low | Explicitly note in the PR that infra purification of the repository is out of scope and tracked separately. |
+| Regression in the (currently untested) error path | Low | New unit test mocks `GetPhotosAsync` to throw `InvalidPhotoSearchPatternException` and asserts the exact response — this is the first real coverage of this path. |
+
+## Specification Amendments
+1. **FR-3 / FR-4 wording:** The spec implies a "new `GetPhotosHandlerTests`," but the file already exists (`backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs`) with mock-based cases. Amend to: *add a new `[Fact]` to the existing `GetPhotosHandlerTests`* asserting that when `GetPhotosAsync` throws `InvalidPhotoSearchPatternException`, the handler returns `Success=false`, `ErrorCode == ErrorCodes.PhotobankInvalidRegexPattern`, and `Params["pattern"]` equals the request search.
+2. **FR-1 / FR-3 — response param source:** Make explicit that `Params["pattern"]` is sourced from `request.Search` in the handler (not from `ex.Pattern`), to preserve the exact untrimmed client-facing value. `Pattern` on the exception is for server-side diagnostics. Without this note, an implementer may "tidy up" to `ex.Pattern` and subtly alter the contract (trimmed vs untrimmed).
+3. **FR-2 — translation location precision:** Confirm the catch lives in `GetPhotosAsync` around the materialization (`CountAsync` + `ToListAsync`), not in `BuildFilterQuery` (which never executes). The spec already leans this way ("`GetPhotosAsync`"); make it unambiguous and require both awaits inside the single `try`.
+
+## Prerequisites
+None. No migrations, config, infrastructure, or package changes. `PostgresException`/`Npgsql` remain available transitively through `Persistence`; `Domain` and `Application` already reference everything required. Implementation can start immediately.

--- a/artifacts/feat-arch-review-photobank-application-layer-/brief.md
+++ b/artifacts/feat-arch-review-photobank-application-layer-/brief.md
@@ -1,0 +1,56 @@
+## Module
+Photobank
+
+## Finding
+`GetPhotosHandler` has a direct dependency on the Npgsql infrastructure library:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+using Npgsql;   // line 9
+
+// ...
+catch (PostgresException ex) when (request.UseRegex && ex.SqlState == "2201B")   // line 43
+{
+    return new GetPhotosResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern,
+        // ...
+    };
+}
+```
+
+The handler catches `PostgresException` with SQL state `2201B` (invalid regular expression) to return a structured error response when the user supplies a bad regex.
+
+## Why it matters
+- Clean Architecture requires the Application layer to be infrastructure-agnostic. Importing `Npgsql` in the Application layer means the Application project now has a hard compile-time dependency on a specific database driver.
+- The intent — converting an infrastructure exception into a domain-level error response — is correct, but the *location* is wrong.
+- If the database is ever swapped or the repository is tested with an in-memory provider, this catch clause silently stops working without any compile error.
+
+## Suggested fix
+Define a domain exception in the repository contract (Domain layer) and throw it from the repository when the invalid-regex error is detected:
+
+```csharp
+// Domain/Features/Photobank/ — new file
+public class InvalidPhotoSearchPatternException : Exception
+{
+    public string Pattern { get; }
+    public InvalidPhotoSearchPatternException(string pattern)
+        : base($"Invalid search pattern: {pattern}") => Pattern = pattern;
+}
+```
+
+In `PhotobankRepository.BuildFilterQuery` (or `GetPhotosAsync`), catch `PostgresException` with `SqlState == "2201B"` and rethrow as `InvalidPhotoSearchPatternException`.
+
+`GetPhotosHandler` then catches `InvalidPhotoSearchPatternException` — no `Npgsql` import needed:
+```csharp
+catch (InvalidPhotoSearchPatternException ex)
+{
+    return new GetPhotosResponse { Success = false, ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern, ... };
+}
+```
+
+Remove `using Npgsql;` from the handler entirely.
+
+---
+_Filed by daily arch-review routine on 2026-05-21._

--- a/artifacts/feat-arch-review-photobank-application-layer-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-photobank-application-layer-/impl/main.r1.md
@@ -1,0 +1,12 @@
+Tests: **150 passed, 0 failed.**
+
+Environment: normal repo (GIT_DIR == GIT_COMMON), named branch `feat-arch-review-photobank-application-layer-`, base branch `main`.
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-photobank-application-layer-/spec.r1.md
+++ b/artifacts/feat-arch-review-photobank-application-layer-/spec.r1.md
@@ -1,0 +1,19 @@
+I've written the specification to `artifacts/feat-arch-review-photobank-application-layer-/spec.md`, grounded in the actual code.
+
+# Specification: Remove Npgsql dependency from Photobank Application layer
+
+## Summary
+`GetPhotosHandler` imports `Npgsql` and catches `PostgresException` (SQL state `2201B`) to convert a bad user regex into a structured error — a Clean Architecture layer leak. The fix introduces a domain exception `InvalidPhotoSearchPatternException`, translates the Npgsql exception inside `PhotobankRepository` (the infrastructure seam), and has the handler catch the domain exception, preserving the exact client-facing contract.
+
+## Functional Requirements
+- **FR-1** — New `InvalidPhotoSearchPatternException` in `Domain/Features/Photobank/`, carrying `Pattern`; no new package refs on Domain (follows the existing `IssuedInvoiceClientException` convention).
+- **FR-2** — `PhotobankRepository.GetPhotosAsync` wraps query execution and rethrows `PostgresException` with `SqlState == "2201B"` (when `useRegex`) as the domain exception. Other `BuildFilterQuery` callers (non-regex) untouched.
+- **FR-3** — Handler drops `using Npgsql;`, catches `InvalidPhotoSearchPatternException`, returns the identical response (`Success=false`, `PhotobankInvalidRegexPattern`, `Params["pattern"]`).
+- **FR-4** — New `GetPhotosHandlerTests` case mocking the repo to throw the domain exception (now unit-testable without a DB).
+
+## Key findings driving the spec
+- `PhotobankRepository` lives in the **Application** project but is the data-access adapter (references EF Core + Persistence), making it the correct translation point.
+- The error path is **currently untested** — `PhotobankRepositoryFilterTests` uses the EF Core **in-memory** provider, which never raises `PostgresException 2201B`, confirming the brief's "silently stops working" concern.
+- Npgsql stays available to the repository transitively via `Anela.Heblo.Persistence`; no new NuGet packages needed.
+
+I marked the spec **COMPLETE** — the refactor is fully determined by the brief and the codebase, with no open questions. Out-of-scope items (relocating the repository to a dedicated infra project; the same anti-pattern in `GridLayouts`/`ConsumptionCalculationService`) are noted explicitly.

--- a/artifacts/feat-arch-review-photobank-application-layer-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-photobank-application-layer-/task-plan.r1.md
@@ -1,0 +1,811 @@
+# Smartsupp Production Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two production bugs — spurious "customer not found" error toast for guest visitors, and double-`?` badge on agentless messages — plus remove the wasteful email-based order fallback.
+
+**Architecture:** Backend handler stops emitting an error when a Shoptet customer is absent (returns `success=true`, `contactInfo=null`); frontend card already hides on null `contactInfo`. `AgentBadge` derives initials from `agentId` when `name` is missing, avoiding duplicate `?` symbols.
+
+**Tech Stack:** .NET 8 / C# 12 (xUnit + FluentAssertions + Moq), React / TypeScript (Vitest + React Testing Library)
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Modify | `backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs` |
+| Modify | `backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs` |
+| Modify | `backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs` |
+| Modify | `frontend/src/api/hooks/useSmartsupp.ts` |
+| Modify | `frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx` |
+| Modify | `frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx` |
+| Modify | `frontend/src/components/customer-support/smartsupp/AgentBadge.tsx` |
+| Modify | `frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx` |
+
+---
+
+## Task 1: Make `ShoptetContactInfoDto.Customer` nullable
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs`
+
+- [ ] **Step 1: Open the DTO file and drop `required`**
+
+Replace the `Customer` property so it is nullable:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Smartsupp.Contracts;
+
+public class ShoptetContactInfoDto
+{
+    public ShoptetCustomerSnapshotDto? Customer { get; set; }
+    public List<ShoptetOrderSnapshotDto> RecentOrders { get; set; } = new();
+    public DateTime? CartUpdatedAt { get; set; }
+}
+
+public class ShoptetCustomerSnapshotDto
+{
+    public string? FullName { get; set; }
+    public string? Email { get; set; }
+    public string? CustomerGroup { get; set; }
+    public string? PriceList { get; set; }
+    public string? DefaultShippingAddress { get; set; }
+}
+
+public class ShoptetOrderSnapshotDto
+{
+    public required string Code { get; set; }
+    public string? StatusName { get; set; }
+    public decimal? TotalWithVat { get; set; }
+    public string? CurrencyCode { get; set; }
+    public DateTime? OrderDate { get; set; }
+    public string? AdminUrl { get; set; }
+}
+```
+
+Only the `ShoptetCustomerSnapshotDto? Customer` line changes (dropped `required`, added `?`). All other lines are identical to the current file.
+
+- [ ] **Step 2: Verify the project still compiles**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: Build succeeded, 0 Error(s).
+
+---
+
+## Task 2: Rewrite backend handler tests (TDD RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs`
+
+The handler will lose its `IEshopOrderClient` constructor parameter and its email-based order fallback. Rewrite the tests now to express the new contract; they will fail until the handler is updated in Task 3.
+
+- [ ] **Step 1: Replace the entire test file**
+
+```csharp
+using System.Globalization;
+using Anela.Heblo.Application.Features.ShoptetCustomers;
+using Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Smartsupp;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Smartsupp;
+
+public class GetSmartsuppContactShoptetInfoHandlerTests
+{
+    private readonly Mock<ISmartsuppRepository> _repo = new();
+    private readonly Mock<IShoptetCustomerClient> _customerClient = new();
+
+    private GetSmartsuppContactShoptetInfoHandler CreateHandler() =>
+        new(_repo.Object, _customerClient.Object);
+
+    private static ShoptetCustomerInfoDto MakeCustomer(string guid = "cust-1") =>
+        new() { Guid = guid, FullName = "Jana Nováková", Email = "jana@test.cz", CustomerGroup = "VIP", PriceList = "Retail" };
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenConversationMissing()
+    {
+        _repo.Setup(r => r.GetConversationAsync("missing", It.IsAny<CancellationToken>()))
+             .ReturnsAsync((SmartsuppConversation?)null);
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "missing" },
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.SmartsuppConversationNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesViaUserGuid_WhenShoptetUserGuidPresent()
+    {
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_user_guid":"user-guid-1","shoptet_guid":"guid-2"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("user-guid-1"));
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo!.Customer!.FullName.Should().Be("Jana Nováková");
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync("user-guid-1", It.IsAny<CancellationToken>()), Times.Once);
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync("guid-2", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ResolvesViaShoptetGuid_WhenUserGuidAbsent()
+    {
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_guid":"guid-abc"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("guid-abc"));
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _customerClient.Verify(c => c.GetCustomerByGuidAsync("guid-abc", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CustomerNotFound_ReturnsSuccessWithNullContactInfo()
+    {
+        // Guest/unregistered visitor — no Shoptet customer record. Expected: success=true, ContactInfo=null (no toast, no panel).
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_guid":"unknown-guid"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("unknown-guid", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync((ShoptetCustomerInfoDto?)null);
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo.Should().BeNull();
+        result.ErrorCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NoGuidsPresent_ReturnsSuccessWithNullContactInfo()
+    {
+        // No guid variables and no email-based lookup — email fallback is intentionally removed.
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            ContactEmail = "guest@example.com",
+            VariablesJson = null,
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ParsesCartUpdatedAt_FromVariables()
+    {
+        var conversation = new SmartsuppConversation
+        {
+            Id = "c1",
+            Status = SmartsuppConversationStatus.Open,
+            VariablesJson = """{"shoptet_guid":"guid-1","shoptet_cart_updated_at":"2026-04-15T12:00:00"}""",
+            Messages = [],
+        };
+        _repo.Setup(r => r.GetConversationAsync("c1", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(conversation);
+        _customerClient.Setup(c => c.GetCustomerByGuidAsync("guid-1", It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(MakeCustomer("guid-1"));
+
+        var result = await CreateHandler().Handle(
+            new GetSmartsuppContactShoptetInfoRequest { ConversationId = "c1" },
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ContactInfo!.CartUpdatedAt.Should().Be(new DateTime(2026, 4, 15, 12, 0, 0));
+        result.ContactInfo.RecentOrders.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail (RED)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests \
+  --filter FullyQualifiedName~GetSmartsuppContactShoptetInfoHandlerTests \
+  --no-build 2>&1 | tail -20
+```
+
+Expected failures:
+- `Handle_ResolvesViaUserGuid_WhenShoptetUserGuidPresent` — fails because old handler calls `GetRecentOrdersByEmailAsync` which is no longer set up (or fails because `CreateHandler()` passes wrong args — compile error)
+- `Handle_NoGuidsPresent_ReturnsSuccessWithNullContactInfo` — fails: old handler returns `success=false` for missing customer
+- `Handle_CustomerNotFound_ReturnsSuccessWithNullContactInfo` — fails: old handler returns `success=false`
+
+> Note: The test file will not compile until Task 3 updates the handler constructor signature to remove `IEshopOrderClient`. A compile error counts as RED — proceed to Task 3.
+
+---
+
+## Task 3: Rewrite handler — drop email fallback and error return (TDD GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs`
+
+- [ ] **Step 1: Replace the entire handler file**
+
+```csharp
+using System.Globalization;
+using System.Text.Json;
+using Anela.Heblo.Application.Features.ShoptetCustomers;
+using Anela.Heblo.Application.Features.Smartsupp.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Smartsupp;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Smartsupp.UseCases.GetContactShoptetInfo;
+
+public class GetSmartsuppContactShoptetInfoHandler
+    : IRequestHandler<GetSmartsuppContactShoptetInfoRequest, GetSmartsuppContactShoptetInfoResponse>
+{
+    private readonly ISmartsuppRepository _repo;
+    private readonly IShoptetCustomerClient _customerClient;
+
+    public GetSmartsuppContactShoptetInfoHandler(
+        ISmartsuppRepository repo,
+        IShoptetCustomerClient customerClient)
+    {
+        _repo = repo;
+        _customerClient = customerClient;
+    }
+
+    public async Task<GetSmartsuppContactShoptetInfoResponse> Handle(
+        GetSmartsuppContactShoptetInfoRequest request,
+        CancellationToken cancellationToken)
+    {
+        var conversation = await _repo.GetConversationAsync(request.ConversationId, cancellationToken);
+        if (conversation is null)
+            return new GetSmartsuppContactShoptetInfoResponse(ErrorCodes.SmartsuppConversationNotFound);
+
+        var variables = ParseVariables(conversation.VariablesJson);
+        variables.TryGetValue("shoptet_user_guid", out var userGuid);
+        variables.TryGetValue("shoptet_guid", out var shoptetGuid);
+        variables.TryGetValue("shoptet_cart_updated_at", out var cartStr);
+
+        ShoptetCustomerInfoDto? customer = null;
+
+        if (!string.IsNullOrWhiteSpace(userGuid))
+            customer = await _customerClient.GetCustomerByGuidAsync(userGuid, cancellationToken);
+        else if (!string.IsNullOrWhiteSpace(shoptetGuid))
+            customer = await _customerClient.GetCustomerByGuidAsync(shoptetGuid, cancellationToken);
+
+        if (customer is null)
+            return new GetSmartsuppContactShoptetInfoResponse { ContactInfo = null };
+
+        DateTime? cartUpdatedAt = null;
+        if (!string.IsNullOrWhiteSpace(cartStr) &&
+            DateTime.TryParse(cartStr, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var parsedCart))
+            cartUpdatedAt = parsedCart;
+
+        return new GetSmartsuppContactShoptetInfoResponse
+        {
+            ContactInfo = new ShoptetContactInfoDto
+            {
+                Customer = new ShoptetCustomerSnapshotDto
+                {
+                    FullName = customer.FullName,
+                    Email = customer.Email,
+                    CustomerGroup = customer.CustomerGroup,
+                    PriceList = customer.PriceList,
+                    DefaultShippingAddress = customer.DefaultShippingAddress,
+                },
+                RecentOrders = new(),
+                CartUpdatedAt = cartUpdatedAt,
+            },
+        };
+    }
+
+    private static Dictionary<string, string> ParseVariables(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new();
+        try { return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new(); }
+        catch (JsonException) { return new(); }
+    }
+}
+```
+
+Key changes from the original:
+- `IEshopOrderClient _orderClient` field and constructor parameter removed
+- `using Anela.Heblo.Application.Features.ShoptetOrders;` removed
+- `RecentOrdersLimit` constant removed
+- Email-based fallback branch (`else if (!string.IsNullOrWhiteSpace(conversation.ContactEmail))`) removed
+- `if (customer is null)` now returns `success=true` with `ContactInfo = null` instead of emitting `SmartsuppShoptetCustomerNotFound`
+- `GetRecentOrdersByEmailAsync`, `GetOrderStatusNamesAsync` calls removed
+- `RecentOrders = new()` (always empty until a future efficient order-lookup path)
+
+> `IEshopOrderClient` itself is NOT removed — it is used by other features. Only the injection into this handler is dropped.
+
+- [ ] **Step 2: Check whether the DI registration needs updating**
+
+Search for where `GetSmartsuppContactShoptetInfoHandler` is registered:
+
+```bash
+grep -r "GetSmartsuppContactShoptetInfoHandler\|AddSmartsuppServices\|AddApplicationServices" \
+  backend/src --include="*.cs" -l
+```
+
+If a DI registration explicitly passes `IEshopOrderClient` as a constructor arg, update it. More likely it is auto-registered via MediatR assembly scanning — in that case no change needed. Confirm by reading the found files.
+
+- [ ] **Step 3: Run backend tests (GREEN)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests \
+  --filter FullyQualifiedName~GetSmartsuppContactShoptetInfoHandlerTests
+```
+
+Expected: All 6 tests pass, 0 failures.
+
+- [ ] **Step 4: Full backend build + format**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: Build succeeded, no format violations. If format reports changes, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply them, then re-run to verify.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Smartsupp/Contracts/ShoptetContactInfoDto.cs \
+  backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/GetContactShoptetInfo/GetSmartsuppContactShoptetInfoHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Smartsupp/GetSmartsuppContactShoptetInfoHandlerTests.cs
+git commit -m "fix(smartsupp): guest customer returns success with null ContactInfo, drop email order fallback"
+```
+
+---
+
+## Task 4: Update frontend TypeScript type for nullable customer
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useSmartsupp.ts`
+
+- [ ] **Step 1: Make `customer` nullable in `ShoptetContactInfoDto`**
+
+In `useSmartsupp.ts`, locate `ShoptetContactInfoDto` (currently around line 137–141) and change `customer`:
+
+```ts
+export interface ShoptetContactInfoDto {
+  customer?: ShoptetCustomerSnapshotDto | null;
+  recentOrders: ShoptetOrderSnapshotDto[];
+  cartUpdatedAt?: string | null;
+}
+```
+
+Only the `customer` line changes — from `customer: ShoptetCustomerSnapshotDto;` to `customer?: ShoptetCustomerSnapshotDto | null;`.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: zero errors (or only pre-existing errors unrelated to this change).
+
+---
+
+## Task 5: Write new `ShoptetCustomerCard` test (TDD RED)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx`
+
+- [ ] **Step 1: Add a test for null customer within a non-null contactInfo**
+
+Add after the existing `describe("ShoptetCustomerCard")` block's last test (before the closing `}`):
+
+```tsx
+  it("renders no customer section when contactInfo.customer is null", () => {
+    mockedHook.mockReturnValue({
+      data: { success: true, contactInfo: { customer: null, recentOrders: [], cartUpdatedAt: null } },
+      isLoading: false,
+    });
+    render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
+    expect(screen.queryByText("Shoptet Zákazník")).not.toBeInTheDocument();
+  });
+
+  it("still renders cart section when customer is null but cartUpdatedAt is set", () => {
+    mockedHook.mockReturnValue({
+      data: {
+        success: true,
+        contactInfo: { customer: null, recentOrders: [], cartUpdatedAt: "2026-04-15T12:00:00" },
+      },
+      isLoading: false,
+    });
+    render(<ShoptetCustomerCard conversationId="c1" />, { wrapper });
+    expect(screen.queryByText("Shoptet Zákazník")).not.toBeInTheDocument();
+    expect(screen.getByText("Shoptet Košík")).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the new tests to confirm RED**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: The two new tests fail (one with a TypeError because `customer.fullName` crashes on null, one for the same reason). Existing tests still pass.
+
+---
+
+## Task 6: Fix `ShoptetCustomerCard.tsx` to guard on nullable customer (TDD GREEN)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx`
+
+- [ ] **Step 1: Replace the component body**
+
+```tsx
+import React from "react";
+import { useSmartsuppShoptetInfo } from "../../../api/hooks/useSmartsupp";
+import Section from "./Section";
+
+interface ShoptetCustomerCardProps {
+  conversationId: string | null;
+}
+
+function ShoptetCustomerCard({ conversationId }: ShoptetCustomerCardProps) {
+  const { data, isLoading } = useSmartsuppShoptetInfo(conversationId);
+
+  if (isLoading) return null;
+  if (!data?.contactInfo) return null;
+
+  const { customer, recentOrders, cartUpdatedAt } = data.contactInfo;
+
+  const hasCustomer = customer != null;
+  const hasOrders = recentOrders.length > 0;
+  const hasCart = !!cartUpdatedAt;
+
+  if (!hasCustomer && !hasOrders && !hasCart) return null;
+
+  return (
+    <>
+      {hasCustomer && (
+        <Section title="Shoptet Zákazník">
+          <div className="space-y-1">
+            {customer.fullName && (
+              <div className="text-sm font-semibold text-gray-900">{customer.fullName}</div>
+            )}
+            {customer.email && (
+              <div className="text-xs text-gray-500">{customer.email}</div>
+            )}
+            {customer.customerGroup && (
+              <div className="text-xs text-gray-700">
+                <span className="text-gray-400">Skupina: </span>{customer.customerGroup}
+              </div>
+            )}
+            {customer.priceList && (
+              <div className="text-xs text-gray-700">
+                <span className="text-gray-400">Ceník: </span>{customer.priceList}
+              </div>
+            )}
+            {customer.defaultShippingAddress && (
+              <div className="text-xs text-gray-600 mt-1">{customer.defaultShippingAddress}</div>
+            )}
+          </div>
+        </Section>
+      )}
+
+      {hasCart && (
+        <Section title="Shoptet Košík">
+          <div className="text-xs text-gray-500">
+            Aktualizován: {new Date(cartUpdatedAt!).toLocaleDateString("cs-CZ")}
+          </div>
+        </Section>
+      )}
+
+      {hasOrders && (
+        <Section title="Poslední objednávky">
+          <div className="space-y-2">
+            {recentOrders.map((order) => (
+              <div key={order.code} className="border-b border-gray-50 pb-1.5 last:border-0">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-gray-800">{order.code}</span>
+                  {order.totalWithVat != null && (
+                    <span className="text-xs text-gray-700">
+                      {order.totalWithVat.toLocaleString("cs-CZ")} {order.currencyCode ?? "Kč"}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center justify-between mt-0.5">
+                  {order.statusName && (
+                    <span className="text-[11px] text-gray-500">{order.statusName}</span>
+                  )}
+                  {order.orderDate && (
+                    <span className="text-[11px] text-gray-400">
+                      {new Date(order.orderDate).toLocaleDateString("cs-CZ")}
+                    </span>
+                  )}
+                </div>
+                {order.adminUrl && (
+                  <a
+                    href={order.adminUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-blue-600 hover:underline"
+                  >
+                    Zobrazit v Shoptet
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </>
+  );
+}
+
+export default ShoptetCustomerCard;
+```
+
+Changes from original: wrapped the customer `<Section>` in `{hasCustomer && ...}`, replaced bare `{cartUpdatedAt && ...}` / `{recentOrders.length > 0 && ...}` with `hasCart` / `hasOrders` booleans, added early return when all three sections are empty.
+
+- [ ] **Step 2: Run all ShoptetCustomerCard tests (GREEN)**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: All 7 tests pass (5 existing + 2 new), 0 failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ..  # back to repo root
+git add \
+  frontend/src/api/hooks/useSmartsupp.ts \
+  frontend/src/components/customer-support/smartsupp/ShoptetCustomerCard.tsx \
+  frontend/src/components/customer-support/smartsupp/__tests__/ShoptetCustomerCard.test.tsx
+git commit -m "fix(smartsupp): silently hide Shoptet panel when customer is absent, guard nullable customer"
+```
+
+---
+
+## Task 7: Rewrite `AgentBadge` tests (TDD RED)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx`
+
+- [ ] **Step 1: Replace the test file**
+
+```tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AgentBadge from "../AgentBadge";
+
+describe("AgentBadge", () => {
+  it("renders the agent name as the label", () => {
+    render(<AgentBadge agentId="a1" name="Petr Novák" />);
+    expect(screen.getByText("Petr Novák")).toBeInTheDocument();
+  });
+
+  it("renders initials from the name when name is provided", () => {
+    render(<AgentBadge agentId="a1" name="Petr Novák" />);
+    expect(screen.getByText("PN")).toBeInTheDocument();
+  });
+
+  it("renders agent label and agentId-derived initials when name is null", () => {
+    render(<AgentBadge agentId="a1" name={null} />);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("A1")).toBeInTheDocument();
+    expect(screen.queryByText("?")).not.toBeInTheDocument();
+  });
+
+  it("renders ? initials and Agent label when both name and agentId are absent", () => {
+    render(<AgentBadge agentId={null} name={null} />);
+    expect(screen.getByText("?")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("uses the same color for the same agentId across renders", () => {
+    const { rerender } = render(<AgentBadge agentId="a1" name="Petr" />);
+    const first = screen.getByTestId("agent-badge").className;
+    rerender(<AgentBadge agentId="a1" name="Petr" />);
+    const second = screen.getByTestId("agent-badge").className;
+    expect(first).toBe(second);
+  });
+
+  it("renders different colors for different agentIds (sanity)", () => {
+    const { rerender } = render(<AgentBadge agentId="aaa" name="A" />);
+    const colorA = screen.getByTestId("agent-badge").className;
+    rerender(<AgentBadge agentId="zzz" name="Z" />);
+    const colorZ = screen.getByTestId("agent-badge").className;
+    expect(colorA).not.toBe(colorZ);
+  });
+});
+```
+
+Key changes:
+- `"renders the initials when no name is provided"` → replaced by two tests: one for `name=null, agentId set` and one for both absent
+- The double-`?` test (`getAllByText("?").length >= 1`) is gone; the new test asserts no `?` appears when `agentId` is set
+
+- [ ] **Step 2: Run the tests to confirm RED**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: `"renders agent label and agentId-derived initials when name is null"` fails (current code renders `?` twice), `"renders ? initials and Agent label when both name and agentId are absent"` fails (current code renders `?` as label too).
+
+---
+
+## Task 8: Fix `AgentBadge.tsx` — eliminate double `?` (TDD GREEN)
+
+**Files:**
+- Modify: `frontend/src/components/customer-support/smartsupp/AgentBadge.tsx`
+
+- [ ] **Step 1: Replace the component file**
+
+```tsx
+import React from "react";
+import { getAgentColor } from "./utils/agentColor";
+
+interface AgentBadgeProps {
+  agentId?: string | null;
+  name?: string | null;
+  showInitials?: boolean;
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  return parts.length >= 2
+    ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+    : name.slice(0, 2).toUpperCase();
+}
+
+const AgentBadge: React.FC<AgentBadgeProps> = ({ agentId, name, showInitials = true }) => {
+  const color = getAgentColor(agentId);
+  const trimmedName = name?.trim();
+  const hasName = !!trimmedName;
+  const initials = hasName
+    ? getInitials(trimmedName!)
+    : agentId
+        ? agentId.slice(0, 2).toUpperCase()
+        : "?";
+  const label = hasName ? trimmedName! : "Agent";
+
+  return (
+    <span
+      data-testid="agent-badge"
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${color.bg} ${color.text}`}
+    >
+      {showInitials && (
+        <span className={`inline-flex items-center justify-center w-4 h-4 rounded-full ring-1 ${color.ring} bg-white text-[10px] font-semibold`}>
+          {initials}
+        </span>
+      )}
+      <span className="truncate max-w-[10rem]">{label}</span>
+    </span>
+  );
+};
+
+export default AgentBadge;
+```
+
+Changes from original:
+- `getInitials` now accepts `string` (not `string | null | undefined`) — caller is responsible for the null check
+- `trimmedName` / `hasName` variables introduced
+- `initials` derived from `agentId` when name absent
+- `label` is `"Agent"` when name absent (not `initials`, so never a `?` label)
+
+- [ ] **Step 2: Run AgentBadge tests (GREEN)**
+
+```bash
+cd frontend && npx vitest run \
+  src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx \
+  2>&1 | tail -20
+```
+
+Expected: All 6 tests pass, 0 failures.
+
+- [ ] **Step 3: Run the full frontend test suite to catch any snapshot or snapshot-like regressions**
+
+```bash
+cd frontend && npx vitest run 2>&1 | tail -30
+```
+
+Expected: All tests pass (or only pre-existing failures). If any other test breaks because it asserts `"?"` text from `AgentBadge`, update that assertion to `"Agent"` / the agentId-derived initials.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ..
+git add \
+  frontend/src/components/customer-support/smartsupp/AgentBadge.tsx \
+  frontend/src/components/customer-support/smartsupp/__tests__/AgentBadge.test.tsx
+git commit -m "fix(smartsupp): derive initials from agentId when name is absent, show Agent label instead of double ?"
+```
+
+---
+
+## Task 9: Final build gates
+
+- [ ] **Step 1: Frontend build + lint**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -20
+npm run lint 2>&1 | tail -20
+```
+
+Expected: Build succeeds, no lint errors.
+
+- [ ] **Step 2: Full backend build**
+
+```bash
+cd .. && dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: Build succeeded, 0 Error(s).
+
+- [ ] **Step 3: Run all backend Smartsupp tests one final time**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests \
+  --filter FullyQualifiedName~Smartsupp
+```
+
+Expected: All pass.
+
+---
+
+## Verification Checklist (manual, against staging)
+
+After deploying:
+
+- [ ] Open a conversation for a guest/unregistered visitor (no Shoptet customer profile). No toast appears. The Shoptet block on the right side is absent.
+- [ ] Open a conversation for a registered Shoptet customer. "Shoptet Zákazník" section appears. "Poslední objednávky" is empty (expected until a future order-lookup path lands).
+- [ ] Open a conversation whose outgoing reply has `authorName = null` but `agentId` set. Badge shows 2-letter initials from the agentId and label `"Agent"`. No two `?` side-by-side.
+- [ ] Watch the browser network panel: no `GET /api/orders?page=1&itemsPerPage=…` calls fire when opening conversations.

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankRepository.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Anela.Heblo.Domain.Features.Photobank;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Anela.Heblo.Application.Features.Photobank
 {
@@ -67,14 +68,21 @@ namespace Anela.Heblo.Application.Features.Photobank
             if (withoutTags)
                 query = query.Where(p => !p.Tags.Any());
 
-            var total = await query.CountAsync(cancellationToken);
-            var items = await query
-                .OrderByDescending(p => p.ModifiedAt)
-                .Skip((page - 1) * pageSize)
-                .Take(pageSize)
-                .ToListAsync(cancellationToken);
+            try
+            {
+                var total = await query.CountAsync(cancellationToken);
+                var items = await query
+                    .OrderByDescending(p => p.ModifiedAt)
+                    .Skip((page - 1) * pageSize)
+                    .Take(pageSize)
+                    .ToListAsync(cancellationToken);
 
-            return (items, total);
+                return (items, total);
+            }
+            catch (PostgresException ex) when (useRegex && ex.SqlState == "2201B")
+            {
+                throw new InvalidPhotoSearchPatternException(search ?? string.Empty);
+            }
         }
 
         public async Task<int> CountFilteredPhotosAsync(

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
@@ -6,7 +6,6 @@ using Anela.Heblo.Application.Features.Photobank.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Photobank;
 using MediatR;
-using Npgsql;
 
 namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
 {
@@ -40,7 +39,7 @@ namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos
                     PageSize = request.PageSize,
                 };
             }
-            catch (PostgresException ex) when (request.UseRegex && ex.SqlState == "2201B")
+            catch (InvalidPhotoSearchPatternException)
             {
                 return new GetPhotosResponse
                 {

--- a/backend/src/Anela.Heblo.Domain/Features/Photobank/InvalidPhotoSearchPatternException.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Photobank/InvalidPhotoSearchPatternException.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Domain.Features.Photobank
+{
+    public class InvalidPhotoSearchPatternException : Exception
+    {
+        public string Pattern { get; }
+
+        public InvalidPhotoSearchPatternException(string pattern)
+            : base($"Invalid search pattern: {pattern}")
+        {
+            Pattern = pattern;
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Photobank/GetPhotosHandlerTests.cs
@@ -161,4 +161,26 @@ public class GetPhotosHandlerTests
 
         _repositoryMock.Verify(r => r.GetPhotosAsync(null, @"^report_\d+", true, false, 1, 48, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async System.Threading.Tasks.Task Handle_InvalidRegexPattern_ReturnsStructuredError()
+    {
+        // Arrange
+        const string invalidPattern = "(unclosed";
+
+        _repositoryMock
+            .Setup(r => r.GetPhotosAsync(null, invalidPattern, true, false, 1, 48, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidPhotoSearchPatternException(invalidPattern));
+
+        var request = new GetPhotosRequest { Search = invalidPattern, UseRegex = true };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.PhotobankInvalidRegexPattern);
+        result.Params.Should().ContainKey("pattern");
+        result.Params!["pattern"].Should().Be(invalidPattern);
+    }
 }


### PR DESCRIPTION
Photobank

## Finding
`GetPhotosHandler` has a direct dependency on the Npgsql infrastructure library:

```csharp
// backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetPhotos/GetPhotosHandler.cs
using Npgsql;   // line 9

// ...
catch (PostgresException ex) when (request.UseRegex && ex.SqlState == "2201B")   // line 43
{
    return new GetPhotosResponse
    {
        Success = false,
        ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern,
        // ...
    };
}
```

The handler catches `PostgresException` with SQL state `2201B` (invalid regular expression) to return a structured error response when the user supplies a bad regex.

## Why it matters
- Clean Architecture requires the Application layer to be infrastructure-agnostic. Importing `Npgsql` in the Application layer means the Application project now has a hard compile-time dependency on a specific database driver.
- The intent — converting an infrastructure exception into a domain-level error response — is correct, but the *location* is wrong.
- If the database is ever swapped or the repository is tested with an in-memory provider, this catch clause silently stops working without any compile error.

## Suggested fix
Define a domain exception in the repository contract (Domain layer) and throw it from the repository when the invalid-regex error is detected:

```csharp
// Domain/Features/Photobank/ — new file
public class InvalidPhotoSearchPatternException : Exception
{
    public string Pattern { get; }
    public InvalidPhotoSearchPatternException(string pattern)
        : base($"Invalid search pattern: {pattern}") => Pattern = pattern;
}
```

In `PhotobankRepository.BuildFilterQuery` (or `GetPhotosAsync`), catch `PostgresException` with `SqlState == "2201B"` and rethrow as `InvalidPhotoSearchPatternException`.

`GetPhotosHandler` then catches `InvalidPhotoSearchPatternException` — no `Npgsql` import needed:
```csharp
catch (InvalidPhotoSearchPatternException ex)
{
    return new GetPhotosResponse { Success = false, ErrorCode = ErrorCodes.PhotobankInvalidRegexPattern, ... };
}
```

Remove `using Npgsql;` from the handler entirely.

---
_Filed by daily arch-review routine on 2026-05-21._

---

Closes #1522

### Tokens used
12084931
