### PR TITLE
feat: Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler

### DIFF
--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/arch-review.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/arch-review.r1.md
@@ -1,0 +1,148 @@
+```markdown
+# Architecture Review: Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a **pure dead-code removal in a single MediatR handler**. It does not introduce architectural deviations — it *restores* alignment with the codebase's stated direction:
+
+- The Catalog domain already exposes `ICatalogRepository.GetByIdsAsync` (`backend/src/Anela.Heblo.Domain/Features/Catalog/ICatalogRepository.cs:54`), explicitly added to avoid N+1 patterns. The removed loop directly contradicted that design.
+- The Purchase feature follows the Application's Vertical Slice convention: each use case is one folder under `Features/Purchase/UseCases/*` with `Handler` + `Request` + `Response`. The edit stays inside `UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs` — no slice boundaries are crossed.
+- The `PurchaseOrderLineDto.MaterialName` is sourced from the denormalized `PurchaseOrderLine.MaterialName` entity field. This is the established convention in both `CreatePurchaseOrderHandler.MapToResponseAsync` (no catalog lookup) and `GetPurchaseOrderByIdHandler` (catalog lookup only because `CatalogNote` lives solely in the catalog). The Update handler is the outlier.
+
+**Integration points** are limited to: the single handler file, its DI registration (unchanged), and any tests that referenced catalog calls inside `MapToResponseAsync` (none exist — only `UpdatePurchaseOrderStatusHandlerTests.cs` lives under the Purchase test folder).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+PUT /api/purchase-orders/{id}
+        │
+        ▼
+PurchaseOrdersController ── MediatR ──► UpdatePurchaseOrderHandler
+                                              │
+                                              ├─ ISupplierRepository.GetByIdAsync  (validates supplier)
+                                              ├─ ICatalogRepository.GetByIdAsync   (USED — to set MaterialName on AddLine/UpdateLine in Handle())
+                                              ├─ IPurchaseOrderRepository           (load, persist)
+                                              │
+                                              └─ MapToResponseAsync(purchaseOrder)  ◄── NO catalog calls after this change
+                                                       │
+                                                       └─► UpdatePurchaseOrderResponse  (MaterialName comes from entity)
+```
+
+The architecture **does not change**. Only the `MapToResponseAsync` method is simplified: the loop body becomes a pure entity-to-DTO projection with no awaits.
+
+### Key Design Decisions
+
+#### Decision 1: Drop the lookup outright vs. switch to `GetByIdsAsync`
+**Options considered:**
+- (a) Delete the two unused lines (spec FR-1).
+- (b) Replace the per-line `GetByIdAsync` with a single `GetByIdsAsync` outside the loop.
+
+**Chosen approach:** (a) — delete.
+
+**Rationale:** The fetched value is never read. Replacing a dead call with a "more efficient" dead call still produces zero observable output and adds a dictionary allocation. `GetByIdsAsync` becomes warranted only when a catalog-only field (e.g. `CatalogNote`) is added to `UpdatePurchaseOrderResponse`; that is explicitly out of scope.
+
+#### Decision 2: Keep `ICatalogRepository` as a constructor dependency
+**Options considered:**
+- (a) Remove `_catalogRepository`, the constructor parameter, and the `using Anela.Heblo.Domain.Features.Catalog;` directive (FR-2's conditional path).
+- (b) Keep the dependency.
+
+**Chosen approach:** (b) — keep.
+
+**Rationale:** Verification of the file shows `ICatalogRepository` is still consumed inside the main `Handle` method at `UpdatePurchaseOrderHandler.cs:80` and `:93`, where it computes `materialName` for `UpdateLine`/`AddLine`. Those calls are legitimate (the result is passed to the domain method). The conditional in spec FR-2 ("If `MapToResponseAsync` was the only consumer…") therefore evaluates to false. Field, constructor parameter, and `using` directive must **stay**.
+
+> This is an amendment to the spec — see "Specification Amendments" below.
+
+#### Decision 3: Scope of the "sibling handler" check (FR-4)
+**Options considered:**
+- (a) Grep narrowly for unused `material` lookups inside response-mapping methods.
+- (b) Grep for any `_catalogRepository.GetByIdAsync(...)` inside a line loop.
+
+**Chosen approach:** (a) — match the spec's definition of "dead" (result unused).
+
+**Rationale:** A grep across `Features/Purchase/UseCases` shows four call sites:
+- `UpdatePurchaseOrderHandler.cs:80, :93` — result **used** in `UpdateLine`/`AddLine`. Not dead. Not an N+1 to fix in this change.
+- `UpdatePurchaseOrderHandler.cs:128` — result **unused**. This is the target of FR-1.
+- `CreatePurchaseOrderHandler.cs:79` — result **used** in `AddLine`. Not dead. `CreatePurchaseOrderHandler.MapToResponseAsync` already does the right thing (no catalog calls). 
+- `GetPurchaseOrderByIdHandler.cs:54` — result **used** for `CatalogNote`. Legitimate per the brief.
+
+Conclusion: only the one site qualifies. The other in-loop `GetByIdAsync` calls in the same handler (`:80`, `:93`) are an N+1 *performance* concern but not "dead." They are out of scope for this brief and should be filed separately if desired.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Single-file edit:
+
+```
+backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/
+    └── UpdatePurchaseOrderHandler.cs   ← edit MapToResponseAsync only
+```
+
+### Interfaces and Contracts
+
+No interface or contract changes:
+- `UpdatePurchaseOrderRequest` / `UpdatePurchaseOrderResponse` / `PurchaseOrderLineDto` shapes are unchanged.
+- `ICatalogRepository`, `IPurchaseOrderRepository`, `ISupplierRepository` are unchanged.
+- The handler's constructor signature is **unchanged** (Decision 2).
+- DI registration is **unchanged**.
+
+### Data Flow
+
+For `PUT /api/purchase-orders/{id}` after the change, the response-mapping phase has the following shape:
+
+```
+purchaseOrder (entity, already loaded with .Lines tracked)
+        │
+        ▼
+foreach line in purchaseOrder.Lines:        ── synchronous, no awaits ──►
+    project to PurchaseOrderLineDto using only entity fields
+        │
+        ▼
+return UpdatePurchaseOrderResponse { ..., Lines = lines }
+```
+
+The handler-level data flow (load → validate supplier → mutate aggregate → save) is untouched.
+
+The concrete edit:
+
+- Remove `UpdatePurchaseOrderHandler.cs:127–129` (the comment and the two `var material` / `var materialName` lines).
+- The enclosing `foreach (var line in purchaseOrder.Lines)` loop body becomes the single `lines.Add(new PurchaseOrderLineDto { … })` block already present at `:131–141`.
+- `MapToResponseAsync` no longer needs to be `async` in principle, **but** keep it `async Task<UpdatePurchaseOrderResponse>` and keep the `CancellationToken cancellationToken` parameter to avoid a ripple change at the single call site (`:110`) and to preserve any future extension point. The compiler will emit a CS1998 ("async method lacks await") — suppress this by either:
+    - (preferred) changing the signature to `private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)` and updating the call site `return MapToResponse(purchaseOrder, request.SupplierId);` — this is the cleaner option and aligns with NFR-2 ("no new warnings").
+    - or adding `await Task.CompletedTask;` — **not recommended**; it just papers over the warning.
+
+> **Recommended:** drop `async`, the `Task<…>` wrapper, and the `CancellationToken` parameter from `MapToResponseAsync`, and rename to `MapToResponse`. Update the call site at `:110` accordingly. This keeps the method honest and satisfies NFR-2 without any warning suppression.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Removing the await turns the method synchronous → CS1998 warning ("no new warnings" NFR-2 violated). | Medium | Apply Decision 3's recommended sub-step: change signature to a sync `MapToResponse` and update the single caller. |
+| A test asserts on a mocked `_catalogRepository.GetByIdAsync` call count for the update flow. | Low | Search `backend/test/**/UpdatePurchaseOrder*` — only `UpdatePurchaseOrderStatusHandlerTests.cs` exists, and it targets a different handler. No update needed. If a test is later found, relax the call-count assertion. |
+| Behavior divergence if `line.MaterialName` were ever stale relative to the catalog. | Low | The behavior is **already** this way — the response always returned `line.MaterialName`. Removing the unused lookup cannot change observable output. The denormalized `MaterialName` is refreshed on every `AddLine`/`UpdateLine` in `Handle` (which still uses the catalog), so staleness is bounded to lines that the user does not touch — same as today. |
+| Accidental removal of `_catalogRepository` field breaks `Handle` at `:80` / `:93`. | High | Decision 2 explicitly keeps the field. Reviewer checklist item: confirm `_catalogRepository` references still resolve after the edit. |
+| `using Anela.Heblo.Domain.Features.Catalog;` removed prematurely. | Low | The `using` is still needed for `ICatalogRepository` type binding in the field declaration. Do not remove. |
+
+## Specification Amendments
+
+1. **FR-2 is a no-op.** Verification confirms `_catalogRepository` is still consumed in `Handle` (lines 80 and 93, used by `UpdateLine`/`AddLine`). The field, constructor parameter, and `using Anela.Heblo.Domain.Features.Catalog;` directive **must remain**. The spec's conditional ("If `MapToResponseAsync` was the only consumer…") evaluates to false. Update the spec to state this explicitly so the implementer does not delete the dependency.
+
+2. **Add sub-step to FR-1: convert `MapToResponseAsync` to a sync `MapToResponse`.** After the two dead lines are removed, the method has no remaining awaits. To honor NFR-2 (no new warnings, no `await Task.CompletedTask` filler), change the signature to `private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)`, drop the unused `CancellationToken`, and update the single call site at `UpdatePurchaseOrderHandler.cs:110`.
+
+3. **FR-4 outcome clarified.** The grep `_catalogRepository.GetByIdAsync` under `Features/Purchase/UseCases` returns four hits; only `UpdatePurchaseOrderHandler.cs:128` matches the "dead" criterion (result unused). The other three in-loop calls (`UpdatePurchaseOrderHandler.cs:80`, `:93`, `CreatePurchaseOrderHandler.cs:79`) use the result and are out of scope. PR description should list this verification explicitly.
+
+4. **Note on adjacent N+1.** `UpdatePurchaseOrderHandler.Handle` itself runs `GetByIdAsync` per line in the request (`:80`, `:93`). This is a genuine N+1 with a *used* result. It is **not** dead code and is therefore out of scope per the brief's framing, but it is the natural next ticket: refactor to a single `GetByIdsAsync(request.Lines.Select(l => l.MaterialId).Distinct())` call outside the loop. Recommend filing as a follow-up brief; do not bundle it here.
+
+## Prerequisites
+
+None. No migrations, configuration, infrastructure, or interface changes are required.
+
+- The `ICatalogRepository.GetByIdsAsync` bulk method already exists and is registered, but is **not used** by this change (Decision 1).
+- No frontend regeneration needed: the OpenAPI schema for `UpdatePurchaseOrderResponse` is byte-identical (NFR-3).
+- No test fixtures or seed data changes.
+- Validation gates per `CLAUDE.md`: `dotnet build` + `dotnet format` + run the Purchase test project. No E2E run required for a behavior-preserving dead-code removal.
+```

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/brief.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/brief.md
@@ -1,0 +1,45 @@
+## Module
+Purchase
+
+## Finding
+`UpdatePurchaseOrderHandler.MapToResponseAsync` fetches a catalog item for every order line, but the fetched object is never used — the DTO maps `line.MaterialName` (already stored on the entity):
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-157
+private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
+{
+    var lines = new List<PurchaseOrderLineDto>();
+    foreach (var line in purchaseOrder.Lines)
+    {
+        // Try to get material name from catalog
+        var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);  // ← fetched
+        var materialName = material?.ProductName ?? "Unknown Material";                              // ← computed
+
+        lines.Add(new PurchaseOrderLineDto
+        {
+            ...
+            MaterialName = line.MaterialName,   // ← entity value used, not 'materialName'
+            ...
+        });
+    }
+```
+
+`materialName` is computed but then discarded — the DTO always reads `line.MaterialName`. For an order with N lines this makes N catalog lookups (each of which queries a large in-memory cache or external system) and throws the results away.
+
+Compare with `GetPurchaseOrderByIdHandler`, which performs the same lookup legitimately: it maps `CatalogNote = catalogItem.Note` — a field that only lives in the catalog and cannot come from the entity.
+
+## Why it matters
+- Every `PUT /api/purchase-orders/{id}` request fires N catalog reads that produce no visible output. This is wasted compute on every update.
+- `ICatalogRepository.GetByIdsAsync` was added specifically to eliminate N+1 patterns (its code comment says so). Using `GetByIdAsync` in a loop already goes against that design; computing and discarding the result compounds the waste.
+
+## Suggested fix
+Delete the two dead lines from `MapToResponseAsync`:
+```csharp
+// Remove:
+var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
+var materialName = material?.ProductName ?? "Unknown Material";
+```
+The DTO already reads `line.MaterialName`; no replacement is needed. If `CatalogNote` ever needs to appear on the update response too, use `GetByIdsAsync` once (bulk) outside the loop, as `GetPurchaseOrderByIdHandler` does.
+
+---
+_Filed by daily arch-review routine on 2026-05-22._

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/impl/main.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/impl/main.r1.md
@@ -1,0 +1,12 @@
+This is a standalone worktree clone (not linked to the main repo's worktree list). GIT_DIR == GIT_COMMON → standard 4-option menu.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/spec.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/spec.r1.md
@@ -1,0 +1,98 @@
+# Specification: Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler
+
+## Summary
+Remove a dead catalog lookup in `UpdatePurchaseOrderHandler.MapToResponseAsync` that performs N catalog reads per order update without using the result. The DTO already sources `MaterialName` from the entity, so the lookup is wasted compute on every `PUT /api/purchase-orders/{id}` request.
+
+## Background
+During the daily architecture review on 2026-05-22, an N+1 anti-pattern was found in the Purchase module's update flow.
+
+`UpdatePurchaseOrderHandler.MapToResponseAsync` (backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-157) iterates over each order line and calls `_catalogRepository.GetByIdAsync(line.MaterialId, ...)`. The fetched `material` is used only to compute a local `materialName` variable that is then discarded — the DTO assigns `MaterialName = line.MaterialName` (the value already persisted on the entity), not the computed variable.
+
+For an order with N lines this triggers N catalog lookups that contribute nothing to the response. The repository's bulk method `GetByIdsAsync` was added explicitly to eliminate this kind of N+1 pattern (per its in-code comment). The sibling handler `GetPurchaseOrderByIdHandler` performs the same lookup *legitimately* because it maps `CatalogNote = catalogItem.Note`, a field that lives only in the catalog. The update handler has no such need.
+
+## Functional Requirements
+
+### FR-1: Remove the unused catalog lookup
+Delete the two unused lines from `MapToResponseAsync` in `UpdatePurchaseOrderHandler`:
+
+```csharp
+var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
+var materialName = material?.ProductName ?? "Unknown Material";
+```
+
+No replacement is required. The DTO continues to read `MaterialName = line.MaterialName` from the entity.
+
+**Acceptance criteria:**
+- Lines 125-126 (approx.) of `UpdatePurchaseOrderHandler.cs` are removed.
+- The `foreach (var line in purchaseOrder.Lines)` loop no longer awaits any catalog repository call.
+- The returned `UpdatePurchaseOrderResponse` is byte-identical to the previous implementation for any valid input (i.e., `MaterialName` values in the response are unchanged because they came from `line.MaterialName` all along).
+- `_catalogRepository` is still injected only if used elsewhere in the handler; otherwise the field, constructor parameter, and `using` for `Anela.Heblo.Domain.Features.Catalog` are removed.
+
+### FR-2: Remove now-dead dependencies on `ICatalogRepository`
+If `MapToResponseAsync` was the only consumer of `ICatalogRepository` in `UpdatePurchaseOrderHandler`, remove:
+- The private readonly `_catalogRepository` field.
+- The constructor parameter and its assignment.
+- Any unused `using` directive for the catalog namespace.
+
+**Acceptance criteria:**
+- `UpdatePurchaseOrderHandler` does not reference `ICatalogRepository` after the change unless another method genuinely uses it.
+- The project compiles (`dotnet build`) with no new warnings.
+- DI registration for the handler still resolves correctly (the handler's constructor takes only the dependencies it actually uses).
+
+### FR-3: Preserve existing handler behavior
+The handler must continue to:
+- Update the purchase order as before.
+- Recompute supplier, totals, and line aggregates exactly as it does today.
+- Return the same shape of `UpdatePurchaseOrderResponse` with the same field values for the same inputs.
+
+**Acceptance criteria:**
+- No change to the public method signatures of `UpdatePurchaseOrderHandler`, the request, or the response DTO.
+- No change to validation, persistence, or transaction semantics.
+- Existing unit/integration tests for `UpdatePurchaseOrderHandler` pass without modification (other than any test that asserted on the catalog call count, if such a test exists).
+
+### FR-4: Verify no other handlers have the same dead lookup
+Briefly check sibling handlers in `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/**` for the same pattern (catalog `GetByIdAsync` inside a line loop whose result is unused). Apply the same removal where confirmed.
+
+**Acceptance criteria:**
+- A grep for `GetByIdAsync(line.MaterialId` (or equivalent) under the Purchase use-cases folder reveals no remaining dead lookups.
+- Any additional removals are listed in the PR description.
+- If `GetPurchaseOrderByIdHandler` is the only other handler with such a call, it is left untouched (its use of `catalogItem.Note` is legitimate).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- After the change, `PUT /api/purchase-orders/{id}` issues zero catalog repository calls during response mapping (down from N per order line).
+- No regression in response time; expected modest improvement proportional to line count and catalog backing-store latency.
+
+### NFR-2: Code quality
+- `dotnet build` produces no new warnings.
+- `dotnet format` leaves the file unchanged after the edit.
+- No dead `using` directives remain.
+
+### NFR-3: Backwards compatibility
+- The HTTP contract for `PUT /api/purchase-orders/{id}` is unchanged.
+- The generated OpenAPI schema for `UpdatePurchaseOrderResponse` is identical.
+- No frontend changes are required.
+
+## Data Model
+No changes. `PurchaseOrderLine` continues to store `MaterialName` as a denormalized field; `UpdatePurchaseOrderResponse.PurchaseOrderLineDto.MaterialName` continues to be sourced from that field.
+
+## API / Interface Design
+No changes. The affected endpoint is `PUT /api/purchase-orders/{id}`; its request and response shapes are unchanged.
+
+## Dependencies
+- `Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder.UpdatePurchaseOrderHandler` (the file being edited).
+- `Anela.Heblo.Domain.Features.Catalog.ICatalogRepository` (dependency may be removed from this handler).
+- Existing test project for the Purchase feature (no new tests required unless coverage gaps are uncovered).
+
+## Out of Scope
+- Refactoring `GetPurchaseOrderByIdHandler` (its catalog lookup is legitimate). If a bulk `GetByIdsAsync` refactor for that handler is desired, it should be filed as a separate brief.
+- Adding `CatalogNote` (or other catalog-only fields) to `UpdatePurchaseOrderResponse`. If product later wants this, the implementation must use `GetByIdsAsync` once outside the loop.
+- Broader audit of N+1 patterns outside the Purchase module.
+- Any frontend changes.
+- Changes to caching policy in `ICatalogRepository`.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/task-plan.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/task-plan.r1.md
@@ -1,0 +1,424 @@
+# Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead, per-line `_catalogRepository.GetByIdAsync` call inside `UpdatePurchaseOrderHandler.MapToResponseAsync` whose result is never used, and convert the now-await-free method to a synchronous helper without changing any observable behavior of `PUT /api/purchase-orders/{id}`.
+
+**Architecture:** Single-file edit in a MediatR handler under Vertical Slice `Features/Purchase/UseCases/UpdatePurchaseOrder/`. The fix is pure dead-code removal — no new interfaces, no DI changes, no contract changes. `ICatalogRepository` stays as a dependency because it is still legitimately consumed in `Handle` (lines 80 and 93) to compute `materialName` for `UpdateLine`/`AddLine`. The response DTO already sourced `MaterialName` from the entity (`line.MaterialName`), so deleting the unused lookup leaves the response byte-identical.
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit + Moq + FluentAssertions for tests, EF Core (via `IPurchaseOrderRepository`).
+
+---
+
+## File Structure
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs` — remove dead lines inside `MapToResponseAsync`, convert it to a synchronous `MapToResponse`, update the single call site.
+
+**Created files:**
+- `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs` — new test file with a focused regression test that proves `MapToResponse` does **not** invoke `ICatalogRepository.GetByIdAsync` on the response-mapping path. Mirrors the structure of the sibling `CreatePurchaseOrderHandlerTests.cs` for consistency.
+
+**Out-of-scope (verified by grep, do not touch):**
+- `CreatePurchaseOrderHandler.cs:79` — catalog lookup result is used in `AddLine`. Not dead.
+- `GetPurchaseOrderByIdHandler.cs:54` — catalog lookup feeds `CatalogNote` (catalog-only field). Legitimate.
+- `UpdatePurchaseOrderHandler.cs:80` and `:93` — catalog lookup result is used by `UpdateLine`/`AddLine`. These are an adjacent N+1 with a *used* result; they are a separate ticket per the arch review and **must not** be changed here.
+
+---
+
+## Task 1: Add regression test that proves `MapToResponse` never calls the catalog
+
+We add the test **first** (TDD red step) so that we have a guarantee that the post-edit behavior really removes the unused call.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs`
+
+### Step 1.1: Write the failing test
+
+- [ ] **Step 1.1:** Create the test file with a single test that exercises the update flow with one existing line and one new line, then asserts that the catalog repository is invoked **at most twice** (once for the `UpdateLine` branch at handler line 80, once for the `AddLine` branch at handler line 93) — i.e. **never** invoked a third time during response mapping.
+
+Create `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Purchase.Contracts;
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Purchase;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Purchase;
+
+public class UpdatePurchaseOrderHandlerTests
+{
+    private readonly Mock<ILogger<UpdatePurchaseOrderHandler>> _loggerMock = new();
+    private readonly Mock<IPurchaseOrderRepository> _repositoryMock = new();
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+    private readonly Mock<ISupplierRepository> _supplierRepositoryMock = new();
+    private readonly UpdatePurchaseOrderHandler _handler;
+
+    private const long ValidSupplierId = 1;
+    private const string ValidSupplierName = "Test Supplier";
+    private const string ExistingMaterialId = "MAT-EXISTING";
+    private const string NewMaterialId = "MAT-NEW";
+
+    public UpdatePurchaseOrderHandlerTests()
+    {
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _supplierRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidSupplierId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Supplier { Id = ValidSupplierId, Name = ValidSupplierName, Code = "SUP001" });
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string id, CancellationToken _) => new CatalogAggregate { ProductCode = id, ProductName = $"Material {id}" });
+
+        _handler = new UpdatePurchaseOrderHandler(
+            _loggerMock.Object,
+            _repositoryMock.Object,
+            _catalogRepositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _supplierRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithUpdateAndAddLines_DoesNotCallCatalogDuringResponseMapping()
+    {
+        // Arrange — seed an order that has one existing line.
+        var order = new PurchaseOrder(
+            orderNumber: "PO-2024-001",
+            supplierId: ValidSupplierId,
+            supplierName: ValidSupplierName,
+            orderDate: new DateTime(2024, 8, 2),
+            expectedDeliveryDate: new DateTime(2024, 8, 16),
+            contactVia: null,
+            notes: null,
+            createdBy: "seed");
+        order.AddLine(ExistingMaterialId, "Existing Material", quantity: 1m, unitPrice: 10m, notes: null);
+        var existingLineId = order.Lines.Single().Id;
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var request = new UpdatePurchaseOrderRequest
+        {
+            Id = order.Id,
+            SupplierId = ValidSupplierId,
+            OrderNumber = order.OrderNumber,
+            ExpectedDeliveryDate = order.ExpectedDeliveryDate,
+            ContactVia = null,
+            Notes = null,
+            Lines = new List<UpdatePurchaseOrderLineRequestDto>
+            {
+                new()
+                {
+                    Id = existingLineId,
+                    MaterialId = ExistingMaterialId,
+                    Name = "Existing Material",
+                    Quantity = 2m,
+                    UnitPrice = 10m,
+                    Notes = null,
+                },
+                new()
+                {
+                    Id = null,
+                    MaterialId = NewMaterialId,
+                    Name = "New Material",
+                    Quantity = 3m,
+                    UnitPrice = 20m,
+                    Notes = null,
+                },
+            },
+        };
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert — response is well-formed and MaterialName comes from the entity.
+        response.Success.Should().BeTrue();
+        response.Lines.Should().HaveCount(2);
+        response.Lines.Should().OnlyContain(line => !string.IsNullOrEmpty(line.MaterialName));
+
+        // Assert — catalog is hit exactly twice (once per request line, inside Handle),
+        // and never again inside MapToResponse. This is the regression guard.
+        _catalogRepositoryMock.Verify(
+            x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}
+```
+
+> **Note for the implementer:** Property names on `UpdatePurchaseOrderRequest`, `UpdatePurchaseOrderLineRequestDto`, `PurchaseOrder`, and `CatalogAggregate` shown above must match the codebase exactly. If a property does not exist with the spelling shown (e.g. `Name` on the line request, or `ProductName`/`ProductCode` on `CatalogAggregate`), open the type and use the actual property name — do not invent fields. The intent of the test is to: (1) drive the handler through both the update-existing-line and add-new-line branches, and (2) verify `_catalogRepositoryMock.GetByIdAsync` is called exactly twice (i.e. zero times during response mapping). Adjust property spellings to match the real types; do not change the assertion semantics.
+
+### Step 1.2: Run the test to confirm it fails
+
+- [ ] **Step 1.2:** Run only the new test. It must fail with a Moq `Times.Exactly(2)` assertion failure showing **3** invocations of `_catalogRepository.GetByIdAsync` (two from `Handle` lines 80/93, plus one from `MapToResponseAsync` line 128).
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdatePurchaseOrderHandlerTests"
+```
+
+Expected: **FAIL** with FluentAssertions/Moq output indicating the mock was invoked 3 times when 2 were expected.
+
+If the test instead fails at the Arrange stage (e.g. with `ArgumentException` or `NullReferenceException`) because property names on the seed types do not match the codebase, **fix the property names in the test only** (do not change the handler), re-run, and confirm the failure mode is the catalog call-count mismatch before proceeding.
+
+### Step 1.3: Commit the failing test
+
+- [ ] **Step 1.3:** Commit the failing test as a guardrail before the source edit.
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
+git commit -m "test(purchase): add regression for unused catalog lookup in UpdatePurchaseOrder mapping"
+```
+
+---
+
+## Task 2: Remove the dead lookup and convert `MapToResponseAsync` to a synchronous helper
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:110` (single call site)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-142` (method signature and body)
+
+### Step 2.1: Delete the dead `material` / `materialName` lines inside `MapToResponseAsync`
+
+- [ ] **Step 2.1:** Remove the comment and two unused variable declarations inside the `foreach (var line in purchaseOrder.Lines)` loop. The `lines.Add(new PurchaseOrderLineDto { … })` block stays exactly as-is and still reads `MaterialName = line.MaterialName` from the entity.
+
+In `UpdatePurchaseOrderHandler.cs`, replace:
+
+```csharp
+        foreach (var line in purchaseOrder.Lines)
+        {
+            // Try to get material name from catalog
+            var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
+            var materialName = material?.ProductName ?? "Unknown Material";
+
+            lines.Add(new PurchaseOrderLineDto
+            {
+                Id = line.Id,
+                MaterialId = line.MaterialId,
+                Code = line.MaterialId, // Code is same as MaterialId
+                MaterialName = line.MaterialName,
+                Quantity = line.Quantity,
+                UnitPrice = line.UnitPrice,
+                LineTotal = line.LineTotal,
+                Notes = line.Notes
+            });
+        }
+```
+
+with:
+
+```csharp
+        foreach (var line in purchaseOrder.Lines)
+        {
+            lines.Add(new PurchaseOrderLineDto
+            {
+                Id = line.Id,
+                MaterialId = line.MaterialId,
+                Code = line.MaterialId, // Code is same as MaterialId
+                MaterialName = line.MaterialName,
+                Quantity = line.Quantity,
+                UnitPrice = line.UnitPrice,
+                LineTotal = line.LineTotal,
+                Notes = line.Notes
+            });
+        }
+```
+
+### Step 2.2: Convert `MapToResponseAsync` to synchronous `MapToResponse`
+
+- [ ] **Step 2.2:** The method body now contains no `await`. To avoid the CS1998 "async method lacks await" warning (NFR-2: no new warnings) without papering over it with `await Task.CompletedTask`, drop `async`, drop the `Task<…>` wrapper, drop the unused `CancellationToken cancellationToken` parameter, and rename `MapToResponseAsync` → `MapToResponse`.
+
+Change the method signature from:
+
+```csharp
+    private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
+    {
+```
+
+to:
+
+```csharp
+    private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)
+    {
+```
+
+The body (the `var lines = new List<PurchaseOrderLineDto>(); foreach …; return new UpdatePurchaseOrderResponse { … };`) stays exactly as edited in Step 2.1.
+
+### Step 2.3: Update the single call site
+
+- [ ] **Step 2.3:** Update the caller at `UpdatePurchaseOrderHandler.cs:110` to drop the `await` and the trailing `cancellationToken` argument, and to use the new method name.
+
+Change:
+
+```csharp
+            return await MapToResponseAsync(purchaseOrder, request.SupplierId, cancellationToken);
+```
+
+to:
+
+```csharp
+            return MapToResponse(purchaseOrder, request.SupplierId);
+```
+
+### Step 2.4: Verify `_catalogRepository`, the constructor parameter, and the `using` directive are unchanged
+
+- [ ] **Step 2.4:** Open `UpdatePurchaseOrderHandler.cs` and confirm — **without making any edits** — that the following are still present:
+  - `using Anela.Heblo.Domain.Features.Catalog;` at the top
+  - `private readonly ICatalogRepository _catalogRepository;` field
+  - `ICatalogRepository catalogRepository` constructor parameter and the `_catalogRepository = catalogRepository;` assignment
+  - The two `_catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken)` calls inside `Handle` at the original lines 80 and 93 (their result is consumed by `UpdateLine`/`AddLine`).
+
+This is a checkpoint, not an edit. If any of the above is missing after Step 2.1–2.3, the edit was too aggressive — revert and redo Step 2.1.
+
+### Step 2.5: Run the new regression test — must now pass
+
+- [ ] **Step 2.5:** Re-run only the new test.
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdatePurchaseOrderHandlerTests"
+```
+
+Expected: **PASS**. The mock now records exactly 2 calls to `GetByIdAsync` (the two inside `Handle`), confirming `MapToResponse` no longer hits the catalog.
+
+### Step 2.6: Run the full Purchase test class to confirm no regression
+
+- [ ] **Step 2.6:** Run all Purchase feature tests to confirm sibling handlers (`CreatePurchaseOrderHandlerTests`, `UpdatePurchaseOrderStatusHandlerTests`, etc.) still pass — they should be unaffected.
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Purchase"
+```
+
+Expected: **PASS** for all tests in the namespace. If any test fails, stop and investigate — the edit must be behavior-preserving for everything except the catalog call count.
+
+### Step 2.7: Build and format
+
+- [ ] **Step 2.7:** Run the project validation gates required by `CLAUDE.md`.
+
+Run:
+
+```bash
+cd backend && dotnet build && dotnet format --verify-no-changes
+```
+
+Expected:
+- `dotnet build`: **succeeds with zero new warnings**. In particular, no `CS1998` warning on `MapToResponseAsync`/`MapToResponse` (the method is now correctly synchronous).
+- `dotnet format --verify-no-changes`: **exit 0**. If it reports formatting differences, run `dotnet format` (without `--verify-no-changes`) and re-run the check.
+
+### Step 2.8: Commit the fix
+
+- [ ] **Step 2.8:** Commit the source edit.
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
+git commit -m "refactor(purchase): remove dead per-line catalog lookup in UpdatePurchaseOrder response mapping"
+```
+
+---
+
+## Task 3: Verify no other Purchase handler has the same dead pattern (FR-4)
+
+This is verification work, not editing. It produces the audit line that goes into the PR description.
+
+### Step 3.1: Re-grep all `_catalogRepository.GetByIdAsync` sites under `Features/Purchase/UseCases`
+
+- [ ] **Step 3.1:** Confirm the only remaining call sites are ones with a *used* result.
+
+Run:
+
+```bash
+cd backend/src/Anela.Heblo.Application/Features/Purchase/UseCases && \
+  grep -rn "_catalogRepository.GetByIdAsync" .
+```
+
+Expected output (line numbers shifted after the edit; line 128 in `UpdatePurchaseOrderHandler.cs` must be gone):
+
+```
+./GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs:54:            var catalogItem = await _catalogRepository.GetByIdAsync(materialId, cancellationToken);
+./UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:80:                    var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+./UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:93:                    var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+./CreatePurchaseOrder/CreatePurchaseOrderHandler.cs:79:                var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+```
+
+Exactly 4 remaining hits. Each one:
+
+- `GetPurchaseOrderByIdHandler.cs:54` — `catalogItem` is consumed to populate `CatalogNote`. **Legitimate, leave it.**
+- `UpdatePurchaseOrderHandler.cs:80` — `material` feeds `UpdateLine`. **Used, out of scope.**
+- `UpdatePurchaseOrderHandler.cs:93` — `material` feeds `AddLine`. **Used, out of scope.**
+- `CreatePurchaseOrderHandler.cs:79` — `material` feeds `AddLine`. **Used, out of scope.**
+
+If the grep shows any **new** call site whose result is not consumed on the next line or two, that is a finding for this brief — repeat Task 2 against that file. Otherwise, the audit is clean.
+
+### Step 3.2: Capture the audit line for the PR description
+
+- [ ] **Step 3.2:** Note the grep result verbatim for inclusion in the PR description under a "Verification" section, e.g.:
+
+> Grep of `_catalogRepository.GetByIdAsync` under `Features/Purchase/UseCases` returns 4 hits: `GetPurchaseOrderByIdHandler.cs:54` (used: `CatalogNote`), `UpdatePurchaseOrderHandler.cs:80`/`:93` (used: `UpdateLine`/`AddLine`), `CreatePurchaseOrderHandler.cs:79` (used: `AddLine`). The dead site at `UpdatePurchaseOrderHandler.cs:128` is gone. The adjacent N+1 in `UpdatePurchaseOrderHandler.Handle` is a separate, follow-up ticket.
+
+No commit in this task — the output goes into the PR description, not the repo.
+
+---
+
+## Task 4: Final validation gates
+
+### Step 4.1: Run the entire backend test suite
+
+- [ ] **Step 4.1:** Confirm nothing outside the Purchase folder breaks.
+
+Run:
+
+```bash
+cd backend && dotnet test
+```
+
+Expected: **PASS** across the whole solution. If unrelated tests fail, they are pre-existing failures and not the concern of this change — note them and proceed. If a test that mentions `UpdatePurchaseOrder` fails, stop and investigate.
+
+### Step 4.2: Confirm the OpenAPI schema is byte-identical (NFR-3)
+
+- [ ] **Step 4.2:** The `UpdatePurchaseOrderResponse` DTO shape is unchanged (no fields added, removed, or renamed) and the handler still returns the same field values. No frontend regeneration is required. To double-check, confirm no DTO file under `Features/Purchase/Contracts/` was modified:
+
+```bash
+git diff --name-only main...HEAD -- backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/
+```
+
+Expected: **empty output**. If anything appears, the edit drifted out of scope — revert the DTO change.
+
+### Step 4.3: Self-review against the spec and arch review
+
+- [ ] **Step 4.3:** Walk the spec's acceptance criteria once and confirm each is satisfied by the change set:
+  - **FR-1:** The two dead lines (and their comment) are gone from `MapToResponse`. The loop has no awaits. The response's `MaterialName` still comes from `line.MaterialName`. ✅
+  - **FR-2 (per arch-review amendment):** `_catalogRepository`, the constructor parameter, and the `using Anela.Heblo.Domain.Features.Catalog;` directive are **retained** because `Handle` still uses them. ✅
+  - **FR-3:** Public method signatures of the handler/request/response are unchanged. Validation, persistence, and transaction semantics are untouched. ✅
+  - **FR-4:** Grep verified — only one site qualified as dead. ✅
+  - **NFR-1:** `PUT /api/purchase-orders/{id}` now issues zero catalog calls during response mapping (proven by Task 1's test). ✅
+  - **NFR-2:** `dotnet build` clean, `dotnet format` clean, no `CS1998`. ✅
+  - **NFR-3:** HTTP contract and OpenAPI schema unchanged. ✅
+
+If any criterion is unsatisfied, return to the corresponding task. Otherwise, the change is ready to ship.
+
+---
+
+## Notes for the implementer
+
+- **Do not touch `Handle` lines 80 and 93.** They look like the same anti-pattern but their result is consumed. Refactoring them to `GetByIdsAsync` is a separate, explicitly-out-of-scope follow-up.
+- **Do not remove `ICatalogRepository` from the constructor.** It is still needed by `Handle`. The spec's conditional FR-2 ("If `MapToResponseAsync` was the only consumer…") is false here — the arch review amended the spec on this point.
+- **Do not add `await Task.CompletedTask`** to silence CS1998. The correct fix is converting the method to synchronous (Task 2.2/2.3).
+- **Do not change the DTO.** Adding `CatalogNote` (or any other catalog-only field) to `UpdatePurchaseOrderResponse` is explicitly out of scope.
+- **Frontend is untouched.** No `npm run build`/lint runs needed for this change.
+- **E2E is not required.** Per `CLAUDE.md`, E2E runs nightly; a behavior-preserving dead-code removal does not warrant an on-demand E2E run.

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
@@ -107,7 +107,7 @@ public class UpdatePurchaseOrderHandler : IRequestHandler<UpdatePurchaseOrderReq
 
             _logger.LogInformation("Purchase order {OrderNumber} updated successfully", purchaseOrder.OrderNumber);
 
-            return await MapToResponseAsync(purchaseOrder, request.SupplierId, cancellationToken);
+            return MapToResponse(purchaseOrder, request.SupplierId);
         }
         catch (InvalidOperationException ex)
         {
@@ -118,16 +118,12 @@ public class UpdatePurchaseOrderHandler : IRequestHandler<UpdatePurchaseOrderReq
     }
 
 
-    private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
+    private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)
     {
         var lines = new List<PurchaseOrderLineDto>();
 
         foreach (var line in purchaseOrder.Lines)
         {
-            // Try to get material name from catalog
-            var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
-            var materialName = material?.ProductName ?? "Unknown Material";
-
             lines.Add(new PurchaseOrderLineDto
             {
                 Id = line.Id,

--- a/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Purchase;
 
-public class UpdatePurchaseOrderHandlerTests
+public sealed class UpdatePurchaseOrderHandlerTests
 {
     private readonly Mock<ILogger<UpdatePurchaseOrderHandler>> _loggerMock;
     private readonly Mock<IPurchaseOrderRepository> _repositoryMock;
@@ -111,9 +111,8 @@ public class UpdatePurchaseOrderHandlerTests
         response.Lines.Should().HaveCount(2);
         response.Lines.Should().OnlyContain(line => !string.IsNullOrEmpty(line.MaterialName));
 
-        // KEY ASSERTION: Verify that GetByIdAsync was called exactly 2 times (once for UpdateLine, once for AddLine)
-        // With the current dead code in MapToResponseAsync, it will be called 3 times (2 in Handle + 1 in MapToResponseAsync)
-        // This test should FAIL initially to prove the dead call exists
+        // Catalog must not be queried during response mapping — only during line updates/adds in Handle.
+        // 1 per request line (1 update + 1 add).
         _catalogRepositoryMock.Verify(
             x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2),

--- a/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
@@ -1,0 +1,122 @@
+using Anela.Heblo.Application.Features.Purchase;
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using Anela.Heblo.Domain.Features.Purchase;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Purchase;
+
+public class UpdatePurchaseOrderHandlerTests
+{
+    private readonly Mock<ILogger<UpdatePurchaseOrderHandler>> _loggerMock;
+    private readonly Mock<IPurchaseOrderRepository> _repositoryMock;
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<ISupplierRepository> _supplierRepositoryMock;
+    private readonly UpdatePurchaseOrderHandler _handler;
+
+    private const long ValidSupplierId = 1;
+    private const string ValidSupplierName = "Test Supplier";
+    private const string ValidMaterialId = "MAT001";
+    private const string ValidMaterialName = "Test Material";
+    private const string NewMaterialId = "MAT002";
+    private const string NewMaterialName = "New Material";
+
+    public UpdatePurchaseOrderHandlerTests()
+    {
+        _loggerMock = new Mock<ILogger<UpdatePurchaseOrderHandler>>();
+        _repositoryMock = new Mock<IPurchaseOrderRepository>();
+        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _supplierRepositoryMock = new Mock<ISupplierRepository>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _supplierRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidSupplierId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Supplier { Id = ValidSupplierId, Name = ValidSupplierName, Code = "SUP001" });
+
+        _handler = new UpdatePurchaseOrderHandler(
+            _loggerMock.Object,
+            _repositoryMock.Object,
+            _catalogRepositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _supplierRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithUpdateAndAddLines_DoesNotCallCatalogDuringResponseMapping()
+    {
+        // Arrange
+        var existingOrder = new PurchaseOrder(
+            "PO-2024-001",
+            ValidSupplierId,
+            ValidSupplierName,
+            DateTime.UtcNow,
+            null,
+            null,
+            "Test notes",
+            "system");
+
+        // Add one existing line to the order
+        existingOrder.AddLine(ValidMaterialId, ValidMaterialName, 10, 25.50m, "Line notes");
+        var existingLineId = existingOrder.Lines.First().Id;
+
+        // Set up repository to return the order when fetched
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(existingOrder.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        // Set up repository to return success on save
+        _repositoryMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Set up catalog repository to return materials when called
+        // This returns a material for each call, so we track the invocation count
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string materialId, CancellationToken ct) =>
+                new CatalogAggregate { ProductCode = materialId, ProductName = $"Material {materialId}" });
+
+        // Build the request with 2 lines:
+        // - Line 1: updates the existing line (Id = existingLineId)
+        // - Line 2: adds a new line (Id = null)
+        var request = new UpdatePurchaseOrderRequest
+        {
+            Id = existingOrder.Id,
+            SupplierId = ValidSupplierId,
+            ExpectedDeliveryDate = DateTime.UtcNow.AddDays(30),
+            ContactVia = null,
+            Notes = "Updated notes",
+            OrderNumber = null,
+            Lines = new List<UpdatePurchaseOrderLineRequest>
+            {
+                new() { Id = existingLineId, MaterialId = ValidMaterialId, Name = ValidMaterialName, Quantity = 15, UnitPrice = 30.00m, Notes = "Updated line" },
+                new() { Id = null, MaterialId = NewMaterialId, Name = NewMaterialName, Quantity = 5, UnitPrice = 50.00m, Notes = "New line" }
+            }
+        };
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Should().NotBeNull();
+        response.Lines.Should().HaveCount(2);
+        response.Lines.Should().OnlyContain(line => !string.IsNullOrEmpty(line.MaterialName));
+
+        // KEY ASSERTION: Verify that GetByIdAsync was called exactly 2 times (once for UpdateLine, once for AddLine)
+        // With the current dead code in MapToResponseAsync, it will be called 3 times (2 in Handle + 1 in MapToResponseAsync)
+        // This test should FAIL initially to prove the dead call exists
+        _catalogRepositoryMock.Verify(
+            x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "Catalog should only be queried during line updates/adds, not during response mapping");
+    }
+}

--- a/docs/superpowers/plans/2026-05-24-remove-dead-catalog-lookup-updatepurchaseorder.md
+++ b/docs/superpowers/plans/2026-05-24-remove-dead-catalog-lookup-updatepurchaseorder.md
@@ -1,0 +1,424 @@
+# Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead, per-line `_catalogRepository.GetByIdAsync` call inside `UpdatePurchaseOrderHandler.MapToResponseAsync` whose result is never used, and convert the now-await-free method to a synchronous helper without changing any observable behavior of `PUT /api/purchase-orders/{id}`.
+
+**Architecture:** Single-file edit in a MediatR handler under Vertical Slice `Features/Purchase/UseCases/UpdatePurchaseOrder/`. The fix is pure dead-code removal — no new interfaces, no DI changes, no contract changes. `ICatalogRepository` stays as a dependency because it is still legitimately consumed in `Handle` (lines 80 and 93) to compute `materialName` for `UpdateLine`/`AddLine`. The response DTO already sourced `MaterialName` from the entity (`line.MaterialName`), so deleting the unused lookup leaves the response byte-identical.
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit + Moq + FluentAssertions for tests, EF Core (via `IPurchaseOrderRepository`).
+
+---
+
+## File Structure
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs` — remove dead lines inside `MapToResponseAsync`, convert it to a synchronous `MapToResponse`, update the single call site.
+
+**Created files:**
+- `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs` — new test file with a focused regression test that proves `MapToResponse` does **not** invoke `ICatalogRepository.GetByIdAsync` on the response-mapping path. Mirrors the structure of the sibling `CreatePurchaseOrderHandlerTests.cs` for consistency.
+
+**Out-of-scope (verified by grep, do not touch):**
+- `CreatePurchaseOrderHandler.cs:79` — catalog lookup result is used in `AddLine`. Not dead.
+- `GetPurchaseOrderByIdHandler.cs:54` — catalog lookup feeds `CatalogNote` (catalog-only field). Legitimate.
+- `UpdatePurchaseOrderHandler.cs:80` and `:93` — catalog lookup result is used by `UpdateLine`/`AddLine`. These are an adjacent N+1 with a *used* result; they are a separate ticket per the arch review and **must not** be changed here.
+
+---
+
+## Task 1: Add regression test that proves `MapToResponse` never calls the catalog
+
+We add the test **first** (TDD red step) so that we have a guarantee that the post-edit behavior really removes the unused call.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs`
+
+### Step 1.1: Write the failing test
+
+- [ ] **Step 1.1:** Create the test file with a single test that exercises the update flow with one existing line and one new line, then asserts that the catalog repository is invoked **at most twice** (once for the `UpdateLine` branch at handler line 80, once for the `AddLine` branch at handler line 93) — i.e. **never** invoked a third time during response mapping.
+
+Create `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Purchase.Contracts;
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Purchase;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Purchase;
+
+public class UpdatePurchaseOrderHandlerTests
+{
+    private readonly Mock<ILogger<UpdatePurchaseOrderHandler>> _loggerMock = new();
+    private readonly Mock<IPurchaseOrderRepository> _repositoryMock = new();
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
+    private readonly Mock<ISupplierRepository> _supplierRepositoryMock = new();
+    private readonly UpdatePurchaseOrderHandler _handler;
+
+    private const long ValidSupplierId = 1;
+    private const string ValidSupplierName = "Test Supplier";
+    private const string ExistingMaterialId = "MAT-EXISTING";
+    private const string NewMaterialId = "MAT-NEW";
+
+    public UpdatePurchaseOrderHandlerTests()
+    {
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
+
+        _supplierRepositoryMock
+            .Setup(x => x.GetByIdAsync(ValidSupplierId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Supplier { Id = ValidSupplierId, Name = ValidSupplierName, Code = "SUP001" });
+
+        _catalogRepositoryMock
+            .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string id, CancellationToken _) => new CatalogAggregate { ProductCode = id, ProductName = $"Material {id}" });
+
+        _handler = new UpdatePurchaseOrderHandler(
+            _loggerMock.Object,
+            _repositoryMock.Object,
+            _catalogRepositoryMock.Object,
+            _currentUserServiceMock.Object,
+            _supplierRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithUpdateAndAddLines_DoesNotCallCatalogDuringResponseMapping()
+    {
+        // Arrange — seed an order that has one existing line.
+        var order = new PurchaseOrder(
+            orderNumber: "PO-2024-001",
+            supplierId: ValidSupplierId,
+            supplierName: ValidSupplierName,
+            orderDate: new DateTime(2024, 8, 2),
+            expectedDeliveryDate: new DateTime(2024, 8, 16),
+            contactVia: null,
+            notes: null,
+            createdBy: "seed");
+        order.AddLine(ExistingMaterialId, "Existing Material", quantity: 1m, unitPrice: 10m, notes: null);
+        var existingLineId = order.Lines.Single().Id;
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(order.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        var request = new UpdatePurchaseOrderRequest
+        {
+            Id = order.Id,
+            SupplierId = ValidSupplierId,
+            OrderNumber = order.OrderNumber,
+            ExpectedDeliveryDate = order.ExpectedDeliveryDate,
+            ContactVia = null,
+            Notes = null,
+            Lines = new List<UpdatePurchaseOrderLineRequestDto>
+            {
+                new()
+                {
+                    Id = existingLineId,
+                    MaterialId = ExistingMaterialId,
+                    Name = "Existing Material",
+                    Quantity = 2m,
+                    UnitPrice = 10m,
+                    Notes = null,
+                },
+                new()
+                {
+                    Id = null,
+                    MaterialId = NewMaterialId,
+                    Name = "New Material",
+                    Quantity = 3m,
+                    UnitPrice = 20m,
+                    Notes = null,
+                },
+            },
+        };
+
+        // Act
+        var response = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert — response is well-formed and MaterialName comes from the entity.
+        response.Success.Should().BeTrue();
+        response.Lines.Should().HaveCount(2);
+        response.Lines.Should().OnlyContain(line => !string.IsNullOrEmpty(line.MaterialName));
+
+        // Assert — catalog is hit exactly twice (once per request line, inside Handle),
+        // and never again inside MapToResponse. This is the regression guard.
+        _catalogRepositoryMock.Verify(
+            x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}
+```
+
+> **Note for the implementer:** Property names on `UpdatePurchaseOrderRequest`, `UpdatePurchaseOrderLineRequestDto`, `PurchaseOrder`, and `CatalogAggregate` shown above must match the codebase exactly. If a property does not exist with the spelling shown (e.g. `Name` on the line request, or `ProductName`/`ProductCode` on `CatalogAggregate`), open the type and use the actual property name — do not invent fields. The intent of the test is to: (1) drive the handler through both the update-existing-line and add-new-line branches, and (2) verify `_catalogRepositoryMock.GetByIdAsync` is called exactly twice (i.e. zero times during response mapping). Adjust property spellings to match the real types; do not change the assertion semantics.
+
+### Step 1.2: Run the test to confirm it fails
+
+- [ ] **Step 1.2:** Run only the new test. It must fail with a Moq `Times.Exactly(2)` assertion failure showing **3** invocations of `_catalogRepository.GetByIdAsync` (two from `Handle` lines 80/93, plus one from `MapToResponseAsync` line 128).
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdatePurchaseOrderHandlerTests"
+```
+
+Expected: **FAIL** with FluentAssertions/Moq output indicating the mock was invoked 3 times when 2 were expected.
+
+If the test instead fails at the Arrange stage (e.g. with `ArgumentException` or `NullReferenceException`) because property names on the seed types do not match the codebase, **fix the property names in the test only** (do not change the handler), re-run, and confirm the failure mode is the catalog call-count mismatch before proceeding.
+
+### Step 1.3: Commit the failing test
+
+- [ ] **Step 1.3:** Commit the failing test as a guardrail before the source edit.
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
+git commit -m "test(purchase): add regression for unused catalog lookup in UpdatePurchaseOrder mapping"
+```
+
+---
+
+## Task 2: Remove the dead lookup and convert `MapToResponseAsync` to a synchronous helper
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:110` (single call site)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-142` (method signature and body)
+
+### Step 2.1: Delete the dead `material` / `materialName` lines inside `MapToResponseAsync`
+
+- [ ] **Step 2.1:** Remove the comment and two unused variable declarations inside the `foreach (var line in purchaseOrder.Lines)` loop. The `lines.Add(new PurchaseOrderLineDto { … })` block stays exactly as-is and still reads `MaterialName = line.MaterialName` from the entity.
+
+In `UpdatePurchaseOrderHandler.cs`, replace:
+
+```csharp
+        foreach (var line in purchaseOrder.Lines)
+        {
+            // Try to get material name from catalog
+            var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
+            var materialName = material?.ProductName ?? "Unknown Material";
+
+            lines.Add(new PurchaseOrderLineDto
+            {
+                Id = line.Id,
+                MaterialId = line.MaterialId,
+                Code = line.MaterialId, // Code is same as MaterialId
+                MaterialName = line.MaterialName,
+                Quantity = line.Quantity,
+                UnitPrice = line.UnitPrice,
+                LineTotal = line.LineTotal,
+                Notes = line.Notes
+            });
+        }
+```
+
+with:
+
+```csharp
+        foreach (var line in purchaseOrder.Lines)
+        {
+            lines.Add(new PurchaseOrderLineDto
+            {
+                Id = line.Id,
+                MaterialId = line.MaterialId,
+                Code = line.MaterialId, // Code is same as MaterialId
+                MaterialName = line.MaterialName,
+                Quantity = line.Quantity,
+                UnitPrice = line.UnitPrice,
+                LineTotal = line.LineTotal,
+                Notes = line.Notes
+            });
+        }
+```
+
+### Step 2.2: Convert `MapToResponseAsync` to synchronous `MapToResponse`
+
+- [ ] **Step 2.2:** The method body now contains no `await`. To avoid the CS1998 "async method lacks await" warning (NFR-2: no new warnings) without papering over it with `await Task.CompletedTask`, drop `async`, drop the `Task<…>` wrapper, drop the unused `CancellationToken cancellationToken` parameter, and rename `MapToResponseAsync` → `MapToResponse`.
+
+Change the method signature from:
+
+```csharp
+    private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
+    {
+```
+
+to:
+
+```csharp
+    private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)
+    {
+```
+
+The body (the `var lines = new List<PurchaseOrderLineDto>(); foreach …; return new UpdatePurchaseOrderResponse { … };`) stays exactly as edited in Step 2.1.
+
+### Step 2.3: Update the single call site
+
+- [ ] **Step 2.3:** Update the caller at `UpdatePurchaseOrderHandler.cs:110` to drop the `await` and the trailing `cancellationToken` argument, and to use the new method name.
+
+Change:
+
+```csharp
+            return await MapToResponseAsync(purchaseOrder, request.SupplierId, cancellationToken);
+```
+
+to:
+
+```csharp
+            return MapToResponse(purchaseOrder, request.SupplierId);
+```
+
+### Step 2.4: Verify `_catalogRepository`, the constructor parameter, and the `using` directive are unchanged
+
+- [ ] **Step 2.4:** Open `UpdatePurchaseOrderHandler.cs` and confirm — **without making any edits** — that the following are still present:
+  - `using Anela.Heblo.Domain.Features.Catalog;` at the top
+  - `private readonly ICatalogRepository _catalogRepository;` field
+  - `ICatalogRepository catalogRepository` constructor parameter and the `_catalogRepository = catalogRepository;` assignment
+  - The two `_catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken)` calls inside `Handle` at the original lines 80 and 93 (their result is consumed by `UpdateLine`/`AddLine`).
+
+This is a checkpoint, not an edit. If any of the above is missing after Step 2.1–2.3, the edit was too aggressive — revert and redo Step 2.1.
+
+### Step 2.5: Run the new regression test — must now pass
+
+- [ ] **Step 2.5:** Re-run only the new test.
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdatePurchaseOrderHandlerTests"
+```
+
+Expected: **PASS**. The mock now records exactly 2 calls to `GetByIdAsync` (the two inside `Handle`), confirming `MapToResponse` no longer hits the catalog.
+
+### Step 2.6: Run the full Purchase test class to confirm no regression
+
+- [ ] **Step 2.6:** Run all Purchase feature tests to confirm sibling handlers (`CreatePurchaseOrderHandlerTests`, `UpdatePurchaseOrderStatusHandlerTests`, etc.) still pass — they should be unaffected.
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Purchase"
+```
+
+Expected: **PASS** for all tests in the namespace. If any test fails, stop and investigate — the edit must be behavior-preserving for everything except the catalog call count.
+
+### Step 2.7: Build and format
+
+- [ ] **Step 2.7:** Run the project validation gates required by `CLAUDE.md`.
+
+Run:
+
+```bash
+cd backend && dotnet build && dotnet format --verify-no-changes
+```
+
+Expected:
+- `dotnet build`: **succeeds with zero new warnings**. In particular, no `CS1998` warning on `MapToResponseAsync`/`MapToResponse` (the method is now correctly synchronous).
+- `dotnet format --verify-no-changes`: **exit 0**. If it reports formatting differences, run `dotnet format` (without `--verify-no-changes`) and re-run the check.
+
+### Step 2.8: Commit the fix
+
+- [ ] **Step 2.8:** Commit the source edit.
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
+git commit -m "refactor(purchase): remove dead per-line catalog lookup in UpdatePurchaseOrder response mapping"
+```
+
+---
+
+## Task 3: Verify no other Purchase handler has the same dead pattern (FR-4)
+
+This is verification work, not editing. It produces the audit line that goes into the PR description.
+
+### Step 3.1: Re-grep all `_catalogRepository.GetByIdAsync` sites under `Features/Purchase/UseCases`
+
+- [ ] **Step 3.1:** Confirm the only remaining call sites are ones with a *used* result.
+
+Run:
+
+```bash
+cd backend/src/Anela.Heblo.Application/Features/Purchase/UseCases && \
+  grep -rn "_catalogRepository.GetByIdAsync" .
+```
+
+Expected output (line numbers shifted after the edit; line 128 in `UpdatePurchaseOrderHandler.cs` must be gone):
+
+```
+./GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs:54:            var catalogItem = await _catalogRepository.GetByIdAsync(materialId, cancellationToken);
+./UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:80:                    var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+./UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:93:                    var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+./CreatePurchaseOrder/CreatePurchaseOrderHandler.cs:79:                var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+```
+
+Exactly 4 remaining hits. Each one:
+
+- `GetPurchaseOrderByIdHandler.cs:54` — `catalogItem` is consumed to populate `CatalogNote`. **Legitimate, leave it.**
+- `UpdatePurchaseOrderHandler.cs:80` — `material` feeds `UpdateLine`. **Used, out of scope.**
+- `UpdatePurchaseOrderHandler.cs:93` — `material` feeds `AddLine`. **Used, out of scope.**
+- `CreatePurchaseOrderHandler.cs:79` — `material` feeds `AddLine`. **Used, out of scope.**
+
+If the grep shows any **new** call site whose result is not consumed on the next line or two, that is a finding for this brief — repeat Task 2 against that file. Otherwise, the audit is clean.
+
+### Step 3.2: Capture the audit line for the PR description
+
+- [ ] **Step 3.2:** Note the grep result verbatim for inclusion in the PR description under a "Verification" section, e.g.:
+
+> Grep of `_catalogRepository.GetByIdAsync` under `Features/Purchase/UseCases` returns 4 hits: `GetPurchaseOrderByIdHandler.cs:54` (used: `CatalogNote`), `UpdatePurchaseOrderHandler.cs:80`/`:93` (used: `UpdateLine`/`AddLine`), `CreatePurchaseOrderHandler.cs:79` (used: `AddLine`). The dead site at `UpdatePurchaseOrderHandler.cs:128` is gone. The adjacent N+1 in `UpdatePurchaseOrderHandler.Handle` is a separate, follow-up ticket.
+
+No commit in this task — the output goes into the PR description, not the repo.
+
+---
+
+## Task 4: Final validation gates
+
+### Step 4.1: Run the entire backend test suite
+
+- [ ] **Step 4.1:** Confirm nothing outside the Purchase folder breaks.
+
+Run:
+
+```bash
+cd backend && dotnet test
+```
+
+Expected: **PASS** across the whole solution. If unrelated tests fail, they are pre-existing failures and not the concern of this change — note them and proceed. If a test that mentions `UpdatePurchaseOrder` fails, stop and investigate.
+
+### Step 4.2: Confirm the OpenAPI schema is byte-identical (NFR-3)
+
+- [ ] **Step 4.2:** The `UpdatePurchaseOrderResponse` DTO shape is unchanged (no fields added, removed, or renamed) and the handler still returns the same field values. No frontend regeneration is required. To double-check, confirm no DTO file under `Features/Purchase/Contracts/` was modified:
+
+```bash
+git diff --name-only main...HEAD -- backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/
+```
+
+Expected: **empty output**. If anything appears, the edit drifted out of scope — revert the DTO change.
+
+### Step 4.3: Self-review against the spec and arch review
+
+- [ ] **Step 4.3:** Walk the spec's acceptance criteria once and confirm each is satisfied by the change set:
+  - **FR-1:** The two dead lines (and their comment) are gone from `MapToResponse`. The loop has no awaits. The response's `MaterialName` still comes from `line.MaterialName`. ✅
+  - **FR-2 (per arch-review amendment):** `_catalogRepository`, the constructor parameter, and the `using Anela.Heblo.Domain.Features.Catalog;` directive are **retained** because `Handle` still uses them. ✅
+  - **FR-3:** Public method signatures of the handler/request/response are unchanged. Validation, persistence, and transaction semantics are untouched. ✅
+  - **FR-4:** Grep verified — only one site qualified as dead. ✅
+  - **NFR-1:** `PUT /api/purchase-orders/{id}` now issues zero catalog calls during response mapping (proven by Task 1's test). ✅
+  - **NFR-2:** `dotnet build` clean, `dotnet format` clean, no `CS1998`. ✅
+  - **NFR-3:** HTTP contract and OpenAPI schema unchanged. ✅
+
+If any criterion is unsatisfied, return to the corresponding task. Otherwise, the change is ready to ship.
+
+---
+
+## Notes for the implementer
+
+- **Do not touch `Handle` lines 80 and 93.** They look like the same anti-pattern but their result is consumed. Refactoring them to `GetByIdsAsync` is a separate, explicitly-out-of-scope follow-up.
+- **Do not remove `ICatalogRepository` from the constructor.** It is still needed by `Handle`. The spec's conditional FR-2 ("If `MapToResponseAsync` was the only consumer…") is false here — the arch review amended the spec on this point.
+- **Do not add `await Task.CompletedTask`** to silence CS1998. The correct fix is converting the method to synchronous (Task 2.2/2.3).
+- **Do not change the DTO.** Adding `CatalogNote` (or any other catalog-only field) to `UpdatePurchaseOrderResponse` is explicitly out of scope.
+- **Frontend is untouched.** No `npm run build`/lint runs needed for this change.
+- **E2E is not required.** Per `CLAUDE.md`, E2E runs nightly; a behavior-preserving dead-code removal does not warrant an on-demand E2E run.


### PR DESCRIPTION
Purchase

## Finding
`UpdatePurchaseOrderHandler.MapToResponseAsync` fetches a catalog item for every order line, but the fetched object is never used — the DTO maps `line.MaterialName` (already stored on the entity):

```csharp
// backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-157
private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
{
    var lines = new List<PurchaseOrderLineDto>();
    foreach (var line in purchaseOrder.Lines)
    {
        // Try to get material name from catalog
        var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);  // ← fetched
        var materialName = material?.ProductName ?? "Unknown Material";                              // ← computed

        lines.Add(new PurchaseOrderLineDto
        {
            ...
            MaterialName = line.MaterialName,   // ← entity value used, not 'materialName'
            ...
        });
    }
```

`materialName` is computed but then discarded — the DTO always reads `line.MaterialName`. For an order with N lines this makes N catalog lookups (each of which queries a large in-memory cache or external system) and throws the results away.

Compare with `GetPurchaseOrderByIdHandler`, which performs the same lookup legitimately: it maps `CatalogNote = catalogItem.Note` — a field that only lives in the catalog and cannot come from the entity.

## Why it matters
- Every `PUT /api/purchase-orders/{id}` request fires N catalog reads that produce no visible output. This is wasted compute on every update.
- `ICatalogRepository.GetByIdsAsync` was added specifically to eliminate N+1 patterns (its code comment says so). Using `GetByIdAsync` in a loop already goes against that design; computing and discarding the result compounds the waste.

## Suggested fix
Delete the two dead lines from `MapToResponseAsync`:
```csharp
// Remove:
var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
var materialName = material?.ProductName ?? "Unknown Material";
```
The DTO already reads `line.MaterialName`; no replacement is needed. If `CatalogNote` ever needs to appear on the update response too, use `GetByIdsAsync` once (bulk) outside the loop, as `GetPurchaseOrderByIdHandler` does.

---
_Filed by daily arch-review routine on 2026-05-22._

---

Closes #1556

### Tokens used
13244622
