### PR TITLE
feat: Remove debug `Console.WriteLine` from `PurchaseOrder.AddLine()`

### DIFF
--- a/artifacts/feat-arch-review-purchase-console-writeline-d/arch-review.r1.md
+++ b/artifacts/feat-arch-review-purchase-console-writeline-d/arch-review.r1.md
@@ -1,0 +1,86 @@
+# Architecture Review: Remove debug `Console.WriteLine` from `PurchaseOrder.AddLine()`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change restores compliance with the project's Clean Architecture / Vertical Slice rules. The Domain layer (`Anela.Heblo.Domain`) is the innermost layer and must have zero infrastructure dependencies — `Console.WriteLine` is an I/O side effect that violates that constraint. A grep confirms this is the **only** `Console.*` call in `backend/src/Anela.Heblo.Domain/`, so the fix is fully localized.
+
+Integration surface: none. `PurchaseOrder.AddLine()` is called from `CreatePurchaseOrderHandler` / `UpdatePurchaseOrderHandler`. Those handlers already have `ILogger<T>` injected if telemetry is ever genuinely required, but adding such logging is explicitly out of scope.
+
+## Proposed Architecture
+
+### Component Overview
+
+No component changes. The only edit is a deletion inside an existing domain method:
+
+```
+[MediatR Handler] --calls--> [PurchaseOrder.AddLine()]
+                                  |
+                                  +-- validates IsEditable
+                                  +-- creates PurchaseOrderLine
+                                  +-- appends to _lines
+                                  +-- (DELETE) Console.WriteLine        <-- removed
+                                  +-- sets UpdatedBy / UpdatedAt
+```
+
+### Key Design Decisions
+
+#### Decision 1: Delete-only, no replacement logging
+**Options considered:**
+- (A) Delete the line outright.
+- (B) Replace with `ILogger.LogDebug(...)` in the handler.
+- (C) Introduce a domain event raised on every line add, observed in the handler for logging.
+
+**Chosen approach:** (A) — straight deletion. The brief and spec mandate "Surgical changes."
+
+**Rationale:** No observed need for per-line telemetry exists; (B) and (C) are speculative work (YAGNI). If a need later emerges, the handler layer is the correct seam — that decision belongs to a future, separately scoped change.
+
+#### Decision 2: Do not introduce a Roslyn analyzer to forbid `Console.*` in the Domain assembly
+**Options considered:**
+- (A) Just delete the line.
+- (B) Add a `BannedApiAnalyzers` rule to prevent recurrence.
+
+**Chosen approach:** (A) for this PR; (B) noted as a separately-scoped follow-up.
+
+**Rationale:** Spec explicitly lists analyzer rules as out of scope. The surgical-change policy dominates.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+One file only:
+- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`
+
+Remove lines 71–72 (the `// Debug logging` comment and the `Console.WriteLine(...)` call). Leave the blank line above `UpdatedBy = CreatedBy;` consistent with surrounding methods (`RemoveLine`, `UpdateLine`).
+
+### Interfaces and Contracts
+
+None changed. `PurchaseOrder.AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)` keeps its signature and observable behavior. No DTOs, MediatR requests/responses, or OpenAPI surfaces are touched; no TypeScript client regeneration is required.
+
+### Data Flow
+
+Unchanged. The only state mutations remain: append to `_lines`, set `UpdatedBy`, set `UpdatedAt`. Domain history entries are not emitted from `AddLine()` today and continue not to be. The deletion removes a stdout side effect, nothing more.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing tests or scripts depend on the stdout output | Low | `PurchaseOrderTests` assertions are behavioral (counts, totals, status); they do not capture stdout. Run `dotnet test` on the Tests project to confirm. |
+| Operators rely on the message in production logs | Low | Message is unstructured, unprefixed, and was clearly a `// Debug logging` leftover — no log-based alert/dashboard could reliably parse it. No mitigation required. |
+| Whitespace-only diff churn (formatter reflow) | Low | Run `dotnet format` on the file after the edit; confirm diff is limited to the two intended lines plus any adjacent blank-line normalization. |
+| Other `Console.*` calls slip back into the Domain layer later | Medium (long-term) | Out-of-scope here; recorded as a follow-up (Roslyn `BannedApiAnalyzers` rule on the Domain assembly). |
+
+## Specification Amendments
+
+None. The spec is precise, the acceptance criteria are testable, and the scope boundaries are correctly drawn. No additions or corrections required.
+
+One minor clarification worth recording in the PR description (already implied by spec FR-2): the `Console.*` scan confirmed only the single occurrence at `PurchaseOrder.cs:72`. No other Domain-layer `Console.*` calls exist, so FR-2's "no additional files modified" condition is trivially satisfied.
+
+## Prerequisites
+
+None.
+
+- No migrations, no config keys, no infrastructure changes, no new packages.
+- No frontend regeneration step (OpenAPI surface unchanged).
+- Standard validation gate applies: `dotnet build` + `dotnet format` + `dotnet test` on `backend/test/Anela.Heblo.Tests/` (specifically the `Domain/Purchase/PurchaseOrderTests` fixture, which exercises `AddLine` across draft/in-transit/completed states).

--- a/artifacts/feat-arch-review-purchase-console-writeline-d/brief.md
+++ b/artifacts/feat-arch-review-purchase-console-writeline-d/brief.md
@@ -1,0 +1,29 @@
+## Module
+Purchase
+
+## Finding
+`PurchaseOrder.AddLine()` contains a raw `Console.WriteLine` debug statement:
+
+```csharp
+// backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs:72
+Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+```
+
+This is inside a domain entity — the purest layer in Clean Architecture. Domain entities must have zero I/O concerns and no dependencies on infrastructure (including the console). Logging belongs in application or infrastructure layers, injected as an abstraction, never as a hard-wired side effect inside a domain method.
+
+## Why it matters
+- Domain entities must remain infrastructure-free. Console I/O is an infrastructure concern.
+- `Console.WriteLine` in a hot path (every `AddLine` call) adds synchronous I/O in a web request context.
+- It produces noise in production logs (stdout is captured by the container runtime) with no structured fields.
+- The comment `// Debug logging` confirms it was never intended to stay.
+
+## Suggested fix
+Delete line 72 entirely:
+```csharp
+// Remove this line:
+Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+```
+If add-line telemetry is genuinely needed, add it at the handler level (`CreatePurchaseOrderHandler` or `UpdatePurchaseOrderHandler`) where a proper `ILogger` is already injected.
+
+---
+_Filed by daily arch-review routine on 2026-05-22._

--- a/artifacts/feat-arch-review-purchase-console-writeline-d/impl/main.r1.md
+++ b/artifacts/feat-arch-review-purchase-console-writeline-d/impl/main.r1.md
@@ -1,0 +1,54 @@
+All tasks complete. Writing the output artifact.
+
+---
+
+# Implementation: Remove debug Console.WriteLine from PurchaseOrder.AddLine()
+
+## What was implemented
+
+Deleted the `// Debug logging` comment and `Console.WriteLine(...)` call from `PurchaseOrder.AddLine()` — a pure 3-line removal that restores the Domain layer's Clean Architecture compliance (zero infrastructure I/O). No replacement logging introduced, no other lines touched.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs` — removed `// Debug logging`, `Console.WriteLine(...)`, and the blank line following it from `AddLine()`
+
+## Tests
+
+No new tests written (deleting a side-effect-only statement has no assertable behavioral change). Existing fixture verified:
+
+- `backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs` — 33 tests passed before and after the change
+
+## How to verify
+
+```bash
+# Confirm no Console.* in Domain layer
+grep -rn "Console\." backend/src/Anela.Heblo.Domain/ --include="*.cs"
+# → no output
+
+# Run PurchaseOrder unit tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Domain.Purchase.PurchaseOrderTests" --nologo
+# → 33 passed
+
+# Verify build
+dotnet build backend/Anela.Heblo.sln --nologo
+# → 0 errors
+```
+
+## Notes
+
+FR-2 scan confirmed: no other `Console.*` calls exist anywhere in `backend/src/Anela.Heblo.Domain/`. The Domain layer is fully clean.
+
+Commit: `3393d038` — `chore(domain): remove debug Console.WriteLine from PurchaseOrder.AddLine`
+
+## PR Summary
+
+Removed a leftover `// Debug logging` + `Console.WriteLine` from `PurchaseOrder.AddLine()` that violated the project's Clean Architecture rule: domain entities must have zero infrastructure I/O. The statement was emitting unstructured noise to container stdout on every line addition during `CreatePurchaseOrder` / `UpdatePurchaseOrder` requests. No replacement logging is introduced — handlers already have `ILogger<T>` available if telemetry is ever genuinely required, but that is a separate concern.
+
+FR-2 scan after the change: `grep -rn 'Console\.' backend/src/Anela.Heblo.Domain/` returns no matches — the Domain layer now has zero `Console.*` calls.
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs` — deleted 3 lines: `// Debug logging` comment, `Console.WriteLine(...)` call, and the trailing blank line
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-purchase-console-writeline-d/spec.r1.md
+++ b/artifacts/feat-arch-review-purchase-console-writeline-d/spec.r1.md
@@ -1,0 +1,79 @@
+# Specification: Remove debug `Console.WriteLine` from `PurchaseOrder.AddLine()`
+
+## Summary
+Remove the stray `Console.WriteLine` debug statement from the `PurchaseOrder` domain entity's `AddLine()` method. This eliminates an infrastructure (I/O) concern from the purest layer of Clean Architecture and stops unstructured noise from being written to container stdout on every line addition.
+
+## Background
+`PurchaseOrder.AddLine()` (`backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs:72`) contains a leftover debug statement:
+
+```csharp
+Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+```
+
+The accompanying `// Debug logging` comment confirms this was never intended to be permanent. The line violates several principles of the project's Clean Architecture:
+
+- **Domain purity**: Domain entities must be free of I/O and infrastructure dependencies. Console I/O is infrastructure.
+- **Performance**: Synchronous stdout I/O on a hot path (called from every `CreatePurchaseOrder` / `UpdatePurchaseOrder` request) adds unnecessary latency.
+- **Observability hygiene**: Stdout is captured by the container runtime and lands in production logs as unstructured text with no log level, scope, or correlation fields.
+- **Maintainability**: Debug `WriteLine` calls are exactly the kind of accidental telemetry that leaks into prod when not policed.
+
+If add-line telemetry is ever genuinely needed, the correct place is the MediatR handler (`CreatePurchaseOrderHandler` / `UpdatePurchaseOrderHandler`), which already has `ILogger<T>` injected. That is out of scope here — the brief explicitly asks for deletion only.
+
+## Functional Requirements
+
+### FR-1: Delete the debug `Console.WriteLine` statement
+Remove the `Console.WriteLine(...)` call (and its preceding `// Debug logging` comment, if present) from `PurchaseOrder.AddLine()`. The behavior of `AddLine()` must remain identical in every other respect: the line is still appended to `_lines`, all invariants and validations execute unchanged, and any domain events raised continue to be raised in the same order.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs` no longer contains `Console.WriteLine` anywhere in the file.
+- The `// Debug logging` comment (if present and directly attached to the deleted line) is removed.
+- No other lines in `AddLine()` are modified — purely a deletion.
+- All existing unit tests for `PurchaseOrder` (e.g. `AddLine` tests) continue to pass without modification.
+- `dotnet build` completes with no new warnings or errors attributable to this change.
+- `dotnet format` reports the file as compliant.
+
+### FR-2: Verify no other production `Console.*` calls exist in the Domain layer
+While addressing this finding, perform a targeted scan of `backend/src/Anela.Heblo.Domain/` for any other `Console.Write`, `Console.WriteLine`, or `Console.Error.*` calls. If any are found, list them in `## Open Questions` (do **not** delete them as part of this change — they may have separate context). If none are found, note that explicitly in the PR description.
+
+**Acceptance criteria:**
+- A grep / ripgrep scan of `backend/src/Anela.Heblo.Domain/**/*.cs` for `Console\.` is performed.
+- Findings (or the absence of findings) are documented in the PR description.
+- No additional files are modified as part of this PR even if other `Console.*` calls are discovered.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Removing synchronous stdout I/O from a per-line hot path is a micro-improvement; no measurable regression is expected and any change in request latency for `CreatePurchaseOrder` / `UpdatePurchaseOrder` should be a (very small) net positive. No benchmarking is required.
+
+### NFR-2: Security & Data Sensitivity
+The deleted statement currently writes `line.Id` and `Id` (purchase order id) to stdout. These are internal identifiers, not PII, but removing them from container logs is a marginal improvement to log hygiene. No secrets are involved.
+
+### NFR-3: Observability
+After this change, no telemetry will be emitted by `PurchaseOrder.AddLine()`. This is the intended state — domain entities should not emit telemetry. If observability gaps arise in the future, they are addressed at the application (handler) layer with `ILogger`, not in the domain.
+
+### NFR-4: Architectural conformance
+The change brings `PurchaseOrder` into compliance with the Clean Architecture rule that domain entities have zero infrastructure dependencies (see `docs/architecture/development_guidelines.md` and `docs/📘 Architecture Documentation – MVP Work.md`).
+
+## Data Model
+No data model changes. No entity properties, value objects, database schema, migrations, or DTOs are touched.
+
+## API / Interface Design
+No API changes. The public signature of `PurchaseOrder.AddLine()` is unchanged. No REST endpoints, MediatR requests/handlers, or generated OpenAPI clients are affected. The frontend is unaffected — no `npm run build` regeneration is required for this change, though the standard build still applies.
+
+## Dependencies
+- **None added or removed.** No NuGet packages, no infrastructure components, no external services.
+- **Files touched:** exactly one — `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`.
+- **Tests affected:** any existing unit tests on `PurchaseOrder.AddLine()` should continue to pass without changes. No new tests are required (deleting a side-effect-only line does not warrant a regression test; the absence of the line cannot be meaningfully asserted from behavior).
+
+## Out of Scope
+- **Adding replacement logging.** No `ILogger.LogInformation(...)` or equivalent is introduced anywhere as a substitute. If telemetry is desired later, it is a separate change at the handler layer.
+- **Refactoring `PurchaseOrder` more broadly.** Per project policy ("Surgical changes — touch only what the task requires"), no adjacent cleanup, renaming, comment editing, or structural refactor of the entity is performed.
+- **Removing other `Console.*` calls** discovered elsewhere in the Domain layer — these are merely reported (FR-2), not deleted.
+- **Backend-wide audit** for `Console.WriteLine` outside `backend/src/Anela.Heblo.Domain/`.
+- **Adding lint / analyzer rules** (e.g., a Roslyn analyzer that forbids `Console.*` in the Domain assembly). Worth considering as a follow-up, but not part of this PR.
+- **Frontend / E2E / migration work.** None required.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-purchase-console-writeline-d/task-plan.r1.md
+++ b/artifacts/feat-arch-review-purchase-console-writeline-d/task-plan.r1.md
@@ -1,0 +1,389 @@
+# Remove Debug `Console.WriteLine` from `PurchaseOrder.AddLine()` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the leftover `// Debug logging` comment and `Console.WriteLine(...)` call from `PurchaseOrder.AddLine()` to restore Clean Architecture compliance (zero infrastructure I/O in the Domain layer).
+
+**Architecture:** Pure deletion in a single Domain-layer file. No replacement logging, no analyzers, no signature or behavior changes. The MediatR handlers that call `AddLine()` already have `ILogger<T>` available if telemetry is ever genuinely needed — that is explicitly out of scope. A separate Domain-wide `Console.*` scan is run as a verification (FR-2) but no other files are modified.
+
+**Tech Stack:** .NET 8, C#, xUnit (existing `PurchaseOrderTests` regression coverage), `dotnet build` + `dotnet format` + `dotnet test` for validation.
+
+---
+
+## File Structure
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs` — remove lines 71–73 (the `// Debug logging` comment, the `Console.WriteLine(...)` call, and the now-redundant trailing blank line) so the method body around `_lines.Add(line);` matches the layout of sibling methods (`RemoveLine`, `UpdateLine`).
+
+**Verified (read-only) files:**
+- `backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs` — existing behavioral tests for `AddLine` must continue to pass without modification.
+- All files under `backend/src/Anela.Heblo.Domain/` — scanned for any other `Console.*` call (FR-2). Findings (or absence) are recorded in the commit/PR description only; no files are edited as part of this verification.
+
+**Created files:** none.
+
+---
+
+## Pre-Flight Context
+
+The file currently contains, around line 61–76 of `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`:
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        // Debug logging
+        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+After the edit it must read exactly:
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+Notes on the diff:
+- The deletion removes three source lines: the `// Debug logging` comment, the `Console.WriteLine(...)` statement, and the blank line immediately following the `Console.WriteLine`.
+- Exactly **one** blank line remains between `_lines.Add(line);` and `UpdatedBy = CreatedBy;` — matching the spacing convention used elsewhere in the file.
+- No other characters in the method or file change. Indentation (8 spaces) is preserved.
+
+---
+
+## Task 1: Confirm baseline state of the file
+
+**Files:**
+- Read: `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`
+
+- [ ] **Step 1: Read the target region and confirm the exact text to remove**
+
+Run:
+
+```bash
+sed -n '61,76p' backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output (verbatim):
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        // Debug logging
+        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+If the output differs (different line numbers, different surrounding lines, or the `Console.WriteLine` is no longer present), **stop and re-read the full file** before proceeding — the line numbers in this plan may have shifted because of an earlier commit, and the `old_string`/`new_string` payload in Task 3 must be updated to match what is actually on disk.
+
+- [ ] **Step 2: Confirm `Console.WriteLine` is the only `Console.*` call in the file**
+
+Run:
+
+```bash
+grep -n "Console\." backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output (exactly one line):
+
+```
+72:        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+```
+
+If there is more than one match, the spec only covers the one at line 72 — leave any others alone (per the FR-2 "no additional files modified" rule) and proceed.
+
+---
+
+## Task 2: Run the existing `PurchaseOrder` unit tests to establish a green baseline
+
+**Files:**
+- Test: `backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs`
+
+- [ ] **Step 1: Run the targeted test fixture before any code change**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Domain.Purchase.PurchaseOrderTests" \
+  --nologo
+```
+
+Expected: **all tests pass.** Record the pass count; the same count must hold after Task 3.
+
+If any test in `PurchaseOrderTests` fails on `main` before this change, **stop**: the baseline is already broken and this PR is not the right place to fix it. Report the failure and exit.
+
+---
+
+## Task 3: Delete the debug comment and `Console.WriteLine` call
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs:69-74` (deletes the comment + `Console.WriteLine` + the trailing blank line)
+
+- [ ] **Step 1: Apply the deletion**
+
+Use a single `Edit` call with this exact `old_string` / `new_string`. The block is anchored on the unique `var line = new PurchaseOrderLine(...)` line above and the `UpdatedBy = CreatedBy;` line below so the match is unambiguous.
+
+`old_string`:
+
+```csharp
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        // Debug logging
+        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+
+        UpdatedBy = CreatedBy;
+```
+
+`new_string`:
+
+```csharp
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        UpdatedBy = CreatedBy;
+```
+
+- [ ] **Step 2: Verify the resulting region**
+
+Run:
+
+```bash
+sed -n '61,73p' backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output (verbatim):
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+If the output does not match (extra blank line, missing blank line, or any other deviation), redo the edit. Do **not** continue with a mismatched layout.
+
+- [ ] **Step 3: Confirm `Console.WriteLine` is gone from the file**
+
+Run:
+
+```bash
+grep -n "Console\." backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output: **no matches** (the command exits with code 1 and prints nothing).
+
+If any `Console.*` reference remains, the deletion missed something — re-apply.
+
+---
+
+## Task 4: Run the Domain-wide `Console.*` scan required by FR-2
+
+This task does not modify any files. It records a verification result that goes into the commit message and PR description.
+
+- [ ] **Step 1: Scan the entire Domain layer for `Console.*` calls**
+
+Run:
+
+```bash
+grep -rn "Console\." backend/src/Anela.Heblo.Domain/ --include="*.cs"
+```
+
+Expected output: **no matches** (the command exits with code 1 and prints nothing). The arch review already confirmed this was the only occurrence; this step re-confirms after the deletion.
+
+- [ ] **Step 2: Capture the scan result for the PR description**
+
+If Step 1 produced no output, note for the PR description:
+
+> Domain-layer `Console.*` scan after the deletion: no remaining matches in `backend/src/Anela.Heblo.Domain/`. FR-2 satisfied.
+
+If Step 1 unexpectedly produced output (a `Console.*` call that was not present at arch-review time, e.g. landed via a concurrent merge), **do not delete it**. Per spec FR-2 and the Out-of-Scope section, additional finds are reported only — list each `path:line` in the PR description and continue.
+
+---
+
+## Task 5: Re-run the `PurchaseOrder` tests to confirm no behavioral regression
+
+- [ ] **Step 1: Re-run the same filtered test set as Task 2**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Domain.Purchase.PurchaseOrderTests" \
+  --nologo
+```
+
+Expected: **same pass count as Task 2**, all green. The deleted line had no return value, raised no exception, and produced no domain event — behavioral parity is the success criterion.
+
+If a test now fails, the most likely cause is an unintended edit elsewhere in the method (e.g. accidentally removing `UpdatedBy = CreatedBy;` or `_lines.Add(line);`). Re-check the region from Task 3 Step 2 before investigating anything else.
+
+---
+
+## Task 6: Run `dotnet format` and `dotnet build` on the Domain project
+
+These are the project's mandatory pre-commit gates (see `CLAUDE.md` → "Validation before completion").
+
+- [ ] **Step 1: Format the edited file**
+
+Run:
+
+```bash
+dotnet format backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj \
+  --include backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs \
+  --verify-no-changes
+```
+
+Expected: exit code `0` with no diff applied (the file is already compliant). If the command reports a change was needed, re-run without `--verify-no-changes` to apply it, then re-check the region from Task 3 Step 2 to ensure formatting did not undo your spacing choice.
+
+- [ ] **Step 2: Build the Domain project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj --nologo
+```
+
+Expected: build succeeds with **zero new warnings or errors** attributable to `PurchaseOrder.cs`. Pre-existing warnings in unrelated files are acceptable but should be ignored — do not "fix" them here (surgical change policy).
+
+- [ ] **Step 3: Build the full solution to catch downstream effects**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: full solution builds. Any failure here would indicate something outside `PurchaseOrder.AddLine()` was relying on the `Console.WriteLine` (extremely unlikely) — investigate before committing.
+
+---
+
+## Task 7: Commit
+
+- [ ] **Step 1: Stage exactly one file**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+git status
+```
+
+Expected: `git status` shows exactly one modified file (`PurchaseOrder.cs`) staged, and no other staged or unstaged changes. If anything else appears (e.g. an accidental edit from a previous task, or a formatter reflow elsewhere), unstage it and investigate before committing.
+
+- [ ] **Step 2: Verify the staged diff is the intended three-line deletion**
+
+Run:
+
+```bash
+git diff --cached backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected: the diff shows exactly three removed lines and zero added lines:
+
+```diff
+         _lines.Add(line);
+
+-        // Debug logging
+-        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+-
+         UpdatedBy = CreatedBy;
+```
+
+If the diff shows anything else (extra context changes, whitespace-only changes elsewhere in the file), revert and redo Task 3.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+chore(domain): remove debug Console.WriteLine from PurchaseOrder.AddLine
+
+The `// Debug logging` + Console.WriteLine call in
+PurchaseOrder.AddLine() was a leftover that violated the Domain layer's
+no-infrastructure-I/O rule and emitted unstructured noise to container
+stdout on every line added during CreatePurchaseOrder /
+UpdatePurchaseOrder. Removed purely; no replacement logging introduced
+(handlers already have ILogger<T> if telemetry is ever required, but
+that is a separate concern out of scope here).
+
+FR-2 verification: grep -rn 'Console\\.' backend/src/Anela.Heblo.Domain/
+returns no matches after this change.
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, **do not amend** — fix the underlying issue and create a new commit.
+
+---
+
+## Out of Scope (reminder — do not do these in this PR)
+
+These items are explicitly excluded by the spec. If you find yourself tempted to do any of them, stop and re-read the spec's "Out of Scope" section:
+
+- Adding `ILogger.LogDebug(...)` or any other replacement telemetry, anywhere.
+- Deleting other `Console.*` calls discovered outside `PurchaseOrder.cs` (only report them).
+- Adding a Roslyn `BannedApiAnalyzers` rule to prevent recurrence (worth a follow-up issue, not part of this PR).
+- Any other refactor, rename, or comment edit inside `PurchaseOrder.cs` (surgical-change policy).
+- Frontend, E2E, migration, or OpenAPI-client regeneration work.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 (delete the `Console.WriteLine` and adjacent `// Debug logging` comment): covered by Task 3.
+- FR-1 acceptance — `Console.WriteLine` absent from the file: Task 3 Step 3 grep.
+- FR-1 acceptance — `// Debug logging` comment removed: Task 3 Step 2 layout check.
+- FR-1 acceptance — no other lines in `AddLine()` modified: Task 3 Step 2 layout check + Task 7 Step 2 diff inspection.
+- FR-1 acceptance — existing unit tests still pass: Tasks 2 (baseline) and 5 (post-change).
+- FR-1 acceptance — `dotnet build` clean: Task 6 Steps 2 and 3.
+- FR-1 acceptance — `dotnet format` compliant: Task 6 Step 1.
+- FR-2 (Domain-wide `Console.*` scan, document findings, do not modify other files): Task 4.
+- NFR-1 to NFR-4: implicitly satisfied by the deletion; no explicit task needed (no benchmarking, no security review, no observability gap to fill — all called out as no-ops by the spec).
+- Out-of-Scope list: re-stated as a reminder block above Tasks.
+
+**Placeholder scan:** none of "TBD", "TODO", "implement later", "add appropriate X", "similar to Task N", or bare "write tests" placeholders. All steps include exact commands, exact expected output, and (where applicable) the exact `old_string`/`new_string` payload.
+
+**Type consistency:** no new types, methods, properties, or signatures introduced. `PurchaseOrder.AddLine(string, string, decimal, decimal, string?)` is the only API referenced and is referenced consistently.

--- a/backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
@@ -68,9 +68,6 @@ public class PurchaseOrder : IEntity<int>
         var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
         _lines.Add(line);
 
-        // Debug logging
-        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
-
         UpdatedBy = CreatedBy;
         UpdatedAt = DateTime.UtcNow;
     }

--- a/docs/superpowers/plans/2026-05-24-remove-purchase-console-writeline.md
+++ b/docs/superpowers/plans/2026-05-24-remove-purchase-console-writeline.md
@@ -1,0 +1,389 @@
+# Remove Debug `Console.WriteLine` from `PurchaseOrder.AddLine()` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the leftover `// Debug logging` comment and `Console.WriteLine(...)` call from `PurchaseOrder.AddLine()` to restore Clean Architecture compliance (zero infrastructure I/O in the Domain layer).
+
+**Architecture:** Pure deletion in a single Domain-layer file. No replacement logging, no analyzers, no signature or behavior changes. The MediatR handlers that call `AddLine()` already have `ILogger<T>` available if telemetry is ever genuinely needed — that is explicitly out of scope. A separate Domain-wide `Console.*` scan is run as a verification (FR-2) but no other files are modified.
+
+**Tech Stack:** .NET 8, C#, xUnit (existing `PurchaseOrderTests` regression coverage), `dotnet build` + `dotnet format` + `dotnet test` for validation.
+
+---
+
+## File Structure
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs` — remove lines 71–73 (the `// Debug logging` comment, the `Console.WriteLine(...)` call, and the now-redundant trailing blank line) so the method body around `_lines.Add(line);` matches the layout of sibling methods (`RemoveLine`, `UpdateLine`).
+
+**Verified (read-only) files:**
+- `backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs` — existing behavioral tests for `AddLine` must continue to pass without modification.
+- All files under `backend/src/Anela.Heblo.Domain/` — scanned for any other `Console.*` call (FR-2). Findings (or absence) are recorded in the commit/PR description only; no files are edited as part of this verification.
+
+**Created files:** none.
+
+---
+
+## Pre-Flight Context
+
+The file currently contains, around line 61–76 of `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`:
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        // Debug logging
+        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+After the edit it must read exactly:
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+Notes on the diff:
+- The deletion removes three source lines: the `// Debug logging` comment, the `Console.WriteLine(...)` statement, and the blank line immediately following the `Console.WriteLine`.
+- Exactly **one** blank line remains between `_lines.Add(line);` and `UpdatedBy = CreatedBy;` — matching the spacing convention used elsewhere in the file.
+- No other characters in the method or file change. Indentation (8 spaces) is preserved.
+
+---
+
+## Task 1: Confirm baseline state of the file
+
+**Files:**
+- Read: `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs`
+
+- [ ] **Step 1: Read the target region and confirm the exact text to remove**
+
+Run:
+
+```bash
+sed -n '61,76p' backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output (verbatim):
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        // Debug logging
+        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+If the output differs (different line numbers, different surrounding lines, or the `Console.WriteLine` is no longer present), **stop and re-read the full file** before proceeding — the line numbers in this plan may have shifted because of an earlier commit, and the `old_string`/`new_string` payload in Task 3 must be updated to match what is actually on disk.
+
+- [ ] **Step 2: Confirm `Console.WriteLine` is the only `Console.*` call in the file**
+
+Run:
+
+```bash
+grep -n "Console\." backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output (exactly one line):
+
+```
+72:        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+```
+
+If there is more than one match, the spec only covers the one at line 72 — leave any others alone (per the FR-2 "no additional files modified" rule) and proceed.
+
+---
+
+## Task 2: Run the existing `PurchaseOrder` unit tests to establish a green baseline
+
+**Files:**
+- Test: `backend/test/Anela.Heblo.Tests/Domain/Purchase/PurchaseOrderTests.cs`
+
+- [ ] **Step 1: Run the targeted test fixture before any code change**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Domain.Purchase.PurchaseOrderTests" \
+  --nologo
+```
+
+Expected: **all tests pass.** Record the pass count; the same count must hold after Task 3.
+
+If any test in `PurchaseOrderTests` fails on `main` before this change, **stop**: the baseline is already broken and this PR is not the right place to fix it. Report the failure and exit.
+
+---
+
+## Task 3: Delete the debug comment and `Console.WriteLine` call
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs:69-74` (deletes the comment + `Console.WriteLine` + the trailing blank line)
+
+- [ ] **Step 1: Apply the deletion**
+
+Use a single `Edit` call with this exact `old_string` / `new_string`. The block is anchored on the unique `var line = new PurchaseOrderLine(...)` line above and the `UpdatedBy = CreatedBy;` line below so the match is unambiguous.
+
+`old_string`:
+
+```csharp
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        // Debug logging
+        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+
+        UpdatedBy = CreatedBy;
+```
+
+`new_string`:
+
+```csharp
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        UpdatedBy = CreatedBy;
+```
+
+- [ ] **Step 2: Verify the resulting region**
+
+Run:
+
+```bash
+sed -n '61,73p' backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output (verbatim):
+
+```csharp
+    public void AddLine(string materialId, string materialName, decimal quantity, decimal unitPrice, string? notes)
+    {
+        if (!IsEditable)
+        {
+            throw new InvalidOperationException("Cannot add lines to completed orders");
+        }
+
+        var line = new PurchaseOrderLine(Id, materialId, materialName, quantity, unitPrice, notes);
+        _lines.Add(line);
+
+        UpdatedBy = CreatedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+```
+
+If the output does not match (extra blank line, missing blank line, or any other deviation), redo the edit. Do **not** continue with a mismatched layout.
+
+- [ ] **Step 3: Confirm `Console.WriteLine` is gone from the file**
+
+Run:
+
+```bash
+grep -n "Console\." backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected output: **no matches** (the command exits with code 1 and prints nothing).
+
+If any `Console.*` reference remains, the deletion missed something — re-apply.
+
+---
+
+## Task 4: Run the Domain-wide `Console.*` scan required by FR-2
+
+This task does not modify any files. It records a verification result that goes into the commit message and PR description.
+
+- [ ] **Step 1: Scan the entire Domain layer for `Console.*` calls**
+
+Run:
+
+```bash
+grep -rn "Console\." backend/src/Anela.Heblo.Domain/ --include="*.cs"
+```
+
+Expected output: **no matches** (the command exits with code 1 and prints nothing). The arch review already confirmed this was the only occurrence; this step re-confirms after the deletion.
+
+- [ ] **Step 2: Capture the scan result for the PR description**
+
+If Step 1 produced no output, note for the PR description:
+
+> Domain-layer `Console.*` scan after the deletion: no remaining matches in `backend/src/Anela.Heblo.Domain/`. FR-2 satisfied.
+
+If Step 1 unexpectedly produced output (a `Console.*` call that was not present at arch-review time, e.g. landed via a concurrent merge), **do not delete it**. Per spec FR-2 and the Out-of-Scope section, additional finds are reported only — list each `path:line` in the PR description and continue.
+
+---
+
+## Task 5: Re-run the `PurchaseOrder` tests to confirm no behavioral regression
+
+- [ ] **Step 1: Re-run the same filtered test set as Task 2**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Domain.Purchase.PurchaseOrderTests" \
+  --nologo
+```
+
+Expected: **same pass count as Task 2**, all green. The deleted line had no return value, raised no exception, and produced no domain event — behavioral parity is the success criterion.
+
+If a test now fails, the most likely cause is an unintended edit elsewhere in the method (e.g. accidentally removing `UpdatedBy = CreatedBy;` or `_lines.Add(line);`). Re-check the region from Task 3 Step 2 before investigating anything else.
+
+---
+
+## Task 6: Run `dotnet format` and `dotnet build` on the Domain project
+
+These are the project's mandatory pre-commit gates (see `CLAUDE.md` → "Validation before completion").
+
+- [ ] **Step 1: Format the edited file**
+
+Run:
+
+```bash
+dotnet format backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj \
+  --include backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs \
+  --verify-no-changes
+```
+
+Expected: exit code `0` with no diff applied (the file is already compliant). If the command reports a change was needed, re-run without `--verify-no-changes` to apply it, then re-check the region from Task 3 Step 2 to ensure formatting did not undo your spacing choice.
+
+- [ ] **Step 2: Build the Domain project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj --nologo
+```
+
+Expected: build succeeds with **zero new warnings or errors** attributable to `PurchaseOrder.cs`. Pre-existing warnings in unrelated files are acceptable but should be ignored — do not "fix" them here (surgical change policy).
+
+- [ ] **Step 3: Build the full solution to catch downstream effects**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: full solution builds. Any failure here would indicate something outside `PurchaseOrder.AddLine()` was relying on the `Console.WriteLine` (extremely unlikely) — investigate before committing.
+
+---
+
+## Task 7: Commit
+
+- [ ] **Step 1: Stage exactly one file**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+git status
+```
+
+Expected: `git status` shows exactly one modified file (`PurchaseOrder.cs`) staged, and no other staged or unstaged changes. If anything else appears (e.g. an accidental edit from a previous task, or a formatter reflow elsewhere), unstage it and investigate before committing.
+
+- [ ] **Step 2: Verify the staged diff is the intended three-line deletion**
+
+Run:
+
+```bash
+git diff --cached backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs
+```
+
+Expected: the diff shows exactly three removed lines and zero added lines:
+
+```diff
+         _lines.Add(line);
+
+-        // Debug logging
+-        Console.WriteLine($"Added line {line.Id} to purchase order {Id}. Total lines: {_lines.Count}");
+-
+         UpdatedBy = CreatedBy;
+```
+
+If the diff shows anything else (extra context changes, whitespace-only changes elsewhere in the file), revert and redo Task 3.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+chore(domain): remove debug Console.WriteLine from PurchaseOrder.AddLine
+
+The `// Debug logging` + Console.WriteLine call in
+PurchaseOrder.AddLine() was a leftover that violated the Domain layer's
+no-infrastructure-I/O rule and emitted unstructured noise to container
+stdout on every line added during CreatePurchaseOrder /
+UpdatePurchaseOrder. Removed purely; no replacement logging introduced
+(handlers already have ILogger<T> if telemetry is ever required, but
+that is a separate concern out of scope here).
+
+FR-2 verification: grep -rn 'Console\\.' backend/src/Anela.Heblo.Domain/
+returns no matches after this change.
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, **do not amend** — fix the underlying issue and create a new commit.
+
+---
+
+## Out of Scope (reminder — do not do these in this PR)
+
+These items are explicitly excluded by the spec. If you find yourself tempted to do any of them, stop and re-read the spec's "Out of Scope" section:
+
+- Adding `ILogger.LogDebug(...)` or any other replacement telemetry, anywhere.
+- Deleting other `Console.*` calls discovered outside `PurchaseOrder.cs` (only report them).
+- Adding a Roslyn `BannedApiAnalyzers` rule to prevent recurrence (worth a follow-up issue, not part of this PR).
+- Any other refactor, rename, or comment edit inside `PurchaseOrder.cs` (surgical-change policy).
+- Frontend, E2E, migration, or OpenAPI-client regeneration work.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 (delete the `Console.WriteLine` and adjacent `// Debug logging` comment): covered by Task 3.
+- FR-1 acceptance — `Console.WriteLine` absent from the file: Task 3 Step 3 grep.
+- FR-1 acceptance — `// Debug logging` comment removed: Task 3 Step 2 layout check.
+- FR-1 acceptance — no other lines in `AddLine()` modified: Task 3 Step 2 layout check + Task 7 Step 2 diff inspection.
+- FR-1 acceptance — existing unit tests still pass: Tasks 2 (baseline) and 5 (post-change).
+- FR-1 acceptance — `dotnet build` clean: Task 6 Steps 2 and 3.
+- FR-1 acceptance — `dotnet format` compliant: Task 6 Step 1.
+- FR-2 (Domain-wide `Console.*` scan, document findings, do not modify other files): Task 4.
+- NFR-1 to NFR-4: implicitly satisfied by the deletion; no explicit task needed (no benchmarking, no security review, no observability gap to fill — all called out as no-ops by the spec).
+- Out-of-Scope list: re-stated as a reminder block above Tasks.
+
+**Placeholder scan:** none of "TBD", "TODO", "implement later", "add appropriate X", "similar to Task N", or bare "write tests" placeholders. All steps include exact commands, exact expected output, and (where applicable) the exact `old_string`/`new_string` payload.
+
+**Type consistency:** no new types, methods, properties, or signatures introduced. `PurchaseOrder.AddLine(string, string, decimal, decimal, string?)` is the only API referenced and is referenced consistently.


### PR DESCRIPTION

Removed a leftover `// Debug logging` + `Console.WriteLine` from `PurchaseOrder.AddLine()` that violated the project's Clean Architecture rule: domain entities must have zero infrastructure I/O. The statement was emitting unstructured noise to container stdout on every line addition during `CreatePurchaseOrder` / `UpdatePurchaseOrder` requests. No replacement logging is introduced — handlers already have `ILogger<T>` available if telemetry is ever genuinely required, but that is a separate concern.

FR-2 scan after the change: `grep -rn 'Console\.' backend/src/Anela.Heblo.Domain/` returns no matches — the Domain layer now has zero `Console.*` calls.

### Changes
- `backend/src/Anela.Heblo.Domain/Features/Purchase/PurchaseOrder.cs` — deleted 3 lines: `// Debug logging` comment, `Console.WriteLine(...)` call, and the trailing blank line

---

Closes #1554

### Tokens used
6029043
