### PR TITLE
feat: Move `BlockOrderRequest` DTO from API to Application layer

### DIFF
--- a/artifacts/feat-arch-review-shoptetorders-blockorderrequ/arch-review.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-blockorderrequ/arch-review.r1.md
@@ -1,0 +1,146 @@
+# Architecture Review: Move `BlockOrderRequest` DTO from API to Application layer
+
+## Skip Design: true
+
+Backend-only relocation with no UI/UX work, no new components, no visual changes.
+
+## Architectural Fit Assessment
+
+The proposal aligns precisely with the project's stated rule in `docs/architecture/development_guidelines.md` (and `CLAUDE.md`): **"`API` project never defines or owns DTOs – it only uses them."** It also matches the codebase's actual file layout conventions verified during review:
+
+- The Application layer uses Vertical Slice organization under `Features/<Module>/UseCases/<UseCase>/`.
+- Sibling use cases (e.g. `GetOrderShipmentLabels`, `CreateOrderShipment`, `GenerateLeaflet`) already collocate `*Request.cs` / `*Response.cs` / `*Handler.cs` in the same use-case folder.
+- The MediatR companion `BlockOrderProcessingRequest.cs` already lives in the target folder; adding the HTTP DTO next to it requires no new conventions.
+
+Integration points are minimal and well-bounded: a single controller action (`PATCH /api/shoptet-orders/{code}/block`), a single MediatR pipeline (handler unchanged), and a single OpenAPI client surface (TS class `BlockOrderRequest`, JSON property `note`). No cross-module dependency, no new DI registration, no schema impact.
+
+A secondary observation: `ShipmentLabelsController.cs` exhibits the same anti-pattern (`GetShipmentLabelsRequest` defined at the bottom of the controller). **Explicitly out of scope here**, but worth noting for a follow-up arch-review entry rather than scope-creeping this change.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP Client
+   │  PATCH /api/shoptet-orders/{code}/block  { "note": "..." }
+   ▼
+┌────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.API                                                │
+│  ShoptetOrdersController.BlockOrder(code, BlockOrderRequest)   │
+│    │                                                           │
+│    │   uses (no longer owns)                                   │
+│    ▼                                                           │
+└────┼───────────────────────────────────────────────────────────┘
+     │
+     ▼
+┌────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Application.Features.ShoptetOrders.UseCases        │
+│   .BlockOrderProcessing                                        │
+│      • BlockOrderRequest        ← NEW LOCATION (HTTP body DTO) │
+│      • BlockOrderProcessingRequest  (MediatR IRequest)         │
+│      • BlockOrderProcessingResponse                            │
+│      • BlockOrderProcessingHandler                             │
+└────────────────────────────────────────────────────────────────┘
+```
+
+Ownership lines after change: Application owns both the HTTP-shape DTO and the internal MediatR contract. API contains routing + binding + mapping only.
+
+### Key Design Decisions
+
+#### Decision 1: Where in the Application layer the DTO lives
+**Options considered:**
+- `Features/ShoptetOrders/Contracts/BlockOrderRequest.cs` (per the table in `development_guidelines.md`).
+- `Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs` (per the spec, matching sibling use cases).
+
+**Chosen approach:** Use-case folder, as the spec proposes.
+
+**Rationale:** The MediatR request and handler for this exact use case already live there, and every comparable use case in the repo (ShipmentLabels, GenerateLeaflet, etc.) keeps `*Request.cs` colocated in the use-case folder rather than promoted to a module-wide `Contracts/`. The `Contracts/` folder in this codebase is in practice used for cross-use-case shared DTOs (e.g. `ShipmentLabelDto`, `CatalogPurchaseRecordDto`), not for one-off HTTP request bodies tied to a single use case. Vertical-slice cohesion wins.
+
+#### Decision 2: Keep `BlockOrderRequest` distinct from `BlockOrderProcessingRequest`
+**Options considered:**
+- Collapse into a single class (bind `BlockOrderProcessingRequest` directly in the controller).
+- Preserve the two-type design (HTTP DTO + MediatR request) and only relocate.
+
+**Chosen approach:** Preserve, as spec mandates.
+
+**Rationale:** The collapse is tempting but introduces semantic coupling (MediatR contract becomes the wire contract; adding a non-HTTP field to the MediatR request would leak into OpenAPI). The split also keeps the route parameter (`OrderCode` from URL) cleanly separated from the body (`Note`). Scope-discipline applies — the spec is correct to defer this to a follow-up.
+
+#### Decision 3: Class vs. record
+**Chosen approach:** `class`, unchanged.
+
+**Rationale:** Project-wide rule from `CLAUDE.md`: "DTOs are classes, never C# records" because NSwag's OpenAPI generator mishandles record positional parameters. Non-negotiable.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**New file:**
+```
+backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs
+```
+
+**Modified file:**
+```
+backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs
+```
+
+### Interfaces and Contracts
+
+**New file `BlockOrderRequest.cs` — exact content:**
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing;
+
+public class BlockOrderRequest
+{
+    [JsonPropertyName("note")]
+    public string Note { get; set; } = string.Empty;
+}
+```
+
+**Controller changes — exact:**
+
+1. Delete lines 56–60 (the inline `BlockOrderRequest` class).
+2. Delete the `using System.Text.Json.Serialization;` directive on line 6 — it is no longer referenced by any type defined in the controller file.
+3. **Do not add** a new `using` for `Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing;` — it is already present on line 1.
+4. The `BlockOrder` action body remains identical, including the `Note = body.Note` mapping into `BlockOrderProcessingRequest`.
+
+### Data Flow
+
+Unchanged. The relocation is purely lexical:
+
+```
+HTTP body { "note": "..." }
+  → ASP.NET model binder → BlockOrderRequest (Application namespace)
+  → controller maps Note → BlockOrderProcessingRequest { OrderCode, Note }
+  → IMediator.Send → BlockOrderProcessingHandler
+  → BlockOrderProcessingResponse → 204 NoContent | HandleResponse(failure)
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| OpenAPI schema name collision: both the moved `BlockOrderRequest` (DTO) and `BlockOrderProcessingRequest` (MediatR request) get serialized into the Swagger schema. NSwag uses short type names — same as before the move, so no new collision is introduced, but verify the generated TS client diffs. | LOW | Run the OpenAPI client regeneration step (`dotnet build` triggers it via project target) and `git diff frontend/src/api/generated/api-client.ts` — expect zero meaningful changes. If the schema name changes, namespace-qualify via NSwag's `SchemaNameGenerator` settings; do not rename the C# class. |
+| Forgetting to remove `using System.Text.Json.Serialization;` leaves a dead import that `dotnet format` may not flag (it warns rather than errors for unused usings in some configs). | LOW | Spec lists it explicitly. Verify with `dotnet build` warnings and a final `grep -n "System.Text.Json.Serialization" ShoptetOrdersController.cs` returning nothing. |
+| `JsonPropertyName` attribute lost in the move would silently change the wire contract from `note` to `Note` (PascalCase), breaking existing FE callers. | HIGH | Acceptance criterion FR-3 + a manual diff of the generated TS client (`BlockOrderRequest` should still serialize `note`). Optional smoke check: POST to `/swagger` schema and grep for `"note"`. |
+| Frontend generated client (`frontend/src/api/generated/api-client.ts`) regenerates with a different class signature, breaking any call sites that import `BlockOrderRequest`. | LOW | The TS class is generated from the C# type's **short name**, not its namespace; the move does not change the wire shape. Verify by regenerating and grepping call sites — there is at least one usage at `api-client.ts:9835`. |
+| Two similarly-named types (`BlockOrderRequest` and `BlockOrderProcessingRequest`) now live in the same C# namespace, increasing IntelliSense noise and risk of mis-import in future edits. | LOW | Accepted as the cost of keeping the relocation pure (per spec "Out of Scope"). Flag for the follow-up that collapses the duplicate contract. |
+| Hidden references to `Anela.Heblo.API.Controllers.BlockOrderRequest` (fully qualified) elsewhere in the solution would fail to compile after the move. | LOW | Grep across the solution confirms only two references, both inside `ShoptetOrdersController.cs` itself (line 30 binding, line 56 definition). Tests (`BlockOrderProcessingHandlerTests.cs`, `BlockOrderProcessingIntegrationTests.cs`) reference only the MediatR request, not the HTTP DTO. No external impact. |
+
+## Specification Amendments
+
+None required. The spec is correct, scoped, and verifiable. Two minor clarifications to fold in if convenient (not blockers):
+
+1. **NFR-1 wording**: state explicitly that the generated TS client at `frontend/src/api/generated/api-client.ts` must show no wire-level diff after regeneration. The spec implies this under FR-3; making it a checked acceptance criterion under NFR-1 closes a gap.
+2. **Verification grep for FR-1**: add an explicit check that `grep -n "class BlockOrderRequest" backend/src/Anela.Heblo.API/` returns no matches after the change — concrete and trivially scriptable.
+
+## Prerequisites
+
+None. This change requires no migrations, no configuration, no new packages, no infrastructure work, and no coordination with other workstreams. It can be implemented and merged independently. After merge:
+
+- A fresh `dotnet build` regenerates the OpenAPI client.
+- `dotnet format` should produce no diff.
+- Existing tests cover the unchanged handler path; no new tests are required.

--- a/artifacts/feat-arch-review-shoptetorders-blockorderrequ/brief.md
+++ b/artifacts/feat-arch-review-shoptetorders-blockorderrequ/brief.md
@@ -1,0 +1,34 @@
+## Module
+ShoptetOrders
+
+## Finding
+`BlockOrderRequest` is defined at the bottom of the API controller file rather than in the Application module's contracts:
+
+```
+backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs — lines 56–60
+```
+
+```csharp
+public class BlockOrderRequest
+{
+    [JsonPropertyName("note")]
+    public string Note { get; set; } = string.Empty;
+}
+```
+
+The API project owns and defines this DTO, which violates the project rule: _"API project never defines or owns DTOs – it only uses them."_ The correct home is `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/` (alongside `BlockOrderProcessingRequest.cs`).
+
+## Why it matters
+The rule exists so that the API project stays a thin host layer with no contract ownership. Placing a DTO here means the Application layer cannot reference it (it would create a reverse dependency), so the controller ends up mapping `BlockOrderRequest.Note → BlockOrderProcessingRequest.Note` with a manual property copy instead of a proper contract. Any future consumer of the Application layer (tests, another endpoint) cannot reuse the type without touching the API project.
+
+## Suggested fix
+Move `BlockOrderRequest` (with its `[JsonPropertyName]` attribute) to:
+
+```
+backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs
+```
+
+Update the `using` in the controller. No logic changes required.
+
+---
+_Filed by daily arch-review routine on 2026-05-23._

--- a/artifacts/feat-arch-review-shoptetorders-blockorderrequ/impl/main.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-blockorderrequ/impl/main.r1.md
@@ -1,0 +1,54 @@
+Now writing the output artifact.
+
+---
+
+# Implementation: Move `BlockOrderRequest` DTO from API to Application layer
+
+## What was implemented
+
+Relocated the `BlockOrderRequest` class from the bottom of `ShoptetOrdersController.cs` (lines 56–60) into a dedicated file in the Application layer's `BlockOrderProcessing` use-case folder. The controller now references the type from the Application namespace (the `using` was already present), and the unused `using System.Text.Json.Serialization;` was removed from the controller.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs` — new file containing the relocated class with file-scoped namespace, `class` keyword (not `record`), and `[JsonPropertyName("note")]` preserved verbatim
+- `backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs` — removed inline `BlockOrderRequest` class definition and the now-unused `using System.Text.Json.Serialization;` directive
+
+## Tests
+
+No new tests required per NFR-2 (pure relocation). Existing tests (`BlockOrderProcessingHandlerTests`, `BlockOrderProcessingIntegrationTests`) reference only the MediatR request, not the HTTP DTO — verified by grep, no test updates needed.
+
+## How to verify
+
+```bash
+# Build succeeds with 0 errors
+dotnet build Anela.Heblo.sln
+
+# DTO no longer defined in API project
+grep -r "class BlockOrderRequest" backend/src/Anela.Heblo.API/   # → no output
+
+# DTO exists in Application layer
+grep -n "class BlockOrderRequest" backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs
+# → 3: public class BlockOrderRequest
+
+# No fully-qualified API references remain
+grep -r "Anela.Heblo.API.Controllers.BlockOrderRequest" backend/   # → no output
+```
+
+## Notes
+
+- The `[JsonPropertyName("note")]` attribute requires `using System.Text.Json.Serialization;` in the new file — this is fine since `System.Text.Json` is part of the .NET 8 BCL (no package change).
+- The two-type design (`BlockOrderRequest` HTTP DTO + `BlockOrderProcessingRequest` MediatR request) is intentionally preserved per spec "Out of Scope."
+- `ShipmentLabelsController.cs` exhibits the same anti-pattern (DTO defined inline); flagged in the arch review as a follow-up, not addressed here per scope discipline.
+
+## PR Summary
+
+Relocated the `BlockOrderRequest` HTTP body DTO from the bottom of `ShoptetOrdersController.cs` into `Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs`, restoring the architectural rule that the API project must not own DTOs — it only uses them.
+
+The API controller already imported the `BlockOrderProcessing` namespace, so no new `using` was needed. The only controller-side change is deleting the inline class definition and removing the `using System.Text.Json.Serialization;` that existed solely for it. Zero behavior change; `dotnet build` succeeds with no new warnings.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs` — new file: relocated DTO with file-scoped namespace, class keyword, `[JsonPropertyName("note")]` preserved
+- `backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs` — removed inline `BlockOrderRequest` class (lines 56–60) and the now-unused `using System.Text.Json.Serialization;`
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-shoptetorders-blockorderrequ/spec.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-blockorderrequ/spec.r1.md
@@ -1,0 +1,132 @@
+# Specification: Move `BlockOrderRequest` DTO from API to Application layer
+
+## Summary
+The `BlockOrderRequest` DTO currently lives at the bottom of `ShoptetOrdersController.cs` in the API project, violating the architectural rule that the API project must not own DTOs. This specification covers moving the type into the corresponding Application use-case folder so the Application layer becomes the sole owner of the contract, and the controller maps directly without a manual property copy.
+
+## Background
+The project follows Clean Architecture with vertical-slice organization under `backend/src/Anela.Heblo.Application/Features/<Module>/UseCases/<UseCase>/`. The standing rule is: **"API project never defines or owns DTOs — it only uses them."** This keeps the API project a thin host layer (routing, model binding, response shaping) and prevents reverse dependencies (Application → API) that would arise if another consumer wanted to reuse a contract.
+
+The current code in `backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs` (lines 56–60) defines:
+
+```csharp
+public class BlockOrderRequest
+{
+    [JsonPropertyName("note")]
+    public string Note { get; set; } = string.Empty;
+}
+```
+
+The controller's `BlockOrder` action receives `BlockOrderRequest` from the body and manually copies `body.Note` into a separately defined `BlockOrderProcessingRequest` (the MediatR request that already lives in `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/`). The duplicate contract and manual mapping exist solely because the API-side DTO cannot be referenced from the Application layer.
+
+This finding was filed by the daily arch-review routine on 2026-05-23.
+
+## Functional Requirements
+
+### FR-1: Relocate `BlockOrderRequest` to the Application layer
+Move the `BlockOrderRequest` class out of `ShoptetOrdersController.cs` and into the existing `BlockOrderProcessing` use-case folder.
+
+**Target file:**
+```
+backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs
+```
+
+**Target namespace:**
+```
+Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing
+```
+
+**Acceptance criteria:**
+- A new file `BlockOrderRequest.cs` exists at the path above containing the moved `BlockOrderRequest` class.
+- The class remains a `class` (not a `record`), per the project rule "DTOs are classes, never C# records." (See `CLAUDE.md` / `docs/architecture/development_guidelines.md`.)
+- The `[JsonPropertyName("note")]` attribute on the `Note` property is preserved verbatim.
+- The `Note` property keeps the same accessibility, type, and default initializer (`public string Note { get; set; } = string.Empty;`).
+- The class definition is removed from `ShoptetOrdersController.cs`.
+
+### FR-2: Update the API controller to use the relocated DTO
+The controller continues to accept `BlockOrderRequest` from the HTTP body but now references the type from the Application namespace.
+
+**Acceptance criteria:**
+- `ShoptetOrdersController.cs` adds (or reuses the existing) `using Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing;` directive — note this `using` is already present in the file.
+- The action signature `BlockOrder(string code, [FromBody] BlockOrderRequest body)` continues to compile and bind against the relocated type.
+- The unused `using System.Text.Json.Serialization;` at the top of the controller is removed if no other type in the file requires it (it was only there for the moved DTO).
+- The manual mapping `Note = body.Note` inside the action body is left as-is for this change. (See "Out of Scope" for the broader question of removing the duplicate contract.)
+
+### FR-3: Preserve HTTP contract and behavior
+The relocation must be transparent to API consumers and the OpenAPI schema.
+
+**Acceptance criteria:**
+- The HTTP endpoint `PATCH /api/shoptet-orders/{code}/block` continues to accept a JSON body of the shape `{ "note": "..." }`.
+- The JSON property name `note` (lowercase) is preserved via the kept `[JsonPropertyName]` attribute.
+- Existing controller authorization (`[Authorize]`) and routing attributes are not modified.
+- Any generated OpenAPI client signatures for this endpoint remain functionally equivalent (same property name and type). A regenerated TypeScript client must continue to compile against existing call sites.
+
+### FR-4: No business logic changes
+This is a pure relocation; no behavior changes.
+
+**Acceptance criteria:**
+- `BlockOrderProcessingRequest`, `BlockOrderProcessingResponse`, and `BlockOrderProcessingHandler` are not modified.
+- The controller's `HandleResponse(response)` failure path and the `NoContent()` success path are unchanged.
+- No new validation, mapping helpers, or abstractions are introduced.
+
+## Non-Functional Requirements
+
+### NFR-1: Build & format
+The change must pass the project's standard validation gates.
+
+- `dotnet build` on the backend solution succeeds with no new warnings attributable to this change.
+- `dotnet format` reports no diff after the change is applied.
+
+### NFR-2: Tests
+Existing tests must continue to pass; no new tests are required for a pure relocation.
+
+- All tests touched by the change must pass.
+- If any test currently references `Anela.Heblo.API.Controllers.BlockOrderRequest` (fully qualified), its import is updated to the new namespace. (None expected, but verify via search.)
+
+### NFR-3: Backwards compatibility
+No deprecation shim, type alias, or `using` re-export is added. The previous type location is fully removed.
+
+### NFR-4: Architecture compliance
+After the change, no DTO is defined inside `backend/src/Anela.Heblo.API/`. A grep for `public class .*Request` or `public class .*Response` under that folder must return no DTO-style results for this endpoint family.
+
+## Data Model
+No data-model change. The DTO carries a single `Note` (string) property and binds to the JSON property `note`.
+
+| Type | Property | JSON name | Type | Default |
+|---|---|---|---|---|
+| `BlockOrderRequest` | `Note` | `note` | `string` | `string.Empty` |
+
+## API / Interface Design
+
+### HTTP endpoint (unchanged)
+- **Method:** `PATCH`
+- **Route:** `/api/shoptet-orders/{code}/block`
+- **Auth:** `[Authorize]` (inherited from controller)
+- **Request body:** `BlockOrderRequest` — `{ "note": "<text>" }`
+- **Success response:** `204 No Content`
+- **Failure response:** Handled by `HandleResponse(response)` when `response.Success == false`.
+
+### Internal flow (unchanged)
+Controller receives `BlockOrderRequest` → constructs `BlockOrderProcessingRequest { OrderCode = code, Note = body.Note }` → `IMediator.Send(...)` → handler returns `BlockOrderProcessingResponse`.
+
+### Files affected
+| File | Change |
+|---|---|
+| `backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs` | Remove `BlockOrderRequest` class (lines 56–60). Remove the `using System.Text.Json.Serialization;` directive if no longer needed in the file. |
+| `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs` | **New file** containing the relocated class with `[JsonPropertyName("note")]` preserved. |
+
+## Dependencies
+- The Application project must already reference `System.Text.Json` (it is part of the .NET 8 BCL; no package change needed).
+- The API project already has `using Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing;`, so no new `using` is required there.
+- OpenAPI client generation pipeline: after the change, a regenerated client should produce the same wire-level contract. Verify by running the generation step locally if applicable.
+
+## Out of Scope
+- **Removing the duplicate contract.** Collapsing `BlockOrderRequest` and `BlockOrderProcessingRequest` into a single DTO (e.g., having the controller bind `BlockOrderProcessingRequest` directly, or using a shared body type) is a follow-up consideration and is **not** part of this change. The current two-type design (HTTP DTO + MediatR request) is preserved so this change stays a pure relocation.
+- **Renaming, restructuring, or splitting other types** in `ShoptetOrdersController.cs` or the `BlockOrderProcessing` use case.
+- **Adding validation attributes** (e.g., `[Required]`, length limits) to `BlockOrderRequest`. Validation behavior remains as-is.
+- **Touching `GetPackingOrder` or any other endpoint** in the same controller.
+- **Documentation updates** beyond what is necessary for the move itself.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-shoptetorders-blockorderrequ/task-plan.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-blockorderrequ/task-plan.r1.md
@@ -1,0 +1,795 @@
+# Photobank Thumbnail Use Case Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the `PhotobankController.GetThumbnail` orchestration into a `GetThumbnail` MediatR use case, reduce the controller to a thin dispatch with an `IMediator`-only constructor, and preserve the endpoint's exact observable HTTP behaviour.
+
+**Architecture:** A new Vertical-Slice use case (`Features/Photobank/UseCases/GetThumbnail/{Request,Response,Handler}.cs`) owns the locator lookup, the Microsoft Graph call, and the infrastructure-exception translation. The handler returns a `GetThumbnailResponse : BaseResponse` carrying the stream + metadata on success and a discriminating `ErrorCodes` on failure (mirroring the three existing binary-download use cases — `GetShipmentLabelPdf`, `DownloadExpeditionList`, `GetManufactureProtocol`). The controller maps `ErrorCode → HTTP status + headers` explicitly (it does **not** route through `HandleResponse`, which has no 502/503 and wraps success in `Ok()`).
+
+**Tech Stack:** .NET 8, MediatR, ASP.NET Core MVC, xUnit + FluentAssertions + Moq. No new packages (MSAL is already a transitive reference of `Anela.Heblo.Application`, used by `UserManagement/Services/GraphService.cs` and others).
+
+---
+
+## Authoritative decision: response shape
+
+The architecture review **reverses spec Decision #2**. Follow the arch-review:
+
+- `GetThumbnailResponse` **inherits `BaseResponse`** (it does NOT use a bespoke `GetThumbnailOutcome` enum). Inheriting `BaseResponse` does not force a JSON success body — the controller still returns `FileStreamResult` on success, exactly as `ShipmentLabelsController.GetLabelPdf` returns `File(...)`.
+- Failures are discriminated by **four new `ErrorCodes` members**, not an enum.
+- The spec's *intent* — preserving the 502-vs-503-vs-404 distinction — is kept.
+
+## File map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` | Modify | Add 4 Photobank-thumbnail error codes (2610–2613) |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailRequest.cs` | Create | `IRequest<GetThumbnailResponse>` with `Id`, `Size` |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailResponse.cs` | Create | `BaseResponse` carrier: `Content`, `ContentType`, `ContentLength`, `RetryAfterSeconds` |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs` | Create | Locator lookup → Graph call → exception translation → result shaping + all logging |
+| `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs` | Modify | Single-dep constructor; thin `GetThumbnail` dispatch + outcome→HTTP mapping |
+| `backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs` | Create | HTTP-free handler unit tests (all outcomes + stream identity + token threading) |
+| `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs` | Overwrite | Mock `IMediator` only; assert outcome→`IActionResult` + header mapping |
+
+**Verified facts the executor can rely on:**
+- `IPhotobankRepository.GetLocatorAsync(int, CancellationToken) → PhotoLocator?` exists (`Domain/Features/Photobank/IPhotobankRepository.cs:26`). `PhotoLocator(string DriveId, string SharePointFileId, DateTime ModifiedAt)`.
+- `IPhotobankGraphService.GetThumbnailAsync(string driveId, string fileId, ThumbnailSize size, CancellationToken) → GraphThumbnail?` exists (`Application/Features/Photobank/Services/IPhotobankGraphService.cs:54`).
+- `GraphThumbnail : IDisposable` with `Stream Content`, `string ContentType`, `long? ContentLength`; `Dispose()` disposes the `Stream`. `ThumbnailSize { Medium, Large }`. `GraphThrottledException.RetryAfter` is `TimeSpan?`.
+- `BaseResponse` (`Application/Shared`) has `bool Success`, `ErrorCodes? ErrorCode`, a default ctor (`Success = true`) and `protected BaseResponse(ErrorCodes errorCode, ...)`.
+- Photobank use-case files use **block-scoped** namespaces (`namespace X { ... }`) — match that style, not file-scoped.
+- The Application project has `<ImplicitUsings>` enabled (the sibling `GetShipmentLabelPdfResponse` uses `Stream?` with no `using System.IO;`).
+- MediatR auto-registers handlers via the existing assembly scan — no `PhotobankModule.cs` / DI change needed.
+
+---
+
+### Task 1: Add the four thumbnail error codes
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`
+
+- [ ] **Step 1: Add the error codes**
+
+In `ErrorCodes.cs`, find the Photobank block ending at `PhotobankInvalidRegexPattern = 2609,` (around line 285). Immediately after that line and before the `// Smartsupp module errors (27XX)` comment, insert:
+
+```csharp
+    [HttpStatusCode(HttpStatusCode.NotFound)]
+    PhotobankThumbnailNotFound = 2610,
+    [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
+    PhotobankThumbnailThrottled = 2611,
+    [HttpStatusCode(HttpStatusCode.ServiceUnavailable)]
+    PhotobankThumbnailAuthUnavailable = 2612,
+    [HttpStatusCode(HttpStatusCode.InternalServerError)]
+    PhotobankThumbnailUpstream = 2613,
+```
+
+> Note: the `[HttpStatusCode(...)]` attributes are decorative for convention only — this endpoint maps `ErrorCode → status` explicitly in the controller and never calls `HandleResponse`. There is no 502 in the `HttpStatusCode` attribute set used here, so `PhotobankThumbnailUpstream` carries `InternalServerError`; the controller maps it to 502 directly.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat: add Photobank thumbnail error codes"
+```
+
+---
+
+### Task 2: Create the request and response contracts
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailRequest.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailResponse.cs`
+
+- [ ] **Step 1: Create `GetThumbnailResponse.cs`**
+
+```csharp
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail
+{
+    public class GetThumbnailResponse : BaseResponse
+    {
+        public Stream? Content { get; set; }
+        public string? ContentType { get; set; }
+        public long? ContentLength { get; set; }
+
+        /// <summary>
+        /// Pre-rounded retry hint (seconds). Populated only on PhotobankThumbnailThrottled.
+        /// </summary>
+        public int? RetryAfterSeconds { get; set; }
+
+        public GetThumbnailResponse() : base()
+        {
+        }
+
+        public GetThumbnailResponse(ErrorCodes errorCode) : base(errorCode)
+        {
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create `GetThumbnailRequest.cs`**
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Services;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail
+{
+    public class GetThumbnailRequest : IRequest<GetThumbnailResponse>
+    {
+        public int Id { get; set; }
+        public ThumbnailSize Size { get; set; }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/
+git commit -m "feat: add GetThumbnail request and response contracts"
+```
+
+---
+
+### Task 3: Implement the handler (TDD)
+
+**Files:**
+- Test: `backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs`
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
+using Moq;
+using System.Net.Http;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public sealed class GetThumbnailHandlerTests
+{
+    private readonly Mock<IPhotobankRepository> _repositoryMock = new();
+    private readonly Mock<IPhotobankGraphService> _graphServiceMock = new();
+    private readonly Mock<ILogger<GetThumbnailHandler>> _loggerMock = new();
+
+    private GetThumbnailHandler CreateHandler() =>
+        new(_repositoryMock.Object, _graphServiceMock.Object, _loggerMock.Object);
+
+    private static GetThumbnailRequest Request(int id = 1, ThumbnailSize size = ThumbnailSize.Medium) =>
+        new() { Id = id, Size = size };
+
+    private void SetupLocator(PhotoLocator? locator, int id = 1) =>
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locator);
+
+    private void SetupGraph(PhotoLocator locator, Func<Mock<IPhotobankGraphService>, Moq.Language.Flow.ISetup<IPhotobankGraphService, Task<GraphThumbnail?>>> _ = null!)
+    {
+        // helper intentionally minimal; tests configure the graph mock directly
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenLocatorMissing()
+    {
+        // Arrange
+        SetupLocator(null);
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailNotFound);
+        _graphServiceMock.Verify(
+            g => g.GetThumbnailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ThumbnailSize>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenGraphReturnsNull()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GraphThumbnail?)null);
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailNotFound);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsThrottledWithRoundedRetryAfter_WhenGraphThrottles()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GraphThrottledException(TimeSpan.FromSeconds(29.3)));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailThrottled);
+        response.RetryAfterSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsThrottledWithoutRetryAfter_WhenRetryAfterNull()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new GraphThrottledException(null));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailThrottled);
+        response.RetryAfterSeconds.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsUpstream_WhenHttpRequestExceptionThrown()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("upstream error"));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailUpstream);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAuthUnavailable_WhenMsalExceptionThrown()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new MsalServiceException("invalid_client", "AADSTS7000215: Invalid client secret"));
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.PhotobankThumbnailAuthUnavailable);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccessWithSameStream_WhenThumbnailReturned()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+        var thumbnail = new GraphThumbnail(stream, "image/jpeg", 12345L);
+        SetupLocator(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thumbnail);
+
+        // Act
+        var response = await CreateHandler().Handle(Request(), CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.ErrorCode.Should().BeNull();
+        response.Content.Should().BeSameAs(stream);
+        response.ContentType.Should().Be("image/jpeg");
+        response.ContentLength.Should().Be(12345L);
+        response.Content!.CanRead.Should().BeTrue("the handler must not dispose the stream before the framework writes it");
+    }
+
+    [Fact]
+    public async Task Handle_PassesCancellationTokenThrough()
+    {
+        // Arrange
+        var locator = new PhotoLocator("driveId", "fileId", DateTime.UtcNow);
+        using var cts = new CancellationTokenSource();
+        _repositoryMock
+            .Setup(r => r.GetLocatorAsync(1, cts.Token))
+            .ReturnsAsync(locator);
+        _graphServiceMock
+            .Setup(g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, cts.Token))
+            .ReturnsAsync((GraphThumbnail?)null);
+
+        // Act
+        await CreateHandler().Handle(Request(), cts.Token);
+
+        // Assert
+        _repositoryMock.Verify(r => r.GetLocatorAsync(1, cts.Token), Times.Once);
+        _graphServiceMock.Verify(
+            g => g.GetThumbnailAsync(locator.DriveId, locator.SharePointFileId, ThumbnailSize.Medium, cts.Token),
+            Times.Once);
+    }
+}
+```
+
+> Remove the unused `SetupGraph` helper before finishing if `dotnet format`/analyzers complain — it is included only as a no-op placeholder and the tests configure `_graphServiceMock` directly. Simpler: delete the `SetupGraph` method entirely; it is not referenced by any test. **Delete it now.**
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetThumbnailHandlerTests"`
+Expected: FAIL — compile error `The type or namespace name 'GetThumbnailHandler' could not be found` (the handler does not exist yet).
+
+- [ ] **Step 3: Implement the handler**
+
+Create `backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs`:
+
+```csharp
+using System.Net.Http;
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Photobank;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
+
+namespace Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail
+{
+    public class GetThumbnailHandler : IRequestHandler<GetThumbnailRequest, GetThumbnailResponse>
+    {
+        private readonly IPhotobankRepository _repository;
+        private readonly IPhotobankGraphService _graphService;
+        private readonly ILogger<GetThumbnailHandler> _logger;
+
+        public GetThumbnailHandler(
+            IPhotobankRepository repository,
+            IPhotobankGraphService graphService,
+            ILogger<GetThumbnailHandler> logger)
+        {
+            _repository = repository;
+            _graphService = graphService;
+            _logger = logger;
+        }
+
+        public async Task<GetThumbnailResponse> Handle(
+            GetThumbnailRequest request,
+            CancellationToken cancellationToken)
+        {
+            var locator = await _repository.GetLocatorAsync(request.Id, cancellationToken);
+            if (locator is null)
+            {
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailNotFound);
+            }
+
+            GraphThumbnail? rawThumbnail;
+            try
+            {
+                rawThumbnail = await _graphService.GetThumbnailAsync(
+                    locator.DriveId, locator.SharePointFileId, request.Size, cancellationToken);
+            }
+            catch (GraphThrottledException ex)
+            {
+                _logger.LogWarning("Microsoft Graph thumbnail request throttled for photo {PhotoId}. RetryAfter: {RetryAfter}",
+                    request.Id, ex.RetryAfter);
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailThrottled)
+                {
+                    RetryAfterSeconds = ex.RetryAfter.HasValue
+                        ? (int)Math.Ceiling(ex.RetryAfter.Value.TotalSeconds)
+                        : null,
+                };
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "Upstream HTTP error fetching thumbnail for photo {PhotoId}", request.Id);
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailUpstream);
+            }
+            catch (MsalException ex)
+            {
+                _logger.LogError(ex, "Token acquisition failed for thumbnail {PhotoId}. MSAL error: {ErrorCode}", request.Id, ex.ErrorCode);
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailAuthUnavailable);
+            }
+
+            if (rawThumbnail is null)
+            {
+                return new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailNotFound);
+            }
+
+            // NFR-3: transfer stream ownership to the response. Do NOT dispose rawThumbnail
+            // (GraphThumbnail.Dispose() closes the underlying Stream); FileStreamResult disposes it after writing.
+            return new GetThumbnailResponse
+            {
+                Content = rawThumbnail.Content,
+                ContentType = rawThumbnail.ContentType,
+                ContentLength = rawThumbnail.ContentLength,
+            };
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetThumbnailHandlerTests"`
+Expected: PASS — 8 passed, 0 failed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Photobank/UseCases/GetThumbnail/GetThumbnailHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Photobank/GetThumbnailHandlerTests.cs
+git commit -m "feat: add GetThumbnail handler with HTTP-free unit tests"
+```
+
+---
+
+### Task 4: Refactor the controller to a thin dispatch (TDD)
+
+**Files:**
+- Overwrite: `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`
+
+- [ ] **Step 1: Rewrite the controller test to mock `IMediator` only**
+
+Overwrite `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs` with:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Photobank.Services;
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail;
+using Anela.Heblo.Application.Shared;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Photobank;
+
+public sealed class PhotobankControllerThumbnailTests
+{
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly PhotobankController _controller;
+
+    public PhotobankControllerThumbnailTests()
+    {
+        _controller = new PhotobankController(_mediatorMock.Object);
+        SetupHttpContext();
+    }
+
+    private void SetupHttpContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, "test-user") })),
+            RequestServices = services.BuildServiceProvider()
+        };
+
+        _controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+    }
+
+    private void SetupResponse(GetThumbnailResponse response) =>
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetThumbnailRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+    [Fact]
+    public async Task GetThumbnail_ReturnsNotFound_WhenResponseNotFound()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailNotFound));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503WithRetryAfter_WhenThrottledWithHint()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailThrottled) { RetryAfterSeconds = 30 });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers["Retry-After"].ToString().Should().Be("30");
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503WithoutRetryAfter_WhenThrottledWithoutHint()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailThrottled) { RetryAfterSeconds = null });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers.ContainsKey("Retry-After").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns503_WhenAuthUnavailable()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailAuthUnavailable));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        _controller.Response.Headers.ContainsKey("Retry-After").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns502_WhenUpstreamError()
+    {
+        // Arrange
+        SetupResponse(new GetThumbnailResponse(ErrorCodes.PhotobankThumbnailUpstream));
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
+    }
+
+    [Fact]
+    public async Task GetThumbnail_Returns200WithCacheHeaders_WhenSuccessful()
+    {
+        // Arrange
+        var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+        SetupResponse(new GetThumbnailResponse { Content = stream, ContentType = "image/jpeg", ContentLength = null });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        var fileResult = result.Should().BeOfType<FileStreamResult>().Subject;
+        fileResult.ContentType.Should().Be("image/jpeg");
+        fileResult.FileStream.Should().BeSameAs(stream);
+        _controller.Response.Headers["Cache-Control"].ToString().Should().Be("public, max-age=31536000, immutable");
+    }
+
+    [Fact]
+    public async Task GetThumbnail_ForwardsContentLength_WhenAvailable()
+    {
+        // Arrange
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        SetupResponse(new GetThumbnailResponse { Content = stream, ContentType = "image/jpeg", ContentLength = 12345L });
+
+        // Act
+        var result = await _controller.GetThumbnail(1, ThumbnailSize.Medium);
+
+        // Assert
+        result.Should().BeOfType<FileStreamResult>();
+        _controller.Response.ContentLength.Should().Be(12345L);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PhotobankControllerThumbnailTests"`
+Expected: FAIL — compile error: `PhotobankController` does not contain a constructor that takes 1 argument (it still takes 3). This is the RED state.
+
+- [ ] **Step 3: Replace the controller constructor and fields**
+
+In `backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs`, replace this block:
+
+```csharp
+        private readonly IMediator _mediator;
+        private readonly IPhotobankRepository _photobankRepository;
+        private readonly IPhotobankGraphService _photobankGraphService;
+
+        public PhotobankController(
+            IMediator mediator,
+            IPhotobankRepository photobankRepository,
+            IPhotobankGraphService photobankGraphService)
+        {
+            _mediator = mediator;
+            _photobankRepository = photobankRepository;
+            _photobankGraphService = photobankGraphService;
+        }
+```
+
+with:
+
+```csharp
+        private readonly IMediator _mediator;
+
+        public PhotobankController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+```
+
+- [ ] **Step 4: Replace the `GetThumbnail` action**
+
+Replace the entire current `GetThumbnail` action (the method beginning at `public async Task<IActionResult> GetThumbnail(` through its closing brace) with:
+
+```csharp
+        [HttpGet("photos/{id:int}/thumbnail/{size}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<IActionResult> GetThumbnail(
+            int id,
+            ThumbnailSize size,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _mediator.Send(
+                new GetThumbnailRequest { Id = id, Size = size }, cancellationToken);
+
+            if (response.Success)
+            {
+                Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";
+                if (response.ContentLength.HasValue)
+                {
+                    Response.ContentLength = response.ContentLength;
+                }
+
+                return new FileStreamResult(response.Content!, response.ContentType!);
+            }
+
+            switch (response.ErrorCode)
+            {
+                case ErrorCodes.PhotobankThumbnailNotFound:
+                    return NotFound();
+                case ErrorCodes.PhotobankThumbnailThrottled:
+                    if (response.RetryAfterSeconds.HasValue)
+                    {
+                        Response.Headers["Retry-After"] = response.RetryAfterSeconds.Value.ToString();
+                    }
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable);
+                case ErrorCodes.PhotobankThumbnailAuthUnavailable:
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable);
+                case ErrorCodes.PhotobankThumbnailUpstream:
+                    return StatusCode(StatusCodes.Status502BadGateway);
+                default:
+                    return StatusCode(StatusCodes.Status502BadGateway);
+            }
+        }
+```
+
+- [ ] **Step 5: Fix the `using` directives**
+
+At the top of `PhotobankController.cs`:
+
+Remove these three lines (they are consumed only by the old `GetThumbnail` action):
+```csharp
+using System.Net.Http;
+using Microsoft.Identity.Client;
+using Anela.Heblo.Domain.Features.Photobank;
+```
+
+Add these two lines (keep the `using` block alphabetically grouped as the file already is):
+```csharp
+using Anela.Heblo.Application.Features.Photobank.UseCases.GetThumbnail;
+using Anela.Heblo.Application.Shared;
+```
+
+> Keep `using Anela.Heblo.Application.Features.Photobank.Services;` — `ThumbnailSize` (the route parameter type) lives there and is still referenced. Keep `System.Collections.Generic`, `System.Threading`, `System.Threading.Tasks`, `Microsoft.AspNetCore.Http`, and `MediatR` — all still used by other actions.
+
+- [ ] **Step 6: Run the controller tests to verify they pass**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PhotobankControllerThumbnailTests"`
+Expected: PASS — 7 passed, 0 failed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/PhotobankController.cs \
+        backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankControllerThumbnailTests.cs
+git commit -m "refactor: reduce PhotobankController.GetThumbnail to thin MediatR dispatch"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the whole backend**
+
+Run: `dotnet build Anela.Heblo.sln`
+Expected: Build succeeded, 0 errors, 0 warnings introduced by these changes.
+
+- [ ] **Step 2: Verify formatting**
+
+Run: `dotnet format Anela.Heblo.sln --verify-no-changes`
+Expected: exit code 0 (no formatting changes needed). If it reports changes, run `dotnet format Anela.Heblo.sln`, review the diff (it must touch only the files in this plan), and amend the relevant commit.
+
+- [ ] **Step 3: Run the full Photobank test slice**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Photobank"`
+Expected: PASS — all Photobank tests green, including the 8 handler tests and 7 controller tests.
+
+- [ ] **Step 4: Confirm no OpenAPI/TS client drift**
+
+The action signature (route params + `IActionResult`) is unchanged and the new `GetThumbnailRequest`/`GetThumbnailResponse` types never appear in a controller method signature, so they do not enter the OpenAPI surface.
+
+Run:
+```bash
+cd frontend && npm run build && cd ..
+git status --porcelain frontend/src/api
+```
+Expected: `npm run build` succeeds; `git status` shows **no** changes under the generated API client directory. (A no-op regen diff, if any, is acceptable per the spec — but none is expected.)
+
+- [ ] **Step 5: Final commit (only if Step 2 or 4 produced changes)**
+
+```bash
+git add -A
+git commit -m "chore: formatting and generated-client sync for thumbnail use case"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 (use case under folder convention; handler injects repo + graph + logger; absorbs logging; threads `CancellationToken`) → Tasks 2 & 3. Logging uses the same message templates and structured properties (`PhotoId`, `RetryAfter`, `ErrorCode`) as the original controller.
+- FR-2 (controller = `_mediator.Send` + outcome→status; route + `[ProducesResponseType]` unchanged) → Task 4 Steps 3–5.
+- FR-3 (single-dep `IMediator` constructor; drop unused usings) → Task 4 Steps 3 & 5; verified by Task 5 Steps 1–2.
+- FR-4 (exact HTTP behaviour: 404 / 503+Retry-After / 503 auth / 502 / 200 + Cache-Control + Content-Length) → controller `switch` (Task 4 Step 4) + controller tests (Task 4 Step 1) + handler tests (Task 3 Step 1).
+- FR-5 (controller tests mock `IMediator` only; new HTTP-free handler tests) → Tasks 3 & 4.
+- NFR-1 (streaming, not buffering; immutable cache header) → response carries `Stream`; `Cache-Control` preserved verbatim.
+- NFR-2 (no client-facing leakage; diagnostics logged server-side only) → only status codes returned; `ex.ErrorCode`/exception detail logged in handler.
+- NFR-3 (stream lifecycle) → handler transfers `.Content` without disposing `GraphThumbnail`; guarded by `Content.CanRead` + `BeSameAs` assertions (handler) and `FileStream.Should().BeSameAs(stream)` (controller).
+- NFR-4 (controller depends only on `IMediator`; no infra exception types in API project) → Task 4.
+- Data Model: `GetThumbnailRequest` (`Id`, `Size`); `GetThumbnailResponse : BaseResponse` (`Content`, `ContentType`, `ContentLength`, `RetryAfterSeconds`) per the **arch-review's reversal** of spec Decision #2.
+- Prerequisite (4 new `ErrorCodes`) → Task 1.
+
+**Placeholder scan:** No TBD/TODO/"add error handling" placeholders — every code step contains complete code. The one no-op test helper (`SetupGraph`) is explicitly flagged for deletion in Task 3 Step 1.
+
+**Type consistency:** `GetThumbnailRequest { int Id; ThumbnailSize Size; }`, `GetThumbnailResponse { Stream? Content; string? ContentType; long? ContentLength; int? RetryAfterSeconds; }`, and `ErrorCodes.PhotobankThumbnail{NotFound,Throttled,AuthUnavailable,Upstream}` are referenced identically across the handler, the controller, and both test files. The controller maps `PhotobankThumbnailUpstream → 502` and both throttle/auth → 503, matching the handler's classification and the FR-4 outcome table.

--- a/backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs
@@ -3,7 +3,6 @@ using Anela.Heblo.Application.Features.ShoptetOrders.UseCases.GetPackingOrder;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Text.Json.Serialization;
 
 namespace Anela.Heblo.API.Controllers;
 
@@ -51,10 +50,4 @@ public class ShoptetOrdersController : BaseApiController
         var response = await _mediator.Send(new GetPackingOrderRequest { Code = code });
         return HandleResponse(response);
     }
-}
-
-public class BlockOrderRequest
-{
-    [JsonPropertyName("note")]
-    public string Note { get; set; } = string.Empty;
 }

--- a/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Anela.Heblo.Application.Features.ShoptetOrders.UseCases.BlockOrderProcessing;
+
+public class BlockOrderRequest
+{
+    [JsonPropertyName("note")]
+    public string Note { get; set; } = string.Empty;
+}


### PR DESCRIPTION

Relocated the `BlockOrderRequest` HTTP body DTO from the bottom of `ShoptetOrdersController.cs` into `Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs`, restoring the architectural rule that the API project must not own DTOs — it only uses them.

The API controller already imported the `BlockOrderProcessing` namespace, so no new `using` was needed. The only controller-side change is deleting the inline class definition and removing the `using System.Text.Json.Serialization;` that existed solely for it. Zero behavior change; `dotnet build` succeeds with no new warnings.

### Changes
- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderRequest.cs` — new file: relocated DTO with file-scoped namespace, class keyword, `[JsonPropertyName("note")]` preserved
- `backend/src/Anela.Heblo.API/Controllers/ShoptetOrdersController.cs` — removed inline `BlockOrderRequest` class (lines 56–60) and the now-unused `using System.Text.Json.Serialization;`

---

Closes #1563

### Tokens used
6637095
