### PR TITLE
feat: Remove Unused `IArticlePipelineStep` Interface

### DIFF
--- a/artifacts/feat-arch-review-article-iarticlepipelinestep/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-iarticlepipelinestep/arch-review.r1.md
@@ -1,0 +1,117 @@
+Verification complete. The spec's claims hold up against the code: only the 5 step classes and the interface file itself reference `IArticlePipelineStep` (no consumer, no test, no DI binding via interface). Writing the review now.
+
+# Architecture Review: Remove Unused `IArticlePipelineStep` Interface
+
+## Skip Design: true
+
+Backend-only deletion of a dead interface — no UI surface, no visual components, no user-facing flows.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with the project's Clean Architecture + Vertical Slice conventions (`docs/architecture/filesystem.md`). The Article module already organizes its generation pipeline under `Application/Features/Article/UseCases/Generate/Pipeline/`, and the surrounding code (`ArticleModule.cs`, `GenerateArticleJob.cs`) consistently treats the steps as concrete scoped services. The interface sits orthogonally to that — it is never bound, never resolved, and never mocked.
+
+Integration points after removal:
+- **DI registration** (`ArticleModule.cs:19-25`): no change — already registers concrete types.
+- **Job composition** (`GenerateArticleJob.cs:13-36`): no change — already injects concrete types and invokes them in a fixed sequence.
+- **Tests** (`backend/test/Anela.Heblo.Tests/Article/Pipeline/*StepTests.cs` + `GenerateArticleJobTests.cs`): grep across `backend/test` for `IArticlePipelineStep` returns zero hits. FR-4 reduces to a verification gate, not an edit.
+
+The change is honest about current usage and consistent with the YAGNI principle baked into the global coding standards. There is no architectural objection.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Application/Features/Article/
+├── ArticleModule.cs                             (unchanged — already concrete-typed)
+└── UseCases/Generate/
+    ├── GenerateArticleJob.cs                    (unchanged — already concrete-typed)
+    └── Pipeline/
+        ├── ArticlePipelineContext.cs            (unchanged)
+        ├── PipelineStepRecorder.cs              (unchanged)
+        ├── IArticlePipelineStep.cs              ❌ DELETE
+        ├── PlanQueriesStep.cs                   ✏️  remove ": IArticlePipelineStep"
+        ├── GatherContextStep.cs                 ✏️  remove ": IArticlePipelineStep"
+        ├── AggregateFactsStep.cs                ✏️  remove ": IArticlePipelineStep"
+        ├── ValidateFactsStep.cs                 ✏️  remove ": IArticlePipelineStep"
+        └── WriteArticleStep.cs                  ✏️  remove ": IArticlePipelineStep"
+```
+
+After the change, the pipeline shape is: `GenerateArticleJob` directly drives five concrete `*Step` services in a fixed order via the shared `ArticlePipelineContext` — the exact composition `GenerateArticleJob.cs:53-61` already encodes.
+
+### Key Design Decisions
+
+#### Decision 1: Option A (delete) vs Option B (actually use the interface)
+**Options considered:**
+- A — Delete the interface entirely.
+- B — Register and inject via `IArticlePipelineStep` (e.g., `IEnumerable<IArticlePipelineStep>` or named registrations) to enable polymorphic mocking.
+
+**Chosen approach:** A — delete.
+
+**Rationale:** The pipeline is intentionally a fixed, ordered sequence in `GenerateArticleJob.RunAsync` with side effects (`MarkAsResearching`, `MarkAsWriting`, intermediate `SaveChangesAsync`) interleaved between steps. Option B would require either (a) keeping that interleaving in the job and still injecting concrete types — which gives no benefit over today, or (b) restructuring the job into a pure pipeline runner that loses the state-machine semantics. Neither is justified by any current requirement. Option A is reversible: re-introducing the interface is a one-file change if a future need arises.
+
+#### Decision 2: Atomicity and scope discipline
+**Options considered:** Single commit vs. five per-step commits.
+**Chosen approach:** Single commit covering all six edits (delete file + five class declaration edits) plus any incidental `dotnet format` output on touched files only.
+**Rationale:** NFR-4 (reversibility). One revert restores the prior state. Avoid drive-by edits to unrelated files in the same commit — surgical-changes rule from `CLAUDE.md`.
+
+#### Decision 3: Class declarations stay `public class`, not `public sealed class`
+**Options considered:** Keep `public class` as-is; or seal each step now that no interface forces extensibility expectations.
+**Chosen approach:** Keep `public class`.
+**Rationale:** Sealing is a behavior change outside this spec's scope. The brief asks to remove dead signal, not to add new constraints. FR-2 explicitly requires no other modifier changes.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+- **Delete:** `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`.
+- **Edit (declaration only):** the five `*Step.cs` files in the same folder. In each, change `public class XxxStep : IArticlePipelineStep` → `public class XxxStep`. No other lines in those files should change.
+- **No new files. No moves. No renames.**
+
+### Interfaces and Contracts
+- **No public/internal contract changes.** No interface, abstract base, or DI marker is introduced in place of `IArticlePipelineStep`. Step classes remain plain concrete services discoverable by their concrete type from the DI container.
+- **`ExecuteAsync(ArticlePipelineContext, CancellationToken)`** stays as the de facto convention across all five steps. It is enforced by `GenerateArticleJob`'s direct calls, not by a compiler-checked interface. This is acceptable because there is exactly one consumer.
+- **Documentation reference:** No mention of `IArticlePipelineStep` exists in published architecture docs (`docs/architecture/*`, `docs/features/*`). The only references outside the deleted/edited files are in a historical plan file at `docs/superpowers/plans/2026-05-08-article-generation-metadata.md`. That file is a frozen plan record, not living architecture documentation — leave it as a historical artifact; do not retroactively edit it.
+
+### Data Flow
+Unchanged. `GenerateArticleJob.RunAsync(articleId, ct)`:
+1. Loads `Article`, marks `Researching`, persists.
+2. Constructs `ArticlePipelineContext` with the article.
+3. Invokes `_planQueries → _gatherContext → _aggregateFacts → _validateFacts` directly on the concrete services, threading the context.
+4. Marks `Writing`, persists, invokes `_writeArticle`.
+5. Marks `Generated`, materializes `ArticleSource` rows from `context.SourceRefs`, persists.
+6. On cancel/exception: marks `Failed` with a non-cancellation token and persists.
+
+The deletion does not touch any branch of this flow.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hidden external consumer outside the solution (e.g., a generated client, reflection-based discovery) | Low | Repo-wide grep confirms zero non-implementer references; module is internal to `Anela.Heblo.Application`. Confirm again post-edit with `grep -r "IArticlePipelineStep"` returning zero hits. |
+| Future need for polymorphic step injection re-emerges shortly after deletion | Low | Reintroducing the interface costs ~6 lines plus DI changes. Decision is explicitly reversible (NFR-4). Mention in PR description that Option B remains available. |
+| `dotnet format` rewrites unrelated whitespace and inflates the diff | Low | Run `dotnet format --include` scoped to the six touched files before committing; reject unrelated reformatting hunks at review time. |
+| Test project still compiles only because no test referenced the interface today; a partially-merged branch elsewhere may add such a reference | Low | Verify against `main` (no such reference exists at HEAD) and rebase/backmerge before merging. |
+| Stale references in historical planning docs cause future-reader confusion | Negligible | Leave `docs/superpowers/plans/2026-05-08-article-generation-metadata.md` untouched (historical artifact). The spec already excludes it via "Documentation updates beyond removing stale references". |
+
+## Specification Amendments
+
+The spec is internally consistent and grounded in the code. Two clarifications to add before implementation:
+
+1. **FR-4 wording:** Replace "If any unit or integration test asserts against, mocks, or names `IArticlePipelineStep`, it must be updated" with the verified state: "A repository-wide search at HEAD confirms no test references `IArticlePipelineStep`. The acceptance criterion reduces to verifying that `grep -r 'IArticlePipelineStep' backend/test` returns zero matches after the change." This avoids implying that test edits are expected when none are.
+
+2. **FR-3 byte-equivalence clause:** The phrase "byte-equivalent to pre-change state" in FR-3 is too strict if `dotnet format` runs over the file. Soften to "functionally and textually equivalent ignoring formatter-induced whitespace; no registered service, lifetime, or registration order changes." This matches NFR-3 intent without booby-trapping the implementer on incidental formatting.
+
+3. **Historical plan file:** Add to "Out of Scope" an explicit clause: "Historical plan documents under `docs/superpowers/plans/` are frozen artifacts and must not be edited as part of this change."
+
+No other amendments needed.
+
+## Prerequisites
+
+None. The change is self-contained within the Article module and requires:
+- No migrations.
+- No configuration changes.
+- No new packages or version bumps.
+- No infrastructure provisioning.
+- No coordination with other in-flight branches (verified — no open PR touches these files at HEAD per `git status` clean and recent commits unrelated to the pipeline interface).
+
+Implementation can start immediately. Validation gates per `CLAUDE.md`: `dotnet build`, `dotnet format`, and `dotnet test` on the touched test project (`Anela.Heblo.Tests`).

--- a/artifacts/feat-arch-review-article-iarticlepipelinestep/brief.md
+++ b/artifacts/feat-arch-review-article-iarticlepipelinestep/brief.md
@@ -1,0 +1,38 @@
+## Module
+Article
+
+## Finding
+`IArticlePipelineStep.cs` defines:
+
+```csharp
+public interface IArticlePipelineStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+All five pipeline step classes implement it (`PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`), but:
+
+1. `GenerateArticleJob.cs:14-18` injects the five concrete types directly — not via `IArticlePipelineStep`.
+2. `ArticleModule.cs:21-25` registers each step as its concrete type — not by interface.
+
+No code anywhere resolves or injects `IArticlePipelineStep`.
+
+## Why it matters
+- The interface is dead code that adds false signal: a reader expects the abstraction to be used somewhere for polymorphism or testability, but it is not.
+- `GenerateArticleJob` tests (when written) must mock the five concrete types, not a single interface, giving up the benefit the interface was presumably created for.
+- YAGNI: the sequential, fixed pipeline does not need runtime-swappable steps; if it ever does, the interface can be introduced then.
+
+## Suggested fix
+Two valid options:
+
+**Option A — Remove the interface** (smallest change, honest about current use):
+Delete `IArticlePipelineStep.cs`. Each step remains a plain class. The pipeline is hard-coded and that is fine for now.
+
+**Option B — Actually use the interface** (if testability is the motivation):
+Register each step by interface in `ArticleModule.cs` and inject `IEnumerable<IArticlePipelineStep>` (or individual named registrations) in `GenerateArticleJob`. Tests can then mock `IArticlePipelineStep` instead of concrete classes.
+
+Option A is recommended unless there is a specific plan to add runtime step composition.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-article-iarticlepipelinestep/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-iarticlepipelinestep/impl/main.r1.md
@@ -1,0 +1,12 @@
+Normal repo (not a linked worktree). Named branch on `feat-arch-review-article-iarticlepipelinestep`. Standard 4 options apply.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-article-iarticlepipelinestep/spec.r1.md
+++ b/artifacts/feat-arch-review-article-iarticlepipelinestep/spec.r1.md
@@ -1,0 +1,112 @@
+# Specification: Remove Unused `IArticlePipelineStep` Interface
+
+## Summary
+The `IArticlePipelineStep` interface in the Article module is dead code — declared and implemented by five pipeline step classes, but never consumed via the abstraction (DI registration and injection both use concrete types). This spec removes the interface to eliminate false architectural signal, following YAGNI. If runtime step composition or polymorphic testability is needed in the future, the interface can be reintroduced at that time.
+
+## Background
+Architecture review on 2026-05-25 surfaced that `IArticlePipelineStep.cs` defines a single-method contract:
+
+```csharp
+public interface IArticlePipelineStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+Five classes implement it: `PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`.
+
+However:
+- `GenerateArticleJob.cs:14-18` injects the five concrete step types directly into its constructor — not the interface.
+- `ArticleModule.cs:21-25` registers each step under its concrete type with the DI container — not against the interface.
+- A repository-wide search reveals no consumer that resolves or injects `IArticlePipelineStep`.
+
+The interface therefore exists as documentation only — it implies a polymorphism or testability benefit that the code does not realize. A reader encountering the interface reasonably expects to find `IEnumerable<IArticlePipelineStep>` injected somewhere, a step factory, or mocks of the interface in tests. None of these exist.
+
+The pipeline is fixed and sequential. There is no requirement (current or in any backlog) for runtime-swappable steps. Option A from the brief (remove the interface) is the recommended path because it is honest about current usage, smaller in blast radius, and reversible.
+
+## Functional Requirements
+
+### FR-1: Delete the `IArticlePipelineStep` interface file
+The file `IArticlePipelineStep.cs` (within the Article module's pipeline namespace) must be removed from the repository.
+
+**Acceptance criteria:**
+- `IArticlePipelineStep.cs` no longer exists in the working tree.
+- No remaining file under the solution references the symbol `IArticlePipelineStep` (verified via repository-wide search).
+
+### FR-2: Remove `IArticlePipelineStep` from step class declarations
+Each of the five step classes — `PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep` — currently declares `: IArticlePipelineStep`. The interface implementation marker must be removed from each class declaration. The `ExecuteAsync(ArticlePipelineContext, CancellationToken)` method on each class must remain unchanged — same signature, same body, same accessibility.
+
+**Acceptance criteria:**
+- None of the five step classes lists `IArticlePipelineStep` in its base type list.
+- Each step class still exposes `public Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct)` with identical signature and behavior to before the change.
+- No other public, protected, or internal members of these classes are added, removed, or renamed.
+
+### FR-3: Preserve DI registrations and job composition
+`ArticleModule.cs:21-25` already registers each step by its concrete type. `GenerateArticleJob.cs:14-18` already injects the five concrete step types. Neither registration nor injection should change. The pipeline must continue to execute the five steps in the same order with the same context.
+
+**Acceptance criteria:**
+- `ArticleModule.cs` registrations for the five step types are byte-equivalent to pre-change state (excluding any incidental whitespace).
+- `GenerateArticleJob` constructor parameters and execution order are unchanged.
+- Running `GenerateArticleJob` against an existing scenario produces the same observable behavior (same calls to downstream services, same `ArticlePipelineContext` mutations, same article output) as before.
+
+### FR-4: Update or remove tests that reference the interface
+If any unit or integration test asserts against, mocks, or names `IArticlePipelineStep`, it must be updated to reference the concrete step types (or removed if it only verifies the interface's existence). Test behavior must continue to validate the pipeline's functional outputs.
+
+**Acceptance criteria:**
+- No test file references `IArticlePipelineStep`.
+- All Article-module tests pass (`dotnet test` for the relevant test project).
+- Test coverage for the Article module does not regress.
+
+### FR-5: Build, format, and validation clean
+After the changes, the solution must build cleanly and pass formatting checks.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with zero new warnings related to the change.
+- `dotnet format` produces no diff against the committed files.
+- All previously passing tests still pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected — the change is purely a type-system cleanup. Runtime behavior, allocation profile, and method dispatch are identical (the interface was never resolved at runtime).
+
+### NFR-2: Security
+No security surface affected. The interface carried no authorization, no input validation, and no cryptographic responsibilities. No secrets, no user input, no external boundaries are touched.
+
+### NFR-3: Maintainability
+Primary driver for this change. After completion, a reader of the Article pipeline code will see exactly what executes — concrete step classes injected into `GenerateArticleJob` — without an abstraction that implies unused flexibility.
+
+### NFR-4: Reversibility
+The change must be a single, atomic commit (or a small, easily-reverted set of commits) so it can be rolled back trivially if a future requirement reintroduces the need for the interface.
+
+## Data Model
+No data model changes. No entities, database schemas, or persisted contracts are affected.
+
+## API / Interface Design
+- **Public HTTP/MediatR contracts:** unchanged.
+- **OpenAPI client:** unchanged (the interface is internal to the Article module).
+- **DI container surface:** unchanged externally; each step continues to be resolvable by its concrete type.
+- **Internal C# surface:** `IArticlePipelineStep` is removed. The five step classes lose one interface from their declaration but retain their `ExecuteAsync` method.
+
+No UI flows, no public API endpoints, no events, and no cross-module contracts are affected.
+
+## Dependencies
+- Article module source (`backend/.../Article/...`) — exact paths per `docs/architecture/filesystem.md`.
+- Article module DI registration (`ArticleModule.cs`).
+- Article module job composition (`GenerateArticleJob.cs`).
+- Article module test project (any tests that reference the interface).
+
+No external libraries, no NuGet packages, no third-party services are involved.
+
+## Out of Scope
+- **Introducing `IEnumerable<IArticlePipelineStep>` injection (Option B from the brief).** Explicitly not pursued — there is no current need for runtime step composition.
+- **Refactoring `GenerateArticleJob` to use a step collection or pipeline builder pattern.** Out of scope; the fixed sequential composition is acceptable.
+- **Adding new tests beyond what is needed to keep coverage stable.** This is a deletion, not a feature.
+- **Renaming, restructuring, or moving the step classes themselves.** Only the interface implementation marker is removed; class names, namespaces, and file paths stay put.
+- **Documentation updates beyond removing stale references.** If the interface is mentioned in `docs/` it should be removed; no new architecture docs are written.
+- **Performance tuning of the pipeline.** Untouched.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-iarticlepipelinestep/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-iarticlepipelinestep/task-plan.r1.md
@@ -1,0 +1,468 @@
+# Remove Unused `IArticlePipelineStep` Interface — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the dead `IArticlePipelineStep` interface and strip its implementation marker from the five step classes in the Article generation pipeline, with zero behavior change.
+
+**Architecture:** Pure deletion. `GenerateArticleJob` and `ArticleModule` already use concrete step types — the interface is documentation-only. After the change, each `*Step` class becomes a plain concrete service registered and injected by its concrete type. No DI wiring, no method signatures, and no data flow change.
+
+**Tech Stack:** C# / .NET 8, xUnit + FluentAssertions tests, Clean Architecture monorepo. No new dependencies.
+
+---
+
+## File Structure
+
+**Files affected (all in `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/`):**
+
+| File | Action |
+|------|--------|
+| `IArticlePipelineStep.cs` | **Delete** |
+| `PlanQueriesStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `GatherContextStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `AggregateFactsStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `ValidateFactsStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `WriteArticleStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+
+**Files NOT touched (verified — already concrete-typed):**
+
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — registers each step under its concrete type.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs` — injects concrete step types and invokes them in fixed order.
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/*StepTests.cs` and `GenerateArticleJobTests.cs` — confirmed via grep to contain zero references to `IArticlePipelineStep`.
+- `docs/superpowers/plans/2026-05-08-article-generation-metadata.md` — historical plan record, frozen artifact, do not edit (per arch-review spec amendment).
+
+**Single commit covers all edits** (per NFR-4 reversibility and arch-review Decision 2). Do not split into multiple commits and do not bundle unrelated changes.
+
+---
+
+## Pre-flight Verification
+
+### Task 0: Confirm baseline state
+
+**Files:**
+- Inspect: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/`
+- Inspect: `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`
+- Inspect: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`
+
+- [ ] **Step 0.1: Verify the interface still exists at HEAD**
+
+Run: `ls backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+Expected: file exists.
+
+- [ ] **Step 0.2: Verify the baseline reference set**
+
+Run: `grep -rn "IArticlePipelineStep" backend/ docs/`
+Expected output (exactly seven hits, six in code + one historical doc):
+
+```
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs: ... interface IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs: public class PlanQueriesStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs: public class GatherContextStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs: public class AggregateFactsStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs: public class ValidateFactsStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs: public class WriteArticleStep : IArticlePipelineStep
+docs/superpowers/plans/2026-05-08-article-generation-metadata.md: <historical reference>
+```
+
+If the count is anything other than `interface declaration (1) + 5 step classes (5) + historical plan (1) = 7 hits`, STOP and investigate before editing. New consumers may have been added since the spec was written.
+
+- [ ] **Step 0.3: Establish a clean baseline build and test run**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds, zero errors.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Article" --no-build`
+Expected: all Article-module tests pass.
+
+Record the pre-change test count (you will compare after the edits).
+
+---
+
+## Task 1: Delete the `IArticlePipelineStep` interface file
+
+**Files:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+
+- [ ] **Step 1.1: Confirm the file contents before deletion**
+
+The file contains exactly:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+public interface IArticlePipelineStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+If the file contains anything else (additional methods, doc comments, attributes, sibling types), STOP — the spec assumed a single empty-body interface only. Surface the discrepancy before proceeding.
+
+- [ ] **Step 1.2: Delete the file**
+
+Run: `git rm backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+Expected: file is staged for deletion; `git status` shows `deleted: ...IArticlePipelineStep.cs`.
+
+- [ ] **Step 1.3: Verify the file no longer exists**
+
+Run: `ls backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+Expected: `No such file or directory`.
+
+---
+
+## Task 2: Remove interface marker from `PlanQueriesStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs:10`
+
+- [ ] **Step 2.1: Edit the class declaration**
+
+Change the single line at the class declaration. The exact change is:
+
+Old line:
+
+```csharp
+public class PlanQueriesStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class PlanQueriesStep
+```
+
+No other lines in the file change. Constructor, fields, `ExecuteAsync(...)`, helpers (`BuildFallback`, `QueryPlanOutput`), and `using` directives stay exactly as-is.
+
+- [ ] **Step 2.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs`
+Expected: a single-line removal (`- ...PlanQueriesStep : IArticlePipelineStep`) and a single-line addition (`+ ...PlanQueriesStep`). No other diff hunks.
+
+If `dotnet format` or your editor reformatted the file, revert and redo with a precise edit.
+
+---
+
+## Task 3: Remove interface marker from `GatherContextStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs:12`
+
+- [ ] **Step 3.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class GatherContextStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class GatherContextStep
+```
+
+No other lines change.
+
+- [ ] **Step 3.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 4: Remove interface marker from `AggregateFactsStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs:11`
+
+- [ ] **Step 4.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class AggregateFactsStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class AggregateFactsStep
+```
+
+No other lines change.
+
+- [ ] **Step 4.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 5: Remove interface marker from `ValidateFactsStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs:11`
+
+- [ ] **Step 5.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class ValidateFactsStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class ValidateFactsStep
+```
+
+No other lines change.
+
+- [ ] **Step 5.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 6: Remove interface marker from `WriteArticleStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs:15`
+
+- [ ] **Step 6.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class WriteArticleStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class WriteArticleStep
+```
+
+No other lines change.
+
+- [ ] **Step 6.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 7: Verify no references remain
+
+- [ ] **Step 7.1: Repository-wide grep for the deleted symbol**
+
+Run: `grep -rn "IArticlePipelineStep" backend/`
+Expected: zero matches.
+
+Run: `grep -rn "IArticlePipelineStep" docs/superpowers/plans/2026-05-08-article-generation-metadata.md`
+Expected: matches in this historical plan file are acceptable and intentionally untouched (per arch-review "Out of Scope" amendment 3). Do not edit this file.
+
+If any hit appears under `backend/` (including tests, generated code, or comments), STOP — find and address the consumer before continuing. The spec assumed zero remaining consumers.
+
+- [ ] **Step 7.2: Confirm the file deletion is staged**
+
+Run: `git status`
+Expected output includes:
+
+```
+deleted:    backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+No other files should appear in the diff.
+
+---
+
+## Task 8: Verify DI registration and job composition are unchanged
+
+This is a guard against accidental drift. The arch-review's FR-3 amendment explicitly requires "functionally and textually equivalent ignoring formatter-induced whitespace; no registered service, lifetime, or registration order changes."
+
+- [ ] **Step 8.1: Re-confirm `ArticleModule.cs` is byte-equivalent to HEAD (modulo whitespace)**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`
+Expected: empty diff.
+
+The file should still contain (lines 19-25):
+
+```csharp
+services.AddScoped<PipelineStepRecorder>();
+services.AddScoped<PlanQueriesStep>();
+services.AddScoped<GatherContextStep>();
+services.AddScoped<AggregateFactsStep>();
+services.AddScoped<ValidateFactsStep>();
+services.AddScoped<WriteArticleStep>();
+services.AddScoped<GenerateArticleJob>();
+```
+
+- [ ] **Step 8.2: Re-confirm `GenerateArticleJob.cs` is byte-equivalent to HEAD**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`
+Expected: empty diff.
+
+The file should still inject the five concrete step types in the constructor (lines 20-27) and invoke them in fixed order inside `RunAsync` (lines 53-61).
+
+---
+
+## Task 9: Build verification
+
+- [ ] **Step 9.1: Build the solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds with zero errors and zero new warnings (compared to the pre-change baseline from Task 0.3).
+
+If a `CS0246` "type or namespace name 'IArticlePipelineStep' could not be found" appears anywhere, you missed a reference — go back to Task 7.1 and grep again.
+
+---
+
+## Task 10: Format verification
+
+- [ ] **Step 10.1: Run formatter scoped to touched files only**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+Expected: no output (formatter is satisfied) or only trivial whitespace adjustments. Do not let the formatter touch any files outside this `--include` list.
+
+- [ ] **Step 10.2: Verify formatter produced no unrelated diff**
+
+Run: `git diff --stat`
+Expected: only the six file paths above appear (5 modified + 1 deleted). If any other file appears, STOP and revert that file — the formatter overreached.
+
+---
+
+## Task 11: Test verification
+
+- [ ] **Step 11.1: Run all Article-module tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Article"`
+Expected: all tests pass with the same test count as the pre-change baseline (Task 0.3). No skipped, no errored, no new failures.
+
+The test files (`PlanQueriesStepTests`, `GatherContextStepTests`, `AggregateFactsStepTests`, `ValidateFactsStepTests`, `WriteArticleStepTests`, `GenerateArticleJobTests`) instantiate step classes by their concrete type and call `ExecuteAsync` directly, so they should continue to compile and pass without any edits.
+
+- [ ] **Step 11.2: Run the full test project as a regression guard**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: same pass/fail/skip counts as before the change. Any new failure outside the Article module indicates collateral damage and must be diagnosed before commit.
+
+---
+
+## Task 12: Final cross-check
+
+- [ ] **Step 12.1: Re-grep to confirm zero remaining backend references**
+
+Run: `grep -rn "IArticlePipelineStep" backend/`
+Expected: zero matches. (Repeat of Task 7.1 — intentional belt-and-braces.)
+
+- [ ] **Step 12.2: Confirm `git diff` covers exactly six files**
+
+Run: `git diff --name-status HEAD`
+Expected output (order may vary):
+
+```
+D       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+Exactly 1 `D` (deletion) and 5 `M` (modifications). Nothing else.
+
+---
+
+## Task 13: Commit
+
+- [ ] **Step 13.1: Stage all six files**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+- [ ] **Step 13.2: Verify staged changes**
+
+Run: `git status`
+Expected: the six paths under "Changes to be committed", nothing under "Changes not staged for commit" except possibly the plan file itself.
+
+- [ ] **Step 13.3: Create the commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(article): remove unused IArticlePipelineStep interface
+
+The interface was never resolved or injected via the abstraction — DI
+registers concrete step types and GenerateArticleJob injects them
+directly. Deleting it removes false architectural signal (YAGNI). The
+five step classes keep their concrete public ExecuteAsync method; DI
+wiring, job composition, and runtime behavior are unchanged.
+
+If runtime step composition is needed later, reintroducing the
+interface is a ~6-line change (Option B from the brief).
+EOF
+)"
+```
+
+Expected: a single commit with one file deletion and five file modifications.
+
+- [ ] **Step 13.4: Confirm the commit is clean**
+
+Run: `git show --stat HEAD`
+Expected: exactly six files affected (1 deletion, 5 modifications). Diff stat should show small line counts (≈1 line changed per step file, ≈7 lines removed for the interface file).
+
+---
+
+## Acceptance Criteria Trace (Spec → Plan)
+
+| Spec requirement | Covered by |
+|---|---|
+| FR-1: Delete `IArticlePipelineStep.cs`; no remaining references | Tasks 1, 7.1, 12.1 |
+| FR-2: Remove interface marker from 5 step classes; preserve `ExecuteAsync` and all other members | Tasks 2–6 (declaration-only edit, diff verification on each) |
+| FR-3 (amended): DI registration and job composition functionally + textually equivalent ignoring whitespace; no lifetime or order changes | Task 8 (empty diff on `ArticleModule.cs` and `GenerateArticleJob.cs`) |
+| FR-4 (amended): verify zero test references via grep (no test edits expected) | Task 7.1, 12.1 |
+| FR-5: `dotnet build` clean, `dotnet format` no diff on committed files, all tests pass | Tasks 9, 10, 11 |
+| NFR-1: no performance impact | Implicit — no runtime change; pipeline still drives concrete services in fixed order |
+| NFR-2: no security surface | Implicit — no input, auth, secrets, or boundaries touched |
+| NFR-3: maintainability — reader sees concrete pipeline composition only | Achieved via Tasks 1–6 |
+| NFR-4: single atomic, easily revertable commit | Task 13 (single commit) |
+| Arch-review amendment 3: do not edit historical plan doc | Tasks 7.1, 10.2, 12.2 (verify no unrelated files in diff) |
+
+---
+
+## Out-of-Scope Reminders
+
+Do not, as part of this change:
+
+- Introduce `IEnumerable<IArticlePipelineStep>` injection or any new abstraction (Option B from the brief).
+- Add `sealed` modifiers to step classes (arch-review Decision 3).
+- Refactor `GenerateArticleJob` into a step-collection runner.
+- Rename, move, or restructure step classes or their files.
+- Edit `docs/superpowers/plans/2026-05-08-article-generation-metadata.md` or any other historical plan record.
+- Reformat unrelated files via a broad `dotnet format` run.
+- Add or remove tests beyond what's needed to keep the suite green (no edits expected per Task 7.1 grep).

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class AggregateFactsStep : IArticlePipelineStep
+public class AggregateFactsStep
 {
     private const int MaxSnippets = 50;
 

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
@@ -9,7 +9,7 @@ using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class GatherContextStep : IArticlePipelineStep
+public class GatherContextStep
 {
     private readonly IMediator _mediator;
     private readonly IWebSearchClient _webSearch;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs
@@ -1,6 +1,0 @@
-namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
-
-public interface IArticlePipelineStep
-{
-    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
-}

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class PlanQueriesStep : IArticlePipelineStep
+public class PlanQueriesStep
 {
     private const int MaxQueries = 8;
 

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class ValidateFactsStep : IArticlePipelineStep
+public class ValidateFactsStep
 {
     private readonly IChatClient _chat;
     private readonly ArticleOptions _options;

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
 
-public class WriteArticleStep : IArticlePipelineStep
+public class WriteArticleStep
 {
     private readonly IChatClient _chat;
     private readonly ArticleOptions _options;

--- a/docs/superpowers/plans/2026-05-25-remove-iarticlepipelinestep.md
+++ b/docs/superpowers/plans/2026-05-25-remove-iarticlepipelinestep.md
@@ -1,0 +1,468 @@
+# Remove Unused `IArticlePipelineStep` Interface — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the dead `IArticlePipelineStep` interface and strip its implementation marker from the five step classes in the Article generation pipeline, with zero behavior change.
+
+**Architecture:** Pure deletion. `GenerateArticleJob` and `ArticleModule` already use concrete step types — the interface is documentation-only. After the change, each `*Step` class becomes a plain concrete service registered and injected by its concrete type. No DI wiring, no method signatures, and no data flow change.
+
+**Tech Stack:** C# / .NET 8, xUnit + FluentAssertions tests, Clean Architecture monorepo. No new dependencies.
+
+---
+
+## File Structure
+
+**Files affected (all in `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/`):**
+
+| File | Action |
+|------|--------|
+| `IArticlePipelineStep.cs` | **Delete** |
+| `PlanQueriesStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `GatherContextStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `AggregateFactsStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `ValidateFactsStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+| `WriteArticleStep.cs` | Edit declaration only: drop `: IArticlePipelineStep` |
+
+**Files NOT touched (verified — already concrete-typed):**
+
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs` — registers each step under its concrete type.
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs` — injects concrete step types and invokes them in fixed order.
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/*StepTests.cs` and `GenerateArticleJobTests.cs` — confirmed via grep to contain zero references to `IArticlePipelineStep`.
+- `docs/superpowers/plans/2026-05-08-article-generation-metadata.md` — historical plan record, frozen artifact, do not edit (per arch-review spec amendment).
+
+**Single commit covers all edits** (per NFR-4 reversibility and arch-review Decision 2). Do not split into multiple commits and do not bundle unrelated changes.
+
+---
+
+## Pre-flight Verification
+
+### Task 0: Confirm baseline state
+
+**Files:**
+- Inspect: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/`
+- Inspect: `backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`
+- Inspect: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`
+
+- [ ] **Step 0.1: Verify the interface still exists at HEAD**
+
+Run: `ls backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+Expected: file exists.
+
+- [ ] **Step 0.2: Verify the baseline reference set**
+
+Run: `grep -rn "IArticlePipelineStep" backend/ docs/`
+Expected output (exactly seven hits, six in code + one historical doc):
+
+```
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs: ... interface IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs: public class PlanQueriesStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs: public class GatherContextStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs: public class AggregateFactsStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs: public class ValidateFactsStep : IArticlePipelineStep
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs: public class WriteArticleStep : IArticlePipelineStep
+docs/superpowers/plans/2026-05-08-article-generation-metadata.md: <historical reference>
+```
+
+If the count is anything other than `interface declaration (1) + 5 step classes (5) + historical plan (1) = 7 hits`, STOP and investigate before editing. New consumers may have been added since the spec was written.
+
+- [ ] **Step 0.3: Establish a clean baseline build and test run**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds, zero errors.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Article" --no-build`
+Expected: all Article-module tests pass.
+
+Record the pre-change test count (you will compare after the edits).
+
+---
+
+## Task 1: Delete the `IArticlePipelineStep` interface file
+
+**Files:**
+- Delete: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+
+- [ ] **Step 1.1: Confirm the file contents before deletion**
+
+The file contains exactly:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.UseCases.Generate.Pipeline;
+
+public interface IArticlePipelineStep
+{
+    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
+}
+```
+
+If the file contains anything else (additional methods, doc comments, attributes, sibling types), STOP — the spec assumed a single empty-body interface only. Surface the discrepancy before proceeding.
+
+- [ ] **Step 1.2: Delete the file**
+
+Run: `git rm backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+Expected: file is staged for deletion; `git status` shows `deleted: ...IArticlePipelineStep.cs`.
+
+- [ ] **Step 1.3: Verify the file no longer exists**
+
+Run: `ls backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs`
+Expected: `No such file or directory`.
+
+---
+
+## Task 2: Remove interface marker from `PlanQueriesStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs:10`
+
+- [ ] **Step 2.1: Edit the class declaration**
+
+Change the single line at the class declaration. The exact change is:
+
+Old line:
+
+```csharp
+public class PlanQueriesStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class PlanQueriesStep
+```
+
+No other lines in the file change. Constructor, fields, `ExecuteAsync(...)`, helpers (`BuildFallback`, `QueryPlanOutput`), and `using` directives stay exactly as-is.
+
+- [ ] **Step 2.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs`
+Expected: a single-line removal (`- ...PlanQueriesStep : IArticlePipelineStep`) and a single-line addition (`+ ...PlanQueriesStep`). No other diff hunks.
+
+If `dotnet format` or your editor reformatted the file, revert and redo with a precise edit.
+
+---
+
+## Task 3: Remove interface marker from `GatherContextStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs:12`
+
+- [ ] **Step 3.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class GatherContextStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class GatherContextStep
+```
+
+No other lines change.
+
+- [ ] **Step 3.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 4: Remove interface marker from `AggregateFactsStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs:11`
+
+- [ ] **Step 4.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class AggregateFactsStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class AggregateFactsStep
+```
+
+No other lines change.
+
+- [ ] **Step 4.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 5: Remove interface marker from `ValidateFactsStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs:11`
+
+- [ ] **Step 5.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class ValidateFactsStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class ValidateFactsStep
+```
+
+No other lines change.
+
+- [ ] **Step 5.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 6: Remove interface marker from `WriteArticleStep`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs:15`
+
+- [ ] **Step 6.1: Edit the class declaration**
+
+Old line:
+
+```csharp
+public class WriteArticleStep : IArticlePipelineStep
+```
+
+New line:
+
+```csharp
+public class WriteArticleStep
+```
+
+No other lines change.
+
+- [ ] **Step 6.2: Verify the rest of the file is untouched**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`
+Expected: exactly one removal hunk and one addition hunk on the declaration line.
+
+---
+
+## Task 7: Verify no references remain
+
+- [ ] **Step 7.1: Repository-wide grep for the deleted symbol**
+
+Run: `grep -rn "IArticlePipelineStep" backend/`
+Expected: zero matches.
+
+Run: `grep -rn "IArticlePipelineStep" docs/superpowers/plans/2026-05-08-article-generation-metadata.md`
+Expected: matches in this historical plan file are acceptable and intentionally untouched (per arch-review "Out of Scope" amendment 3). Do not edit this file.
+
+If any hit appears under `backend/` (including tests, generated code, or comments), STOP — find and address the consumer before continuing. The spec assumed zero remaining consumers.
+
+- [ ] **Step 7.2: Confirm the file deletion is staged**
+
+Run: `git status`
+Expected output includes:
+
+```
+deleted:    backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
+modified:   backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+No other files should appear in the diff.
+
+---
+
+## Task 8: Verify DI registration and job composition are unchanged
+
+This is a guard against accidental drift. The arch-review's FR-3 amendment explicitly requires "functionally and textually equivalent ignoring formatter-induced whitespace; no registered service, lifetime, or registration order changes."
+
+- [ ] **Step 8.1: Re-confirm `ArticleModule.cs` is byte-equivalent to HEAD (modulo whitespace)**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/ArticleModule.cs`
+Expected: empty diff.
+
+The file should still contain (lines 19-25):
+
+```csharp
+services.AddScoped<PipelineStepRecorder>();
+services.AddScoped<PlanQueriesStep>();
+services.AddScoped<GatherContextStep>();
+services.AddScoped<AggregateFactsStep>();
+services.AddScoped<ValidateFactsStep>();
+services.AddScoped<WriteArticleStep>();
+services.AddScoped<GenerateArticleJob>();
+```
+
+- [ ] **Step 8.2: Re-confirm `GenerateArticleJob.cs` is byte-equivalent to HEAD**
+
+Run: `git diff backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs`
+Expected: empty diff.
+
+The file should still inject the five concrete step types in the constructor (lines 20-27) and invoke them in fixed order inside `RunAsync` (lines 53-61).
+
+---
+
+## Task 9: Build verification
+
+- [ ] **Step 9.1: Build the solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds with zero errors and zero new warnings (compared to the pre-change baseline from Task 0.3).
+
+If a `CS0246` "type or namespace name 'IArticlePipelineStep' could not be found" appears anywhere, you missed a reference — go back to Task 7.1 and grep again.
+
+---
+
+## Task 10: Format verification
+
+- [ ] **Step 10.1: Run formatter scoped to touched files only**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+Expected: no output (formatter is satisfied) or only trivial whitespace adjustments. Do not let the formatter touch any files outside this `--include` list.
+
+- [ ] **Step 10.2: Verify formatter produced no unrelated diff**
+
+Run: `git diff --stat`
+Expected: only the six file paths above appear (5 modified + 1 deleted). If any other file appears, STOP and revert that file — the formatter overreached.
+
+---
+
+## Task 11: Test verification
+
+- [ ] **Step 11.1: Run all Article-module tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Anela.Heblo.Tests.Article"`
+Expected: all tests pass with the same test count as the pre-change baseline (Task 0.3). No skipped, no errored, no new failures.
+
+The test files (`PlanQueriesStepTests`, `GatherContextStepTests`, `AggregateFactsStepTests`, `ValidateFactsStepTests`, `WriteArticleStepTests`, `GenerateArticleJobTests`) instantiate step classes by their concrete type and call `ExecuteAsync` directly, so they should continue to compile and pass without any edits.
+
+- [ ] **Step 11.2: Run the full test project as a regression guard**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: same pass/fail/skip counts as before the change. Any new failure outside the Article module indicates collateral damage and must be diagnosed before commit.
+
+---
+
+## Task 12: Final cross-check
+
+- [ ] **Step 12.1: Re-grep to confirm zero remaining backend references**
+
+Run: `grep -rn "IArticlePipelineStep" backend/`
+Expected: zero matches. (Repeat of Task 7.1 — intentional belt-and-braces.)
+
+- [ ] **Step 12.2: Confirm `git diff` covers exactly six files**
+
+Run: `git diff --name-status HEAD`
+Expected output (order may vary):
+
+```
+D       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs
+M       backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+Exactly 1 `D` (deletion) and 5 `M` (modifications). Nothing else.
+
+---
+
+## Task 13: Commit
+
+- [ ] **Step 13.1: Stage all six files**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/IArticlePipelineStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/PlanQueriesStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/GatherContextStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/AggregateFactsStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/ValidateFactsStep.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+```
+
+- [ ] **Step 13.2: Verify staged changes**
+
+Run: `git status`
+Expected: the six paths under "Changes to be committed", nothing under "Changes not staged for commit" except possibly the plan file itself.
+
+- [ ] **Step 13.3: Create the commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor(article): remove unused IArticlePipelineStep interface
+
+The interface was never resolved or injected via the abstraction — DI
+registers concrete step types and GenerateArticleJob injects them
+directly. Deleting it removes false architectural signal (YAGNI). The
+five step classes keep their concrete public ExecuteAsync method; DI
+wiring, job composition, and runtime behavior are unchanged.
+
+If runtime step composition is needed later, reintroducing the
+interface is a ~6-line change (Option B from the brief).
+EOF
+)"
+```
+
+Expected: a single commit with one file deletion and five file modifications.
+
+- [ ] **Step 13.4: Confirm the commit is clean**
+
+Run: `git show --stat HEAD`
+Expected: exactly six files affected (1 deletion, 5 modifications). Diff stat should show small line counts (≈1 line changed per step file, ≈7 lines removed for the interface file).
+
+---
+
+## Acceptance Criteria Trace (Spec → Plan)
+
+| Spec requirement | Covered by |
+|---|---|
+| FR-1: Delete `IArticlePipelineStep.cs`; no remaining references | Tasks 1, 7.1, 12.1 |
+| FR-2: Remove interface marker from 5 step classes; preserve `ExecuteAsync` and all other members | Tasks 2–6 (declaration-only edit, diff verification on each) |
+| FR-3 (amended): DI registration and job composition functionally + textually equivalent ignoring whitespace; no lifetime or order changes | Task 8 (empty diff on `ArticleModule.cs` and `GenerateArticleJob.cs`) |
+| FR-4 (amended): verify zero test references via grep (no test edits expected) | Task 7.1, 12.1 |
+| FR-5: `dotnet build` clean, `dotnet format` no diff on committed files, all tests pass | Tasks 9, 10, 11 |
+| NFR-1: no performance impact | Implicit — no runtime change; pipeline still drives concrete services in fixed order |
+| NFR-2: no security surface | Implicit — no input, auth, secrets, or boundaries touched |
+| NFR-3: maintainability — reader sees concrete pipeline composition only | Achieved via Tasks 1–6 |
+| NFR-4: single atomic, easily revertable commit | Task 13 (single commit) |
+| Arch-review amendment 3: do not edit historical plan doc | Tasks 7.1, 10.2, 12.2 (verify no unrelated files in diff) |
+
+---
+
+## Out-of-Scope Reminders
+
+Do not, as part of this change:
+
+- Introduce `IEnumerable<IArticlePipelineStep>` injection or any new abstraction (Option B from the brief).
+- Add `sealed` modifiers to step classes (arch-review Decision 3).
+- Refactor `GenerateArticleJob` into a step-collection runner.
+- Rename, move, or restructure step classes or their files.
+- Edit `docs/superpowers/plans/2026-05-08-article-generation-metadata.md` or any other historical plan record.
+- Reformat unrelated files via a broad `dotnet format` run.
+- Add or remove tests beyond what's needed to keep the suite green (no edits expected per Task 7.1 grep).


### PR DESCRIPTION
Article

## Finding
`IArticlePipelineStep.cs` defines:

```csharp
public interface IArticlePipelineStep
{
    Task ExecuteAsync(ArticlePipelineContext context, CancellationToken ct);
}
```

All five pipeline step classes implement it (`PlanQueriesStep`, `GatherContextStep`, `AggregateFactsStep`, `ValidateFactsStep`, `WriteArticleStep`), but:

1. `GenerateArticleJob.cs:14-18` injects the five concrete types directly — not via `IArticlePipelineStep`.
2. `ArticleModule.cs:21-25` registers each step as its concrete type — not by interface.

No code anywhere resolves or injects `IArticlePipelineStep`.

## Why it matters
- The interface is dead code that adds false signal: a reader expects the abstraction to be used somewhere for polymorphism or testability, but it is not.
- `GenerateArticleJob` tests (when written) must mock the five concrete types, not a single interface, giving up the benefit the interface was presumably created for.
- YAGNI: the sequential, fixed pipeline does not need runtime-swappable steps; if it ever does, the interface can be introduced then.

## Suggested fix
Two valid options:

**Option A — Remove the interface** (smallest change, honest about current use):
Delete `IArticlePipelineStep.cs`. Each step remains a plain class. The pipeline is hard-coded and that is fine for now.

**Option B — Actually use the interface** (if testability is the motivation):
Register each step by interface in `ArticleModule.cs` and inject `IEnumerable<IArticlePipelineStep>` (or individual named registrations) in `GenerateArticleJob`. Tests can then mock `IArticlePipelineStep` instead of concrete classes.

Option A is recommended unless there is a specific plan to add runtime step composition.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1642

### Tokens used
10538936
