### PR TITLE
feat: Restore Clean Architecture Boundary in PurchaseModule DI Registration

### DIFF
--- a/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/arch-review.r1.md
+++ b/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/arch-review.r1.md
@@ -1,0 +1,147 @@
+I have full context now. Generating the architecture review.
+
+```markdown
+# Architecture Review: Restore Clean Architecture Boundary in PurchaseModule DI Registration
+
+## Skip Design: true
+
+No UI/UX work — pure backend DI relocation. No visual components, screens, layouts, or HTTP contracts change.
+
+## Architectural Fit Assessment
+
+The proposed change is a direct, surgical correction that brings `PurchaseModule.cs` into line with patterns already in force across the codebase. Verification against the actual code confirms every assumption in the spec:
+
+- **Pattern already established.** `PersistenceModule.cs:127-163` registers 13 other repository pairs as `services.AddScoped<IFoo, FooRepository>()` (one-liner, no factory lambda). The Purchase repo is the sole deviation.
+- **Composition order is safe.** `API/Program.cs` calls `AddPersistenceServices` before `AddApplicationServices` → `AddPurchaseModule`. Whether `IPurchaseOrderRepository` is registered in the Persistence call or the Application call, both fire before any handler resolves it. There is no ordering coupling.
+- **DI validation is enforced in tests.** `CompositionRootTests.ServiceContainer_ValidateOnBuild_NoLifetimeMismatchesOrUnresolvableServices` runs `ValidateOnBuild = true; ValidateScopes = true` against the real `Program` graph. Any duplicate or missing registration will fail CI immediately. This is the strongest possible safety net for this refactor.
+- **Test override seam is preserved.** `PurchaseOrdersTestFactory` (test file lines 564-585) does not override `IPurchaseOrderRepository`; it relies on the host's default registration plus the in-memory `ApplicationDbContext`. Moving the registration to `PersistenceModule` keeps that seam working because `AddPersistenceServices` runs first in the test host as well.
+- **The `InMemoryPurchaseOrderRepository` (Application/Features/Purchase/Services) is not currently DI-registered** — `grep` confirms it is referenced only inside tests, not as a default. The Persistence-layer EF repository is genuinely the only production binding, so relocation does not silently swap behavior.
+
+The change has zero behavioral surface and high architectural value. Recommend proceeding exactly as the spec states.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before (violation):
+
+  API/Program.cs
+       │
+       ├─► AddPersistenceServices()  → registers ApplicationDbContext + 13 repos
+       │
+       └─► AddApplicationServices()
+              └─► AddPurchaseModule()
+                     │   imports Anela.Heblo.Persistence       ← VIOLATION
+                     │   imports Anela.Heblo.Persistence.Purchase.PurchaseOrders
+                     ├── IPurchaseOrderRepository → factory(provider) new PurchaseOrderRepository(ctx)
+                     ├── IPurchaseOrderNumberGenerator → PurchaseOrderNumberGenerator
+                     ├── IStockSeverityCalculator → StockSeverityCalculator
+                     ├── IValidator<Create/Update PurchaseOrderRequest>
+                     └── RegisterTile<LowStockEfficiencyTile>
+
+After (clean):
+
+  API/Program.cs
+       │
+       ├─► AddPersistenceServices()
+       │      └── …
+       │      └── // Purchase repositories
+       │            services.AddScoped<IPurchaseOrderRepository, PurchaseOrderRepository>();
+       │
+       └─► AddApplicationServices()
+              └─► AddPurchaseModule()              ← no Persistence imports
+                     ├── IPurchaseOrderNumberGenerator → PurchaseOrderNumberGenerator
+                     ├── IStockSeverityCalculator → StockSeverityCalculator
+                     ├── IValidator<Create/Update PurchaseOrderRequest>
+                     └── RegisterTile<LowStockEfficiencyTile>
+```
+
+The dependency arrow `Application → Persistence` for *this module's wiring* is eliminated. The project-level reference remains (other modules still use it; out of scope per spec).
+
+### Key Design Decisions
+
+#### Decision 1: Use concrete-type registration, not factory lambda
+**Options considered:**
+- (A) Port the existing factory `provider => new PurchaseOrderRepository(provider.GetRequiredService<ApplicationDbContext>())` verbatim into `PersistenceModule`.
+- (B) Collapse to the conventional `services.AddScoped<IPurchaseOrderRepository, PurchaseOrderRepository>()`.
+
+**Chosen approach:** (B).
+
+**Rationale:** Once both `PurchaseOrderRepository` and `ApplicationDbContext` live in the same assembly, the factory adds no value — DI will satisfy the constructor parameter via normal resolution. Every other repo in `PersistenceModule` (lines 128-163) uses the one-liner. Matching the established pattern improves readability and removes a needless closure.
+
+#### Decision 2: Where in `PersistenceModule` to place the registration
+**Options considered:**
+- (A) At the end of the repository block (after Feature Flags).
+- (B) Grouped by module, ordered alphabetically.
+- (C) In a new `// Purchase repositories` comment block, slotted by feature grouping similar to neighboring sections (Bank, Stock, KnowledgeBase, etc.).
+
+**Chosen approach:** (C). Insert immediately after one of the existing single-line module groups (e.g., after "Background Jobs repositories" or "Stock repositories"). The spec mandates the `// Purchase repositories` comment header.
+
+**Rationale:** The existing file organizes registrations by feature module with a one-line comment header per group. Following that convention keeps the file self-consistent and discoverable for future module cleanups.
+
+#### Decision 3: Do not touch `InMemoryPurchaseOrderRepository`
+**Options considered:**
+- (A) Delete the unused class while editing the area.
+- (B) Leave it untouched.
+
+**Chosen approach:** (B).
+
+**Rationale:** It is not in this brief's scope, `CLAUDE.md` mandates surgical changes, and the class may be intended for future test wiring. If it is genuinely dead, it should be removed by a separate cleanup finding, not bundled here.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Two existing files modified:
+
+```
+backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs  (edit: remove 2 usings + 5 lines of registration)
+backend/src/Anela.Heblo.Persistence/PersistenceModule.cs                 (edit: add 2 lines — comment + registration)
+```
+
+### Interfaces and Contracts
+
+No interface or contract changes. The contract `IPurchaseOrderRepository` already lives in `backend/src/Anela.Heblo.Domain/Features/Purchase/IPurchaseOrderRepository.cs` (correct location — Domain layer) and is unchanged. `PurchaseOrderRepository` constructor signature `(ApplicationDbContext context)` is unchanged.
+
+### Data Flow
+
+Resolution path is identical to today's behavior:
+
+```
+Handler (e.g. CreatePurchaseOrderHandler)
+   ├─ ctor: IPurchaseOrderRepository repo  ──► resolved by DI
+                                                  │
+                                                  ▼
+                                           PurchaseOrderRepository
+                                                  │
+                                                  ▼  ctor: ApplicationDbContext context
+                                           ApplicationDbContext (Scoped)
+                                                  │
+                                                  ▼  uses
+                                           NpgsqlDataSource (Singleton, in non-InMemory mode)
+```
+
+Only the *registration site* changes. Resolution graph, lifetimes (Scoped for both repo and context), and DbContext options (NpgsqlDataSource singleton + interceptors) are untouched.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Duplicate `IPurchaseOrderRepository` registration if old line is not removed | High | `CompositionRootTests.ValidateOnBuild` will not fail on duplicates per se, but a manual `grep -rn "IPurchaseOrderRepository" backend/src/**/*.cs` after the edit will confirm exactly one registration site. Also: `PurchaseOrdersControllerTests` runtime resolution would surface any mismatch immediately. |
+| `PurchaseModule.cs` accidentally left with a stale `using Anela.Heblo.Persistence*` directive | Medium | Spec-mandated verification: `grep -n "Anela\.Heblo\.Persistence" backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` must return no matches. `dotnet format` will also flag unused usings. |
+| Test factory `PurchaseOrdersTestFactory` silently loses its repository binding | Low | The factory does not override `IPurchaseOrderRepository`; it relies on the host registration. Since `AddPersistenceServices` runs first in both `Program.cs` and `HebloWebApplicationFactory`, the binding remains. `PurchaseOrdersControllerTests` CRUD coverage will catch any breakage. |
+| Hidden consumer in `InMemoryPurchaseOrderRepository` or elsewhere that assumed registration from `PurchaseModule` | Low | `grep` confirms no production code registers or references `InMemoryPurchaseOrderRepository`. No risk. |
+| Future modules following the wrong pattern by copying old `PurchaseModule.cs` | Low | The cleanup itself removes the bad exemplar. Other ~20 violations are tracked separately per the spec's Out of Scope. |
+
+## Specification Amendments
+
+None required. The spec is precise, scoped tightly, and matches the actual codebase verbatim. The few minor refinements worth tracking during implementation but not changing the spec:
+
+1. **Recommended placement** in `PersistenceModule.cs`: insert after line 141 (`// Background Jobs repositories` block) or after line 138 (`// Stock repositories` block) — either keeps related domain groupings adjacent. The spec does not pin a line and should not.
+2. **Verification command** for FR-2 in spec is correct; suggest also running `dotnet format --verify-no-changes` on `backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` to catch any leftover blank-line drift after the using removal.
+
+## Prerequisites
+
+None. No migrations, configuration, infrastructure, or upstream PRs are required. The change is self-contained and runs against the existing `dotnet build` + `dotnet test` pipeline. Validation gate is `CompositionRootTests.ServiceContainer_ValidateOnBuild_NoLifetimeMismatchesOrUnresolvableServices` plus the existing `PurchaseOrdersControllerTests` suite — both already in CI.
+```

--- a/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/brief.md
+++ b/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/brief.md
@@ -1,0 +1,28 @@
+## Module
+Purchase
+
+## Finding
+`PurchaseModule.cs` is an Application-layer file that imports and directly references types from the Persistence (Infrastructure) layer:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs
+using Anela.Heblo.Persistence;                                    // line 7
+using Anela.Heblo.Persistence.Purchase.PurchaseOrders;            // line 8
+...
+services.AddScoped<IPurchaseOrderRepository>(provider =>
+{
+    var context = provider.GetRequiredService<ApplicationDbContext>();  // Persistence type
+    return new PurchaseOrderRepository(context);                        // Persistence type
+});
+```
+
+The Application layer must not depend on the Infrastructure/Persistence layer. That dependency is supposed to flow in the opposite direction (Persistence implements interfaces defined in Domain/Application). The DI wiring that binds `IPurchaseOrderRepository` → `PurchaseOrderRepository` belongs in `PersistenceModule.cs` or at the composition root (API layer), not in the Application module registration.
+
+## Why it matters
+This is a direct violation of the Clean Architecture dependency rule: Application → Infrastructure is forbidden. It couples the Application layer to a concrete database implementation, making it impossible to test Application logic without the Persistence project. It also defeats the purpose of the repository interface abstraction.
+
+## Suggested fix
+Move the `IPurchaseOrderRepository` → `PurchaseOrderRepository` DI registration to `backend/src/Anela.Heblo.Persistence/PersistenceModule.cs`, following the pattern used by other modules (e.g. the Catalog or Journal repositories registered there). Remove the `using Anela.Heblo.Persistence` and `using Anela.Heblo.Persistence.Purchase.PurchaseOrders` imports from `PurchaseModule.cs` entirely.
+
+---
+_Filed by daily arch-review routine on 2026-05-22._

--- a/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/impl/main.r1.md
+++ b/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/impl/main.r1.md
@@ -1,0 +1,12 @@
+Tests pass (154/154). One commit ahead of `main`. **Step 4: Present options**
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/spec.r1.md
+++ b/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/spec.r1.md
@@ -1,0 +1,127 @@
+# Specification: Restore Clean Architecture Boundary in PurchaseModule DI Registration
+
+## Summary
+The Application-layer `PurchaseModule.cs` currently imports and directly instantiates Persistence-layer types (`ApplicationDbContext`, `PurchaseOrderRepository`) to wire up `IPurchaseOrderRepository`. This violates the Clean Architecture dependency rule (Application must not depend on Infrastructure/Persistence). The fix moves the `IPurchaseOrderRepository` → `PurchaseOrderRepository` DI registration into `PersistenceModule.cs` and removes the offending `using Anela.Heblo.Persistence*` imports from `PurchaseModule.cs`.
+
+## Background
+The codebase follows Clean Architecture with four layers: Domain → Application → Persistence/Infrastructure → API. Dependencies must flow inward: Persistence implements interfaces defined in Domain/Application, and the composition root (API layer via `AddPersistenceServices` + `AddApplicationServices`) wires them together.
+
+`backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs:7-23` breaks this rule:
+
+```csharp
+using Anela.Heblo.Persistence;                          // Persistence namespace
+using Anela.Heblo.Persistence.Purchase.PurchaseOrders;  // Persistence namespace
+...
+services.AddScoped<IPurchaseOrderRepository>(provider =>
+{
+    var context = provider.GetRequiredService<ApplicationDbContext>();
+    return new PurchaseOrderRepository(context);
+});
+```
+
+The Application project references the Persistence project to compile, making Application logic untestable without the Persistence assembly and defeating the purpose of the `IPurchaseOrderRepository` abstraction.
+
+All other repository registrations already live in `PersistenceModule.cs` (`backend/src/Anela.Heblo.Persistence/PersistenceModule.cs:127-163`) — `IUserDashboardSettingsRepository`, `IBankStatementImportRepository`, `IArticleRepository`, etc. The Purchase repository is the deviation.
+
+This finding was filed by the daily arch-review routine on 2026-05-22.
+
+## Functional Requirements
+
+### FR-1: Move `IPurchaseOrderRepository` registration to PersistenceModule
+The factory registration that binds `IPurchaseOrderRepository` to `PurchaseOrderRepository` (resolving `ApplicationDbContext` via the provider) must be relocated from `PurchaseModule.AddPurchaseModule` to `PersistenceModule.AddPersistenceServices`.
+
+The registration in `PersistenceModule.cs` should follow the same pattern used by the surrounding repository registrations (concrete-class registration; the factory lambda is no longer required because `PurchaseOrderRepository` and `ApplicationDbContext` are now in the same assembly):
+
+```csharp
+// Purchase repositories
+services.AddScoped<IPurchaseOrderRepository, PurchaseOrderRepository>();
+```
+
+**Acceptance criteria:**
+- `IPurchaseOrderRepository` is registered exactly once at composition time, inside `AddPersistenceServices` in `backend/src/Anela.Heblo.Persistence/PersistenceModule.cs`.
+- The scope (`Scoped`) is preserved.
+- `PurchaseModule.cs` no longer contains any registration for `IPurchaseOrderRepository`.
+- The registration appears in a section commented `// Purchase repositories` (matching the existing style for other modules in `PersistenceModule.cs`).
+
+### FR-2: Remove Persistence imports from PurchaseModule.cs
+After FR-1, the `PurchaseModule.cs` file must have no references to types in `Anela.Heblo.Persistence.*` namespaces.
+
+**Acceptance criteria:**
+- `using Anela.Heblo.Persistence;` is removed from `PurchaseModule.cs`.
+- `using Anela.Heblo.Persistence.Purchase.PurchaseOrders;` is removed from `PurchaseModule.cs`.
+- No other `Anela.Heblo.Persistence*` `using` directive is introduced.
+- `grep -n "Anela\.Heblo\.Persistence" backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` returns no matches.
+
+### FR-3: Preserve all other PurchaseModule registrations
+The remaining registrations in `PurchaseModule.AddPurchaseModule` must continue to function unchanged. These belong in the Application layer because they reference Application/Domain types only:
+
+- `IPurchaseOrderNumberGenerator` → `PurchaseOrderNumberGenerator` (Domain type)
+- `IStockSeverityCalculator` → `StockSeverityCalculator` (Application service)
+- `IValidator<CreatePurchaseOrderRequest>` → `CreatePurchaseOrderRequestValidator`
+- `IValidator<UpdatePurchaseOrderRequest>` → `UpdatePurchaseOrderRequestValidator`
+- `LowStockEfficiencyTile` via `RegisterTile<>`
+
+**Acceptance criteria:**
+- All five registrations above remain in `PurchaseModule.cs` with identical lifetimes and target types.
+- `PurchaseModule.AddPurchaseModule` continues to return `IServiceCollection` and is still invoked from `ApplicationModule.cs:78`.
+
+### FR-4: Preserve runtime behavior end-to-end
+The end-to-end Purchase Order flow (create / read / update / list / status-change) must behave identically before and after the change. This is a pure DI relocation, not a behavioral change.
+
+**Acceptance criteria:**
+- Application starts under both Development and Production configurations without DI validation errors.
+- DI validation (`ValidateScopes`/`ValidateOnBuild` as currently configured) does not report a missing or duplicate `IPurchaseOrderRepository` registration.
+- All existing tests in `backend/test/Anela.Heblo.Tests/Features/Purchase/**` and `backend/test/Anela.Heblo.Tests/Controllers/PurchaseOrdersControllerTests.cs` continue to pass without modification.
+- The integration test factory `PurchaseOrdersTestFactory` (which currently relies on the default repository registration coming from the host) still resolves `IPurchaseOrderRepository` against the EF Core in-memory `ApplicationDbContext`.
+
+### FR-5: Composition root invocation order remains valid
+`API/Program.cs:74` calls `AddPersistenceServices` before `AddApplicationServices` (which calls `AddPurchaseModule`). The new registration location must remain compatible with this order. Since `PurchaseModule` no longer registers `IPurchaseOrderRepository`, no ordering coupling is introduced.
+
+**Acceptance criteria:**
+- No change required in `Program.cs` invocation order.
+- The Application project's reference to the Persistence project may remain (other application modules still reference Persistence; that broader violation is out of scope — see "Out of Scope"). What matters is that `PurchaseModule.cs` itself no longer imports Persistence namespaces.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact. The relocation changes only the DI registration site; resolution semantics, lifetime (`Scoped`), and instantiation cost are unchanged.
+
+### NFR-2: Security
+No security impact. No auth surface, configuration, secret handling, or data validation is modified.
+
+### NFR-3: Build & Static Analysis
+- `dotnet build` for the full solution must succeed with no new warnings or errors.
+- `dotnet format` must report no formatting drift on the modified files.
+- No new analyzer suppressions are introduced.
+
+### NFR-4: Testability
+After the change, the Application project's compilation does not require any reference to a concrete `ApplicationDbContext` for the Purchase feature wiring. Unit tests targeting Application/Purchase handlers already mock `IPurchaseOrderRepository`; this NFR captures that the abstraction is intact.
+
+## Data Model
+Not affected. No schema, entity, migration, or column change. The `PurchaseOrder` entity, its `Lines` and `History`, and `ApplicationDbContext`'s `DbSet<PurchaseOrder>` configuration remain as-is.
+
+## API / Interface Design
+Not affected. No HTTP endpoint, request/response DTO, MediatR contract, or public service signature changes. The change is purely an internal DI composition refactor.
+
+## Dependencies
+- Existing types touched (read-only references): `Anela.Heblo.Domain.Features.Purchase.IPurchaseOrderRepository`, `Anela.Heblo.Persistence.Purchase.PurchaseOrders.PurchaseOrderRepository`, `Anela.Heblo.Persistence.ApplicationDbContext`.
+- Files modified:
+  - `backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` (remove registration + imports)
+  - `backend/src/Anela.Heblo.Persistence/PersistenceModule.cs` (add registration)
+- Tests exercised (no modifications expected):
+  - `backend/test/Anela.Heblo.Tests/Features/Purchase/*`
+  - `backend/test/Anela.Heblo.Tests/Controllers/PurchaseOrdersControllerTests.cs`
+  - `backend/test/Anela.Heblo.Tests/Persistence/PersistenceModuleTests.cs`
+
+## Out of Scope
+- **Other Application modules with the same violation.** A grep shows ~20 other files in `backend/src/Anela.Heblo.Application/**` that `using Anela.Heblo.Persistence*` (e.g. `SmartsuppModule.cs`, `PhotobankModule.cs`, `CatalogModule.cs`, `ManufactureModule.cs`, etc.). Those are not in this brief and must not be touched. Each will be addressed by its own arch-review finding.
+- **Removing the Application → Persistence project reference.** Until every Application module is cleaned up, the project-level reference cannot be removed. That is a follow-up only after all per-module fixes land.
+- **Refactoring `PurchaseOrderRepository` itself**, `BaseRepository<T,TKey>`, or any of its methods.
+- **Changing `IPurchaseOrderNumberGenerator`, `IStockSeverityCalculator`, or any validator** — these correctly stay in `PurchaseModule.cs`.
+- **Changing the EAN code generator branching** or any other unrelated `PersistenceModule.cs` logic.
+- **Integration test infrastructure** (`HebloWebApplicationFactory`, `PurchaseOrdersTestFactory`) — these are expected to keep working unchanged.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/task-plan.r1.md
+++ b/artifacts/feat-arch-review-purchase-purchasemodule-cs-i/task-plan.r1.md
@@ -1,0 +1,795 @@
+# Photobank Thumbnail Use Case Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the `PhotobankController.GetThumbnail` orchestration into a `GetThumbnail` MediatR use case, reduce the controller to a thin dispatch with an `IMediator`-only constructor, and preserve the endpoint's exact observable HTTP behaviour.
+
+**Architecture:** A new Vertical-Slice use case (`Features/Photobank/UseCases/GetThumbnail/{Request,Response,Handler}.cs`) owns the locator lookup, the Microsoft Graph call, and the infrastructure-exception translation. The handler returns a `GetThumbnailResponse : BaseResponse` carrying the stream + metadata on success and a discriminating `ErrorCodes` on failure (mirroring the three existing binary-download use cases — `GetShipmentLabelPdf`, `DownloadExpeditionList`, `GetManufactureProtocol`). The controller maps `ErrorCode → HTTP status + headers` explicitly (it does **not** route through `HandleResponse`, which has no 502/503 and wraps success in `Ok()`).
+
+**Tech Stack:** .NET 8, MediatR, ASP.NET Core MVC, xUnit + FluentAssertions + Moq. No new packages (MSAL is already a transitive reference of `Anela.Heblo.Application`, used by `UserManagement/Services/GraphService.cs` and others).
+
+---
+
+## Authoritative decision: response shape
+
+The architecture review **reverses spec Decision #2**. Follow the arch-review:
+
+- `GetThumbnailResponse` **inherits `BaseResponse`** (it does NOT use a bespoke `GetThumbnailOutcome` enum). Inheriting `BaseResponse` does not force a JSON success body — the controller still returns `FileStreamResult` on success, exactly as `ShipmentLabelsController.GetLabelPdf` returns `File(...)`.
+- Failures are discriminated by **four new `ErrorCodes` members**, not an enum.
+- The spec's *intent* — preserving the 502-vs-503-vs-404 distinction — is kept.
+
+## File map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` | Modify | Add 4 Photobank-thumbnail error codes (2610–2613) |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailRequest.cs` | Create | `IRequest<GetThumbnailResponse>` with `Id`, `Size` |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailResponse.cs` | Create | `BaseResponse` carrier: `Content`, `ContentType`, `ContentLength`, `RetryAfterSeconds` |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs` | Create | Locator lookup → Graph call → exception translation → result shaping + all logging |
+| `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` | Modify | Single-dep constructor; thin `GetThumbnail` dispatch + outcome→HTTP mapping |
+| `backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs` | Create | HTTP-free handler unit tests (all outcomes + stream identity + token threading) |
+| `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs` | Overwrite | Mock `IMediator` only; assert outcome→`IActionResult` + header mapping |
+
+**Verified facts the executor can rely on:**
+- `IPhotobankRepository.GetLocatorAsync(int, CancellationToken) → PhotoLocator?` exists (`Domain/Features/Photobank/IPhotobankRepository.cs:26`). `PhotoLocator(string DriveId, string SharePointFileId, DateTime ModifiedAt)`.
+- `IPhotobankGraphService.GetThumbnailAsync(string driveId, string fileId, ThumbnailSize size, CancellationToken) → GraphThumbnail?` exists (`Application/Features/Photobank/Services/IPhotobankGraphService.cs:54`).
+- `GraphThumbnail : IDisposable` with `Stream Content`, `string ContentType`, `long? ContentLength`; `Dispose()` disposes the `Stream`. `ThumbnailSize { Medium, Large }`. `GraphThrottledException.RetryAfter` is `TimeSpan?`.
+- `BaseResponse` (`Application/Shared`) has `bool Success`, `ErrorCodes? ErrorCode`, a default ctor (`Success = true`) and `protected BaseResponse(ErrorCodes errorCode, ...)`.
+- Photobank use-case files use **block-scoped** namespaces (`namespace X { ... }`) — match that style, not file-scoped.
+- The Application project has `<ImplicitUsings>` enabled (the sibling `GetShipmentLabelPdfResponse` uses `Stream?` with no `using System.IO;`).
+- MediatR auto-registers handlers via the existing assembly scan — no `PhotobankModule.cs` / DI change needed.
+
+---
+
+### Task 1: Add the four thumbnail error codes
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`
+
+- [ ] **Step 1: Add the error codes**
+
+In `ErrorCodes.cs`, find the Photobank block ending at `PhotobankInvalidRegexPattern = 2609,` (around line 285). Immediately after that line and before the `// Smartsupp module errors (27XX)` comment, insert:
+
+```csharp
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotobankThumbnailNotFound = 2610,
+    [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
+    PhotobankThumbnailThrottled = 2611,
+    [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
+    PhotobankThumbnailAuthUnavailable = 2612,
+    [HttpStatusCode(HttpStatusCode.InternalServerError)]
+    PhotobankThumbnailUpstream = 2613,
+```
+
+> Note: the `[HttpStatusCode(...)]` attributes are decorative for convention only — this endpoint maps `ErrorCode → status` explicitly in the controller and never calls `HandleResponse`. There is no 502 in the `HttpStatusCode` attribute set used here, so `PhotobankThumbnailUpstream` carries `InternalServerError`; the controller maps it to 502 directly.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat: add Photobank thumbnail error codes"
+```
+
+---
+
+### Task 2: Create the request and response contracts
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailResponse.cs`
+
+- [ ] **Step 1: Create `GetThumbnailResponse.cs`**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail
+{
+    public class GetThumbnailResponse : BaseResponse
+    {
+        public Stream? Content { get; set; }
+        public string? ContentType { get; set; }
+        public long? ContentLength { get; set; }
+
+        /// <summary>
+        /// Pre-rounded retry hint (seconds). Populated only on PhotobankThumbnailThrottled.
+        /// </summary>
+        public int? RetryAfterSeconds { get; set; }
+
+        public GetThumbnailResponse() : base()
+        {
+        }
+
+        public GetThumbnailResponse(ErrorCodes errorCode) : base(errorCode)
+        {
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create `GetThumbnailRequest.cs`**
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Services;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail
+{
+    public class GetThumbnailRequest : IRequest<GetThumbnailResponse>
+    {
+        public int Id { get; set; }
+        public ThumbnailSize Size { get; set; }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/
+git commit -m "feat: add GetThumbnail request and response contracts"
+```
+
+---
+
+### Task 3: Implement the handler (TDD)
+
+**Files:**
+- Test: `backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs`
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
+using Moq;
+using System.Net.Http;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public sealed class GetThumbnailHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock = new();
+    private readonly Mock<IPhotobankGraphService> _graphServiceMock = new();
+    private readonly Mock<ILogger<GetThumbnailHandler>> _loggerMock = new();
+
+    private GetThumbnailHandler CreateHandler() =>
+        new(_repositoryMock.Object, _graphServiceMock.Object, _loggerMock.Object);
+
+    private static GetThumbnailRequest Request(int id = 1, ThumbnailSize size = ThumbnailSize.Medium) =>
+        new() { Id = id, Size = size };
+
+    private void SetupLocator(PhotoLocator? locator, int id = 1) =>
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+    private void SetupGraph(PhotoLocator locator, Func<Mock<IPhotobankGraphService>, Moq.Language.Flow.ISetup<IPhotobankGraphService, Task<GraphThumbnail?>>> _ = null!)
+    {
+        // helper intentionally minimal; tests configure the graph mock directly
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenLocatorMissing()
+    {
+        // Arrange
+        SetupLocator(null);
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailNotFound);
+        _graphServiceMock.Verify(
+            g => g.GetThumbnailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ThumbnailSize>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenGraphReturnsNull()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GraphThumbnail?)null);
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsThrottledWithRoundedRetryAfter_WhenGraphThrottles()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GraphThrottledException(TimeSpan.FromSeconds(29.3)));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailThrottled);
+        response.RetryAfterSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsThrottledWithoutRetryAfter_WhenRetryAfterNull()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GraphThrottledException(null));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailThrottled);
+        response.RetryAfterSeconds.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsUpstream_WhenHttpRequestExceptionThrown()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("upstream error"));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailUpstream);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAuthUnavailable_WhenMsalExceptionThrown()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new MsalServiceException("invalid_client", "AADSTS7000215: Invalid client secret"));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailAuthUnavailable);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccessWithSameStream_WhenThumbnailReturned()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+        var thumbnail = new GraphThumbnail(stream, "image/jpeg", 12345L);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thumbnail);
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Content.Should().BeSameAs(stream);
+        response.ContentType.Should().Be("image/jpeg");
+        response.ContentLength.Should().Be(12345L);
+        response.Content!.CanRead.Should().BeTrue("the handler must not dispose the stream before the framework writes it");
+    }
+
+    [Fact]
+    public async Task Handle_PassesCancellationTokenThrough()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        using var cts = new CancellationTokenSource();
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, cts.Token))
+            .ReturnsAsync(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, cts.Token))
+            .ReturnsAsync((GraphThumbnail?)null);
+
+        // Act
+        await CreateHandler().Handle(Request(), cts.Token);
+
+        // Assert
+        _repositoryMock.Verify(r => r.GetLocatorAsync(1, cts.Token), Times.Once);
+        _graphServiceMock.Verify(
+            g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, cts.Token),
+            Times.Once);
+    }
+}
+```
+
+> Remove the unused `SetupGraph` helper before finishing if `dotnet format`/analyzers complain — it is included only as a no-op placeholder and the tests configure `_graphServiceMock` directly. Simpler: delete the `SetupGraph` method entirely; it is not referenced by any test. **Delete it now.**
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetThumbnailHandlerTests"`
+Expected: FAIL — compile error `The type or namespace name 'GetThumbnailHandler' could not be found` (the handler does not exist yet).
+
+- [ ] **Step 3: Implement the handler**
+
+Create `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs`:
+
+```csharp
+using System.Net.Http;
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail
+{
+    public class GetThumbnailHandler : IRequestHandler<GetThumbnailRequest, GetThumbnailResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+        private readonly IPhotobankGraphService _graphService;
+        private readonly ILogger<GetThumbnailHandler> _logger;
+
+        public GetThumbnailHandler(
+            IPhotobankRepository repository,
+            IPhotobankGraphService graphService,
+            ILogger<GetThumbnailHandler> logger)
+        {
+            _repository = repository;
+            _graphService = graphService;
+            _logger = logger;
+        }
+
+        public async Task<GetThumbnailResponse> Handle(
+            GetThumbnailRequest request,
+            CancellationToken cancellationToken)
+        {
+            var locator = await _repository.GetLocatorAsync(request.Id, cancellationToken);
+            if (locator is null)
+            {
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailNotFound);
+            }
+
+            GraphThumbnail? rawThumbnail;
+            try
+            {
+                rawThumbnail = await _graphService.GetThumbnailAsync(
+                    locator.DriveId, locator.SharePointFileId, request.Size, cancellationToken);
+            }
+            catch (GraphThrottledException ex)
+            {
+                _logger.LogWarning("Microsoft Graph thumbnail request throttled for photo {PhotoId}. RetryAfter: {RetryAfter}",
+                    request.Id, ex.RetryAfter);
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailThrottled)
+                {
+                    RetryAfterSeconds = ex.RetryAfter.HasValue
+                        ? (int)Math.Ceiling(ex.RetryAfter.Value.TotalSeconds)
+                        : null,
+                };
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "Upstream HTTP error fetching thumbnail for photo {PhotoId}", request.Id);
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailUpstream);
+            }
+            catch (MsalException ex)
+            {
+                _logger.LogError(ex, "Token acquisition failed for thumbnail {PhotoId}. MSAL error: {ErrorCode}", request.Id, ex.ErrorCode);
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailAuthUnavailable);
+            }
+
+            if (rawThumbnail is null)
+            {
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailNotFound);
+            }
+
+            // NFR-3: transfer stream ownership to the response. Do NOT dispose rawThumbnail
+            // (GraphThumbnail.Dispose() closes the underlying Stream); FileStreamResult disposes it after writing.
+            return new GetThumbnailResponse
+            {
+                Content = rawThumbnail.Content,
+                ContentType = rawThumbnail.ContentType,
+                ContentLength = rawThumbnail.ContentLength,
+            };
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetThumbnailHandlerTests"`
+Expected: PASS — 8 passed, 0 failed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs
+git commit -m "feat: add GetThumbnail handler with HTTP-free unit tests"
+```
+
+---
+
+### Task 4: Refactor the controller to a thin dispatch (TDD)
+
+**Files:**
+- Overwrite: `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`
+
+- [ ] **Step 1: Rewrite the controller test to mock `IMediator` only**
+
+Overwrite `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs` with:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail;
+using Anela.Heblo.Application.Shared;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public sealed class PhotobankControllerThumbnailTests
+{
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly PhotobankController _controller;
+
+    public PhotobankControllerThumbnailTests()
+    {
+        _controller = new PhotobankController(_mediatorMock.Object);
+        SetupHttpContext();
+    }
+
+    private void SetupHttpContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, "test-user") })),
+            RequestServices = services.BuildServiceProvider()
+        };
+
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+    }
+
+    private void SetupResponse(GetThumbnailResponse response) =>
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetThumbnailRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+    [Fact]
+    public async Task GetThumbnail_ReturnsNotFound_WhenResponseNotFound()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailNotFound));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503WithRetryAfter_WhenThrottledWithHint()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailThrottled) { RetryAfterSeconds = 30 });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers["Retry-After"].ToString().Should().Be("30");
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503WithoutRetryAfter_WhenThrottledWithoutHint()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailThrottled) { RetryAfterSeconds = null });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers.ContainsKey("Retry-After").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503_WhenAuthUnavailable()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailAuthUnavailable));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers.ContainsKey("Retry-After").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns502_WhenUpstreamError()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailUpstream));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns200WithCacheHeaders_WhenSuccessful()
+    {
+        // Arrange
+        var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+        SetupResponse(new GetThumbnailResponse { Content = stream, ContentType = "image/jpeg", ContentLength = null });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var fileResult = result.Should().BeOfType<FileStreamResult>().Subject;
+        fileResult.ContentType.Should().Be("image/jpeg");
+        fileResult.FileStream.Should().BeSameAs(stream);
+        _controller.Response.Headers["Cache-Control"].ToString().Should().Be("public, max-age=31536000, immutable");
+    }
+
+    [Fact]
+    public async Task GetThumbnail_ForwardsContentLength_WhenAvailable()
+    {
+        // Arrange
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        SetupResponse(new GetThumbnailResponse { Content = stream, ContentType = "image/jpeg", ContentLength = 12345L });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeOfType<FileStreamResult>();
+        _controller.Response.ContentLength.Should().Be(12345L);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PhotobankControllerThumbnailTests"`
+Expected: FAIL — compile error: `PhotobankController` does not contain a constructor that takes 1 argument (it still takes 3). This is the RED state.
+
+- [ ] **Step 3: Replace the controller constructor and fields**
+
+In `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`, replace this block:
+
+```csharp
+        private readonly IMediator _mediator;
+        private readonly IPhotobankRepository _photobankRepository;
+        private readonly IPhotobankGraphService _photobankGraphService;
+
+        public PhotobankController(
+            IMediator mediator,
+            IPhotobankRepository photobankRepository,
+            IPhotobankGraphService photobankGraphService)
+        {
+            _mediator = mediator;
+            _photobankRepository = photobankRepository;
+            _photobankGraphService = photobankGraphService;
+        }
+```
+
+with:
+
+```csharp
+        private readonly IMediator _mediator;
+
+        public PhotobankController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+```
+
+- [ ] **Step 4: Replace the `GetThumbnail` action**
+
+Replace the entire current `GetThumbnail` action (the method beginning at `public async Task<IActionResult> GetThumbnail(` through its closing brace) with:
+
+```csharp
+        [HttpGet("photos/{id:int}/thumbnail/{size}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<IActionResult> GetThumbnail(
+            int id,
+            ThumbnailSize size,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(
+                new GetThumbnailRequest { Id = id, Size = size }, cancellationToken);
+
+            if (response.Success)
+            {
+                Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
+                if (response.ContentLength.HasValue)
+                {
+                    Response.ContentLength = response.ContentLength;
+                }
+
+                return new FileStreamResult(response.Content!, response.ContentType!);
+            }
+
+            switch (response.ErrorCode)
+            {
+                case ErrorCodes.PhotobankThumbnailNotFound:
+                    return NotFound();
+                case ErrorCodes.PhotobankThumbnailThrottled:
+                    if (response.RetryAfterSeconds.HasValue)
+                    {
+                        Response.Headers["Retry-After"] = response.RetryAfterSeconds.Value.ToString();
+                    }
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable);
+                case ErrorCodes.PhotobankThumbnailAuthUnavailable:
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable);
+                case ErrorCodes.PhotobankThumbnailUpstream:
+                    return StatusCode(StatusCodes.Status502BadGateway);
+                default:
+                    return StatusCode(StatusCodes.Status502BadGateway);
+            }
+        }
+```
+
+- [ ] **Step 5: Fix the `using` directives**
+
+At the top of `PhotobankController.cs`:
+
+Remove these three lines (they are consumed only by the old `GetThumbnail` action):
+```csharp
+using System.Net.Http;
+using Microsoft.Identity.Client;
+using Anela.Heblo.Domain.Features.Photobank;
+```
+
+Add these two lines (keep the `using` block alphabetically grouped as the file already is):
+```csharp
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail;
+using Anela.Heblo.Application.Shared;
+```
+
+> Keep `using Anela.Heblo.Application.Features.Photobank.Services;` — `ThumbnailSize` (the route parameter type) lives there and is still referenced. Keep `System.Collections.Generic`, `System.Threading`, `System.Threading.Tasks`, `Microsoft.AspNetCore.Http`, and `MediatR` — all still used by other actions.
+
+- [ ] **Step 6: Run the controller tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PhotobankControllerThumbnailTests"`
+Expected: PASS — 7 passed, 0 failed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs \
+        backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
+git commit -m "refactor: reduce PhotobankController.GetThumbnail to thin MediatR dispatch"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the whole backend**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors, 0 warnings introduced by these changes.
+
+- [ ] **Step 2: Verify formatting**
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes`
+Expected: exit code 0 (no formatting changes needed). If it reports changes, run `dotnet format Anela.Heblo.sln`, review the diff (it must touch only the files in this plan), and amend the relevant commit.
+
+- [ ] **Step 3: Run the full Photobank test slice**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Photobank"`
+Expected: PASS — all Photobank tests green, including the 8 handler tests and 7 controller tests.
+
+- [ ] **Step 4: Confirm no OpenAPI/TS client drift**
+
+The action signature (route params + `IActionResult`) is unchanged and the new `GetThumbnailRequest`/`GetThumbnailResponse` types never appear in a controller method signature, so they do not enter the OpenAPI surface.
+
+Run:
+```bash
+cd frontend && npm run build && cd ..
+git status --porcelain frontend/src/api
+```
+Expected: `npm run build` succeeds; `git status` shows **no** changes under the generated API client directory. (A no-op regen diff, if any, is acceptable per the spec — but none is expected.)
+
+- [ ] **Step 5: Final commit (only if Step 2 or 4 produced changes)**
+
+```bash
+git add -A
+git commit -m "chore: formatting and generated-client sync for thumbnail use case"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 (use case under folder convention; handler injects repo + graph + logger; absorbs logging; threads `CancellationToken`) → Tasks 2 & 3. Logging uses the same message templates and structured properties (`PhotoId`, `RetryAfter`, `ErrorCode`) as the original controller.
+- FR-2 (controller = `_mediator.Send` + outcome→status; route + `[ProducesResponseType]` unchanged) → Task 4 Steps 3–5.
+- FR-3 (single-dep `IMediator` constructor; drop unused usings) → Task 4 Steps 3 & 5; verified by Task 5 Steps 1–2.
+- FR-4 (exact HTTP behaviour: 404 / 503+Retry-After / 503 auth / 502 / 200 + Cache-Control + Content-Length) → controller `switch` (Task 4 Step 4) + controller tests (Task 4 Step 1) + handler tests (Task 3 Step 1).
+- FR-5 (controller tests mock `IMediator` only; new HTTP-free handler tests) → Tasks 3 & 4.
+- NFR-1 (streaming, not buffering; immutable cache header) → response carries `Stream`; `Cache-Control` preserved verbatim.
+- NFR-2 (no client-facing leakage; diagnostics logged server-side only) → only status codes returned; `ex.ErrorCode`/exception detail logged in handler.
+- NFR-3 (stream lifecycle) → handler transfers `.Content` without disposing `GraphThumbnail`; guarded by `Content.CanRead` + `BeSameAs` assertions (handler) and `FileStream.Should().BeSameAs(stream)` (controller).
+- NFR-4 (controller depends only on `IMediator`; no infra exception types in API project) → Task 4.
+- Data Model: `GetThumbnailRequest` (`Id`, `Size`); `GetThumbnailResponse : BaseResponse` (`Content`, `ContentType`, `ContentLength`, `RetryAfterSeconds`) per the **arch-review's reversal** of spec Decision #2.
+- Prerequisite (4 new `ErrorCodes`) → Task 1.
+
+**Placeholder scan:** No TBD/TODO/"add error handling" placeholders — every code step contains complete code. The one no-op test helper (`SetupGraph`) is explicitly flagged for deletion in Task 3 Step 1.
+
+**Type consistency:** `GetThumbnailRequest { int Id; ThumbnailSize Size; }`, `GetThumbnailResponse { Stream? Content; string? ContentType; long? ContentLength; int? RetryAfterSeconds; }`, and `ErrorCodes.PhotobankThumbnail{NotFound,Throttled,AuthUnavailable,Upstream}` are referenced identically across the handler, the controller, and both test files. The controller maps `PhotobankThumbnailUpstream → 502` and both throttle/auth → 503, matching the handler's classification and the FR-4 outcome table.

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs
@@ -4,8 +4,6 @@ using Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
 using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
 using Anela.Heblo.Application.Features.Purchase.DashboardTiles;
 using Anela.Heblo.Domain.Features.Purchase;
-using Anela.Heblo.Persistence;
-using Anela.Heblo.Persistence.Purchase.PurchaseOrders;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentValidation;
 
@@ -15,13 +13,6 @@ public static class PurchaseModule
 {
     public static IServiceCollection AddPurchaseModule(this IServiceCollection services)
     {
-        // Register default implementations - tests can override these
-        services.AddScoped<IPurchaseOrderRepository>(provider =>
-        {
-            var context = provider.GetRequiredService<ApplicationDbContext>();
-            return new PurchaseOrderRepository(context);
-        });
-
         services.AddScoped<IPurchaseOrderNumberGenerator, PurchaseOrderNumberGenerator>();
 
         // Register stock severity calculator

--- a/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
+++ b/backend/src/Anela.Heblo.Persistence/PersistenceModule.cs
@@ -4,6 +4,7 @@ using Anela.Heblo.Domain.Features.FeatureFlags;
 using Anela.Heblo.Persistence.FeatureFlags;
 using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Domain.Features.Bank;
+using Anela.Heblo.Domain.Features.Purchase;
 using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Persistence.GridLayouts;
 using Anela.Heblo.Domain.Features.Catalog.Inventory;
@@ -23,6 +24,7 @@ using Anela.Heblo.Persistence.InvoiceClassification;
 using Anela.Heblo.Persistence.Features.Article;
 using Anela.Heblo.Persistence.Features.Leaflet;
 using Anela.Heblo.Persistence.KnowledgeBase;
+using Anela.Heblo.Persistence.Purchase.PurchaseOrders;
 using Anela.Heblo.Persistence.MeetingTasks;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using Anela.Heblo.Xcc.Telemetry;
@@ -161,6 +163,9 @@ public static class PersistenceModule
 
         // Feature Flags repositories
         services.AddScoped<IFeatureFlagOverrideRepository, FeatureFlagOverrideRepository>();
+
+        // Purchase repositories
+        services.AddScoped<IPurchaseOrderRepository, PurchaseOrderRepository>();
 
         return services;
     }


### PR DESCRIPTION
Purchase

## Finding
`PurchaseModule.cs` is an Application-layer file that imports and directly references types from the Persistence (Infrastructure) layer:

```csharp
// backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs
using Anela.Heblo.Persistence;                                    // line 7
using Anela.Heblo.Persistence.Purchase.PurchaseOrders;            // line 8
...
services.AddScoped<IPurchaseOrderRepository>(provider =>
{
    var context = provider.GetRequiredService<ApplicationDbContext>();  // Persistence type
    return new PurchaseOrderRepository(context);                        // Persistence type
});
```

The Application layer must not depend on the Infrastructure/Persistence layer. That dependency is supposed to flow in the opposite direction (Persistence implements interfaces defined in Domain/Application). The DI wiring that binds `IPurchaseOrderRepository` → `PurchaseOrderRepository` belongs in `PersistenceModule.cs` or at the composition root (API layer), not in the Application module registration.

## Why it matters
This is a direct violation of the Clean Architecture dependency rule: Application → Infrastructure is forbidden. It couples the Application layer to a concrete database implementation, making it impossible to test Application logic without the Persistence project. It also defeats the purpose of the repository interface abstraction.

## Suggested fix
Move the `IPurchaseOrderRepository` → `PurchaseOrderRepository` DI registration to `backend/src/Anela.Heblo.Persistence/PersistenceModule.cs`, following the pattern used by other modules (e.g. the Catalog or Journal repositories registered there). Remove the `using Anela.Heblo.Persistence` and `using Anela.Heblo.Persistence.Purchase.PurchaseOrders` imports from `PurchaseModule.cs` entirely.

---
_Filed by daily arch-review routine on 2026-05-22._

---

Closes #1552

### Tokens used
10142374
