### PR TITLE
feat: add unique ID to expedition list PDF header and archive screen

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolData.cs
@@ -5,6 +5,7 @@ namespace Anela.Heblo.Adapters.ShoptetApi.Expedition;
 public class ExpeditionProtocolData
 {
     public string CarrierDisplayName { get; set; } = null!;
+    public string ListId { get; set; } = string.Empty;
     public List<ExpeditionOrder> Orders { get; set; } = new();
 }
 

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ExpeditionProtocolDocument.cs
@@ -55,6 +55,12 @@ public class ExpeditionProtocolDocument : IDocument
             page.Margin(1f, Unit.Centimetre);
             page.DefaultTextStyle(x => x.FontSize(8));
 
+            if (!string.IsNullOrWhiteSpace(_data.ListId))
+            {
+                page.Header().AlignRight().Text($"ID: {_data.ListId}")
+                    .FontSize(7).FontColor(Colors.Grey.Darken1);
+            }
+
             page.Content().Column(col =>
             {
                 // Title

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
@@ -128,14 +128,17 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
                     locationByCode,
                     coolingByCode);
 
+                var fileName = $"{timestamp}_{method.Name}_{batchIndex}.pdf";
+                var listId = Path.GetFileNameWithoutExtension(fileName);
+
                 var data = new ExpeditionProtocolData
                 {
                     CarrierDisplayName = carrierDisplayName,
+                    ListId = listId,
                     Orders = batch,
                 };
 
                 var pdfBytes = _generateDocument(data);
-                var fileName = $"{timestamp}_{method.Name}_{batchIndex}.pdf";
                 var filePath = Path.Combine(Path.GetTempPath(), fileName);
                 await File.WriteAllBytesAsync(filePath, pdfBytes, cancellationToken);
                 exportedFiles.Add(filePath);

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/Contracts/ExpeditionListItemDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/Contracts/ExpeditionListItemDto.cs
@@ -4,6 +4,7 @@ public class ExpeditionListItemDto
 {
     public string BlobPath { get; set; } = string.Empty;
     public string FileName { get; set; } = string.Empty;
+    public string ListId { get; set; } = string.Empty;
     public DateTimeOffset? CreatedOn { get; set; }
     public long? ContentLength { get; set; }
 }

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs
@@ -32,6 +32,7 @@ public class GetExpeditionListsByDateHandler : IRequestHandler<GetExpeditionList
             {
                 BlobPath = b.Name,
                 FileName = b.FileName,
+                ListId = Path.GetFileNameWithoutExtension(b.FileName),
                 CreatedOn = b.CreatedOn,
                 ContentLength = b.ContentLength
             })

--- a/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ExpeditionProtocolDocumentTests.cs
@@ -50,6 +50,7 @@ public class ExpeditionProtocolDocumentTests
         new()
         {
             CarrierDisplayName = "PPL (do ruky)",
+            ListId = "20260522-143012_PPL_0",
             Orders = new List<ExpeditionOrder>
             {
                 new()
@@ -515,6 +516,32 @@ public class ExpeditionProtocolDocumentTests
                 },
             },
         };
+
+        var act = () => ExpeditionProtocolDocument.Generate(data);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Generate_WithListId_DoesNotThrow()
+    {
+        // Setting ListId enables the page header. Visual inspection lives in
+        // Generate_SampleData_SavesToDiskForVisualInspection (which sets ListId on BuildSampleData).
+        var data = BuildData();
+        data.ListId = "20260522-143012_DPD_0";
+
+        var act = () => ExpeditionProtocolDocument.Generate(data);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Generate_WithEmptyListId_DoesNotThrow()
+    {
+        // Empty ListId must skip the header without error (back-compat for callers
+        // that have not been updated to provide an id).
+        var data = BuildData();
+        data.ListId = string.Empty;
 
         var act = () => ExpeditionProtocolDocument.Generate(data);
 

--- a/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs
@@ -45,6 +45,8 @@ public class GetExpeditionListsByDateHandlerTests
         Assert.Equal("picking-list-001.pdf", result.Items[0].FileName);
         Assert.Equal($"{date}/picking-list-001.pdf", result.Items[0].BlobPath);
         Assert.Equal(512000, result.Items[0].ContentLength);
+        Assert.Equal("picking-list-001", result.Items[0].ListId);
+        Assert.Equal("picking-list-002", result.Items[1].ListId);
     }
 
     [Fact]

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -6,6 +6,7 @@ import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
 export interface ExpeditionListItemDto {
   blobPath: string;
   fileName: string;
+  listId: string;
   createdOn: string | null;
   contentLength: number | null;
 }

--- a/frontend/src/pages/ExpeditionListArchivePage.tsx
+++ b/frontend/src/pages/ExpeditionListArchivePage.tsx
@@ -229,6 +229,7 @@ const ExpeditionListArchivePage: React.FC = () => {
               <table className="min-w-full divide-y divide-gray-200">
                 <thead className="bg-gray-50">
                   <tr>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">ID</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Soubor</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Nahráno</th>
                     <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Velikost</th>
@@ -238,6 +239,9 @@ const ExpeditionListArchivePage: React.FC = () => {
                 <tbody className="bg-white divide-y divide-gray-100">
                   {itemsData.items.map((item) => (
                     <tr key={item.blobPath} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 text-sm font-mono text-gray-700 whitespace-nowrap">
+                        {item.listId}
+                      </td>
                       <td className="px-4 py-3 text-sm text-gray-900 flex items-center gap-2">
                         <FileText size={16} className="text-red-400 flex-shrink-0" />
                         {item.fileName}


### PR DESCRIPTION
Surfaces the existing filename-stem as a human-readable ID (e.g. `20260522-143012_DPD_0`) in two places so a printed sheet can be matched instantly to its archive entry.

- **PDF**: ID rendered top-right in a small grey `page.Header()` on every page, so it survives split sheets
- **Archive screen**: new first "ID" column (monospaced) on `/logistics/expedition-archive`
- **DTO**: `ExpeditionListItemDto.ListId` populated via `Path.GetFileNameWithoutExtension(fileName)`; frontend type updated to match
- **Reprints** automatically keep the original ID — the reprint handler streams the stored blob byte-for-byte

No new infrastructure: reuses the timestamp-based filename that was already unique.