### PR TITLE
feat: Article Writing Prompt Configuration Fix

### DIFF
--- a/artifacts/feat-arch-review-article-articleoptions-write/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-articleoptions-write/arch-review.r1.md
@@ -1,0 +1,161 @@
+# Architecture Review: Article Writing Prompt Configuration Fix
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with patterns already established in this codebase. `ArticleOptions` is a strongly-typed POCO bound via the standard `IOptions<>` pattern (`AddOptions<ArticleOptions>().Bind(...).ValidateDataAnnotations().ValidateOnStart()`), and three of the four pipeline steps (`PlanQueriesStep`, `AggregateFactsStep`, `ValidateFactsStep`) already expose their system prompts as configurable string properties named `<Step>SystemPrompt` and pass them as `ChatRole.System`. `WriteArticleStep` is the lone outlier — this refactor brings it into conformance.
+
+Integration points are tightly scoped:
+- `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs` (property surface)
+- `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs` (chat invocation + `BuildSystemPrompt` style-guide wrapper)
+- `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs` (new test for FR-3)
+- `docs/features/article-generation.md:307` (key rename in docs)
+
+No DI changes, no migration, no API/DTO/OpenAPI surface change, no frontend impact, no new dependencies. This is a pure refactor.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+appsettings.json ("Articles" section)
+        │  (binds via Options Pattern, ValidateDataAnnotations)
+        ▼
+ArticleOptions (POCO)
+  ├── WriteArticleSystemPrompt       ← NEW, default = current SystemInstruction
+  └── WriteArticleUserPromptTemplate ← RENAMED from WriteArticleSystemPromptTemplate
+        │
+        ▼ (injected via IOptions<ArticleOptions>)
+WriteArticleStep
+  ├── BuildSystemPrompt(styleGuide)   ← still wraps with "STYLE GUIDE — follow this exactly:\n..."
+  │      └── reads _options.WriteArticleSystemPrompt
+  ├── BuildUserMessage(context)
+  │      └── reads _options.WriteArticleUserPromptTemplate
+  └── IChatClient.GetResponseAsync([System, User], …)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Style-guide composition stays in code, not in the configured prompt
+**Options considered:**
+- (A) Move the `"STYLE GUIDE — follow this exactly:\n{styleGuide}\n\n"` wrapper into the configured default value, parametrised with a `{style_guide}` placeholder.
+- (B) Keep `BuildSystemPrompt(styleGuideText)` in code; have it concatenate the wrapper around `_options.WriteArticleSystemPrompt` only when `styleGuideText != null`.
+
+**Chosen approach:** (B). The configured `WriteArticleSystemPrompt` default equals the existing `SystemInstruction` constant **verbatim** (the editor persona + JSON output contract). The conditional style-guide prefix remains in `BuildSystemPrompt`.
+
+**Rationale:** FR-1 explicitly says "default MUST equal the current `SystemInstruction` constant character-for-character." The style-guide prefix is a runtime composition — its presence depends on `context.StyleGuideText != null`. Encoding that in the static configured string would require either a placeholder + always-on string.Replace (changing behaviour when style guide is null because the prefix would leak) or a separate config key. Keeping the wrapper in code preserves FR-5 (byte-identical defaults) with zero behavioural risk.
+
+#### Decision 2: No `[Required, MinLength(1)]` data annotations on the new properties
+**Options considered:**
+- (A) Add `[Required, MinLength(1)]` to both `WriteArticleSystemPrompt` and `WriteArticleUserPromptTemplate`, matching the model-name properties.
+- (B) Leave them unannotated, matching the sibling `*SystemPrompt` properties (`QueryPlannerSystemPrompt`, `AggregateFactsSystemPrompt`, `ValidateFactsSystemPrompt`).
+
+**Chosen approach:** (B). No validation attributes.
+
+**Rationale:** Consistency with the three siblings is the stated goal of NFR-4. Adding attributes only to the write step would re-introduce the inconsistency this refactor is removing. Defaults are non-null and non-empty; `ValidateOnStart` already guarantees the section binds successfully.
+
+#### Decision 3: Section name is `Articles` (plural), not `Article` — spec needs correction
+**Options considered:** N/A — pure factual correction.
+
+**Chosen approach:** The configuration section is `ArticleOptions.SectionName = "Articles"`. All examples and runbook items in the spec referring to `Article:WriteArticleSystemPromptTemplate` must be updated to `Articles:WriteArticleSystemPromptTemplate` / `Articles:WriteArticleUserPromptTemplate`. See Specification Amendments below.
+
+#### Decision 4: Do not add the new keys to any `appsettings*.json`
+**Options considered:**
+- (A) Populate `appsettings.json` with the verbatim default values to make the configurable surface discoverable.
+- (B) Leave `appsettings.json` clean; rely on the POCO default.
+
+**Chosen approach:** (B). The base `appsettings.json` `Articles` section currently contains only the model/token/topK knobs — it does **not** contain any prompt strings today. Match that pattern.
+
+**Rationale:** Duplicating long Czech prompt strings between code and JSON creates a drift hazard and offers no value when the default is authoritative. Operators who need to override learn the key from the POCO or docs.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Touch only:
+1. `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs`
+2. `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`
+3. `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs` (add one test for FR-3)
+4. `docs/features/article-generation.md` (rename key at line 307; add `WriteArticleSystemPrompt` if it improves discoverability — optional)
+
+### Interfaces and Contracts
+
+`ArticleOptions` final shape for the affected properties:
+
+```csharp
+public string WriteArticleSystemPrompt { get; set; } =
+    """
+    Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+    Odpověz POUZE validním JSON bez markdown nebo code fences.
+    V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
+    {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
+    """;
+
+public string WriteArticleUserPromptTemplate { get; set; } =
+    """
+    Napiš článek na téma {topic} pro publikum {audience}.
+    Délka: {length}. Úhel pohledu: {angle}.
+    Využij tato fakta: {facts}
+    {style_guide}
+    """;
+```
+
+`WriteArticleStep.cs` mechanical edits:
+- Delete the `private const string SystemInstruction = ...` block (lines 86–92).
+- In `BuildSystemPrompt`, replace both references to `SystemInstruction` with `_options.WriteArticleSystemPrompt`. The `"STYLE GUIDE — follow this exactly:\n..."` wrapper stays.
+- In `BuildUserMessage`, rename `_options.WriteArticleSystemPromptTemplate` → `_options.WriteArticleUserPromptTemplate`.
+- No changes to `ChatRole.System` / `ChatRole.User` wiring at lines 56–58 — it already does the right thing.
+
+### Data Flow
+
+For the two key cases:
+
+**No style guide (`context.StyleGuideText == null`):**
+```
+_options.WriteArticleSystemPrompt ────────────────────────► ChatRole.System
+_options.WriteArticleUserPromptTemplate
+  → string.Replace({topic}, {audience}, {length},
+                   {angle}, {facts}, {style_guide}="") ───► ChatRole.User
+```
+
+**With style guide:**
+```
+"STYLE GUIDE — follow this exactly:\n{styleGuide}\n\n"
+  + _options.WriteArticleSystemPrompt ────────────────────► ChatRole.System
+_options.WriteArticleUserPromptTemplate
+  → string.Replace(..., {style_guide}=styleGuideText) ───► ChatRole.User
+```
+
+(This double-injection of the style guide into both system and user messages is pre-existing behavior and is preserved as-is per FR-5.)
+
+### New unit test (FR-3 acceptance)
+Add to `WriteArticleStepTests.cs` — use `Moq.Verify` on `IChatClient.GetResponseAsync` to capture the `IEnumerable<ChatMessage>` and assert the `System`-role message equals `_options.WriteArticleSystemPrompt` after overriding it via a fresh `ArticleOptions` instance. Use the existing `_chat` mock + AAA structure mirroring the file's conventions (xUnit + FluentAssertions + Moq).
+
+Suggested name: `ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage`.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `Azure App Service Configuration` (not in source control) has an override under the old key `Articles:WriteArticleSystemPromptTemplate`. After deploy, that override silently becomes dead config; the runtime falls back to the default user template — no error, no log. | HIGH | Pre-deploy: SSH/Portal-verify Azure App Service settings for Dev/Staging/Production. Rename or remove the old key in lockstep with the deploy. Add an explicit step to the release notes / PR description (NFR-3 already mandates this). |
+| Style-guide composition (`BuildSystemPrompt`) accidentally lost during the refactor, causing a silent behaviour change for runs with a style guide. | MEDIUM | Add a unit test (or extend an existing one) that supplies `context.StyleGuideText = "X"` and asserts the `System` message **starts with** `"STYLE GUIDE — follow this exactly:\nX"` and **ends with** the configured prompt. Cheap, prevents regression. |
+| Future developer notices the now-renamed property in `appsettings.json` keys differs from what's bound by `Options` and silently re-introduces the old name. | LOW | One-line note in `docs/features/article-generation.md` (next to the JSON sample) explaining the system/user role mapping and naming convention. |
+| Historical plan file `docs/superpowers/plans/2026-05-08-article-generation-metadata.md:1421` references the old name; future search confuses readers. | LOW | Leave it — historical plans are immutable records. Spec's FR-4 acceptance ("grepping the repo for `WriteArticleSystemPromptTemplate` returns zero hits") must be relaxed to exclude `docs/superpowers/plans/`. See Specification Amendments. |
+
+## Specification Amendments
+
+1. **FR-4 grep scope** — Change "Grepping the repo for `WriteArticleSystemPromptTemplate` returns zero hits" to "Grepping `backend/`, `frontend/`, and `docs/features/` returns zero hits. Historical plans under `docs/superpowers/plans/` are excluded." Rationale: those plans are point-in-time records; rewriting them rewrites history.
+
+2. **Section name** — Replace every occurrence of `Article:WriteArticleSystemPromptTemplate` and `Article:WriteArticleUserPromptTemplate` in the spec (Background, NFR-3, NFR-3 acceptance) with the correct `Articles:` prefix. The bound section name is `Articles` (`ArticleOptions.SectionName = "Articles"`).
+
+3. **FR-3 acceptance — preserve style-guide wrapper** — Add: "The `BuildSystemPrompt(string? styleGuideText)` style-guide prefix composition is preserved. When `styleGuideText != null`, the `ChatRole.System` message MUST equal `\"STYLE GUIDE — follow this exactly:\\n{styleGuideText}\\n\\n\" + _options.WriteArticleSystemPrompt`. When null, it MUST equal `_options.WriteArticleSystemPrompt` exactly." This is implicit in FR-5 but worth making explicit since the constant is being deleted.
+
+4. **FR-4 reality check** — No `appsettings*.json` in this repo currently overrides `WriteArticleSystemPromptTemplate`. The runbook step in NFR-3 only applies to environments where the override exists outside source control (Azure App Service config). Strike "appsettings*.json files (Development, Production, Staging, default) that currently contain..." since none do — replace with "Any environment-specific config source (file or Azure App Service Configuration) that currently sets `Articles:WriteArticleSystemPromptTemplate` must be migrated."
+
+5. **NFR-4 user-prompt column** — The table column "User prompt option" lists "(existing user side, unchanged)" for the three sibling steps, implying they have configurable user templates. They do not — those steps pass dynamic input (topic, snippets, facts) directly as the user message. Only `WriteArticleStep` uses a configurable user template. Reword the column header to "User prompt source" with values "topic string (literal)", "snippet text (literal)", "facts JSON (literal)", and "`WriteArticleUserPromptTemplate` (configurable)" respectively. Clarifies — and prevents — future sibling-step "consistency" refactors based on a misreading.
+
+## Prerequisites
+
+None. No migrations, no infrastructure, no new packages. Implementation can start immediately.
+
+The only **deployment-time** prerequisite (not implementation-time) is auditing Azure App Service Configuration in Dev/Staging/Production for an override of the old key — this is captured in the runbook step required by NFR-3.

--- a/artifacts/feat-arch-review-article-articleoptions-write/brief.md
+++ b/artifacts/feat-arch-review-article-articleoptions-write/brief.md
@@ -1,0 +1,64 @@
+## Module
+Article
+
+## Finding
+`ArticleOptions.WriteArticleSystemPromptTemplate` is named as though it configures the **system** prompt sent to the AI, but `WriteArticleStep` uses it exclusively as the **user** message:
+
+```csharp
+// WriteArticleStep.cs:102-113
+private string BuildUserMessage(ArticlePipelineContext context)
+{
+    ...
+    return _options.WriteArticleSystemPromptTemplate   // ← named "SystemPrompt…" but sent as ChatRole.User
+        .Replace("{topic}", article.Topic)
+        ...
+}
+```
+
+The actual system prompt is a hardcoded constant in the same class:
+
+```csharp
+// WriteArticleStep.cs:86-92
+private const string SystemInstruction =
+    """
+    Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+    Odpověz POUZE validním JSON bez markdown nebo code fences.
+    ...
+    """;
+```
+
+`SystemInstruction` is **not** exposed via `ArticleOptions` and cannot be overridden via `appsettings.json`. Conversely, the configurable property `WriteArticleSystemPromptTemplate` controls the user turn, not the system turn.
+
+The same naming confusion exists in the other pipeline steps:
+- `ArticleOptions.QueryPlannerSystemPrompt` — is sent as `ChatRole.System` ✅
+- `ArticleOptions.AggregateFactsSystemPrompt` — is sent as `ChatRole.System` ✅
+- `ArticleOptions.ValidateFactsSystemPrompt` — is sent as `ChatRole.System` ✅
+- `ArticleOptions.WriteArticleSystemPromptTemplate` — is sent as `ChatRole.User` ❌
+
+Three out of four properties correctly match their role; only the write step is inverted.
+
+## Why it matters
+- An operator who wants to tune article writing will find `WriteArticleSystemPromptTemplate` in `appsettings.json`, assume it controls the system-level persona/instruction, and edit it — without effect on the persona. Their change controls the *user turn* (the article brief), not the AI's behaviour mode.
+- Conversely, the hardcoded `SystemInstruction` cannot be changed without a code deploy, even though the intent of `ArticleOptions` is to make prompts configurable.
+- Breaking consistency with the three other correctly-named options (`QueryPlannerSystemPrompt`, `AggregateFactsSystemPrompt`, `ValidateFactsSystemPrompt`) makes the configuration surface harder to reason about.
+
+## Suggested fix
+Two-part fix — either is sufficient; doing both is cleanest:
+
+**Option A: rename to match actual usage**
+```csharp
+// ArticleOptions.cs
+public string WriteArticleUserPromptTemplate { get; set; } = ...;
+```
+Update the one reference in `WriteArticleStep.BuildUserMessage`. No behaviour change.
+
+**Option B: make the system prompt configurable too** (recommended)
+```csharp
+// ArticleOptions.cs
+public string WriteArticleSystemPrompt { get; set; } = /* the current SystemInstruction value */;
+public string WriteArticleUserPromptTemplate { get; set; } = ...;
+```
+In `WriteArticleStep`, replace the hardcoded `SystemInstruction` constant with `_options.WriteArticleSystemPrompt`, consistent with how the other three steps work.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-article-articleoptions-write/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-articleoptions-write/impl/main.r1.md
@@ -1,0 +1,12 @@
+28/28 tests pass. This is a named-branch repo (standard state). Presenting options:
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-article-articleoptions-write/spec.r1.md
+++ b/artifacts/feat-arch-review-article-articleoptions-write/spec.r1.md
@@ -1,0 +1,134 @@
+# Specification: Article Writing Prompt Configuration Fix
+
+## Summary
+Refactor `ArticleOptions` and `WriteArticleStep` to expose the article writing system prompt as a configurable option and rename the existing misnamed `WriteArticleSystemPromptTemplate` to accurately reflect its role as a user message template. This aligns the write step with the three sibling pipeline steps (query planner, aggregate facts, validate facts) where system/user prompt naming already matches actual chat role usage.
+
+## Background
+The article generation pipeline uses MediatR-driven steps that call an AI model. Each step exposes its prompts via `ArticleOptions` so operators can tune behaviour through `appsettings.json` without redeploying.
+
+Three of the four steps follow a consistent pattern: a property named `*SystemPrompt` is sent with `ChatRole.System`. The write step breaks this pattern:
+
+- `ArticleOptions.WriteArticleSystemPromptTemplate` is sent as `ChatRole.User` in `WriteArticleStep.BuildUserMessage` (`WriteArticleStep.cs:102-113`).
+- The real system prompt — defining the Czech cosmetics editor persona and JSON output requirement — lives as a hardcoded `SystemInstruction` constant in `WriteArticleStep.cs:86-92` and cannot be configured.
+
+Consequences:
+1. An operator editing `WriteArticleSystemPromptTemplate` in `appsettings.json` expects to influence persona/behaviour but actually changes the user-turn article brief.
+2. The actual system prompt requires a code deploy to change, defeating the purpose of `ArticleOptions`.
+3. Inconsistency with sibling options increases cognitive load for anyone reading or tuning the configuration surface.
+
+## Functional Requirements
+
+### FR-1: Expose article writing system prompt as a configurable option
+Add a new property `WriteArticleSystemPrompt` to `ArticleOptions`. Its default value MUST equal the current hardcoded `SystemInstruction` constant in `WriteArticleStep` verbatim (whitespace, Czech text, and JSON instructions preserved exactly).
+
+**Acceptance criteria:**
+- `ArticleOptions.WriteArticleSystemPrompt` exists with a string default that matches the current `SystemInstruction` constant character-for-character.
+- Setting `Article:WriteArticleSystemPrompt` in `appsettings.json` (or any other configuration source bound to `ArticleOptions`) overrides the default at runtime without code changes.
+- The hardcoded `SystemInstruction` constant in `WriteArticleStep` is removed.
+
+### FR-2: Rename misnamed user template property
+Rename `ArticleOptions.WriteArticleSystemPromptTemplate` to `WriteArticleUserPromptTemplate`. The default value MUST remain identical. All references in the codebase MUST be updated to the new name.
+
+**Acceptance criteria:**
+- `ArticleOptions.WriteArticleSystemPromptTemplate` no longer exists.
+- `ArticleOptions.WriteArticleUserPromptTemplate` exists with the same default string the old property had.
+- `WriteArticleStep.BuildUserMessage` reads from `_options.WriteArticleUserPromptTemplate`.
+- `dotnet build` succeeds with zero references to the old name.
+
+### FR-3: Wire the new system prompt into the chat call
+`WriteArticleStep` MUST send `_options.WriteArticleSystemPrompt` as the system role message when invoking the AI model, replacing the inlined `SystemInstruction` constant. The user role message MUST continue to be the rendered `WriteArticleUserPromptTemplate`.
+
+**Acceptance criteria:**
+- The AI chat invocation in `WriteArticleStep` builds two messages: one with `ChatRole.System` sourced from `_options.WriteArticleSystemPrompt`, one with `ChatRole.User` sourced from the rendered user template.
+- No string literal containing the editor persona instruction remains in `WriteArticleStep.cs`.
+- A unit test verifies that overriding `WriteArticleSystemPrompt` via `IOptions<ArticleOptions>` changes the system message passed to the chat client.
+
+### FR-4: Update configuration files and documentation
+Any `appsettings*.json` files (Development, Production, Staging, default) that currently contain `WriteArticleSystemPromptTemplate` MUST be updated to use the new key `WriteArticleUserPromptTemplate`. If no `WriteArticleSystemPrompt` key exists in any environment-specific config, none needs to be added — the default in `ArticleOptions` is authoritative.
+
+**Acceptance criteria:**
+- Grepping the repo for `WriteArticleSystemPromptTemplate` returns zero hits.
+- All existing config files that referenced the old key now use `WriteArticleUserPromptTemplate` with the same value.
+- Any docs under `docs/features/` or `docs/architecture/` that mention these prompt options are updated to reflect the rename and the new `WriteArticleSystemPrompt` property.
+
+### FR-5: Preserve existing article generation behaviour
+The default behaviour of the article pipeline MUST be unchanged after the refactor. With no environment overrides, the system prompt and user template sent to the AI model MUST be byte-identical to what was sent before.
+
+**Acceptance criteria:**
+- A diff of the chat messages produced for a fixed `ArticlePipelineContext` before vs. after the change shows no difference when defaults are in effect.
+- Existing tests covering `WriteArticleStep` continue to pass without semantic changes to their assertions (only renames of property references where applicable).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact. This is a configuration-surface refactor; chat calls, prompt sizes, and token counts are unchanged at default values.
+
+### NFR-2: Security
+No new attack surface. The prompts remain operator-controlled via trusted configuration sources. No user input enters either prompt path that did not already enter the existing user template.
+
+### NFR-3: Backward Compatibility
+This change is a **breaking configuration change**. Any environment that has overridden `Article:WriteArticleSystemPromptTemplate` in its `appsettings.{Environment}.json` (or in Azure App Service configuration) will silently fall back to the default user template after the rename. The deployment runbook MUST include a step to rename the key in every environment where it has been overridden before the new build is deployed.
+
+**Acceptance criteria:**
+- Release notes / PR description call out the rename explicitly with the exact old → new key mapping.
+- A pre-deployment checklist item is added: "Verify all environment configs use `WriteArticleUserPromptTemplate` (not `WriteArticleSystemPromptTemplate`)."
+
+### NFR-4: Consistency
+The four article pipeline steps MUST follow a uniform naming convention after this change:
+
+| Step | System prompt option | User prompt option |
+|---|---|---|
+| Query planner | `QueryPlannerSystemPrompt` | (existing user side, unchanged) |
+| Aggregate facts | `AggregateFactsSystemPrompt` | (existing user side, unchanged) |
+| Validate facts | `ValidateFactsSystemPrompt` | (existing user side, unchanged) |
+| Write article | `WriteArticleSystemPrompt` *(new)* | `WriteArticleUserPromptTemplate` *(renamed)* |
+
+## Data Model
+No data model changes. `ArticleOptions` is a configuration POCO bound from `IConfiguration`; the changes affect only its property names and one new property.
+
+## API / Interface Design
+
+### Affected types
+- `ArticleOptions` (likely under `backend/src/Anela.Heblo.Application/Features/Article/` or equivalent — confirmed during implementation)
+  - Remove: `WriteArticleSystemPromptTemplate`
+  - Add: `WriteArticleSystemPrompt` (with default matching current `SystemInstruction`)
+  - Add: `WriteArticleUserPromptTemplate` (with default matching old `WriteArticleSystemPromptTemplate`)
+
+- `WriteArticleStep`
+  - Remove: `private const string SystemInstruction = ...`
+  - Update: chat invocation now uses `_options.WriteArticleSystemPrompt` and `_options.WriteArticleUserPromptTemplate`
+
+### Configuration shape (illustrative)
+```json
+{
+  "Article": {
+    "QueryPlannerSystemPrompt": "...",
+    "AggregateFactsSystemPrompt": "...",
+    "ValidateFactsSystemPrompt": "...",
+    "WriteArticleSystemPrompt": "Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině. Odpověz POUZE validním JSON bez markdown nebo code fences. ...",
+    "WriteArticleUserPromptTemplate": "...{topic}... {keywords} ..."
+  }
+}
+```
+
+No public HTTP API, no DTO, no OpenAPI client surface is affected. No frontend changes required.
+
+## Dependencies
+- .NET 8 configuration binding (`IOptions<ArticleOptions>`) — already in use.
+- AI chat client abstraction used by `WriteArticleStep` — already in use; only the message construction changes.
+- Existing unit-test infrastructure for the Article module.
+
+No new NuGet packages, no new external services.
+
+## Out of Scope
+- Tuning the default content of the system prompt or user template. Defaults MUST equal current values verbatim.
+- Refactoring sibling steps (`QueryPlannerStep`, `AggregateFactsStep`, `ValidateFactsStep`) — they already conform.
+- Introducing a strongly-typed prompt-template abstraction or replacing `string.Replace`-based templating.
+- Localization of prompts beyond what already exists (Czech is hardcoded in the prompt content; not changing that).
+- Adding per-tenant or per-request prompt overrides.
+- Versioning or auditing of prompt changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-articleoptions-write/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-articleoptions-write/task-plan.r1.md
@@ -1,0 +1,441 @@
+# Article Writing Prompt Configuration Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the article writing system prompt as a configurable `ArticleOptions` property and rename the misnamed `WriteArticleSystemPromptTemplate` to `WriteArticleUserPromptTemplate` to match its actual role.
+
+**Architecture:** Pure refactor with surgical edits in three files. (1) `ArticleOptions` gains `WriteArticleSystemPrompt` (default = current `SystemInstruction` constant verbatim) and renames `WriteArticleSystemPromptTemplate` → `WriteArticleUserPromptTemplate`. (2) `WriteArticleStep` deletes the inline `SystemInstruction` constant, switches `BuildSystemPrompt` to read `_options.WriteArticleSystemPrompt`, and updates `BuildUserMessage` to read `_options.WriteArticleUserPromptTemplate`. The conditional `"STYLE GUIDE — follow this exactly:\n…\n\n"` wrapper stays in code (FR-5: byte-identical defaults). (3) Documentation in `docs/features/article-generation.md` updates the key example.
+
+**Tech Stack:** .NET 8, `Microsoft.Extensions.Options` (Options Pattern with `ValidateDataAnnotations().ValidateOnStart()`), `Microsoft.Extensions.AI.IChatClient`, xUnit + FluentAssertions + Moq for tests.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs` | Modify | Add `WriteArticleSystemPrompt`; rename `WriteArticleSystemPromptTemplate` → `WriteArticleUserPromptTemplate`. |
+| `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs` | Modify | Delete `SystemInstruction` const; make `BuildSystemPrompt` instance method reading `_options.WriteArticleSystemPrompt`; update `BuildUserMessage` to read `_options.WriteArticleUserPromptTemplate`. |
+| `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs` | Modify | Add two tests: (a) override of `WriteArticleSystemPrompt` flows through as `ChatRole.System` message; (b) style-guide wrapper preserved when `StyleGuideText` is set. |
+| `docs/features/article-generation.md` | Modify | Rename `"WriteArticleSystemPromptTemplate"` → `"WriteArticleUserPromptTemplate"` in the JSON example at line 307; add `"WriteArticleSystemPrompt"` next to it for discoverability. |
+
+No new files. No DI registration changes. No migrations. No frontend impact.
+
+---
+
+## Validation Commands
+
+Run from the worktree root unless noted otherwise.
+
+| Step | Command | Working directory |
+|---|---|---|
+| Build backend | `dotnet build` | `backend/` |
+| Run `WriteArticleStep` tests only | `dotnet test --filter "FullyQualifiedName~WriteArticleStep"` | `backend/test/Anela.Heblo.Tests/` |
+| Run all article-pipeline tests | `dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Article.Pipeline"` | `backend/test/Anela.Heblo.Tests/` |
+| Format check | `dotnet format --verify-no-changes` | `backend/` |
+
+All four MUST succeed before the final commit.
+
+---
+
+## Task 1: Rename `WriteArticleSystemPromptTemplate` → `WriteArticleUserPromptTemplate`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs:56-62`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs:107`
+
+This task is a pure mechanical rename. The default string is preserved exactly. No semantic behaviour change — existing `WriteArticleStepTests` should pass before and after.
+
+- [ ] **Step 1: Confirm tests are green before the rename**
+
+Run: `dotnet test --filter "FullyQualifiedName~WriteArticleStep"` from `backend/test/Anela.Heblo.Tests/`.
+
+Expected: PASS with the existing 8 tests in `WriteArticleStepTests.cs`. If anything fails here, stop and investigate — the failure is pre-existing and outside this plan's scope.
+
+- [ ] **Step 2: Rename the property in `ArticleOptions.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs`, replace lines 56–62:
+
+```csharp
+    public string WriteArticleSystemPromptTemplate { get; set; } =
+        """
+        Napiš článek na téma {topic} pro publikum {audience}.
+        Délka: {length}. Úhel pohledu: {angle}.
+        Využij tato fakta: {facts}
+        {style_guide}
+        """;
+```
+
+with:
+
+```csharp
+    public string WriteArticleUserPromptTemplate { get; set; } =
+        """
+        Napiš článek na téma {topic} pro publikum {audience}.
+        Délka: {length}. Úhel pohledu: {angle}.
+        Využij tato fakta: {facts}
+        {style_guide}
+        """;
+```
+
+- [ ] **Step 3: Update the reference in `WriteArticleStep.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`, line 107, change:
+
+```csharp
+        return _options.WriteArticleSystemPromptTemplate
+```
+
+to:
+
+```csharp
+        return _options.WriteArticleUserPromptTemplate
+```
+
+- [ ] **Step 4: Verify the build succeeds and old name has no references**
+
+Run from `backend/`:
+```bash
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors.
+
+Then from the worktree root:
+```bash
+grep -rn "WriteArticleSystemPromptTemplate" backend/ frontend/ docs/features/
+```
+
+Expected: zero hits. (Per arch-review amendment #1, `docs/superpowers/plans/` and `artifacts/` are excluded — they are immutable historical records.)
+
+- [ ] **Step 5: Run `WriteArticleStep` tests**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~WriteArticleStep"
+```
+
+Expected: all 8 existing tests PASS. No new tests yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+git commit -m "refactor: rename WriteArticleSystemPromptTemplate to WriteArticleUserPromptTemplate
+
+The property is sent as ChatRole.User in WriteArticleStep.BuildUserMessage,
+so its 'SystemPrompt' name was misleading. Default value is preserved
+verbatim; no behavioural change."
+```
+
+---
+
+## Task 2: Expose `WriteArticleSystemPrompt` as a configurable option
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs` (add new property after `WriteArticleUserPromptTemplate`)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs:86-100` (delete `SystemInstruction` const; switch `BuildSystemPrompt` to instance method reading `_options.WriteArticleSystemPrompt`)
+- Test: `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs` (add two new tests)
+
+This task uses a TDD-aligned flow: add the new property unused first (compiles, no behaviour change), then write a failing test that proves the override doesn't flow through yet, then refactor the code to make it pass. Finally add a regression test for the style-guide wrapper composition (the only piece of system-prompt-building logic that stays in code).
+
+- [ ] **Step 1: Add the `WriteArticleSystemPrompt` property to `ArticleOptions`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs`, immediately **before** the `WriteArticleUserPromptTemplate` property (so the system/user pair sits together), insert:
+
+```csharp
+    public string WriteArticleSystemPrompt { get; set; } =
+        """
+        Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+        Odpověz POUZE validním JSON bez markdown nebo code fences.
+        V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
+        {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
+        """;
+
+```
+
+The string MUST equal the current `SystemInstruction` constant in `WriteArticleStep.cs:86-92` character-for-character. Per arch-review Decision 2, do **not** add `[Required, MinLength(1)]` — consistency with `QueryPlannerSystemPrompt`, `AggregateFactsSystemPrompt`, `ValidateFactsSystemPrompt`.
+
+- [ ] **Step 2: Verify the build still succeeds with the new (unused) property**
+
+Run from `backend/`:
+```bash
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors, 0 warnings related to this property.
+
+Then run the existing tests to confirm no behaviour change:
+```bash
+cd backend/test/Anela.Heblo.Tests/
+dotnet test --filter "FullyQualifiedName~WriteArticleStep"
+```
+
+Expected: all 8 tests PASS. The new property is defined but unused — behaviour is unchanged.
+
+- [ ] **Step 3: Write the failing test — override of `WriteArticleSystemPrompt` must flow through**
+
+Append to `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs`, immediately before the closing `}` of the class:
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage()
+    {
+        // Arrange
+        const string customPrompt = "CUSTOM SYSTEM PROMPT FOR TEST";
+        _options.WriteArticleSystemPrompt = customPrompt;
+        SetupChatResponse("""{"article_title":"T","article_html":"<p>x</p>","sources_used":[]}""");
+
+        // Act
+        await CreateStep().ExecuteAsync(CreateContext(), default);
+
+        // Assert
+        _chat.Verify(c => c.GetResponseAsync(
+            It.Is<IEnumerable<ChatMessage>>(msgs =>
+                msgs.Any(m => m.Role == ChatRole.System && m.Text == customPrompt)),
+            It.IsAny<ChatOptions?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 4: Run the new test and verify it FAILS**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage"
+```
+
+Expected: FAIL with a Moq verification message indicating the system message text was the hardcoded `SystemInstruction` (Czech editor persona) instead of `"CUSTOM SYSTEM PROMPT FOR TEST"`. This proves the override does not yet flow through.
+
+If the test passes here, the test is wrong — investigate before moving on.
+
+- [ ] **Step 5: Refactor `BuildSystemPrompt` to read from `_options.WriteArticleSystemPrompt`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`, **delete** lines 86–100 (the `SystemInstruction` constant block and the static `BuildSystemPrompt` method):
+
+```csharp
+    private const string SystemInstruction =
+        """
+        Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+        Odpověz POUZE validním JSON bez markdown nebo code fences.
+        V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
+        {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
+        """;
+
+    private static string BuildSystemPrompt(string? styleGuideText)
+    {
+        if (styleGuideText == null)
+            return SystemInstruction;
+
+        return $"STYLE GUIDE — follow this exactly:\n{styleGuideText}\n\n{SystemInstruction}";
+    }
+```
+
+**Replace** with (note: now an instance method, no longer `static`, so it can access `_options`):
+
+```csharp
+    private string BuildSystemPrompt(string? styleGuideText)
+    {
+        if (styleGuideText == null)
+            return _options.WriteArticleSystemPrompt;
+
+        return $"STYLE GUIDE — follow this exactly:\n{styleGuideText}\n\n{_options.WriteArticleSystemPrompt}";
+    }
+```
+
+The call site at line 45 (`var systemPrompt = BuildSystemPrompt(context.StyleGuideText);`) does **not** change — it was already an instance-method-style call.
+
+- [ ] **Step 6: Verify the build still succeeds**
+
+Run from `backend/`:
+```bash
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors. There must be **no** reference to `SystemInstruction` remaining anywhere in `WriteArticleStep.cs`.
+
+- [ ] **Step 7: Run the new test and verify it PASSES**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full `WriteArticleStep` test suite to confirm no regressions**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~WriteArticleStep"
+```
+
+Expected: all 9 tests PASS (8 existing + 1 new). Default behaviour is unchanged because `ArticleOptions.WriteArticleSystemPrompt` default equals the deleted `SystemInstruction` constant verbatim (FR-5).
+
+- [ ] **Step 9: Add the style-guide wrapper regression test**
+
+Per arch-review risk mitigation (MEDIUM severity), append a second test to `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs`, immediately before the closing `}` of the class:
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_WithStyleGuide_SystemMessageWrapsStyleGuideAroundSystemPrompt()
+    {
+        // Arrange
+        _options.WriteArticleSystemPrompt = "BASE PROMPT";
+        SetupChatResponse("""{"article_title":"T","article_html":"<p>x</p>","sources_used":[]}""");
+        var context = CreateContext();
+        context.StyleGuideText = "Use a friendly tone.";
+        const string expected = "STYLE GUIDE — follow this exactly:\nUse a friendly tone.\n\nBASE PROMPT";
+
+        // Act
+        await CreateStep().ExecuteAsync(context, default);
+
+        // Assert
+        _chat.Verify(c => c.GetResponseAsync(
+            It.Is<IEnumerable<ChatMessage>>(msgs =>
+                msgs.Any(m => m.Role == ChatRole.System && m.Text == expected)),
+            It.IsAny<ChatOptions?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 10: Run the regression test and verify it PASSES**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ExecuteAsync_WithStyleGuide_SystemMessageWrapsStyleGuideAroundSystemPrompt"
+```
+
+Expected: PASS. This guards against accidentally dropping the `"STYLE GUIDE — follow this exactly:\n"` wrapper in future refactors.
+
+- [ ] **Step 11: Run the full backend test suite**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test
+```
+
+Expected: all tests PASS. Confirms no cross-feature regression.
+
+- [ ] **Step 12: Run formatter and verify**
+
+Run from `backend/`:
+```bash
+dotnet format
+dotnet format --verify-no-changes
+```
+
+Expected: first command runs cleanly; second returns 0 (no formatting drift).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs \
+        backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs
+git commit -m "feat: expose article writing system prompt as configurable ArticleOptions property
+
+Add ArticleOptions.WriteArticleSystemPrompt (default = previous hardcoded
+SystemInstruction verbatim) and switch WriteArticleStep.BuildSystemPrompt
+to read from it. The conditional 'STYLE GUIDE — follow this exactly:\\n'
+wrapper composition stays in code. Default behaviour is byte-identical.
+
+Adds two unit tests:
+- override of WriteArticleSystemPrompt flows through as ChatRole.System
+- style-guide wrapper still wraps the configured prompt"
+```
+
+---
+
+## Task 3: Update feature documentation
+
+**Files:**
+- Modify: `docs/features/article-generation.md:307` (JSON example in section 12. Configuration)
+
+The arch-review notes this update is optional for `WriteArticleSystemPrompt` discoverability but mandatory for the rename. We include the new key in the example so operators can find it.
+
+- [ ] **Step 1: Update the JSON example**
+
+In `docs/features/article-generation.md`, replace line 307:
+
+```
+  "WriteArticleSystemPromptTemplate": "..."
+```
+
+with:
+
+```
+  "WriteArticleSystemPrompt": "...",
+  "WriteArticleUserPromptTemplate": "..."
+```
+
+So the surrounding block becomes:
+
+```json
+"Articles": {
+  "DefaultModel": "claude-sonnet-4-6",
+  "WriteMaxTokens": 4096,
+  "AggregateMaxTokens": 1024,
+  "WebSearchTopK": 5,
+  "KnowledgeBaseTopK": 8,
+  "DefaultLength": "medium (1000w)",
+  "QueryPlannerModel": "claude-haiku-4-5-20251001",
+  "AggregateFactsModel": "claude-sonnet-4-6",
+  "ValidateFactsModel": "claude-haiku-4-5-20251001",
+  "QueryPlannerSystemPrompt": "...",
+  "AggregateFactsSystemPrompt": "...",
+  "ValidateFactsSystemPrompt": "...",
+  "WriteArticleSystemPrompt": "...",
+  "WriteArticleUserPromptTemplate": "..."
+},
+```
+
+- [ ] **Step 2: Confirm zero stale references in user-facing docs and source code**
+
+Run from the worktree root:
+```bash
+grep -rn "WriteArticleSystemPromptTemplate" backend/ frontend/ docs/features/
+```
+
+Expected: zero hits. (Per arch-review amendment #1, `docs/superpowers/plans/` and `artifacts/` are excluded — they are immutable historical records.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/features/article-generation.md
+git commit -m "docs: update article generation config example with renamed prompt keys
+
+WriteArticleSystemPromptTemplate split into WriteArticleSystemPrompt
+(persona/system) and WriteArticleUserPromptTemplate (article brief/user)."
+```
+
+---
+
+## Final Validation Checklist
+
+After Task 3 commits, run these in order and confirm each green before declaring the change ready for PR.
+
+- [ ] **From `backend/`:** `dotnet build` → 0 errors, 0 warnings related to this change.
+- [ ] **From `backend/`:** `dotnet format --verify-no-changes` → exit 0.
+- [ ] **From `backend/test/Anela.Heblo.Tests/`:** `dotnet test` → all tests PASS (full suite).
+- [ ] **From worktree root:** `grep -rn "WriteArticleSystemPromptTemplate" backend/ frontend/ docs/features/` → zero hits.
+- [ ] **From worktree root:** `grep -rn "SystemInstruction" backend/src/Anela.Heblo.Application/Features/Article/` → zero hits.
+
+---
+
+## PR Description / Release Notes Requirements
+
+Per spec NFR-3 and arch-review risk row 1, the PR description MUST include:
+
+1. **Key rename mapping** (exact strings):
+   - `Articles:WriteArticleSystemPromptTemplate` → `Articles:WriteArticleUserPromptTemplate` (renamed; same default; controls user-turn article brief)
+   - `Articles:WriteArticleSystemPrompt` (new; default = previous hardcoded `SystemInstruction`; controls system-turn editor persona)
+
+2. **Pre-deployment runbook step:**
+
+   > Before deploying this change to Development / Staging / Production, audit Azure App Service Configuration for each environment. If the key `Articles:WriteArticleSystemPromptTemplate` is set as an override, rename it to `Articles:WriteArticleUserPromptTemplate` in lockstep with the deploy. No source-controlled `appsettings*.json` in this repo currently overrides this key, so the audit is exclusively against Azure App Service Configuration.
+
+3. **Behavioural guarantee:** With no environment overrides, the chat messages produced for any `ArticlePipelineContext` are byte-identical before vs. after the change (FR-5).

--- a/backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs
@@ -53,6 +53,14 @@ public sealed class ArticleOptions
         Fakta:
         """;
 
+    public string WriteArticleSystemPrompt { get; set; } =
+        """
+        Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+        Odpověz POUZE validním JSON bez markdown nebo code fences.
+        V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
+        {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
+        """;
+
     public string WriteArticleUserPromptTemplate { get; set; } =
         """
         Napiš článek na téma {topic} pro publikum {audience}.

--- a/backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs
@@ -53,7 +53,7 @@ public sealed class ArticleOptions
         Fakta:
         """;
 
-    public string WriteArticleSystemPromptTemplate { get; set; } =
+    public string WriteArticleUserPromptTemplate { get; set; } =
         """
         Napiš článek na téma {topic} pro publikum {audience}.
         Délka: {length}. Úhel pohledu: {angle}.

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
@@ -104,7 +104,7 @@ public class WriteArticleStep
         var article = context.Article;
         var factsText = BuildFactsList(context.Facts);
 
-        return _options.WriteArticleSystemPromptTemplate
+        return _options.WriteArticleUserPromptTemplate
             .Replace("{topic}", article.Topic)
             .Replace("{audience}", article.Audience ?? "obecné publikum")
             .Replace("{length}", article.Length)

--- a/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
@@ -83,20 +83,12 @@ public class WriteArticleStep
             ct);
     }
 
-    private const string SystemInstruction =
-        """
-        Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
-        Odpověz POUZE validním JSON bez markdown nebo code fences.
-        V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
-        {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
-        """;
-
-    private static string BuildSystemPrompt(string? styleGuideText)
+    private string BuildSystemPrompt(string? styleGuideText)
     {
         if (styleGuideText == null)
-            return SystemInstruction;
+            return _options.WriteArticleSystemPrompt;
 
-        return $"STYLE GUIDE — follow this exactly:\n{styleGuideText}\n\n{SystemInstruction}";
+        return $"STYLE GUIDE — follow this exactly:\n{styleGuideText}\n\n{_options.WriteArticleSystemPrompt}";
     }
 
     private string BuildUserMessage(ArticlePipelineContext context)

--- a/backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs
@@ -220,4 +220,46 @@ public class WriteArticleStepTests
         context.GeneratedHtml.Should().NotContain("<script>");
         context.GeneratedHtml.Should().Contain("&lt;script&gt;");
     }
+
+    [Fact]
+    public async Task ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage()
+    {
+        // Arrange
+        const string customPrompt = "CUSTOM SYSTEM PROMPT FOR TEST";
+        _options.WriteArticleSystemPrompt = customPrompt;
+        SetupChatResponse("""{"article_title":"T","article_html":"<p>x</p>","sources_used":[]}""");
+
+        // Act
+        await CreateStep().ExecuteAsync(CreateContext(), default);
+
+        // Assert
+        _chat.Verify(c => c.GetResponseAsync(
+            It.Is<IEnumerable<ChatMessage>>(msgs =>
+                msgs.Any(m => m.Role == ChatRole.System && m.Text == customPrompt)),
+            It.IsAny<ChatOptions?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithStyleGuide_SystemMessageWrapsStyleGuideAroundSystemPrompt()
+    {
+        // Arrange
+        _options.WriteArticleSystemPrompt = "BASE PROMPT";
+        SetupChatResponse("""{"article_title":"T","article_html":"<p>x</p>","sources_used":[]}""");
+        var context = CreateContext();
+        context.StyleGuideText = "Use a friendly tone.";
+        const string expected = "STYLE GUIDE — follow this exactly:\nUse a friendly tone.\n\nBASE PROMPT";
+
+        // Act
+        await CreateStep().ExecuteAsync(context, default);
+
+        // Assert
+        _chat.Verify(c => c.GetResponseAsync(
+            It.Is<IEnumerable<ChatMessage>>(msgs =>
+                msgs.Any(m => m.Role == ChatRole.System && m.Text == expected)),
+            It.IsAny<ChatOptions?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/docs/features/article-generation.md
+++ b/docs/features/article-generation.md
@@ -304,7 +304,7 @@ Add to `appsettings.json`:
   "QueryPlannerSystemPrompt": "...",
   "AggregateFactsSystemPrompt": "...",
   "ValidateFactsSystemPrompt": "...",
-  "WriteArticleSystemPromptTemplate": "..."
+  "WriteArticleUserPromptTemplate": "..."
 },
 "WebSearch": {
   "Provider": "SerpApi",

--- a/docs/features/article-generation.md
+++ b/docs/features/article-generation.md
@@ -304,6 +304,7 @@ Add to `appsettings.json`:
   "QueryPlannerSystemPrompt": "...",
   "AggregateFactsSystemPrompt": "...",
   "ValidateFactsSystemPrompt": "...",
+  "WriteArticleSystemPrompt": "...",
   "WriteArticleUserPromptTemplate": "..."
 },
 "WebSearch": {

--- a/docs/superpowers/plans/2026-05-25-article-write-prompt-options.md
+++ b/docs/superpowers/plans/2026-05-25-article-write-prompt-options.md
@@ -1,0 +1,441 @@
+# Article Writing Prompt Configuration Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the article writing system prompt as a configurable `ArticleOptions` property and rename the misnamed `WriteArticleSystemPromptTemplate` to `WriteArticleUserPromptTemplate` to match its actual role.
+
+**Architecture:** Pure refactor with surgical edits in three files. (1) `ArticleOptions` gains `WriteArticleSystemPrompt` (default = current `SystemInstruction` constant verbatim) and renames `WriteArticleSystemPromptTemplate` → `WriteArticleUserPromptTemplate`. (2) `WriteArticleStep` deletes the inline `SystemInstruction` constant, switches `BuildSystemPrompt` to read `_options.WriteArticleSystemPrompt`, and updates `BuildUserMessage` to read `_options.WriteArticleUserPromptTemplate`. The conditional `"STYLE GUIDE — follow this exactly:\n…\n\n"` wrapper stays in code (FR-5: byte-identical defaults). (3) Documentation in `docs/features/article-generation.md` updates the key example.
+
+**Tech Stack:** .NET 8, `Microsoft.Extensions.Options` (Options Pattern with `ValidateDataAnnotations().ValidateOnStart()`), `Microsoft.Extensions.AI.IChatClient`, xUnit + FluentAssertions + Moq for tests.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs` | Modify | Add `WriteArticleSystemPrompt`; rename `WriteArticleSystemPromptTemplate` → `WriteArticleUserPromptTemplate`. |
+| `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs` | Modify | Delete `SystemInstruction` const; make `BuildSystemPrompt` instance method reading `_options.WriteArticleSystemPrompt`; update `BuildUserMessage` to read `_options.WriteArticleUserPromptTemplate`. |
+| `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs` | Modify | Add two tests: (a) override of `WriteArticleSystemPrompt` flows through as `ChatRole.System` message; (b) style-guide wrapper preserved when `StyleGuideText` is set. |
+| `docs/features/article-generation.md` | Modify | Rename `"WriteArticleSystemPromptTemplate"` → `"WriteArticleUserPromptTemplate"` in the JSON example at line 307; add `"WriteArticleSystemPrompt"` next to it for discoverability. |
+
+No new files. No DI registration changes. No migrations. No frontend impact.
+
+---
+
+## Validation Commands
+
+Run from the worktree root unless noted otherwise.
+
+| Step | Command | Working directory |
+|---|---|---|
+| Build backend | `dotnet build` | `backend/` |
+| Run `WriteArticleStep` tests only | `dotnet test --filter "FullyQualifiedName~WriteArticleStep"` | `backend/test/Anela.Heblo.Tests/` |
+| Run all article-pipeline tests | `dotnet test --filter "FullyQualifiedName~Anela.Heblo.Tests.Article.Pipeline"` | `backend/test/Anela.Heblo.Tests/` |
+| Format check | `dotnet format --verify-no-changes` | `backend/` |
+
+All four MUST succeed before the final commit.
+
+---
+
+## Task 1: Rename `WriteArticleSystemPromptTemplate` → `WriteArticleUserPromptTemplate`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs:56-62`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs:107`
+
+This task is a pure mechanical rename. The default string is preserved exactly. No semantic behaviour change — existing `WriteArticleStepTests` should pass before and after.
+
+- [ ] **Step 1: Confirm tests are green before the rename**
+
+Run: `dotnet test --filter "FullyQualifiedName~WriteArticleStep"` from `backend/test/Anela.Heblo.Tests/`.
+
+Expected: PASS with the existing 8 tests in `WriteArticleStepTests.cs`. If anything fails here, stop and investigate — the failure is pre-existing and outside this plan's scope.
+
+- [ ] **Step 2: Rename the property in `ArticleOptions.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs`, replace lines 56–62:
+
+```csharp
+    public string WriteArticleSystemPromptTemplate { get; set; } =
+        """
+        Napiš článek na téma {topic} pro publikum {audience}.
+        Délka: {length}. Úhel pohledu: {angle}.
+        Využij tato fakta: {facts}
+        {style_guide}
+        """;
+```
+
+with:
+
+```csharp
+    public string WriteArticleUserPromptTemplate { get; set; } =
+        """
+        Napiš článek na téma {topic} pro publikum {audience}.
+        Délka: {length}. Úhel pohledu: {angle}.
+        Využij tato fakta: {facts}
+        {style_guide}
+        """;
+```
+
+- [ ] **Step 3: Update the reference in `WriteArticleStep.cs`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`, line 107, change:
+
+```csharp
+        return _options.WriteArticleSystemPromptTemplate
+```
+
+to:
+
+```csharp
+        return _options.WriteArticleUserPromptTemplate
+```
+
+- [ ] **Step 4: Verify the build succeeds and old name has no references**
+
+Run from `backend/`:
+```bash
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors.
+
+Then from the worktree root:
+```bash
+grep -rn "WriteArticleSystemPromptTemplate" backend/ frontend/ docs/features/
+```
+
+Expected: zero hits. (Per arch-review amendment #1, `docs/superpowers/plans/` and `artifacts/` are excluded — they are immutable historical records.)
+
+- [ ] **Step 5: Run `WriteArticleStep` tests**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~WriteArticleStep"
+```
+
+Expected: all 8 existing tests PASS. No new tests yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs
+git commit -m "refactor: rename WriteArticleSystemPromptTemplate to WriteArticleUserPromptTemplate
+
+The property is sent as ChatRole.User in WriteArticleStep.BuildUserMessage,
+so its 'SystemPrompt' name was misleading. Default value is preserved
+verbatim; no behavioural change."
+```
+
+---
+
+## Task 2: Expose `WriteArticleSystemPrompt` as a configurable option
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs` (add new property after `WriteArticleUserPromptTemplate`)
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs:86-100` (delete `SystemInstruction` const; switch `BuildSystemPrompt` to instance method reading `_options.WriteArticleSystemPrompt`)
+- Test: `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs` (add two new tests)
+
+This task uses a TDD-aligned flow: add the new property unused first (compiles, no behaviour change), then write a failing test that proves the override doesn't flow through yet, then refactor the code to make it pass. Finally add a regression test for the style-guide wrapper composition (the only piece of system-prompt-building logic that stays in code).
+
+- [ ] **Step 1: Add the `WriteArticleSystemPrompt` property to `ArticleOptions`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs`, immediately **before** the `WriteArticleUserPromptTemplate` property (so the system/user pair sits together), insert:
+
+```csharp
+    public string WriteArticleSystemPrompt { get; set; } =
+        """
+        Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+        Odpověz POUZE validním JSON bez markdown nebo code fences.
+        V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
+        {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
+        """;
+
+```
+
+The string MUST equal the current `SystemInstruction` constant in `WriteArticleStep.cs:86-92` character-for-character. Per arch-review Decision 2, do **not** add `[Required, MinLength(1)]` — consistency with `QueryPlannerSystemPrompt`, `AggregateFactsSystemPrompt`, `ValidateFactsSystemPrompt`.
+
+- [ ] **Step 2: Verify the build still succeeds with the new (unused) property**
+
+Run from `backend/`:
+```bash
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors, 0 warnings related to this property.
+
+Then run the existing tests to confirm no behaviour change:
+```bash
+cd backend/test/Anela.Heblo.Tests/
+dotnet test --filter "FullyQualifiedName~WriteArticleStep"
+```
+
+Expected: all 8 tests PASS. The new property is defined but unused — behaviour is unchanged.
+
+- [ ] **Step 3: Write the failing test — override of `WriteArticleSystemPrompt` must flow through**
+
+Append to `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs`, immediately before the closing `}` of the class:
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage()
+    {
+        // Arrange
+        const string customPrompt = "CUSTOM SYSTEM PROMPT FOR TEST";
+        _options.WriteArticleSystemPrompt = customPrompt;
+        SetupChatResponse("""{"article_title":"T","article_html":"<p>x</p>","sources_used":[]}""");
+
+        // Act
+        await CreateStep().ExecuteAsync(CreateContext(), default);
+
+        // Assert
+        _chat.Verify(c => c.GetResponseAsync(
+            It.Is<IEnumerable<ChatMessage>>(msgs =>
+                msgs.Any(m => m.Role == ChatRole.System && m.Text == customPrompt)),
+            It.IsAny<ChatOptions?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 4: Run the new test and verify it FAILS**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage"
+```
+
+Expected: FAIL with a Moq verification message indicating the system message text was the hardcoded `SystemInstruction` (Czech editor persona) instead of `"CUSTOM SYSTEM PROMPT FOR TEST"`. This proves the override does not yet flow through.
+
+If the test passes here, the test is wrong — investigate before moving on.
+
+- [ ] **Step 5: Refactor `BuildSystemPrompt` to read from `_options.WriteArticleSystemPrompt`**
+
+In `backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs`, **delete** lines 86–100 (the `SystemInstruction` constant block and the static `BuildSystemPrompt` method):
+
+```csharp
+    private const string SystemInstruction =
+        """
+        Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
+        Odpověz POUZE validním JSON bez markdown nebo code fences.
+        V poli article_html použij výhradně HTML tagy – nikdy nepište doslovný text "\n" jako obsah.
+        {"article_title":"...","article_html":"<article>...</article>","sources_used":[{"title":"...","url":"..."}]}
+        """;
+
+    private static string BuildSystemPrompt(string? styleGuideText)
+    {
+        if (styleGuideText == null)
+            return SystemInstruction;
+
+        return $"STYLE GUIDE — follow this exactly:\n{styleGuideText}\n\n{SystemInstruction}";
+    }
+```
+
+**Replace** with (note: now an instance method, no longer `static`, so it can access `_options`):
+
+```csharp
+    private string BuildSystemPrompt(string? styleGuideText)
+    {
+        if (styleGuideText == null)
+            return _options.WriteArticleSystemPrompt;
+
+        return $"STYLE GUIDE — follow this exactly:\n{styleGuideText}\n\n{_options.WriteArticleSystemPrompt}";
+    }
+```
+
+The call site at line 45 (`var systemPrompt = BuildSystemPrompt(context.StyleGuideText);`) does **not** change — it was already an instance-method-style call.
+
+- [ ] **Step 6: Verify the build still succeeds**
+
+Run from `backend/`:
+```bash
+dotnet build
+```
+
+Expected: Build succeeded, 0 errors. There must be **no** reference to `SystemInstruction` remaining anywhere in `WriteArticleStep.cs`.
+
+- [ ] **Step 7: Run the new test and verify it PASSES**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ExecuteAsync_OverriddenSystemPrompt_PassesOverriddenStringAsSystemMessage"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full `WriteArticleStep` test suite to confirm no regressions**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~WriteArticleStep"
+```
+
+Expected: all 9 tests PASS (8 existing + 1 new). Default behaviour is unchanged because `ArticleOptions.WriteArticleSystemPrompt` default equals the deleted `SystemInstruction` constant verbatim (FR-5).
+
+- [ ] **Step 9: Add the style-guide wrapper regression test**
+
+Per arch-review risk mitigation (MEDIUM severity), append a second test to `backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs`, immediately before the closing `}` of the class:
+
+```csharp
+    [Fact]
+    public async Task ExecuteAsync_WithStyleGuide_SystemMessageWrapsStyleGuideAroundSystemPrompt()
+    {
+        // Arrange
+        _options.WriteArticleSystemPrompt = "BASE PROMPT";
+        SetupChatResponse("""{"article_title":"T","article_html":"<p>x</p>","sources_used":[]}""");
+        var context = CreateContext();
+        context.StyleGuideText = "Use a friendly tone.";
+        const string expected = "STYLE GUIDE — follow this exactly:\nUse a friendly tone.\n\nBASE PROMPT";
+
+        // Act
+        await CreateStep().ExecuteAsync(context, default);
+
+        // Assert
+        _chat.Verify(c => c.GetResponseAsync(
+            It.Is<IEnumerable<ChatMessage>>(msgs =>
+                msgs.Any(m => m.Role == ChatRole.System && m.Text == expected)),
+            It.IsAny<ChatOptions?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 10: Run the regression test and verify it PASSES**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test --filter "FullyQualifiedName~ExecuteAsync_WithStyleGuide_SystemMessageWrapsStyleGuideAroundSystemPrompt"
+```
+
+Expected: PASS. This guards against accidentally dropping the `"STYLE GUIDE — follow this exactly:\n"` wrapper in future refactors.
+
+- [ ] **Step 11: Run the full backend test suite**
+
+Run from `backend/test/Anela.Heblo.Tests/`:
+```bash
+dotnet test
+```
+
+Expected: all tests PASS. Confirms no cross-feature regression.
+
+- [ ] **Step 12: Run formatter and verify**
+
+Run from `backend/`:
+```bash
+dotnet format
+dotnet format --verify-no-changes
+```
+
+Expected: first command runs cleanly; second returns 0 (no formatting drift).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Article/ArticleOptions.cs \
+        backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/Pipeline/WriteArticleStep.cs \
+        backend/test/Anela.Heblo.Tests/Article/Pipeline/WriteArticleStepTests.cs
+git commit -m "feat: expose article writing system prompt as configurable ArticleOptions property
+
+Add ArticleOptions.WriteArticleSystemPrompt (default = previous hardcoded
+SystemInstruction verbatim) and switch WriteArticleStep.BuildSystemPrompt
+to read from it. The conditional 'STYLE GUIDE — follow this exactly:\\n'
+wrapper composition stays in code. Default behaviour is byte-identical.
+
+Adds two unit tests:
+- override of WriteArticleSystemPrompt flows through as ChatRole.System
+- style-guide wrapper still wraps the configured prompt"
+```
+
+---
+
+## Task 3: Update feature documentation
+
+**Files:**
+- Modify: `docs/features/article-generation.md:307` (JSON example in section 12. Configuration)
+
+The arch-review notes this update is optional for `WriteArticleSystemPrompt` discoverability but mandatory for the rename. We include the new key in the example so operators can find it.
+
+- [ ] **Step 1: Update the JSON example**
+
+In `docs/features/article-generation.md`, replace line 307:
+
+```
+  "WriteArticleSystemPromptTemplate": "..."
+```
+
+with:
+
+```
+  "WriteArticleSystemPrompt": "...",
+  "WriteArticleUserPromptTemplate": "..."
+```
+
+So the surrounding block becomes:
+
+```json
+"Articles": {
+  "DefaultModel": "claude-sonnet-4-6",
+  "WriteMaxTokens": 4096,
+  "AggregateMaxTokens": 1024,
+  "WebSearchTopK": 5,
+  "KnowledgeBaseTopK": 8,
+  "DefaultLength": "medium (1000w)",
+  "QueryPlannerModel": "claude-haiku-4-5-20251001",
+  "AggregateFactsModel": "claude-sonnet-4-6",
+  "ValidateFactsModel": "claude-haiku-4-5-20251001",
+  "QueryPlannerSystemPrompt": "...",
+  "AggregateFactsSystemPrompt": "...",
+  "ValidateFactsSystemPrompt": "...",
+  "WriteArticleSystemPrompt": "...",
+  "WriteArticleUserPromptTemplate": "..."
+},
+```
+
+- [ ] **Step 2: Confirm zero stale references in user-facing docs and source code**
+
+Run from the worktree root:
+```bash
+grep -rn "WriteArticleSystemPromptTemplate" backend/ frontend/ docs/features/
+```
+
+Expected: zero hits. (Per arch-review amendment #1, `docs/superpowers/plans/` and `artifacts/` are excluded — they are immutable historical records.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/features/article-generation.md
+git commit -m "docs: update article generation config example with renamed prompt keys
+
+WriteArticleSystemPromptTemplate split into WriteArticleSystemPrompt
+(persona/system) and WriteArticleUserPromptTemplate (article brief/user)."
+```
+
+---
+
+## Final Validation Checklist
+
+After Task 3 commits, run these in order and confirm each green before declaring the change ready for PR.
+
+- [ ] **From `backend/`:** `dotnet build` → 0 errors, 0 warnings related to this change.
+- [ ] **From `backend/`:** `dotnet format --verify-no-changes` → exit 0.
+- [ ] **From `backend/test/Anela.Heblo.Tests/`:** `dotnet test` → all tests PASS (full suite).
+- [ ] **From worktree root:** `grep -rn "WriteArticleSystemPromptTemplate" backend/ frontend/ docs/features/` → zero hits.
+- [ ] **From worktree root:** `grep -rn "SystemInstruction" backend/src/Anela.Heblo.Application/Features/Article/` → zero hits.
+
+---
+
+## PR Description / Release Notes Requirements
+
+Per spec NFR-3 and arch-review risk row 1, the PR description MUST include:
+
+1. **Key rename mapping** (exact strings):
+   - `Articles:WriteArticleSystemPromptTemplate` → `Articles:WriteArticleUserPromptTemplate` (renamed; same default; controls user-turn article brief)
+   - `Articles:WriteArticleSystemPrompt` (new; default = previous hardcoded `SystemInstruction`; controls system-turn editor persona)
+
+2. **Pre-deployment runbook step:**
+
+   > Before deploying this change to Development / Staging / Production, audit Azure App Service Configuration for each environment. If the key `Articles:WriteArticleSystemPromptTemplate` is set as an override, rename it to `Articles:WriteArticleUserPromptTemplate` in lockstep with the deploy. No source-controlled `appsettings*.json` in this repo currently overrides this key, so the audit is exclusively against Azure App Service Configuration.
+
+3. **Behavioural guarantee:** With no environment overrides, the chat messages produced for any `ArticlePipelineContext` are byte-identical before vs. after the change (FR-5).


### PR DESCRIPTION
Article

## Finding
`ArticleOptions.WriteArticleSystemPromptTemplate` is named as though it configures the **system** prompt sent to the AI, but `WriteArticleStep` uses it exclusively as the **user** message:

```csharp
// WriteArticleStep.cs:102-113
private string BuildUserMessage(ArticlePipelineContext context)
{
    ...
    return _options.WriteArticleSystemPromptTemplate   // ← named "SystemPrompt…" but sent as ChatRole.User
        .Replace("{topic}", article.Topic)
        ...
}
```

The actual system prompt is a hardcoded constant in the same class:

```csharp
// WriteArticleStep.cs:86-92
private const string SystemInstruction =
    """
    Jsi zkušený redaktor kosmetického obsahu. Píšeš výhradně v češtině.
    Odpověz POUZE validním JSON bez markdown nebo code fences.
    ...
    """;
```

`SystemInstruction` is **not** exposed via `ArticleOptions` and cannot be overridden via `appsettings.json`. Conversely, the configurable property `WriteArticleSystemPromptTemplate` controls the user turn, not the system turn.

The same naming confusion exists in the other pipeline steps:
- `ArticleOptions.QueryPlannerSystemPrompt` — is sent as `ChatRole.System` ✅
- `ArticleOptions.AggregateFactsSystemPrompt` — is sent as `ChatRole.System` ✅
- `ArticleOptions.ValidateFactsSystemPrompt` — is sent as `ChatRole.System` ✅
- `ArticleOptions.WriteArticleSystemPromptTemplate` — is sent as `ChatRole.User` ❌

Three out of four properties correctly match their role; only the write step is inverted.

## Why it matters
- An operator who wants to tune article writing will find `WriteArticleSystemPromptTemplate` in `appsettings.json`, assume it controls the system-level persona/instruction, and edit it — without effect on the persona. Their change controls the *user turn* (the article brief), not the AI's behaviour mode.
- Conversely, the hardcoded `SystemInstruction` cannot be changed without a code deploy, even though the intent of `ArticleOptions` is to make prompts configurable.
- Breaking consistency with the three other correctly-named options (`QueryPlannerSystemPrompt`, `AggregateFactsSystemPrompt`, `ValidateFactsSystemPrompt`) makes the configuration surface harder to reason about.

## Suggested fix
Two-part fix — either is sufficient; doing both is cleanest:

**Option A: rename to match actual usage**
```csharp
// ArticleOptions.cs
public string WriteArticleUserPromptTemplate { get; set; } = ...;
```
Update the one reference in `WriteArticleStep.BuildUserMessage`. No behaviour change.

**Option B: make the system prompt configurable too** (recommended)
```csharp
// ArticleOptions.cs
public string WriteArticleSystemPrompt { get; set; } = /* the current SystemInstruction value */;
public string WriteArticleUserPromptTemplate { get; set; } = ...;
```
In `WriteArticleStep`, replace the hardcoded `SystemInstruction` constant with `_options.WriteArticleSystemPrompt`, consistent with how the other three steps work.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1690

### Tokens used
15145276
