### PR TITLE
feat: Persist Currency, Description, and RawData on Imported Marketing Transactions

### DIFF
--- a/artifacts/feat-arch-review-marketinginvoices-currency-f/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-currency-f/arch-review.r1.md
@@ -1,0 +1,233 @@
+I have enough context. The codebase confirms: Vertical Slice + MediatR + EF Core, single `ApplicationDbContext`, manual migrations, existing precedent for "add-as-nullable → backfill → alter NOT NULL" (see `20251208184900_AddTransferIdColumnWithDataHandling`). The spec's proposal aligns with all existing patterns. Now I'll write the review.
+
+```markdown
+# Architecture Review: Persist Currency, Description, and RawData on Imported Marketing Transactions
+
+## Skip Design: true
+
+This is a backend-only data-layer change. No UI, no API surface change, no new visual components.
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with established patterns in this codebase:
+
+- **Vertical Slice + module boundary respected.** All touched files live inside the `MarketingInvoices` slice (Domain entity, Persistence configuration, Application service, Migrations). No cross-module reach (`development_guidelines.md` ADR-001, ADR-002, ADR-003).
+- **Single-DbContext / shared migrations folder convention** is honored — the migration lives in `Anela.Heblo.Persistence/Migrations/` and updates `ApplicationDbContextModelSnapshot.cs` (Phase 1 ADR).
+- **Add-nullable → backfill → alter-NOT-NULL** is an established migration pattern in this repo (see `20251208184900_AddTransferIdColumnWithDataHandling.cs:44-67`, which adds `TransferId` as nullable, runs `UPDATE … WHERE … IS NULL`, then `AlterColumn(nullable: false)`). The spec should follow this exact shape rather than the "ADD COLUMN … DEFAULT 'CZK' then drop default" variant it currently describes — the project's prior art uses the multi-step pattern, and it's safer because backfill is an explicit, reviewable SQL statement rather than an implicit side-effect of `DEFAULT`.
+- **Repository pattern** is unaffected; `IImportedMarketingTransactionRepository` does not need changes (purely additive on the entity).
+- **Domain entity is a `class`, not a `record`** — already correct per the project's "DTOs/entities are classes" gotcha (CLAUDE.md). Spec preserves this.
+- **Adapters already populate all three fields** — `GoogleAdsTransactionSource.cs:42-44` and `MetaAdsTransactionSource.cs:71-73` are unchanged-by-design. Existing adapter contracts are honored.
+- **Test seam is intact** — `MarketingInvoiceImportServiceTests.cs` already sets `Currency`/`Description` on its `MarketingTransaction` fixtures (lines 38-39, 74, 103-104, 139-140, 197-198), so existing tests will compile unchanged. New behavior gets new tests.
+
+The only architectural friction is FR-6's "skip on empty Currency" — see Decision 2 below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    Application slice: MarketingInvoices                 │
+│                                                                         │
+│  ImportMarketingInvoicesHandler  ──►  MarketingInvoiceImportService     │
+│  (MediatR, unchanged)                  (FR-5: extend object initializer,│
+│                                         FR-6: guard empty Currency)     │
+│                                              │                          │
+│                                              ▼                          │
+│                          IImportedMarketingTransactionRepository        │
+│                          (unchanged contract)                           │
+└────────────────────────────────────────────────┬────────────────────────┘
+                                                 │
+                                                 ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Domain: MarketingInvoices                                              │
+│                                                                         │
+│  ImportedMarketingTransaction (entity, IEntity<int>)                    │
+│  ── +Currency : string                                                  │
+│  ── +Description : string?                                              │
+│  ── +RawData : string?                                                  │
+└────────────────────────────────────────────────┬────────────────────────┘
+                                                 │
+                                                 ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Persistence: MarketingInvoices                                         │
+│                                                                         │
+│  ImportedMarketingTransactionConfiguration                              │
+│  ── +Property(Currency)    column varchar(3), NOT NULL                  │
+│  ── +Property(Description) column varchar(500), nullable                │
+│  ── +Property(RawData)     column text, nullable                        │
+│                                                                         │
+│  Migrations/{ts}_AddCurrencyDescriptionRawDataToImportedMarketing…cs    │
+│  (add-nullable → backfill 'CZK' → alter NOT NULL → snapshot updated)    │
+└─────────────────────────────────────────────────────────────────────────┘
+
+Adapters (UNCHANGED, already producing all three fields):
+  GoogleAdsTransactionSource  ──►  MarketingTransaction { Currency, Description, RawData, … }
+  MetaAdsTransactionSource    ──►  MarketingTransaction { Currency, Description, RawData, … }
+```
+
+### Key Design Decisions
+
+#### Decision 1: Migration mechanics — add-nullable + UPDATE + alter, not DEFAULT-then-drop-default
+
+**Options considered:**
+- **(A) Spec's current approach:** `ADD COLUMN Currency varchar(3) NOT NULL DEFAULT 'CZK'`, then `ALTER COLUMN … DROP DEFAULT` (encoded as `AlterColumn` without `DefaultValue`).
+- **(B) Three-step pattern used elsewhere in this repo:** `AddColumn(nullable: true)` → `migrationBuilder.Sql("UPDATE … SET Currency = 'CZK' WHERE Currency IS NULL")` → `AlterColumn(nullable: false)`.
+
+**Chosen approach:** (B). The migration should follow the same shape as `20251208184900_AddTransferIdColumnWithDataHandling.cs`.
+
+**Rationale:**
+- Backfill becomes an explicit, reviewable SQL statement. A future reader reading the migration sees the assumption `'CZK'` on its own line, not implied via a transient `DEFAULT` clause.
+- Generating this from EF tooling is cleaner: `dotnet ef migrations add …` does not natively emit "add with default then drop default" — you'd hand-edit the generated file. The three-step pattern can be expressed with a one-line `migrationBuilder.Sql(…)` inserted between two generated calls.
+- `AlterColumn` to change a NOT NULL constraint after backfill is exactly what the prior migration does; reviewers will recognize the pattern.
+
+#### Decision 2: Empty-Currency policy — fail-loud with explicit per-source override, or always-skip?
+
+**Options considered:**
+- **(A) Spec's FR-6:** Silently skip and count under `result.Failed` with a warning log.
+- **(B) Reject loudly:** Treat empty Currency as a programming error in the adapter, throw a domain exception, fail the whole import batch.
+- **(C) Skip + log, AND emit a metric / structured event so ops sees it.**
+
+**Chosen approach:** (A) as specified, with one tightening — see Spec Amendment 1.
+
+**Rationale:**
+- (B) is too aggressive: a transient bad row from an upstream API would poison the whole batch. The existing per-transaction `try/catch` in `MarketingInvoiceImportService.cs:37-79` already establishes "isolate per-row failures, keep going" as the project's import philosophy.
+- (A) is consistent with that philosophy. It does need to be counted as `Failed` (not `Skipped`), because `Skipped` in the existing service means "duplicate / already-imported" — a benign condition. Currency missing is a real defect, and conflating it with duplicates would hide it. The spec already gets this right.
+- (C) is YAGNI today — the warning log with structured `TransactionId` + `Platform` properties is already pickup-able by whatever log aggregator exists, and there is no metrics infrastructure in scope here.
+
+**Important nuance the spec doesn't state explicitly:** FR-6's guard must run **before** the duplicate-check (`ExistsAsync`) and before staging. Otherwise a malformed row would still consume a DB round-trip for `ExistsAsync`. See Spec Amendment 2.
+
+#### Decision 3: Column types and sizes
+
+**Options considered:**
+- **Currency:** `varchar(3)` vs `char(3)` vs unbounded `text`.
+- **Description:** `varchar(500)` vs `text`.
+- **RawData:** `text` vs `jsonb`.
+
+**Chosen approach:** Spec is correct as-is: `varchar(3)` / `varchar(500)` / `text`.
+
+**Rationale:**
+- `varchar(3)` matches ISO 4217 alphabetic codes and provides a cheap, defense-in-depth check against an upstream adapter accidentally writing `"EURO"`. `char(3)` would pad with spaces in some Postgres clients — undesirable.
+- `varchar(500)` is generous for `Description` (Google Ads campaign names cap well under that; Meta `payment_type` is a short enum string).
+- `text` for `RawData` is correct: payload size is unbounded and `jsonb` would force Postgres to validate JSON on every write, which the spec correctly rejects in "Out of Scope" (no validation of source payloads). Stay with `text`.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+All changes are edits to existing files plus one new migration. No new directories.
+
+| File | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` | Add three properties: `Currency` (non-nullable, default `string.Empty`), `Description` (`string?`), `RawData` (`string?`). |
+| `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` | Add three `builder.Property(…)` calls matching the existing style (explicit `HasColumnName`, `HasColumnType`, `IsRequired()` for Currency only). |
+| `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` | Extend the object initializer at lines 58-66 with the three fields. Insert the empty-Currency guard **before** the duplicate-check at line 39 (see Spec Amendment 2). |
+| `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` | New file. Three-step `Currency` migration (add-nullable, backfill `'CZK'`, alter NOT NULL); plain add-nullable for `Description` and `RawData`. |
+| `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` | Regenerated automatically by `dotnet ef migrations add`. |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Add three new test cases: (1) Currency round-trips non-CZK value, (2) Description+RawData round-trip, (3) empty Currency increments `Failed`, logs warning, does not call `AddAsync`. |
+
+### Interfaces and Contracts
+
+**No public interface changes.** Specifically unchanged:
+
+- `IMarketingTransactionSource` — adapters already populate the fields; no contract amendment.
+- `IImportedMarketingTransactionRepository` — purely additive entity changes are transparent to the repository surface.
+- `ImportMarketingInvoicesRequest` / `Response` MediatR DTOs — no new fields.
+
+**Internal signature change inside `MarketingInvoiceImportService`:** none — the existing `ImportAsync(source, from, to, ct)` signature stays. Only the body changes.
+
+### Data Flow
+
+For a single transaction during import:
+
+```
+1. ImportMarketingInvoicesHandler.Handle
+     resolves IMarketingTransactionSource by Platform
+2. MarketingInvoiceImportService.ImportAsync
+     source.GetTransactionsAsync → List<MarketingTransaction>   (already carries Currency/Desc/RawData)
+3. For each MarketingTransaction:
+   a. [NEW — Spec Amendment 2] if string.IsNullOrWhiteSpace(transaction.Currency)
+        → _logger.LogWarning(TransactionId, Platform, "missing currency, skipping")
+        → result.Failed++
+        → continue
+   b. if stagedIds.Contains(TransactionId)  → Skipped++, continue   (unchanged)
+   c. if await _repository.ExistsAsync(…)   → Skipped++, continue   (unchanged)
+   d. Construct ImportedMarketingTransaction with all 7 mapped fields incl. Currency/Desc/RawData
+   e. await _repository.AddAsync(entity, ct)
+4. await _repository.SaveChangesAsync(ct)                          (single flush, unchanged)
+```
+
+The flush remains a single `SaveChangesAsync` call — NFR-1 holds because nothing new touches the DB per-row.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Existing production rows are not 100% CZK; backfill mis-labels them. | High | Per the spec's open question: run `SELECT DISTINCT Platform, COUNT(*) FROM "ImportedMarketingTransactions"` on staging/prod and cross-check with the source ad accounts' billing currencies **before** running the migration in prod. If any non-CZK accounts have imported historically, change the backfill SQL to a per-Platform `CASE WHEN Platform = 'GoogleAds' THEN 'EUR' …` mapping, or null-out the column and only enforce NOT NULL on rows newer than `now()`. Solo-dev project + manual migrations (CLAUDE.md project facts) makes this verification easy. |
+| Currency string from upstream isn't a valid ISO 4217 code (typo, "eur" lowercase, "EURO"). | Medium | Out of scope per spec, but flag: if Meta Ads ever returns `"eur"` lowercased, downstream queries like `WHERE Currency = 'EUR'` will silently miss it. Acceptable for now; consider a normalization (`ToUpperInvariant()`) in a follow-up. Do **not** add ISO-4217 enum validation now — adapter responsibility per spec. |
+| FR-6 skip-on-empty changes the meaning of `result.Failed` — callers (Hangfire job, monitoring) may interpret a non-zero `Failed` differently when its causes broaden. | Low | The existing per-transaction `catch` in `MarketingInvoiceImportService.cs:72-79` already increments `Failed` for unexpected exceptions, so "Failed includes non-DB errors" is already true. The empty-Currency case slots into existing semantics. No caller change needed; verify via the existing tests at lines 95-128. |
+| RawData column holds raw API payloads that may contain secrets (access tokens, account IDs). | Medium | Inspect what `JsonSerializer.Serialize(item)` actually emits for both adapters — `MetaAdsTransactionSource.cs:113` uses `access_token` in URLs but not in the `item` model fields (which are `id`, `time`, `amount`, `currency`, `payment_type`). Google Ads `r` should be inspected too. If any token/secret appears in serialized payloads, redact in the adapter **before** assigning `RawData`. Out of scope for this spec, but call out in code review. |
+| `Description` truncation to 500 chars silently drops data. | Low | Google Ads `Name` is well under 500; Meta `PaymentType` is a short enum. Acceptable. If truncation ever happens, EF Core will throw at `SaveChangesAsync` (Npgsql will reject), surfacing as a Failed row — fail-loud is correct here. |
+| Migration runs on prod before staging verification of CZK assumption. | High | Manual migrations are the project norm (CLAUDE.md project facts). Add a one-line note in the migration's XML comment: `// Backfills existing rows to 'CZK'; verify SELECT DISTINCT Platform first.` Solo-developer environment makes this sufficient. |
+
+## Specification Amendments
+
+### Amendment 1: Migration shape — switch to add-nullable + UPDATE + alter
+Replace FR-4's "ADD COLUMN … NOT NULL DEFAULT 'CZK' then remove default" mechanic with the project's established three-step pattern (see Decision 1, prior art `20251208184900_AddTransferIdColumnWithDataHandling.cs:44-67`):
+
+```csharp
+// 1. Add Currency as nullable
+migrationBuilder.AddColumn<string>(
+    name: "Currency",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "character varying(3)",
+    maxLength: 3,
+    nullable: true);
+
+// 2. Backfill (assumes all historical rows are CZK — verify on staging)
+migrationBuilder.Sql(
+    "UPDATE public.\"ImportedMarketingTransactions\" SET \"Currency\" = 'CZK' WHERE \"Currency\" IS NULL;");
+
+// 3. Enforce NOT NULL
+migrationBuilder.AlterColumn<string>(
+    name: "Currency",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "character varying(3)",
+    maxLength: 3,
+    nullable: false,
+    oldClrType: typeof(string),
+    oldType: "character varying(3)",
+    oldMaxLength: 3,
+    oldNullable: true);
+
+// Description and RawData: simple AddColumn(nullable: true), no backfill, no alter.
+```
+
+`Down` reverses with three `DropColumn` calls.
+
+### Amendment 2: Empty-Currency guard runs first, before duplicate-check
+FR-6's "skip on empty Currency" guard must be placed **at the top of the per-transaction loop body, before** the `stagedIds.Contains` and `ExistsAsync` checks (lines 39 and 48 of the current service). Otherwise an empty-Currency row consumes a database round-trip and may be miscounted under `Skipped` if it happens to duplicate a prior valid row.
+
+Updated acceptance criterion for FR-6:
+> The guard appears at the top of the loop body, before the duplicate-check at line 39. Test asserts `ExistsAsync` is **never called** for an empty-Currency transaction.
+
+### Amendment 3: Test additions
+The existing test class already constructs fixtures with `Currency = "CZK"` everywhere (lines 38-39, 74, 103-104, 139-140, 197-198), so existing tests will keep passing without code change. Add explicitly:
+
+1. **`ImportAsync_NewTransaction_PersistsCurrency_DescriptionAndRawData`** — single transaction with `Currency = "EUR"`, `Description = "campaign X"`, `RawData = "{\"foo\":1}"`. Capture the entity passed to `AddAsync` via `Moq.Callback` and assert all three round-trip verbatim (Currency must NOT be coerced to CZK).
+2. **`ImportAsync_EmptyCurrency_Skips_CountsFailed_LogsWarning`** — `Currency = ""` ⇒ `result.Failed == 1`, `result.Imported == 0`, `_mockRepository.Verify(AddAsync, Never)`, `_mockRepository.Verify(ExistsAsync, Never)`, verify warning log with `TransactionId` and `Platform` structured properties.
+3. **`ImportAsync_WhitespaceCurrency_TreatedAsEmpty`** — `Currency = "   "` ⇒ same outcome as case 2 (covers the `IsNullOrWhiteSpace` branch).
+
+### Amendment 4: Document the CZK-assumption verification step
+The spec's "Open Questions" section currently notes the CZK backfill assumption but doesn't tie it to a concrete pre-deploy check. Add to FR-4 acceptance criteria:
+> Before running the migration against production, the developer runs `SELECT DISTINCT "Platform", COUNT(*) FROM public."ImportedMarketingTransactions" GROUP BY "Platform";` on prod, manually cross-checks expected billing currency per platform/account against the connected ad-account configuration, and confirms 100% CZK. If any platform's billing currency is not CZK, the migration's backfill SQL is amended to a per-Platform `CASE` expression before deploy.
+
+## Prerequisites
+
+- **None at the infrastructure / config / package level.** No new dependencies, no new DI registrations, no new secrets, no new feature flag.
+- **Operational prerequisite (one-time, manual):** the CZK-assumption query in Amendment 4 must be run against production before `dotnet ef database update` is invoked there. This is consistent with "Database migrations are manual (not automated in deployment)" per CLAUDE.md.
+- **Build prerequisite:** after editing `ImportedMarketingTransaction` and the configuration, run `dotnet ef migrations add AddCurrencyDescriptionRawDataToImportedMarketingTransactions --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API`, then hand-edit the generated migration to insert the `Sql("UPDATE …")` between the `AddColumn` and `AlterColumn` calls per Amendment 1.
+- **Verification before declaring done** (per CLAUDE.md): `dotnet build` + `dotnet format` clean; `dotnet test` on `Anela.Heblo.Tests` passes (existing 6 tests + 3 new); `dotnet ef database update` runs cleanly against a fresh local Postgres dev database; spot-check via `psql` that all three new columns exist with correct types and that the backfill populated `Currency = 'CZK'` for any pre-existing rows.
+```

--- a/artifacts/feat-arch-review-marketinginvoices-currency-f/brief.md
+++ b/artifacts/feat-arch-review-marketinginvoices-currency-f/brief.md
@@ -1,0 +1,47 @@
+## Module
+MarketingInvoices
+
+## Finding
+`MarketingTransaction` (the domain value object returned by `IMarketingTransactionSource`) declares three fields that are never mapped to `ImportedMarketingTransaction` during the import:
+
+```
+backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs
+  line 8:   public string Description { get; set; }
+  line 9:   public string Currency { get; set; }
+  line 11:  public string? RawData { get; set; }
+```
+
+The import service constructs the persisted entity without any of these:
+
+```
+backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+  lines 58–65:
+      var entity = new ImportedMarketingTransaction
+      {
+          TransactionId = transaction.TransactionId,
+          Platform = source.Platform,
+          Amount = transaction.Amount,
+          TransactionDate = transaction.TransactionDate,
+          ImportedAt = DateTime.UtcNow,
+          IsSynced = false,
+      };
+```
+
+`Currency` is the most critical omission: `Amount` is stored as `numeric(18,2)` without any currency context (`ImportedMarketingTransactionConfiguration.cs`, line 33). If a Google Ads or Meta Ads account operates in EUR while the rest of the system assumes CZK, the stored amounts are silently misrepresented.
+
+## Why it matters
+Storing a monetary `Amount` without its `Currency` is an implicit assumption that will break if ad accounts ever bill in a currency other than the expected one. The domain model signals these fields matter (otherwise why declare them?) but the persistence layer discards them with no comment. This is either a latent bug or unnecessary bloat on `MarketingTransaction`.
+
+## Suggested fix
+Choose one path:
+
+**A — Persist currency (preferred if multi-currency is possible):**
+1. Add `Currency string` column to `ImportedMarketingTransaction` and `ImportedMarketingTransactionConfiguration`.
+2. Map `transaction.Currency` in `MarketingInvoiceImportService` lines 58–65.
+3. Add a migration.
+
+**B — Remove unused fields (if single-currency is a firm constraint):**
+Remove `Description`, `Currency`, and `RawData` from `MarketingTransaction` and document the assumption in a code comment on the class.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-marketinginvoices-currency-f/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-currency-f/impl/main.r1.md
@@ -1,0 +1,64 @@
+---
+
+# Implementation: Persist Currency, Description, and RawData on Imported Marketing Transactions
+
+## What was implemented
+
+Added `Currency` (ISO 4217, NOT NULL), `Description` (nullable varchar(500)), and `RawData` (nullable text) to the `ImportedMarketingTransaction` entity and the `public."ImportedMarketingTransactions"` table. The import service now maps all three fields from `MarketingTransaction`, and rejects any transaction with an empty/whitespace `Currency` (increments `Failed`, logs a Warning, skips without any DB round-trips). A backfill migration sets all existing rows to `'CZK'`.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` — three new properties: `Currency` (string), `Description` (string?), `RawData` (string?)
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` — three new `builder.Property(...)` mappings
+- `backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` — three-step migration: add nullable → SQL backfill 'CZK' → ALTER NOT NULL; Description and RawData as plain nullable adds
+- `backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs` — auto-generated designer
+- `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` — auto-regenerated snapshot
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — empty-Currency guard at top of loop + three new fields in object initializer
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — 3 new tests
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` — regression fix: added `Currency = "CZK"` to handler test fixture
+
+## Tests
+
+`MarketingInvoiceImportServiceTests.cs` — 9 tests total (6 pre-existing + 3 new):
+- `ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData` — verifies EUR currency is NOT coerced to CZK; Description and RawData round-trip verbatim
+- `ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd` — empty string → `Failed=1`, no DB calls, warning logged with TransactionId+Platform
+- `ImportAsync_WhitespaceCurrency_TreatedAsEmpty_CountsFailed` — whitespace → same outcome as empty; pins `IsNullOrWhiteSpace` behavior
+
+## How to verify
+
+```bash
+# From the repo root
+dotnet build backend/Anela.Heblo.sln          # 0 errors
+dotnet format backend/Anela.Heblo.sln         # no changes
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+# Expected: 9 MarketingInvoiceImportServiceTests pass; 3947/3950 total pass
+
+# Before applying migration to production, run on prod DB:
+# SELECT "Platform", COUNT(*) FROM public."ImportedMarketingTransactions" GROUP BY "Platform";
+# Confirm all platforms are CZK-billed. If not, amend the backfill SQL before deploying.
+```
+
+## Notes
+
+- Migration uses the project's established three-step pattern (not DEFAULT+drop-default) — matches prior art in `20251208184900_AddTransferIdColumnWithDataHandling.cs`
+- Currency is stored verbatim (no ISO-4217 validation, no `ToUpperInvariant()` — out of scope per spec)
+- Description empty string is stored as `""` not null (EF/Npgsql does not coerce; spec says verbatim mapping)
+- Pre-deploy CZK verification is a manual step documented in the migration comment
+
+## PR Summary
+
+Persists the `Currency`, `Description`, and `RawData` fields that every marketing transaction adapter (Google Ads, Meta Ads) has always populated but the import service was silently discarding. The most critical fix is `Currency`: storing monetary amounts without a currency code creates a silent multi-currency bug whenever any ad account bills outside CZK.
+
+The change is purely additive — three new columns, one guard, no public API or interface changes. Existing rows are backfilled to `'CZK'` using the repo's established add-nullable→UPDATE→ALTER migration pattern. Any inbound transaction with a missing currency is rejected early (before any DB round-trips), counted as `Failed`, and logged with full diagnostic context.
+
+### Changes
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` — three new POCO properties
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` — EF column mappings for the three new properties
+- `backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` — migration with three-step Currency backfill + nullable adds for Description/RawData
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — empty-Currency guard + all three fields in object initializer
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — 3 new tests (round-trip, empty-currency, whitespace-currency)
+- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` — regression fix: handler test fixture now supplies `Currency = "CZK"`
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-marketinginvoices-currency-f/spec.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-currency-f/spec.r1.md
@@ -1,0 +1,184 @@
+# Specification: Persist Currency, Description, and RawData on Imported Marketing Transactions
+
+## Summary
+The `MarketingInvoiceImportService` discards three fields (`Currency`, `Description`, `RawData`) that are populated by every existing `IMarketingTransactionSource` adapter (Google Ads, Meta Ads). The most critical of these is `Currency`: storing `Amount` as `numeric(18,2)` without a currency code creates a silent multi-currency bug the moment any ad account bills in a non-default currency. This spec persists all three fields end-to-end, adds a migration, and backfills existing rows with the assumed default currency code so monetary data carries explicit context.
+
+## Background
+`MarketingTransaction` (domain value object) declares seven properties; the import path only maps four of them onto the persisted entity `ImportedMarketingTransaction`:
+
+| Property        | Populated by adapters? | Persisted? |
+|-----------------|------------------------|------------|
+| `TransactionId` | Yes                    | Yes        |
+| `Platform`      | Yes (from source)      | Yes        |
+| `Amount`        | Yes                    | Yes        |
+| `TransactionDate` | Yes                  | Yes        |
+| `Description`   | **Yes**                | **No**     |
+| `Currency`      | **Yes**                | **No**     |
+| `RawData`       | **Yes**                | **No**     |
+
+Adapter evidence (already in the codebase):
+- `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs:42-44` sets `Currency = r.CurrencyCode`, `Description = r.Name ?? "Google Ads billing period"`, `RawData = JsonSerializer.Serialize(r)`.
+- `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs:71-73` sets `Currency = item.Currency`, `Description = item.PaymentType`, `RawData = JsonSerializer.Serialize(item, JsonOptions)`.
+
+The mapping in `MarketingInvoiceImportService.cs:58-65` then throws this data away. Because adapters actually provide currency values today (Google Ads returns ISO 4217 in `CurrencyCode`; the Meta Ads Graph API returns it in the `currency` field), the brief's option **A — persist currency** is the right path: removing the fields would mean deleting real upstream signal. Description and RawData are persisted alongside Currency because they share the same pipeline, are already populated, and provide audit/diagnostic value at trivial storage cost.
+
+## Functional Requirements
+
+### FR-1: Add `Currency` column to `ImportedMarketingTransaction`
+Add a non-nullable `Currency` property (ISO 4217 alphabetic code, 3 characters) to the entity and its EF configuration. The import service must map `MarketingTransaction.Currency` into this column on insert.
+
+**Acceptance criteria:**
+- `ImportedMarketingTransaction.Currency` exists as `string` (non-nullable, default `string.Empty`).
+- `ImportedMarketingTransactionConfiguration` registers the column as `character varying(3)`, `IsRequired()`, column name `Currency`.
+- `MarketingInvoiceImportService.ImportAsync` copies `transaction.Currency` into the new entity at line 58-65.
+- Unit test in `MarketingInvoiceImportServiceTests` verifies an imported entity carries the source transaction's currency.
+
+### FR-2: Add `Description` column to `ImportedMarketingTransaction`
+Add a nullable `Description` property to the entity and its EF configuration; map it in the import service.
+
+**Acceptance criteria:**
+- `ImportedMarketingTransaction.Description` exists as `string?`.
+- EF configuration registers column `Description` as `character varying(500)`, nullable.
+- Import service maps `transaction.Description` (passing through empty strings as-is — adapters guarantee non-null).
+- Unit test asserts description round-trips through import.
+
+### FR-3: Add `RawData` column to `ImportedMarketingTransaction`
+Add a nullable `RawData` property to the entity and its EF configuration; map it in the import service.
+
+**Acceptance criteria:**
+- `ImportedMarketingTransaction.RawData` exists as `string?`.
+- EF configuration registers column `RawData` as `text`, nullable.
+- Import service maps `transaction.RawData`.
+- Unit test asserts raw-data payload round-trips through import.
+
+### FR-4: Database migration with backfill
+Create a new EF Core migration that adds the three columns and backfills existing rows. Existing rows are assumed to be CZK (see Open Questions / Assumptions).
+
+**Acceptance criteria:**
+- New migration file `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` exists.
+- Migration `Up` adds three columns to `public."ImportedMarketingTransactions"`:
+  - `Currency character varying(3) NOT NULL DEFAULT 'CZK'` (default exists only to satisfy NOT NULL during backfill; remove default after column is added).
+  - `Description character varying(500) NULL`.
+  - `RawData text NULL`.
+- After the column is created with the default, the migration removes the default constraint so new inserts must supply a value explicitly (`AlterColumn` without `DefaultValue`).
+- Migration `Down` drops all three columns.
+- `ApplicationDbContextModelSnapshot.cs` updated accordingly.
+- `dotnet ef database update` runs cleanly against a fresh dev database.
+
+### FR-5: Import service maps all three fields
+The construction of `ImportedMarketingTransaction` inside `MarketingInvoiceImportService.ImportAsync` must include `Currency`, `Description`, and `RawData`. No other behavior changes.
+
+**Acceptance criteria:**
+- The object initializer at `MarketingInvoiceImportService.cs:58-65` includes the three additional properties.
+- All existing tests in `MarketingInvoiceImportServiceTests` continue to pass.
+- A new test verifies that when the source transaction has `Currency = "EUR"`, the persisted entity has `Currency = "EUR"` (i.e. it is not normalized or coerced to CZK).
+
+### FR-6: Empty / missing Currency defensive handling
+If an adapter ever returns a `MarketingTransaction` with an empty or whitespace `Currency`, the import service must log a warning and skip the transaction (counting it under `result.Failed`). Storing a transaction with an unknown currency is worse than skipping it, because downstream consumers cannot disambiguate.
+
+**Acceptance criteria:**
+- Empty/whitespace `transaction.Currency` ⇒ transaction not persisted, `result.Failed++`, warning logged with `TransactionId` and `Platform`.
+- Unit test covers this path.
+- Description and RawData are NOT subject to this check (they are optional/diagnostic).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No regression to import throughput. The added columns are simple scalar writes; no extra round-trips or queries.
+
+**Acceptance criteria:**
+- No new database calls introduced in `ImportAsync`.
+- Existing batch behavior (single `SaveChangesAsync` at the end) is preserved.
+
+### NFR-2: Data integrity
+Currency must always be present on newly-imported rows. Existing rows are explicitly backfilled to a known value rather than left null, so every row in the table has an interpretable currency.
+
+**Acceptance criteria:**
+- `Currency` column is `NOT NULL` after migration.
+- No code path can insert a row with `Currency = null` or `Currency = ""` (FR-6 enforces this).
+- Migration backfill is deterministic and idempotent.
+
+### NFR-3: Backward compatibility
+This change is purely additive at the data layer. Existing callers of `IImportedMarketingTransactionRepository` keep working because no fields were removed or renamed.
+
+**Acceptance criteria:**
+- No existing test fails on the change set unrelated to the new behavior.
+- No public method signatures change.
+
+### NFR-4: Observability
+Failed imports caused by missing currency are visible in logs with enough context to diagnose which adapter produced bad data.
+
+**Acceptance criteria:**
+- Warning log includes structured properties `TransactionId`, `Platform`, and a clear message about the missing currency.
+
+## Data Model
+
+### `ImportedMarketingTransaction` entity (after change)
+```csharp
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty; // new — ISO 4217
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public bool IsSynced { get; set; } = false;
+    public string? ErrorMessage { get; set; }
+    public string? Description { get; set; } // new
+    public string? RawData { get; set; }     // new
+}
+```
+
+### Table `public."ImportedMarketingTransactions"` (after migration)
+| Column            | Type                     | Null | Notes                              |
+|-------------------|--------------------------|------|------------------------------------|
+| Id                | integer                  | NO   | identity                           |
+| TransactionId     | character varying(255)   | NO   | unique with Platform               |
+| Platform          | character varying(50)    | NO   | unique with TransactionId          |
+| Amount            | numeric(18,2)            | NO   |                                    |
+| **Currency**      | **character varying(3)** | **NO** | **NEW; ISO 4217**                |
+| TransactionDate   | timestamp                | NO   |                                    |
+| ImportedAt        | timestamp                | NO   |                                    |
+| IsSynced          | boolean                  | NO   | default false                      |
+| ErrorMessage      | text                     | YES  |                                    |
+| **Description**   | **character varying(500)** | **YES** | **NEW**                       |
+| **RawData**       | **text**                 | **YES** | **NEW; serialized source payload** |
+
+Unique index `IX_ImportedMarketingTransactions_Platform_TransactionId` is unchanged.
+
+## API / Interface Design
+No public API changes. The change is internal to the marketing-invoices import pipeline.
+
+Internal seams touched:
+- `Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` — three new properties.
+- `Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` — three new property configurations.
+- `Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs:58-65` — extend object initializer, add empty-currency guard.
+- `Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` — new migration.
+
+## Dependencies
+- EF Core (already in use) for migration tooling.
+- xUnit + FluentAssertions + NSubstitute (already used by `MarketingInvoiceImportServiceTests`).
+- Postgres dev/staging database for migration verification (database migrations are manual per CLAUDE.md project facts).
+
+No new packages, no new external services.
+
+## Out of Scope
+- Currency conversion at import time (amounts are stored verbatim in source currency; conversion to a reporting currency is a downstream concern).
+- Backfilling historical `Description` or `RawData` for existing rows — those columns stay null for pre-migration data because the original payloads were not retained.
+- Adding aggregate/reporting views that group by currency.
+- Validating currency codes against an ISO 4217 enumeration. The column accepts any 3-character string; validation is upstream's responsibility.
+- Renaming or otherwise restructuring `MarketingTransaction` or `ImportedMarketingTransaction`.
+- Changes to `IsSynced` / downstream sync behavior (e.g. propagating currency to whatever consumes `IsSynced = false` rows).
+- Frontend or API surface changes — there is no consumer of these columns outside the import pipeline today.
+
+## Open Questions
+
+### Assumed and decided (please flag if wrong)
+1. **Backfill currency for existing rows = `"CZK"`.** The brief states "the rest of the system assumes CZK"; this is the assumed default for pre-migration data. If existing rows include any non-CZK ad accounts, the migration would mislabel them. Recommended verification: run `SELECT DISTINCT Platform FROM "ImportedMarketingTransactions"` on staging and confirm all imports to date were from CZK-billed accounts before applying the migration to production.
+
+### Genuinely open
+*(none — proceeding on the assumption above; flag if it doesn't hold and the migration backfill logic will be revised before production rollout.)*
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketinginvoices-currency-f/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-currency-f/task-plan.r1.md
@@ -1,0 +1,900 @@
+# Persist Currency, Description, and RawData on Imported Marketing Transactions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist `Currency`, `Description`, and `RawData` from `MarketingTransaction` into `ImportedMarketingTransaction` end-to-end (domain entity, EF mapping, database schema, import service), so monetary data carries an explicit ISO 4217 currency code and adapter-supplied audit context isn't discarded.
+
+**Architecture:** Pure additive change inside the `MarketingInvoices` vertical slice. Three columns are added to the `public."ImportedMarketingTransactions"` table; `Currency` is non-nullable and backfilled to `'CZK'` for existing rows using the project's established three-step migration pattern (add-nullable → `UPDATE` backfill → `ALTER` to NOT NULL). The import service maps the three fields verbatim and skips (counts `Failed`) any inbound transaction with an empty/whitespace `Currency`. No public API, contract, or interface signature changes.
+
+**Tech Stack:** .NET 8, EF Core 8 (Npgsql provider), PostgreSQL, MediatR (untouched), xUnit + Moq for tests.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` | Modify | Add three POCO properties to the persisted entity. |
+| `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` | Modify | Add three EF property mappings (column names, types, length constraints, NOT NULL for `Currency`). |
+| `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` | Create (via EF tooling, then hand-edit) | Add the three columns to the database; backfill `Currency = 'CZK'`; enforce NOT NULL on `Currency`. |
+| `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs` | Create (auto-generated) | Standard EF migration designer snapshot. |
+| `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` | Modify (auto-regenerated) | Snapshot reflects the new properties. |
+| `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` | Modify | (a) Add empty-Currency guard at top of per-transaction loop (before duplicate-check). (b) Extend object initializer to map `Currency`, `Description`, `RawData`. |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Modify | Add three test cases: full round-trip, empty-Currency, whitespace-Currency. |
+
+No new files for production code beyond the migration. No new directories. No DI registration changes.
+
+---
+
+## Task 1: Add Currency, Description, RawData properties to the domain entity
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+
+This is a structural change that unblocks the EF configuration (Task 2) and the test fixtures (Task 6). On its own it ships compile-only behavior.
+
+- [ ] **Step 1: Open the entity file and add three properties**
+
+Current content of `ImportedMarketingTransaction.cs`:
+
+```csharp
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public bool IsSynced { get; set; } = false;
+    public string? ErrorMessage { get; set; }
+}
+```
+
+Replace its contents with:
+
+```csharp
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public bool IsSynced { get; set; } = false;
+    public string? ErrorMessage { get; set; }
+    public string? Description { get; set; }
+    public string? RawData { get; set; }
+}
+```
+
+Notes:
+- `Currency` is non-nullable (matches `MarketingTransaction.Currency`, which is also non-nullable `string` defaulted to `string.Empty`).
+- `Description` and `RawData` are nullable (`string?`) — adapters may legitimately provide null/empty for description, and `RawData` is purely diagnostic.
+- Keep the entity a `class` (not a `record`) — see CLAUDE.md "DTOs/entities are classes" gotcha.
+
+- [ ] **Step 2: Build the solution to confirm no compile errors**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds (`Build succeeded. 0 Error(s)`).
+
+The existing tests in `MarketingInvoiceImportServiceTests.cs` will still compile because they don't reference the new entity properties yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs
+git commit -m "feat: add Currency, Description, RawData properties to ImportedMarketingTransaction entity"
+```
+
+---
+
+## Task 2: Configure the three new columns in EF Core
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`
+
+This makes EF Core aware of the new columns. It will be picked up by `dotnet ef migrations add` in Task 3.
+
+- [ ] **Step 1: Open the configuration file**
+
+Current configuration (file end, before the `HasIndex` call at line 57):
+
+```csharp
+        builder.Property(e => e.ErrorMessage)
+            .HasColumnName("ErrorMessage")
+            .HasColumnType("text");
+
+        builder.HasIndex(e => new { e.Platform, e.TransactionId })
+            .IsUnique()
+            .HasDatabaseName("IX_ImportedMarketingTransactions_Platform_TransactionId");
+```
+
+- [ ] **Step 2: Insert three new `builder.Property(...)` calls before the `HasIndex(...)` call**
+
+After the `ErrorMessage` configuration block and before `builder.HasIndex(...)`, add:
+
+```csharp
+        builder.Property(e => e.Currency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasColumnName("Currency")
+            .HasColumnType("character varying(3)");
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500)
+            .HasColumnName("Description")
+            .HasColumnType("character varying(500)");
+
+        builder.Property(e => e.RawData)
+            .HasColumnName("RawData")
+            .HasColumnType("text");
+```
+
+Notes:
+- Style matches the existing `Property(...)` calls in the file (explicit `HasColumnName` + `HasColumnType`).
+- `IsRequired()` only on `Currency` — others are nullable.
+- No `HasDefaultValue('CZK')` here; the default is purely a migration concern (existing rows), not a runtime EF concern.
+
+- [ ] **Step 3: Build to confirm no compile errors**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
+git commit -m "feat: configure Currency, Description, RawData columns in EF mapping"
+```
+
+---
+
+## Task 3: Scaffold the EF migration with `dotnet ef migrations add`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs`
+- Modify (auto-regenerated): `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`
+
+The CLI generates a vanilla `AddColumn` migration. We will hand-edit it in Task 4 to add the backfill + `AlterColumn`.
+
+- [ ] **Step 1: Run the EF migrations add command**
+
+Run from the repo root:
+
+```bash
+dotnet ef migrations add AddCurrencyDescriptionRawDataToImportedMarketingTransactions \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected: three new/changed files appear in `backend/src/Anela.Heblo.Persistence/Migrations/`:
+1. `{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` (new)
+2. `{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs` (new)
+3. `ApplicationDbContextModelSnapshot.cs` (modified — should now include the three new properties on the `ImportedMarketingTransaction` entity block)
+
+- [ ] **Step 2: Verify the generated `.cs` migration has three `AddColumn` calls**
+
+Open the newly-generated `{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`. The `Up` method should contain something like:
+
+```csharp
+migrationBuilder.AddColumn<string>(
+    name: "Currency",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "character varying(3)",
+    maxLength: 3,
+    nullable: false,
+    defaultValue: "");
+
+migrationBuilder.AddColumn<string>(
+    name: "Description",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "character varying(500)",
+    maxLength: 500,
+    nullable: true);
+
+migrationBuilder.AddColumn<string>(
+    name: "RawData",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "text",
+    nullable: true);
+```
+
+(The exact `defaultValue` clause on `Currency` will depend on EF's defaults — EF emits `defaultValue: ""` when scaffolding NOT NULL string columns. This is exactly what we will replace in Task 4 with the explicit three-step pattern.)
+
+The `Down` method should contain three `DropColumn` calls.
+
+- [ ] **Step 3: Verify the snapshot was updated correctly**
+
+In `ApplicationDbContextModelSnapshot.cs`, the `ImportedMarketingTransaction` block (around line 2336) should now include three additional `b.Property<string>(...)` entries for `Currency`, `Description`, and `RawData`.
+
+Quick spot-check command (no need to run; visual inspection is fine):
+
+```bash
+grep -n "Currency\|Description\|RawData" backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs | head -30
+```
+
+Expected: lines showing the three new properties registered on the `Anela.Heblo.Domain.Features.MarketingInvoices.ImportedMarketingTransaction` entity.
+
+- [ ] **Step 4: Build to confirm the scaffolded files compile**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit the scaffolded migration as-is**
+
+We will hand-edit it in Task 4; committing the scaffold first makes the manual changes reviewable as a separate diff.
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "chore: scaffold migration for Currency, Description, RawData columns"
+```
+
+---
+
+## Task 4: Hand-edit the migration to use the add-nullable → backfill → alter pattern
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`
+
+Background — see arch review Decision 1 and Amendment 1. The prior art `20251208184900_AddTransferIdColumnWithDataHandling.cs:44-67` adds a NOT NULL column safely on an existing table by:
+1. Adding the column as nullable.
+2. Running an explicit `UPDATE … WHERE … IS NULL` to backfill.
+3. Altering the column to NOT NULL.
+
+`Description` and `RawData` are nullable, so they stay as plain `AddColumn(nullable: true)` calls. Only `Currency` needs the three-step pattern.
+
+- [ ] **Step 1: Replace the `Up` method**
+
+Open the migration file and replace the body of `Up(MigrationBuilder migrationBuilder)` with the following. The existing `using` directives and class skeleton stay as-is.
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    // Currency: add as nullable so backfill can populate existing rows.
+    migrationBuilder.AddColumn<string>(
+        name: "Currency",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "character varying(3)",
+        maxLength: 3,
+        nullable: true);
+
+    // Backfill existing rows. Assumption verified pre-deploy: all historical
+    // ImportedMarketingTransactions rows are CZK-billed (see spec FR-4 and
+    // arch review Amendment 4 — confirm with the SELECT DISTINCT query on prod
+    // before applying this migration there).
+    migrationBuilder.Sql(
+        "UPDATE public.\"ImportedMarketingTransactions\" SET \"Currency\" = 'CZK' WHERE \"Currency\" IS NULL;");
+
+    // Now enforce NOT NULL. New inserts must supply Currency explicitly;
+    // the FR-6 guard in MarketingInvoiceImportService rejects empties.
+    migrationBuilder.AlterColumn<string>(
+        name: "Currency",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "character varying(3)",
+        maxLength: 3,
+        nullable: false,
+        oldClrType: typeof(string),
+        oldType: "character varying(3)",
+        oldMaxLength: 3,
+        oldNullable: true);
+
+    // Description: nullable, no backfill needed.
+    migrationBuilder.AddColumn<string>(
+        name: "Description",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "character varying(500)",
+        maxLength: 500,
+        nullable: true);
+
+    // RawData: nullable, no backfill needed.
+    migrationBuilder.AddColumn<string>(
+        name: "RawData",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "text",
+        nullable: true);
+}
+```
+
+- [ ] **Step 2: Replace the `Down` method**
+
+Replace the `Down` body with three `DropColumn` calls (the order doesn't matter for `Down`):
+
+```csharp
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "RawData",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "Description",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "Currency",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+}
+```
+
+- [ ] **Step 3: Build to confirm the hand-edited migration compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 4: Apply the migration to a fresh local Postgres dev database**
+
+Run from the repo root:
+
+```bash
+dotnet ef database update \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected: command completes with `Done.` and no error. If the local database already has the columns (from a prior partial attempt), drop and recreate it, or revert to the pre-migration state with `dotnet ef database update <previous-migration-name>` first.
+
+- [ ] **Step 5: Spot-check the schema via `psql`**
+
+If `psql` is available locally, verify the three columns exist with the right types and that `Currency` is NOT NULL:
+
+```bash
+psql "$ConnectionStrings__DefaultConnection" -c "\d public.\"ImportedMarketingTransactions\""
+```
+
+Expected output includes lines roughly like:
+
+```
+ Currency        | character varying(3)   | not null
+ Description     | character varying(500) |
+ RawData         | text                   |
+```
+
+If the local DB had any pre-existing rows, also verify the backfill:
+
+```bash
+psql "$ConnectionStrings__DefaultConnection" \
+  -c "SELECT \"Currency\", COUNT(*) FROM public.\"ImportedMarketingTransactions\" GROUP BY \"Currency\";"
+```
+
+Expected: any existing rows show `Currency = 'CZK'`; new ones (none yet) will follow.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "feat: backfill Currency='CZK' on existing ImportedMarketingTransactions rows"
+```
+
+---
+
+## Task 5: Add failing test for Currency/Description/RawData round-trip in import service
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+We follow the project's TDD discipline: write the test first, watch it fail, then implement (Task 6).
+
+- [ ] **Step 1: Add the new test case to `MarketingInvoiceImportServiceTests.cs`**
+
+Append the following test inside the class (after `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce`, before the closing `}` of the class):
+
+```csharp
+[Fact]
+public async Task ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData()
+{
+    // Arrange
+    var from = new DateTime(2026, 4, 1);
+    var to = new DateTime(2026, 4, 2);
+
+    var transactions = new List<MarketingTransaction>
+    {
+        new()
+        {
+            TransactionId = "TX-EUR-001",
+            Platform = "TestPlatform",
+            Amount = 123.45m,
+            TransactionDate = from,
+            Description = "campaign X",
+            Currency = "EUR",
+            RawData = "{\"foo\":1}",
+        },
+    };
+
+    _mockSource
+        .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transactions);
+
+    _mockRepository
+        .Setup(x => x.ExistsAsync("TestPlatform", "TX-EUR-001", It.IsAny<CancellationToken>()))
+        .ReturnsAsync(false);
+
+    ImportedMarketingTransaction? captured = null;
+    _mockRepository
+        .Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+        .Callback<ImportedMarketingTransaction, CancellationToken>((entity, _) => captured = entity)
+        .Returns(Task.CompletedTask);
+
+    _mockRepository
+        .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+        .ReturnsAsync(1);
+
+    // Act
+    var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+    // Assert
+    Assert.Equal(1, result.Imported);
+    Assert.Equal(0, result.Skipped);
+    Assert.Equal(0, result.Failed);
+    Assert.NotNull(captured);
+    Assert.Equal("EUR", captured!.Currency);
+    Assert.Equal("campaign X", captured.Description);
+    Assert.Equal("{\"foo\":1}", captured.RawData);
+}
+```
+
+Notes:
+- `Currency = "EUR"` confirms FR-5's "must not be coerced to CZK" requirement.
+- `captured` is set via Moq `Callback` (same pattern Moq uses elsewhere in this codebase).
+- `MarketingTransaction` already has `Currency`, `Description`, `RawData` properties (see `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`).
+- Entity `Currency`, `Description`, `RawData` properties exist now thanks to Task 1.
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData"
+```
+
+Expected: test fails on one of the three `Assert.Equal(...)` checks — `captured.Currency` will be `""` (default), `captured.Description` and `captured.RawData` will be `null`. The service has not yet been updated to map these fields.
+
+If the test passes unexpectedly, the implementation is already wrong — re-read the current `MarketingInvoiceImportService.cs:58-66` object initializer and verify it does NOT yet include `Currency`/`Description`/`RawData`.
+
+(Do NOT commit yet — test + impl get committed together in Task 6.)
+
+---
+
+## Task 6: Update import service to map Currency, Description, RawData
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+- [ ] **Step 1: Extend the object initializer**
+
+Open `MarketingInvoiceImportService.cs`. Find the existing object initializer at lines 58-66:
+
+```csharp
+var entity = new ImportedMarketingTransaction
+{
+    TransactionId = transaction.TransactionId,
+    Platform = source.Platform,
+    Amount = transaction.Amount,
+    TransactionDate = transaction.TransactionDate,
+    ImportedAt = DateTime.UtcNow,
+    IsSynced = false,
+};
+```
+
+Replace it with:
+
+```csharp
+var entity = new ImportedMarketingTransaction
+{
+    TransactionId = transaction.TransactionId,
+    Platform = source.Platform,
+    Amount = transaction.Amount,
+    Currency = transaction.Currency,
+    TransactionDate = transaction.TransactionDate,
+    ImportedAt = DateTime.UtcNow,
+    IsSynced = false,
+    Description = transaction.Description,
+    RawData = transaction.RawData,
+};
+```
+
+Notes:
+- `Currency` is passed verbatim — no `ToUpperInvariant()`, no normalization. ISO-4217 validation is upstream's responsibility per the spec's "Out of Scope".
+- `Description` from `MarketingTransaction` is non-nullable `string` (defaults to `string.Empty`); the entity stores it as `string?`. Passing a value through this assignment is implicit conversion — empty strings pass through verbatim.
+- `RawData` is `string?` on both sides — pass through.
+
+- [ ] **Step 2: Run the Task-5 test to confirm it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData"
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Run the full import-service test class to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+
+Expected: all tests pass (6 pre-existing + 1 new = 7). The existing tests already construct fixtures with `Currency = "CZK"`, `Description = "Ad charge"` (see test file lines 38-39, 74, 103-104, 139-140, 197-198), so they're unaffected by the additive mapping.
+
+- [ ] **Step 4: Commit test + implementation together**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs \
+        backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+git commit -m "feat: map Currency, Description, RawData in MarketingInvoiceImportService"
+```
+
+---
+
+## Task 7: Add failing test for the empty-Currency guard
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+This test drives the FR-6 behavior. Per arch review Amendment 2, the guard must run **before** the `stagedIds` check at line 39 and the `ExistsAsync` call at line 48. We assert this directly via `Times.Never` on both `AddAsync` and `ExistsAsync`.
+
+- [ ] **Step 1: Add the empty-Currency test**
+
+Append inside the class:
+
+```csharp
+[Fact]
+public async Task ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd()
+{
+    // Arrange
+    var from = new DateTime(2026, 4, 1);
+    var to = new DateTime(2026, 4, 2);
+
+    var transactions = new List<MarketingTransaction>
+    {
+        new()
+        {
+            TransactionId = "TX-BAD-001",
+            Platform = "TestPlatform",
+            Amount = 100m,
+            TransactionDate = from,
+            Description = "missing currency",
+            Currency = "",
+        },
+    };
+
+    _mockSource
+        .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transactions);
+
+    // Act
+    var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+    // Assert
+    Assert.Equal(0, result.Imported);
+    Assert.Equal(0, result.Skipped);
+    Assert.Equal(1, result.Failed);
+    _mockRepository.Verify(
+        x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _mockRepository.Verify(
+        x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _mockRepository.Verify(
+        x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+        Times.Never);
+
+    // Warning log: verify it was emitted with TransactionId and Platform context.
+    _mockLogger.Verify(
+        l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, _) =>
+                v.ToString()!.Contains("TX-BAD-001") &&
+                v.ToString()!.Contains("TestPlatform")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.AtLeastOnce);
+}
+```
+
+Notes:
+- The `_mockLogger.Verify(...)` block is the canonical Moq pattern for asserting `ILogger.Log` was called at a specific level — it works because `ILogger.LogWarning(...)` is an extension method that resolves to `ILogger.Log(LogLevel.Warning, ...)` internally.
+- The `v.ToString()!.Contains(...)` checks are loose — they confirm structured properties were inlined into the formatted message. The Task-8 implementation will use `_logger.LogWarning("...", transaction.TransactionId, source.Platform)`-style structured logging, which Moq's `It.IsAnyType` captures via the formatted state object.
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd"
+```
+
+Expected: test fails. With no guard in place, the empty-currency transaction will flow through `ExistsAsync` (returns `false` from the default Moq stub) and `AddAsync`, so the `Verify(..., Times.Never)` assertions will fail (most likely the `ExistsAsync` one fails first).
+
+(Do not commit yet — Task 8 commits guard + tests together with the whitespace test from Task 9.)
+
+---
+
+## Task 8: Add the empty-Currency guard at the top of the import loop
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+Per arch review Amendment 2, the guard runs **first** inside the `try` block, before the `stagedIds.Contains(...)` check and before `ExistsAsync`.
+
+- [ ] **Step 1: Insert the guard at the top of the per-transaction loop body**
+
+Open `MarketingInvoiceImportService.cs`. Find the loop body (lines 35-79). Inside the existing `try { ... }` (starting at line 37), the current first statement is the `stagedIds.Contains(transaction.TransactionId)` check.
+
+Insert the new guard immediately after `try {` and before that check. The body of the `try` block becomes:
+
+```csharp
+try
+{
+    if (string.IsNullOrWhiteSpace(transaction.Currency))
+    {
+        _logger.LogWarning(
+            "Marketing transaction {TransactionId} for {Platform} has empty Currency — skipping",
+            transaction.TransactionId, source.Platform);
+        result.Failed++;
+        continue;
+    }
+
+    if (stagedIds.Contains(transaction.TransactionId))
+    {
+        _logger.LogDebug(
+            "Transaction {TransactionId} for {Platform} already staged in this run — skipping",
+            transaction.TransactionId, source.Platform);
+        result.Skipped++;
+        continue;
+    }
+
+    var exists = await _repository.ExistsAsync(source.Platform, transaction.TransactionId, ct);
+    if (exists)
+    {
+        _logger.LogDebug(
+            "Transaction {TransactionId} for {Platform} already imported — skipping",
+            transaction.TransactionId, source.Platform);
+        result.Skipped++;
+        continue;
+    }
+
+    var entity = new ImportedMarketingTransaction
+    {
+        TransactionId = transaction.TransactionId,
+        Platform = source.Platform,
+        Amount = transaction.Amount,
+        Currency = transaction.Currency,
+        TransactionDate = transaction.TransactionDate,
+        ImportedAt = DateTime.UtcNow,
+        IsSynced = false,
+        Description = transaction.Description,
+        RawData = transaction.RawData,
+    };
+
+    await _repository.AddAsync(entity, ct);
+    stagedIds.Add(transaction.TransactionId);
+    stagedCount++;
+}
+catch (Exception ex)
+{
+    // unchanged
+}
+```
+
+Notes:
+- `string.IsNullOrWhiteSpace(...)` handles `null`, `""`, and `"   "` in one check (covers Task 9's case automatically).
+- `result.Failed++` (not `Skipped`) — per arch review Decision 2, this is a real defect, not a benign skip.
+- `continue` moves to the next transaction; the per-row `try/catch` philosophy is preserved.
+- The log message uses structured properties so the Moq verify in Task 7 will match.
+
+- [ ] **Step 2: Run the Task-7 test to confirm it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd"
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Run the full import-service test class to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+
+Expected: 8 tests pass, 0 fail. The existing tests use `Currency = "CZK"` everywhere so they still pass through the guard.
+
+(Do not commit yet — Task 9 adds the whitespace test, then we commit the guard + both new tests together.)
+
+---
+
+## Task 9: Add whitespace-Currency test (regression guard for `IsNullOrWhiteSpace` branch)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+This is a defensive test that pins the `IsNullOrWhiteSpace` behavior. If a future engineer refactors the guard to `string.IsNullOrEmpty(...)`, this test fails and protects the contract.
+
+- [ ] **Step 1: Add the whitespace test**
+
+Append inside the class:
+
+```csharp
+[Fact]
+public async Task ImportAsync_WhitespaceCurrency_TreatedAsEmpty_CountsFailed()
+{
+    // Arrange
+    var from = new DateTime(2026, 4, 1);
+    var to = new DateTime(2026, 4, 2);
+
+    var transactions = new List<MarketingTransaction>
+    {
+        new()
+        {
+            TransactionId = "TX-WS-001",
+            Platform = "TestPlatform",
+            Amount = 50m,
+            TransactionDate = from,
+            Description = "whitespace currency",
+            Currency = "   ",
+        },
+    };
+
+    _mockSource
+        .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transactions);
+
+    // Act
+    var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+    // Assert
+    Assert.Equal(0, result.Imported);
+    Assert.Equal(0, result.Skipped);
+    Assert.Equal(1, result.Failed);
+    _mockRepository.Verify(
+        x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _mockRepository.Verify(
+        x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_WhitespaceCurrency_TreatedAsEmpty_CountsFailed"
+```
+
+Expected: 1 passed. The guard implemented in Task 8 already uses `IsNullOrWhiteSpace`, so this should pass on the first run.
+
+If it fails, the Task-8 implementation used `IsNullOrEmpty` (or similar) — go back and fix to `IsNullOrWhiteSpace`.
+
+- [ ] **Step 3: Run the full import-service test class**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+
+Expected: 9 tests pass, 0 fail.
+
+- [ ] **Step 4: Commit guard + empty + whitespace tests together**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs \
+        backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+git commit -m "feat: skip and fail-count marketing transactions with empty Currency"
+```
+
+---
+
+## Task 10: Final validation and cleanup
+
+**Files:**
+- (Verification only — no file changes expected.)
+
+Per CLAUDE.md "Validation before completion":
+
+- [ ] **Step 1: Full backend build (clean)**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: `Build succeeded. 0 Error(s)`. Warnings unchanged from baseline.
+
+- [ ] **Step 2: Code formatting**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: no diff produced. If `dotnet format` reformatted any of the files touched in this plan, inspect the changes — they should be small whitespace fixes only.
+
+If `dotnet format` made changes, commit them as a separate housekeeping commit:
+
+```bash
+git add -A
+git status
+# Review the diff
+git commit -m "chore: dotnet format on marketing-invoice-currency changes"
+```
+
+- [ ] **Step 3: Full backend test suite (touched test project)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: all tests pass. The `MarketingInvoiceImportServiceTests` class should report 9 tests (6 original + 3 new). No unrelated tests should fail.
+
+- [ ] **Step 4: Confirm migration still applies cleanly to a fresh database**
+
+If you have access to a throwaway local Postgres, drop and re-create the dev database, then run:
+
+```bash
+dotnet ef database update \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected: all migrations apply in order; the new migration runs at the end without error; the table has the three new columns with the right types and `Currency` is NOT NULL.
+
+- [ ] **Step 5: Pre-deploy verification reminder (manual, NOT executed here)**
+
+Before applying this migration to production, the developer must verify the CZK-backfill assumption holds on the production database. From arch review Amendment 4:
+
+```sql
+SELECT "Platform", COUNT(*)
+FROM public."ImportedMarketingTransactions"
+GROUP BY "Platform";
+```
+
+Then, for each platform listed, manually cross-check the connected ad account's billing currency. **If any platform is not 100% CZK-billed**, the migration's backfill SQL must be amended to a per-Platform `CASE WHEN` expression before deploy. This is a one-time operational step — do not skip it.
+
+This step is documented here as a checklist item but is NOT part of the implementation commits. The plan is "ship-ready" once Steps 1-4 above are green.
+
+- [ ] **Step 6: Final commit summary check**
+
+Run: `git log --oneline main..HEAD`
+
+Expected commit list (in order):
+1. `feat: add Currency, Description, RawData properties to ImportedMarketingTransaction entity`
+2. `feat: configure Currency, Description, RawData columns in EF mapping`
+3. `chore: scaffold migration for Currency, Description, RawData columns`
+4. `feat: backfill Currency='CZK' on existing ImportedMarketingTransactions rows`
+5. `feat: map Currency, Description, RawData in MarketingInvoiceImportService`
+6. `feat: skip and fail-count marketing transactions with empty Currency`
+7. (Optional) `chore: dotnet format on marketing-invoice-currency changes`
+
+Each commit is independently reviewable and revertable.
+
+---
+
+## Spec Coverage Matrix
+
+| Spec requirement | Task(s) | Notes |
+|---|---|---|
+| FR-1 — Currency column on entity, EF, mapping | Tasks 1, 2, 6 | Entity prop in Task 1; EF config in Task 2; import service mapping in Task 6; round-trip test in Tasks 5+6. |
+| FR-2 — Description column on entity, EF, mapping | Tasks 1, 2, 6 | Same flow as FR-1; round-trip test in Tasks 5+6. |
+| FR-3 — RawData column on entity, EF, mapping | Tasks 1, 2, 6 | Same flow as FR-1; round-trip test in Tasks 5+6. |
+| FR-4 — Migration with three-step backfill (per arch review Amendment 1) | Tasks 3, 4 | Scaffold in Task 3, hand-edit to three-step pattern in Task 4. |
+| FR-5 — Import service maps all three fields | Task 6 | Verbatim mapping, no normalization of Currency. |
+| FR-6 — Empty/whitespace Currency ⇒ skip + Failed++ + warning log; guard runs FIRST (per arch review Amendment 2) | Tasks 7, 8, 9 | Test, implement, regression-guard. |
+| NFR-1 — No throughput regression | Task 6, 8 | No new DB calls; single `SaveChangesAsync` at end preserved. |
+| NFR-2 — Currency NOT NULL after migration | Task 4 | `AlterColumn(nullable: false)` after backfill. |
+| NFR-3 — Backward compatibility | All tasks | Purely additive; no public API changes; existing tests unchanged. |
+| NFR-4 — Structured warning log with TransactionId + Platform | Task 8 | `_logger.LogWarning(..., transaction.TransactionId, source.Platform)`; asserted in Task 7. |
+| Arch review Amendment 4 — Pre-deploy CZK verification SQL | Task 10 Step 5 | Documented as operational checklist; not part of implementation commits. |

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
@@ -36,6 +36,15 @@ public class MarketingInvoiceImportService
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(transaction.Currency))
+                {
+                    _logger.LogWarning(
+                        "Marketing transaction {TransactionId} for {Platform} has empty Currency — skipping",
+                        transaction.TransactionId, source.Platform);
+                    result.Failed++;
+                    continue;
+                }
+
                 if (stagedIds.Contains(transaction.TransactionId))
                 {
                     _logger.LogDebug(

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
@@ -60,9 +60,12 @@ public class MarketingInvoiceImportService
                     TransactionId = transaction.TransactionId,
                     Platform = source.Platform,
                     Amount = transaction.Amount,
+                    Currency = transaction.Currency,
                     TransactionDate = transaction.TransactionDate,
                     ImportedAt = DateTime.UtcNow,
                     IsSynced = false,
+                    Description = transaction.Description,
+                    RawData = transaction.RawData,
                 };
 
                 await _repository.AddAsync(entity, ct);

--- a/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs
@@ -8,8 +8,11 @@ public class ImportedMarketingTransaction : IEntity<int>
     public string TransactionId { get; set; } = string.Empty;
     public string Platform { get; set; } = string.Empty;
     public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
     public DateTime TransactionDate { get; set; }
     public DateTime ImportedAt { get; set; }
     public bool IsSynced { get; set; } = false;
     public string? ErrorMessage { get; set; }
+    public string? Description { get; set; }
+    public string? RawData { get; set; }
 }

--- a/backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
@@ -54,6 +54,21 @@ public class ImportedMarketingTransactionConfiguration : IEntityTypeConfiguratio
             .HasColumnName("ErrorMessage")
             .HasColumnType("text");
 
+        builder.Property(e => e.Currency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasColumnName("Currency")
+            .HasColumnType("character varying(3)");
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500)
+            .HasColumnName("Description")
+            .HasColumnType("character varying(500)");
+
+        builder.Property(e => e.RawData)
+            .HasColumnName("RawData")
+            .HasColumnType("text");
+
         builder.HasIndex(e => new { e.Platform, e.TransactionId })
             .IsUnique()
             .HasDatabaseName("IX_ImportedMarketingTransactions_Platform_TransactionId");

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions")]
+    partial class AddCurrencyDescriptionRawDataToImportedMarketingTransactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCurrencyDescriptionRawDataToImportedMarketingTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Currency: add as nullable so backfill can populate existing rows.
+            migrationBuilder.AddColumn<string>(
+                name: "Currency",
+                schema: "public",
+                table: "ImportedMarketingTransactions",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: true);
+
+            // Backfill existing rows. All historical ImportedMarketingTransactions rows
+            // are CZK-billed (verify with SELECT DISTINCT "Platform" on prod before deploy).
+            migrationBuilder.Sql(
+                "UPDATE public.\"ImportedMarketingTransactions\" SET \"Currency\" = 'CZK' WHERE \"Currency\" IS NULL;");
+
+            // Enforce NOT NULL. New inserts must supply Currency explicitly.
+            migrationBuilder.AlterColumn<string>(
+                name: "Currency",
+                schema: "public",
+                table: "ImportedMarketingTransactions",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(3)",
+                oldMaxLength: 3,
+                oldNullable: true);
+
+            // Description: nullable, no backfill needed.
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                schema: "public",
+                table: "ImportedMarketingTransactions",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            // RawData: nullable, no backfill needed.
+            migrationBuilder.AddColumn<string>(
+                name: "RawData",
+                schema: "public",
+                table: "ImportedMarketingTransactions",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RawData",
+                schema: "public",
+                table: "ImportedMarketingTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                schema: "public",
+                table: "ImportedMarketingTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "Currency",
+                schema: "public",
+                table: "ImportedMarketingTransactions");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs
@@ -35,7 +35,7 @@ public class ImportMarketingInvoicesHandlerTests
         meta.Setup(s => s.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MarketingTransaction>
             {
-                new() { TransactionId = "TX-1", Platform = "MetaAds", Amount = 10m, TransactionDate = from },
+                new() { TransactionId = "TX-1", Platform = "MetaAds", Amount = 10m, TransactionDate = from, Currency = "CZK" },
             });
 
         var google = SourceFor("GoogleAds");

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -221,4 +221,56 @@ public class MarketingInvoiceImportServiceTests
         _mockRepository.Verify(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockRepository.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new()
+            {
+                TransactionId = "TX-EUR-001",
+                Platform = "TestPlatform",
+                Amount = 123.45m,
+                TransactionDate = from,
+                Description = "campaign X",
+                Currency = "EUR",
+                RawData = "{\"foo\":1}",
+            },
+        };
+
+        _mockSource
+            .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        _mockRepository
+            .Setup(x => x.ExistsAsync("TestPlatform", "TX-EUR-001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        ImportedMarketingTransaction? captured = null;
+        _mockRepository
+            .Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+            .Callback<ImportedMarketingTransaction, CancellationToken>((entity, _) => captured = entity)
+            .Returns(Task.CompletedTask);
+
+        _mockRepository
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(0, result.Failed);
+        Assert.NotNull(captured);
+        Assert.Equal("EUR", captured!.Currency);
+        Assert.Equal("campaign X", captured.Description);
+        Assert.Equal("{\"foo\":1}", captured.RawData);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -364,5 +364,8 @@ public class MarketingInvoiceImportServiceTests
         _mockRepository.Verify(
             x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        _mockRepository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -273,4 +273,96 @@ public class MarketingInvoiceImportServiceTests
         Assert.Equal("campaign X", captured.Description);
         Assert.Equal("{\"foo\":1}", captured.RawData);
     }
+
+    [Fact]
+    public async Task ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new()
+            {
+                TransactionId = "TX-BAD-001",
+                Platform = "TestPlatform",
+                Amount = 100m,
+                TransactionDate = from,
+                Description = "missing currency",
+                Currency = "",
+            },
+        };
+
+        _mockSource
+            .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Act
+        var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(1, result.Failed);
+        _mockRepository.Verify(
+            x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("TX-BAD-001") &&
+                    v.ToString()!.Contains("TestPlatform")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhitespaceCurrency_TreatedAsEmpty_CountsFailed()
+    {
+        // Arrange
+        var from = new DateTime(2026, 4, 1);
+        var to = new DateTime(2026, 4, 2);
+
+        var transactions = new List<MarketingTransaction>
+        {
+            new()
+            {
+                TransactionId = "TX-WS-001",
+                Platform = "TestPlatform",
+                Amount = 50m,
+                TransactionDate = from,
+                Description = "whitespace currency",
+                Currency = "   ",
+            },
+        };
+
+        _mockSource
+            .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+
+        // Act
+        var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+        // Assert
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Skipped);
+        Assert.Equal(1, result.Failed);
+        _mockRepository.Verify(
+            x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockRepository.Verify(
+            x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -367,5 +367,15 @@ public class MarketingInvoiceImportServiceTests
         _mockRepository.Verify(
             x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
             Times.Never);
+        _mockLogger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("TX-WS-001") &&
+                    v.ToString()!.Contains("TestPlatform")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
     }
 }

--- a/docs/superpowers/plans/2026-05-25-marketinginvoices-currency-description-rawdata.md
+++ b/docs/superpowers/plans/2026-05-25-marketinginvoices-currency-description-rawdata.md
@@ -1,0 +1,900 @@
+# Persist Currency, Description, and RawData on Imported Marketing Transactions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist `Currency`, `Description`, and `RawData` from `MarketingTransaction` into `ImportedMarketingTransaction` end-to-end (domain entity, EF mapping, database schema, import service), so monetary data carries an explicit ISO 4217 currency code and adapter-supplied audit context isn't discarded.
+
+**Architecture:** Pure additive change inside the `MarketingInvoices` vertical slice. Three columns are added to the `public."ImportedMarketingTransactions"` table; `Currency` is non-nullable and backfilled to `'CZK'` for existing rows using the project's established three-step migration pattern (add-nullable → `UPDATE` backfill → `ALTER` to NOT NULL). The import service maps the three fields verbatim and skips (counts `Failed`) any inbound transaction with an empty/whitespace `Currency`. No public API, contract, or interface signature changes.
+
+**Tech Stack:** .NET 8, EF Core 8 (Npgsql provider), PostgreSQL, MediatR (untouched), xUnit + Moq for tests.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` | Modify | Add three POCO properties to the persisted entity. |
+| `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` | Modify | Add three EF property mappings (column names, types, length constraints, NOT NULL for `Currency`). |
+| `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` | Create (via EF tooling, then hand-edit) | Add the three columns to the database; backfill `Currency = 'CZK'`; enforce NOT NULL on `Currency`. |
+| `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs` | Create (auto-generated) | Standard EF migration designer snapshot. |
+| `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` | Modify (auto-regenerated) | Snapshot reflects the new properties. |
+| `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` | Modify | (a) Add empty-Currency guard at top of per-transaction loop (before duplicate-check). (b) Extend object initializer to map `Currency`, `Description`, `RawData`. |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Modify | Add three test cases: full round-trip, empty-Currency, whitespace-Currency. |
+
+No new files for production code beyond the migration. No new directories. No DI registration changes.
+
+---
+
+## Task 1: Add Currency, Description, RawData properties to the domain entity
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+
+This is a structural change that unblocks the EF configuration (Task 2) and the test fixtures (Task 6). On its own it ships compile-only behavior.
+
+- [ ] **Step 1: Open the entity file and add three properties**
+
+Current content of `ImportedMarketingTransaction.cs`:
+
+```csharp
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public bool IsSynced { get; set; } = false;
+    public string? ErrorMessage { get; set; }
+}
+```
+
+Replace its contents with:
+
+```csharp
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public bool IsSynced { get; set; } = false;
+    public string? ErrorMessage { get; set; }
+    public string? Description { get; set; }
+    public string? RawData { get; set; }
+}
+```
+
+Notes:
+- `Currency` is non-nullable (matches `MarketingTransaction.Currency`, which is also non-nullable `string` defaulted to `string.Empty`).
+- `Description` and `RawData` are nullable (`string?`) — adapters may legitimately provide null/empty for description, and `RawData` is purely diagnostic.
+- Keep the entity a `class` (not a `record`) — see CLAUDE.md "DTOs/entities are classes" gotcha.
+
+- [ ] **Step 2: Build the solution to confirm no compile errors**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds (`Build succeeded. 0 Error(s)`).
+
+The existing tests in `MarketingInvoiceImportServiceTests.cs` will still compile because they don't reference the new entity properties yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs
+git commit -m "feat: add Currency, Description, RawData properties to ImportedMarketingTransaction entity"
+```
+
+---
+
+## Task 2: Configure the three new columns in EF Core
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`
+
+This makes EF Core aware of the new columns. It will be picked up by `dotnet ef migrations add` in Task 3.
+
+- [ ] **Step 1: Open the configuration file**
+
+Current configuration (file end, before the `HasIndex` call at line 57):
+
+```csharp
+        builder.Property(e => e.ErrorMessage)
+            .HasColumnName("ErrorMessage")
+            .HasColumnType("text");
+
+        builder.HasIndex(e => new { e.Platform, e.TransactionId })
+            .IsUnique()
+            .HasDatabaseName("IX_ImportedMarketingTransactions_Platform_TransactionId");
+```
+
+- [ ] **Step 2: Insert three new `builder.Property(...)` calls before the `HasIndex(...)` call**
+
+After the `ErrorMessage` configuration block and before `builder.HasIndex(...)`, add:
+
+```csharp
+        builder.Property(e => e.Currency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasColumnName("Currency")
+            .HasColumnType("character varying(3)");
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500)
+            .HasColumnName("Description")
+            .HasColumnType("character varying(500)");
+
+        builder.Property(e => e.RawData)
+            .HasColumnName("RawData")
+            .HasColumnType("text");
+```
+
+Notes:
+- Style matches the existing `Property(...)` calls in the file (explicit `HasColumnName` + `HasColumnType`).
+- `IsRequired()` only on `Currency` — others are nullable.
+- No `HasDefaultValue('CZK')` here; the default is purely a migration concern (existing rows), not a runtime EF concern.
+
+- [ ] **Step 3: Build to confirm no compile errors**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
+git commit -m "feat: configure Currency, Description, RawData columns in EF mapping"
+```
+
+---
+
+## Task 3: Scaffold the EF migration with `dotnet ef migrations add`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs`
+- Modify (auto-regenerated): `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`
+
+The CLI generates a vanilla `AddColumn` migration. We will hand-edit it in Task 4 to add the backfill + `AlterColumn`.
+
+- [ ] **Step 1: Run the EF migrations add command**
+
+Run from the repo root:
+
+```bash
+dotnet ef migrations add AddCurrencyDescriptionRawDataToImportedMarketingTransactions \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected: three new/changed files appear in `backend/src/Anela.Heblo.Persistence/Migrations/`:
+1. `{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` (new)
+2. `{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.Designer.cs` (new)
+3. `ApplicationDbContextModelSnapshot.cs` (modified — should now include the three new properties on the `ImportedMarketingTransaction` entity block)
+
+- [ ] **Step 2: Verify the generated `.cs` migration has three `AddColumn` calls**
+
+Open the newly-generated `{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`. The `Up` method should contain something like:
+
+```csharp
+migrationBuilder.AddColumn<string>(
+    name: "Currency",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "character varying(3)",
+    maxLength: 3,
+    nullable: false,
+    defaultValue: "");
+
+migrationBuilder.AddColumn<string>(
+    name: "Description",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "character varying(500)",
+    maxLength: 500,
+    nullable: true);
+
+migrationBuilder.AddColumn<string>(
+    name: "RawData",
+    schema: "public",
+    table: "ImportedMarketingTransactions",
+    type: "text",
+    nullable: true);
+```
+
+(The exact `defaultValue` clause on `Currency` will depend on EF's defaults — EF emits `defaultValue: ""` when scaffolding NOT NULL string columns. This is exactly what we will replace in Task 4 with the explicit three-step pattern.)
+
+The `Down` method should contain three `DropColumn` calls.
+
+- [ ] **Step 3: Verify the snapshot was updated correctly**
+
+In `ApplicationDbContextModelSnapshot.cs`, the `ImportedMarketingTransaction` block (around line 2336) should now include three additional `b.Property<string>(...)` entries for `Currency`, `Description`, and `RawData`.
+
+Quick spot-check command (no need to run; visual inspection is fine):
+
+```bash
+grep -n "Currency\|Description\|RawData" backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs | head -30
+```
+
+Expected: lines showing the three new properties registered on the `Anela.Heblo.Domain.Features.MarketingInvoices.ImportedMarketingTransaction` entity.
+
+- [ ] **Step 4: Build to confirm the scaffolded files compile**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit the scaffolded migration as-is**
+
+We will hand-edit it in Task 4; committing the scaffold first makes the manual changes reviewable as a separate diff.
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "chore: scaffold migration for Currency, Description, RawData columns"
+```
+
+---
+
+## Task 4: Hand-edit the migration to use the add-nullable → backfill → alter pattern
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Migrations/{timestamp}_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`
+
+Background — see arch review Decision 1 and Amendment 1. The prior art `20251208184900_AddTransferIdColumnWithDataHandling.cs:44-67` adds a NOT NULL column safely on an existing table by:
+1. Adding the column as nullable.
+2. Running an explicit `UPDATE … WHERE … IS NULL` to backfill.
+3. Altering the column to NOT NULL.
+
+`Description` and `RawData` are nullable, so they stay as plain `AddColumn(nullable: true)` calls. Only `Currency` needs the three-step pattern.
+
+- [ ] **Step 1: Replace the `Up` method**
+
+Open the migration file and replace the body of `Up(MigrationBuilder migrationBuilder)` with the following. The existing `using` directives and class skeleton stay as-is.
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    // Currency: add as nullable so backfill can populate existing rows.
+    migrationBuilder.AddColumn<string>(
+        name: "Currency",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "character varying(3)",
+        maxLength: 3,
+        nullable: true);
+
+    // Backfill existing rows. Assumption verified pre-deploy: all historical
+    // ImportedMarketingTransactions rows are CZK-billed (see spec FR-4 and
+    // arch review Amendment 4 — confirm with the SELECT DISTINCT query on prod
+    // before applying this migration there).
+    migrationBuilder.Sql(
+        "UPDATE public.\"ImportedMarketingTransactions\" SET \"Currency\" = 'CZK' WHERE \"Currency\" IS NULL;");
+
+    // Now enforce NOT NULL. New inserts must supply Currency explicitly;
+    // the FR-6 guard in MarketingInvoiceImportService rejects empties.
+    migrationBuilder.AlterColumn<string>(
+        name: "Currency",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "character varying(3)",
+        maxLength: 3,
+        nullable: false,
+        oldClrType: typeof(string),
+        oldType: "character varying(3)",
+        oldMaxLength: 3,
+        oldNullable: true);
+
+    // Description: nullable, no backfill needed.
+    migrationBuilder.AddColumn<string>(
+        name: "Description",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "character varying(500)",
+        maxLength: 500,
+        nullable: true);
+
+    // RawData: nullable, no backfill needed.
+    migrationBuilder.AddColumn<string>(
+        name: "RawData",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "text",
+        nullable: true);
+}
+```
+
+- [ ] **Step 2: Replace the `Down` method**
+
+Replace the `Down` body with three `DropColumn` calls (the order doesn't matter for `Down`):
+
+```csharp
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "RawData",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "Description",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "Currency",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+}
+```
+
+- [ ] **Step 3: Build to confirm the hand-edited migration compiles**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds.
+
+- [ ] **Step 4: Apply the migration to a fresh local Postgres dev database**
+
+Run from the repo root:
+
+```bash
+dotnet ef database update \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected: command completes with `Done.` and no error. If the local database already has the columns (from a prior partial attempt), drop and recreate it, or revert to the pre-migration state with `dotnet ef database update <previous-migration-name>` first.
+
+- [ ] **Step 5: Spot-check the schema via `psql`**
+
+If `psql` is available locally, verify the three columns exist with the right types and that `Currency` is NOT NULL:
+
+```bash
+psql "$ConnectionStrings__DefaultConnection" -c "\d public.\"ImportedMarketingTransactions\""
+```
+
+Expected output includes lines roughly like:
+
+```
+ Currency        | character varying(3)   | not null
+ Description     | character varying(500) |
+ RawData         | text                   |
+```
+
+If the local DB had any pre-existing rows, also verify the backfill:
+
+```bash
+psql "$ConnectionStrings__DefaultConnection" \
+  -c "SELECT \"Currency\", COUNT(*) FROM public.\"ImportedMarketingTransactions\" GROUP BY \"Currency\";"
+```
+
+Expected: any existing rows show `Currency = 'CZK'`; new ones (none yet) will follow.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Migrations/
+git commit -m "feat: backfill Currency='CZK' on existing ImportedMarketingTransactions rows"
+```
+
+---
+
+## Task 5: Add failing test for Currency/Description/RawData round-trip in import service
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+We follow the project's TDD discipline: write the test first, watch it fail, then implement (Task 6).
+
+- [ ] **Step 1: Add the new test case to `MarketingInvoiceImportServiceTests.cs`**
+
+Append the following test inside the class (after `ImportAsync_DuplicateTransactionIdWithinSameRun_StagesOnlyOnce`, before the closing `}` of the class):
+
+```csharp
+[Fact]
+public async Task ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData()
+{
+    // Arrange
+    var from = new DateTime(2026, 4, 1);
+    var to = new DateTime(2026, 4, 2);
+
+    var transactions = new List<MarketingTransaction>
+    {
+        new()
+        {
+            TransactionId = "TX-EUR-001",
+            Platform = "TestPlatform",
+            Amount = 123.45m,
+            TransactionDate = from,
+            Description = "campaign X",
+            Currency = "EUR",
+            RawData = "{\"foo\":1}",
+        },
+    };
+
+    _mockSource
+        .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transactions);
+
+    _mockRepository
+        .Setup(x => x.ExistsAsync("TestPlatform", "TX-EUR-001", It.IsAny<CancellationToken>()))
+        .ReturnsAsync(false);
+
+    ImportedMarketingTransaction? captured = null;
+    _mockRepository
+        .Setup(x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()))
+        .Callback<ImportedMarketingTransaction, CancellationToken>((entity, _) => captured = entity)
+        .Returns(Task.CompletedTask);
+
+    _mockRepository
+        .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+        .ReturnsAsync(1);
+
+    // Act
+    var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+    // Assert
+    Assert.Equal(1, result.Imported);
+    Assert.Equal(0, result.Skipped);
+    Assert.Equal(0, result.Failed);
+    Assert.NotNull(captured);
+    Assert.Equal("EUR", captured!.Currency);
+    Assert.Equal("campaign X", captured.Description);
+    Assert.Equal("{\"foo\":1}", captured.RawData);
+}
+```
+
+Notes:
+- `Currency = "EUR"` confirms FR-5's "must not be coerced to CZK" requirement.
+- `captured` is set via Moq `Callback` (same pattern Moq uses elsewhere in this codebase).
+- `MarketingTransaction` already has `Currency`, `Description`, `RawData` properties (see `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`).
+- Entity `Currency`, `Description`, `RawData` properties exist now thanks to Task 1.
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData"
+```
+
+Expected: test fails on one of the three `Assert.Equal(...)` checks — `captured.Currency` will be `""` (default), `captured.Description` and `captured.RawData` will be `null`. The service has not yet been updated to map these fields.
+
+If the test passes unexpectedly, the implementation is already wrong — re-read the current `MarketingInvoiceImportService.cs:58-66` object initializer and verify it does NOT yet include `Currency`/`Description`/`RawData`.
+
+(Do NOT commit yet — test + impl get committed together in Task 6.)
+
+---
+
+## Task 6: Update import service to map Currency, Description, RawData
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+- [ ] **Step 1: Extend the object initializer**
+
+Open `MarketingInvoiceImportService.cs`. Find the existing object initializer at lines 58-66:
+
+```csharp
+var entity = new ImportedMarketingTransaction
+{
+    TransactionId = transaction.TransactionId,
+    Platform = source.Platform,
+    Amount = transaction.Amount,
+    TransactionDate = transaction.TransactionDate,
+    ImportedAt = DateTime.UtcNow,
+    IsSynced = false,
+};
+```
+
+Replace it with:
+
+```csharp
+var entity = new ImportedMarketingTransaction
+{
+    TransactionId = transaction.TransactionId,
+    Platform = source.Platform,
+    Amount = transaction.Amount,
+    Currency = transaction.Currency,
+    TransactionDate = transaction.TransactionDate,
+    ImportedAt = DateTime.UtcNow,
+    IsSynced = false,
+    Description = transaction.Description,
+    RawData = transaction.RawData,
+};
+```
+
+Notes:
+- `Currency` is passed verbatim — no `ToUpperInvariant()`, no normalization. ISO-4217 validation is upstream's responsibility per the spec's "Out of Scope".
+- `Description` from `MarketingTransaction` is non-nullable `string` (defaults to `string.Empty`); the entity stores it as `string?`. Passing a value through this assignment is implicit conversion — empty strings pass through verbatim.
+- `RawData` is `string?` on both sides — pass through.
+
+- [ ] **Step 2: Run the Task-5 test to confirm it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_NewTransaction_PersistsCurrencyDescriptionAndRawData"
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Run the full import-service test class to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+
+Expected: all tests pass (6 pre-existing + 1 new = 7). The existing tests already construct fixtures with `Currency = "CZK"`, `Description = "Ad charge"` (see test file lines 38-39, 74, 103-104, 139-140, 197-198), so they're unaffected by the additive mapping.
+
+- [ ] **Step 4: Commit test + implementation together**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs \
+        backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+git commit -m "feat: map Currency, Description, RawData in MarketingInvoiceImportService"
+```
+
+---
+
+## Task 7: Add failing test for the empty-Currency guard
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+This test drives the FR-6 behavior. Per arch review Amendment 2, the guard must run **before** the `stagedIds` check at line 39 and the `ExistsAsync` call at line 48. We assert this directly via `Times.Never` on both `AddAsync` and `ExistsAsync`.
+
+- [ ] **Step 1: Add the empty-Currency test**
+
+Append inside the class:
+
+```csharp
+[Fact]
+public async Task ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd()
+{
+    // Arrange
+    var from = new DateTime(2026, 4, 1);
+    var to = new DateTime(2026, 4, 2);
+
+    var transactions = new List<MarketingTransaction>
+    {
+        new()
+        {
+            TransactionId = "TX-BAD-001",
+            Platform = "TestPlatform",
+            Amount = 100m,
+            TransactionDate = from,
+            Description = "missing currency",
+            Currency = "",
+        },
+    };
+
+    _mockSource
+        .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transactions);
+
+    // Act
+    var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+    // Assert
+    Assert.Equal(0, result.Imported);
+    Assert.Equal(0, result.Skipped);
+    Assert.Equal(1, result.Failed);
+    _mockRepository.Verify(
+        x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _mockRepository.Verify(
+        x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _mockRepository.Verify(
+        x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+        Times.Never);
+
+    // Warning log: verify it was emitted with TransactionId and Platform context.
+    _mockLogger.Verify(
+        l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, _) =>
+                v.ToString()!.Contains("TX-BAD-001") &&
+                v.ToString()!.Contains("TestPlatform")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.AtLeastOnce);
+}
+```
+
+Notes:
+- The `_mockLogger.Verify(...)` block is the canonical Moq pattern for asserting `ILogger.Log` was called at a specific level — it works because `ILogger.LogWarning(...)` is an extension method that resolves to `ILogger.Log(LogLevel.Warning, ...)` internally.
+- The `v.ToString()!.Contains(...)` checks are loose — they confirm structured properties were inlined into the formatted message. The Task-8 implementation will use `_logger.LogWarning("...", transaction.TransactionId, source.Platform)`-style structured logging, which Moq's `It.IsAnyType` captures via the formatted state object.
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd"
+```
+
+Expected: test fails. With no guard in place, the empty-currency transaction will flow through `ExistsAsync` (returns `false` from the default Moq stub) and `AddAsync`, so the `Verify(..., Times.Never)` assertions will fail (most likely the `ExistsAsync` one fails first).
+
+(Do not commit yet — Task 8 commits guard + tests together with the whitespace test from Task 9.)
+
+---
+
+## Task 8: Add the empty-Currency guard at the top of the import loop
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+Per arch review Amendment 2, the guard runs **first** inside the `try` block, before the `stagedIds.Contains(...)` check and before `ExistsAsync`.
+
+- [ ] **Step 1: Insert the guard at the top of the per-transaction loop body**
+
+Open `MarketingInvoiceImportService.cs`. Find the loop body (lines 35-79). Inside the existing `try { ... }` (starting at line 37), the current first statement is the `stagedIds.Contains(transaction.TransactionId)` check.
+
+Insert the new guard immediately after `try {` and before that check. The body of the `try` block becomes:
+
+```csharp
+try
+{
+    if (string.IsNullOrWhiteSpace(transaction.Currency))
+    {
+        _logger.LogWarning(
+            "Marketing transaction {TransactionId} for {Platform} has empty Currency — skipping",
+            transaction.TransactionId, source.Platform);
+        result.Failed++;
+        continue;
+    }
+
+    if (stagedIds.Contains(transaction.TransactionId))
+    {
+        _logger.LogDebug(
+            "Transaction {TransactionId} for {Platform} already staged in this run — skipping",
+            transaction.TransactionId, source.Platform);
+        result.Skipped++;
+        continue;
+    }
+
+    var exists = await _repository.ExistsAsync(source.Platform, transaction.TransactionId, ct);
+    if (exists)
+    {
+        _logger.LogDebug(
+            "Transaction {TransactionId} for {Platform} already imported — skipping",
+            transaction.TransactionId, source.Platform);
+        result.Skipped++;
+        continue;
+    }
+
+    var entity = new ImportedMarketingTransaction
+    {
+        TransactionId = transaction.TransactionId,
+        Platform = source.Platform,
+        Amount = transaction.Amount,
+        Currency = transaction.Currency,
+        TransactionDate = transaction.TransactionDate,
+        ImportedAt = DateTime.UtcNow,
+        IsSynced = false,
+        Description = transaction.Description,
+        RawData = transaction.RawData,
+    };
+
+    await _repository.AddAsync(entity, ct);
+    stagedIds.Add(transaction.TransactionId);
+    stagedCount++;
+}
+catch (Exception ex)
+{
+    // unchanged
+}
+```
+
+Notes:
+- `string.IsNullOrWhiteSpace(...)` handles `null`, `""`, and `"   "` in one check (covers Task 9's case automatically).
+- `result.Failed++` (not `Skipped`) — per arch review Decision 2, this is a real defect, not a benign skip.
+- `continue` moves to the next transaction; the per-row `try/catch` philosophy is preserved.
+- The log message uses structured properties so the Moq verify in Task 7 will match.
+
+- [ ] **Step 2: Run the Task-7 test to confirm it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_EmptyCurrency_Skips_CountsFailed_DoesNotCallExistsOrAdd"
+```
+
+Expected: 1 passed, 0 failed.
+
+- [ ] **Step 3: Run the full import-service test class to confirm no regressions**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+
+Expected: 8 tests pass, 0 fail. The existing tests use `Currency = "CZK"` everywhere so they still pass through the guard.
+
+(Do not commit yet — Task 9 adds the whitespace test, then we commit the guard + both new tests together.)
+
+---
+
+## Task 9: Add whitespace-Currency test (regression guard for `IsNullOrWhiteSpace` branch)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+This is a defensive test that pins the `IsNullOrWhiteSpace` behavior. If a future engineer refactors the guard to `string.IsNullOrEmpty(...)`, this test fails and protects the contract.
+
+- [ ] **Step 1: Add the whitespace test**
+
+Append inside the class:
+
+```csharp
+[Fact]
+public async Task ImportAsync_WhitespaceCurrency_TreatedAsEmpty_CountsFailed()
+{
+    // Arrange
+    var from = new DateTime(2026, 4, 1);
+    var to = new DateTime(2026, 4, 2);
+
+    var transactions = new List<MarketingTransaction>
+    {
+        new()
+        {
+            TransactionId = "TX-WS-001",
+            Platform = "TestPlatform",
+            Amount = 50m,
+            TransactionDate = from,
+            Description = "whitespace currency",
+            Currency = "   ",
+        },
+    };
+
+    _mockSource
+        .Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(transactions);
+
+    // Act
+    var result = await _service.ImportAsync(_mockSource.Object, from, to);
+
+    // Assert
+    Assert.Equal(0, result.Imported);
+    Assert.Equal(0, result.Skipped);
+    Assert.Equal(1, result.Failed);
+    _mockRepository.Verify(
+        x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+    _mockRepository.Verify(
+        x => x.AddAsync(It.IsAny<ImportedMarketingTransaction>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it PASSES**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ImportAsync_WhitespaceCurrency_TreatedAsEmpty_CountsFailed"
+```
+
+Expected: 1 passed. The guard implemented in Task 8 already uses `IsNullOrWhiteSpace`, so this should pass on the first run.
+
+If it fails, the Task-8 implementation used `IsNullOrEmpty` (or similar) — go back and fix to `IsNullOrWhiteSpace`.
+
+- [ ] **Step 3: Run the full import-service test class**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoiceImportServiceTests"
+```
+
+Expected: 9 tests pass, 0 fail.
+
+- [ ] **Step 4: Commit guard + empty + whitespace tests together**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs \
+        backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+git commit -m "feat: skip and fail-count marketing transactions with empty Currency"
+```
+
+---
+
+## Task 10: Final validation and cleanup
+
+**Files:**
+- (Verification only — no file changes expected.)
+
+Per CLAUDE.md "Validation before completion":
+
+- [ ] **Step 1: Full backend build (clean)**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: `Build succeeded. 0 Error(s)`. Warnings unchanged from baseline.
+
+- [ ] **Step 2: Code formatting**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: no diff produced. If `dotnet format` reformatted any of the files touched in this plan, inspect the changes — they should be small whitespace fixes only.
+
+If `dotnet format` made changes, commit them as a separate housekeeping commit:
+
+```bash
+git add -A
+git status
+# Review the diff
+git commit -m "chore: dotnet format on marketing-invoice-currency changes"
+```
+
+- [ ] **Step 3: Full backend test suite (touched test project)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj`
+Expected: all tests pass. The `MarketingInvoiceImportServiceTests` class should report 9 tests (6 original + 3 new). No unrelated tests should fail.
+
+- [ ] **Step 4: Confirm migration still applies cleanly to a fresh database**
+
+If you have access to a throwaway local Postgres, drop and re-create the dev database, then run:
+
+```bash
+dotnet ef database update \
+  --project backend/src/Anela.Heblo.Persistence \
+  --startup-project backend/src/Anela.Heblo.API
+```
+
+Expected: all migrations apply in order; the new migration runs at the end without error; the table has the three new columns with the right types and `Currency` is NOT NULL.
+
+- [ ] **Step 5: Pre-deploy verification reminder (manual, NOT executed here)**
+
+Before applying this migration to production, the developer must verify the CZK-backfill assumption holds on the production database. From arch review Amendment 4:
+
+```sql
+SELECT "Platform", COUNT(*)
+FROM public."ImportedMarketingTransactions"
+GROUP BY "Platform";
+```
+
+Then, for each platform listed, manually cross-check the connected ad account's billing currency. **If any platform is not 100% CZK-billed**, the migration's backfill SQL must be amended to a per-Platform `CASE WHEN` expression before deploy. This is a one-time operational step — do not skip it.
+
+This step is documented here as a checklist item but is NOT part of the implementation commits. The plan is "ship-ready" once Steps 1-4 above are green.
+
+- [ ] **Step 6: Final commit summary check**
+
+Run: `git log --oneline main..HEAD`
+
+Expected commit list (in order):
+1. `feat: add Currency, Description, RawData properties to ImportedMarketingTransaction entity`
+2. `feat: configure Currency, Description, RawData columns in EF mapping`
+3. `chore: scaffold migration for Currency, Description, RawData columns`
+4. `feat: backfill Currency='CZK' on existing ImportedMarketingTransactions rows`
+5. `feat: map Currency, Description, RawData in MarketingInvoiceImportService`
+6. `feat: skip and fail-count marketing transactions with empty Currency`
+7. (Optional) `chore: dotnet format on marketing-invoice-currency changes`
+
+Each commit is independently reviewable and revertable.
+
+---
+
+## Spec Coverage Matrix
+
+| Spec requirement | Task(s) | Notes |
+|---|---|---|
+| FR-1 — Currency column on entity, EF, mapping | Tasks 1, 2, 6 | Entity prop in Task 1; EF config in Task 2; import service mapping in Task 6; round-trip test in Tasks 5+6. |
+| FR-2 — Description column on entity, EF, mapping | Tasks 1, 2, 6 | Same flow as FR-1; round-trip test in Tasks 5+6. |
+| FR-3 — RawData column on entity, EF, mapping | Tasks 1, 2, 6 | Same flow as FR-1; round-trip test in Tasks 5+6. |
+| FR-4 — Migration with three-step backfill (per arch review Amendment 1) | Tasks 3, 4 | Scaffold in Task 3, hand-edit to three-step pattern in Task 4. |
+| FR-5 — Import service maps all three fields | Task 6 | Verbatim mapping, no normalization of Currency. |
+| FR-6 — Empty/whitespace Currency ⇒ skip + Failed++ + warning log; guard runs FIRST (per arch review Amendment 2) | Tasks 7, 8, 9 | Test, implement, regression-guard. |
+| NFR-1 — No throughput regression | Task 6, 8 | No new DB calls; single `SaveChangesAsync` at end preserved. |
+| NFR-2 — Currency NOT NULL after migration | Task 4 | `AlterColumn(nullable: false)` after backfill. |
+| NFR-3 — Backward compatibility | All tasks | Purely additive; no public API changes; existing tests unchanged. |
+| NFR-4 — Structured warning log with TransactionId + Platform | Task 8 | `_logger.LogWarning(..., transaction.TransactionId, source.Platform)`; asserted in Task 7. |
+| Arch review Amendment 4 — Pre-deploy CZK verification SQL | Task 10 Step 5 | Documented as operational checklist; not part of implementation commits. |


### PR DESCRIPTION

Persists the `Currency`, `Description`, and `RawData` fields that every marketing transaction adapter (Google Ads, Meta Ads) has always populated but the import service was silently discarding. The most critical fix is `Currency`: storing monetary amounts without a currency code creates a silent multi-currency bug whenever any ad account bills outside CZK.

The change is purely additive — three new columns, one guard, no public API or interface changes. Existing rows are backfilled to `'CZK'` using the repo's established add-nullable→UPDATE→ALTER migration pattern. Any inbound transaction with a missing currency is rejected early (before any DB round-trips), counted as `Failed`, and logged with full diagnostic context.

### Changes
- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` — three new POCO properties
- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` — EF column mappings for the three new properties
- `backend/src/Anela.Heblo.Persistence/Migrations/20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs` — migration with three-step Currency backfill + nullable adds for Description/RawData
- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — empty-Currency guard + all three fields in object initializer
- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` — 3 new tests (round-trip, empty-currency, whitespace-currency)
- `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/ImportMarketingInvoicesHandlerTests.cs` — regression fix: handler test fixture now supplies `Currency = "CZK"`

---

Closes #1651

### Tokens used
30440115
