### PR TITLE
feat: Remove duplicate type declarations in `useUserManagement.ts`

### DIFF
--- a/artifacts/feat-arch-review-usermanagement-frontend-hook/arch-review.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-frontend-hook/arch-review.r1.md
@@ -1,0 +1,148 @@
+```markdown
+# Architecture Review: Remove duplicate type declarations in `useUserManagement.ts`
+
+## Skip Design: true
+
+No UI, layout, or visual design work. The change is internal to a single TypeScript hook file and erased at compile time.
+
+## Architectural Fit Assessment
+
+The proposal is fully aligned with the codebase's existing API contract strategy: the OpenAPI → NSwag pipeline regenerates `frontend/src/api/generated/api-client.ts` from the backend's OpenAPI spec on every build, and most hooks consume those generated symbols. `useUserManagement.ts` is an outlier that hand-redeclares two DTOs the generator already produces — exactly the drift hazard the pipeline exists to prevent.
+
+Two architectural nuances surface when grounding the spec in the actual generated code:
+
+1. **The generated symbols are classes with optional fields, not interfaces with required fields.** The hand-written `UserDto` declares `id`, `displayName`, `email` as **required** strings. The generated `UserDto` declares them as **optional** (`id?: string; ...`) and is a `class` (with `fromJS`/`toJSON`/`init`). The matching pure interface is `IUserDto`. The same shape mismatch applies to `GetGroupMembersResponse` vs `IGetGroupMembersResponse` (where `members` is `UserDto[] | undefined`). The spec describes the change as type-system-only with no consumer impact, but switching to the generated types **narrows what TypeScript proves about runtime values** — fields become possibly-`undefined` and consumers must either narrow or stop relying on the previously-promised non-null guarantees.
+2. **The generated client already exposes the call.** `ManufactureOrderClient.manufactureOrder_GetResponsiblePersons()` (api-client.ts:6625) returns `Promise<GetGroupMembersResponse>` and reuses the generated runtime. The hook currently bypasses it with a raw `(apiClient as any).http.fetch(...)`. This is **out of scope** for the current spec, but worth flagging as the next obvious cleanup — see Specification Amendments.
+
+Verified consumer surface: only two files import from `useUserManagement` (`ResponsiblePersonCombobox.tsx`, `useUserManagement.test.tsx`). Neither imports the `UserDto`/`GetGroupMembersResponse` symbols — both reference the hook function only — so FR-3 has no external rewrite work to do.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend OpenAPI spec
+      │ (build-time codegen)
+      ▼
+frontend/src/api/generated/api-client.ts        ← single source of truth
+      │  exports: class UserDto, interface IUserDto,
+      │           class GetGroupMembersResponse, interface IGetGroupMembersResponse
+      │
+      ▼
+frontend/src/api/hooks/useUserManagement.ts     ← consumes generated types
+      │  useResponsiblePersonsQuery(): UseQueryResult<GetGroupMembersResponse>
+      ▼
+frontend/src/components/common/ResponsiblePersonCombobox.tsx
+      ▼
+UI (Select component, downstream pages)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Import the I-prefixed interface, not the class
+
+**Options considered:**
+- **A.** `import type { UserDto, GetGroupMembersResponse } from '../generated/api-client'` — uses the class symbols as types.
+- **B.** `import type { IUserDto, IGetGroupMembersResponse } from '../generated/api-client'` — uses the pure structural interfaces.
+- **C.** Wrap the generated types in a local alias that re-asserts required fields (`type ResponsiblePerson = Required<IUserDto>`).
+
+**Chosen approach:** **Option A** — import `UserDto` and `GetGroupMembersResponse` (the classes used as type positions). This is what the spec writes and what other generated-type consumers in the codebase do. Type-only imports of classes are erased at compile time, so no runtime cost.
+
+**Rationale:** Matches the spec verbatim, matches conventional NSwag usage elsewhere, and keeps the hook's JSDoc/IntelliSense pointing at the named class (more discoverable than the `I…` interface). The `I…` interface is structurally identical to the class shape for typing purposes, so Option B would be functionally equivalent but stylistically inconsistent with the rest of the codebase. Option C would silently lie about runtime data — if the backend omits a field, `Required<…>` would still claim it is present.
+
+#### Decision 2: Accept the optional-field semantics
+
+**Options considered:**
+- **A.** Leave the consumer alone; rely on existing `response?.members || []` and trust that `displayName`/`email` are present at runtime (with implicit non-null assumption).
+- **B.** Tighten the combobox to explicitly narrow `member.displayName` / `member.email` before use.
+- **C.** Introduce a local "narrowed" view model inside the hook that maps the generated optional-field DTO to a required-field shape, preserving the consumer's current invariants.
+
+**Chosen approach:** **Option A** for this PR — defer B/C to a follow-up. The spec is explicitly a type-only refactor with behavioral parity (FR-4), and the consumer already defends against `members` being undefined.
+
+**Rationale:** Touching the consumer expands the diff beyond what the spec authorizes and the brief asked for. However, the architect must flag that **TypeScript may emit new errors on lines 46–49 of `ResponsiblePersonCombobox.tsx`** (`member.displayName`, `member.email` used as `string` when they are now `string | undefined`). If those errors appear, the surgical fix is `member.displayName ?? ''` / `member.email ?? ''` at the call site — see Specification Amendments.
+
+#### Decision 3: Do not migrate the raw fetch to the generated client method
+
+**Options considered:**
+- **A.** Replace the `(apiClient as any).http.fetch(...)` block with `apiClient.manufactureOrder_GetResponsiblePersons()`.
+- **B.** Leave the runtime path untouched.
+
+**Chosen approach:** **Option B**, deferred. The spec scopes the change to type declarations only (Out of Scope: "Refactoring the hook's query logic"). The migration to the generated method is a separate, clearly-justified follow-up.
+
+**Rationale:** Discipline. The brief is surgical. Bundling unrelated cleanup violates "every changed line should trace directly to the request."
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. All edits land in:
+- `frontend/src/api/hooks/useUserManagement.ts` (modify)
+
+Possibly affected (if TypeScript flags optional-field usage):
+- `frontend/src/components/common/ResponsiblePersonCombobox.tsx` (defensive `??` fallbacks only)
+
+### Interfaces and Contracts
+
+The hook's exported signature stays:
+
+```ts
+export const useResponsiblePersonsQuery = (): UseQueryResult<GetGroupMembersResponse, Error>
+```
+
+where `GetGroupMembersResponse` now resolves to the generated class symbol (`members?: UserDto[]` with `UserDto` having `id?`, `displayName?`, `email?` all optional).
+
+Implementation diff is essentially:
+
+```diff
++ import type { GetGroupMembersResponse, UserDto } from '../generated/api-client';
+  import { useQuery } from '@tanstack/react-query';
+  import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
+
+- export interface UserDto { id: string; displayName: string; email: string; }
+- export interface GetGroupMembersResponse {
+-   success: boolean;
+-   errorCode?: number;
+-   params?: Record<string, string>;
+-   members: UserDto[];
+- }
+```
+
+`UserDto` may be unused after deletion if no annotation in the file references it directly (the `queryFn` only annotates `GetGroupMembersResponse`). If unused, omit it from the import to keep `npm run lint` clean.
+
+### Data Flow
+
+Unchanged at runtime. The hook still:
+1. Awaits `getAuthenticatedApiClient()`.
+2. Builds absolute URL with `${baseUrl}/api/ManufactureOrder/responsible-persons`.
+3. Calls `http.fetch`, throws on non-OK, returns `response.json()`.
+4. React Query caches under `[...QUERY_KEYS.userManagement, 'responsible-persons']` for 15 minutes.
+
+The only change is that the compiler now types the JSON payload via the generated class shape rather than the local interface.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Generated `UserDto`/`GetGroupMembersResponse` fields are optional; consumer code assuming non-null may break at compile time | Medium | Run `npm run build` immediately after the swap. If errors surface in `ResponsiblePersonCombobox.tsx`, apply `member.displayName ?? ''` / `member.email ?? ''` narrowing in that file. Do **not** widen the generated types. |
+| `UserDto` import unused after edit, tripping `no-unused-vars` lint | Low | Only import what the file references. If `UserDto` is not annotated anywhere in the file, import only `GetGroupMembersResponse`. |
+| Generated `GetGroupMembersResponse` lacks the runtime fields `success`/`errorCode`/`params` that the old manual interface had | Medium | The generated `GetGroupMembersResponse extends BaseResponse` — `BaseResponse` provides those fields. Verify by reading `BaseResponse` definition; if the inherited shape covers the consumer's actual usage, no consumer change is needed. If a field used by a consumer is missing, that is a backend OpenAPI gap, not a frontend bug — file as a separate finding. |
+| Test file (`useUserManagement.test.tsx`) mocks payloads as plain objects — generated class types may demand `fromJS()` construction | Low | Tests assert on React Query lifecycle (`isLoading`, `failureCount`, etc.) and never type-check the response payload itself. Spot-check after the change; no edit anticipated. |
+| Future contributor re-introduces a manual DTO declaration in another hook | Low | Mention `useMeetingTasks.ts` (lines 6–101) in the PR description as an out-of-scope sibling already justified with a `// TODO: migrate to generated client when /api/meeting-tasks is added to NSwag` comment. No action this PR. |
+
+## Specification Amendments
+
+1. **FR-4 (Behavioral parity) needs a caveat.** The generated `UserDto` declares `id`, `displayName`, `email` as **optional**; the manual interface declared them as **required**. Even though runtime payloads are unchanged, the compiler may emit new errors at consumer sites. Amend FR-4 to read: *"The hook's runtime behavior must remain identical. Compile-time errors arising solely from the stricter optional-field typing on consumers may be resolved with nullish-coalescing fallbacks (`?? ''`) at the call site, scoped to the minimum necessary lines."*
+
+2. **FR-3 acceptance is already satisfied.** Repo-wide grep confirms no consumer imports `UserDto` or `GetGroupMembersResponse` from `useUserManagement` — only the hook function is imported. The "consumers updated" branch of the acceptance criteria does not apply. Note this in the PR description rather than auditing again.
+
+3. **Add an explicit "next steps" non-requirement.** Two follow-up opportunities surfaced during review but are correctly out of scope:
+   - Replace the raw `(apiClient as any).http.fetch(...)` with `apiClient.manufactureOrder_GetResponsiblePersons()` — eliminates the `as any` cast and uses the generated request pipeline.
+   - Audit `useMeetingTasks.ts` once `/api/meeting-tasks` is added to the NSwag spec (already TODO'd).
+   Both should be filed as separate issues from the PR description; do not bundle.
+
+## Prerequisites
+
+- `frontend/src/api/generated/api-client.ts` already contains the up-to-date `UserDto` and `GetGroupMembersResponse` exports (verified at lines 26226 and 26267).
+- `npm run build` must run cleanly on `main` before the change so any new errors are unambiguously attributable to the refactor.
+- No backend changes, migrations, infrastructure, or config required.
+```

--- a/artifacts/feat-arch-review-usermanagement-frontend-hook/brief.md
+++ b/artifacts/feat-arch-review-usermanagement-frontend-hook/brief.md
@@ -1,0 +1,27 @@
+## Module
+UserManagement
+
+## Finding
+`frontend/src/api/hooks/useUserManagement.ts` (lines 4–15) manually declares `UserDto` and `GetGroupMembersResponse` interfaces:
+
+```typescript
+export interface UserDto { id: string; displayName: string; email: string; }
+export interface GetGroupMembersResponse { success: boolean; errorCode?: number; params?: Record<string, string>; members: UserDto[]; }
+```
+
+These types already exist in the auto-generated TypeScript client at `frontend/src/api/generated/api-client.ts` (lines 25618–25659 for `GetGroupMembersResponse`, line 25659 for `UserDto`). The generated versions are derived from the backend's OpenAPI spec and are guaranteed to stay in sync with the backend contracts.
+
+## Why it matters
+Manual duplication creates drift risk: if the backend contract changes (e.g. a field is added to `UserDto`), the generated client is updated automatically on build but the manual declaration in `useUserManagement.ts` is not — leading to a type mismatch that TypeScript cannot catch (since both sides are structural). This is exactly the problem the OpenAPI client generation pipeline is designed to prevent.
+
+## Suggested fix
+Import the generated types instead of re-declaring them:
+
+```typescript
+import type { GetGroupMembersResponse, UserDto } from '../generated/api-client';
+```
+
+Remove lines 4–15 from `useUserManagement.ts`. The hook's `queryFn` return type annotation and `response.members` usage will then reference the canonical generated types.
+
+---
+_Filed by daily arch-review routine on 2026-05-24._

--- a/artifacts/feat-arch-review-usermanagement-frontend-hook/impl/main.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-frontend-hook/impl/main.r1.md
@@ -1,0 +1,41 @@
+Final review: ✅ APPROVED with no issues.
+
+---
+
+# Implementation: Remove duplicate type declarations in `useUserManagement.ts`
+
+## What was implemented
+Deleted the hand-rolled `UserDto` and `GetGroupMembersResponse` interface declarations from `useUserManagement.ts` and replaced them with a type-only import from the auto-generated OpenAPI client. Applied the authorized `?? ''` narrowing fallback in `ResponsiblePersonCombobox.tsx` where the now-optional generated fields were previously assumed non-null.
+
+## Files created/modified
+- `frontend/src/api/hooks/useUserManagement.ts` — removed 12 lines of manual type declarations (lines 4–15); added `import type { GetGroupMembersResponse } from '../generated/api-client'`
+- `frontend/src/components/common/ResponsiblePersonCombobox.tsx` — added `?? ''` nullish-coalescing fallbacks on lines 46–49 for `member.displayName` and `member.email`
+
+## Tests
+Pre-existing Jest configuration is broken (TypeScript preset not configured) — a pre-existing issue unrelated to this refactor. Build (`npm run build`) and lint (`npm run lint`) both pass cleanly with no new errors.
+
+## How to verify
+```bash
+git -C <worktree> show --stat HEAD   # 2 files, commit ca6685fb
+cd frontend && npm run build          # exits 0, no TS errors
+cd frontend && npm run lint           # exits 0, 149 pre-existing warnings
+```
+
+## Notes
+- Baseline Jest infrastructure was broken before this change — flagged, not fixed (out of scope)
+- `UserDto` was not imported since it is not referenced anywhere in the hook body; importing it unused would trip lint
+- Two follow-ups documented in the commit message but not touched:
+  1. Replace `(apiClient as any).http.fetch(...)` with `apiClient.manufactureOrder_GetResponsiblePersons()`
+  2. Audit `useMeetingTasks.ts` once `/api/meeting-tasks` is added to the NSwag spec
+
+## PR Summary
+Removes the hand-rolled `UserDto` and `GetGroupMembersResponse` interfaces from `useUserManagement.ts` and imports them from the auto-generated API client instead. This was the only hook in the codebase still re-declaring generated DTOs, so after this change the OpenAPI → NSwag pipeline is the single source of truth for both shapes and contract drift becomes structurally impossible.
+
+The generated `UserDto` declares `displayName`/`email` as optional, so `ResponsiblePersonCombobox.tsx` receives the minimum-scope `?? ''` narrowing fallback at the call site rather than widening the generated types.
+
+### Changes
+- `frontend/src/api/hooks/useUserManagement.ts` — removed 12-line manual type block; added `import type { GetGroupMembersResponse } from '../generated/api-client'`
+- `frontend/src/components/common/ResponsiblePersonCombobox.tsx` — added `?? ''` fallbacks on 4 lines to satisfy the generated type's optional-field semantics
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-usermanagement-frontend-hook/spec.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-frontend-hook/spec.r1.md
@@ -1,0 +1,80 @@
+# Specification: Remove duplicate type declarations in `useUserManagement.ts`
+
+## Summary
+The `useUserManagement.ts` hook manually re-declares `UserDto` and `GetGroupMembersResponse` types that already exist in the auto-generated OpenAPI TypeScript client. Replace the manual declarations with imports from the generated client to eliminate contract drift risk.
+
+## Background
+The frontend consumes backend contracts via an auto-generated TypeScript client at `frontend/src/api/generated/api-client.ts`, produced from the backend's OpenAPI spec on every build. This pipeline exists specifically to keep frontend types in lockstep with backend DTOs.
+
+`frontend/src/api/hooks/useUserManagement.ts` bypasses this pipeline by declaring its own `UserDto` (line 4) and `GetGroupMembersResponse` (lines 6–15). These shadow the generated definitions at lines 25618–25659 of `api-client.ts`. Because the structural-typing rules in TypeScript treat the two definitions as compatible when their shapes match, drift between the manual and generated versions cannot be detected by the compiler. If the backend adds, renames, or removes a field on either DTO, the hook will silently retain a stale shape until a runtime bug surfaces — exactly the failure mode the generation pipeline was introduced to prevent.
+
+This is a small, surgical cleanup that aligns the file with the existing pattern used by every other API hook in the codebase.
+
+## Functional Requirements
+
+### FR-1: Remove manual type declarations
+Delete the manually authored `UserDto` and `GetGroupMembersResponse` interface declarations (lines 4–15) from `frontend/src/api/hooks/useUserManagement.ts`.
+
+**Acceptance criteria:**
+- The file no longer contains an `export interface UserDto` declaration.
+- The file no longer contains an `export interface GetGroupMembersResponse` declaration.
+- No other code in the file references the deleted declarations as local symbols.
+
+### FR-2: Import canonical types from generated client
+Add a type-only import of `UserDto` and `GetGroupMembersResponse` from `../generated/api-client` so the rest of the hook references the generated symbols.
+
+**Acceptance criteria:**
+- A single `import type { GetGroupMembersResponse, UserDto } from '../generated/api-client';` statement (or equivalent) is present at the top of the file.
+- All in-file references to `UserDto` and `GetGroupMembersResponse` (e.g., the `useQuery` generic parameter and the `queryFn` return type) resolve to the imported types.
+- TypeScript compilation succeeds (`npm run build`).
+- Lint passes (`npm run lint`).
+
+### FR-3: Preserve external consumer compatibility
+The hook previously re-exported `UserDto` and `GetGroupMembersResponse` (via the `export interface` form). Any module that imports those symbols from `useUserManagement.ts` must continue to compile after the change.
+
+**Acceptance criteria:**
+- A repository-wide search for `from '.*useUserManagement'` reveals no consumers importing `UserDto` or `GetGroupMembersResponse` from this hook, **or** any such consumers are updated to import the symbols directly from `../generated/api-client`.
+- No new TypeScript errors appear in dependent files after the change.
+
+### FR-4: Behavioral parity
+The hook's runtime behavior — query key, fetch URL, response handling, error mapping, and React Query options — must remain identical. This is a type-system-only refactor.
+
+**Acceptance criteria:**
+- A diff of the file shows no changes outside the type declarations, the new import line, and any type annotations that now reference the imported symbols.
+- Any existing tests covering the hook (unit or integration) pass without modification.
+- Manual smoke test: the user-management UI that consumes the hook continues to render group members correctly.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. Type-only imports are erased at compile time.
+
+### NFR-2: Security
+No security impact. No data flows, auth boundaries, or input handling are modified.
+
+### NFR-3: Maintainability
+After this change, contract drift between frontend and backend for the affected DTOs becomes structurally impossible: the generated client is the single source of truth and is regenerated on every build from the backend's OpenAPI spec.
+
+## Data Model
+No data model changes. The shapes of `UserDto` and `GetGroupMembersResponse` are unchanged — only the location of their canonical declaration moves from a hand-written hook file to the generated client.
+
+For reference, the generated shapes (as of the brief) are:
+- `UserDto`: `{ id: string; displayName: string; email: string; }`
+- `GetGroupMembersResponse`: `{ success: boolean; errorCode?: number; params?: Record<string, string>; members: UserDto[]; }`
+
+## API / Interface Design
+No API or UI changes. The change is internal to `frontend/src/api/hooks/useUserManagement.ts`.
+
+## Dependencies
+- `frontend/src/api/generated/api-client.ts` — must contain the up-to-date `UserDto` and `GetGroupMembersResponse` exports. Regenerated on every build from the backend OpenAPI spec; no manual action required.
+
+## Out of Scope
+- Audit or migration of other hooks that may also re-declare generated types. If discovered during this change, mention them but do not modify them in the same PR.
+- Any change to the backend DTOs, OpenAPI spec, or the client generation pipeline itself.
+- Refactoring the hook's query logic, error handling, or React Query configuration.
+- Renaming the hook, its file, or its public API.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-usermanagement-frontend-hook/task-plan.r1.md
+++ b/artifacts/feat-arch-review-usermanagement-frontend-hook/task-plan.r1.md
@@ -1,0 +1,321 @@
+# Remove Duplicate Type Declarations in `useUserManagement.ts` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the hand-rolled `UserDto` and `GetGroupMembersResponse` interfaces in `frontend/src/api/hooks/useUserManagement.ts` and consume the generated symbols from `frontend/src/api/generated/api-client.ts` instead, so the hook can never drift from the backend OpenAPI contract.
+
+**Architecture:** Pure type-system refactor. The generated client classes (`UserDto`, `GetGroupMembersResponse`) replace the local interfaces; the hook's runtime body is untouched (FR-4 behavioral parity). The generated `UserDto` has **optional** fields (`id?`, `displayName?`, `email?`), so the consumer `ResponsiblePersonCombobox.tsx` will fail TypeScript compilation at lines 46–49 and needs nullish-coalescing fallbacks (`?? ''`) — the only allowed deviation from "type-only" per the architecture review's FR-4 caveat. No backend, infra, lint, test, or runtime changes.
+
+**Tech Stack:** TypeScript, React, `@tanstack/react-query`, NSwag-generated API client.
+
+---
+
+## Context the executor needs
+
+- **Spec:** `artifacts/feat-arch-review-usermanagement-frontend-hook/spec.r1.md` (see Inputs)
+- **Architecture review:** `artifacts/feat-arch-review-usermanagement-frontend-hook/arch-review.r1.md` (see Inputs)
+- **Project rule:** API hooks use absolute URLs (`${apiClient.baseUrl}${relativeUrl}`) — unchanged here, just noting that the existing pattern in the hook body must not be "improved" during this refactor.
+- **Generated client is regenerated on every build.** Do not edit `frontend/src/api/generated/api-client.ts` by hand — it is produced from the backend OpenAPI spec.
+- **Surgical changes only.** Every changed line must trace directly to the spec. Do not migrate the raw `(apiClient as any).http.fetch(...)` call to `apiClient.manufactureOrder_GetResponsiblePersons()` — that is explicitly Out of Scope (arch review Decision 3).
+- **Working directory:** All commands below assume the repo root `frontend/` subfolder is the JS workspace. Run `cd frontend` before `npm` commands or use `npm --prefix frontend ...`.
+
+## File Structure
+
+Files modified by this plan:
+
+- `frontend/src/api/hooks/useUserManagement.ts` — delete 12 lines of manual type declarations (lines 4–15); add one type-only import.
+- `frontend/src/components/common/ResponsiblePersonCombobox.tsx` — add `?? ''` fallbacks on lines 46–49 **only if** TypeScript reports errors there after the swap. May be unchanged.
+
+Files read but not modified:
+
+- `frontend/src/api/generated/api-client.ts` — verify `UserDto` (line ~26267) and `GetGroupMembersResponse` (line ~26226) exports exist.
+- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — existing tests must continue to pass without edits.
+
+No new files. No deleted files.
+
+---
+
+## Task 1: Establish a clean baseline
+
+**Why:** Any new TypeScript or lint error after the refactor must be unambiguously attributable to this change. If `main` is already dirty, you can't tell.
+
+**Files:** None (read-only verification).
+
+- [ ] **Step 1: Verify the working tree is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean` on branch `feat-arch-review-usermanagement-frontend-hook`.
+
+- [ ] **Step 2: Verify the frontend builds cleanly before any edits**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build completes with no TypeScript errors. If the build fails on `main`, STOP and report — the failure is pre-existing and outside this plan's scope.
+
+- [ ] **Step 3: Verify lint is clean before any edits**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: lint exits 0 (warnings on unrelated files are fine; record the count so you can compare after the refactor).
+
+- [ ] **Step 4: Verify the existing useUserManagement test passes**
+
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useUserManagement.test.tsx
+```
+
+Expected: all tests pass. If they fail on baseline, STOP and report.
+
+---
+
+## Task 2: Confirm the generated symbols exist and inspect their shape
+
+**Why:** The plan assumes `UserDto` and `GetGroupMembersResponse` are exported from `../generated/api-client` with the optional-field shape described in the architecture review. Verify, don't trust.
+
+**Files:** None (read-only).
+
+- [ ] **Step 1: Confirm `UserDto` export shape**
+
+```bash
+grep -n "^export class UserDto\b" frontend/src/api/generated/api-client.ts
+grep -n "^export interface IUserDto\b" frontend/src/api/generated/api-client.ts
+```
+
+Expected: both grep hits return one line each. Read the surrounding 10 lines and confirm `id?: string;`, `displayName?: string;`, `email?: string;` are all optional. This is the shape the consumer will see after the swap.
+
+- [ ] **Step 2: Confirm `GetGroupMembersResponse` export shape**
+
+```bash
+grep -n "^export class GetGroupMembersResponse\b" frontend/src/api/generated/api-client.ts
+```
+
+Expected: one hit. Read the surrounding 15 lines and confirm `members?: UserDto[];` is the only declared field and that the class `extends BaseResponse` (which supplies the `success`/`errorCode`/`params` fields the old manual interface had).
+
+- [ ] **Step 3: Verify no other file in `frontend/src` imports `UserDto` or `GetGroupMembersResponse` from `useUserManagement`**
+
+```bash
+grep -rn "from ['\"].*useUserManagement['\"]" frontend/src
+```
+
+Expected: two hits — `ResponsiblePersonCombobox.tsx` and `useUserManagement.test.tsx`, both importing only `useResponsiblePersonsQuery` (the hook function). No consumer imports the DTO types, so FR-3 has no rewrite work to do. If a third hit appears or one of these imports a DTO symbol, STOP and add a consumer-rewrite task before proceeding.
+
+---
+
+## Task 3: Replace manual types with generated imports
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useUserManagement.ts:1-15`
+
+- [ ] **Step 1: Apply the type-system swap**
+
+Edit `frontend/src/api/hooks/useUserManagement.ts` so the top of the file changes from:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
+
+export interface UserDto {
+  id: string;
+  displayName: string;
+  email: string;
+}
+
+export interface GetGroupMembersResponse {
+  success: boolean;
+  errorCode?: number;
+  params?: Record<string, string>;
+  members: UserDto[];
+}
+
+export const useResponsiblePersonsQuery = () => {
+```
+
+to:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import type { GetGroupMembersResponse } from '../generated/api-client';
+import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
+
+export const useResponsiblePersonsQuery = () => {
+```
+
+Notes for the executor:
+- Do **not** import `UserDto`. It is not referenced anywhere else in this file (only `GetGroupMembersResponse` is annotated on the `queryFn` return type at line 20). Importing an unused symbol will trip `no-unused-vars`.
+- Use `import type` (not `import`) so the import is erased at compile time. The generated symbol is a class, but we are using it purely in type positions, so the type-only import is correct and consistent with project convention.
+- Keep import order: external (`@tanstack/react-query`) → generated client → relative project imports.
+- Leave everything from `export const useResponsiblePersonsQuery` downward (current lines 17–39) **byte-for-byte unchanged**, including the `(apiClient as any)` cast on the fetch call. The cast cleanup is explicitly Out of Scope per the architecture review.
+
+- [ ] **Step 2: Confirm the file now has 31 lines and no `export interface` declarations**
+
+```bash
+wc -l frontend/src/api/hooks/useUserManagement.ts
+grep -c "^export interface" frontend/src/api/hooks/useUserManagement.ts
+```
+
+Expected: `31 frontend/src/api/hooks/useUserManagement.ts` and grep count `0`.
+
+---
+
+## Task 4: Verify the build and fix consumer narrowing if needed
+
+**Why:** The generated `UserDto.displayName` and `UserDto.email` are `string | undefined`, but `ResponsiblePersonCombobox.tsx:46-49` currently assigns them to fields typed `string` in `ResponsiblePersonSelectOption`. TypeScript will emit errors. The arch review authorizes a `?? ''` narrowing at the call site as the minimum-scope fix.
+
+**Files:**
+- Possibly modify: `frontend/src/components/common/ResponsiblePersonCombobox.tsx:45-50`
+
+- [ ] **Step 1: Run the build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected outcomes (handle whichever you get):
+
+- **Outcome A (build succeeds):** TypeScript inferred the narrowing on its own (unlikely but possible). Skip Step 2, go to Step 3.
+- **Outcome B (build fails with errors only in `ResponsiblePersonCombobox.tsx` around lines 46–49 saying `Type 'string | undefined' is not assignable to type 'string'` for `value`, `label`, `displayName`, or `email`):** This is the expected outcome. Proceed to Step 2.
+- **Outcome C (build fails with errors elsewhere or with different error messages):** STOP. The plan's assumptions are wrong. Report the error verbatim before changing anything else.
+
+- [ ] **Step 2: Apply the narrowing fallback in the consumer (only if Outcome B)**
+
+Edit `frontend/src/components/common/ResponsiblePersonCombobox.tsx` lines 45–50, changing:
+
+```typescript
+    const memberOptions: ResponsiblePersonSelectOption[] = members.map((member) => ({
+      value: member.displayName,
+      label: `${member.displayName} (${member.email})`,
+      displayName: member.displayName,
+      email: member.email,
+    }));
+```
+
+to:
+
+```typescript
+    const memberOptions: ResponsiblePersonSelectOption[] = members.map((member) => ({
+      value: member.displayName ?? '',
+      label: `${member.displayName ?? ''} (${member.email ?? ''})`,
+      displayName: member.displayName ?? '',
+      email: member.email ?? '',
+    }));
+```
+
+Notes:
+- Do not touch any other line in this file. The `members` variable on line 44 (`response?.members || []`) already handles the `members?` optionality on the response.
+- Do not introduce a helper function, a filter for missing `displayName`, or any other "improvement". The single-line `?? ''` fallback is the minimum-scope change authorized by the arch review (FR-4 caveat).
+
+- [ ] **Step 3: Re-run the build and confirm it passes**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build completes with no TypeScript errors. If errors remain, STOP and report.
+
+---
+
+## Task 5: Verify lint and tests are still clean
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Run lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: lint exits 0 with the same warning count recorded in Task 1 Step 3. A new warning means we either left an unused import or violated a stylistic rule — fix before continuing.
+
+- [ ] **Step 2: Run the useUserManagement unit test**
+
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useUserManagement.test.tsx
+```
+
+Expected: all tests pass without modification (FR-4 acceptance criterion). The tests assert on React Query lifecycle (`isLoading`, `failureCount`, etc.) and do not type-check the payload shape, so they should be unaffected by the swap.
+
+- [ ] **Step 3: Run any tests covering the consumer (only if Step 2 of Task 4 modified the consumer)**
+
+```bash
+cd frontend && npx jest ResponsiblePersonCombobox
+```
+
+Expected: if a test exists, it passes. If no test exists, jest reports "no tests found" — that is acceptable; the spec does not require adding one.
+
+- [ ] **Step 4: Sanity-diff the change**
+
+```bash
+git diff --stat
+git diff frontend/src/api/hooks/useUserManagement.ts
+```
+
+Expected diff:
+- `useUserManagement.ts`: −12 lines, +1 line (net −11), affecting only lines 1–15.
+- `ResponsiblePersonCombobox.tsx` (if Outcome B in Task 4): 4 single-line edits within lines 46–49, no other changes.
+- No other files modified.
+
+If the diff shows changes outside these regions, revert them before proceeding.
+
+---
+
+## Task 6: Commit
+
+**Files:** None (git operation).
+
+- [ ] **Step 1: Stage and review**
+
+```bash
+git add frontend/src/api/hooks/useUserManagement.ts
+# Only if Task 4 Step 2 ran:
+git add frontend/src/components/common/ResponsiblePersonCombobox.tsx
+git diff --cached
+```
+
+Confirm one final time that the staged diff matches the expectations in Task 5 Step 4.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(frontend): consume generated UserDto types in useUserManagement hook
+
+Removes the hand-rolled UserDto and GetGroupMembersResponse interfaces from
+useUserManagement.ts and imports them from the auto-generated API client
+instead. This was the only hook re-declaring generated DTOs, so the codebase
+now uniformly trusts the OpenAPI → NSwag pipeline as the single source of
+truth for these shapes and contract drift becomes structurally impossible.
+
+The generated UserDto declares displayName/email as optional, so
+ResponsiblePersonCombobox.tsx gets the minimum-scope narrowing fallback
+(?? '') at the call site rather than widening the generated types.
+
+Spec: artifacts/feat-arch-review-usermanagement-frontend-hook/spec.r1.md
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, fix the underlying issue and create a **new** commit — do not `--amend`.
+
+- [ ] **Step 3: Note the deferred follow-ups in the PR description (not in this commit)**
+
+The architecture review surfaced two adjacent cleanups that are explicitly Out of Scope here. Capture them in the PR description so they aren't lost:
+
+1. Replace `(apiClient as any).http.fetch('/api/ManufactureOrder/responsible-persons', ...)` in `useUserManagement.ts:23-27` with `apiClient.manufactureOrder_GetResponsiblePersons()` — eliminates the `as any` cast and uses the generated request pipeline.
+2. Audit `useMeetingTasks.ts` (already TODO'd) once `/api/meeting-tasks` is added to the NSwag spec; it still declares ~95 lines of manual DTOs for the same drift-hazard reason.
+
+Do not file these as separate issues from inside this plan — the brief is a single PR. Just mention them in the PR body so the reviewer can decide whether to open follow-up issues.
+
+---
+
+## Self-review checklist (executor: skip; author: complete)
+
+- **Spec coverage:** FR-1 (delete interfaces) → Task 3. FR-2 (add import + compile) → Task 3 + Task 4. FR-3 (consumer compatibility) → Task 2 Step 3 (verification only — no consumers reference the DTO symbols). FR-4 (behavioral parity) → Task 4 (narrowing fallback authorized by arch review amendment) + Task 5 Step 4 (diff scope check). NFR-1/2/3 — no work required, just don't violate them.
+- **Placeholder scan:** No "TBD" / "implement later" / "add appropriate error handling" / "similar to Task N" anywhere. Every edit step contains the full before/after code.
+- **Type consistency:** `GetGroupMembersResponse` and `UserDto` reference the generated symbols throughout. The narrowing pattern (`?? ''`) is the same in all four lines of the consumer edit.

--- a/docs/superpowers/plans/2026-05-25-remove-duplicate-types-useusermanagement.md
+++ b/docs/superpowers/plans/2026-05-25-remove-duplicate-types-useusermanagement.md
@@ -1,0 +1,321 @@
+# Remove Duplicate Type Declarations in `useUserManagement.ts` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the hand-rolled `UserDto` and `GetGroupMembersResponse` interfaces in `frontend/src/api/hooks/useUserManagement.ts` and consume the generated symbols from `frontend/src/api/generated/api-client.ts` instead, so the hook can never drift from the backend OpenAPI contract.
+
+**Architecture:** Pure type-system refactor. The generated client classes (`UserDto`, `GetGroupMembersResponse`) replace the local interfaces; the hook's runtime body is untouched (FR-4 behavioral parity). The generated `UserDto` has **optional** fields (`id?`, `displayName?`, `email?`), so the consumer `ResponsiblePersonCombobox.tsx` will fail TypeScript compilation at lines 46–49 and needs nullish-coalescing fallbacks (`?? ''`) — the only allowed deviation from "type-only" per the architecture review's FR-4 caveat. No backend, infra, lint, test, or runtime changes.
+
+**Tech Stack:** TypeScript, React, `@tanstack/react-query`, NSwag-generated API client.
+
+---
+
+## Context the executor needs
+
+- **Spec:** `artifacts/feat-arch-review-usermanagement-frontend-hook/spec.r1.md` (see Inputs)
+- **Architecture review:** `artifacts/feat-arch-review-usermanagement-frontend-hook/arch-review.r1.md` (see Inputs)
+- **Project rule:** API hooks use absolute URLs (`${apiClient.baseUrl}${relativeUrl}`) — unchanged here, just noting that the existing pattern in the hook body must not be "improved" during this refactor.
+- **Generated client is regenerated on every build.** Do not edit `frontend/src/api/generated/api-client.ts` by hand — it is produced from the backend OpenAPI spec.
+- **Surgical changes only.** Every changed line must trace directly to the spec. Do not migrate the raw `(apiClient as any).http.fetch(...)` call to `apiClient.manufactureOrder_GetResponsiblePersons()` — that is explicitly Out of Scope (arch review Decision 3).
+- **Working directory:** All commands below assume the repo root `frontend/` subfolder is the JS workspace. Run `cd frontend` before `npm` commands or use `npm --prefix frontend ...`.
+
+## File Structure
+
+Files modified by this plan:
+
+- `frontend/src/api/hooks/useUserManagement.ts` — delete 12 lines of manual type declarations (lines 4–15); add one type-only import.
+- `frontend/src/components/common/ResponsiblePersonCombobox.tsx` — add `?? ''` fallbacks on lines 46–49 **only if** TypeScript reports errors there after the swap. May be unchanged.
+
+Files read but not modified:
+
+- `frontend/src/api/generated/api-client.ts` — verify `UserDto` (line ~26267) and `GetGroupMembersResponse` (line ~26226) exports exist.
+- `frontend/src/api/hooks/__tests__/useUserManagement.test.tsx` — existing tests must continue to pass without edits.
+
+No new files. No deleted files.
+
+---
+
+## Task 1: Establish a clean baseline
+
+**Why:** Any new TypeScript or lint error after the refactor must be unambiguously attributable to this change. If `main` is already dirty, you can't tell.
+
+**Files:** None (read-only verification).
+
+- [ ] **Step 1: Verify the working tree is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean` on branch `feat-arch-review-usermanagement-frontend-hook`.
+
+- [ ] **Step 2: Verify the frontend builds cleanly before any edits**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build completes with no TypeScript errors. If the build fails on `main`, STOP and report — the failure is pre-existing and outside this plan's scope.
+
+- [ ] **Step 3: Verify lint is clean before any edits**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: lint exits 0 (warnings on unrelated files are fine; record the count so you can compare after the refactor).
+
+- [ ] **Step 4: Verify the existing useUserManagement test passes**
+
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useUserManagement.test.tsx
+```
+
+Expected: all tests pass. If they fail on baseline, STOP and report.
+
+---
+
+## Task 2: Confirm the generated symbols exist and inspect their shape
+
+**Why:** The plan assumes `UserDto` and `GetGroupMembersResponse` are exported from `../generated/api-client` with the optional-field shape described in the architecture review. Verify, don't trust.
+
+**Files:** None (read-only).
+
+- [ ] **Step 1: Confirm `UserDto` export shape**
+
+```bash
+grep -n "^export class UserDto\b" frontend/src/api/generated/api-client.ts
+grep -n "^export interface IUserDto\b" frontend/src/api/generated/api-client.ts
+```
+
+Expected: both grep hits return one line each. Read the surrounding 10 lines and confirm `id?: string;`, `displayName?: string;`, `email?: string;` are all optional. This is the shape the consumer will see after the swap.
+
+- [ ] **Step 2: Confirm `GetGroupMembersResponse` export shape**
+
+```bash
+grep -n "^export class GetGroupMembersResponse\b" frontend/src/api/generated/api-client.ts
+```
+
+Expected: one hit. Read the surrounding 15 lines and confirm `members?: UserDto[];` is the only declared field and that the class `extends BaseResponse` (which supplies the `success`/`errorCode`/`params` fields the old manual interface had).
+
+- [ ] **Step 3: Verify no other file in `frontend/src` imports `UserDto` or `GetGroupMembersResponse` from `useUserManagement`**
+
+```bash
+grep -rn "from ['\"].*useUserManagement['\"]" frontend/src
+```
+
+Expected: two hits — `ResponsiblePersonCombobox.tsx` and `useUserManagement.test.tsx`, both importing only `useResponsiblePersonsQuery` (the hook function). No consumer imports the DTO types, so FR-3 has no rewrite work to do. If a third hit appears or one of these imports a DTO symbol, STOP and add a consumer-rewrite task before proceeding.
+
+---
+
+## Task 3: Replace manual types with generated imports
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useUserManagement.ts:1-15`
+
+- [ ] **Step 1: Apply the type-system swap**
+
+Edit `frontend/src/api/hooks/useUserManagement.ts` so the top of the file changes from:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
+
+export interface UserDto {
+  id: string;
+  displayName: string;
+  email: string;
+}
+
+export interface GetGroupMembersResponse {
+  success: boolean;
+  errorCode?: number;
+  params?: Record<string, string>;
+  members: UserDto[];
+}
+
+export const useResponsiblePersonsQuery = () => {
+```
+
+to:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import type { GetGroupMembersResponse } from '../generated/api-client';
+import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
+
+export const useResponsiblePersonsQuery = () => {
+```
+
+Notes for the executor:
+- Do **not** import `UserDto`. It is not referenced anywhere else in this file (only `GetGroupMembersResponse` is annotated on the `queryFn` return type at line 20). Importing an unused symbol will trip `no-unused-vars`.
+- Use `import type` (not `import`) so the import is erased at compile time. The generated symbol is a class, but we are using it purely in type positions, so the type-only import is correct and consistent with project convention.
+- Keep import order: external (`@tanstack/react-query`) → generated client → relative project imports.
+- Leave everything from `export const useResponsiblePersonsQuery` downward (current lines 17–39) **byte-for-byte unchanged**, including the `(apiClient as any)` cast on the fetch call. The cast cleanup is explicitly Out of Scope per the architecture review.
+
+- [ ] **Step 2: Confirm the file now has 31 lines and no `export interface` declarations**
+
+```bash
+wc -l frontend/src/api/hooks/useUserManagement.ts
+grep -c "^export interface" frontend/src/api/hooks/useUserManagement.ts
+```
+
+Expected: `31 frontend/src/api/hooks/useUserManagement.ts` and grep count `0`.
+
+---
+
+## Task 4: Verify the build and fix consumer narrowing if needed
+
+**Why:** The generated `UserDto.displayName` and `UserDto.email` are `string | undefined`, but `ResponsiblePersonCombobox.tsx:46-49` currently assigns them to fields typed `string` in `ResponsiblePersonSelectOption`. TypeScript will emit errors. The arch review authorizes a `?? ''` narrowing at the call site as the minimum-scope fix.
+
+**Files:**
+- Possibly modify: `frontend/src/components/common/ResponsiblePersonCombobox.tsx:45-50`
+
+- [ ] **Step 1: Run the build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected outcomes (handle whichever you get):
+
+- **Outcome A (build succeeds):** TypeScript inferred the narrowing on its own (unlikely but possible). Skip Step 2, go to Step 3.
+- **Outcome B (build fails with errors only in `ResponsiblePersonCombobox.tsx` around lines 46–49 saying `Type 'string | undefined' is not assignable to type 'string'` for `value`, `label`, `displayName`, or `email`):** This is the expected outcome. Proceed to Step 2.
+- **Outcome C (build fails with errors elsewhere or with different error messages):** STOP. The plan's assumptions are wrong. Report the error verbatim before changing anything else.
+
+- [ ] **Step 2: Apply the narrowing fallback in the consumer (only if Outcome B)**
+
+Edit `frontend/src/components/common/ResponsiblePersonCombobox.tsx` lines 45–50, changing:
+
+```typescript
+    const memberOptions: ResponsiblePersonSelectOption[] = members.map((member) => ({
+      value: member.displayName,
+      label: `${member.displayName} (${member.email})`,
+      displayName: member.displayName,
+      email: member.email,
+    }));
+```
+
+to:
+
+```typescript
+    const memberOptions: ResponsiblePersonSelectOption[] = members.map((member) => ({
+      value: member.displayName ?? '',
+      label: `${member.displayName ?? ''} (${member.email ?? ''})`,
+      displayName: member.displayName ?? '',
+      email: member.email ?? '',
+    }));
+```
+
+Notes:
+- Do not touch any other line in this file. The `members` variable on line 44 (`response?.members || []`) already handles the `members?` optionality on the response.
+- Do not introduce a helper function, a filter for missing `displayName`, or any other "improvement". The single-line `?? ''` fallback is the minimum-scope change authorized by the arch review (FR-4 caveat).
+
+- [ ] **Step 3: Re-run the build and confirm it passes**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build completes with no TypeScript errors. If errors remain, STOP and report.
+
+---
+
+## Task 5: Verify lint and tests are still clean
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Run lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: lint exits 0 with the same warning count recorded in Task 1 Step 3. A new warning means we either left an unused import or violated a stylistic rule — fix before continuing.
+
+- [ ] **Step 2: Run the useUserManagement unit test**
+
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useUserManagement.test.tsx
+```
+
+Expected: all tests pass without modification (FR-4 acceptance criterion). The tests assert on React Query lifecycle (`isLoading`, `failureCount`, etc.) and do not type-check the payload shape, so they should be unaffected by the swap.
+
+- [ ] **Step 3: Run any tests covering the consumer (only if Step 2 of Task 4 modified the consumer)**
+
+```bash
+cd frontend && npx jest ResponsiblePersonCombobox
+```
+
+Expected: if a test exists, it passes. If no test exists, jest reports "no tests found" — that is acceptable; the spec does not require adding one.
+
+- [ ] **Step 4: Sanity-diff the change**
+
+```bash
+git diff --stat
+git diff frontend/src/api/hooks/useUserManagement.ts
+```
+
+Expected diff:
+- `useUserManagement.ts`: −12 lines, +1 line (net −11), affecting only lines 1–15.
+- `ResponsiblePersonCombobox.tsx` (if Outcome B in Task 4): 4 single-line edits within lines 46–49, no other changes.
+- No other files modified.
+
+If the diff shows changes outside these regions, revert them before proceeding.
+
+---
+
+## Task 6: Commit
+
+**Files:** None (git operation).
+
+- [ ] **Step 1: Stage and review**
+
+```bash
+git add frontend/src/api/hooks/useUserManagement.ts
+# Only if Task 4 Step 2 ran:
+git add frontend/src/components/common/ResponsiblePersonCombobox.tsx
+git diff --cached
+```
+
+Confirm one final time that the staged diff matches the expectations in Task 5 Step 4.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(frontend): consume generated UserDto types in useUserManagement hook
+
+Removes the hand-rolled UserDto and GetGroupMembersResponse interfaces from
+useUserManagement.ts and imports them from the auto-generated API client
+instead. This was the only hook re-declaring generated DTOs, so the codebase
+now uniformly trusts the OpenAPI → NSwag pipeline as the single source of
+truth for these shapes and contract drift becomes structurally impossible.
+
+The generated UserDto declares displayName/email as optional, so
+ResponsiblePersonCombobox.tsx gets the minimum-scope narrowing fallback
+(?? '') at the call site rather than widening the generated types.
+
+Spec: artifacts/feat-arch-review-usermanagement-frontend-hook/spec.r1.md
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, fix the underlying issue and create a **new** commit — do not `--amend`.
+
+- [ ] **Step 3: Note the deferred follow-ups in the PR description (not in this commit)**
+
+The architecture review surfaced two adjacent cleanups that are explicitly Out of Scope here. Capture them in the PR description so they aren't lost:
+
+1. Replace `(apiClient as any).http.fetch('/api/ManufactureOrder/responsible-persons', ...)` in `useUserManagement.ts:23-27` with `apiClient.manufactureOrder_GetResponsiblePersons()` — eliminates the `as any` cast and uses the generated request pipeline.
+2. Audit `useMeetingTasks.ts` (already TODO'd) once `/api/meeting-tasks` is added to the NSwag spec; it still declares ~95 lines of manual DTOs for the same drift-hazard reason.
+
+Do not file these as separate issues from inside this plan — the brief is a single PR. Just mention them in the PR body so the reviewer can decide whether to open follow-up issues.
+
+---
+
+## Self-review checklist (executor: skip; author: complete)
+
+- **Spec coverage:** FR-1 (delete interfaces) → Task 3. FR-2 (add import + compile) → Task 3 + Task 4. FR-3 (consumer compatibility) → Task 2 Step 3 (verification only — no consumers reference the DTO symbols). FR-4 (behavioral parity) → Task 4 (narrowing fallback authorized by arch review amendment) + Task 5 Step 4 (diff scope check). NFR-1/2/3 — no work required, just don't violate them.
+- **Placeholder scan:** No "TBD" / "implement later" / "add appropriate error handling" / "similar to Task N" anywhere. Every edit step contains the full before/after code.
+- **Type consistency:** `GetGroupMembersResponse` and `UserDto` reference the generated symbols throughout. The narrowing pattern (`?? ''`) is the same in all four lines of the consumer edit.

--- a/frontend/src/api/hooks/useUserManagement.ts
+++ b/frontend/src/api/hooks/useUserManagement.ts
@@ -1,18 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
+import type { GetGroupMembersResponse } from '../generated/api-client';
 import { getAuthenticatedApiClient, QUERY_KEYS } from '../client';
-
-export interface UserDto {
-  id: string;
-  displayName: string;
-  email: string;
-}
-
-export interface GetGroupMembersResponse {
-  success: boolean;
-  errorCode?: number;
-  params?: Record<string, string>;
-  members: UserDto[];
-}
 
 export const useResponsiblePersonsQuery = () => {
   return useQuery({

--- a/frontend/src/components/common/ResponsiblePersonCombobox.tsx
+++ b/frontend/src/components/common/ResponsiblePersonCombobox.tsx
@@ -43,10 +43,10 @@ const ResponsiblePersonCombobox: React.FC<ResponsiblePersonComboboxProps> = ({
   const options = useMemo((): ResponsiblePersonSelectOption[] => {
     const members = response?.members || [];
     const memberOptions: ResponsiblePersonSelectOption[] = members.map((member) => ({
-      value: member.displayName,
-      label: `${member.displayName} (${member.email})`,
-      displayName: member.displayName,
-      email: member.email,
+      value: member.displayName ?? '',
+      label: `${member.displayName ?? ''} (${member.email ?? ''})`,
+      displayName: member.displayName ?? '',
+      email: member.email ?? '',
     }));
 
     // If manual entry is allowed and there's an input value that doesn't match any member


### PR DESCRIPTION
Removes the hand-rolled `UserDto` and `GetGroupMembersResponse` interfaces from `useUserManagement.ts` and imports them from the auto-generated API client instead. This was the only hook in the codebase still re-declaring generated DTOs, so after this change the OpenAPI → NSwag pipeline is the single source of truth for both shapes and contract drift becomes structurally impossible.

The generated `UserDto` declares `displayName`/`email` as optional, so `ResponsiblePersonCombobox.tsx` receives the minimum-scope `?? ''` narrowing fallback at the call site rather than widening the generated types.

### Changes
- `frontend/src/api/hooks/useUserManagement.ts` — removed 12-line manual type block; added `import type { GetGroupMembersResponse } from '../generated/api-client'`
- `frontend/src/components/common/ResponsiblePersonCombobox.tsx` — added `?? ''` fallbacks on 4 lines to satisfy the generated type's optional-field semantics

---

Closes #1611

### Tokens used
10377450
