### PR TITLE
feat: Fix `useArticleFeedbackListQuery` Type/Field Mismatches

### DIFF
--- a/artifacts/feat-arch-review-article-usearticlefeedbackli/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-usearticlefeedbackli/arch-review.r1.md
@@ -1,0 +1,181 @@
+I have enough context. Writing the review.
+
+# Architecture Review: Fix `useArticleFeedbackListQuery` Type/Field Mismatches
+
+## Skip Design: true
+
+This is a frontend TypeScript-only correctness fix. No new screens, visual components, or layout decisions are introduced.
+
+## Architectural Fit Assessment
+
+The fix aligns with the established frontend pattern in `useArticles.ts`: each query function performs an explicit field-by-field mapping after `await client.<endpoint>()`, projecting the generated NSwag DTO onto a hand-written frontend interface. `useGetArticleQuery` (lines 149–196) and `useListArticlesQuery` (lines 125–147) already follow this shape. The brief originally described the hook as still using raw `fetch`, but a parallel refactor (see `docs/superpowers/plans/2026-05-25-article-frontend-hooks-bypass-refactor.md`) has already migrated `useArticleFeedbackListQuery` to `client.articles_FeedbackList`. So the work remaining is **strictly the rename + consumer/test alignment**, not the raw-fetch removal anymore. The spec text in FR-1 (“awaits `response.json()` into an untyped intermediate value”, “No direct cast of the raw payload”) is stale relative to current code — it should be re-stated against the generated-client shape (`raw` is now the typed NSwag DTO returned by `articles_FeedbackList`).
+
+The main integration points are:
+- The generated client `client.articles_FeedbackList` (already in use, types match backend: `items`, `createdAt`, `hasComment`).
+- The hand-written interfaces `ArticleFeedbackListResponse` and `ArticleFeedbackSummary` (still expose legacy frontend names: `articles`, `generatedAt`, `hasFeedback`, `feedbackComment`).
+- The single consumer `useArticleFeedbackAdapter.ts`, which projects article fields onto the domain-neutral `FeedbackDetail` interface in `components/feedback/types.ts`.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend                 generated NSwag DTO         frontend hook contract        generic UI contract
+─────────────────────   ─────────────────────       ──────────────────────────    ──────────────────────────
+GetArticleFeedback      ArticleFeedbackSummaryDto   ArticleFeedbackSummary        FeedbackRow / FeedbackDetail
+ListHandler                                         (renamed in this work)        (unchanged, domain-neutral)
+                        items                  →   articles                  →   rows
+                        createdAt              →   createdAt  (was generatedAt)→  createdAt
+                        hasComment             →   hasComment (was hasFeedback)→  hasFeedback (domain-neutral)
+                        (not emitted)              [feedbackComment removed]  →   feedbackComment = null
+```
+
+Two contract layers are intentional:
+1. **`ArticleFeedbackSummary`** — mirrors the backend article feedback list shape on the frontend. **This is where the rename lands.**
+2. **`FeedbackRow` / `FeedbackDetail`** in `components/feedback/types.ts` — a domain-neutral row contract shared by article, leaflet, and KB adapters. Its `hasFeedback` and `feedbackComment` fields are about “does this row carry feedback for the generic table to render”, not about article-specific naming. **These do NOT get renamed.** Renaming them would cascade through `useLeafletFeedbackAdapter`, `useKbFeedbackAdapter`, `GenericFeedbackTable`, `GenericFeedbackDetailModal`, and their tests for no semantic gain.
+
+### Key Design Decisions
+
+#### Decision 1: Rename article-specific names; keep generic feedback-row names
+
+**Options considered:**
+- (A) Rename `FeedbackRow.hasFeedback` → `hasComment` everywhere (deep rename across all feedback adapters).
+- (B) Rename only `ArticleFeedbackSummary.hasFeedback` → `hasComment`, keep `FeedbackRow.hasFeedback` as the domain-neutral name; map between them in the adapter.
+
+**Chosen approach:** (B).
+
+**Rationale:** `FeedbackRow.hasFeedback` is a UI abstraction that means “the row has scored/commented feedback worth showing.” For leaflet rows, it’s computed from score presence (`useLeafletFeedbackAdapter.ts:22`); for KB, it’s a per-log flag. Only the article version happens to be sourced from a `hasComment` backend bit. Cascading the rename would conflate the article-specific semantics with the generic abstraction and trigger a much larger churn (4+ files, 3+ test files) for no correctness benefit. The spec (FR-3, FR-4) only requires the frontend article type to match the backend; the generic row contract is out of scope and should stay put.
+
+#### Decision 2: Keep `feedbackComment: null` flowing into `FeedbackDetail`
+
+**Options considered:**
+- (A) Remove `feedbackComment` from `FeedbackDetail` since the article list never has it.
+- (B) Keep `FeedbackDetail.feedbackComment?: string | null` as-is; the article adapter explicitly passes `null` (other adapters pass real values).
+
+**Chosen approach:** (B).
+
+**Rationale:** Leaflet and KB adapters carry real comment text on their list rows (`useLeafletFeedbackAdapter.ts:23`, `useKbFeedbackAdapter.ts:23`), and `GenericFeedbackDetailModal.tsx:83` renders it. Removing the field breaks those consumers. The article adapter already passes `null` explicitly; keep that. The only thing that goes away is `ArticleFeedbackSummary.feedbackComment` (the hand-written article type field), because the backend never populates it for the list endpoint.
+
+#### Decision 3: Use NSwag DTO directly as the “raw” input, not `response.json()`
+
+**Options considered:**
+- (A) Follow the spec literally: switch back to raw `fetch` + `response.json()` for the mapping.
+- (B) Treat the typed DTO returned by `articles_FeedbackList` as the “raw” input to mapping, identical pattern to `useGetArticleQuery`.
+
+**Chosen approach:** (B).
+
+**Rationale:** A parallel refactor already removed the raw `fetch` from this hook. Reverting that to satisfy spec wording would undo a deliberate architectural improvement. The intent of FR-1 — explicit field-by-field mapping, no untyped passthrough — is satisfied by mapping from the typed DTO. The spec should be amended (see Specification Amendments).
+
+#### Decision 4: New unit tests target the hook itself, not just the adapter
+
+**Options considered:**
+- (A) Cover the mapping only through the existing `useArticleFeedbackAdapter.test.ts`.
+- (B) Add a new `frontend/src/api/hooks/__tests__/useArticles.test.ts` that mocks `getAuthenticatedApiClient().articles_FeedbackList` and asserts the hook’s mapping directly. Keep the adapter tests too.
+
+**Chosen approach:** (B).
+
+**Rationale:** FR-5 calls out three mapping cases (populated, all-nullable, empty `items`) that are properties of the hook’s mapping function, not the adapter. The adapter tests can’t cover the “missing `items` yields `[]`” case because they mock the hook’s output directly. Co-locating hook tests under `frontend/src/api/hooks/__tests__/` follows the established convention (`useKnowledgeBase.test.ts`, `useJournal.test.ts`, etc.).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Files to modify:
+- `frontend/src/api/hooks/useArticles.ts` — rename fields on `ArticleFeedbackSummary`, drop `feedbackComment` from this interface, update the mapping inside `useArticleFeedbackListQuery`.
+- `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — read `article.createdAt`/`article.hasComment`; pass `feedbackComment: null` into `FeedbackDetail` (or omit, since it’s optional on `FeedbackDetail`).
+- `frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts` — update mock fixtures (`generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment` from the mocked article shape); rename the “maps generatedAt to createdAt” / “uses empty string for createdAt when generatedAt is null” test descriptions to reflect the new source field.
+
+Files to create:
+- `frontend/src/api/hooks/__tests__/useArticles.test.ts` (new) — hook-level mapping tests per FR-5. Mock `getAuthenticatedApiClient` to return a stub whose `articles_FeedbackList` returns crafted DTOs.
+
+Files explicitly NOT touched:
+- `frontend/src/components/feedback/types.ts` (generic `FeedbackRow`/`FeedbackDetail`).
+- `frontend/src/components/feedback/GenericFeedbackTable.tsx`, `GenericFeedbackDetailModal.tsx`, `GenericFeedbackFilters.tsx`.
+- `frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts`, `useKbFeedbackAdapter.ts` and their tests.
+- `frontend/src/features/articles/ArticleFeedbackSection.tsx` — reads `article.feedbackComment` from `ArticleDetail` (not from the list summary). Stays as-is.
+- `frontend/src/api/hooks/useLeaflet.ts` — its own `feedbackComment`/`hasFeedback` belong to a different domain type.
+- Any backend file.
+
+### Interfaces and Contracts
+
+```ts
+// Post-change shape — exactly what FR-3 mandates.
+export interface ArticleFeedbackSummary {
+  id: string;
+  topic: string;
+  title: string | null;
+  requestedBy: string;
+  createdAt: string | null;        // was generatedAt
+  precisionScore: number | null;
+  styleScore: number | null;
+  hasComment: boolean;             // was hasFeedback
+  // feedbackComment removed
+}
+
+export interface ArticleFeedbackListResponse {
+  articles: ArticleFeedbackSummary[];  // mapped from raw.items
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  stats: ArticleFeedbackStats;
+}
+```
+
+Adapter projection rule (single source of truth, in `useArticleFeedbackAdapter.ts`):
+
+```
+article.id              → row.id
+article.title ?? topic  → row.primaryText
+article.topic           → row.secondaryText
+article.createdAt ?? '' → row.createdAt
+article.requestedBy     → row.userId
+article.precisionScore  → row.precisionScore
+article.styleScore      → row.styleScore
+article.hasComment      → row.hasFeedback        (generic semantics)
+null                    → row.feedbackComment    (list endpoint never sends it)
+```
+
+### Data Flow
+
+1. Adapter calls `useArticleFeedbackListQuery(params)`.
+2. Hook calls `client.articles_FeedbackList(...)` → typed NSwag DTO `data`.
+3. Hook maps:
+   - `articles = (data.items ?? []).map(mapSummary)` where `mapSummary` returns the new `ArticleFeedbackSummary` shape with `createdAt`/`hasComment` (no `feedbackComment`).
+   - `totalCount`/`page`/`pageSize`/`totalPages` with numeric defaults.
+   - `stats` with the same default object as today.
+4. React Query caches the typed `ArticleFeedbackListResponse`.
+5. Adapter reads `query.data.articles` and projects each row onto `FeedbackDetail`, mapping `hasComment` → `FeedbackRow.hasFeedback` and `createdAt` → `FeedbackRow.createdAt`.
+6. `GenericFeedbackTable` and `GenericFeedbackDetailModal` consume `FeedbackRow.hasFeedback` / `FeedbackDetail.feedbackComment` without any change.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Cascading the rename into the generic `FeedbackRow.hasFeedback` would touch leaflet + KB adapters and their tests with no semantic benefit. | Medium | Decision 1 above — restrict rename to `ArticleFeedbackSummary`. Reviewer should reject any PR that also renames `FeedbackRow.hasFeedback`. |
+| Existing adapter tests use the legacy article field names in their mocks, so they currently pass against the **wrong** runtime shape. Renaming only the interface without updating mocks could leave tests green while the type is wrong. | High | Update `useArticleFeedbackAdapter.test.ts` mock fixtures (`mockArticle`, `mockArticleNoTitle`) in the same PR. Adapter test names that mention `generatedAt` must be renamed too. |
+| `ArticleFeedbackSection.tsx` reads `article.feedbackComment` from `ArticleDetail` (the **detail** type, not the list summary) — easy to conflate and accidentally edit. | Low | Restrict edits to `ArticleFeedbackSummary`/`ArticleFeedbackListResponse`. Leave `ArticleDetail.feedbackComment` and `ArticleFeedbackSection.tsx` alone. |
+| The spec wording assumes raw `fetch` + `response.json()`, but the hook already uses the generated client. Following the spec literally would regress that. | High | See Specification Amendments below — rewrite FR-1’s wording to map from the typed DTO. |
+| Stats default-object branch is duplicated (lines 287–298). Spec NFR-4 forbids new abstractions just for the fix. | Low | Leave the duplication intact; the fix scope is rename-only. |
+| Removing `feedbackComment` from `ArticleFeedbackSummary` could regress any consumer that today happens to read `article.feedbackComment` (even though it’s always `null`). | Low | Grep confirms only the adapter reads it on a list row (`useArticleFeedbackAdapter.ts:24`), and that line will be updated. `ArticleFeedbackSection` reads from `ArticleDetail`, a different type. |
+| A future addition of `feedbackComment` to the list endpoint would re-introduce the type. | Low | Documented as out-of-scope; if/when added on the backend, regenerate the client and extend `ArticleFeedbackSummary` then. |
+
+## Specification Amendments
+
+1. **FR-1 wording is stale.** Replace:
+   > “The query function awaits `response.json()` into an untyped intermediate value.”
+   with:
+   > “The query function calls `client.articles_FeedbackList(...)` and treats the returned NSwag DTO as the input to a field-by-field mapping. No untyped passthrough or direct cast of the DTO to `ArticleFeedbackListResponse` remains; every field on the returned `ArticleFeedbackListResponse` is populated by explicit mapping.”
+   This preserves the intent (no implicit passthrough) without forcing a regression to raw `fetch`.
+
+2. **FR-3 “field types unchanged” clarification.** The current `ArticleFeedbackSummary.id` is typed `string` in the hand-written interface, but the generated DTO exposes `id` as `string | undefined` and the existing mapping uses `item.id ?? ''`. Keep the post-change interface as `id: string` and continue defaulting to `''`. State this explicitly in FR-3 so reviewers do not flag it.
+
+3. **FR-4 scope clarification.** Add a sentence: “`FeedbackRow`/`FeedbackDetail` in `components/feedback/types.ts` are domain-neutral and are NOT renamed. Article-specific renames stop at `ArticleFeedbackSummary`; the article adapter performs the projection from `hasComment` to `FeedbackRow.hasFeedback`.”
+
+4. **FR-5 test placement.** Add: “Hook-level mapping tests live in `frontend/src/api/hooks/__tests__/useArticles.test.ts` (new file, follows existing convention). Adapter-level tests (`useArticleFeedbackAdapter.test.ts`) get their mock fixtures updated in the same PR but remain focused on adapter projection, not on the hook’s mapping.”
+
+5. **Out-of-scope addendum.** Explicitly add: “Renaming `FeedbackRow.hasFeedback` or `FeedbackDetail.feedbackComment` is out of scope. The leaflet/KB adapters and the generic feedback table/modal remain untouched.”
+
+## Prerequisites
+
+- None. No backend change, no migration, no config flag, no infrastructure work. The NSwag client already exposes `articles_FeedbackList` with the correct backend field names; no client regeneration is required for this fix. The PR is a single-commit, frontend-only TypeScript refactor with accompanying test updates and one new test file.

--- a/artifacts/feat-arch-review-article-usearticlefeedbackli/brief.md
+++ b/artifacts/feat-arch-review-article-usearticlefeedbackli/brief.md
@@ -1,0 +1,59 @@
+## Module
+Article
+
+## Finding
+`useArticleFeedbackListQuery` in `useArticles.ts` uses raw `fetch` (bypassing the NSwag-generated client) and does `return response.json()` directly, casting the result to `ArticleFeedbackListResponse`. The TypeScript type and the actual JSON shape do not match on multiple fields:
+
+### Top-level collection key mismatch
+
+| Backend (`GetArticleFeedbackListResponse`) | Frontend TypeScript `ArticleFeedbackListResponse` |
+|---|---|
+| `items: ArticleFeedbackSummary[]` | `articles: ArticleFeedbackSummary[]` |
+
+`useArticles.ts:98` declares `articles: ArticleFeedbackSummary[]`, but the serialised JSON from `GetArticleFeedbackListHandler` has the key `items`. Any component that accesses `.articles` gets `undefined` at runtime.
+
+### Per-item field mismatches
+
+| Backend `ArticleFeedbackSummary` (`GetArticleFeedbackListRequest.cs:33`) | Frontend `ArticleFeedbackSummary` (`useArticles.ts:78`) |
+|---|---|
+| `CreatedAt: DateTimeOffset` | `generatedAt: string \| null` (key mismatch) |
+| `HasComment: bool` | `hasFeedback: boolean` (key mismatch — semantically different too) |
+| *(not present)* | `feedbackComment: string \| null` (extra field that will always be `undefined`) |
+
+The handler maps `HasComment = !string.IsNullOrWhiteSpace(a.FeedbackComment)` (`GetArticleFeedbackListHandler.cs:54`), so the backend sends `hasComment` (a boolean indicating comment presence), not `feedbackComment` (the actual text). The frontend TypeScript type expects `feedbackComment` (the text) and will never receive it from this endpoint.
+
+All mismatches are invisible at compile time because the query function casts directly without any field-level mapping (`return response.json()`).
+
+## Why it matters
+- At runtime, any component consuming the feedback list will see `undefined` for `articles`, `generatedAt`, `feedbackComment`, and `hasFeedback`.
+- TypeScript provides no protection because the cast bypasses the type system.
+- Contrast with `useGetArticleQuery` which does an explicit field-by-field mapping (lines 155-188 in `useArticles.ts`), making the intent of that query clear. The feedback list query does the opposite, making it appear safe while hiding the divergence.
+
+## Suggested fix
+Add an explicit mapping in `useArticleFeedbackListQuery` that mirrors the pattern used in `useGetArticleQuery`:
+
+```typescript
+const raw = await response.json();
+return {
+  articles: (raw.items ?? []).map((a: any) => ({
+    id: a.id,
+    topic: a.topic ?? '',
+    title: a.title ?? null,
+    requestedBy: a.requestedBy ?? '',
+    createdAt: a.createdAt ?? null,          // align TS field name with backend
+    precisionScore: a.precisionScore ?? null,
+    styleScore: a.styleScore ?? null,
+    hasComment: a.hasComment ?? false,       // rename to match backend
+  })),
+  totalCount: raw.totalCount ?? 0,
+  page: raw.page ?? 1,
+  pageSize: raw.pageSize ?? 20,
+  totalPages: raw.totalPages ?? 0,
+  stats: raw.stats ?? { totalArticles: 0, totalWithFeedback: 0, avgPrecisionScore: null, avgStyleScore: null },
+};
+```
+
+Also update the `ArticleFeedbackSummary` TypeScript interface and any consuming components to use `articles`, `createdAt`, and `hasComment`.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-article-usearticlefeedbackli/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-usearticlefeedbackli/impl/main.r1.md
@@ -1,0 +1,12 @@
+All 13 tests pass. Implementation is committed on `feat-arch-review-article-usearticlefeedbackli` branched from `main`.
+
+---
+
+**Implementation complete. What would you like to do?**
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-article-usearticlefeedbackli/spec.r1.md
+++ b/artifacts/feat-arch-review-article-usearticlefeedbackli/spec.r1.md
@@ -1,0 +1,139 @@
+# Specification: Fix `useArticleFeedbackListQuery` Type/Field Mismatches
+
+## Summary
+The `useArticleFeedbackListQuery` hook in `frontend/src/api/hooks/useArticles.ts` uses raw `fetch` and casts the JSON response directly to a TypeScript type that does not match the backend payload. This causes consumers to receive `undefined` for several fields at runtime. The fix is to add an explicit field-by-field mapping (mirroring `useGetArticleQuery`) and to realign the TypeScript types and consuming components with the backend contract.
+
+## Background
+`GetArticleFeedbackListHandler` returns a JSON payload whose shape diverges from the frontend `ArticleFeedbackListResponse`/`ArticleFeedbackSummary` types at multiple points:
+
+- **Top-level collection key**: backend serialises `items`, frontend reads `articles`.
+- **Per-item timestamp**: backend `CreatedAt` vs. frontend `generatedAt`.
+- **Per-item comment indicator**: backend boolean `HasComment` (true when a non-empty comment exists) vs. frontend boolean `hasFeedback`.
+- **Per-item phantom field**: frontend declares `feedbackComment: string | null`, which the backend never sends from this endpoint.
+
+The bug is invisible to TypeScript because `return response.json()` is cast directly to the response type, bypassing structural checking. Other hooks in the same file (notably `useGetArticleQuery` at lines ~155–188) handle this correctly by doing an explicit field-by-field mapping after `await response.json()`. The feedback list hook should follow the same pattern. This work is filed by the daily architecture review routine; it is a correctness/contract-alignment fix, not a feature change.
+
+## Functional Requirements
+
+### FR-1: Map backend payload to frontend type inside the query function
+`useArticleFeedbackListQuery` must perform an explicit field-by-field mapping from the raw JSON response to the typed result, instead of casting `response.json()` directly. The mapping must mirror the structure used in `useGetArticleQuery` (consistent style across the file).
+
+**Acceptance criteria:**
+- The query function awaits `response.json()` into an untyped intermediate value.
+- Each field returned to React Query is populated from a known backend field with a safe default for null/undefined values.
+- No direct cast of the raw payload to `ArticleFeedbackListResponse` remains.
+- The mapping handles `raw.items` being `undefined` (returns `[]`) and provides defaults for pagination/stats fields.
+
+### FR-2: Align top-level collection key
+The frontend type and consumer code must expose the list under the field name `articles` (the established frontend term), while the mapping reads from `raw.items` (the backend key).
+
+**Acceptance criteria:**
+- `ArticleFeedbackListResponse.articles: ArticleFeedbackSummary[]` remains the public TypeScript shape returned by the hook.
+- The hook reads `raw.items ?? []` and assigns it to `articles` after per-item mapping.
+- No consumer reads `items` directly from the hook's result.
+
+### FR-3: Align per-item field names with backend
+`ArticleFeedbackSummary` must reflect the actual backend contract:
+
+- Replace `generatedAt: string | null` with `createdAt: string | null`.
+- Replace `hasFeedback: boolean` with `hasComment: boolean`.
+- Remove `feedbackComment: string | null` (this endpoint does not return the comment text).
+
+**Acceptance criteria:**
+- `ArticleFeedbackSummary` in `useArticles.ts` exposes exactly: `id`, `topic`, `title`, `requestedBy`, `createdAt`, `precisionScore`, `styleScore`, `hasComment`. (Field types unchanged from current except for the renames and removal above.)
+- The mapping in FR-1 emits these names.
+- A grep for `generatedAt`, `hasFeedback`, and `feedbackComment` in feedback-list usage sites returns no remaining references after the change.
+
+### FR-4: Update consuming components
+Any frontend component that reads from `useArticleFeedbackListQuery` must be updated to the new field names: `articles`, `createdAt`, `hasComment`. Any reference to the removed `feedbackComment` on list rows must be removed or replaced (e.g., a row-level "has comment" indicator that previously relied on `feedbackComment` truthiness should use `hasComment` instead).
+
+**Acceptance criteria:**
+- All `.tsx`/`.ts` files that consume the feedback list query compile cleanly against the updated types.
+- UI behaviour that previously depended on `generatedAt`/`hasFeedback`/`feedbackComment` continues to render the equivalent information using the renamed fields.
+- Existing visual layout, column order, and copy are unchanged unless a consumer was rendering a field that simply never had data (in which case it is replaced with the correct field).
+
+### FR-5: Test coverage for the mapping
+Add or update unit tests that exercise the mapping function with representative backend payloads, including: a typical populated row, a row with all nullable fields null, and an empty `items` array.
+
+**Acceptance criteria:**
+- A unit test asserts that given a sample raw payload with `items`, `totalCount`, `page`, `pageSize`, `totalPages`, and `stats`, the hook's mapped result has the expected typed shape with all renames applied.
+- A unit test asserts that a payload missing `items` yields `articles: []` and does not throw.
+- A unit test asserts that `hasComment` is preserved from the backend (i.e., the frontend does not synthesize it from another field).
+- Tests live in the existing test file for `useArticles` (or a co-located new file if none exists) and use the project's existing test runner (jest/vitest, whichever is in use for `frontend/`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance change is expected. The mapping is an O(n) pass over a paginated list (page size already capped server-side) and runs once per query response. No additional network calls.
+
+### NFR-2: Security
+No change in data sensitivity or auth posture. The endpoint and its auth requirements are unchanged. No new fields are exposed; one field (`feedbackComment`) that was never actually delivered is removed from the type.
+
+### NFR-3: Backwards compatibility
+This is a frontend-only correctness fix. Because the previous code returned `undefined` for the affected fields, no working consumer can depend on the old names with the old behaviour. The TypeScript renames are breaking at the type level but align the code with runtime reality.
+
+### NFR-4: Code consistency
+The mapping must follow the same structural style as `useGetArticleQuery` in the same file so that both hooks read similarly. No new abstraction or helper is introduced solely for this fix (YAGNI).
+
+## Data Model
+
+**Backend (unchanged) — `GetArticleFeedbackListResponse`:**
+- `items: ArticleFeedbackSummary[]`
+- `totalCount: int`
+- `page: int`
+- `pageSize: int`
+- `totalPages: int`
+- `stats: { totalArticles, totalWithFeedback, avgPrecisionScore, avgStyleScore }`
+
+**Backend (unchanged) — `ArticleFeedbackSummary`:**
+- `Id`, `Topic`, `Title`, `RequestedBy`
+- `CreatedAt: DateTimeOffset`
+- `PrecisionScore: int?`, `StyleScore: int?`
+- `HasComment: bool` (computed server-side as `!string.IsNullOrWhiteSpace(FeedbackComment)`)
+
+**Frontend (after change) — `ArticleFeedbackListResponse`:**
+- `articles: ArticleFeedbackSummary[]` (mapped from `items`)
+- `totalCount`, `page`, `pageSize`, `totalPages`, `stats` (unchanged)
+
+**Frontend (after change) — `ArticleFeedbackSummary`:**
+- `id`, `topic`, `title`, `requestedBy`
+- `createdAt: string | null` (renamed from `generatedAt`)
+- `precisionScore: number | null`, `styleScore: number | null`
+- `hasComment: boolean` (renamed from `hasFeedback`)
+- `feedbackComment` removed
+
+## API / Interface Design
+
+No backend API change. No new endpoints, events, or routes.
+
+The hook signature `useArticleFeedbackListQuery(params)` is unchanged; only the shape of its returned data is corrected. The internal flow becomes:
+
+1. `fetch` the list endpoint as today.
+2. `await response.json()` into an untyped `raw` value.
+3. Build the typed `ArticleFeedbackListResponse`:
+   - `articles = (raw.items ?? []).map(mapSummary)`
+   - `totalCount`, `page`, `pageSize`, `totalPages` with numeric defaults
+   - `stats` with the existing default object when missing
+4. Return the typed object to React Query.
+
+Per-item mapping (`mapSummary`) produces: `{ id, topic, title, requestedBy, createdAt, precisionScore, styleScore, hasComment }` with safe defaults as shown in the brief.
+
+## Dependencies
+
+- React Query (existing, no version change).
+- No new libraries.
+- Backend `GetArticleFeedbackListHandler` is the source of truth and is not modified.
+
+## Out of Scope
+
+- Migrating `useArticleFeedbackListQuery` to the NSwag-generated client. The brief proposes a localized mapping fix, not a migration; a generated-client migration is a larger architectural change and should be tracked separately if desired.
+- Exposing the actual `feedbackComment` text on the list endpoint. If a future UI needs the comment text on list rows, that is a backend change (extend `ArticleFeedbackSummary`) and is not part of this fix.
+- Refactoring other hooks in `useArticles.ts` that use raw `fetch`. Only the feedback list hook is in scope.
+- Backend changes of any kind.
+- E2E test additions. The E2E suite runs nightly and is not gated on this fix; unit tests are sufficient to lock in the mapping.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-usearticlefeedbackli/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-usearticlefeedbackli/task-plan.r1.md
@@ -1,0 +1,627 @@
+# Fix `useArticleFeedbackListQuery` Type/Field Mismatches Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the frontend article-feedback list summary fields (`generatedAt` → `createdAt`, `hasFeedback` → `hasComment`) and drop the phantom `feedbackComment` field so the `ArticleFeedbackSummary` interface and `useArticleFeedbackListQuery` mapping reflect the actual backend payload, then update the single consumer and tests to compile and pass.
+
+**Architecture:** Strictly frontend TypeScript-only rename. The hook already uses the generated NSwag client `client.articles_FeedbackList`; it returns a typed DTO with the correct backend field names (`createdAt`, `hasComment`, no `feedbackComment` on list rows). Only the hand-written frontend interface and the single consuming adapter are misaligned. The generic `FeedbackRow`/`FeedbackDetail` contract is domain-neutral and is **not** renamed — the article adapter projects from `hasComment` onto `FeedbackRow.hasFeedback` and writes `feedbackComment: null` (since the list endpoint never carries comment text).
+
+**Tech Stack:** React, TypeScript, @tanstack/react-query, jest + @testing-library/react (via react-scripts), NSwag-generated API client.
+
+---
+
+## File Structure
+
+**Files to modify:**
+
+- `frontend/src/api/hooks/useArticles.ts` — `ArticleFeedbackSummary` interface (rename + remove `feedbackComment`); per-item mapping inside `useArticleFeedbackListQuery`.
+- `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — read `article.createdAt` / `article.hasComment`; pass `feedbackComment: null` into `FeedbackDetail` (list endpoint never provides it).
+- `frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts` — rename mock-fixture fields (`generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment`); rename two test descriptions that mention `generatedAt`.
+
+**Files to create:**
+
+- `frontend/src/api/hooks/__tests__/useArticles.test.ts` — new hook-level tests covering the mapping for: populated `items`, missing `items`, and `hasComment` preservation. Follows the pattern of `__tests__/useJournal.test.ts` and `__tests__/useKnowledgeBase.test.ts`: mock `getAuthenticatedApiClient` to return a stub whose `articles_FeedbackList` returns crafted DTOs.
+
+**Files explicitly NOT touched** (per arch-review Decisions 1 & 2):
+
+- `frontend/src/components/feedback/types.ts` — generic `FeedbackRow.hasFeedback` and `FeedbackDetail.feedbackComment` stay as-is (domain-neutral).
+- `frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts`, `useKbFeedbackAdapter.ts` and their tests.
+- `frontend/src/components/feedback/GenericFeedbackTable.tsx`, `GenericFeedbackDetailModal.tsx`, `GenericFeedbackFilters.tsx`.
+- `frontend/src/features/articles/ArticleFeedbackSection.tsx` — reads `article.feedbackComment` from `ArticleDetail` (the detail type, not the list summary); it stays.
+- `frontend/src/api/hooks/useArticles.ts` — `ArticleDetail.feedbackComment` and `useGetArticleQuery` mapping stay. Only `ArticleFeedbackSummary` and `useArticleFeedbackListQuery` change.
+- `frontend/src/api/generated/api-client.ts` — generated, not manually edited.
+- Any backend file.
+
+---
+
+## Task 1: Add hook-level mapping tests (RED)
+
+**Files:**
+- Create: `frontend/src/api/hooks/__tests__/useArticles.test.ts`
+
+The new tests will fail to compile (or fail at runtime) because today’s `ArticleFeedbackSummary` exposes `generatedAt`/`hasFeedback`/`feedbackComment`, not `createdAt`/`hasComment`. That’s the RED step we want before the rename in Task 2.
+
+- [ ] **Step 1: Create the new test file with three mapping tests**
+
+Create `frontend/src/api/hooks/__tests__/useArticles.test.ts`:
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useArticleFeedbackListQuery } from '../useArticles';
+import * as clientModule from '../../client';
+
+jest.mock('../../client', () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  QUERY_KEYS: {
+    articles: ['articles'],
+  },
+}));
+
+const mockGetAuthenticatedApiClient =
+  clientModule.getAuthenticatedApiClient as jest.MockedFunction<
+    typeof clientModule.getAuthenticatedApiClient
+  >;
+
+const createWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    children,
+  );
+};
+
+describe('useArticleFeedbackListQuery mapping', () => {
+  let mockArticlesFeedbackList: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockArticlesFeedbackList = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      articles_FeedbackList: mockArticlesFeedbackList,
+    } as any);
+  });
+
+  it('maps a populated DTO row to the renamed frontend shape (createdAt, hasComment, no feedbackComment)', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      items: [
+        {
+          id: 'art-1',
+          topic: 'Topic A',
+          title: 'Title A',
+          requestedBy: 'user@anela.cz',
+          createdAt: new Date('2026-01-15T10:30:00Z'),
+          precisionScore: 4,
+          styleScore: 5,
+          hasComment: true,
+        },
+      ],
+      totalCount: 1,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+      stats: {
+        totalArticles: 1,
+        totalWithFeedback: 1,
+        avgPrecisionScore: 4,
+        avgStyleScore: 5,
+      },
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.articles).toHaveLength(1);
+    expect(result.current.data!.articles[0]).toEqual({
+      id: 'art-1',
+      topic: 'Topic A',
+      title: 'Title A',
+      requestedBy: 'user@anela.cz',
+      createdAt: '2026-01-15T10:30:00.000Z',
+      precisionScore: 4,
+      styleScore: 5,
+      hasComment: true,
+    });
+    expect(result.current.data!.totalCount).toBe(1);
+    expect(result.current.data!.stats).toEqual({
+      totalArticles: 1,
+      totalWithFeedback: 1,
+      avgPrecisionScore: 4,
+      avgStyleScore: 5,
+    });
+  });
+
+  it('returns empty articles and default stats when items and stats are missing from the DTO', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      totalCount: 0,
+      page: 1,
+      pageSize: 20,
+      totalPages: 0,
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.articles).toEqual([]);
+    expect(result.current.data!.stats).toEqual({
+      totalArticles: 0,
+      totalWithFeedback: 0,
+      avgPrecisionScore: null,
+      avgStyleScore: null,
+    });
+  });
+
+  it('preserves hasComment per row (does not synthesize it from other fields) and maps null createdAt', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      items: [
+        {
+          id: 'art-with-comment',
+          topic: 'T',
+          title: null,
+          requestedBy: 'u',
+          createdAt: undefined,
+          precisionScore: null,
+          styleScore: null,
+          hasComment: true,
+        },
+        {
+          id: 'art-without-comment',
+          topic: 'T',
+          title: null,
+          requestedBy: 'u',
+          createdAt: undefined,
+          precisionScore: null,
+          styleScore: null,
+          hasComment: false,
+        },
+      ],
+      totalCount: 2,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [withComment, withoutComment] = result.current.data!.articles;
+    expect(withComment.hasComment).toBe(true);
+    expect(withComment.createdAt).toBeNull();
+    expect(withoutComment.hasComment).toBe(false);
+    expect(withoutComment.createdAt).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run from the `frontend/` directory:
+
+```bash
+cd frontend && CI=true npx react-scripts test src/api/hooks/__tests__/useArticles.test.ts --watchAll=false
+```
+
+Expected: tests FAIL. The current mapping emits `generatedAt`/`hasFeedback`/`feedbackComment`, so the `toEqual` in test 1 will not match and `hasComment`/`createdAt` accesses in tests 1 and 3 will read `undefined`. This is the RED step — we want failure here.
+
+- [ ] **Step 3: Do not commit yet**
+
+The plan commits once at the end (Task 6) after all related changes compile and pass together. Leave the new test file uncommitted for now.
+
+---
+
+## Task 2: Rename `ArticleFeedbackSummary` fields and update the hook mapping (GREEN for Task 1 tests, RED for adapter)
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useArticles.ts:78-88, 268-281`
+
+This step renames the public hook contract and updates the per-item mapping accordingly. The hook tests from Task 1 will pass after this step. The adapter file will now fail to compile because it reads `article.generatedAt`/`article.hasFeedback`/`article.feedbackComment`, which no longer exist — that breakage is intentional and is fixed in Task 3.
+
+- [ ] **Step 1: Update the `ArticleFeedbackSummary` interface**
+
+In `frontend/src/api/hooks/useArticles.ts`, replace the current interface (lines 78–88):
+
+```typescript
+export interface ArticleFeedbackSummary {
+  id: string;
+  topic: string;
+  title: string | null;
+  requestedBy: string;
+  generatedAt: string | null;
+  precisionScore: number | null;
+  styleScore: number | null;
+  feedbackComment: string | null;
+  hasFeedback: boolean;
+}
+```
+
+with:
+
+```typescript
+export interface ArticleFeedbackSummary {
+  id: string;
+  topic: string;
+  title: string | null;
+  requestedBy: string;
+  createdAt: string | null;
+  precisionScore: number | null;
+  styleScore: number | null;
+  hasComment: boolean;
+}
+```
+
+Rationale per spec FR-3: `generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment`. Keep `id: string` (not `string | undefined`); the existing `item.id ?? ''` default handles the NSwag `string | undefined`.
+
+- [ ] **Step 2: Update the per-item mapping inside `useArticleFeedbackListQuery`**
+
+In the same file, replace the mapping block in `useArticleFeedbackListQuery` (current lines 268–281):
+
+```typescript
+articles: (data.items ?? []).map((item) => ({
+  id: item.id ?? '',
+  topic: item.topic ?? '',
+  title: item.title ?? null,
+  requestedBy: item.requestedBy ?? '',
+  generatedAt: item.createdAt?.toISOString() ?? null,
+  precisionScore: item.precisionScore ?? null,
+  styleScore: item.styleScore ?? null,
+  // Backend list endpoint never emits a per-item feedback comment
+  // (only the boolean hasComment), so projecting null here is exact
+  // behavior preservation, not data loss.
+  feedbackComment: null,
+  hasFeedback: item.hasComment ?? false,
+})),
+```
+
+with:
+
+```typescript
+articles: (data.items ?? []).map((item) => ({
+  id: item.id ?? '',
+  topic: item.topic ?? '',
+  title: item.title ?? null,
+  requestedBy: item.requestedBy ?? '',
+  createdAt: item.createdAt?.toISOString() ?? null,
+  precisionScore: item.precisionScore ?? null,
+  styleScore: item.styleScore ?? null,
+  hasComment: item.hasComment ?? false,
+})),
+```
+
+Leave the surrounding `totalCount` / `page` / `pageSize` / `totalPages` / `stats` defaults exactly as they are (NFR-4 forbids adding helpers/abstractions just for this fix).
+
+- [ ] **Step 3: Run the hook tests and verify they now pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test src/api/hooks/__tests__/useArticles.test.ts --watchAll=false
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 4: Verify the adapter file is now broken (expected)**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep useArticleFeedbackAdapter
+```
+
+Expected: errors mentioning `Property 'generatedAt' does not exist`, `Property 'hasFeedback' does not exist`, `Property 'feedbackComment' does not exist` on the article row type. This confirms Task 3 is the next required step. Do not commit yet.
+
+---
+
+## Task 3: Update the article feedback adapter to read renamed fields
+
+**Files:**
+- Modify: `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts:15-25`
+
+The adapter is the only file outside `useArticles.ts` that reads from `ArticleFeedbackSummary`. Per arch-review Decision 1, do **not** rename `FeedbackRow.hasFeedback` (domain-neutral). Per Decision 2, explicitly pass `feedbackComment: null` (the list endpoint never carries it).
+
+- [ ] **Step 1: Update the row-projection block**
+
+In `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts`, replace the current `rows` mapping (lines 15–25):
+
+```typescript
+const rows: FeedbackDetail[] = (query.data?.articles ?? []).map((article) => ({
+  id: article.id,
+  primaryText: article.title ?? article.topic,
+  secondaryText: article.topic,
+  createdAt: article.generatedAt ?? '',
+  userId: article.requestedBy,
+  precisionScore: article.precisionScore,
+  styleScore: article.styleScore,
+  hasFeedback: article.hasFeedback,
+  feedbackComment: article.feedbackComment,
+}));
+```
+
+with:
+
+```typescript
+const rows: FeedbackDetail[] = (query.data?.articles ?? []).map((article) => ({
+  id: article.id,
+  primaryText: article.title ?? article.topic,
+  secondaryText: article.topic,
+  createdAt: article.createdAt ?? '',
+  userId: article.requestedBy,
+  precisionScore: article.precisionScore,
+  styleScore: article.styleScore,
+  hasFeedback: article.hasComment,
+  feedbackComment: null,
+}));
+```
+
+Leave the `stats` block (lines 27–34) and the `return` block (36–44) unchanged.
+
+- [ ] **Step 2: Verify the adapter compiles**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep useArticleFeedbackAdapter
+```
+
+Expected: no output (no errors). If errors remain, fix them before continuing.
+
+- [ ] **Step 3: Confirm the adapter tests now fail at runtime**
+
+The adapter test fixtures still use the old field names, so its runtime assertions will break:
+
+```bash
+cd frontend && CI=true npx react-scripts test src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts --watchAll=false
+```
+
+Expected: failures in `maps generatedAt to createdAt` and `uses empty string for createdAt when generatedAt is null` (the mocks still have `generatedAt`, so `article.createdAt` reads as `undefined` and the projected `createdAt` becomes `''`). This confirms Task 4 is needed next.
+
+---
+
+## Task 4: Update adapter test fixtures and descriptions
+
+**Files:**
+- Modify: `frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts:9-31, 81-89`
+
+Mocks must match the new `ArticleFeedbackSummary` shape. Two test descriptions reference the old `generatedAt` field name and must be renamed too.
+
+- [ ] **Step 1: Update `mockArticle`**
+
+Replace the current `mockArticle` declaration (lines 9–19):
+
+```typescript
+const mockArticle = {
+  id: 'art-1',
+  topic: 'Péče o pleť v létě',
+  title: 'Jak pečovat o pleť v letních měsících',
+  requestedBy: 'user@anela.cz',
+  generatedAt: '2026-01-15T10:30:00Z',
+  precisionScore: 4,
+  styleScore: 5,
+  feedbackComment: 'Skvělý článek.',
+  hasFeedback: true,
+};
+```
+
+with:
+
+```typescript
+const mockArticle = {
+  id: 'art-1',
+  topic: 'Péče o pleť v létě',
+  title: 'Jak pečovat o pleť v letních měsících',
+  requestedBy: 'user@anela.cz',
+  createdAt: '2026-01-15T10:30:00Z',
+  precisionScore: 4,
+  styleScore: 5,
+  hasComment: true,
+};
+```
+
+- [ ] **Step 2: Update `mockArticleNoTitle`**
+
+Replace the current `mockArticleNoTitle` declaration (lines 21–31):
+
+```typescript
+const mockArticleNoTitle = {
+  id: 'art-2',
+  topic: 'Zimní vlasová péče',
+  title: null,
+  requestedBy: 'other@anela.cz',
+  generatedAt: null,
+  precisionScore: null,
+  styleScore: null,
+  feedbackComment: null,
+  hasFeedback: false,
+};
+```
+
+with:
+
+```typescript
+const mockArticleNoTitle = {
+  id: 'art-2',
+  topic: 'Zimní vlasová péče',
+  title: null,
+  requestedBy: 'other@anela.cz',
+  createdAt: null,
+  precisionScore: null,
+  styleScore: null,
+  hasComment: false,
+};
+```
+
+- [ ] **Step 3: Rename the two test descriptions that reference `generatedAt`**
+
+Replace:
+
+```typescript
+test('maps generatedAt to createdAt', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[0].createdAt).toBe('2026-01-15T10:30:00Z');
+});
+
+test('uses empty string for createdAt when generatedAt is null', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[1].createdAt).toBe('');
+});
+```
+
+with:
+
+```typescript
+test('maps article createdAt onto row createdAt', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[0].createdAt).toBe('2026-01-15T10:30:00Z');
+});
+
+test('uses empty string for row createdAt when article createdAt is null', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[1].createdAt).toBe('');
+});
+```
+
+Leave all other tests in this file unchanged — the `primaryText`/`secondaryText`/`userId`/`stats`/`params translation`/`loading`/`error` tests do not depend on the renamed fields.
+
+- [ ] **Step 4: Run the adapter tests and verify they pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts --watchAll=false
+```
+
+Expected: all adapter tests PASS.
+
+---
+
+## Task 5: Verify no other consumers reference the old field names
+
+**Files:** No edits. This is a guard step to confirm the rename is complete in the article-feedback path and has not leaked into unrelated code.
+
+- [ ] **Step 1: Grep for stale references in feedback-list usage sites**
+
+```bash
+cd frontend && grep -rn 'generatedAt\|hasFeedback\|feedbackComment' src/components/feedback/adapters src/api/hooks/useArticles.ts src/api/hooks/__tests__/useArticles.test.ts src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts
+```
+
+Expected matches (allowed — domain-neutral or unrelated to the article list summary):
+
+- `src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — `hasFeedback: article.hasComment,` (mapping onto the generic row contract; Decision 1).
+- `src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — `feedbackComment: null,` (explicit projection onto `FeedbackDetail`; Decision 2).
+- `src/components/feedback/adapters/useLeafletFeedbackAdapter.ts` and `useKbFeedbackAdapter.ts` — out of scope; their own `hasFeedback`/`feedbackComment` fields are sourced from different backends and stay.
+
+Expected to NOT match (must be gone):
+
+- Any `generatedAt` in `useArticleFeedbackAdapter.*` or in the article feedback list mapping.
+- Any `feedbackComment:` reference inside `useArticles.ts` that targets `ArticleFeedbackSummary` (the `useGetArticleQuery` mapping for `ArticleDetail.feedbackComment` is allowed — that’s the detail endpoint, not the list).
+- Any `hasFeedback` on a row read from `useArticleFeedbackListQuery` (the adapter writes `hasFeedback` onto the generic row; that’s allowed).
+
+If any disallowed match is found, fix it before continuing.
+
+- [ ] **Step 2: Grep the wider tree for stale references to the renamed `ArticleFeedbackSummary` fields**
+
+```bash
+cd frontend && grep -rn 'useArticleFeedbackListQuery' src
+```
+
+Expected: only `useArticleFeedbackAdapter.ts` and `__tests__/useArticles.test.ts` consume the hook. If any other consumer appears, update it to read `createdAt`/`hasComment` (no `feedbackComment`).
+
+---
+
+## Task 6: Run full validation, then commit
+
+**Files:** No edits. This is the standard-validation + single-commit step.
+
+- [ ] **Step 1: Type-check the frontend**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. If the compiler complains about `ArticleFeedbackSummary`, `useArticleFeedbackListQuery`, or `useArticleFeedbackAdapter`, fix before continuing.
+
+- [ ] **Step 2: Run all touched test files together**
+
+```bash
+cd frontend && CI=true npx react-scripts test src/api/hooks/__tests__/useArticles.test.ts src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts --watchAll=false
+```
+
+Expected: every test PASS. No `console.error` about act warnings or missing query data.
+
+- [ ] **Step 3: Build the frontend**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds. CRA may emit lint warnings — they should not include any unused-variable or type errors introduced by this change.
+
+- [ ] **Step 4: Lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: no new errors. Pre-existing warnings unrelated to the changed files are acceptable.
+
+- [ ] **Step 5: Stage only the files this plan changes**
+
+```bash
+git add frontend/src/api/hooks/useArticles.ts \
+        frontend/src/api/hooks/__tests__/useArticles.test.ts \
+        frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts \
+        frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts
+```
+
+Expected: `git status` shows exactly four files staged (one new, three modified). If any other file appears modified, investigate before committing — the plan is meant to be a single-commit, surgical change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix: align ArticleFeedbackSummary with backend (createdAt, hasComment)
+
+Renames the hand-written ArticleFeedbackSummary fields to match the
+backend payload returned by GetArticleFeedbackListHandler / NSwag DTO:
+generatedAt -> createdAt, hasFeedback -> hasComment. Removes the phantom
+feedbackComment field (the list endpoint never emits it; only the
+boolean hasComment).
+
+The single consumer useArticleFeedbackAdapter is updated to read the
+renamed fields and to pass feedbackComment: null explicitly into the
+generic FeedbackDetail (Decision 2 in the architecture review). The
+domain-neutral FeedbackRow.hasFeedback contract is intentionally left
+in place (Decision 1) so leaflet and KB adapters remain untouched.
+
+Adds hook-level mapping tests for useArticleFeedbackListQuery covering
+populated rows, missing items, and hasComment preservation.
+EOF
+)"
+```
+
+Expected: commit succeeds. `git log -1 --stat` should list exactly the four files above.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- FR-1 (explicit field-by-field mapping, no untyped passthrough) — Task 2 step 2 keeps the existing explicit mapping; no `as any` cast of the DTO is introduced. Per arch-review amendment 1, FR-1 is satisfied by mapping from the typed NSwag DTO rather than from `response.json()`.
+- FR-2 (frontend exposes `articles`, hook reads `raw.items`) — Task 2 step 2 retains `articles: (data.items ?? []).map(...)`. No consumer reads `items` directly (verified in Task 5 step 2).
+- FR-3 (rename `generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment` on `ArticleFeedbackSummary`) — Task 2 step 1. `id: string` is kept (arch-review amendment 2).
+- FR-4 (consuming components updated; behavior preserved) — Task 3 (adapter rename) + Task 4 (test mocks rename). Per arch-review amendment 3, `FeedbackRow`/`FeedbackDetail` are not renamed; the adapter projects between them.
+- FR-5 (unit tests for mapping: populated row, all-nullable row, empty `items`; `hasComment` preserved) — Task 1 covers all three cases plus the `hasComment` preservation assertion. Per arch-review amendment 4, the new tests live in `frontend/src/api/hooks/__tests__/useArticles.test.ts` and the adapter tests are updated separately.
+- NFR-1/2/3/4 — Performance (no change), security (no change), backwards-compat (TypeScript-only rename), code consistency (no new abstraction introduced; mapping mirrors `useGetArticleQuery` style).
+- Out-of-scope items (NSwag migration of the hook, exposing `feedbackComment` on list, refactoring sibling hooks, backend changes, E2E additions) are not touched by any task.
+
+**Placeholder scan:** No `TBD`/`TODO`/`implement later`/`add appropriate X`/`similar to Task N` strings anywhere in the plan. Every code step contains the full replacement code; every command step contains the exact command and expected outcome.
+
+**Type consistency:** Across tasks, the interface field names (`createdAt`, `hasComment`), the adapter projection (`article.createdAt`, `article.hasComment`, `hasFeedback: article.hasComment`, `feedbackComment: null`), and the test mock keys (`createdAt`, `hasComment`) all match. The hook test uses `result.current.data!.articles[0]` and asserts the same renamed keys. No drift between tasks.

--- a/docs/superpowers/plans/2026-05-25-fix-usearticlefeedbacklist-field-rename.md
+++ b/docs/superpowers/plans/2026-05-25-fix-usearticlefeedbacklist-field-rename.md
@@ -1,0 +1,627 @@
+# Fix `useArticleFeedbackListQuery` Type/Field Mismatches Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the frontend article-feedback list summary fields (`generatedAt` → `createdAt`, `hasFeedback` → `hasComment`) and drop the phantom `feedbackComment` field so the `ArticleFeedbackSummary` interface and `useArticleFeedbackListQuery` mapping reflect the actual backend payload, then update the single consumer and tests to compile and pass.
+
+**Architecture:** Strictly frontend TypeScript-only rename. The hook already uses the generated NSwag client `client.articles_FeedbackList`; it returns a typed DTO with the correct backend field names (`createdAt`, `hasComment`, no `feedbackComment` on list rows). Only the hand-written frontend interface and the single consuming adapter are misaligned. The generic `FeedbackRow`/`FeedbackDetail` contract is domain-neutral and is **not** renamed — the article adapter projects from `hasComment` onto `FeedbackRow.hasFeedback` and writes `feedbackComment: null` (since the list endpoint never carries comment text).
+
+**Tech Stack:** React, TypeScript, @tanstack/react-query, jest + @testing-library/react (via react-scripts), NSwag-generated API client.
+
+---
+
+## File Structure
+
+**Files to modify:**
+
+- `frontend/src/api/hooks/useArticles.ts` — `ArticleFeedbackSummary` interface (rename + remove `feedbackComment`); per-item mapping inside `useArticleFeedbackListQuery`.
+- `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — read `article.createdAt` / `article.hasComment`; pass `feedbackComment: null` into `FeedbackDetail` (list endpoint never provides it).
+- `frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts` — rename mock-fixture fields (`generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment`); rename two test descriptions that mention `generatedAt`.
+
+**Files to create:**
+
+- `frontend/src/api/hooks/__tests__/useArticles.test.ts` — new hook-level tests covering the mapping for: populated `items`, missing `items`, and `hasComment` preservation. Follows the pattern of `__tests__/useJournal.test.ts` and `__tests__/useKnowledgeBase.test.ts`: mock `getAuthenticatedApiClient` to return a stub whose `articles_FeedbackList` returns crafted DTOs.
+
+**Files explicitly NOT touched** (per arch-review Decisions 1 & 2):
+
+- `frontend/src/components/feedback/types.ts` — generic `FeedbackRow.hasFeedback` and `FeedbackDetail.feedbackComment` stay as-is (domain-neutral).
+- `frontend/src/components/feedback/adapters/useLeafletFeedbackAdapter.ts`, `useKbFeedbackAdapter.ts` and their tests.
+- `frontend/src/components/feedback/GenericFeedbackTable.tsx`, `GenericFeedbackDetailModal.tsx`, `GenericFeedbackFilters.tsx`.
+- `frontend/src/features/articles/ArticleFeedbackSection.tsx` — reads `article.feedbackComment` from `ArticleDetail` (the detail type, not the list summary); it stays.
+- `frontend/src/api/hooks/useArticles.ts` — `ArticleDetail.feedbackComment` and `useGetArticleQuery` mapping stay. Only `ArticleFeedbackSummary` and `useArticleFeedbackListQuery` change.
+- `frontend/src/api/generated/api-client.ts` — generated, not manually edited.
+- Any backend file.
+
+---
+
+## Task 1: Add hook-level mapping tests (RED)
+
+**Files:**
+- Create: `frontend/src/api/hooks/__tests__/useArticles.test.ts`
+
+The new tests will fail to compile (or fail at runtime) because today’s `ArticleFeedbackSummary` exposes `generatedAt`/`hasFeedback`/`feedbackComment`, not `createdAt`/`hasComment`. That’s the RED step we want before the rename in Task 2.
+
+- [ ] **Step 1: Create the new test file with three mapping tests**
+
+Create `frontend/src/api/hooks/__tests__/useArticles.test.ts`:
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useArticleFeedbackListQuery } from '../useArticles';
+import * as clientModule from '../../client';
+
+jest.mock('../../client', () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  QUERY_KEYS: {
+    articles: ['articles'],
+  },
+}));
+
+const mockGetAuthenticatedApiClient =
+  clientModule.getAuthenticatedApiClient as jest.MockedFunction<
+    typeof clientModule.getAuthenticatedApiClient
+  >;
+
+const createWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    children,
+  );
+};
+
+describe('useArticleFeedbackListQuery mapping', () => {
+  let mockArticlesFeedbackList: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockArticlesFeedbackList = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      articles_FeedbackList: mockArticlesFeedbackList,
+    } as any);
+  });
+
+  it('maps a populated DTO row to the renamed frontend shape (createdAt, hasComment, no feedbackComment)', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      items: [
+        {
+          id: 'art-1',
+          topic: 'Topic A',
+          title: 'Title A',
+          requestedBy: 'user@anela.cz',
+          createdAt: new Date('2026-01-15T10:30:00Z'),
+          precisionScore: 4,
+          styleScore: 5,
+          hasComment: true,
+        },
+      ],
+      totalCount: 1,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+      stats: {
+        totalArticles: 1,
+        totalWithFeedback: 1,
+        avgPrecisionScore: 4,
+        avgStyleScore: 5,
+      },
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.articles).toHaveLength(1);
+    expect(result.current.data!.articles[0]).toEqual({
+      id: 'art-1',
+      topic: 'Topic A',
+      title: 'Title A',
+      requestedBy: 'user@anela.cz',
+      createdAt: '2026-01-15T10:30:00.000Z',
+      precisionScore: 4,
+      styleScore: 5,
+      hasComment: true,
+    });
+    expect(result.current.data!.totalCount).toBe(1);
+    expect(result.current.data!.stats).toEqual({
+      totalArticles: 1,
+      totalWithFeedback: 1,
+      avgPrecisionScore: 4,
+      avgStyleScore: 5,
+    });
+  });
+
+  it('returns empty articles and default stats when items and stats are missing from the DTO', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      totalCount: 0,
+      page: 1,
+      pageSize: 20,
+      totalPages: 0,
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.articles).toEqual([]);
+    expect(result.current.data!.stats).toEqual({
+      totalArticles: 0,
+      totalWithFeedback: 0,
+      avgPrecisionScore: null,
+      avgStyleScore: null,
+    });
+  });
+
+  it('preserves hasComment per row (does not synthesize it from other fields) and maps null createdAt', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      items: [
+        {
+          id: 'art-with-comment',
+          topic: 'T',
+          title: null,
+          requestedBy: 'u',
+          createdAt: undefined,
+          precisionScore: null,
+          styleScore: null,
+          hasComment: true,
+        },
+        {
+          id: 'art-without-comment',
+          topic: 'T',
+          title: null,
+          requestedBy: 'u',
+          createdAt: undefined,
+          precisionScore: null,
+          styleScore: null,
+          hasComment: false,
+        },
+      ],
+      totalCount: 2,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [withComment, withoutComment] = result.current.data!.articles;
+    expect(withComment.hasComment).toBe(true);
+    expect(withComment.createdAt).toBeNull();
+    expect(withoutComment.hasComment).toBe(false);
+    expect(withoutComment.createdAt).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run from the `frontend/` directory:
+
+```bash
+cd frontend && CI=true npx react-scripts test src/api/hooks/__tests__/useArticles.test.ts --watchAll=false
+```
+
+Expected: tests FAIL. The current mapping emits `generatedAt`/`hasFeedback`/`feedbackComment`, so the `toEqual` in test 1 will not match and `hasComment`/`createdAt` accesses in tests 1 and 3 will read `undefined`. This is the RED step — we want failure here.
+
+- [ ] **Step 3: Do not commit yet**
+
+The plan commits once at the end (Task 6) after all related changes compile and pass together. Leave the new test file uncommitted for now.
+
+---
+
+## Task 2: Rename `ArticleFeedbackSummary` fields and update the hook mapping (GREEN for Task 1 tests, RED for adapter)
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useArticles.ts:78-88, 268-281`
+
+This step renames the public hook contract and updates the per-item mapping accordingly. The hook tests from Task 1 will pass after this step. The adapter file will now fail to compile because it reads `article.generatedAt`/`article.hasFeedback`/`article.feedbackComment`, which no longer exist — that breakage is intentional and is fixed in Task 3.
+
+- [ ] **Step 1: Update the `ArticleFeedbackSummary` interface**
+
+In `frontend/src/api/hooks/useArticles.ts`, replace the current interface (lines 78–88):
+
+```typescript
+export interface ArticleFeedbackSummary {
+  id: string;
+  topic: string;
+  title: string | null;
+  requestedBy: string;
+  generatedAt: string | null;
+  precisionScore: number | null;
+  styleScore: number | null;
+  feedbackComment: string | null;
+  hasFeedback: boolean;
+}
+```
+
+with:
+
+```typescript
+export interface ArticleFeedbackSummary {
+  id: string;
+  topic: string;
+  title: string | null;
+  requestedBy: string;
+  createdAt: string | null;
+  precisionScore: number | null;
+  styleScore: number | null;
+  hasComment: boolean;
+}
+```
+
+Rationale per spec FR-3: `generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment`. Keep `id: string` (not `string | undefined`); the existing `item.id ?? ''` default handles the NSwag `string | undefined`.
+
+- [ ] **Step 2: Update the per-item mapping inside `useArticleFeedbackListQuery`**
+
+In the same file, replace the mapping block in `useArticleFeedbackListQuery` (current lines 268–281):
+
+```typescript
+articles: (data.items ?? []).map((item) => ({
+  id: item.id ?? '',
+  topic: item.topic ?? '',
+  title: item.title ?? null,
+  requestedBy: item.requestedBy ?? '',
+  generatedAt: item.createdAt?.toISOString() ?? null,
+  precisionScore: item.precisionScore ?? null,
+  styleScore: item.styleScore ?? null,
+  // Backend list endpoint never emits a per-item feedback comment
+  // (only the boolean hasComment), so projecting null here is exact
+  // behavior preservation, not data loss.
+  feedbackComment: null,
+  hasFeedback: item.hasComment ?? false,
+})),
+```
+
+with:
+
+```typescript
+articles: (data.items ?? []).map((item) => ({
+  id: item.id ?? '',
+  topic: item.topic ?? '',
+  title: item.title ?? null,
+  requestedBy: item.requestedBy ?? '',
+  createdAt: item.createdAt?.toISOString() ?? null,
+  precisionScore: item.precisionScore ?? null,
+  styleScore: item.styleScore ?? null,
+  hasComment: item.hasComment ?? false,
+})),
+```
+
+Leave the surrounding `totalCount` / `page` / `pageSize` / `totalPages` / `stats` defaults exactly as they are (NFR-4 forbids adding helpers/abstractions just for this fix).
+
+- [ ] **Step 3: Run the hook tests and verify they now pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test src/api/hooks/__tests__/useArticles.test.ts --watchAll=false
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 4: Verify the adapter file is now broken (expected)**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep useArticleFeedbackAdapter
+```
+
+Expected: errors mentioning `Property 'generatedAt' does not exist`, `Property 'hasFeedback' does not exist`, `Property 'feedbackComment' does not exist` on the article row type. This confirms Task 3 is the next required step. Do not commit yet.
+
+---
+
+## Task 3: Update the article feedback adapter to read renamed fields
+
+**Files:**
+- Modify: `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts:15-25`
+
+The adapter is the only file outside `useArticles.ts` that reads from `ArticleFeedbackSummary`. Per arch-review Decision 1, do **not** rename `FeedbackRow.hasFeedback` (domain-neutral). Per Decision 2, explicitly pass `feedbackComment: null` (the list endpoint never carries it).
+
+- [ ] **Step 1: Update the row-projection block**
+
+In `frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts`, replace the current `rows` mapping (lines 15–25):
+
+```typescript
+const rows: FeedbackDetail[] = (query.data?.articles ?? []).map((article) => ({
+  id: article.id,
+  primaryText: article.title ?? article.topic,
+  secondaryText: article.topic,
+  createdAt: article.generatedAt ?? '',
+  userId: article.requestedBy,
+  precisionScore: article.precisionScore,
+  styleScore: article.styleScore,
+  hasFeedback: article.hasFeedback,
+  feedbackComment: article.feedbackComment,
+}));
+```
+
+with:
+
+```typescript
+const rows: FeedbackDetail[] = (query.data?.articles ?? []).map((article) => ({
+  id: article.id,
+  primaryText: article.title ?? article.topic,
+  secondaryText: article.topic,
+  createdAt: article.createdAt ?? '',
+  userId: article.requestedBy,
+  precisionScore: article.precisionScore,
+  styleScore: article.styleScore,
+  hasFeedback: article.hasComment,
+  feedbackComment: null,
+}));
+```
+
+Leave the `stats` block (lines 27–34) and the `return` block (36–44) unchanged.
+
+- [ ] **Step 2: Verify the adapter compiles**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep useArticleFeedbackAdapter
+```
+
+Expected: no output (no errors). If errors remain, fix them before continuing.
+
+- [ ] **Step 3: Confirm the adapter tests now fail at runtime**
+
+The adapter test fixtures still use the old field names, so its runtime assertions will break:
+
+```bash
+cd frontend && CI=true npx react-scripts test src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts --watchAll=false
+```
+
+Expected: failures in `maps generatedAt to createdAt` and `uses empty string for createdAt when generatedAt is null` (the mocks still have `generatedAt`, so `article.createdAt` reads as `undefined` and the projected `createdAt` becomes `''`). This confirms Task 4 is needed next.
+
+---
+
+## Task 4: Update adapter test fixtures and descriptions
+
+**Files:**
+- Modify: `frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts:9-31, 81-89`
+
+Mocks must match the new `ArticleFeedbackSummary` shape. Two test descriptions reference the old `generatedAt` field name and must be renamed too.
+
+- [ ] **Step 1: Update `mockArticle`**
+
+Replace the current `mockArticle` declaration (lines 9–19):
+
+```typescript
+const mockArticle = {
+  id: 'art-1',
+  topic: 'Péče o pleť v létě',
+  title: 'Jak pečovat o pleť v letních měsících',
+  requestedBy: 'user@anela.cz',
+  generatedAt: '2026-01-15T10:30:00Z',
+  precisionScore: 4,
+  styleScore: 5,
+  feedbackComment: 'Skvělý článek.',
+  hasFeedback: true,
+};
+```
+
+with:
+
+```typescript
+const mockArticle = {
+  id: 'art-1',
+  topic: 'Péče o pleť v létě',
+  title: 'Jak pečovat o pleť v letních měsících',
+  requestedBy: 'user@anela.cz',
+  createdAt: '2026-01-15T10:30:00Z',
+  precisionScore: 4,
+  styleScore: 5,
+  hasComment: true,
+};
+```
+
+- [ ] **Step 2: Update `mockArticleNoTitle`**
+
+Replace the current `mockArticleNoTitle` declaration (lines 21–31):
+
+```typescript
+const mockArticleNoTitle = {
+  id: 'art-2',
+  topic: 'Zimní vlasová péče',
+  title: null,
+  requestedBy: 'other@anela.cz',
+  generatedAt: null,
+  precisionScore: null,
+  styleScore: null,
+  feedbackComment: null,
+  hasFeedback: false,
+};
+```
+
+with:
+
+```typescript
+const mockArticleNoTitle = {
+  id: 'art-2',
+  topic: 'Zimní vlasová péče',
+  title: null,
+  requestedBy: 'other@anela.cz',
+  createdAt: null,
+  precisionScore: null,
+  styleScore: null,
+  hasComment: false,
+};
+```
+
+- [ ] **Step 3: Rename the two test descriptions that reference `generatedAt`**
+
+Replace:
+
+```typescript
+test('maps generatedAt to createdAt', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[0].createdAt).toBe('2026-01-15T10:30:00Z');
+});
+
+test('uses empty string for createdAt when generatedAt is null', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[1].createdAt).toBe('');
+});
+```
+
+with:
+
+```typescript
+test('maps article createdAt onto row createdAt', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[0].createdAt).toBe('2026-01-15T10:30:00Z');
+});
+
+test('uses empty string for row createdAt when article createdAt is null', () => {
+  const { result } = renderHook(() => useArticleFeedbackAdapter(params));
+  expect(result.current.rows[1].createdAt).toBe('');
+});
+```
+
+Leave all other tests in this file unchanged — the `primaryText`/`secondaryText`/`userId`/`stats`/`params translation`/`loading`/`error` tests do not depend on the renamed fields.
+
+- [ ] **Step 4: Run the adapter tests and verify they pass**
+
+```bash
+cd frontend && CI=true npx react-scripts test src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts --watchAll=false
+```
+
+Expected: all adapter tests PASS.
+
+---
+
+## Task 5: Verify no other consumers reference the old field names
+
+**Files:** No edits. This is a guard step to confirm the rename is complete in the article-feedback path and has not leaked into unrelated code.
+
+- [ ] **Step 1: Grep for stale references in feedback-list usage sites**
+
+```bash
+cd frontend && grep -rn 'generatedAt\|hasFeedback\|feedbackComment' src/components/feedback/adapters src/api/hooks/useArticles.ts src/api/hooks/__tests__/useArticles.test.ts src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts
+```
+
+Expected matches (allowed — domain-neutral or unrelated to the article list summary):
+
+- `src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — `hasFeedback: article.hasComment,` (mapping onto the generic row contract; Decision 1).
+- `src/components/feedback/adapters/useArticleFeedbackAdapter.ts` — `feedbackComment: null,` (explicit projection onto `FeedbackDetail`; Decision 2).
+- `src/components/feedback/adapters/useLeafletFeedbackAdapter.ts` and `useKbFeedbackAdapter.ts` — out of scope; their own `hasFeedback`/`feedbackComment` fields are sourced from different backends and stay.
+
+Expected to NOT match (must be gone):
+
+- Any `generatedAt` in `useArticleFeedbackAdapter.*` or in the article feedback list mapping.
+- Any `feedbackComment:` reference inside `useArticles.ts` that targets `ArticleFeedbackSummary` (the `useGetArticleQuery` mapping for `ArticleDetail.feedbackComment` is allowed — that’s the detail endpoint, not the list).
+- Any `hasFeedback` on a row read from `useArticleFeedbackListQuery` (the adapter writes `hasFeedback` onto the generic row; that’s allowed).
+
+If any disallowed match is found, fix it before continuing.
+
+- [ ] **Step 2: Grep the wider tree for stale references to the renamed `ArticleFeedbackSummary` fields**
+
+```bash
+cd frontend && grep -rn 'useArticleFeedbackListQuery' src
+```
+
+Expected: only `useArticleFeedbackAdapter.ts` and `__tests__/useArticles.test.ts` consume the hook. If any other consumer appears, update it to read `createdAt`/`hasComment` (no `feedbackComment`).
+
+---
+
+## Task 6: Run full validation, then commit
+
+**Files:** No edits. This is the standard-validation + single-commit step.
+
+- [ ] **Step 1: Type-check the frontend**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. If the compiler complains about `ArticleFeedbackSummary`, `useArticleFeedbackListQuery`, or `useArticleFeedbackAdapter`, fix before continuing.
+
+- [ ] **Step 2: Run all touched test files together**
+
+```bash
+cd frontend && CI=true npx react-scripts test src/api/hooks/__tests__/useArticles.test.ts src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts --watchAll=false
+```
+
+Expected: every test PASS. No `console.error` about act warnings or missing query data.
+
+- [ ] **Step 3: Build the frontend**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds. CRA may emit lint warnings — they should not include any unused-variable or type errors introduced by this change.
+
+- [ ] **Step 4: Lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: no new errors. Pre-existing warnings unrelated to the changed files are acceptable.
+
+- [ ] **Step 5: Stage only the files this plan changes**
+
+```bash
+git add frontend/src/api/hooks/useArticles.ts \
+        frontend/src/api/hooks/__tests__/useArticles.test.ts \
+        frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts \
+        frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts
+```
+
+Expected: `git status` shows exactly four files staged (one new, three modified). If any other file appears modified, investigate before committing — the plan is meant to be a single-commit, surgical change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix: align ArticleFeedbackSummary with backend (createdAt, hasComment)
+
+Renames the hand-written ArticleFeedbackSummary fields to match the
+backend payload returned by GetArticleFeedbackListHandler / NSwag DTO:
+generatedAt -> createdAt, hasFeedback -> hasComment. Removes the phantom
+feedbackComment field (the list endpoint never emits it; only the
+boolean hasComment).
+
+The single consumer useArticleFeedbackAdapter is updated to read the
+renamed fields and to pass feedbackComment: null explicitly into the
+generic FeedbackDetail (Decision 2 in the architecture review). The
+domain-neutral FeedbackRow.hasFeedback contract is intentionally left
+in place (Decision 1) so leaflet and KB adapters remain untouched.
+
+Adds hook-level mapping tests for useArticleFeedbackListQuery covering
+populated rows, missing items, and hasComment preservation.
+EOF
+)"
+```
+
+Expected: commit succeeds. `git log -1 --stat` should list exactly the four files above.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- FR-1 (explicit field-by-field mapping, no untyped passthrough) — Task 2 step 2 keeps the existing explicit mapping; no `as any` cast of the DTO is introduced. Per arch-review amendment 1, FR-1 is satisfied by mapping from the typed NSwag DTO rather than from `response.json()`.
+- FR-2 (frontend exposes `articles`, hook reads `raw.items`) — Task 2 step 2 retains `articles: (data.items ?? []).map(...)`. No consumer reads `items` directly (verified in Task 5 step 2).
+- FR-3 (rename `generatedAt` → `createdAt`, `hasFeedback` → `hasComment`, drop `feedbackComment` on `ArticleFeedbackSummary`) — Task 2 step 1. `id: string` is kept (arch-review amendment 2).
+- FR-4 (consuming components updated; behavior preserved) — Task 3 (adapter rename) + Task 4 (test mocks rename). Per arch-review amendment 3, `FeedbackRow`/`FeedbackDetail` are not renamed; the adapter projects between them.
+- FR-5 (unit tests for mapping: populated row, all-nullable row, empty `items`; `hasComment` preserved) — Task 1 covers all three cases plus the `hasComment` preservation assertion. Per arch-review amendment 4, the new tests live in `frontend/src/api/hooks/__tests__/useArticles.test.ts` and the adapter tests are updated separately.
+- NFR-1/2/3/4 — Performance (no change), security (no change), backwards-compat (TypeScript-only rename), code consistency (no new abstraction introduced; mapping mirrors `useGetArticleQuery` style).
+- Out-of-scope items (NSwag migration of the hook, exposing `feedbackComment` on list, refactoring sibling hooks, backend changes, E2E additions) are not touched by any task.
+
+**Placeholder scan:** No `TBD`/`TODO`/`implement later`/`add appropriate X`/`similar to Task N` strings anywhere in the plan. Every code step contains the full replacement code; every command step contains the exact command and expected outcome.
+
+**Type consistency:** Across tasks, the interface field names (`createdAt`, `hasComment`), the adapter projection (`article.createdAt`, `article.hasComment`, `hasFeedback: article.hasComment`, `feedbackComment: null`), and the test mock keys (`createdAt`, `hasComment`) all match. The hook test uses `result.current.data!.articles[0]` and asserts the same renamed keys. No drift between tasks.

--- a/frontend/src/api/hooks/__tests__/useArticles.test.ts
+++ b/frontend/src/api/hooks/__tests__/useArticles.test.ts
@@ -1,0 +1,161 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useArticleFeedbackListQuery } from '../useArticles';
+import * as clientModule from '../../client';
+
+jest.mock('../../client', () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  QUERY_KEYS: {
+    articles: ['articles'],
+  },
+}));
+
+const mockGetAuthenticatedApiClient =
+  clientModule.getAuthenticatedApiClient as jest.MockedFunction<
+    typeof clientModule.getAuthenticatedApiClient
+  >;
+
+const createWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    children,
+  );
+};
+
+describe('useArticleFeedbackListQuery mapping', () => {
+  let mockArticlesFeedbackList: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockArticlesFeedbackList = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      articles_FeedbackList: mockArticlesFeedbackList,
+    } as any);
+  });
+
+  it('maps a populated DTO row to the renamed frontend shape (createdAt, hasComment, no feedbackComment)', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      items: [
+        {
+          id: 'art-1',
+          topic: 'Topic A',
+          title: 'Title A',
+          requestedBy: 'user@anela.cz',
+          createdAt: new Date('2026-01-15T10:30:00Z'),
+          precisionScore: 4,
+          styleScore: 5,
+          hasComment: true,
+        },
+      ],
+      totalCount: 1,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+      stats: {
+        totalArticles: 1,
+        totalWithFeedback: 1,
+        avgPrecisionScore: 4,
+        avgStyleScore: 5,
+      },
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.articles).toHaveLength(1);
+    expect(result.current.data!.articles[0]).toEqual({
+      id: 'art-1',
+      topic: 'Topic A',
+      title: 'Title A',
+      requestedBy: 'user@anela.cz',
+      createdAt: '2026-01-15T10:30:00.000Z',
+      precisionScore: 4,
+      styleScore: 5,
+      hasComment: true,
+    });
+    expect(result.current.data!.totalCount).toBe(1);
+    expect(result.current.data!.stats).toEqual({
+      totalArticles: 1,
+      totalWithFeedback: 1,
+      avgPrecisionScore: 4,
+      avgStyleScore: 5,
+    });
+  });
+
+  it('returns empty articles and default stats when items and stats are missing from the DTO', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      totalCount: 0,
+      page: 1,
+      pageSize: 20,
+      totalPages: 0,
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data!.articles).toEqual([]);
+    expect(result.current.data!.stats).toEqual({
+      totalArticles: 0,
+      totalWithFeedback: 0,
+      avgPrecisionScore: null,
+      avgStyleScore: null,
+    });
+  });
+
+  it('preserves hasComment per row (does not synthesize it from other fields) and maps null createdAt', async () => {
+    mockArticlesFeedbackList.mockResolvedValue({
+      items: [
+        {
+          id: 'art-with-comment',
+          topic: 'T',
+          title: null,
+          requestedBy: 'u',
+          createdAt: undefined,
+          precisionScore: null,
+          styleScore: null,
+          hasComment: true,
+        },
+        {
+          id: 'art-without-comment',
+          topic: 'T',
+          title: null,
+          requestedBy: 'u',
+          createdAt: undefined,
+          precisionScore: null,
+          styleScore: null,
+          hasComment: false,
+        },
+      ],
+      totalCount: 2,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    });
+
+    const { result } = renderHook(() => useArticleFeedbackListQuery({}), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [withComment, withoutComment] = result.current.data!.articles;
+    expect(withComment.hasComment).toBe(true);
+    expect(withComment.createdAt).toBeNull();
+    expect(withoutComment.hasComment).toBe(false);
+    expect(withoutComment.createdAt).toBeNull();
+  });
+});

--- a/frontend/src/api/hooks/useArticles.ts
+++ b/frontend/src/api/hooks/useArticles.ts
@@ -80,11 +80,10 @@ export interface ArticleFeedbackSummary {
   topic: string;
   title: string | null;
   requestedBy: string;
-  generatedAt: string | null;
+  createdAt: string | null;
   precisionScore: number | null;
   styleScore: number | null;
-  feedbackComment: string | null;
-  hasFeedback: boolean;
+  hasComment: boolean;
 }
 
 export interface ArticleFeedbackStats {
@@ -270,14 +269,10 @@ export const useArticleFeedbackListQuery = (params: ArticleFeedbackListParams = 
           topic: item.topic ?? '',
           title: item.title ?? null,
           requestedBy: item.requestedBy ?? '',
-          generatedAt: item.createdAt?.toISOString() ?? null,
+          createdAt: item.createdAt?.toISOString() ?? null,
           precisionScore: item.precisionScore ?? null,
           styleScore: item.styleScore ?? null,
-          // Backend list endpoint never emits a per-item feedback comment
-          // (only the boolean hasComment), so projecting null here is exact
-          // behavior preservation, not data loss.
-          feedbackComment: null,
-          hasFeedback: item.hasComment ?? false,
+          hasComment: item.hasComment ?? false,
         })),
         totalCount: data.totalCount ?? 0,
         page: data.page ?? params.page ?? 1,

--- a/frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts
+++ b/frontend/src/components/feedback/adapters/__tests__/useArticleFeedbackAdapter.test.ts
@@ -11,11 +11,10 @@ const mockArticle = {
   topic: 'Péče o pleť v létě',
   title: 'Jak pečovat o pleť v letních měsících',
   requestedBy: 'user@anela.cz',
-  generatedAt: '2026-01-15T10:30:00Z',
+  createdAt: '2026-01-15T10:30:00Z',
   precisionScore: 4,
   styleScore: 5,
-  feedbackComment: 'Skvělý článek.',
-  hasFeedback: true,
+  hasComment: true,
 };
 
 const mockArticleNoTitle = {
@@ -23,11 +22,10 @@ const mockArticleNoTitle = {
   topic: 'Zimní vlasová péče',
   title: null,
   requestedBy: 'other@anela.cz',
-  generatedAt: null,
+  createdAt: null,
   precisionScore: null,
   styleScore: null,
-  feedbackComment: null,
-  hasFeedback: false,
+  hasComment: false,
 };
 
 const mockStats = {
@@ -78,12 +76,12 @@ test('maps requestedBy to userId', () => {
   expect(result.current.rows[0].userId).toBe('user@anela.cz');
 });
 
-test('maps generatedAt to createdAt', () => {
+test('maps article createdAt onto row createdAt', () => {
   const { result } = renderHook(() => useArticleFeedbackAdapter(params));
   expect(result.current.rows[0].createdAt).toBe('2026-01-15T10:30:00Z');
 });
 
-test('uses empty string for createdAt when generatedAt is null', () => {
+test('uses empty string for row createdAt when article createdAt is null', () => {
   const { result } = renderHook(() => useArticleFeedbackAdapter(params));
   expect(result.current.rows[1].createdAt).toBe('');
 });

--- a/frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts
+++ b/frontend/src/components/feedback/adapters/useArticleFeedbackAdapter.ts
@@ -16,12 +16,12 @@ export function useArticleFeedbackAdapter(params: GenericFeedbackParams) {
     id: article.id,
     primaryText: article.title ?? article.topic,
     secondaryText: article.topic,
-    createdAt: article.generatedAt ?? '',
+    createdAt: article.createdAt ?? '',
     userId: article.requestedBy,
     precisionScore: article.precisionScore,
     styleScore: article.styleScore,
-    hasFeedback: article.hasFeedback,
-    feedbackComment: article.feedbackComment,
+    hasFeedback: article.hasComment,
+    feedbackComment: null,
   }));
 
   const stats: GenericFeedbackStats | undefined = query.data?.stats


### PR DESCRIPTION
Article

## Finding
`useArticleFeedbackListQuery` in `useArticles.ts` uses raw `fetch` (bypassing the NSwag-generated client) and does `return response.json()` directly, casting the result to `ArticleFeedbackListResponse`. The TypeScript type and the actual JSON shape do not match on multiple fields:

### Top-level collection key mismatch

| Backend (`GetArticleFeedbackListResponse`) | Frontend TypeScript `ArticleFeedbackListResponse` |
|---|---|
| `items: ArticleFeedbackSummary[]` | `articles: ArticleFeedbackSummary[]` |

`useArticles.ts:98` declares `articles: ArticleFeedbackSummary[]`, but the serialised JSON from `GetArticleFeedbackListHandler` has the key `items`. Any component that accesses `.articles` gets `undefined` at runtime.

### Per-item field mismatches

| Backend `ArticleFeedbackSummary` (`GetArticleFeedbackListRequest.cs:33`) | Frontend `ArticleFeedbackSummary` (`useArticles.ts:78`) |
|---|---|
| `CreatedAt: DateTimeOffset` | `generatedAt: string \| null` (key mismatch) |
| `HasComment: bool` | `hasFeedback: boolean` (key mismatch — semantically different too) |
| *(not present)* | `feedbackComment: string \| null` (extra field that will always be `undefined`) |

The handler maps `HasComment = !string.IsNullOrWhiteSpace(a.FeedbackComment)` (`GetArticleFeedbackListHandler.cs:54`), so the backend sends `hasComment` (a boolean indicating comment presence), not `feedbackComment` (the actual text). The frontend TypeScript type expects `feedbackComment` (the text) and will never receive it from this endpoint.

All mismatches are invisible at compile time because the query function casts directly without any field-level mapping (`return response.json()`).

## Why it matters
- At runtime, any component consuming the feedback list will see `undefined` for `articles`, `generatedAt`, `feedbackComment`, and `hasFeedback`.
- TypeScript provides no protection because the cast bypasses the type system.
- Contrast with `useGetArticleQuery` which does an explicit field-by-field mapping (lines 155-188 in `useArticles.ts`), making the intent of that query clear. The feedback list query does the opposite, making it appear safe while hiding the divergence.

## Suggested fix
Add an explicit mapping in `useArticleFeedbackListQuery` that mirrors the pattern used in `useGetArticleQuery`:

```typescript
const raw = await response.json();
return {
  articles: (raw.items ?? []).map((a: any) => ({
    id: a.id,
    topic: a.topic ?? '',
    title: a.title ?? null,
    requestedBy: a.requestedBy ?? '',
    createdAt: a.createdAt ?? null,          // align TS field name with backend
    precisionScore: a.precisionScore ?? null,
    styleScore: a.styleScore ?? null,
    hasComment: a.hasComment ?? false,       // rename to match backend
  })),
  totalCount: raw.totalCount ?? 0,
  page: raw.page ?? 1,
  pageSize: raw.pageSize ?? 20,
  totalPages: raw.totalPages ?? 0,
  stats: raw.stats ?? { totalArticles: 0, totalWithFeedback: 0, avgPrecisionScore: null, avgStyleScore: null },
};
```

Also update the `ArticleFeedbackSummary` TypeScript interface and any consuming components to use `articles`, `createdAt`, and `hasComment`.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1691

### Tokens used
14804010
