### PR TITLE
feat: Decouple Article Module from KnowledgeBase Module via Consumer-Owned Contract

### DIFF
--- a/artifacts/feat-arch-review-article-gathercontextstep-di/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-gathercontextstep-di/arch-review.r1.md
@@ -1,0 +1,219 @@
+# Architecture Review: Decouple Article Module from KnowledgeBase via `IArticleStyleGuideSource`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposal aligns directly with the codebase's documented cross-module communication pattern (`docs/architecture/development_guidelines.md` §Cross-Module Communication Example). It is a literal application of the `ILeafletKnowledgeSource` precedent already implemented and validated by `ModuleBoundariesTests.cs`. No new patterns are introduced; this is a "second instance of an existing pattern" refactor.
+
+Integration points:
+- **Consumer-owned contract** in `Application/Features/Article/Contracts/` (new folder for Article — it does not exist yet; only `UseCases/` lives under Article today).
+- **Provider adapter** in `Application/Features/KnowledgeBase/Infrastructure/`, sitting next to `KnowledgeBaseLeafletSourceAdapter.cs`.
+- **DI binding** added inside `KnowledgeBaseModule.AddKnowledgeBaseModule`, next to the existing `services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();` line.
+- **Architecture test** extended via a new `ModuleBoundaryRule` entry in `Rules()` TheoryData — the existing `[Theory]/[MemberData]` infrastructure handles this without code changes.
+
+One issue requires resolution before implementation: the spec scope addresses only `IOneDriveService`, but `GatherContextStep` also imports `Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments` (uses `SearchDocumentsRequest` via MediatR at line 89). A new module-boundary rule with no allowlist will fail. See *Specification Amendments* below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Article module                            KnowledgeBase module
+─────────────────────────                  ─────────────────────────────────────
+Contracts/                                 Infrastructure/
+  IArticleStyleGuideSource  ◄────── impl ─ KnowledgeBaseArticleStyleGuideSource
+       │                                     │
+       │ injected by                         │ delegates to
+       ▼                                     ▼
+UseCases/Generate/Pipeline/                Services/
+  GatherContextStep                        IOneDriveService
+                                              (existing, unchanged)
+
+KnowledgeBaseModule.cs (DI composition root)
+  services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();
+
+ModuleBoundariesTests.cs
+  ModuleBoundaryRule "Article -> KnowledgeBase" (new TheoryData entry, with allowlist
+  for SearchDocumentsRequest until that consumption is also lifted behind a contract).
+```
+
+### Key Design Decisions
+
+#### Decision 1: Adapter naming — `KnowledgeBaseArticleStyleGuideSource`
+**Options considered:**
+- A. `OneDriveArticleStyleGuideSource` (spec proposal — leads with backing service)
+- B. `KnowledgeBaseArticleStyleGuideSource` (matches existing `KnowledgeBaseLeafletSourceAdapter`)
+
+**Chosen approach:** B.
+
+**Rationale:** Consistency with `KnowledgeBaseLeafletSourceAdapter`. The adapter is owned by the KnowledgeBase module and its name should advertise *which provider* is satisfying the consumer contract, not *which infrastructure detail* it happens to use today (OneDrive could be replaced internally without renaming the adapter).
+
+#### Decision 2: Where to place the architecture rule
+**Options considered:**
+- A. New `[Fact]` test method, mirroring `Logistics_types_should_not_reference_Purchase_owned_namespaces`.
+- B. New entry in the existing `Rules()` TheoryData, reused by the parameterised `Consumer_types_should_not_reference_provider_owned_namespaces` theory.
+
+**Chosen approach:** B.
+
+**Rationale:** The existing theory already supports per-rule allowlists, multiple forbidden namespace prefixes, and full reflection traversal. Adding a `ModuleBoundaryRule` row is one TheoryData entry plus an allowlist `HashSet`. Code duplication (Option A) is unwarranted.
+
+#### Decision 3: Adapter visibility — `internal sealed`
+**Options considered:** `public` vs `internal sealed`.
+
+**Chosen approach:** `internal sealed` (mirroring `KnowledgeBaseLeafletSourceAdapter`).
+
+**Rationale:** The adapter is implementation detail of the KnowledgeBase module. Only DI registration needs to see it. `sealed` prevents accidental subclassing of an adapter that should not have behavior of its own.
+
+#### Decision 4: Method signature — preserve `driveId`/`path` parameters verbatim
+**Options considered:**
+- A. Pass `driveId` and `path` (spec proposal).
+- B. Lift to a higher-level `LoadAsync(Article article)` that hides the OneDrive shape.
+
+**Chosen approach:** A.
+
+**Rationale:** The Article domain entity already owns these as first-class properties (`StyleGuideDriveId`, `StyleGuideItemPath`). The contract is for a *style-guide source*, not for *style-guide resolution*. Article remains responsible for "which style guide" and the contract for "fetch the bytes". Option B would couple the adapter to the Article domain entity, creating a backwards module reference.
+
+#### Decision 5: Architecture rule scope and allowlist
+**Options considered:**
+- A. Add the rule with an empty allowlist and block the spec scope from expanding (test would fail because of `SearchDocumentsRequest`).
+- B. Add the rule with an allowlist entry for the surviving `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` references, mirroring the pre-existing `LeafletAllowlist` precedent. Track follow-up to lift the search query behind another consumer-owned contract.
+- C. Expand spec scope to also lift `SearchDocumentsRequest` now.
+
+**Chosen approach:** B.
+
+**Rationale:** The spec explicitly forbids silent scope expansion ("Out of Scope" §"Auditing other Article-module files…"). Allowlist precedent already exists in the same test class for exactly this situation (`LeafletAllowlist` carries entries for `IDocumentTextExtractor` and `IOneDriveService` with TODO comments). Adding the rule with an empty allowlist (Option A) would make CI red on day one. Lifting `SearchDocumentsRequest` now (Option C) violates the spec's explicit scope.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/
+├── Article/
+│   ├── Contracts/                                      ← NEW folder
+│   │   └── IArticleStyleGuideSource.cs                 ← NEW
+│   ├── ArticleModule.cs                                (unchanged)
+│   └── UseCases/Generate/Pipeline/
+│       └── GatherContextStep.cs                        ← MODIFIED
+└── KnowledgeBase/
+    ├── Infrastructure/
+    │   ├── KnowledgeBaseLeafletSourceAdapter.cs        (precedent — reference)
+    │   └── KnowledgeBaseArticleStyleGuideSource.cs     ← NEW
+    └── KnowledgeBaseModule.cs                          ← MODIFIED (one line)
+
+backend/test/Anela.Heblo.Tests/
+├── Architecture/
+│   └── ModuleBoundariesTests.cs                        ← MODIFIED (new Rule + allowlist)
+└── Article/Pipeline/
+    └── GatherContextStepTests.cs                       ← MODIFIED (mock type swap)
+```
+
+### Interfaces and Contracts
+
+```csharp
+// Article/Contracts/IArticleStyleGuideSource.cs
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Retrieves the Article module's style guide text from an external source.
+/// Implemented by the KnowledgeBase module via an adapter.
+/// </summary>
+public interface IArticleStyleGuideSource
+{
+    Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken);
+}
+```
+
+```csharp
+// KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+
+internal sealed class KnowledgeBaseArticleStyleGuideSource : IArticleStyleGuideSource
+{
+    private readonly IOneDriveService _oneDrive;
+
+    public KnowledgeBaseArticleStyleGuideSource(IOneDriveService oneDrive)
+    {
+        _oneDrive = oneDrive;
+    }
+
+    public Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken) =>
+        _oneDrive.DownloadFileTextByPathAsync(driveId, path, cancellationToken);
+}
+```
+
+DI registration (inside `KnowledgeBaseModule.AddKnowledgeBaseModule`, next to the existing Leaflet binding):
+
+```csharp
+services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();
+```
+
+Lifetime: `Scoped`, matching `ILeafletKnowledgeSource`. The adapter holds no state; it inherits the lifetime of the underlying `IOneDriveService` (also `Scoped`).
+
+### Data Flow
+
+```
+ArticlePipelineContext (Article domain Article with StyleGuideDriveId, StyleGuideItemPath)
+  → GatherContextStep.LoadStyleGuideAsync
+  → IArticleStyleGuideSource.DownloadStyleGuideTextAsync(driveId, path, ct)
+  → KnowledgeBaseArticleStyleGuideSource (adapter, KnowledgeBase-owned)
+  → IOneDriveService.DownloadFileTextByPathAsync(driveId, path, ct)
+  → GraphOneDriveService | MockOneDriveService (selected by KnowledgeBaseModule based on
+    SharePoint config + auth mode — unchanged)
+  → string returned all the way back to context.StyleGuideText
+```
+
+Error/cancellation propagation: the adapter does not catch. Existing `try/catch (Exception ex) when (ex is not OperationCanceledException)` block in `GatherContextStep.LoadStyleGuideAsync` continues to log warnings and return `null` for non-cancellation exceptions. Cancellation surfaces as `OperationCanceledException` unchanged.
+
+### Test refactor
+
+`GatherContextStepTests.cs` currently has `Mock<IOneDriveService> _oneDrive = new();` and constructs the step with `_oneDrive.Object`. After the refactor:
+- Replace with `Mock<IArticleStyleGuideSource> _styleGuideSource = new();`.
+- Remove `using Anela.Heblo.Application.Features.KnowledgeBase.Services;` (the file still imports `KnowledgeBase.UseCases.SearchDocuments` to type the `SearchDocumentsRequest` MediatR mock — that mirrors the spec's accepted out-of-scope item and is allowed in test code, which is not under the architecture rule).
+- Existing tests do not currently exercise the style guide path. Consider adding a minimal happy-path test for `LoadStyleGuideAsync` to lock the wiring through the new contract.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| New `ModuleBoundaryRule` for Article → KnowledgeBase fails because `GatherContextStep` still references `SearchDocumentsRequest` / `SearchDocumentsResponse` / `ChunkResult` via MediatR. | **High** — would break CI immediately. | Add allowlist entries for these three types in a new `ArticleAllowlist`, with an inline comment explaining the deferral and linking to the follow-up. Pattern is established by `LeafletAllowlist`. |
+| Adapter naming drift between spec (`OneDriveArticleStyleGuideSource`) and Leaflet precedent (`KnowledgeBaseLeafletSourceAdapter`). | Low | Use `KnowledgeBaseArticleStyleGuideSource` for consistency. |
+| Implementer puts `IArticleStyleGuideSource` in `Article/Services/` or similar, breaking the documented `Contracts/` ownership rule. | Medium | Spec is explicit: `Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`. New `Contracts/` folder must be created — Article does not have one yet. |
+| Reflection-based architecture test passes locally but fails under different compile flags (e.g., trimming, async state machines). | Low | The existing helper `EnumerateReferencedTypes` already inspects async state machines indirectly via field types and the test handles compiler-generated nested types through the `DeclaringType` check (see ModuleBoundariesTests.cs:152-159). |
+| Future regression where a new Article use case re-imports a KnowledgeBase namespace. | Low (by design) | The new architecture rule is the regression guard. CI will block the PR. |
+
+## Specification Amendments
+
+1. **FR-5 must include an allowlist for surviving `SearchDocumentsRequest` references.**
+   `GatherContextStep` calls `_mediator.Send(new SearchDocumentsRequest { ... }, ct)` at line 89 and binds `response.Chunks` (`ChunkResult`) at lines 92–99. These types live in `Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments` and will be flagged by the new rule. Per the spec's own "Out of Scope" statement, do not lift them now — add allowlist entries with a TODO comment, mirroring `LeafletAllowlist` (ModuleBoundariesTests.cs:29-45). Required entries:
+   - `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsRequest`
+   - `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsResponse`
+   - `Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.ChunkResult`
+
+2. **Adapter name: `KnowledgeBaseArticleStyleGuideSource`** (not `OneDriveArticleStyleGuideSource`) for consistency with `KnowledgeBaseLeafletSourceAdapter`.
+
+3. **Acceptance for FR-5 should add:** "An `ArticleAllowlist : HashSet<string>` constant is added next to the existing per-module allowlists, each entry annotated with a comment explaining the deferred decoupling work."
+
+4. **FR-4 should explicitly note** that `using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;` *remains* in `GatherContextStep.cs` for `SearchDocumentsRequest` until the follow-up. Only the `using Anela.Heblo.Application.Features.KnowledgeBase.Services;` line is removed. This clarifies the "no `using Anela.Heblo.Application.Features.KnowledgeBase...` line" criterion which is currently overstated.
+
+5. **Open the follow-up explicitly.** File a tracking item: "Lift `SearchDocumentsRequest` behind a consumer-owned `IArticleKnowledgeSearch` contract; remove `ArticleAllowlist` entries." Spec currently buries this in "Out of Scope" without an artifact.
+
+## Prerequisites
+
+None. All required infrastructure exists:
+- `Contracts/` folder convention is documented and used by `Leaflet/Contracts/`.
+- `KnowledgeBase/Infrastructure/` adapter folder exists and already houses one adapter.
+- `KnowledgeBaseModule.AddKnowledgeBaseModule` already registers one cross-module contract.
+- `ModuleBoundariesTests` supports adding new rules via `Rules()` TheoryData with no test infrastructure changes.
+- `IOneDriveService` DI registration (mock vs Graph based on environment) is unchanged and automatically inherited by the new adapter.
+- No NuGet packages, migrations, configuration, or environment variables required.

--- a/artifacts/feat-arch-review-article-gathercontextstep-di/brief.md
+++ b/artifacts/feat-arch-review-article-gathercontextstep-di/brief.md
@@ -1,0 +1,61 @@
+## Module
+Article
+
+## Finding
+`GatherContextStep.cs:1` imports:
+
+```csharp
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+```
+
+and at line 17 injects:
+
+```csharp
+private readonly IOneDriveService _oneDrive;
+```
+
+`IOneDriveService` is defined in `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/`. The Article module directly depends on a service interface owned by the KnowledgeBase module without going through a consumer-owned contract.
+
+The development guidelines (`docs/architecture/development_guidelines.md`) are explicit:
+
+> Communication between modules **exclusively through `contracts/`** (e.g., `IProductQueryService`)
+
+> **Cross-Module Communication Pattern (ILeafletKnowledgeSource):** The consumer (A) defines the contract. Module A declares an interface in its own `Contracts/` folder... The provider (B) implements the contract via an adapter... A reflection-based test in `ModuleBoundariesTests.cs` enforces that types contain no references to the other module's namespaces.
+
+Using `KnowledgeBase.Services.IOneDriveService` directly in the Article module creates a hard compile-time dependency on the KnowledgeBase namespace, which the architecture tests are designed to prevent.
+
+## Why it matters
+- Violates the module-boundary invariant that the architecture tests enforce for other cross-module relationships.
+- If KnowledgeBase module reorganises or renames `IOneDriveService` (e.g., moves it to a shared infrastructure adapter), the Article module breaks silently.
+- Prevents future extraction of either module into a separate deployable without refactoring Article.
+- The `ILeafletKnowledgeSource` pattern exists in this codebase precisely for this scenario — it is the documented pattern to follow.
+
+## Suggested fix
+Apply the same pattern used for `ILeafletKnowledgeSource`:
+
+1. **Article module defines its own contract** in `Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`:
+   ```csharp
+   public interface IArticleStyleGuideSource
+   {
+       Task<string> DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken ct);
+   }
+   ```
+
+2. **KnowledgeBase (or a shared adapter) implements it** in its `Infrastructure/` folder:
+   ```csharp
+   public class OneDriveArticleStyleGuideSource : IArticleStyleGuideSource
+   {
+       private readonly IOneDriveService _oneDrive;
+       public Task<string> DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken ct)
+           => _oneDrive.DownloadFileTextByPathAsync(driveId, path, ct);
+   }
+   ```
+
+3. **KnowledgeBase module registers the binding** in its `KnowledgeBaseModule.cs`.
+
+4. **`GatherContextStep` injects `IArticleStyleGuideSource`** instead of `IOneDriveService`.
+
+5. **Add a module-boundary architecture test** for Article → KnowledgeBase, mirroring `ModuleBoundariesTests.cs`.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-article-gathercontextstep-di/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-gathercontextstep-di/impl/main.r1.md
@@ -1,0 +1,12 @@
+This is a normal git repository (GIT_DIR == GIT_COMMON), on branch `feat-arch-review-article-gathercontextstep-di`, base branch is `main`.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-article-gathercontextstep-di/spec.r1.md
+++ b/artifacts/feat-arch-review-article-gathercontextstep-di/spec.r1.md
@@ -1,0 +1,145 @@
+# Specification: Decouple Article Module from KnowledgeBase Module via Consumer-Owned Contract
+
+## Summary
+The Article module's `GatherContextStep` currently injects `IOneDriveService` directly from the `KnowledgeBase` namespace, violating the codebase's documented cross-module communication pattern. This specification replaces that direct dependency with a consumer-owned contract (`IArticleStyleGuideSource`) defined in the Article module and implemented by a KnowledgeBase adapter, mirroring the existing `ILeafletKnowledgeSource` pattern. An architecture test will lock the invariant going forward.
+
+## Background
+`docs/architecture/development_guidelines.md` mandates that all inter-module communication go through consumer-owned `Contracts/` interfaces. Today, `backend/src/Anela.Heblo.Application/Features/Article/.../GatherContextStep.cs` imports `Anela.Heblo.Application.Features.KnowledgeBase.Services` and injects `IOneDriveService` directly. This:
+
+- Creates a compile-time dependency from Article on KnowledgeBase internals.
+- Bypasses the module-boundary invariant enforced elsewhere by `ModuleBoundariesTests.cs`.
+- Breaks Article silently if KnowledgeBase reorganises, renames, or relocates `IOneDriveService`.
+- Blocks future extraction of either module into a separate deployable without refactoring.
+
+A precedent fix already exists in the codebase: `ILeafletKnowledgeSource` was introduced specifically for this scenario. This spec applies the same pattern to the Article → KnowledgeBase relationship for style guide retrieval.
+
+The only consumption point identified is the style guide retrieval performed by `GatherContextStep`. The new contract is scoped narrowly to that use case rather than re-exposing the full `IOneDriveService` surface.
+
+## Functional Requirements
+
+### FR-1: Define consumer-owned contract in Article module
+Introduce `IArticleStyleGuideSource` in `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`. The interface exposes only what `GatherContextStep` needs to retrieve the article style guide content.
+
+**Signature:**
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+public interface IArticleStyleGuideSource
+{
+    Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken);
+}
+```
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`.
+- Namespace is `Anela.Heblo.Application.Features.Article.Contracts`.
+- Interface contains no references to any `KnowledgeBase` namespace, type, or DTO.
+- Method signature matches the behaviour previously obtained via `IOneDriveService.DownloadFileTextByPathAsync(driveId, path, ct)`.
+- XML doc comment on the interface describes its purpose ("Retrieves the Article module's style guide text from an external source").
+
+### FR-2: KnowledgeBase implements the contract via adapter
+Add `OneDriveArticleStyleGuideSource` inside the KnowledgeBase module's `Infrastructure/` folder. It implements `IArticleStyleGuideSource` by delegating to the existing `IOneDriveService`.
+
+**Acceptance criteria:**
+- File lives under `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/OneDriveArticleStyleGuideSource.cs` (or `Adapters/` if that subfolder is the established convention — match the location used by `Leaflet` adapter).
+- Class is `internal` if all existing adapters in KnowledgeBase are internal; otherwise match local convention.
+- Class depends on `IOneDriveService` via constructor injection; no `IOneDriveService` reference exists in the Article module after the refactor.
+- `DownloadStyleGuideTextAsync` forwards arguments directly to `IOneDriveService.DownloadFileTextByPathAsync` and returns its result without transformation.
+- Cancellation token is propagated unchanged.
+
+### FR-3: Register the contract binding in KnowledgeBase module DI
+The KnowledgeBase module's composition root (`KnowledgeBaseModule.cs` or equivalent `IServiceCollection` extension) registers `IArticleStyleGuideSource` → `OneDriveArticleStyleGuideSource`.
+
+**Acceptance criteria:**
+- Registration uses the same lifetime (`Scoped`/`Singleton`/`Transient`) as `ILeafletKnowledgeSource` — match the precedent.
+- Article module's DI registration contains no reference to `OneDriveArticleStyleGuideSource` or any KnowledgeBase type.
+- Application starts successfully and resolves `IArticleStyleGuideSource` when `GatherContextStep` is constructed.
+
+### FR-4: Refactor `GatherContextStep` to use the new contract
+`GatherContextStep` no longer imports any `KnowledgeBase` namespace. It injects `IArticleStyleGuideSource` in place of `IOneDriveService` and calls `DownloadStyleGuideTextAsync` where it previously called `IOneDriveService.DownloadFileTextByPathAsync`.
+
+**Acceptance criteria:**
+- `GatherContextStep.cs` contains no `using Anela.Heblo.Application.Features.KnowledgeBase...` line.
+- The private field is renamed from `_oneDrive` to a name consistent with the new contract (e.g., `_styleGuideSource`).
+- All existing call sites within `GatherContextStep` route through `IArticleStyleGuideSource` — no other `IOneDriveService` member is used by Article code.
+- Behaviour observable from the step's output is unchanged (same text returned for same `driveId` + `path`).
+- Existing unit/integration tests for `GatherContextStep` pass after the refactor; mocks/fakes are updated to `IArticleStyleGuideSource`.
+
+### FR-5: Add module-boundary architecture test
+Extend `ModuleBoundariesTests.cs` (or add a sibling test class following the established pattern) with a reflection-based assertion that types in the Article module's assembly do not reference any `Anela.Heblo.Application.Features.KnowledgeBase` namespace.
+
+**Acceptance criteria:**
+- New test method named in line with existing conventions (e.g., `Article_Module_Should_Not_Reference_KnowledgeBase_Namespaces`).
+- Test scans all types within the Article namespace and inspects field types, method parameters, return types, base types, generic arguments, and attribute usages — mirror the scope of the existing `Leaflet`/`KnowledgeBase` test.
+- Test fails if a future change reintroduces a direct `KnowledgeBase` dependency in Article.
+- Test passes after the refactor in this spec is applied.
+- Test runs as part of the standard `dotnet test` suite (no new test project required if an existing architecture-test project already exists).
+
+### FR-6: No regression in style guide retrieval
+The end-to-end behaviour of article context gathering (including the style guide text content, error propagation, and cancellation handling) is identical before and after the refactor.
+
+**Acceptance criteria:**
+- Any existing automated test exercising `GatherContextStep` and style guide retrieval continues to pass with no behavioural changes expected.
+- Exceptions thrown by the underlying `IOneDriveService` propagate through the adapter unchanged (no wrapping, no swallowing).
+- Cancellation behaviour is preserved — cancelling the token surfaces an `OperationCanceledException` to the caller as it did previously.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- The adapter introduces a single virtual method call; no measurable latency impact on `GatherContextStep`.
+- No additional allocations beyond the adapter instance itself (lifetime determined by FR-3).
+
+### NFR-2: Security
+- No change to authentication, authorisation, or data sensitivity. The adapter performs no transformation; it forwards arguments verbatim to the existing `IOneDriveService`.
+- No new secrets, configuration, or network surface introduced.
+
+### NFR-3: Maintainability
+- Article module is fully compilable without referencing any `KnowledgeBase` symbol after the change.
+- The architecture test (FR-5) acts as the long-term guarantor — any future regression is caught at CI time.
+
+### NFR-4: Backwards compatibility
+- `IOneDriveService` remains in place and unchanged. Other consumers (e.g., the Leaflet flow) continue to use it directly as before. This refactor is local to the Article ↔ KnowledgeBase boundary.
+
+## Data Model
+No data-model changes. Existing `driveId` / `path` parameters carry the same semantics as today and are passed through unchanged.
+
+## API / Interface Design
+
+### New contract (consumer-owned)
+- Location: `Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`
+- Namespace: `Anela.Heblo.Application.Features.Article.Contracts`
+- Single method: `Task<string> DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken cancellationToken)`
+
+### New adapter (provider-owned)
+- Location: `Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/OneDriveArticleStyleGuideSource.cs` (match local convention if it differs)
+- Implements: `IArticleStyleGuideSource`
+- Depends on: `IOneDriveService` (constructor injection)
+
+### DI registration
+- Module composition root within KnowledgeBase wires the contract → adapter binding using the same lifetime as `ILeafletKnowledgeSource`.
+
+### No external API changes
+- No HTTP endpoints, MediatR handlers, MVC controllers, or OpenAPI surfaces change.
+- No frontend changes; OpenAPI generation is unaffected.
+
+## Dependencies
+- Existing `IOneDriveService` in the KnowledgeBase module (unchanged).
+- Existing reflection-based architecture test infrastructure (e.g., `ModuleBoundariesTests.cs` and its supporting helpers).
+- No new NuGet packages.
+- No database migrations.
+
+## Out of Scope
+- Refactoring or splitting `IOneDriveService` itself.
+- Generalising the contract to support arbitrary file downloads — the interface is intentionally scoped to the Article style guide use case.
+- Auditing other Article-module files for additional cross-module dependencies beyond `GatherContextStep`. Only the documented violation is addressed here. (If the implementer encounters another Article→KnowledgeBase dependency during the refactor, surface it for a follow-up task — do not silently expand scope.)
+- Moving the adapter into a hypothetical shared infrastructure project.
+- Changes to the frontend or to any HTTP/OpenAPI surface.
+- Documentation updates beyond inline XML doc comments.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-gathercontextstep-di/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-gathercontextstep-di/task-plan.r1.md
@@ -1,0 +1,824 @@
+# Decouple Article Module from KnowledgeBase — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `GatherContextStep`'s direct dependency on KnowledgeBase's `IOneDriveService` with a consumer-owned contract `IArticleStyleGuideSource` defined in the Article module and implemented by a KnowledgeBase adapter, plus an architecture test that locks the new boundary in place.
+
+**Architecture:** Mirror of the existing `ILeafletKnowledgeSource` precedent. Article declares the narrow contract it needs (download a style guide text by drive id and path). KnowledgeBase ships an `internal sealed` adapter that delegates to its existing `IOneDriveService`. KnowledgeBase's composition root wires the binding so Article's DI graph stays free of any KnowledgeBase symbols. A new `ModuleBoundaryRule` row in `ModuleBoundariesTests.Rules()` enforces the invariant — its allowlist temporarily covers the surviving `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` references in `GatherContextStep` which are explicitly out of scope per the spec.
+
+**Tech Stack:** .NET 8, C# nullable reference types, xUnit, FluentAssertions, Moq, MediatR, `Microsoft.Extensions.DependencyInjection`, `System.Reflection`. No new NuGet packages, no migrations, no configuration changes.
+
+---
+
+## File Structure
+
+### New files
+| Path | Responsibility |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs` | Article-owned read-only abstraction for downloading the style guide text. Only surface the Article module is allowed to depend on for this concern. |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs` | `internal sealed` adapter implementing `IArticleStyleGuideSource` by delegating verbatim to `IOneDriveService.DownloadFileTextByPathAsync`. |
+| `backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs` | Unit tests for the adapter: happy-path delegation, cancellation propagation, exception propagation. |
+
+### Files modified — behavior change
+| Path | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs` | Drop `using Anela.Heblo.Application.Features.KnowledgeBase.Services;`. Swap `IOneDriveService _oneDrive` for `IArticleStyleGuideSource _styleGuideSource`. Call `_styleGuideSource.DownloadStyleGuideTextAsync(...)` inside `LoadStyleGuideAsync`. `using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;` is **kept** — `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` are explicitly out of scope (spec §Out of Scope; arch-review §Specification Amendments). |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` | Register `services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();` immediately after the existing `ILeafletKnowledgeSource` binding. |
+
+### Files modified — tests
+| Path | Change |
+|---|---|
+| `backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs` | Drop `using Anela.Heblo.Application.Features.KnowledgeBase.Services;`. Replace `Mock<IOneDriveService> _oneDrive` with `Mock<IArticleStyleGuideSource> _styleGuideSource`. Wire `_styleGuideSource.Object` into the `CreateStep` factory. Add a happy-path test that exercises `LoadStyleGuideAsync` through the new contract. The file may keep `using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;` because the test project is not under the architecture rule and `SearchDocumentsRequest` is still consumed by the step under test. |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Add `ArticleAllowlist` (`HashSet<string>`) with the three `SearchDocuments` entries documented in arch-review §Specification Amendments. Append one new `ModuleBoundaryRule` to `Rules()` TheoryData: `Name: "Article -> KnowledgeBase"`, `InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article"`, three forbidden namespace prefixes covering `Domain.Features.KnowledgeBase`, `Application.Features.KnowledgeBase`, and `Persistence.KnowledgeBase`, `Allowlist: ArticleAllowlist`. |
+
+### Files NOT modified
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — must not gain any reference to `OneDriveService`, the new adapter, or any KnowledgeBase type. Leave untouched.
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/IOneDriveService.cs` and its implementations — unchanged.
+- Any EF migration, controller, or frontend file — none of this touches API/HTTP/OpenAPI surface or persistence.
+
+---
+
+## Task 1: Define the consumer-owned contract `IArticleStyleGuideSource`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`
+
+- [ ] **Step 1.1: Create the new file**
+
+Write `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Retrieves the Article module's style guide text from an external source.
+/// Implemented by the KnowledgeBase module via an adapter.
+/// </summary>
+public interface IArticleStyleGuideSource
+{
+    Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken);
+}
+```
+
+Constraints — verify before moving on:
+- Namespace is exactly `Anela.Heblo.Application.Features.Article.Contracts`.
+- File contains zero `using` directives referencing `Anela.Heblo.Application.Features.KnowledgeBase`, `Anela.Heblo.Domain.Features.KnowledgeBase`, or `Anela.Heblo.Persistence.KnowledgeBase`.
+- File contains zero references to `IOneDriveService`, `OneDriveFile`, or any other KnowledgeBase-owned type.
+- Method signature matches the call site in `GatherContextStep.LoadStyleGuideAsync` — three parameters in the order `driveId`, `path`, `cancellationToken`, returning `Task<string>` (not `Task<string?>` — the underlying `IOneDriveService.DownloadFileTextByPathAsync` returns non-null `Task<string>`; the step decides whether to wrap with `null` on exception, not the contract).
+
+- [ ] **Step 1.2: Compile the solution to confirm the file is well-formed**
+
+Run:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with no errors. The new interface has no implementers yet so DI will not resolve it, but compilation must pass.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+cd backend && git add src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs
+git commit -m "feat(article): add IArticleStyleGuideSource consumer-owned contract"
+```
+
+---
+
+## Task 2: Write the adapter test (RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs`
+
+The adapter does three things: forwards arguments verbatim to `IOneDriveService.DownloadFileTextByPathAsync`, returns its result unchanged, and lets exceptions/cancellation propagate. One test per behavior. Tests go first; the adapter implementation follows in Task 3.
+
+- [ ] **Step 2.1: Verify the test directory exists; create if missing**
+
+Run:
+
+```bash
+cd backend && mkdir -p test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure
+```
+
+Expected: no error (directory either pre-existed or was created).
+
+- [ ] **Step 2.2: Write the failing adapter test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.KnowledgeBase.Infrastructure;
+
+public class KnowledgeBaseArticleStyleGuideSourceTests
+{
+    private readonly Mock<IOneDriveService> _oneDrive = new();
+
+    private IArticleStyleGuideSource CreateSut() =>
+        new KnowledgeBaseArticleStyleGuideSource(_oneDrive.Object);
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_ForwardsArgumentsAndReturnsResult()
+    {
+        const string driveId = "drive-abc";
+        const string path = "/style-guides/article.md";
+        const string expected = "guide body";
+
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(driveId, path, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var sut = CreateSut();
+
+        var actual = await sut.DownloadStyleGuideTextAsync(driveId, path, CancellationToken.None);
+
+        actual.Should().Be(expected);
+        _oneDrive.Verify(
+            o => o.DownloadFileTextByPathAsync(driveId, path, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_PropagatesUnderlyingException()
+    {
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("OneDrive down"));
+
+        var sut = CreateSut();
+
+        var act = () => sut.DownloadStyleGuideTextAsync("drive", "path", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("OneDrive down");
+    }
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var sut = CreateSut();
+
+        var act = () => sut.DownloadStyleGuideTextAsync("drive", "path", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}
+```
+
+- [ ] **Step 2.3: Run the new tests to confirm they fail with "type does not exist"**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseArticleStyleGuideSourceTests"
+```
+
+Expected: compile error `CS0246: The type or namespace name 'KnowledgeBaseArticleStyleGuideSource' could not be found`. This proves the test is referencing the concrete type by name and will fail if Task 3 produces the wrong shape.
+
+> Do not commit yet — failing tests get committed together with their implementation in Task 3.
+
+---
+
+## Task 3: Implement `KnowledgeBaseArticleStyleGuideSource` (GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs`
+
+- [ ] **Step 3.1: Create the adapter file**
+
+Write `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+
+internal sealed class KnowledgeBaseArticleStyleGuideSource : IArticleStyleGuideSource
+{
+    private readonly IOneDriveService _oneDrive;
+
+    public KnowledgeBaseArticleStyleGuideSource(IOneDriveService oneDrive)
+    {
+        _oneDrive = oneDrive;
+    }
+
+    public Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken) =>
+        _oneDrive.DownloadFileTextByPathAsync(driveId, path, cancellationToken);
+}
+```
+
+Constraints to verify:
+- Class is `internal sealed` (matches `KnowledgeBaseLeafletSourceAdapter`).
+- Constructor takes a single `IOneDriveService` dependency (matches existing adapter pattern).
+- Method body is a one-line expression-bodied member that forwards all three arguments verbatim. No transformation, no logging, no try/catch — the calling step already handles exceptions.
+
+- [ ] **Step 3.2: Run the adapter tests — expect green**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseArticleStyleGuideSourceTests"
+```
+
+Expected: all three tests pass. `DownloadStyleGuideTextAsync_ForwardsArgumentsAndReturnsResult`, `..._PropagatesUnderlyingException`, `..._PropagatesCancellation`.
+
+- [ ] **Step 3.3: Commit adapter + its tests together**
+
+```bash
+cd backend && git add \
+  src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs \
+  test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs
+git commit -m "feat(knowledgebase): add KnowledgeBaseArticleStyleGuideSource adapter"
+```
+
+---
+
+## Task 4: Register the adapter in `KnowledgeBaseModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`
+
+- [ ] **Step 4.1: Add the using directive for the Article contract**
+
+Open `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`. The existing using block already imports `Anela.Heblo.Application.Features.Leaflet.Contracts`. Add the Article contracts import directly below it.
+
+Find:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.Leaflet.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+```
+
+(Article comes first alphabetically — match the rest of the file's alphabetical-within-block ordering.)
+
+- [ ] **Step 4.2: Register the binding next to the Leaflet binding**
+
+In the same file, find the existing Leaflet registration block:
+
+```csharp
+        // Cross-module contract: KnowledgeBase implements Leaflet's ILeafletKnowledgeSource via adapter.
+        // DI registration owned by provider (KnowledgeBase), not consumer (Leaflet) — keeps the
+        // dependency direction inverted properly.
+        services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();
+```
+
+Replace with:
+
+```csharp
+        // Cross-module contract: KnowledgeBase implements Leaflet's ILeafletKnowledgeSource via adapter.
+        // DI registration owned by provider (KnowledgeBase), not consumer (Leaflet) — keeps the
+        // dependency direction inverted properly.
+        services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();
+
+        // Cross-module contract: KnowledgeBase implements Article's IArticleStyleGuideSource via adapter.
+        // Same provider-owned-DI pattern as the Leaflet binding above.
+        services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();
+```
+
+Constraints — verify:
+- Lifetime is `AddScoped` (matches `ILeafletKnowledgeSource` registration and the lifetime of the underlying `IOneDriveService`, which is also `Scoped`).
+- The Article module's composition root (`ArticleModule.cs`) is **not** modified — the binding lives in the provider's module by design.
+
+- [ ] **Step 4.3: Build to confirm the wiring compiles**
+
+Run:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+cd backend && git add src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+git commit -m "feat(knowledgebase): register IArticleStyleGuideSource adapter"
+```
+
+---
+
+## Task 5: Update `GatherContextStepTests` to drive the contract swap (RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs`
+
+The existing test file uses `Mock<IOneDriveService>` but no current test actually exercises `LoadStyleGuideAsync`. After this task: (a) the existing tests still pass (they don't touch the style guide path), (b) the test file no longer imports `IOneDriveService`, (c) a new test locks the happy-path wiring through `IArticleStyleGuideSource`. This drives the production refactor in Task 6.
+
+- [ ] **Step 5.1: Replace the `IOneDriveService` mock with `IArticleStyleGuideSource`**
+
+Open `backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs`.
+
+Find:
+
+```csharp
+using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+```
+
+(The `KnowledgeBase.Services` using is removed. `KnowledgeBase.UseCases.SearchDocuments` stays — `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` remain in use by the step and the test, per spec §Out of Scope.)
+
+Find:
+
+```csharp
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IWebSearchClient> _webSearch = new();
+    private readonly Mock<IOneDriveService> _oneDrive = new();
+    private readonly ArticleOptions _options = new();
+```
+
+Replace with:
+
+```csharp
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IWebSearchClient> _webSearch = new();
+    private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
+    private readonly ArticleOptions _options = new();
+```
+
+Find:
+
+```csharp
+    private GatherContextStep CreateStep() =>
+        new(_mediator.Object, _webSearch.Object, _oneDrive.Object,
+            Options.Create(_options), NullLogger<GatherContextStep>.Instance, CreateNoOpRecorder());
+```
+
+Replace with:
+
+```csharp
+    private GatherContextStep CreateStep() =>
+        new(_mediator.Object, _webSearch.Object, _styleGuideSource.Object,
+            Options.Create(_options), NullLogger<GatherContextStep>.Instance, CreateNoOpRecorder());
+```
+
+- [ ] **Step 5.2: Add a happy-path test that exercises the style guide contract**
+
+Append this test inside `GatherContextStepTests` (after the existing `ExecuteAsync_DuplicateWebUrls_DeduplicatesByUrl` test, before the closing class brace):
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_StyleGuideConfigured_LoadsTextViaContract()
+    {
+        const string driveId = "drive-1";
+        const string itemPath = "/style.md";
+        const string guide = "Tone: friendly";
+
+        _styleGuideSource
+            .Setup(s => s.DownloadStyleGuideTextAsync(driveId, itemPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guide);
+
+        var article = new DomainArticle
+        {
+            Topic = "Topic",
+            UsedKnowledgeBase = false,
+            UsedWebSearch = false,
+            StyleGuideDriveId = driveId,
+            StyleGuideItemPath = itemPath
+        };
+        var context = new ArticlePipelineContext
+        {
+            Article = article,
+            SearchQueries = new List<string>()
+        };
+
+        await CreateStep().ExecuteAsync(context, default);
+
+        context.StyleGuideText.Should().Be(guide);
+        _styleGuideSource.Verify(
+            s => s.DownloadStyleGuideTextAsync(driveId, itemPath, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 5.3: Run the tests — expect compile failure on `GatherContextStep` constructor**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GatherContextStepTests"
+```
+
+Expected: build error — `GatherContextStep` constructor still expects `IOneDriveService`, but the test now passes `IArticleStyleGuideSource`. Error message similar to `CS1503: Argument 3: cannot convert from 'Anela.Heblo.Application.Features.Article.Contracts.IArticleStyleGuideSource' to 'Anela.Heblo.Application.Features.KnowledgeBase.Services.IOneDriveService'`. This is the expected RED state — Task 6 makes it green.
+
+> Do not commit yet — test changes commit together with the production refactor in Task 6.
+
+---
+
+## Task 6: Refactor `GatherContextStep` to consume `IArticleStyleGuideSource` (GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`
+
+- [ ] **Step 6.1: Update using directives**
+
+Open `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`.
+
+Find:
+
+```csharp
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+using Anela.Heblo.Application.Shared.WebSearch;
+using Anela.Heblo.Domain.Features.Article;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+using Anela.Heblo.Application.Shared.WebSearch;
+using Anela.Heblo.Domain.Features.Article;
+```
+
+(The `KnowledgeBase.Services` using — which pulled in `IOneDriveService` — is removed. The `KnowledgeBase.UseCases.SearchDocuments` using is **kept** for `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` per spec §Out of Scope. Article contracts using is added.)
+
+- [ ] **Step 6.2: Swap the field and constructor parameter**
+
+Find:
+
+```csharp
+    private readonly IMediator _mediator;
+    private readonly IWebSearchClient _webSearch;
+    private readonly IOneDriveService _oneDrive;
+    private readonly ArticleOptions _options;
+    private readonly ILogger<GatherContextStep> _logger;
+    private readonly PipelineStepRecorder _recorder;
+
+    public GatherContextStep(
+        IMediator mediator,
+        IWebSearchClient webSearch,
+        IOneDriveService oneDrive,
+        IOptions<ArticleOptions> options,
+        ILogger<GatherContextStep> logger,
+        PipelineStepRecorder recorder)
+    {
+        _mediator = mediator;
+        _webSearch = webSearch;
+        _oneDrive = oneDrive;
+        _options = options.Value;
+        _logger = logger;
+        _recorder = recorder;
+    }
+```
+
+Replace with:
+
+```csharp
+    private readonly IMediator _mediator;
+    private readonly IWebSearchClient _webSearch;
+    private readonly IArticleStyleGuideSource _styleGuideSource;
+    private readonly ArticleOptions _options;
+    private readonly ILogger<GatherContextStep> _logger;
+    private readonly PipelineStepRecorder _recorder;
+
+    public GatherContextStep(
+        IMediator mediator,
+        IWebSearchClient webSearch,
+        IArticleStyleGuideSource styleGuideSource,
+        IOptions<ArticleOptions> options,
+        ILogger<GatherContextStep> logger,
+        PipelineStepRecorder recorder)
+    {
+        _mediator = mediator;
+        _webSearch = webSearch;
+        _styleGuideSource = styleGuideSource;
+        _options = options.Value;
+        _logger = logger;
+        _recorder = recorder;
+    }
+```
+
+- [ ] **Step 6.3: Update the single call site inside `LoadStyleGuideAsync`**
+
+Find:
+
+```csharp
+    private async Task<string?> LoadStyleGuideAsync(DomainArticle article, CancellationToken ct)
+    {
+        try
+        {
+            return await _oneDrive.DownloadFileTextByPathAsync(
+                article.StyleGuideDriveId!,
+                article.StyleGuideItemPath!,
+                ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to load style guide from '{Path}'", article.StyleGuideItemPath);
+            return null;
+        }
+    }
+```
+
+Replace with:
+
+```csharp
+    private async Task<string?> LoadStyleGuideAsync(DomainArticle article, CancellationToken ct)
+    {
+        try
+        {
+            return await _styleGuideSource.DownloadStyleGuideTextAsync(
+                article.StyleGuideDriveId!,
+                article.StyleGuideItemPath!,
+                ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to load style guide from '{Path}'", article.StyleGuideItemPath);
+            return null;
+        }
+    }
+```
+
+(Only the call target changes — argument list, ordering, cancellation handling, and warning log are preserved exactly so behavior observable from `context.StyleGuideText` is identical.)
+
+Constraints — verify:
+- `GatherContextStep.cs` no longer contains the substring `IOneDriveService` anywhere.
+- `GatherContextStep.cs` no longer contains the substring `KnowledgeBase.Services` anywhere.
+- `GatherContextStep.cs` *still* contains `KnowledgeBase.UseCases.SearchDocuments` (intentional — see Task 7 allowlist).
+- The exception-handling block is unchanged: non-cancellation exceptions are logged at Warning and the method returns `null`; `OperationCanceledException` flows out unchanged.
+
+- [ ] **Step 6.4: Run all `GatherContextStepTests` — expect green**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GatherContextStepTests"
+```
+
+Expected: all six tests pass (five pre-existing + the new `ExecuteAsync_StyleGuideConfigured_LoadsTextViaContract`).
+
+- [ ] **Step 6.5: Run the whole Article test folder to confirm no other suite regressed**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Article"
+```
+
+Expected: all Article-namespaced tests pass.
+
+- [ ] **Step 6.6: Commit production refactor + test updates together**
+
+```bash
+cd backend && git add \
+  src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+  test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs
+git commit -m "refactor(article): route GatherContextStep style guide load through IArticleStyleGuideSource"
+```
+
+---
+
+## Task 7: Add the Article → KnowledgeBase architecture rule
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 7.1: Add `ArticleAllowlist` next to the existing per-module allowlists**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`.
+
+Find the end of the `LeafletAllowlist` declaration (the closing `};` after the `OneDriveFile` entry). Immediately after it, insert a new `ArticleAllowlist` block:
+
+```csharp
+    // Allowlist for Article → KnowledgeBase. Each entry needs a comment with the justification.
+    // Entries should be removed as the underlying violations are fixed.
+    private static readonly HashSet<string> ArticleAllowlist = new(StringComparer.Ordinal)
+    {
+        // Pre-existing dependency: GatherContextStep dispatches SearchDocumentsRequest via MediatR
+        // to obtain knowledge-base snippets during article generation. Lifting this behind a
+        // consumer-owned contract (e.g. IArticleKnowledgeSearch) is out of scope for the
+        // 2026-05-25 Article ↔ KnowledgeBase style-guide decoupling and is tracked as a follow-up.
+        // Remove these three entries when SearchDocumentsRequest is replaced by an Article-owned
+        // contract.
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsRequest",
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsResponse",
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.ChunkResult",
+    };
+```
+
+Placement must keep alphabetical-by-consumer-module order consistent with the existing file: `Leaflet`, then add `Article` (no — file is grouped by relevance, not alphabetically; just put `ArticleAllowlist` directly after `LeafletAllowlist` as the next logical neighbor).
+
+- [ ] **Step 7.2: Add the `ModuleBoundaryRule` row to `Rules()` TheoryData**
+
+In the same file, find the `Rules()` method's TheoryData initializer. The existing entries are ordered: Leaflet → KnowledgeBase, Logistics → Manufacture, PackingMaterials → Invoices, Purchase → Catalog. Add the Article → KnowledgeBase rule directly after the Leaflet rule so related rules sit together.
+
+Find:
+
+```csharp
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+```
+
+Replace with:
+
+```csharp
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Article -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: ArticleAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+```
+
+Constraints — verify:
+- `InspectedNamespacePrefix` is exactly `Anela.Heblo.Application.Features.Article` (no trailing dot — the existing helper handles both equality and `prefix + "."` start).
+- All three forbidden prefixes are present — copy them from the Leaflet rule above to avoid typos.
+- `Allowlist: ArticleAllowlist` references the new constant, not `LeafletAllowlist`.
+
+- [ ] **Step 7.3: Run the architecture test for the new rule**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: all `ModuleBoundariesTests` theories pass, including the new `Consumer_types_should_not_reference_provider_owned_namespaces(rule: Article -> KnowledgeBase)` case.
+
+If this fails with a violation other than the three allowlisted `SearchDocuments` entries, it means another `Anela.Heblo.Application.Features.Article` type still references a KnowledgeBase-owned namespace. Per spec §Out of Scope, do **not** silently expand scope or add more allowlist entries — surface the finding to the reviewer with the exact `Consumer -> Provider` line from the violation message so it can be tracked as a follow-up.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+cd backend && git add test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test(architecture): enforce Article -> KnowledgeBase boundary with SearchDocuments allowlist"
+```
+
+---
+
+## Task 8: Full validation
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 8.1: Run the full backend test suite**
+
+Run:
+
+```bash
+cd backend && dotnet test
+```
+
+Expected: every test project passes. If any pre-existing test fails, stop and investigate — the refactor in this plan must be behavior-preserving outside the swapped DI seam.
+
+- [ ] **Step 8.2: Build the full solution**
+
+Run:
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: zero errors. Warning count should not increase vs. the pre-refactor baseline (`git stash && dotnet build` on the parent commit if a baseline comparison is needed).
+
+- [ ] **Step 8.3: Apply formatter**
+
+Run:
+
+```bash
+cd backend && dotnet format
+```
+
+Expected: command completes; any files it rewrites should be limited to the ones touched in this plan. If unrelated files change, revert those — surgical-change rule applies.
+
+- [ ] **Step 8.4: Commit any formatter changes (only if dotnet format modified files in this PR's diff)**
+
+```bash
+cd backend && git status
+# if there are changes:
+git add -A
+git commit -m "style: apply dotnet format"
+```
+
+(Skip if `git status` is clean.)
+
+- [ ] **Step 8.5: Sanity-check the final boundary**
+
+Run two `grep`-style scans to confirm the refactor sticks:
+
+```bash
+cd backend && grep -rn "IOneDriveService\|KnowledgeBase.Services" src/Anela.Heblo.Application/Features/Article/
+```
+
+Expected: zero matches.
+
+```bash
+cd backend && grep -n "IArticleStyleGuideSource" src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+```
+
+Expected: at least three matches (using directive, field type, constructor parameter type — plus method call inside `LoadStyleGuideAsync`).
+
+```bash
+cd backend && grep -n "IArticleStyleGuideSource" src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+```
+
+Expected: at least two matches (using directive + `AddScoped<...>` line).
+
+---
+
+## Self-Review
+
+**Spec coverage** — every functional requirement maps to at least one task:
+
+| Requirement | Tasks |
+|---|---|
+| FR-1: Define `IArticleStyleGuideSource` in Article/Contracts | Task 1 |
+| FR-2: KnowledgeBase adapter implementing the contract | Tasks 2, 3 |
+| FR-3: DI registration owned by KnowledgeBase, same lifetime as Leaflet | Task 4 |
+| FR-4: `GatherContextStep` swaps to new contract, no `KnowledgeBase.Services` import | Tasks 5, 6 (arch-review §Amendment 4 acknowledged — `KnowledgeBase.UseCases.SearchDocuments` using stays) |
+| FR-5: Architecture test rule + ArticleAllowlist | Task 7 (incorporates arch-review §Amendments 1 and 3) |
+| FR-6: No behavioral regression in style guide retrieval | Task 6.3 (exception handling preserved verbatim), Task 6.4 (existing test suite passes), Task 8.1 (full suite) |
+| NFR-1 Performance | One virtual call adapter, no new allocations beyond the scoped instance — design unchanged from Leaflet precedent |
+| NFR-2 Security | No new secrets/config/network surface — adapter forwards arguments verbatim |
+| NFR-3 Maintainability | Architecture rule is the long-term guarantor (Task 7) |
+| NFR-4 Backwards compatibility | `IOneDriveService` unchanged (only `GatherContextStep` consumer is swapped) — Tasks 6 and 8.5 verify |
+
+Arch-review amendments are all addressed:
+- Amendment 1 (allowlist for `SearchDocuments` types) → Task 7.1
+- Amendment 2 (adapter name `KnowledgeBaseArticleStyleGuideSource`) → Task 3.1
+- Amendment 3 (`ArticleAllowlist` constant with comments) → Task 7.1
+- Amendment 4 (clarify that `KnowledgeBase.UseCases.SearchDocuments` using stays) → Task 6.1
+- Amendment 5 (follow-up tracking) → Comment inside `ArticleAllowlist` in Task 7.1 explicitly names the follow-up as a tracking item
+
+**Type consistency check** — verified:
+- Interface name `IArticleStyleGuideSource` and method `DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken cancellationToken)` are identical across Task 1 (definition), Task 2 (test), Task 3 (adapter), Task 5 (test mock), Task 6 (call site), Task 7 (allowlist not affected — it tracks `SearchDocuments` types, not the new contract).
+- Adapter type `KnowledgeBaseArticleStyleGuideSource` is identical across Tasks 2, 3, 4.
+- Field name `_styleGuideSource` is identical across Tasks 5 (mock) and 6 (production).
+- The kept-using `Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments` and the removed-using `Anela.Heblo.Application.Features.KnowledgeBase.Services` are spelled consistently in Tasks 5 and 6.
+
+**Placeholder scan** — no `TBD`, no "implement later", no "similar to Task N", no orphan type references. Every code-changing step contains the exact code to write or replace.

--- a/backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs
@@ -1,0 +1,13 @@
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Retrieves the Article module's style guide text from an external source.
+/// Implemented by the KnowledgeBase module via an adapter.
+/// </summary>
+public interface IArticleStyleGuideSource
+{
+    Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using Anela.Heblo.Application.Shared.WebSearch;
 using Anela.Heblo.Domain.Features.Article;
@@ -13,7 +13,7 @@ public class GatherContextStep : IArticlePipelineStep
 {
     private readonly IMediator _mediator;
     private readonly IWebSearchClient _webSearch;
-    private readonly IOneDriveService _oneDrive;
+    private readonly IArticleStyleGuideSource _styleGuideSource;
     private readonly ArticleOptions _options;
     private readonly ILogger<GatherContextStep> _logger;
     private readonly PipelineStepRecorder _recorder;
@@ -21,14 +21,14 @@ public class GatherContextStep : IArticlePipelineStep
     public GatherContextStep(
         IMediator mediator,
         IWebSearchClient webSearch,
-        IOneDriveService oneDrive,
+        IArticleStyleGuideSource styleGuideSource,
         IOptions<ArticleOptions> options,
         ILogger<GatherContextStep> logger,
         PipelineStepRecorder recorder)
     {
         _mediator = mediator;
         _webSearch = webSearch;
-        _oneDrive = oneDrive;
+        _styleGuideSource = styleGuideSource;
         _options = options.Value;
         _logger = logger;
         _recorder = recorder;
@@ -144,7 +144,7 @@ public class GatherContextStep : IArticlePipelineStep
     {
         try
         {
-            return await _oneDrive.DownloadFileTextByPathAsync(
+            return await _styleGuideSource.DownloadStyleGuideTextAsync(
                 article.StyleGuideDriveId!,
                 article.StyleGuideItemPath!,
                 ct);

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs
@@ -1,0 +1,20 @@
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+
+internal sealed class KnowledgeBaseArticleStyleGuideSource : IArticleStyleGuideSource
+{
+    private readonly IOneDriveService _oneDrive;
+
+    public KnowledgeBaseArticleStyleGuideSource(IOneDriveService oneDrive)
+    {
+        _oneDrive = oneDrive;
+    }
+
+    public Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken) =>
+        _oneDrive.DownloadFileTextByPathAsync(driveId, path, cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.KnowledgeBase.Pipeline;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Application.Features.Leaflet.Contracts;
@@ -36,6 +37,10 @@ public static class KnowledgeBaseModule
         // DI registration owned by provider (KnowledgeBase), not consumer (Leaflet) — keeps the
         // dependency direction inverted properly.
         services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();
+
+        // Cross-module contract: KnowledgeBase implements Article's IArticleStyleGuideSource via adapter.
+        // Same provider-owned-DI pattern as the Leaflet binding above.
+        services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();
 
         // IKnowledgeBaseRepository is registered in PersistenceModule (real EF Core implementation)
 

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -44,6 +44,21 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.Leaflet.Infrastructure.Jobs.LeafletIngestionJob -> Anela.Heblo.Application.Features.KnowledgeBase.Services.OneDriveFile",
     };
 
+    // Allowlist for Article → KnowledgeBase. Each entry needs a comment with the justification.
+    // Entries should be removed as the underlying violations are fixed.
+    private static readonly HashSet<string> ArticleAllowlist = new(StringComparer.Ordinal)
+    {
+        // Pre-existing dependency: GatherContextStep dispatches SearchDocumentsRequest via MediatR
+        // to obtain knowledge-base snippets during article generation. Lifting this behind a
+        // consumer-owned contract (e.g. IArticleKnowledgeSearch) is out of scope for the
+        // 2026-05-25 Article ↔ KnowledgeBase style-guide decoupling and is tracked as a follow-up.
+        // Remove these three entries when SearchDocumentsRequest is replaced by an Article-owned
+        // contract.
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsRequest",
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsResponse",
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.ChunkResult",
+    };
+
     // Allowlist for Logistics → Manufacture. Each entry needs a comment with the justification.
     // Entries should be removed as the underlying violations are fixed.
     private static readonly HashSet<string> LogisticsAllowlist = new(StringComparer.Ordinal)
@@ -88,6 +103,17 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.KnowledgeBase",
             },
             Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Article -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: ArticleAllowlist),
 
         new ModuleBoundaryRule(
             Name: "Logistics -> Manufacture",

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs
@@ -1,6 +1,6 @@
 using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
-using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using Anela.Heblo.Application.Shared.WebSearch;
 using Anela.Heblo.Domain.Features.Article;
@@ -17,7 +17,7 @@ public class GatherContextStepTests
 {
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IWebSearchClient> _webSearch = new();
-    private readonly Mock<IOneDriveService> _oneDrive = new();
+    private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
     private readonly ArticleOptions _options = new();
 
     private static PipelineStepRecorder CreateNoOpRecorder()
@@ -30,7 +30,7 @@ public class GatherContextStepTests
     }
 
     private GatherContextStep CreateStep() =>
-        new(_mediator.Object, _webSearch.Object, _oneDrive.Object,
+        new(_mediator.Object, _webSearch.Object, _styleGuideSource.Object,
             Options.Create(_options), NullLogger<GatherContextStep>.Instance, CreateNoOpRecorder());
 
     private static ArticlePipelineContext CreateContext(
@@ -178,5 +178,38 @@ public class GatherContextStepTests
 
         context.ContextSnippets.Should().ContainSingle();
         context.ContextSnippets[0].Title.Should().Be("First");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StyleGuideConfigured_LoadsTextViaContract()
+    {
+        const string driveId = "drive-1";
+        const string itemPath = "/style.md";
+        const string guide = "Tone: friendly";
+
+        _styleGuideSource
+            .Setup(s => s.DownloadStyleGuideTextAsync(driveId, itemPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guide);
+
+        var article = new DomainArticle
+        {
+            Topic = "Topic",
+            UsedKnowledgeBase = false,
+            UsedWebSearch = false,
+            StyleGuideDriveId = driveId,
+            StyleGuideItemPath = itemPath
+        };
+        var context = new ArticlePipelineContext
+        {
+            Article = article,
+            SearchQueries = new List<string>()
+        };
+
+        await CreateStep().ExecuteAsync(context, default);
+
+        context.StyleGuideText.Should().Be(guide);
+        _styleGuideSource.Verify(
+            s => s.DownloadStyleGuideTextAsync(driveId, itemPath, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/GenerateArticleJobTests.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
-using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Application.Shared.WebSearch;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
@@ -20,7 +20,7 @@ public class GenerateArticleJobTests
     private readonly Mock<IChatClient> _chat = new();
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IWebSearchClient> _webSearch = new();
-    private readonly Mock<IOneDriveService> _oneDrive = new();
+    private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
     private readonly ArticleOptions _options = new();
 
     private static DomainArticle CreateArticle() =>
@@ -52,7 +52,7 @@ public class GenerateArticleJobTests
         return new GenerateArticleJob(
             _repository.Object,
             planQueries ?? new PlanQueriesStep(_chat.Object, optionsWrapper, NullLogger<PlanQueriesStep>.Instance, recorder),
-            gatherContext ?? new GatherContextStep(_mediator.Object, _webSearch.Object, _oneDrive.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
+            gatherContext ?? new GatherContextStep(_mediator.Object, _webSearch.Object, _styleGuideSource.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
             aggregateFacts ?? new AggregateFactsStep(_chat.Object, optionsWrapper, NullLogger<AggregateFactsStep>.Instance, recorder),
             validateFacts ?? new ValidateFactsStep(_chat.Object, optionsWrapper, NullLogger<ValidateFactsStep>.Instance, recorder),
             writeArticle ?? new WriteArticleStep(_chat.Object, optionsWrapper, NullLogger<WriteArticleStep>.Instance, recorder),

--- a/backend/test/Anela.Heblo.Tests/Article/UseCases/SourceEnrichmentIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/UseCases/SourceEnrichmentIntegrationTests.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate;
 using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
-using Anela.Heblo.Application.Features.KnowledgeBase.Services;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
 using Anela.Heblo.Application.Shared.WebSearch;
 using Anela.Heblo.Domain.Features.Article;
@@ -21,7 +21,7 @@ public class SourceEnrichmentIntegrationTests
     private readonly Mock<IChatClient> _chat = new();
     private readonly Mock<IMediator> _mediator = new();
     private readonly Mock<IWebSearchClient> _webSearch = new();
-    private readonly Mock<IOneDriveService> _oneDrive = new();
+    private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
     private readonly ArticleOptions _options = new();
 
     [Fact]
@@ -84,7 +84,7 @@ public class SourceEnrichmentIntegrationTests
         var job = new GenerateArticleJob(
             _repository.Object,
             new PlanQueriesStep(_chat.Object, optionsWrapper, NullLogger<PlanQueriesStep>.Instance, recorder),
-            new GatherContextStep(_mediator.Object, _webSearch.Object, _oneDrive.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
+            new GatherContextStep(_mediator.Object, _webSearch.Object, _styleGuideSource.Object, optionsWrapper, NullLogger<GatherContextStep>.Instance, recorder),
             new AggregateFactsStep(_chat.Object, optionsWrapper, NullLogger<AggregateFactsStep>.Instance, recorder),
             new ValidateFactsStep(_chat.Object, optionsWrapper, NullLogger<ValidateFactsStep>.Instance, recorder),
             new WriteArticleStep(_chat.Object, optionsWrapper, NullLogger<WriteArticleStep>.Instance, recorder),

--- a/backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs
@@ -1,0 +1,70 @@
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.KnowledgeBase.Infrastructure;
+
+public class KnowledgeBaseArticleStyleGuideSourceTests
+{
+    private readonly Mock<IOneDriveService> _oneDrive = new();
+
+    private IArticleStyleGuideSource CreateSut() =>
+        new KnowledgeBaseArticleStyleGuideSource(_oneDrive.Object);
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_ForwardsArgumentsAndReturnsResult()
+    {
+        const string driveId = "drive-abc";
+        const string path = "/style-guides/article.md";
+        const string expected = "guide body";
+
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(driveId, path, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var sut = CreateSut();
+
+        var actual = await sut.DownloadStyleGuideTextAsync(driveId, path, CancellationToken.None);
+
+        actual.Should().Be(expected);
+        _oneDrive.Verify(
+            o => o.DownloadFileTextByPathAsync(driveId, path, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_PropagatesUnderlyingException()
+    {
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("OneDrive down"));
+
+        var sut = CreateSut();
+
+        var act = () => sut.DownloadStyleGuideTextAsync("drive", "path", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("OneDrive down");
+    }
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var sut = CreateSut();
+
+        var act = () => sut.DownloadStyleGuideTextAsync("drive", "path", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/docs/superpowers/plans/2026-05-25-decouple-article-from-knowledgebase.md
+++ b/docs/superpowers/plans/2026-05-25-decouple-article-from-knowledgebase.md
@@ -1,0 +1,824 @@
+# Decouple Article Module from KnowledgeBase — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `GatherContextStep`'s direct dependency on KnowledgeBase's `IOneDriveService` with a consumer-owned contract `IArticleStyleGuideSource` defined in the Article module and implemented by a KnowledgeBase adapter, plus an architecture test that locks the new boundary in place.
+
+**Architecture:** Mirror of the existing `ILeafletKnowledgeSource` precedent. Article declares the narrow contract it needs (download a style guide text by drive id and path). KnowledgeBase ships an `internal sealed` adapter that delegates to its existing `IOneDriveService`. KnowledgeBase's composition root wires the binding so Article's DI graph stays free of any KnowledgeBase symbols. A new `ModuleBoundaryRule` row in `ModuleBoundariesTests.Rules()` enforces the invariant — its allowlist temporarily covers the surviving `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` references in `GatherContextStep` which are explicitly out of scope per the spec.
+
+**Tech Stack:** .NET 8, C# nullable reference types, xUnit, FluentAssertions, Moq, MediatR, `Microsoft.Extensions.DependencyInjection`, `System.Reflection`. No new NuGet packages, no migrations, no configuration changes.
+
+---
+
+## File Structure
+
+### New files
+| Path | Responsibility |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs` | Article-owned read-only abstraction for downloading the style guide text. Only surface the Article module is allowed to depend on for this concern. |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs` | `internal sealed` adapter implementing `IArticleStyleGuideSource` by delegating verbatim to `IOneDriveService.DownloadFileTextByPathAsync`. |
+| `backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs` | Unit tests for the adapter: happy-path delegation, cancellation propagation, exception propagation. |
+
+### Files modified — behavior change
+| Path | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs` | Drop `using Anela.Heblo.Application.Features.KnowledgeBase.Services;`. Swap `IOneDriveService _oneDrive` for `IArticleStyleGuideSource _styleGuideSource`. Call `_styleGuideSource.DownloadStyleGuideTextAsync(...)` inside `LoadStyleGuideAsync`. `using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;` is **kept** — `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` are explicitly out of scope (spec §Out of Scope; arch-review §Specification Amendments). |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` | Register `services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();` immediately after the existing `ILeafletKnowledgeSource` binding. |
+
+### Files modified — tests
+| Path | Change |
+|---|---|
+| `backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs` | Drop `using Anela.Heblo.Application.Features.KnowledgeBase.Services;`. Replace `Mock<IOneDriveService> _oneDrive` with `Mock<IArticleStyleGuideSource> _styleGuideSource`. Wire `_styleGuideSource.Object` into the `CreateStep` factory. Add a happy-path test that exercises `LoadStyleGuideAsync` through the new contract. The file may keep `using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;` because the test project is not under the architecture rule and `SearchDocumentsRequest` is still consumed by the step under test. |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Add `ArticleAllowlist` (`HashSet<string>`) with the three `SearchDocuments` entries documented in arch-review §Specification Amendments. Append one new `ModuleBoundaryRule` to `Rules()` TheoryData: `Name: "Article -> KnowledgeBase"`, `InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article"`, three forbidden namespace prefixes covering `Domain.Features.KnowledgeBase`, `Application.Features.KnowledgeBase`, and `Persistence.KnowledgeBase`, `Allowlist: ArticleAllowlist`. |
+
+### Files NOT modified
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — must not gain any reference to `OneDriveService`, the new adapter, or any KnowledgeBase type. Leave untouched.
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/IOneDriveService.cs` and its implementations — unchanged.
+- Any EF migration, controller, or frontend file — none of this touches API/HTTP/OpenAPI surface or persistence.
+
+---
+
+## Task 1: Define the consumer-owned contract `IArticleStyleGuideSource`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`
+
+- [ ] **Step 1.1: Create the new file**
+
+Write `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Retrieves the Article module's style guide text from an external source.
+/// Implemented by the KnowledgeBase module via an adapter.
+/// </summary>
+public interface IArticleStyleGuideSource
+{
+    Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken);
+}
+```
+
+Constraints — verify before moving on:
+- Namespace is exactly `Anela.Heblo.Application.Features.Article.Contracts`.
+- File contains zero `using` directives referencing `Anela.Heblo.Application.Features.KnowledgeBase`, `Anela.Heblo.Domain.Features.KnowledgeBase`, or `Anela.Heblo.Persistence.KnowledgeBase`.
+- File contains zero references to `IOneDriveService`, `OneDriveFile`, or any other KnowledgeBase-owned type.
+- Method signature matches the call site in `GatherContextStep.LoadStyleGuideAsync` — three parameters in the order `driveId`, `path`, `cancellationToken`, returning `Task<string>` (not `Task<string?>` — the underlying `IOneDriveService.DownloadFileTextByPathAsync` returns non-null `Task<string>`; the step decides whether to wrap with `null` on exception, not the contract).
+
+- [ ] **Step 1.2: Compile the solution to confirm the file is well-formed**
+
+Run:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with no errors. The new interface has no implementers yet so DI will not resolve it, but compilation must pass.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+cd backend && git add src/Anela.Heblo.Application/Features/Article/Contracts/IArticleStyleGuideSource.cs
+git commit -m "feat(article): add IArticleStyleGuideSource consumer-owned contract"
+```
+
+---
+
+## Task 2: Write the adapter test (RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs`
+
+The adapter does three things: forwards arguments verbatim to `IOneDriveService.DownloadFileTextByPathAsync`, returns its result unchanged, and lets exceptions/cancellation propagate. One test per behavior. Tests go first; the adapter implementation follows in Task 3.
+
+- [ ] **Step 2.1: Verify the test directory exists; create if missing**
+
+Run:
+
+```bash
+cd backend && mkdir -p test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure
+```
+
+Expected: no error (directory either pre-existed or was created).
+
+- [ ] **Step 2.2: Write the failing adapter test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.KnowledgeBase.Infrastructure;
+
+public class KnowledgeBaseArticleStyleGuideSourceTests
+{
+    private readonly Mock<IOneDriveService> _oneDrive = new();
+
+    private IArticleStyleGuideSource CreateSut() =>
+        new KnowledgeBaseArticleStyleGuideSource(_oneDrive.Object);
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_ForwardsArgumentsAndReturnsResult()
+    {
+        const string driveId = "drive-abc";
+        const string path = "/style-guides/article.md";
+        const string expected = "guide body";
+
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(driveId, path, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var sut = CreateSut();
+
+        var actual = await sut.DownloadStyleGuideTextAsync(driveId, path, CancellationToken.None);
+
+        actual.Should().Be(expected);
+        _oneDrive.Verify(
+            o => o.DownloadFileTextByPathAsync(driveId, path, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_PropagatesUnderlyingException()
+    {
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("OneDrive down"));
+
+        var sut = CreateSut();
+
+        var act = () => sut.DownloadStyleGuideTextAsync("drive", "path", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("OneDrive down");
+    }
+
+    [Fact]
+    public async Task DownloadStyleGuideTextAsync_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _oneDrive
+            .Setup(o => o.DownloadFileTextByPathAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var sut = CreateSut();
+
+        var act = () => sut.DownloadStyleGuideTextAsync("drive", "path", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}
+```
+
+- [ ] **Step 2.3: Run the new tests to confirm they fail with "type does not exist"**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseArticleStyleGuideSourceTests"
+```
+
+Expected: compile error `CS0246: The type or namespace name 'KnowledgeBaseArticleStyleGuideSource' could not be found`. This proves the test is referencing the concrete type by name and will fail if Task 3 produces the wrong shape.
+
+> Do not commit yet — failing tests get committed together with their implementation in Task 3.
+
+---
+
+## Task 3: Implement `KnowledgeBaseArticleStyleGuideSource` (GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs`
+
+- [ ] **Step 3.1: Create the adapter file**
+
+Write `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+
+namespace Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+
+internal sealed class KnowledgeBaseArticleStyleGuideSource : IArticleStyleGuideSource
+{
+    private readonly IOneDriveService _oneDrive;
+
+    public KnowledgeBaseArticleStyleGuideSource(IOneDriveService oneDrive)
+    {
+        _oneDrive = oneDrive;
+    }
+
+    public Task<string> DownloadStyleGuideTextAsync(
+        string driveId,
+        string path,
+        CancellationToken cancellationToken) =>
+        _oneDrive.DownloadFileTextByPathAsync(driveId, path, cancellationToken);
+}
+```
+
+Constraints to verify:
+- Class is `internal sealed` (matches `KnowledgeBaseLeafletSourceAdapter`).
+- Constructor takes a single `IOneDriveService` dependency (matches existing adapter pattern).
+- Method body is a one-line expression-bodied member that forwards all three arguments verbatim. No transformation, no logging, no try/catch — the calling step already handles exceptions.
+
+- [ ] **Step 3.2: Run the adapter tests — expect green**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~KnowledgeBaseArticleStyleGuideSourceTests"
+```
+
+Expected: all three tests pass. `DownloadStyleGuideTextAsync_ForwardsArgumentsAndReturnsResult`, `..._PropagatesUnderlyingException`, `..._PropagatesCancellation`.
+
+- [ ] **Step 3.3: Commit adapter + its tests together**
+
+```bash
+cd backend && git add \
+  src/Anela.Heblo.Application/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSource.cs \
+  test/Anela.Heblo.Tests/Features/KnowledgeBase/Infrastructure/KnowledgeBaseArticleStyleGuideSourceTests.cs
+git commit -m "feat(knowledgebase): add KnowledgeBaseArticleStyleGuideSource adapter"
+```
+
+---
+
+## Task 4: Register the adapter in `KnowledgeBaseModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`
+
+- [ ] **Step 4.1: Add the using directive for the Article contract**
+
+Open `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs`. The existing using block already imports `Anela.Heblo.Application.Features.Leaflet.Contracts`. Add the Article contracts import directly below it.
+
+Find:
+
+```csharp
+using Anela.Heblo.Application.Features.Leaflet.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.Leaflet.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
+```
+
+(Article comes first alphabetically — match the rest of the file's alphabetical-within-block ordering.)
+
+- [ ] **Step 4.2: Register the binding next to the Leaflet binding**
+
+In the same file, find the existing Leaflet registration block:
+
+```csharp
+        // Cross-module contract: KnowledgeBase implements Leaflet's ILeafletKnowledgeSource via adapter.
+        // DI registration owned by provider (KnowledgeBase), not consumer (Leaflet) — keeps the
+        // dependency direction inverted properly.
+        services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();
+```
+
+Replace with:
+
+```csharp
+        // Cross-module contract: KnowledgeBase implements Leaflet's ILeafletKnowledgeSource via adapter.
+        // DI registration owned by provider (KnowledgeBase), not consumer (Leaflet) — keeps the
+        // dependency direction inverted properly.
+        services.AddScoped<ILeafletKnowledgeSource, KnowledgeBaseLeafletSourceAdapter>();
+
+        // Cross-module contract: KnowledgeBase implements Article's IArticleStyleGuideSource via adapter.
+        // Same provider-owned-DI pattern as the Leaflet binding above.
+        services.AddScoped<IArticleStyleGuideSource, KnowledgeBaseArticleStyleGuideSource>();
+```
+
+Constraints — verify:
+- Lifetime is `AddScoped` (matches `ILeafletKnowledgeSource` registration and the lifetime of the underlying `IOneDriveService`, which is also `Scoped`).
+- The Article module's composition root (`ArticleModule.cs`) is **not** modified — the binding lives in the provider's module by design.
+
+- [ ] **Step 4.3: Build to confirm the wiring compiles**
+
+Run:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+cd backend && git add src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+git commit -m "feat(knowledgebase): register IArticleStyleGuideSource adapter"
+```
+
+---
+
+## Task 5: Update `GatherContextStepTests` to drive the contract swap (RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs`
+
+The existing test file uses `Mock<IOneDriveService>` but no current test actually exercises `LoadStyleGuideAsync`. After this task: (a) the existing tests still pass (they don't touch the style guide path), (b) the test file no longer imports `IOneDriveService`, (c) a new test locks the happy-path wiring through `IArticleStyleGuideSource`. This drives the production refactor in Task 6.
+
+- [ ] **Step 5.1: Replace the `IOneDriveService` mock with `IArticleStyleGuideSource`**
+
+Open `backend/test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs`.
+
+Find:
+
+```csharp
+using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article;
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+```
+
+(The `KnowledgeBase.Services` using is removed. `KnowledgeBase.UseCases.SearchDocuments` stays — `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` remain in use by the step and the test, per spec §Out of Scope.)
+
+Find:
+
+```csharp
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IWebSearchClient> _webSearch = new();
+    private readonly Mock<IOneDriveService> _oneDrive = new();
+    private readonly ArticleOptions _options = new();
+```
+
+Replace with:
+
+```csharp
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IWebSearchClient> _webSearch = new();
+    private readonly Mock<IArticleStyleGuideSource> _styleGuideSource = new();
+    private readonly ArticleOptions _options = new();
+```
+
+Find:
+
+```csharp
+    private GatherContextStep CreateStep() =>
+        new(_mediator.Object, _webSearch.Object, _oneDrive.Object,
+            Options.Create(_options), NullLogger<GatherContextStep>.Instance, CreateNoOpRecorder());
+```
+
+Replace with:
+
+```csharp
+    private GatherContextStep CreateStep() =>
+        new(_mediator.Object, _webSearch.Object, _styleGuideSource.Object,
+            Options.Create(_options), NullLogger<GatherContextStep>.Instance, CreateNoOpRecorder());
+```
+
+- [ ] **Step 5.2: Add a happy-path test that exercises the style guide contract**
+
+Append this test inside `GatherContextStepTests` (after the existing `ExecuteAsync_DuplicateWebUrls_DeduplicatesByUrl` test, before the closing class brace):
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_StyleGuideConfigured_LoadsTextViaContract()
+    {
+        const string driveId = "drive-1";
+        const string itemPath = "/style.md";
+        const string guide = "Tone: friendly";
+
+        _styleGuideSource
+            .Setup(s => s.DownloadStyleGuideTextAsync(driveId, itemPath, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(guide);
+
+        var article = new DomainArticle
+        {
+            Topic = "Topic",
+            UsedKnowledgeBase = false,
+            UsedWebSearch = false,
+            StyleGuideDriveId = driveId,
+            StyleGuideItemPath = itemPath
+        };
+        var context = new ArticlePipelineContext
+        {
+            Article = article,
+            SearchQueries = new List<string>()
+        };
+
+        await CreateStep().ExecuteAsync(context, default);
+
+        context.StyleGuideText.Should().Be(guide);
+        _styleGuideSource.Verify(
+            s => s.DownloadStyleGuideTextAsync(driveId, itemPath, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 5.3: Run the tests — expect compile failure on `GatherContextStep` constructor**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GatherContextStepTests"
+```
+
+Expected: build error — `GatherContextStep` constructor still expects `IOneDriveService`, but the test now passes `IArticleStyleGuideSource`. Error message similar to `CS1503: Argument 3: cannot convert from 'Anela.Heblo.Application.Features.Article.Contracts.IArticleStyleGuideSource' to 'Anela.Heblo.Application.Features.KnowledgeBase.Services.IOneDriveService'`. This is the expected RED state — Task 6 makes it green.
+
+> Do not commit yet — test changes commit together with the production refactor in Task 6.
+
+---
+
+## Task 6: Refactor `GatherContextStep` to consume `IArticleStyleGuideSource` (GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`
+
+- [ ] **Step 6.1: Update using directives**
+
+Open `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`.
+
+Find:
+
+```csharp
+using Anela.Heblo.Application.Features.KnowledgeBase.Services;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+using Anela.Heblo.Application.Shared.WebSearch;
+using Anela.Heblo.Domain.Features.Article;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments;
+using Anela.Heblo.Application.Shared.WebSearch;
+using Anela.Heblo.Domain.Features.Article;
+```
+
+(The `KnowledgeBase.Services` using — which pulled in `IOneDriveService` — is removed. The `KnowledgeBase.UseCases.SearchDocuments` using is **kept** for `SearchDocumentsRequest`/`SearchDocumentsResponse`/`ChunkResult` per spec §Out of Scope. Article contracts using is added.)
+
+- [ ] **Step 6.2: Swap the field and constructor parameter**
+
+Find:
+
+```csharp
+    private readonly IMediator _mediator;
+    private readonly IWebSearchClient _webSearch;
+    private readonly IOneDriveService _oneDrive;
+    private readonly ArticleOptions _options;
+    private readonly ILogger<GatherContextStep> _logger;
+    private readonly PipelineStepRecorder _recorder;
+
+    public GatherContextStep(
+        IMediator mediator,
+        IWebSearchClient webSearch,
+        IOneDriveService oneDrive,
+        IOptions<ArticleOptions> options,
+        ILogger<GatherContextStep> logger,
+        PipelineStepRecorder recorder)
+    {
+        _mediator = mediator;
+        _webSearch = webSearch;
+        _oneDrive = oneDrive;
+        _options = options.Value;
+        _logger = logger;
+        _recorder = recorder;
+    }
+```
+
+Replace with:
+
+```csharp
+    private readonly IMediator _mediator;
+    private readonly IWebSearchClient _webSearch;
+    private readonly IArticleStyleGuideSource _styleGuideSource;
+    private readonly ArticleOptions _options;
+    private readonly ILogger<GatherContextStep> _logger;
+    private readonly PipelineStepRecorder _recorder;
+
+    public GatherContextStep(
+        IMediator mediator,
+        IWebSearchClient webSearch,
+        IArticleStyleGuideSource styleGuideSource,
+        IOptions<ArticleOptions> options,
+        ILogger<GatherContextStep> logger,
+        PipelineStepRecorder recorder)
+    {
+        _mediator = mediator;
+        _webSearch = webSearch;
+        _styleGuideSource = styleGuideSource;
+        _options = options.Value;
+        _logger = logger;
+        _recorder = recorder;
+    }
+```
+
+- [ ] **Step 6.3: Update the single call site inside `LoadStyleGuideAsync`**
+
+Find:
+
+```csharp
+    private async Task<string?> LoadStyleGuideAsync(DomainArticle article, CancellationToken ct)
+    {
+        try
+        {
+            return await _oneDrive.DownloadFileTextByPathAsync(
+                article.StyleGuideDriveId!,
+                article.StyleGuideItemPath!,
+                ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to load style guide from '{Path}'", article.StyleGuideItemPath);
+            return null;
+        }
+    }
+```
+
+Replace with:
+
+```csharp
+    private async Task<string?> LoadStyleGuideAsync(DomainArticle article, CancellationToken ct)
+    {
+        try
+        {
+            return await _styleGuideSource.DownloadStyleGuideTextAsync(
+                article.StyleGuideDriveId!,
+                article.StyleGuideItemPath!,
+                ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to load style guide from '{Path}'", article.StyleGuideItemPath);
+            return null;
+        }
+    }
+```
+
+(Only the call target changes — argument list, ordering, cancellation handling, and warning log are preserved exactly so behavior observable from `context.StyleGuideText` is identical.)
+
+Constraints — verify:
+- `GatherContextStep.cs` no longer contains the substring `IOneDriveService` anywhere.
+- `GatherContextStep.cs` no longer contains the substring `KnowledgeBase.Services` anywhere.
+- `GatherContextStep.cs` *still* contains `KnowledgeBase.UseCases.SearchDocuments` (intentional — see Task 7 allowlist).
+- The exception-handling block is unchanged: non-cancellation exceptions are logged at Warning and the method returns `null`; `OperationCanceledException` flows out unchanged.
+
+- [ ] **Step 6.4: Run all `GatherContextStepTests` — expect green**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GatherContextStepTests"
+```
+
+Expected: all six tests pass (five pre-existing + the new `ExecuteAsync_StyleGuideConfigured_LoadsTextViaContract`).
+
+- [ ] **Step 6.5: Run the whole Article test folder to confirm no other suite regressed**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Article"
+```
+
+Expected: all Article-namespaced tests pass.
+
+- [ ] **Step 6.6: Commit production refactor + test updates together**
+
+```bash
+cd backend && git add \
+  src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+  test/Anela.Heblo.Tests/Article/Pipeline/GatherContextStepTests.cs
+git commit -m "refactor(article): route GatherContextStep style guide load through IArticleStyleGuideSource"
+```
+
+---
+
+## Task 7: Add the Article → KnowledgeBase architecture rule
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 7.1: Add `ArticleAllowlist` next to the existing per-module allowlists**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`.
+
+Find the end of the `LeafletAllowlist` declaration (the closing `};` after the `OneDriveFile` entry). Immediately after it, insert a new `ArticleAllowlist` block:
+
+```csharp
+    // Allowlist for Article → KnowledgeBase. Each entry needs a comment with the justification.
+    // Entries should be removed as the underlying violations are fixed.
+    private static readonly HashSet<string> ArticleAllowlist = new(StringComparer.Ordinal)
+    {
+        // Pre-existing dependency: GatherContextStep dispatches SearchDocumentsRequest via MediatR
+        // to obtain knowledge-base snippets during article generation. Lifting this behind a
+        // consumer-owned contract (e.g. IArticleKnowledgeSearch) is out of scope for the
+        // 2026-05-25 Article ↔ KnowledgeBase style-guide decoupling and is tracked as a follow-up.
+        // Remove these three entries when SearchDocumentsRequest is replaced by an Article-owned
+        // contract.
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsRequest",
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.SearchDocumentsResponse",
+        "Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline.GatherContextStep -> Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments.ChunkResult",
+    };
+```
+
+Placement must keep alphabetical-by-consumer-module order consistent with the existing file: `Leaflet`, then add `Article` (no — file is grouped by relevance, not alphabetically; just put `ArticleAllowlist` directly after `LeafletAllowlist` as the next logical neighbor).
+
+- [ ] **Step 7.2: Add the `ModuleBoundaryRule` row to `Rules()` TheoryData**
+
+In the same file, find the `Rules()` method's TheoryData initializer. The existing entries are ordered: Leaflet → KnowledgeBase, Logistics → Manufacture, PackingMaterials → Invoices, Purchase → Catalog. Add the Article → KnowledgeBase rule directly after the Leaflet rule so related rules sit together.
+
+Find:
+
+```csharp
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+```
+
+Replace with:
+
+```csharp
+    public static TheoryData<ModuleBoundaryRule> Rules() => new()
+    {
+        new ModuleBoundaryRule(
+            Name: "Leaflet -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Leaflet",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: LeafletAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Article -> KnowledgeBase",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.KnowledgeBase",
+                "Anela.Heblo.Application.Features.KnowledgeBase",
+                "Anela.Heblo.Persistence.KnowledgeBase",
+            },
+            Allowlist: ArticleAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Manufacture",
+```
+
+Constraints — verify:
+- `InspectedNamespacePrefix` is exactly `Anela.Heblo.Application.Features.Article` (no trailing dot — the existing helper handles both equality and `prefix + "."` start).
+- All three forbidden prefixes are present — copy them from the Leaflet rule above to avoid typos.
+- `Allowlist: ArticleAllowlist` references the new constant, not `LeafletAllowlist`.
+
+- [ ] **Step 7.3: Run the architecture test for the new rule**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: all `ModuleBoundariesTests` theories pass, including the new `Consumer_types_should_not_reference_provider_owned_namespaces(rule: Article -> KnowledgeBase)` case.
+
+If this fails with a violation other than the three allowlisted `SearchDocuments` entries, it means another `Anela.Heblo.Application.Features.Article` type still references a KnowledgeBase-owned namespace. Per spec §Out of Scope, do **not** silently expand scope or add more allowlist entries — surface the finding to the reviewer with the exact `Consumer -> Provider` line from the violation message so it can be tracked as a follow-up.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+cd backend && git add test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test(architecture): enforce Article -> KnowledgeBase boundary with SearchDocuments allowlist"
+```
+
+---
+
+## Task 8: Full validation
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 8.1: Run the full backend test suite**
+
+Run:
+
+```bash
+cd backend && dotnet test
+```
+
+Expected: every test project passes. If any pre-existing test fails, stop and investigate — the refactor in this plan must be behavior-preserving outside the swapped DI seam.
+
+- [ ] **Step 8.2: Build the full solution**
+
+Run:
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: zero errors. Warning count should not increase vs. the pre-refactor baseline (`git stash && dotnet build` on the parent commit if a baseline comparison is needed).
+
+- [ ] **Step 8.3: Apply formatter**
+
+Run:
+
+```bash
+cd backend && dotnet format
+```
+
+Expected: command completes; any files it rewrites should be limited to the ones touched in this plan. If unrelated files change, revert those — surgical-change rule applies.
+
+- [ ] **Step 8.4: Commit any formatter changes (only if dotnet format modified files in this PR's diff)**
+
+```bash
+cd backend && git status
+# if there are changes:
+git add -A
+git commit -m "style: apply dotnet format"
+```
+
+(Skip if `git status` is clean.)
+
+- [ ] **Step 8.5: Sanity-check the final boundary**
+
+Run two `grep`-style scans to confirm the refactor sticks:
+
+```bash
+cd backend && grep -rn "IOneDriveService\|KnowledgeBase.Services" src/Anela.Heblo.Application/Features/Article/
+```
+
+Expected: zero matches.
+
+```bash
+cd backend && grep -n "IArticleStyleGuideSource" src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+```
+
+Expected: at least three matches (using directive, field type, constructor parameter type — plus method call inside `LoadStyleGuideAsync`).
+
+```bash
+cd backend && grep -n "IArticleStyleGuideSource" src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+```
+
+Expected: at least two matches (using directive + `AddScoped<...>` line).
+
+---
+
+## Self-Review
+
+**Spec coverage** — every functional requirement maps to at least one task:
+
+| Requirement | Tasks |
+|---|---|
+| FR-1: Define `IArticleStyleGuideSource` in Article/Contracts | Task 1 |
+| FR-2: KnowledgeBase adapter implementing the contract | Tasks 2, 3 |
+| FR-3: DI registration owned by KnowledgeBase, same lifetime as Leaflet | Task 4 |
+| FR-4: `GatherContextStep` swaps to new contract, no `KnowledgeBase.Services` import | Tasks 5, 6 (arch-review §Amendment 4 acknowledged — `KnowledgeBase.UseCases.SearchDocuments` using stays) |
+| FR-5: Architecture test rule + ArticleAllowlist | Task 7 (incorporates arch-review §Amendments 1 and 3) |
+| FR-6: No behavioral regression in style guide retrieval | Task 6.3 (exception handling preserved verbatim), Task 6.4 (existing test suite passes), Task 8.1 (full suite) |
+| NFR-1 Performance | One virtual call adapter, no new allocations beyond the scoped instance — design unchanged from Leaflet precedent |
+| NFR-2 Security | No new secrets/config/network surface — adapter forwards arguments verbatim |
+| NFR-3 Maintainability | Architecture rule is the long-term guarantor (Task 7) |
+| NFR-4 Backwards compatibility | `IOneDriveService` unchanged (only `GatherContextStep` consumer is swapped) — Tasks 6 and 8.5 verify |
+
+Arch-review amendments are all addressed:
+- Amendment 1 (allowlist for `SearchDocuments` types) → Task 7.1
+- Amendment 2 (adapter name `KnowledgeBaseArticleStyleGuideSource`) → Task 3.1
+- Amendment 3 (`ArticleAllowlist` constant with comments) → Task 7.1
+- Amendment 4 (clarify that `KnowledgeBase.UseCases.SearchDocuments` using stays) → Task 6.1
+- Amendment 5 (follow-up tracking) → Comment inside `ArticleAllowlist` in Task 7.1 explicitly names the follow-up as a tracking item
+
+**Type consistency check** — verified:
+- Interface name `IArticleStyleGuideSource` and method `DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken cancellationToken)` are identical across Task 1 (definition), Task 2 (test), Task 3 (adapter), Task 5 (test mock), Task 6 (call site), Task 7 (allowlist not affected — it tracks `SearchDocuments` types, not the new contract).
+- Adapter type `KnowledgeBaseArticleStyleGuideSource` is identical across Tasks 2, 3, 4.
+- Field name `_styleGuideSource` is identical across Tasks 5 (mock) and 6 (production).
+- The kept-using `Anela.Heblo.Application.Features.KnowledgeBase.UseCases.SearchDocuments` and the removed-using `Anela.Heblo.Application.Features.KnowledgeBase.Services` are spelled consistently in Tasks 5 and 6.
+
+**Placeholder scan** — no `TBD`, no "implement later", no "similar to Task N", no orphan type references. Every code-changing step contains the exact code to write or replace.


### PR DESCRIPTION
Article

## Finding
`GatherContextStep.cs:1` imports:

```csharp
using Anela.Heblo.Application.Features.KnowledgeBase.Services;
```

and at line 17 injects:

```csharp
private readonly IOneDriveService _oneDrive;
```

`IOneDriveService` is defined in `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/Services/`. The Article module directly depends on a service interface owned by the KnowledgeBase module without going through a consumer-owned contract.

The development guidelines (`docs/architecture/development_guidelines.md`) are explicit:

> Communication between modules **exclusively through `contracts/`** (e.g., `IProductQueryService`)

> **Cross-Module Communication Pattern (ILeafletKnowledgeSource):** The consumer (A) defines the contract. Module A declares an interface in its own `Contracts/` folder... The provider (B) implements the contract via an adapter... A reflection-based test in `ModuleBoundariesTests.cs` enforces that types contain no references to the other module's namespaces.

Using `KnowledgeBase.Services.IOneDriveService` directly in the Article module creates a hard compile-time dependency on the KnowledgeBase namespace, which the architecture tests are designed to prevent.

## Why it matters
- Violates the module-boundary invariant that the architecture tests enforce for other cross-module relationships.
- If KnowledgeBase module reorganises or renames `IOneDriveService` (e.g., moves it to a shared infrastructure adapter), the Article module breaks silently.
- Prevents future extraction of either module into a separate deployable without refactoring Article.
- The `ILeafletKnowledgeSource` pattern exists in this codebase precisely for this scenario — it is the documented pattern to follow.

## Suggested fix
Apply the same pattern used for `ILeafletKnowledgeSource`:

1. **Article module defines its own contract** in `Application/Features/Article/Contracts/IArticleStyleGuideSource.cs`:
   ```csharp
   public interface IArticleStyleGuideSource
   {
       Task<string> DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken ct);
   }
   ```

2. **KnowledgeBase (or a shared adapter) implements it** in its `Infrastructure/` folder:
   ```csharp
   public class OneDriveArticleStyleGuideSource : IArticleStyleGuideSource
   {
       private readonly IOneDriveService _oneDrive;
       public Task<string> DownloadStyleGuideTextAsync(string driveId, string path, CancellationToken ct)
           => _oneDrive.DownloadFileTextByPathAsync(driveId, path, ct);
   }
   ```

3. **KnowledgeBase module registers the binding** in its `KnowledgeBaseModule.cs`.

4. **`GatherContextStep` injects `IArticleStyleGuideSource`** instead of `IOneDriveService`.

5. **Add a module-boundary architecture test** for Article → KnowledgeBase, mirroring `ModuleBoundariesTests.cs`.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1636

### Tokens used
21024371
