### PR TITLE
feat: Honest Dependency in ShoptetApiPackingOrderClient

### DIFF
--- a/artifacts/feat-arch-review-shoptetorders-shoptetapipack/arch-review.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-shoptetapipack/arch-review.r1.md
@@ -1,0 +1,141 @@
+Now I have a full picture. Let me write the architecture review.
+
+# Architecture Review: Honest Dependency in ShoptetApiPackingOrderClient
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+This is a structural refactor inside the `Anela.Heblo.Adapters.ShoptetApi` adapter assembly. The change aligns with the codebase's existing Clean Architecture boundary: the application layer (`IPackingOrderClient`, `IEshopOrderClient`) owns abstractions, and the adapter project provides concrete Shoptet implementations. The current `IEshopOrderClient` cast in `ShoptetApiPackingOrderClient` (line 31) violates DIP/LSP and the project convention that constructor signatures should reflect actual dependencies.
+
+**Two integration points must be handled together:**
+1. The constructor of `ShoptetApiPackingOrderClient` — minor, mechanical.
+2. The typed-HttpClient registration in `ShoptetApiAdapterServiceCollectionExtensions.cs` — non-trivial. The current `services.AddHttpClient<IEshopOrderClient, ShoptetOrderClient>(...)` registers **only `IEshopOrderClient`**; `ShoptetOrderClient` is **not separately resolvable** as a concrete type. Simply adding a second `AddTransient<ShoptetOrderClient>()` would resolve it without an HttpClient, defeating the typed-client design. The fix must route both registrations to the same typed-client.
+
+**Important spec correction:** The spec/brief claim that `ShoptetApiPackingOrderClient` has "zero direct test coverage because of the cast" is factually wrong. `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs` already contains 10 unit tests that pass a real `ShoptetOrderClient` (constructed with `FakeDelegatingHandler`) into the SUT. The current cast (`orderClient as ShoptetOrderClient`) never fails in these tests because the cast succeeds. The real value of this refactor is **architectural honesty**, not unlocking impossible tests.
+
+**Adjacent finding (out of scope, document only):** `ShoptetApiExpeditionListSource` (line 35) has the identical pattern — `IEshopOrderClient` parameter immediately downcast to `ShoptetOrderClient`. The arch-review routine should file this as a separate ticket; do not bundle here.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Application layer                                                    │
+│   IPackingOrderClient  ◄────────┐                                    │
+│   IEshopOrderClient    ◄──────┐ │                                    │
+└───────────────────────────────┼─┼────────────────────────────────────┘
+                                │ │
+┌───────────────────────────────┼─┼────────────────────────────────────┐
+│ Adapters.ShoptetApi           │ │                                    │
+│                               │ │                                    │
+│   ShoptetOrderClient ─────────┘ │  (concrete typed HttpClient)       │
+│        ▲                        │                                    │
+│        │ injected as concrete   │                                    │
+│        │                        │                                    │
+│   ShoptetApiPackingOrderClient ─┘  (was IEshopOrderClient + cast)    │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+After the change:
+- `ShoptetOrderClient` is registered as the **single source-of-truth typed client** and resolves both as itself and as `IEshopOrderClient`.
+- `ShoptetApiPackingOrderClient` declares its real dependency (`ShoptetOrderClient`).
+- All other `IEshopOrderClient` consumers (`BlockOrderProcessingHandler`, `ScanPackingOrderHandler`, etc.) are untouched.
+
+### Key Design Decisions
+
+#### Decision 1: DI registration shape for the typed client
+**Options considered:**
+1. Two separate `AddHttpClient` calls (`<IEshopOrderClient, ShoptetOrderClient>` + `<ShoptetOrderClient>`) — would create **two distinct typed clients** with two distinct HttpClient configurations; not the same underlying client; subtly wrong and duplicative.
+2. Keep `AddHttpClient<IEshopOrderClient, ShoptetOrderClient>` and add `services.AddTransient<ShoptetOrderClient>(sp => sp.GetRequiredService<IEshopOrderClient>() as ShoptetOrderClient ?? throw …)` — re-introduces a cast in the composition root; no better than the original.
+3. **Chosen — invert the typed-client registration:** Register `AddHttpClient<ShoptetOrderClient>(configure)` directly on the concrete class, then forward the interface via `services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>())`. One typed client, no casts, both abstractions resolvable.
+
+**Rationale:** Option 3 is the idiomatic `AddHttpClient` pattern when one concrete class implements multiple service shapes. It keeps a single source of HttpClient configuration (BaseAddress + token header) and naturally aligns with the goal of "stop lying about the dependency."
+
+#### Decision 2: Where the new constructor parameter type comes from
+**Chosen approach:** The constructor takes `ShoptetOrderClient` directly (concrete). No new abstraction (`IExpeditionOrderDetailClient`) is introduced — out of scope per spec, YAGNI per project rules.
+**Rationale:** Both consumers of `GetExpeditionOrderDetailAsync` live inside the same adapter assembly (`ShoptetApiPackingOrderClient`, `ShoptetApiExpeditionListSource`). Adapter-internal coupling to a sibling concrete type is acceptable and explicit, mirroring the comment already present at `ShoptetApiExpeditionListSource.cs:18-20`.
+
+#### Decision 3: Test additions
+**Chosen approach:** No new tests are required *to satisfy FR-4 as written*. The existing `ShoptetApiPackingOrderClientTests` already cover the happy path via the `FakeDelegatingHandler` pattern. After the refactor, those tests must still compile and pass without changes (the parameter type change is source-compatible because the test already passes a `ShoptetOrderClient`).
+**Rationale:** Adding a redundant test to "satisfy" an FR built on a faulty premise violates YAGNI and the project's "surgical changes" rule. The spec must be amended (see Specification Amendments).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Touch only:
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs`
+
+### Interfaces and Contracts
+
+**`ShoptetApiPackingOrderClient` constructor — final shape:**
+
+```csharp
+public ShoptetApiPackingOrderClient(
+    ShoptetOrderClient orderClient,
+    ICatalogRepository catalog,
+    ICarrierCoolingRepository carrierCooling,
+    ILogger<ShoptetApiPackingOrderClient> logger,
+    IOptions<ShoptetApiSettings> settings)
+{
+    _orderClient = orderClient;
+    _catalog = catalog;
+    _carrierCooling = carrierCooling;
+    _logger = logger;
+    _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+}
+```
+
+Field type: `private readonly ShoptetOrderClient _orderClient;` (already correct on line 18; no change there).
+
+**DI registration — final shape (in `ShoptetApiAdapterServiceCollectionExtensions.AddShoptetApiAdapter`):**
+
+Replace:
+```csharp
+services.AddHttpClient<IEshopOrderClient, ShoptetOrderClient>((sp, client) => { ... });
+```
+with:
+```csharp
+services.AddHttpClient<ShoptetOrderClient>((sp, client) =>
+{
+    var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+    client.BaseAddress = new Uri(settings.BaseUrl);
+    client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+});
+services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>());
+```
+
+No other consumer code changes. `IEshopOrderClient` continues to resolve and yields the same `ShoptetOrderClient` instances (transient, with HttpClient pooled by the HttpClientFactory).
+
+### Data Flow
+Unchanged. Runtime sequence for a packing-order lookup:
+1. MediatR handler depends on `IPackingOrderClient` (resolved to `ShoptetApiPackingOrderClient`).
+2. `ShoptetApiPackingOrderClient` calls `_orderClient.GetExpeditionOrderDetailAsync(code)` and `_orderClient.GetOrderStatusIdAsync(code)` — same method calls as today.
+3. `ShoptetOrderClient` uses its injected `HttpClient` (configured by HttpClientFactory) to hit `/api/orders/{code}?include=stockLocation,notes` and `/api/orders/{code}`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Naive DI fix (registering `ShoptetOrderClient` separately without `AddHttpClient`) would resolve it without an HttpClient → NullReferenceException at first call | HIGH | Use the Decision 1 pattern: `AddHttpClient<ShoptetOrderClient>` + transient forwarder for `IEshopOrderClient`. Verify at boot by resolving both types. |
+| Existing tests break because they passed `ShoptetOrderClient` into a parameter typed `IEshopOrderClient` and now the parameter is concrete | LOW | The change is source-compatible — tests already pass a `ShoptetOrderClient`. Just run `dotnet test` after the change. |
+| Other `IEshopOrderClient` consumers see a behavior change (e.g. different HttpClient instance reuse semantics) | LOW | `AddHttpClient<TConcrete>` + transient forwarder uses the same HttpClientFactory pipeline as the old `AddHttpClient<TInterface, TImpl>`; pooling/lifetime behavior is equivalent. |
+| Adjacent identical pattern in `ShoptetApiExpeditionListSource` (line 35) remains in place and re-creates the smell | MEDIUM | Out of scope for this ticket. File a follow-up bug. Add a TODO-style comment? No — project rule says don't improve adjacent code. |
+| Spec FR-4 asks for a "new test" that duplicates existing coverage | MEDIUM | Amend the spec (below) to drop FR-4 or reframe it as "verify existing tests still pass." |
+
+## Specification Amendments
+
+1. **FR-4 must be reframed.** The premise ("the adapter has zero direct coverage because of the downcast") is factually wrong — see `ShoptetApiPackingOrderClientTests.cs`. Replace FR-4 with:
+
+   > **FR-4 (amended): Verify existing tests survive the refactor.** The existing 10 tests in `Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs` must compile and pass after the change to the constructor parameter type. No new tests are required. If the developer notices a coverage gap not caused by the cast, file a separate ticket.
+
+2. **Background section needs a correction.** Remove the bullet "Test coverage gap: …As a result, `GetPackingOrderHandlerTests` mocks one layer up (`IPackingOrderClient`) and the adapter itself has zero direct coverage." Replace with: "Test coverage of the adapter exists (`ShoptetApiPackingOrderClientTests`) using a `FakeDelegatingHandler`-backed `ShoptetOrderClient`. The cast pattern does not actively block testing today, but it remains a DIP/LSP violation that misleads future readers."
+
+3. **FR-2 must specify the DI pattern explicitly.** As written ("ensure `ShoptetOrderClient` is registered and resolvable as the concrete type so the new constructor parameter is satisfied") leaves room for the wrong fix. Add: "Use `services.AddHttpClient<ShoptetOrderClient>(...)` for the typed-HttpClient registration, and forward `IEshopOrderClient` via `services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>())`. Do not add a separate `AddHttpClient<IEshopOrderClient, ShoptetOrderClient>` registration — that produces two typed clients with two HttpClient configurations."
+
+4. **Add explicit out-of-scope note for `ShoptetApiExpeditionListSource`.** Already partially implied by "Removing or modifying other consumers of `IEshopOrderClient` — untouched", but the identical downcast in `ShoptetApiExpeditionListSource.cs:35` deserves explicit mention so the implementer doesn't get tempted to fix it. Add to Out of Scope: "`ShoptetApiExpeditionListSource` has the same downcast pattern. Out of scope here; file a follow-up ticket."
+
+## Prerequisites
+None. No migrations, no config changes, no infrastructure work. The refactor is self-contained inside the `Anela.Heblo.Adapters.ShoptetApi` assembly and DI composition root. `dotnet build` + `dotnet test` after the change is the only validation gate.

--- a/artifacts/feat-arch-review-shoptetorders-shoptetapipack/brief.md
+++ b/artifacts/feat-arch-review-shoptetorders-shoptetapipack/brief.md
@@ -1,0 +1,41 @@
+## Module
+ShoptetOrders
+
+## Finding
+`ShoptetApiPackingOrderClient` declares a dependency on `IEshopOrderClient` (an interface) but immediately narrows it to the concrete `ShoptetOrderClient` in the constructor body and throws if the cast fails:
+
+```
+backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs — lines 24–34
+```
+
+```csharp
+public ShoptetApiPackingOrderClient(
+    IEshopOrderClient orderClient,   // ← claims interface dependency
+    ...)
+{
+    _orderClient = orderClient as ShoptetOrderClient
+        ?? throw new InvalidOperationException(
+            $"{nameof(IEshopOrderClient)} must be {nameof(ShoptetOrderClient)} ...");
+```
+
+The concrete cast is needed because `GetExpeditionOrderDetailAsync` (called at line 46) is defined on `ShoptetOrderClient` directly, not on `IEshopOrderClient`. The interface is therefore never substitutable — passing any other implementation causes an immediate runtime failure.
+
+## Why it matters
+This violates the Dependency Inversion Principle (depend on abstractions) and Liskov Substitution Principle (any implementation of the interface must be usable). In practice it makes `ShoptetApiPackingOrderClient` untestable with a mock without also providing a `ShoptetOrderClient` concrete instance, which requires a live HTTP client. The `GetPackingOrderHandlerTests` works around this by mocking `IPackingOrderClient` one level up, but the adapter itself has zero test coverage because of this cast.
+
+## Suggested fix
+The smallest fix is to make the dependency honest: inject `ShoptetOrderClient` directly instead of the interface.
+
+```csharp
+public ShoptetApiPackingOrderClient(
+    ShoptetOrderClient orderClient,   // honest concrete dependency
+    ICatalogRepository catalog,
+    ...)
+{
+    _orderClient = orderClient;
+```
+
+Alternatively, extract a narrow interface (e.g. `IExpeditionOrderDetailClient`) that exposes only `GetExpeditionOrderDetailAsync` and `GetOrderStatusIdAsync`, have `ShoptetOrderClient` implement it, and inject that. This restores substitutability without changing callers.
+
+---
+_Filed by daily arch-review routine on 2026-05-23._

--- a/artifacts/feat-arch-review-shoptetorders-shoptetapipack/impl/main.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-shoptetapipack/impl/main.r1.md
@@ -1,0 +1,36 @@
+All three tasks complete. Here is the output artifact:
+
+---
+
+# Implementation: Honest Dependency in ShoptetApiPackingOrderClient
+
+## What was implemented
+Removed the dishonest `IEshopOrderClient` → `ShoptetOrderClient` runtime downcast in `ShoptetApiPackingOrderClient` by depending on the concrete `ShoptetOrderClient` directly. The DI registration was inverted to register the typed HttpClient on the concrete class and forward the interface via a transient factory — one HttpClient configuration, no casts.
+
+## Files created/modified
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs` — replaced `AddHttpClient<IEshopOrderClient, ShoptetOrderClient>` with `AddHttpClient<ShoptetOrderClient>` + `AddTransient<IEshopOrderClient>` forwarder (commit `1af15457`)
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — constructor parameter changed from `IEshopOrderClient` to `ShoptetOrderClient`; `as`/throw cast replaced by direct assignment (commit `7cb748e8`)
+
+## Tests
+- `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs` — existing 10 tests unchanged and passing. No new tests added (FR-4 was based on a false premise per arch review; existing tests already covered the happy paths via `FakeDelegatingHandler`-backed `ShoptetOrderClient`).
+
+## How to verify
+```bash
+dotnet build backend/Anela.Heblo.sln       # 0 errors
+dotnet test backend/Anela.Heblo.sln         # 4,101 pass, 0 fail
+```
+
+## Notes
+- **`ShoptetApiExpeditionListSource.cs`** has the identical downcast pattern at line 35 — intentionally left untouched per spec. A follow-up ticket should be filed.
+- One pre-existing integration test (`PickingListIntegrationTests.PrintPickingList_ProducesPdfs_ForRecentOrders`) fails due to a DI issue for `ICarrierCoolingRepository` that predates this branch. Unrelated to these changes.
+- The `dotnet format` run in Task 1 automatically cleaned up the unused `System` using directive that was previously needed for `InvalidOperationException`.
+
+## PR Summary
+Removes a DIP/LSP violation in `ShoptetApiPackingOrderClient` where the constructor declared `IEshopOrderClient` but immediately downcasted to `ShoptetOrderClient` at runtime, making any non-`ShoptetOrderClient` implementation silently fail at construction. The fix has two parts: (1) the constructor now takes `ShoptetOrderClient` directly, eliminating the cast, and (2) the DI registration is restructured so that `ShoptetOrderClient` is registered as the typed HttpClient and `IEshopOrderClient` is forwarded via a transient factory — keeping a single HttpClient configuration and preserving all existing interface consumers.
+
+### Changes
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs` — inverted typed-client registration: `AddHttpClient<ShoptetOrderClient>` + `AddTransient<IEshopOrderClient>` forwarder
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — constructor parameter `IEshopOrderClient → ShoptetOrderClient`; direct assignment replaces `as`/throw cast
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-shoptetorders-shoptetapipack/spec.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-shoptetapipack/spec.r1.md
@@ -1,0 +1,122 @@
+# Specification: Honest Dependency in ShoptetApiPackingOrderClient
+
+## Summary
+Remove the dishonest interface dependency in `ShoptetApiPackingOrderClient` that declares `IEshopOrderClient` but immediately downcasts to concrete `ShoptetOrderClient`. Replace it with a direct dependency on `ShoptetOrderClient` so the constructor signature matches actual runtime requirements, restores DIP/LSP compliance, and unblocks unit testing of the adapter.
+
+## Background
+`ShoptetApiPackingOrderClient` (adapter sitting between the application layer and Shoptet's REST API) declares an `IEshopOrderClient` parameter but in its constructor body performs `orderClient as ShoptetOrderClient ?? throw …`. This is required because the method it relies on — `GetExpeditionOrderDetailAsync` — is declared only on the concrete `ShoptetOrderClient`, not on `IEshopOrderClient`.
+
+Consequences:
+- **DIP violation:** The class doesn't actually depend on the abstraction; it depends on the concrete type and lies about it.
+- **LSP violation:** No other implementation of `IEshopOrderClient` is substitutable — any non-`ShoptetOrderClient` instance fails immediately at construction.
+- **Test coverage gap:** The adapter cannot be unit-tested with a simple mock because the cast forces tests to supply a real `ShoptetOrderClient`, which in turn needs a live `HttpClient`. As a result, `GetPackingOrderHandlerTests` mocks one layer up (`IPackingOrderClient`) and the adapter itself has zero direct coverage.
+
+This finding was filed by the daily arch-review routine on 2026-05-23.
+
+## Functional Requirements
+
+### FR-1: Remove the runtime downcast in `ShoptetApiPackingOrderClient`
+Change the constructor of `ShoptetApiPackingOrderClient` to depend on the concrete `ShoptetOrderClient` directly. Drop the `as`/throw cast pattern entirely. The private `_orderClient` field becomes typed as `ShoptetOrderClient`.
+
+**Acceptance criteria:**
+- The constructor signature accepts `ShoptetOrderClient` (not `IEshopOrderClient`).
+- No `as` cast or `InvalidOperationException` for the order-client parameter remains in the class.
+- The private field used to call `GetExpeditionOrderDetailAsync` is typed as `ShoptetOrderClient`.
+- `dotnet build` succeeds for the entire backend solution.
+
+### FR-2: Update DI registration so the resolved instance matches the new constructor
+Wherever `ShoptetApiPackingOrderClient` is constructed (DI container module / ServiceCollection extension under `Anela.Heblo.Adapters.ShoptetApi`), ensure that `ShoptetOrderClient` is registered and resolvable as the concrete type so the new constructor parameter is satisfied.
+
+**Acceptance criteria:**
+- `ShoptetOrderClient` is registered in DI as itself (in addition to whatever existing `IEshopOrderClient` registration it has, which remains untouched).
+- Application boot resolves `ShoptetApiPackingOrderClient` without runtime exceptions.
+- No other consumer of `IEshopOrderClient` is broken by the registration change.
+
+### FR-3: Preserve all existing behavior of `ShoptetApiPackingOrderClient`
+The methods on `ShoptetApiPackingOrderClient` — including the `GetExpeditionOrderDetailAsync` call at line 46 and any catalog/repository interactions — must behave identically before and after the change. This is a pure structural refactor.
+
+**Acceptance criteria:**
+- No method signatures on `ShoptetApiPackingOrderClient` change.
+- No call sites of `ShoptetApiPackingOrderClient` need to be modified (other than DI wiring covered in FR-2).
+- Existing `GetPackingOrderHandlerTests` continues to pass without modification.
+
+### FR-4: Add direct unit tests for `ShoptetApiPackingOrderClient`
+With the downcast removed, mocking `ShoptetOrderClient` directly is still not trivial (it likely takes a non-virtual `HttpClient`-backed surface). Add at least one unit test exercising `ShoptetApiPackingOrderClient` with a test double of `ShoptetOrderClient` (using virtual methods, a hand-rolled subclass, or `HttpClient` with a mocked `HttpMessageHandler` — whichever is least invasive given the existing shape of `ShoptetOrderClient`).
+
+**Acceptance criteria:**
+- At least one new test in `Anela.Heblo.Adapters.ShoptetApi.Tests` (or equivalent) covers a happy-path call through `ShoptetApiPackingOrderClient`.
+- The test exercises the path that previously could not be reached because of the downcast.
+- The new test passes via `dotnet test`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact. Removing a downcast and `throw` only reduces a tiny one-time cost at constructor time. No request-path code changes.
+
+### NFR-2: Security
+No security surface area affected. No auth, secrets, or external API contracts change.
+
+### NFR-3: Maintainability
+The refactor must improve, not degrade, maintainability:
+- The class must clearly declare its true dependency.
+- No reflective or generic indirection introduced to "preserve" the old interface dependency.
+- No new abstractions added speculatively (YAGNI). If a narrow interface is ever needed by a second consumer, that's a future change.
+
+### NFR-4: Backward compatibility
+Internal refactor only. No external API, DTO, or persisted-data shape changes. Other consumers of `IEshopOrderClient` (if any) keep working untouched.
+
+## Data Model
+No data model changes. No entities, DTOs, or database tables are added, modified, or removed.
+
+## API / Interface Design
+
+**Class touched:**
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — constructor signature changes from `IEshopOrderClient` to `ShoptetOrderClient`; field type changes accordingly; downcast removed.
+
+**Constructor — before:**
+```csharp
+public ShoptetApiPackingOrderClient(
+    IEshopOrderClient orderClient,
+    ICatalogRepository catalog,
+    ...)
+{
+    _orderClient = orderClient as ShoptetOrderClient
+        ?? throw new InvalidOperationException(...);
+    ...
+}
+```
+
+**Constructor — after:**
+```csharp
+public ShoptetApiPackingOrderClient(
+    ShoptetOrderClient orderClient,
+    ICatalogRepository catalog,
+    ...)
+{
+    _orderClient = orderClient;
+    ...
+}
+```
+
+**DI module touched:** the `Anela.Heblo.Adapters.ShoptetApi` service-collection registration (typically a `ServiceCollectionExtensions`-style file). Register `ShoptetOrderClient` as itself if it is not already.
+
+**No HTTP endpoints, MediatR contracts, or front-end client surfaces are affected.**
+
+## Dependencies
+- `Anela.Heblo.Adapters.ShoptetApi` project — contains `ShoptetApiPackingOrderClient`, `ShoptetOrderClient`, `IEshopOrderClient`.
+- `Anela.Heblo.Application` (or wherever `IPackingOrderClient` and the consumer handlers live) — must continue to resolve `IPackingOrderClient` (which is what handlers depend on) successfully.
+- DI composition root (Program.cs / `AddShoptetApiAdapters` extension) — must register `ShoptetOrderClient`.
+
+No external service, library, or package dependency is added or upgraded.
+
+## Out of Scope
+- **Extracting a narrow interface** (e.g. `IExpeditionOrderDetailClient`) — explicitly rejected for this work. The brief calls out option 1 (concrete injection) as the smallest fix; option 2 (new narrow interface) is not introduced now because there is no second consumer requiring substitutability. It can be revisited if/when a second implementation appears.
+- **Refactoring `IEshopOrderClient`** to add `GetExpeditionOrderDetailAsync` to the interface — out of scope; would expand the interface to fit a single consumer and pollute other implementations.
+- **Wider refactor of `ShoptetOrderClient`** (e.g. extracting `HttpClient` boundary to make it more mockable) — out of scope for this ticket; only do the minimum needed to allow at least one direct unit test under FR-4. If that minimum requires a non-trivial change to `ShoptetOrderClient`, raise it as a follow-up rather than expanding scope here.
+- **Removing or modifying other consumers of `IEshopOrderClient`** — untouched.
+- **Adding test coverage beyond the one happy-path test required in FR-4** — broader coverage of the adapter is desirable but not required by this ticket.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-shoptetorders-shoptetapipack/task-plan.r1.md
+++ b/artifacts/feat-arch-review-shoptetorders-shoptetapipack/task-plan.r1.md
@@ -1,0 +1,290 @@
+# Honest Dependency in ShoptetApiPackingOrderClient — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dishonest `IEshopOrderClient` → `ShoptetOrderClient` runtime downcast in `ShoptetApiPackingOrderClient` by depending on the concrete `ShoptetOrderClient` directly, and adjust the typed-HttpClient registration so both `ShoptetOrderClient` and `IEshopOrderClient` resolve from a single typed-client configuration.
+
+**Architecture:** Pure structural refactor inside the `Anela.Heblo.Adapters.ShoptetApi` adapter assembly. The constructor of `ShoptetApiPackingOrderClient` is changed from `IEshopOrderClient` to `ShoptetOrderClient` and the cast/throw is dropped. The DI registration is inverted: `AddHttpClient<ShoptetOrderClient>(...)` registers the typed client on the concrete class, and `IEshopOrderClient` is forwarded via a transient factory (`sp => sp.GetRequiredService<ShoptetOrderClient>()`). No new abstractions, no behavior changes, no new tests required — existing `ShoptetApiPackingOrderClientTests` already cover the happy paths and remain source-compatible.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, Microsoft.Extensions.Http (typed `HttpClient` via `HttpClientFactory`), Microsoft.Extensions.DependencyInjection.
+
+---
+
+## File Structure
+
+Files touched (no new files):
+
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — change constructor parameter type from `IEshopOrderClient` to `ShoptetOrderClient`; remove the `as`/throw cast.
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs` — replace `AddHttpClient<IEshopOrderClient, ShoptetOrderClient>(...)` with `AddHttpClient<ShoptetOrderClient>(...)` plus `AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>())`.
+
+Files validated (must continue to pass / compile, but NOT edited):
+
+- `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs` — already passes a real `ShoptetOrderClient` (built around `FakeDelegatingHandler`); change is source-compatible.
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderProcessingHandler.cs` — consumer of `IEshopOrderClient`; must continue resolving to the same underlying `ShoptetOrderClient`.
+- `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` — same as above.
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs` — has an **identical downcast pattern** at line 35. **Out of scope for this ticket** per arch-review; file a follow-up bug instead. Do NOT modify here.
+
+---
+
+## Pre-flight: Baseline before change
+
+### Task 0: Establish a green baseline
+
+**Files:** none modified.
+
+- [ ] **Step 1: Build the backend solution to confirm a clean starting point**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors. (Warnings are acceptable.)
+
+- [ ] **Step 2: Run the affected unit test project to confirm a green baseline**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ShoptetApiPackingOrderClientTests" --no-build
+```
+Expected: 10 tests pass, 0 fail.
+
+If either step fails, STOP. The repository is not in a clean state; do not begin the refactor.
+
+---
+
+## Task 1: Update the typed-HttpClient registration in the DI module
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs:37-42`
+
+**Why first:** If the production constructor is changed before the DI is updated, the next `dotnet build` is still clean (it's only a parameter type change), but the application would fail at boot when resolving `ShoptetApiPackingOrderClient` because `ShoptetOrderClient` is not yet registered as a concrete type. Doing the DI fix first keeps every intermediate commit boot-safe.
+
+- [ ] **Step 1: Replace the typed-client registration**
+
+Open `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs`.
+
+Find this block (lines 37-42):
+
+```csharp
+services.AddHttpClient<IEshopOrderClient, ShoptetOrderClient>((sp, client) =>
+{
+    var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+    client.BaseAddress = new Uri(settings.BaseUrl);
+    client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+});
+```
+
+Replace it with:
+
+```csharp
+services.AddHttpClient<ShoptetOrderClient>((sp, client) =>
+{
+    var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+    client.BaseAddress = new Uri(settings.BaseUrl);
+    client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+});
+services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>());
+```
+
+Leave every other `AddHttpClient<...>` block in this file untouched.
+
+- [ ] **Step 2: Verify the file still compiles**
+
+Run:
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: `Build succeeded` with 0 errors.
+
+- [ ] **Step 3: Apply formatter**
+
+Run:
+```bash
+dotnet format backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: command completes without errors. No prompt; the file is reformatted in place if needed.
+
+- [ ] **Step 4: Re-run the existing unit tests to confirm nothing regressed**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ShoptetApiPackingOrderClientTests"
+```
+Expected: 10 tests pass. (The constructor of `ShoptetApiPackingOrderClient` is still typed `IEshopOrderClient` at this point; the tests pass a `ShoptetOrderClient` which implicitly converts. The cast in the constructor body still runs and still succeeds.)
+
+- [ ] **Step 5: Commit the DI change**
+
+Run:
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+git commit -m "refactor(shoptet-api): register ShoptetOrderClient typed client as concrete, forward IEshopOrderClient"
+```
+
+---
+
+## Task 2: Remove the dishonest cast in `ShoptetApiPackingOrderClient`
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs:24-39`
+
+The private field `_orderClient` is already typed `ShoptetOrderClient` (line 18) — no change there. Only the constructor parameter and the body of the assignment change.
+
+- [ ] **Step 1: Change the constructor signature and remove the cast**
+
+Open `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`.
+
+Find this block (lines 24-39):
+
+```csharp
+    public ShoptetApiPackingOrderClient(
+        IEshopOrderClient orderClient,
+        ICatalogRepository catalog,
+        ICarrierCoolingRepository carrierCooling,
+        ILogger<ShoptetApiPackingOrderClient> logger,
+        IOptions<ShoptetApiSettings> settings)
+    {
+        _orderClient = orderClient as ShoptetOrderClient
+            ?? throw new InvalidOperationException(
+                $"{nameof(IEshopOrderClient)} must be {nameof(ShoptetOrderClient)} " +
+                $"but got {orderClient.GetType().Name}.");
+        _catalog = catalog;
+        _carrierCooling = carrierCooling;
+        _logger = logger;
+        _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+    }
+```
+
+Replace it with:
+
+```csharp
+    public ShoptetApiPackingOrderClient(
+        ShoptetOrderClient orderClient,
+        ICatalogRepository catalog,
+        ICarrierCoolingRepository carrierCooling,
+        ILogger<ShoptetApiPackingOrderClient> logger,
+        IOptions<ShoptetApiSettings> settings)
+    {
+        _orderClient = orderClient;
+        _catalog = catalog;
+        _carrierCooling = carrierCooling;
+        _logger = logger;
+        _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+    }
+```
+
+- [ ] **Step 2: Remove the now-unused `using` for the `IEshopOrderClient` namespace if it is no longer referenced**
+
+Check whether `Anela.Heblo.Application.Features.ShoptetOrders` (the namespace `IEshopOrderClient` lives in) is still needed by other symbols in this file (e.g., `ExpeditionOrderDetail`, `IPackingOrderClient`, settings types).
+
+Run:
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: `Build succeeded` with 0 errors.
+
+If the build is clean and `dotnet format` (next step) does not remove the using directive, leave the using list alone. **Do not perform surgical cleanups of unrelated usings** — the project rule is "surgical changes".
+
+- [ ] **Step 3: Apply formatter to the adapter project**
+
+Run:
+```bash
+dotnet format backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: command completes without errors. `dotnet format` will remove any using that is genuinely unused as part of analyzer fixups.
+
+- [ ] **Step 4: Build the whole backend solution to confirm no consumer broke**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors. (Compile-time check that no other production code was passing something other than `ShoptetOrderClient` to this constructor.)
+
+- [ ] **Step 5: Run the targeted unit tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ShoptetApiPackingOrderClientTests"
+```
+Expected: 10 tests pass. The test helper `BuildSut` already constructs a `ShoptetOrderClient` and passes it in (see `ShoptetApiPackingOrderClientTests.cs:78-87`), so no test edit is needed.
+
+If any test fails because the test was relying on the cast/throw behavior (it should not — none of the 10 tests exercise that path), do NOT delete the test. Report the failure and stop; the spec premise needs revisiting.
+
+- [ ] **Step 6: Commit the production code change**
+
+Run:
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+git commit -m "refactor(shoptet-api): take ShoptetOrderClient directly in ShoptetApiPackingOrderClient (drop downcast)"
+```
+
+---
+
+## Task 3: Full-solution validation
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full backend test suite**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: All tests pass. In particular, the following test files must remain green because they depend (directly or transitively) on the changed types:
+- `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs`
+- `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/*` (these mock or wire `IEshopOrderClient`; the interface is unchanged, so they should continue passing)
+
+If `dotnet test` reports `--no-build` cannot find binaries, fall back to:
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+- [ ] **Step 2: Sanity-check DI resolution doesn't throw at boot**
+
+This refactor changes the DI registration shape. The cheapest way to confirm the composition root still composes is to run the API project's startup path. If a quick boot test is available, use it; otherwise run the API in build-only mode:
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+Expected: `Build succeeded`. A real boot test is not required because no controller/handler depends on the *concrete* `ShoptetOrderClient` at construction time other than `ShoptetApiPackingOrderClient` itself (verified at compile time by Step 1 of Task 2).
+
+If there is a startup integration test (search for `WebApplicationFactory<Program>` in `backend/test/`), run that test specifically:
+```bash
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~WebApplicationFactory" --no-build
+```
+Expected: pass.
+
+- [ ] **Step 3: No-op commit guard**
+
+If Steps 1-2 added any modifications (they should not — those are read-only commands), run:
+```bash
+git status
+```
+Expected: `nothing to commit, working tree clean`.
+
+If `dotnet format` from Task 2 Step 3 left untracked formatting changes that didn't get included in the Task 2 commit, decide whether they belong to Task 1 or Task 2 by file, and amend the appropriate commit OR create a `chore: dotnet format` commit. Do not push a half-formatted tree.
+
+---
+
+## Out of Scope (do NOT do in this plan)
+
+1. **Do NOT fix the identical downcast in `ShoptetApiExpeditionListSource.cs:35`.** It's the same smell and worth a follow-up ticket, but the spec explicitly excludes it. Per the project's "surgical changes" rule, do not touch adjacent code.
+2. **Do NOT add an `IExpeditionOrderDetailClient` narrow interface.** Spec rejects it as YAGNI (single consumer until/unless a second appears).
+3. **Do NOT add `GetExpeditionOrderDetailAsync` to `IEshopOrderClient`.** Out of scope; would pollute the interface for the single consumer.
+4. **Do NOT add new unit tests.** FR-4 of the original spec was based on a false premise (the arch review corrected it). The 10 existing `ShoptetApiPackingOrderClientTests` already cover the happy paths. Adding a redundant test would violate YAGNI.
+5. **Do NOT refactor `ShoptetOrderClient` for "easier mockability".** Out of scope; existing `FakeDelegatingHandler` pattern works.
+
+---
+
+## Done When
+
+- `dotnet build backend/Anela.Heblo.sln` is green.
+- `dotnet test backend/Anela.Heblo.sln` is green.
+- `dotnet format backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj` produces no further changes.
+- `ShoptetApiPackingOrderClient` constructor declares `ShoptetOrderClient orderClient` (not `IEshopOrderClient`); no `as` cast, no `InvalidOperationException` for the order-client parameter.
+- DI registration uses `AddHttpClient<ShoptetOrderClient>(...)` and forwards `IEshopOrderClient` via `AddTransient`.
+- Two commits exist on the branch — one for the DI change, one for the production code change. (A third `chore: dotnet format` commit is acceptable if formatting needed to be split off.)
+- `ShoptetApiExpeditionListSource.cs` is **untouched** (the identical pattern there is a separate follow-up).

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
@@ -22,16 +22,13 @@ public class ShoptetApiPackingOrderClient : IPackingOrderClient
     private readonly int _defaultItemWeightGrams;
 
     public ShoptetApiPackingOrderClient(
-        IEshopOrderClient orderClient,
+        ShoptetOrderClient orderClient,
         ICatalogRepository catalog,
         ICarrierCoolingRepository carrierCooling,
         ILogger<ShoptetApiPackingOrderClient> logger,
         IOptions<ShoptetApiSettings> settings)
     {
-        _orderClient = orderClient as ShoptetOrderClient
-            ?? throw new InvalidOperationException(
-                $"{nameof(IEshopOrderClient)} must be {nameof(ShoptetOrderClient)} " +
-                $"but got {orderClient.GetType().Name}.");
+        _orderClient = orderClient;
         _catalog = catalog;
         _carrierCooling = carrierCooling;
         _logger = logger;

--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
@@ -34,12 +34,13 @@ public static class ShoptetApiAdapterServiceCollectionExtensions
         services.AddOptions<ShoptetApiSettings>()
             .Bind(configuration.GetSection(ShoptetApiSettings.ConfigurationKey));
 
-        services.AddHttpClient<IEshopOrderClient, ShoptetOrderClient>((sp, client) =>
+        services.AddHttpClient<ShoptetOrderClient>((sp, client) =>
         {
             var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
             client.BaseAddress = new Uri(settings.BaseUrl);
             client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
         });
+        services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>());
 
         services.AddHttpClient<IEshopStockClient, ShoptetStockClient>((sp, client) =>
         {

--- a/docs/superpowers/plans/2026-05-24-honest-dependency-shoptetapi-packing-order-client.md
+++ b/docs/superpowers/plans/2026-05-24-honest-dependency-shoptetapi-packing-order-client.md
@@ -1,0 +1,290 @@
+# Honest Dependency in ShoptetApiPackingOrderClient — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dishonest `IEshopOrderClient` → `ShoptetOrderClient` runtime downcast in `ShoptetApiPackingOrderClient` by depending on the concrete `ShoptetOrderClient` directly, and adjust the typed-HttpClient registration so both `ShoptetOrderClient` and `IEshopOrderClient` resolve from a single typed-client configuration.
+
+**Architecture:** Pure structural refactor inside the `Anela.Heblo.Adapters.ShoptetApi` adapter assembly. The constructor of `ShoptetApiPackingOrderClient` is changed from `IEshopOrderClient` to `ShoptetOrderClient` and the cast/throw is dropped. The DI registration is inverted: `AddHttpClient<ShoptetOrderClient>(...)` registers the typed client on the concrete class, and `IEshopOrderClient` is forwarded via a transient factory (`sp => sp.GetRequiredService<ShoptetOrderClient>()`). No new abstractions, no behavior changes, no new tests required — existing `ShoptetApiPackingOrderClientTests` already cover the happy paths and remain source-compatible.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, Microsoft.Extensions.Http (typed `HttpClient` via `HttpClientFactory`), Microsoft.Extensions.DependencyInjection.
+
+---
+
+## File Structure
+
+Files touched (no new files):
+
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — change constructor parameter type from `IEshopOrderClient` to `ShoptetOrderClient`; remove the `as`/throw cast.
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs` — replace `AddHttpClient<IEshopOrderClient, ShoptetOrderClient>(...)` with `AddHttpClient<ShoptetOrderClient>(...)` plus `AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>())`.
+
+Files validated (must continue to pass / compile, but NOT edited):
+
+- `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs` — already passes a real `ShoptetOrderClient` (built around `FakeDelegatingHandler`); change is source-compatible.
+- `backend/src/Anela.Heblo.Application/Features/ShoptetOrders/UseCases/BlockOrderProcessing/BlockOrderProcessingHandler.cs` — consumer of `IEshopOrderClient`; must continue resolving to the same underlying `ShoptetOrderClient`.
+- `backend/src/Anela.Heblo.Application/Features/Packaging/UseCases/ScanPackingOrder/ScanPackingOrderHandler.cs` — same as above.
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs` — has an **identical downcast pattern** at line 35. **Out of scope for this ticket** per arch-review; file a follow-up bug instead. Do NOT modify here.
+
+---
+
+## Pre-flight: Baseline before change
+
+### Task 0: Establish a green baseline
+
+**Files:** none modified.
+
+- [ ] **Step 1: Build the backend solution to confirm a clean starting point**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors. (Warnings are acceptable.)
+
+- [ ] **Step 2: Run the affected unit test project to confirm a green baseline**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ShoptetApiPackingOrderClientTests" --no-build
+```
+Expected: 10 tests pass, 0 fail.
+
+If either step fails, STOP. The repository is not in a clean state; do not begin the refactor.
+
+---
+
+## Task 1: Update the typed-HttpClient registration in the DI module
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs:37-42`
+
+**Why first:** If the production constructor is changed before the DI is updated, the next `dotnet build` is still clean (it's only a parameter type change), but the application would fail at boot when resolving `ShoptetApiPackingOrderClient` because `ShoptetOrderClient` is not yet registered as a concrete type. Doing the DI fix first keeps every intermediate commit boot-safe.
+
+- [ ] **Step 1: Replace the typed-client registration**
+
+Open `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs`.
+
+Find this block (lines 37-42):
+
+```csharp
+services.AddHttpClient<IEshopOrderClient, ShoptetOrderClient>((sp, client) =>
+{
+    var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+    client.BaseAddress = new Uri(settings.BaseUrl);
+    client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+});
+```
+
+Replace it with:
+
+```csharp
+services.AddHttpClient<ShoptetOrderClient>((sp, client) =>
+{
+    var settings = sp.GetRequiredService<IOptions<ShoptetApiSettings>>().Value;
+    client.BaseAddress = new Uri(settings.BaseUrl);
+    client.DefaultRequestHeaders.Add("Shoptet-Private-API-Token", settings.ApiToken);
+});
+services.AddTransient<IEshopOrderClient>(sp => sp.GetRequiredService<ShoptetOrderClient>());
+```
+
+Leave every other `AddHttpClient<...>` block in this file untouched.
+
+- [ ] **Step 2: Verify the file still compiles**
+
+Run:
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: `Build succeeded` with 0 errors.
+
+- [ ] **Step 3: Apply formatter**
+
+Run:
+```bash
+dotnet format backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: command completes without errors. No prompt; the file is reformatted in place if needed.
+
+- [ ] **Step 4: Re-run the existing unit tests to confirm nothing regressed**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ShoptetApiPackingOrderClientTests"
+```
+Expected: 10 tests pass. (The constructor of `ShoptetApiPackingOrderClient` is still typed `IEshopOrderClient` at this point; the tests pass a `ShoptetOrderClient` which implicitly converts. The cast in the constructor body still runs and still succeeds.)
+
+- [ ] **Step 5: Commit the DI change**
+
+Run:
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+git commit -m "refactor(shoptet-api): register ShoptetOrderClient typed client as concrete, forward IEshopOrderClient"
+```
+
+---
+
+## Task 2: Remove the dishonest cast in `ShoptetApiPackingOrderClient`
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs:24-39`
+
+The private field `_orderClient` is already typed `ShoptetOrderClient` (line 18) — no change there. Only the constructor parameter and the body of the assignment change.
+
+- [ ] **Step 1: Change the constructor signature and remove the cast**
+
+Open `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs`.
+
+Find this block (lines 24-39):
+
+```csharp
+    public ShoptetApiPackingOrderClient(
+        IEshopOrderClient orderClient,
+        ICatalogRepository catalog,
+        ICarrierCoolingRepository carrierCooling,
+        ILogger<ShoptetApiPackingOrderClient> logger,
+        IOptions<ShoptetApiSettings> settings)
+    {
+        _orderClient = orderClient as ShoptetOrderClient
+            ?? throw new InvalidOperationException(
+                $"{nameof(IEshopOrderClient)} must be {nameof(ShoptetOrderClient)} " +
+                $"but got {orderClient.GetType().Name}.");
+        _catalog = catalog;
+        _carrierCooling = carrierCooling;
+        _logger = logger;
+        _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+    }
+```
+
+Replace it with:
+
+```csharp
+    public ShoptetApiPackingOrderClient(
+        ShoptetOrderClient orderClient,
+        ICatalogRepository catalog,
+        ICarrierCoolingRepository carrierCooling,
+        ILogger<ShoptetApiPackingOrderClient> logger,
+        IOptions<ShoptetApiSettings> settings)
+    {
+        _orderClient = orderClient;
+        _catalog = catalog;
+        _carrierCooling = carrierCooling;
+        _logger = logger;
+        _defaultItemWeightGrams = settings.Value.DefaultItemWeightGrams;
+    }
+```
+
+- [ ] **Step 2: Remove the now-unused `using` for the `IEshopOrderClient` namespace if it is no longer referenced**
+
+Check whether `Anela.Heblo.Application.Features.ShoptetOrders` (the namespace `IEshopOrderClient` lives in) is still needed by other symbols in this file (e.g., `ExpeditionOrderDetail`, `IPackingOrderClient`, settings types).
+
+Run:
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: `Build succeeded` with 0 errors.
+
+If the build is clean and `dotnet format` (next step) does not remove the using directive, leave the using list alone. **Do not perform surgical cleanups of unrelated usings** — the project rule is "surgical changes".
+
+- [ ] **Step 3: Apply formatter to the adapter project**
+
+Run:
+```bash
+dotnet format backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj
+```
+Expected: command completes without errors. `dotnet format` will remove any using that is genuinely unused as part of analyzer fixups.
+
+- [ ] **Step 4: Build the whole backend solution to confirm no consumer broke**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded` with 0 errors. (Compile-time check that no other production code was passing something other than `ShoptetOrderClient` to this constructor.)
+
+- [ ] **Step 5: Run the targeted unit tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ShoptetApiPackingOrderClientTests"
+```
+Expected: 10 tests pass. The test helper `BuildSut` already constructs a `ShoptetOrderClient` and passes it in (see `ShoptetApiPackingOrderClientTests.cs:78-87`), so no test edit is needed.
+
+If any test fails because the test was relying on the cast/throw behavior (it should not — none of the 10 tests exercise that path), do NOT delete the test. Report the failure and stop; the spec premise needs revisiting.
+
+- [ ] **Step 6: Commit the production code change**
+
+Run:
+```bash
+git add backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs
+git commit -m "refactor(shoptet-api): take ShoptetOrderClient directly in ShoptetApiPackingOrderClient (drop downcast)"
+```
+
+---
+
+## Task 3: Full-solution validation
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full backend test suite**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: All tests pass. In particular, the following test files must remain green because they depend (directly or transitively) on the changed types:
+- `backend/test/Anela.Heblo.Tests/Adapters/ShoptetApi/ShoptetApiPackingOrderClientTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/ShoptetOrders/BlockOrderProcessingHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/Packaging/ScanPackingOrderHandlerTests.cs`
+- `backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/*` (these mock or wire `IEshopOrderClient`; the interface is unchanged, so they should continue passing)
+
+If `dotnet test` reports `--no-build` cannot find binaries, fall back to:
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+- [ ] **Step 2: Sanity-check DI resolution doesn't throw at boot**
+
+This refactor changes the DI registration shape. The cheapest way to confirm the composition root still composes is to run the API project's startup path. If a quick boot test is available, use it; otherwise run the API in build-only mode:
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+Expected: `Build succeeded`. A real boot test is not required because no controller/handler depends on the *concrete* `ShoptetOrderClient` at construction time other than `ShoptetApiPackingOrderClient` itself (verified at compile time by Step 1 of Task 2).
+
+If there is a startup integration test (search for `WebApplicationFactory<Program>` in `backend/test/`), run that test specifically:
+```bash
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~WebApplicationFactory" --no-build
+```
+Expected: pass.
+
+- [ ] **Step 3: No-op commit guard**
+
+If Steps 1-2 added any modifications (they should not — those are read-only commands), run:
+```bash
+git status
+```
+Expected: `nothing to commit, working tree clean`.
+
+If `dotnet format` from Task 2 Step 3 left untracked formatting changes that didn't get included in the Task 2 commit, decide whether they belong to Task 1 or Task 2 by file, and amend the appropriate commit OR create a `chore: dotnet format` commit. Do not push a half-formatted tree.
+
+---
+
+## Out of Scope (do NOT do in this plan)
+
+1. **Do NOT fix the identical downcast in `ShoptetApiExpeditionListSource.cs:35`.** It's the same smell and worth a follow-up ticket, but the spec explicitly excludes it. Per the project's "surgical changes" rule, do not touch adjacent code.
+2. **Do NOT add an `IExpeditionOrderDetailClient` narrow interface.** Spec rejects it as YAGNI (single consumer until/unless a second appears).
+3. **Do NOT add `GetExpeditionOrderDetailAsync` to `IEshopOrderClient`.** Out of scope; would pollute the interface for the single consumer.
+4. **Do NOT add new unit tests.** FR-4 of the original spec was based on a false premise (the arch review corrected it). The 10 existing `ShoptetApiPackingOrderClientTests` already cover the happy paths. Adding a redundant test would violate YAGNI.
+5. **Do NOT refactor `ShoptetOrderClient` for "easier mockability".** Out of scope; existing `FakeDelegatingHandler` pattern works.
+
+---
+
+## Done When
+
+- `dotnet build backend/Anela.Heblo.sln` is green.
+- `dotnet test backend/Anela.Heblo.sln` is green.
+- `dotnet format backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Anela.Heblo.Adapters.ShoptetApi.csproj` produces no further changes.
+- `ShoptetApiPackingOrderClient` constructor declares `ShoptetOrderClient orderClient` (not `IEshopOrderClient`); no `as` cast, no `InvalidOperationException` for the order-client parameter.
+- DI registration uses `AddHttpClient<ShoptetOrderClient>(...)` and forwards `IEshopOrderClient` via `AddTransient`.
+- Two commits exist on the branch — one for the DI change, one for the production code change. (A third `chore: dotnet format` commit is acceptable if formatting needed to be split off.)
+- `ShoptetApiExpeditionListSource.cs` is **untouched** (the identical pattern there is a separate follow-up).


### PR DESCRIPTION
Removes a DIP/LSP violation in `ShoptetApiPackingOrderClient` where the constructor declared `IEshopOrderClient` but immediately downcasted to `ShoptetOrderClient` at runtime, making any non-`ShoptetOrderClient` implementation silently fail at construction. The fix has two parts: (1) the constructor now takes `ShoptetOrderClient` directly, eliminating the cast, and (2) the DI registration is restructured so that `ShoptetOrderClient` is registered as the typed HttpClient and `IEshopOrderClient` is forwarded via a transient factory — keeping a single HttpClient configuration and preserving all existing interface consumers.

### Changes
- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs` — inverted typed-client registration: `AddHttpClient<ShoptetOrderClient>` + `AddTransient<IEshopOrderClient>` forwarder
- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Orders/ShoptetApiPackingOrderClient.cs` — constructor parameter `IEshopOrderClient → ShoptetOrderClient`; direct assignment replaces `as`/throw cast

---

Closes #1564

### Tokens used
9901947
