### PR TITLE
feat: Refactor UpdateManufactureOrderStatusHandler to use ICurrentUserService

### DIFF
--- a/artifacts/feat-arch-review-users-updatemanufactureorder/arch-review.r1.md
+++ b/artifacts/feat-arch-review-users-updatemanufactureorder/arch-review.r1.md
@@ -1,0 +1,207 @@
+# Architecture Review: Refactor UpdateManufactureOrderStatusHandler to use ICurrentUserService
+
+## Skip Design: true
+
+Backend-only refactor of an Application-layer handler. No UI components, screens, layouts, HTTP contracts, or visible behavior changes. No design work required.
+
+## Architectural Fit Assessment
+
+The refactor aligns with an **established, dominant pattern** in the Application layer: ~50 handlers and services across the codebase already depend on `ICurrentUserService` (e.g. `UpdatePurchaseOrderStatusHandler`, `CreateManufactureOrderHandler`, `UpdateManufactureOrderHandler` — the latter two living in the *same* `Manufacture/UseCases` folder). `UpdateManufactureOrderStatusHandler` is currently the outlier; the proposed change removes that outlier rather than introducing anything novel.
+
+Key integration points:
+- **`ICurrentUserService`** (`backend/src/Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs`) — the abstraction the handler will depend on.
+- **`CurrentUserService`** (`backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs`) — concrete impl, registered as **Singleton** in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130` (works because `HttpContext` is resolved through the singleton `IHttpContextAccessor` per-request).
+- **`CurrentUserExtensions.GetDisplayName()`** (`backend/src/Anela.Heblo.Domain/Features/Users/CurrentUserExtensions.cs`) — the spec-mandated display-name helper. Returns `"System"` when unauthenticated, `user.Name ?? "Unknown User"` otherwise.
+- **Two call-sites** inside the handler: `Handle()` line 64 (`order.StateChangedByUser = GetCurrentUserName()`) and `WriteDownInventoryAsync()` line 177 (`var user = GetCurrentUserName()`). The `request.Note` block on line 122 also derives from `order.StateChangedByUser` transitively, so it inherits the correction without code change.
+
+There is one notable inconsistency in the codebase that this review surfaces (see Specification Amendments): the closest sibling, `UpdatePurchaseOrderStatusHandler`, uses `currentUser.Name ?? "System"` rather than `GetDisplayName()`. The spec correctly prescribes the extension method, which is the more abstraction-aware path.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ API Layer (controller, auth pipeline)                          │
+│  └─ Populates ClaimsPrincipal on HttpContext                   │
+└────────────────────────────────────────────────────────────────┘
+                          │ MediatR dispatch
+                          ▼
+┌────────────────────────────────────────────────────────────────┐
+│ Application Layer                                              │
+│                                                                │
+│  UpdateManufactureOrderStatusHandler                           │
+│   ├─ IManufactureOrderRepository       (existing)              │
+│   ├─ IManufacturedProductInventoryRepository (existing)        │
+│   ├─ TimeProvider                       (existing)             │
+│   ├─ ILogger<...>                       (existing)             │
+│   ├─ IConditionsReadingProvider         (existing)             │
+│   └─ ICurrentUserService  ◄── REPLACES IHttpContextAccessor    │
+│           │                                                    │
+│           ▼                                                    │
+│       CurrentUserService (Singleton)                           │
+│           └─ IHttpContextAccessor (Singleton)                  │
+└────────────────────────────────────────────────────────────────┘
+                          │ writes
+                          ▼
+┌────────────────────────────────────────────────────────────────┐
+│ Domain: ManufactureOrder.StateChangedByUser, Notes[].CreatedBy │
+│ Domain: ManufacturedProductInventoryItem.CreatedBy             │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Use `CurrentUserExtensions.GetDisplayName()` rather than ad-hoc `currentUser.Name ?? "System"`
+
+**Options considered:**
+1. Call `_currentUserService.GetCurrentUser().GetDisplayName()` (spec-mandated).
+2. Inline `currentUser.Name ?? "System"` like `UpdatePurchaseOrderStatusHandler` does.
+
+**Chosen approach:** Option 1 — the extension method.
+
+**Rationale:** The extension exists specifically to centralise the "System for anonymous, name for authenticated" rule. Inlining the coalesce duplicates that rule and silently diverges if `GetDisplayName()` ever evolves (e.g. to prefer email when name is missing). The handler should consume the abstraction's full intent, not just its data record. This also nudges the codebase toward a single convention; the inline pattern in `UpdatePurchaseOrderStatusHandler` is a smell that should be cleaned up separately, not propagated.
+
+#### Decision 2: Resolve the display name **once** per `Handle` invocation
+
+**Options considered:**
+1. Call `_currentUserService.GetCurrentUser().GetDisplayName()` at each call-site (2 sites: `Handle` line 64, `WriteDownInventoryAsync` line 177).
+2. Resolve once at the top of `Handle`, store in a local `currentUserName`, pass into `WriteDownInventoryAsync` as a parameter.
+
+**Chosen approach:** Option 2.
+
+**Rationale:** The current code already exhibits this pattern — `WriteDownInventoryAsync` calls `GetCurrentUserName()` again, which re-walks the claims. Resolving once tightens consistency (the inventory `CreatedBy` is guaranteed to match `StateChangedByUser` for the same transition), simplifies testing (one mock setup), and matches the intent of "stamp this transition by this user." The cost is a single method parameter on a private helper.
+
+#### Decision 3: Keep constructor parameter order stable except for the swap
+
+**Options considered:**
+1. Drop `IHttpContextAccessor`, insert `ICurrentUserService` in the same positional slot.
+2. Move dependencies around to match some preferred ordering convention.
+
+**Chosen approach:** Option 1.
+
+**Rationale:** This is a surgical refactor (per CLAUDE.md "Surgical changes"). Re-ordering forces both test files to re-author all six positional arguments and creates noise in the diff. Slot-replacement keeps the change minimal.
+
+#### Decision 4: Do not extend `CurrentUserService.GetCurrentUser()` Name-claim fallbacks
+
+**Options considered:**
+1. Adopt the spec as-written (use existing chain).
+2. Extend the Name fallback in `CurrentUserService` to include `preferred_username` / `upn` so authenticated Entra ID users without a `name` claim land on their UPN instead of `"Unknown User"`.
+
+**Chosen approach:** Option 1, but **flag a spec gap** (see Specification Amendments).
+
+**Rationale:** The spec explicitly puts redefining `CurrentUserService` fallbacks Out of Scope. Honour that boundary. However, the spec's FR-4 acceptance criterion implicitly assumes a fallback that does not exist today — that gap belongs in the spec, not in this handler's refactor.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Touched files:
+
+```
+backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/
+  └── UpdateManufactureOrderStatusHandler.cs      (edit)
+
+backend/test/Anela.Heblo.Tests/Features/Manufacture/
+  ├── UpdateManufactureOrderStatusHandlerTests.cs            (edit — mock swap + add fallback test)
+  └── UpdateManufactureOrderStatusHandlerConditionsTests.cs  (edit — mock swap)
+```
+
+No DI registration changes required. `ICurrentUserService` is already registered (`ServiceCollectionExtensions.cs:130`) and `IHttpContextAccessor` registration must remain — other consumers still depend on it.
+
+### Interfaces and Contracts
+
+**Constructor (new signature):**
+```csharp
+public UpdateManufactureOrderStatusHandler(
+    IManufactureOrderRepository repository,
+    TimeProvider timeProvider,
+    ILogger<UpdateManufactureOrderStatusHandler> logger,
+    ICurrentUserService currentUserService,        // ← swapped in
+    IConditionsReadingProvider conditionsProvider,
+    IManufacturedProductInventoryRepository inventoryRepository)
+```
+
+**Field:**
+```csharp
+private readonly ICurrentUserService _currentUserService;
+```
+
+**Resolution call (replaces `GetCurrentUserName()`):**
+```csharp
+var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
+```
+
+**`using` directives:**
+- Remove: `using Microsoft.AspNetCore.Http;`
+- Add: `using Anela.Heblo.Domain.Features.Users;`
+
+**Private method `GetCurrentUserName()`:** deleted.
+
+**Private method `WriteDownInventoryAsync` signature:** add a `string changedByUser` parameter; remove its internal `var user = GetCurrentUserName();`.
+
+### Data Flow
+
+For a `Handle(UpdateManufactureOrderStatusRequest)` invocation:
+
+1. Controller validates auth, MediatR routes the request.
+2. Handler resolves `currentUserName = _currentUserService.GetCurrentUser().GetDisplayName()` **once**.
+3. Handler reads the order; validates the state transition.
+4. Handler mutates the order, stamping `order.StateChangedByUser = currentUserName`.
+5. If a note is supplied, `Note.CreatedByUser` inherits `order.StateChangedByUser` (unchanged).
+6. If transitioning to `Completed`, `WriteDownInventoryAsync(order, currentUserName, ct)` projects products into `ManufacturedProductInventoryItem(createdBy: currentUserName, …)`.
+7. Repository persists the order; response carries `StateChangedByUser`.
+
+Resolution path inside `CurrentUserService.GetCurrentUser()` (unchanged by this refactor):
+- `Name`: `Identity.Name` → `ClaimTypes.Name` → `"name"` → `"Unknown User"` (authenticated) / `"Anonymous"` (anonymous).
+- `IsAuthenticated`: drives `GetDisplayName()` to short-circuit to `"System"` when false.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **Spec FR-4 acceptance criterion is unachievable as written.** `CurrentUserService.GetCurrentUser()` Name fallbacks are `Identity.Name → ClaimTypes.Name → "name"`. The `preferred_username` / `upn` / `oid` / `sub` claims feed Id/Email **only**, not Name. An authenticated request with only `preferred_username` will record `"Unknown User"`, not the UPN. | **HIGH** | Amend FR-4 (see below). Either (a) revise the test to assert `"Unknown User"` and reframe the bug fix as "stops recording `System` for authenticated users; records `Unknown User` when no Name claim is provided," or (b) file a follow-up to extend `CurrentUserService` Name fallbacks (out of scope per the spec; would require its own ADR). Without amendment, FR-4 will be written, then fail, then either get loosened in review or the implementer will silently broaden the `CurrentUserService` chain — both bad outcomes. |
+| Singleton `ICurrentUserService` capturing per-request state could leak across requests. | LOW | Already mitigated — `CurrentUserService` itself stores no per-request state; it dereferences `IHttpContextAccessor.HttpContext` on every call. Existing 50+ consumers prove the pattern is safe. No change required. |
+| Tests using positional constructor args break compilation if the slot order is wrong. | LOW | Replace `_httpContextAccessorMock.Object` with a `Mock<ICurrentUserService>` in the same positional slot in both test files. Both test files use named or positional args clearly — straightforward swap. |
+| Existing test `Handle_WithoutHttpContext_ShouldUseSystemAsUser` (line 195) relies on `HttpContext == null` to produce `"System"`. | LOW | After refactor: mock `ICurrentUserService.GetCurrentUser()` to return `new CurrentUser(null, null, null, IsAuthenticated: false)`. `GetDisplayName()` will return `"System"`. Same assertion holds. |
+| Inventory `CreatedBy` (`WriteDownInventoryAsync`) may diverge from `StateChangedByUser` if resolved twice and claims change mid-call. | LOW (theoretical) | Decision 2 above: resolve once, pass in. Eliminates the divergence vector. |
+| Other code paths still depend on `IHttpContextAccessor` in the Application layer. | INFO | Spec Out of Scope. Issue #1716 tracks the broader effort; this refactor moves the needle from N to N-1. |
+
+## Specification Amendments
+
+### Amendment 1 — FR-4 acceptance criterion is unachievable as written (REQUIRED)
+
+The spec states:
+
+> A unit/integration test exercising a state change with a `ClaimsPrincipal` that has `preferred_username` but no `Identity.Name` records the `preferred_username` value (or the first matching fallback claim) in `StateChangedByUser`, not `"System"`.
+
+This contradicts the actual implementation of `CurrentUserService.GetCurrentUser()`, which constructs `Name` only from `Identity.Name → ClaimTypes.Name → "name"`. The `preferred_username` claim is never inspected for the display name; it only contributes to `Email`.
+
+**Required change:** Pick one of:
+
+- **Amendment 1a (Recommended — keeps scope tight).** Rewrite the FR-4 acceptance criterion to: "A test exercising a state change with a `ClaimsPrincipal` whose `Identity.Name` is null but with `IsAuthenticated == true` records `"Unknown User"` (not `"System"`) in `StateChangedByUser`." This honours the existing fallback chain, still proves the bug is fixed (authenticated users no longer collapse to `"System"`), and changes nothing about `CurrentUserService`.
+- **Amendment 1b.** Re-scope to include extending `CurrentUserService` Name fallbacks to `preferred_username` / `upn`. This is a separate architectural decision touching every consumer of `GetCurrentUser().Name` and should not piggyback on this refactor.
+
+The brief itself (filed by the daily arch-review routine) is also slightly misleading on this point — it asserts that `CurrentUserService` applies a `preferred_username` / `upn` / `oid` / `sub` fallback chain, which is true for `Id` and `Email`, not for `Name`. The amendment should clarify this.
+
+### Amendment 2 — Pass resolved user into `WriteDownInventoryAsync` (REQUIRED)
+
+The spec describes the call-site replacement at FR-2 but does not specify whether the two call-sites independently call `_currentUserService.GetCurrentUser().GetDisplayName()` or share a single resolution. Per Decision 2, resolve once in `Handle`, pass to `WriteDownInventoryAsync` as a parameter. Add this as an implementation note to FR-2:
+
+> The user name MUST be resolved at most once per `Handle` invocation and reused across all audit fields written for that transition.
+
+### Amendment 3 — Note clarifying that audit "user" precision is improved but not perfected (INFO)
+
+After this refactor, authenticated users whose token lacks a `name` / `Identity.Name` claim will be stamped as `"Unknown User"` rather than the bug's `"System"`. This is an improvement (`"Unknown User"` is at least distinguishable from background-job traffic in audit queries), but it is not the user's real identity. A follow-up may be warranted to broaden the Name fallback chain — that is a separate spec.
+
+## Prerequisites
+
+None. All required infrastructure already exists:
+
+- `ICurrentUserService` interface defined (`backend/src/Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs`).
+- `CurrentUserService` registered as Singleton (`backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130`).
+- `CurrentUserExtensions.GetDisplayName()` defined (`backend/src/Anela.Heblo.Domain/Features/Users/CurrentUserExtensions.cs`).
+- `IHttpContextAccessor` registration remains in place for other consumers — do not remove it.
+- No database migration, no config change, no feature flag.
+
+Validation before completion: `dotnet build`, `dotnet format`, both affected test classes (`UpdateManufactureOrderStatusHandlerTests`, `UpdateManufactureOrderStatusHandlerConditionsTests`) green.

--- a/artifacts/feat-arch-review-users-updatemanufactureorder/brief.md
+++ b/artifacts/feat-arch-review-users-updatemanufactureorder/brief.md
@@ -1,0 +1,44 @@
+## Module
+Users (violation in Manufacture module)
+
+## Finding
+`UpdateManufactureOrderStatusHandler` injects `IHttpContextAccessor` directly and resolves the current user itself, duplicating and diverging from the existing `ICurrentUserService` abstraction.
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs, lines 17–24, 169–173
+private readonly IHttpContextAccessor _httpContextAccessor;
+
+public UpdateManufactureOrderStatusHandler(
+    ...
+    IHttpContextAccessor httpContextAccessor,
+    ...)
+
+private string GetCurrentUserName()
+{
+    var user = _httpContextAccessor.HttpContext?.User;
+    return user?.Identity?.Name ?? "System";
+}
+```
+
+`ICurrentUserService.GetCurrentUser()` (in `CurrentUserService.cs`) applies a chain of Entra ID claim fallbacks (`preferred_username`, `upn`, `oid`, `sub`, …). This handler reads only `Identity.Name` with no fallbacks, so in Entra ID access-token flows where `Name` is absent the stored `StateChangedByUser` will be `"System"` even for authenticated users.
+
+## Why it matters
+- Bypasses the `ICurrentUserService` abstraction that was introduced specifically to centralise Entra ID claim resolution, producing inconsistent audit trail entries.
+- Adds a second direct `IHttpContextAccessor` consumer in the Application layer, worsening the coupling identified in #1716.
+- The handler has an additional responsibility (HTTP identity extraction) that violates Single Responsibility.
+
+## Suggested fix
+Replace the `IHttpContextAccessor` dependency with `ICurrentUserService`:
+
+```csharp
+// Remove: private readonly IHttpContextAccessor _httpContextAccessor;
+private readonly ICurrentUserService _currentUserService;
+
+// In constructor: replace httpContextAccessor parameter with ICurrentUserService currentUserService
+// Remove GetCurrentUserName() and replace its two call-sites with:
+_currentUserService.GetCurrentUser().GetDisplayName()
+// (using the existing CurrentUserExtensions.GetDisplayName())
+```
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-users-updatemanufactureorder/impl/main.r1.md
+++ b/artifacts/feat-arch-review-users-updatemanufactureorder/impl/main.r1.md
@@ -1,0 +1,14 @@
+`GIT_DIR == GIT_COMMON` — this is a standalone repo clone (not a git worktree), just placed under `.worktrees/`. Standard 4-option menu applies, no worktree cleanup needed.
+
+Tests: 28/28 pass. Branch: `feat-arch-review-users-updatemanufactureorder`. Base: `main`.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-users-updatemanufactureorder/spec.r1.md
+++ b/artifacts/feat-arch-review-users-updatemanufactureorder/spec.r1.md
@@ -1,0 +1,133 @@
+# Specification: Refactor UpdateManufactureOrderStatusHandler to use ICurrentUserService
+
+## Summary
+Replace the direct `IHttpContextAccessor` dependency in `UpdateManufactureOrderStatusHandler` with the existing `ICurrentUserService` abstraction so that the handler resolves the current user through the same Entra ID claim fallback chain used elsewhere in the application. This eliminates a duplicate, divergent user-resolution path that currently causes audit trail entries to be stamped as `"System"` for authenticated users when the `Identity.Name` claim is absent.
+
+## Background
+The Application layer introduced `ICurrentUserService` as the single point of truth for resolving the current user from an Entra ID access token. Its implementation (`CurrentUserService.GetCurrentUser()`) walks an ordered chain of claims (`preferred_username`, `upn`, `oid`, `sub`, …) plus `Identity.Name` to robustly identify the caller, and exposes the display value via `CurrentUserExtensions.GetDisplayName()`.
+
+`UpdateManufactureOrderStatusHandler` (in `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`) was implemented before — or in parallel with — that abstraction and bypasses it. It injects `IHttpContextAccessor` directly, exposes a private `GetCurrentUserName()` that returns `HttpContext.User.Identity.Name ?? "System"`, and writes that value to the manufacture-order audit fields (`StateChangedByUser` and any other call sites).
+
+Concrete consequences observed today:
+- Entra ID access-token flows frequently omit the `Name` identity claim. In those flows the handler stamps `"System"` on state-change records even though the request is fully authenticated, polluting the audit trail.
+- The handler is the second direct consumer of `IHttpContextAccessor` in the Application layer (the first is tracked under issue #1716), reinforcing a coupling the architecture explicitly wants to remove.
+- The handler picks up an unrelated responsibility (HTTP identity extraction) on top of its core orchestration of manufacture-order state transitions, violating SRP.
+
+This refactor aligns the handler with the established pattern, removes the duplicate logic, and restores a consistent audit trail without changing externally observable behaviour for users whose `Name` claim is present.
+
+## Functional Requirements
+
+### FR-1: Replace IHttpContextAccessor dependency with ICurrentUserService
+The handler's constructor must no longer take `IHttpContextAccessor`. It must take `ICurrentUserService` instead and store it in a `_currentUserService` field. The private `GetCurrentUserName()` method must be removed.
+
+**Acceptance criteria:**
+- `UpdateManufactureOrderStatusHandler` has no `IHttpContextAccessor` field, parameter, or `using` import.
+- `UpdateManufactureOrderStatusHandler` has a single `ICurrentUserService _currentUserService` field assigned from a constructor parameter.
+- The class no longer defines `GetCurrentUserName()`.
+- The project compiles (`dotnet build`) with no new warnings.
+
+### FR-2: Resolve current user via the shared abstraction
+Every call site that previously called `GetCurrentUserName()` must instead call `_currentUserService.GetCurrentUser().GetDisplayName()` using the existing `CurrentUserExtensions.GetDisplayName()` helper.
+
+**Acceptance criteria:**
+- All previous call sites of `GetCurrentUserName()` (the two sites identified in the brief, plus any others discovered during refactor) now read the user name through `ICurrentUserService` + `GetDisplayName()`.
+- A grep for `_httpContextAccessor` in the handler returns no matches.
+- The audit field `StateChangedByUser` (and any other user-stamp fields written by this handler) is populated from `GetDisplayName()`.
+
+### FR-3: Preserve audit-trail behaviour for fully populated identities
+For requests where `Identity.Name` is present (the case that already works today), the persisted user value must remain identical to the pre-refactor value, so existing data continues to round-trip cleanly.
+
+**Acceptance criteria:**
+- A unit/integration test exercising a state change with a `ClaimsPrincipal` whose `Identity.Name = "user@example.com"` records `"user@example.com"` in `StateChangedByUser`.
+- No existing manufacture-order test assertion on user stamping needs to be loosened to pass.
+
+### FR-4: Correctly stamp authenticated users when Name claim is absent
+For requests where `Identity.Name` is null but other Entra ID identity claims are present (`preferred_username`, `upn`, `oid`, `sub`, etc.), the persisted user value must come from the fallback chain implemented in `CurrentUserService`, not the literal `"System"`.
+
+**Acceptance criteria:**
+- A unit/integration test exercising a state change with a `ClaimsPrincipal` that has `preferred_username` but no `Identity.Name` records the `preferred_username` value (or the first matching fallback claim) in `StateChangedByUser`, not `"System"`.
+- The fallback semantics match `CurrentUserService.GetCurrentUser()` exactly — this refactor does not redefine them.
+
+### FR-5: Preserve unauthenticated/system fallback
+For requests with no authenticated user (e.g. background jobs that go through the same handler, or an absent `HttpContext`), the persisted user value must continue to be the sentinel string `"System"` so existing rows and downstream consumers remain consistent.
+
+**Acceptance criteria:**
+- When `ICurrentUserService.GetCurrentUser()` returns an anonymous/unauthenticated user, `GetDisplayName()` resolves to `"System"` and the audit field is stamped as `"System"`.
+- If `GetDisplayName()` does not currently return `"System"` for the anonymous case, this is treated as an Open Question rather than silently introducing a different sentinel.
+
+### FR-6: Update handler registration and tests to match the new constructor
+All DI registrations, manual `new UpdateManufactureOrderStatusHandler(...)` constructions, and test doubles must be updated to supply `ICurrentUserService` in place of `IHttpContextAccessor`.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds across solution.
+- All existing tests that instantiate the handler compile and pass.
+- No test continues to mock `IHttpContextAccessor` solely for this handler.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance change is expected. `ICurrentUserService` resolution cost is equivalent to direct `HttpContext.User` access plus a short claim lookup. The handler must not introduce additional async work or extra service-locator calls.
+
+**Acceptance criteria:**
+- Per-request latency for `UpdateManufactureOrderStatus` is unchanged within normal noise on local benchmarks (no new I/O, no new awaits, no reflection).
+
+### NFR-2: Security
+The refactor must not relax or alter the authentication/authorization model. `ICurrentUserService` must continue to read from the request's `ClaimsPrincipal` only; no new trust boundaries are introduced. The handler's existing authorization requirements (already enforced upstream by the controller/policy) remain unchanged.
+
+**Acceptance criteria:**
+- No new endpoints, claims, or permission checks are added or removed.
+- Audit trail entries cannot be spoofed by clients beyond what was already possible (i.e. they still derive only from the validated access-token claims).
+
+### NFR-3: Maintainability / Architecture
+The refactor must reduce Application-layer coupling to `IHttpContextAccessor` by one consumer and bring the handler in line with the SRP boundary documented in `docs/architecture/development_guidelines.md`.
+
+**Acceptance criteria:**
+- `Anela.Heblo.Application` has one fewer file that imports `Microsoft.AspNetCore.Http.IHttpContextAccessor`.
+- The handler's responsibilities are limited to manufacture-order state-transition orchestration; HTTP identity concerns no longer appear in it.
+
+### NFR-4: Observability
+Existing logs and metrics emitted by the handler must continue to include the user identifier. Where the log message previously used the locally-resolved name, it must now use the `GetDisplayName()` result.
+
+**Acceptance criteria:**
+- Any log statement that referenced the user name in the handler still emits a non-empty user identifier for authenticated requests.
+- Structured log property names (e.g. `User`, `ChangedBy`) are unchanged.
+
+## Data Model
+
+No schema changes. Affected fields and their owners:
+
+- `ManufactureOrder.StateChangedByUser` (string) — populated by this handler on state transitions.
+- Any additional user-stamp fields written inside the same handler (e.g. state-change history rows on a related entity). The refactor preserves their column types and semantics; only the source of the string changes from `HttpContext.User.Identity.Name ?? "System"` to `ICurrentUserService.GetCurrentUser().GetDisplayName()`.
+
+Existing rows are not migrated. Historical `"System"` rows that were caused by the bug remain `"System"` — this spec does not include a backfill.
+
+## API / Interface Design
+
+No public API surface change. The MediatR request, response DTOs, controller route, and HTTP contract for `UpdateManufactureOrderStatus` are untouched.
+
+Internal interface impact:
+- `UpdateManufactureOrderStatusHandler` constructor signature changes: `IHttpContextAccessor` parameter is removed and replaced by `ICurrentUserService`. Parameter ordering inside the constructor should preserve existing positions for the remaining dependencies; the swapped parameter takes the slot of the removed one.
+- DI container registration of `ICurrentUserService` must already cover this handler's scope (it does — `CurrentUserService` is registered for the Application layer).
+
+## Dependencies
+
+- `ICurrentUserService` and its `CurrentUserService` implementation (existing).
+- `CurrentUserExtensions.GetDisplayName()` (existing).
+- Standard MediatR + DI infrastructure (existing).
+
+No new NuGet packages. No new external services.
+
+## Out of Scope
+
+- Backfilling historical manufacture-order rows whose `StateChangedByUser` was incorrectly stamped `"System"` because of this bug.
+- Refactoring the other Application-layer consumer of `IHttpContextAccessor` tracked in issue #1716 — that is a separate change.
+- Changing the claim fallback order inside `CurrentUserService`. This spec uses the existing chain as-is.
+- Renaming `StateChangedByUser` or any related audit columns.
+- Adding new audit fields (e.g. user object id alongside display name).
+- Frontend changes. The HTTP contract is unchanged, so no frontend work is required.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-users-updatemanufactureorder/task-plan.r1.md
+++ b/artifacts/feat-arch-review-users-updatemanufactureorder/task-plan.r1.md
@@ -1,0 +1,760 @@
+# Refactor UpdateManufactureOrderStatusHandler to use ICurrentUserService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct `IHttpContextAccessor` dependency in `UpdateManufactureOrderStatusHandler` with the existing `ICurrentUserService` abstraction so that audit fields use the same identity-resolution chain as the rest of the Application layer, stopping authenticated users from being incorrectly stamped as `"System"` when the `Identity.Name` claim is absent.
+
+**Architecture:** Surgical refactor of a single Application-layer handler. The handler stops resolving `HttpContext.User.Identity.Name` directly and instead calls `ICurrentUserService.GetCurrentUser().GetDisplayName()` once per `Handle` invocation, passing the resolved name into `WriteDownInventoryAsync` so both audit fields (`order.StateChangedByUser` and `ManufacturedProductInventoryItem.CreatedBy`) come from a single resolution. Two existing test classes swap their `IHttpContextAccessor` mock for an `ICurrentUserService` mock; one new test covers the bug-fix scenario (authenticated principal without a `Name` claim → `"Unknown User"`, not `"System"`).
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, Moq, FluentAssertions. No new packages.
+
+**Spec amendments adopted from arch-review:**
+- **Amendment 1a (FR-4):** Test asserts `"Unknown User"` (not `preferred_username`) for an authenticated principal whose `Name` is null. The existing `CurrentUserService` chain (`Identity.Name → ClaimTypes.Name → "name" → "Unknown User"`) is *not* modified in this refactor.
+- **Amendment 2 (FR-2):** The user name is resolved exactly once per `Handle` invocation and passed into `WriteDownInventoryAsync` as a parameter, so `StateChangedByUser` and `ManufacturedProductInventoryItem.CreatedBy` cannot diverge for the same transition.
+
+---
+
+## File Structure
+
+**Modified (3 files):**
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs` — swap dependency, delete `GetCurrentUserName`, resolve user once, parameterise `WriteDownInventoryAsync`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs` — swap mock, rename `Handle_WithoutHttpContext_ShouldUseSystemAsUser`, add the new FR-4 test.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs` — swap mock.
+
+**Not modified (verified):**
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — `ICurrentUserService` is already registered (line 130). `IHttpContextAccessor` registration remains, other consumers still need it.
+- `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs` — Out of scope (Amendment 1b explicitly rejected).
+- `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUserExtensions.cs` — already returns `"System"` for unauthenticated, `Name ?? "Unknown User"` for authenticated.
+
+**No DI registration changes**, no DB migrations, no frontend changes, no config flags, no new files.
+
+---
+
+## Task 1: Refactor test files to use ICurrentUserService mock + add FR-4 test (RED)
+
+> TDD anchor — write the tests against the new constructor *before* changing the handler. The solution will fail to build at the end of this task; that is the RED state we want before Task 2 makes it GREEN.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`
+
+### Step 1.1: Rewrite test class `UpdateManufactureOrderStatusHandlerTests` constructor and setup
+
+- [ ] **Replace the `using` block, field declarations, constants, and constructor in `UpdateManufactureOrderStatusHandlerTests.cs`** so the test class mocks `ICurrentUserService` instead of `IHttpContextAccessor`.
+
+In `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`:
+
+Replace lines 1-11 (the `using` block) with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+(Removed: `Microsoft.AspNetCore.Http`, `System.Security.Claims`.)
+
+Replace lines 17-67 (field declarations through the end of the constructor) with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
+    private readonly UpdateManufactureOrderStatusHandler _handler;
+
+    private const int ValidOrderId = 1;
+    private const int NonExistentOrderId = 999;
+    private const string TestUserName = "Test User";
+    private const string ValidChangeReason = "Moving to next phase";
+
+    public UpdateManufactureOrderStatusHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: TestUserName,
+                Email: "test@example.com",
+                IsAuthenticated: true));
+
+        _conditionsProviderMock
+            .Setup(x => x.GetCurrentSnapshotAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConditionsSnapshot(null, null, null, null, DateTime.UtcNow, ConditionsReadingSource.Unavailable));
+
+        _inventoryRepositoryMock
+            .Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<ManufacturedProductInventoryItem>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<ManufacturedProductInventoryItem> items, CancellationToken _) => items);
+
+        _handler = new UpdateManufactureOrderStatusHandler(
+            _repositoryMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _conditionsProviderMock.Object,
+            _inventoryRepositoryMock.Object);
+    }
+```
+
+**Notes for the implementer:**
+- The positional ordering of constructor args in the `new UpdateManufactureOrderStatusHandler(...)` call is identical to the production constructor (per Decision 3): `_currentUserServiceMock.Object` takes the slot previously occupied by `_httpContextAccessorMock.Object`.
+- `CurrentUser` is a record in `Anela.Heblo.Domain.Features.Users` (already in scope via the new `using`).
+
+### Step 1.2: Rewrite the existing "WithoutHttpContext" test as an unauthenticated-user test
+
+- [ ] **Replace the `Handle_WithoutHttpContext_ShouldUseSystemAsUser` test (lines 194-230 of the original file)** with an unauthenticated-user setup that drives the same assertion through the new abstraction.
+
+Find:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithoutHttpContext_ShouldUseSystemAsUser()
+    {
+        _httpContextAccessorMock
+            .Setup(x => x.HttpContext)
+            .Returns((HttpContext?)null);
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+```
+
+Replace with:
+
+```csharp
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_ShouldUseSystemAsUser()
+    {
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: null,
+                Name: null,
+                Email: null,
+                IsAuthenticated: false));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+```
+
+**Rationale:** `CurrentUserExtensions.GetDisplayName()` returns `"System"` exactly when `IsAuthenticated == false`. Setting up an unauthenticated `CurrentUser` is the new abstraction's analogue of the old "no HttpContext" scenario, and preserves the FR-5 acceptance criterion.
+
+### Step 1.3: Add the new FR-4 bug-fix test
+
+- [ ] **Insert a new test immediately after the renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser` test** (i.e. right before `Handle_WhenRepositoryGetThrows_ShouldReturnInternalServerError`):
+
+```csharp
+    [Fact]
+    public async Task Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem()
+    {
+        // Entra ID access tokens frequently omit the Name/upn claim used by Identity.Name.
+        // Before the refactor this case fell through to "System" (the bug). Per spec FR-4
+        // (Amendment 1a), the handler should now stamp "Unknown User" for an authenticated
+        // principal whose Name is null.
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "abc123",
+                Name: null,
+                Email: "user@example.com",
+                IsAuthenticated: true));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("Unknown User");
+        result.StateChangedByUser.Should().NotBe("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("Unknown User");
+    }
+```
+
+### Step 1.4: Rewrite test class `UpdateManufactureOrderStatusHandlerConditionsTests` to use the same mock swap
+
+- [ ] **Edit `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`** — replace the imports, mock field, constructor setup, and `CreateHandler()` body.
+
+Replace lines 1-9 (the `using` block) with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+```
+
+(Removed: `Microsoft.AspNetCore.Http`, `System.Security.Claims`.)
+
+Replace lines 15-47 (field declarations through end of `CreateHandler`) with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
+
+    public UpdateManufactureOrderStatusHandlerConditionsTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
+        _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: "Test User",
+                Email: "test@example.com",
+                IsAuthenticated: true));
+
+        _inventoryRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem item, CancellationToken _) => item);
+    }
+
+    private UpdateManufactureOrderStatusHandler CreateHandler() =>
+        new UpdateManufactureOrderStatusHandler(
+            _repositoryMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _conditionsProviderMock.Object,
+            _inventoryRepositoryMock.Object);
+```
+
+### Step 1.5: Verify the solution does NOT compile (RED)
+
+- [ ] **Run `dotnet build` from the repository root** and confirm compilation fails.
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: FAIL.
+
+Expected error symptom (one or both files):
+- `CS0246: The type or namespace name 'IHttpContextAccessor' could not be found` — only if leftover references slipped through; if you see this, re-grep and clean.
+- `CS1503: cannot convert from 'Moq.Mock<ICurrentUserService>.Object' to 'IHttpContextAccessor'` — this is the *expected* failure: the production constructor still demands `IHttpContextAccessor`. This is what proves the tests now drive a constructor change.
+
+Do **not** proceed if you see only `IHttpContextAccessor` missing-import errors — that means the test files still reference it. Re-check Step 1.1 / Step 1.4 imports.
+
+### Step 1.6: Commit the failing tests
+
+- [ ] **Commit the two test files** so the RED state is captured in history before the handler refactor.
+
+Run:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+git commit -m "test: drive UpdateManufactureOrderStatusHandler to ICurrentUserService
+
+Replace IHttpContextAccessor mock with ICurrentUserService mock in both
+handler test classes, rename the no-HttpContext test to an
+unauthenticated-user test, and add a new test covering FR-4 (authenticated
+principal without Name claim must record \"Unknown User\", not \"System\").
+
+Solution does not build yet — production handler still requires
+IHttpContextAccessor. The next commit refactors the handler to match."
+```
+
+---
+
+## Task 2: Refactor handler to use ICurrentUserService (GREEN)
+
+> Now that the tests drive the new contract, change the production code minimally to match.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+
+### Step 2.1: Swap imports and dependency field
+
+- [ ] **In `UpdateManufactureOrderStatusHandler.cs`**, replace the imports and the dependency field.
+
+Find (lines 1-7):
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+Then find (line 17):
+
+```csharp
+    private readonly IHttpContextAccessor _httpContextAccessor;
+```
+
+Replace with:
+
+```csharp
+    private readonly ICurrentUserService _currentUserService;
+```
+
+### Step 2.2: Swap constructor parameter and assignment
+
+- [ ] **Update the constructor**. Find lines 20-34:
+
+```csharp
+    public UpdateManufactureOrderStatusHandler(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider,
+        ILogger<UpdateManufactureOrderStatusHandler> logger,
+        IHttpContextAccessor httpContextAccessor,
+        IConditionsReadingProvider conditionsProvider,
+        IManufacturedProductInventoryRepository inventoryRepository)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _httpContextAccessor = httpContextAccessor;
+        _conditionsProvider = conditionsProvider;
+        _inventoryRepository = inventoryRepository;
+    }
+```
+
+Replace with:
+
+```csharp
+    public UpdateManufactureOrderStatusHandler(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider,
+        ILogger<UpdateManufactureOrderStatusHandler> logger,
+        ICurrentUserService currentUserService,
+        IConditionsReadingProvider conditionsProvider,
+        IManufacturedProductInventoryRepository inventoryRepository)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _currentUserService = currentUserService;
+        _conditionsProvider = conditionsProvider;
+        _inventoryRepository = inventoryRepository;
+    }
+```
+
+The slot position of the swapped parameter is unchanged (slot 4 of 6) per arch-review Decision 3.
+
+### Step 2.3: Resolve user name once and reuse across call sites
+
+- [ ] **Inside `Handle`, resolve the user name once after the state-transition validation and use it for both audit fields.**
+
+Find (lines 48-64 of the original — the block from `var oldState = order.State;` through `order.StateChangedByUser = GetCurrentUserName();`):
+
+```csharp
+            var oldState = order.State;
+
+            // Validate state transition (basic validation - can be extended)
+            if (!IsValidStateTransition(oldState, request.NewState))
+            {
+                return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
+                    new Dictionary<string, string>
+                    {
+                        { "oldState", oldState.ToString() },
+                        { "newState", request.NewState.ToString() }
+                    });
+            }
+
+            // Update state
+            order.State = request.NewState;
+            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+            order.StateChangedByUser = GetCurrentUserName();
+```
+
+Replace with:
+
+```csharp
+            var oldState = order.State;
+
+            // Validate state transition (basic validation - can be extended)
+            if (!IsValidStateTransition(oldState, request.NewState))
+            {
+                return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
+                    new Dictionary<string, string>
+                    {
+                        { "oldState", oldState.ToString() },
+                        { "newState", request.NewState.ToString() }
+                    });
+            }
+
+            var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
+
+            // Update state
+            order.State = request.NewState;
+            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+            order.StateChangedByUser = currentUserName;
+```
+
+**Why resolve here, not at the top of the method?** Resolving after the validation guard skips the (cheap) extension-method call for failed validations and matches the previous placement of `GetCurrentUserName()` — keeps the diff surgical.
+
+### Step 2.4: Pass the resolved user into `WriteDownInventoryAsync`
+
+- [ ] **Update the `WriteDownInventoryAsync` call site.** Find (line 135):
+
+```csharp
+                await WriteDownInventoryAsync(order, cancellationToken);
+```
+
+Replace with:
+
+```csharp
+                await WriteDownInventoryAsync(order, currentUserName, cancellationToken);
+```
+
+### Step 2.5: Update `WriteDownInventoryAsync` signature and body
+
+- [ ] **Add the `string changedByUser` parameter and remove the in-body resolution.** Find (lines 175-195 of the original):
+
+```csharp
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, CancellationToken cancellationToken)
+    {
+        var user = GetCurrentUserName();
+        var timestamp = _timeProvider.GetUtcNow().DateTime;
+
+        var items = order.Products
+            .Where(p => p.ActualQuantity is > 0)
+            .Select(p => new ManufacturedProductInventoryItem(
+                productCode: p.ProductCode,
+                productName: p.ProductName,
+                amount: p.ActualQuantity!.Value,
+                createdBy: user,
+                createdAt: timestamp,
+                lotNumber: p.LotNumber,
+                expirationDate: p.ExpirationDate,
+                manufactureOrderId: order.Id))
+            .ToList();
+
+        if (items.Count > 0)
+            await _inventoryRepository.AddRangeAsync(items, cancellationToken);
+    }
+```
+
+Replace with:
+
+```csharp
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, string changedByUser, CancellationToken cancellationToken)
+    {
+        var timestamp = _timeProvider.GetUtcNow().DateTime;
+
+        var items = order.Products
+            .Where(p => p.ActualQuantity is > 0)
+            .Select(p => new ManufacturedProductInventoryItem(
+                productCode: p.ProductCode,
+                productName: p.ProductName,
+                amount: p.ActualQuantity!.Value,
+                createdBy: changedByUser,
+                createdAt: timestamp,
+                lotNumber: p.LotNumber,
+                expirationDate: p.ExpirationDate,
+                manufactureOrderId: order.Id))
+            .ToList();
+
+        if (items.Count > 0)
+            await _inventoryRepository.AddRangeAsync(items, cancellationToken);
+    }
+```
+
+### Step 2.6: Delete the obsolete `GetCurrentUserName()` helper
+
+- [ ] **Remove the entire `GetCurrentUserName()` method.** Find (lines 169-173):
+
+```csharp
+    private string GetCurrentUserName()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        return user?.Identity?.Name ?? "System";
+    }
+```
+
+Delete those five lines plus the blank line that precedes them. After deletion, `IsValidStateTransition` should be immediately followed by `WriteDownInventoryAsync` (with one blank line between them, as in the rest of the file).
+
+### Step 2.7: Verify no stale references to `IHttpContextAccessor` or `GetCurrentUserName` remain in the handler
+
+- [ ] **Grep the handler file to confirm a clean refactor.**
+
+Run:
+
+```bash
+grep -n "IHttpContextAccessor\|_httpContextAccessor\|GetCurrentUserName\|Microsoft\.AspNetCore\.Http" \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+```
+
+Expected: no output (exit code 1). If any line matches, return to the appropriate sub-step above.
+
+### Step 2.8: Build the solution (GREEN — compile)
+
+- [ ] **Compile and confirm success.**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: PASS, zero new warnings.
+
+If the build fails:
+- **`CS0246` on `ICurrentUserService` or `CurrentUserExtensions`**: the `using Anela.Heblo.Domain.Features.Users;` import is missing in the handler. Add it.
+- **`CS1503` constructor argument mismatch in some other consumer**: there are no other consumers — `UpdateManufactureOrderStatusHandler` is only newed up via DI and in the two test classes you already updated. If you see this, you missed a test-class swap; redo Task 1.
+
+### Step 2.9: Run the affected test classes (GREEN — behavior)
+
+- [ ] **Run both targeted test classes.**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdateManufactureOrderStatusHandlerTests|FullyQualifiedName~UpdateManufactureOrderStatusHandlerConditionsTests" \
+  --no-build
+```
+
+Expected:
+- All tests in `UpdateManufactureOrderStatusHandlerTests` pass — including the new `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` and the renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser`.
+- All tests in `UpdateManufactureOrderStatusHandlerConditionsTests` pass — the conditions logic is independent of the user resolution.
+
+If a test fails:
+- `Handle_WithValidTransition_ShouldUpdateStateAndReturnResponse` asserting `TestUserName == "Test User"`: verify the constructor mock setup in Step 1.1 returns `Name: TestUserName` (not null).
+- `Handle_TransitionToCompleted_CreatesInventoryItemsForFinishedProducts` asserting `i.CreatedBy == TestUserName`: same diagnosis — the mock's `Name` must be `TestUserName`. The inventory `CreatedBy` now flows from the same resolution as `StateChangedByUser`, so the assertion still holds.
+- `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` asserting `"Unknown User"`: confirm Step 2.3 calls `GetDisplayName()` (not `currentUser.Name`). The display-name extension is what produces `"Unknown User"` for authenticated principals whose `Name` is null.
+
+### Step 2.10: Commit the handler refactor
+
+- [ ] **Commit the production change.**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+git commit -m "refactor: UpdateManufactureOrderStatusHandler uses ICurrentUserService
+
+Replace the direct IHttpContextAccessor dependency with the shared
+ICurrentUserService abstraction and resolve the user display name once
+per Handle invocation via CurrentUserExtensions.GetDisplayName(). Pass
+the resolved name into WriteDownInventoryAsync so order.StateChangedByUser
+and ManufacturedProductInventoryItem.CreatedBy share a single source.
+
+Fixes audit-trail entries that were stamped as \"System\" for authenticated
+users whose Entra ID token omits the Name/upn claim. Such users are now
+stamped \"Unknown User\" (per existing CurrentUserService fallback chain);
+truly unauthenticated callers (background jobs) continue to stamp \"System\".
+
+Removes one Application-layer consumer of IHttpContextAccessor (moves the
+broader cleanup from N to N-1; sibling consumer tracked in #1716)."
+```
+
+---
+
+## Task 3: Full validation, format, and final sweep
+
+**Files:** No code changes in this task; validation only.
+
+### Step 3.1: Apply formatting and analyzer fixes
+
+- [ ] **Run `dotnet format` over the touched files.**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+```
+
+Expected: command exits 0, no changes (or only trivial whitespace alignment).
+
+If `dotnet format` did modify files, inspect the diff with `git diff` to confirm only whitespace / import ordering changes. Then commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+git commit -m "chore: dotnet format"
+```
+
+(Skip the commit step if there were no changes.)
+
+### Step 3.2: Run the full backend test suite
+
+- [ ] **Run the entire backend test project** to confirm nothing else regressed.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build`
+
+Expected: all tests pass.
+
+If something unrelated fails, do not "fix" it inside this refactor — note it for the user and stop. Per CLAUDE.md, every changed line must trace directly to the request.
+
+### Step 3.3: Final IHttpContextAccessor consumer audit (informational)
+
+- [ ] **Grep the Application project for remaining `IHttpContextAccessor` consumers** and confirm the count dropped by exactly one.
+
+Run:
+
+```bash
+grep -rl "IHttpContextAccessor" backend/src/Anela.Heblo.Application/
+```
+
+Expected: `UpdateManufactureOrderStatusHandler.cs` no longer appears in the list. Other consumers (tracked in issue #1716) remain and are out of scope for this refactor — do not touch them.
+
+This step produces no commit; it confirms NFR-3 (`Anela.Heblo.Application` has one fewer file that imports `IHttpContextAccessor`).
+
+---
+
+## Self-review against the spec
+
+This section is a checklist run by the implementer before declaring the refactor done. Each spec requirement is matched to a task that implements it.
+
+| Spec section | Acceptance criterion | Implementing step |
+|---|---|---|
+| **FR-1** | No `IHttpContextAccessor` field/param/import in handler | Step 2.1, 2.2, 2.7 |
+| **FR-1** | Single `ICurrentUserService _currentUserService` field | Step 2.1, 2.2 |
+| **FR-1** | `GetCurrentUserName()` removed | Step 2.6 |
+| **FR-1** | `dotnet build` succeeds, no new warnings | Step 2.8 |
+| **FR-2** | All previous call sites use `GetCurrentUser().GetDisplayName()` | Step 2.3, 2.5 |
+| **FR-2** | No `_httpContextAccessor` in handler | Step 2.7 |
+| **FR-2** | `StateChangedByUser` populated from `GetDisplayName()` | Step 2.3 |
+| **FR-2** (Amendment 2) | User name resolved at most once per `Handle` invocation | Step 2.3, 2.4, 2.5 |
+| **FR-3** | Test with `Name = "user@example.com"` records that exact value | Existing `Handle_WithValidTransition_ShouldUpdateStateAndReturnResponse` (asserts `TestUserName`) — preserved via Step 1.1 mock default |
+| **FR-3** | No existing assertion loosened | All original assertions kept (Step 1.1 keeps `TestUserName`; the `CreatedBy == TestUserName` assertions in `Handle_TransitionToCompleted_...` are preserved) |
+| **FR-4** (Amendment 1a) | Authenticated principal with `Name = null` records `"Unknown User"`, not `"System"` | Step 1.3 (new test), Step 2.3 (production path) |
+| **FR-5** | Unauthenticated user → `"System"` | Step 1.2 (renamed test), Step 2.3 via `GetDisplayName()` |
+| **FR-6** | All test doubles updated to supply `ICurrentUserService` | Step 1.1, 1.4 |
+| **FR-6** | `dotnet build` succeeds across solution | Step 2.8 |
+| **FR-6** | No test mocks `IHttpContextAccessor` solely for this handler | Step 1.1, 1.4 (both swap completely) |
+| **NFR-1** | No additional async / I/O / reflection | Step 2.3 (single sync extension-method call), Step 2.5 (in-body resolution removed) |
+| **NFR-2** | No new endpoints / claims / permission checks | No code changes outside the handler & its tests |
+| **NFR-3** | One fewer Application-layer file importing `IHttpContextAccessor` | Step 2.1, 2.7, 3.3 |
+| **NFR-4** | Existing log statements still emit user identifier | The handler's `_logger.LogError` (line 150 of original) does not reference the user; observability is unchanged. No log message wired to the local user variable existed — nothing to update. |
+| **Out of scope: backfill** | Historical `"System"` rows untouched | Step 3.2 is test-only; no migration in plan |
+| **Out of scope: sibling #1716** | Other Application consumer of `IHttpContextAccessor` untouched | Step 3.3 explicitly checks for this and does not modify other files |
+
+**Type/name consistency sweep** (per writing-plans self-review):
+- Field name across handler and tests: `_currentUserService` ✓ (Step 1.1, 1.4, 2.1, 2.2)
+- Local variable inside `Handle`: `currentUserName` ✓ (Step 2.3, 2.4)
+- New parameter on `WriteDownInventoryAsync`: `changedByUser` (string) ✓ (Step 2.4, 2.5)
+- Mock field in both test classes: `_currentUserServiceMock` ✓ (Step 1.1, 1.4)
+- `CurrentUser` record positional args: `(Id, Name, Email, IsAuthenticated)` — verified against `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs` ✓ (Step 1.1, 1.2, 1.3, 1.4)
+- `CurrentUserExtensions.GetDisplayName()` returns `"System"` when `IsAuthenticated == false`, otherwise `Name ?? "Unknown User"` — verified against source ✓ (drives Step 1.2 and Step 1.3 expected values)
+
+**Placeholder scan:** no `TBD`, no `TODO`, no "implement later", no "similar to Task N", no "add appropriate error handling" — every step contains exact code or exact command output expectations.
+
+---
+
+## Done criteria
+
+- [ ] Three commits land on the branch (test refactor, handler refactor, optional format), or two if `dotnet format` was a no-op.
+- [ ] `dotnet build backend/Anela.Heblo.sln` → succeeds with no new warnings.
+- [ ] `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build` → all tests pass.
+- [ ] `dotnet format` → exit 0, no further changes.
+- [ ] Grep on `IHttpContextAccessor` in `backend/src/Anela.Heblo.Application/` no longer returns `UpdateManufactureOrderStatusHandler.cs`.
+- [ ] The new `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` test passes (FR-4, Amendment 1a).
+- [ ] The renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser` test passes (FR-5).

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
@@ -2,9 +2,9 @@ using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Http;
 
 namespace Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
 
@@ -14,21 +14,21 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
     private readonly IManufacturedProductInventoryRepository _inventoryRepository;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<UpdateManufactureOrderStatusHandler> _logger;
-    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ICurrentUserService _currentUserService;
     private readonly IConditionsReadingProvider _conditionsProvider;
 
     public UpdateManufactureOrderStatusHandler(
         IManufactureOrderRepository repository,
         TimeProvider timeProvider,
         ILogger<UpdateManufactureOrderStatusHandler> logger,
-        IHttpContextAccessor httpContextAccessor,
+        ICurrentUserService currentUserService,
         IConditionsReadingProvider conditionsProvider,
         IManufacturedProductInventoryRepository inventoryRepository)
     {
         _repository = repository;
         _timeProvider = timeProvider;
         _logger = logger;
-        _httpContextAccessor = httpContextAccessor;
+        _currentUserService = currentUserService;
         _conditionsProvider = conditionsProvider;
         _inventoryRepository = inventoryRepository;
     }
@@ -58,10 +58,12 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
                     });
             }
 
+            var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
+
             // Update state
             order.State = request.NewState;
             order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
-            order.StateChangedByUser = GetCurrentUserName();
+            order.StateChangedByUser = currentUserName;
 
             if (request.ManualActionRequired.HasValue)
                 order.ManualActionRequired = request.ManualActionRequired.Value;
@@ -132,7 +134,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
 
             if (request.NewState == ManufactureOrderState.Completed)
             {
-                await WriteDownInventoryAsync(order, cancellationToken);
+                await WriteDownInventoryAsync(order, currentUserName, cancellationToken);
             }
 
             await _repository.UpdateOrderAsync(order, cancellationToken);
@@ -166,15 +168,8 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
         };
     }
 
-    private string GetCurrentUserName()
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, string changedByUser, CancellationToken cancellationToken)
     {
-        var user = _httpContextAccessor.HttpContext?.User;
-        return user?.Identity?.Name ?? "System";
-    }
-
-    private async Task WriteDownInventoryAsync(ManufactureOrder order, CancellationToken cancellationToken)
-    {
-        var user = GetCurrentUserName();
         var timestamp = _timeProvider.GetUtcNow().DateTime;
 
         var items = order.Products
@@ -183,7 +178,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
                 productCode: p.ProductCode,
                 productName: p.ProductName,
                 amount: p.ActualQuantity!.Value,
-                createdBy: user,
+                createdBy: changedByUser,
                 createdAt: timestamp,
                 lotNumber: p.LotNumber,
                 expirationDate: p.ExpirationDate,

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
@@ -1,10 +1,9 @@
-using System.Security.Claims;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -14,7 +13,7 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
-    private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
     private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
 
@@ -24,13 +23,15 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
         _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
         _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
-        _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
 
-        var claims = new List<Claim> { new(ClaimTypes.Name, "Test User") };
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
-        var httpContext = new Mock<HttpContext>();
-        httpContext.Setup(x => x.User).Returns(principal);
-        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext.Object);
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: "Test User",
+                Email: "test@example.com",
+                IsAuthenticated: true));
 
         _inventoryRepositoryMock
             .Setup(r => r.AddAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()))
@@ -42,7 +43,7 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
             _repositoryMock.Object,
             TimeProvider.System,
             _loggerMock.Object,
-            _httpContextAccessorMock.Object,
+            _currentUserServiceMock.Object,
             _conditionsProviderMock.Object,
             _inventoryRepositoryMock.Object);
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
@@ -3,11 +3,10 @@ using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System.Security.Claims;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.Manufacture;
@@ -17,7 +16,7 @@ public class UpdateManufactureOrderStatusHandlerTests
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
     private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
-    private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
     private readonly UpdateManufactureOrderStatusHandler _handler;
 
@@ -31,23 +30,16 @@ public class UpdateManufactureOrderStatusHandlerTests
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
-        _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
         _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
 
-        // Setup HTTP context with user
-        var claims = new List<Claim>
-        {
-            new Claim(ClaimTypes.Name, TestUserName)
-        };
-        var identity = new ClaimsIdentity(claims, "test");
-        var principal = new ClaimsPrincipal(identity);
-
-        var httpContext = new Mock<HttpContext>();
-        httpContext.Setup(x => x.User).Returns(principal);
-
-        _httpContextAccessorMock
-            .Setup(x => x.HttpContext)
-            .Returns(httpContext.Object);
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: TestUserName,
+                Email: "test@example.com",
+                IsAuthenticated: true));
 
         _conditionsProviderMock
             .Setup(x => x.GetCurrentSnapshotAsync(It.IsAny<CancellationToken>()))
@@ -61,7 +53,7 @@ public class UpdateManufactureOrderStatusHandlerTests
             _repositoryMock.Object,
             TimeProvider.System,
             _loggerMock.Object,
-            _httpContextAccessorMock.Object,
+            _currentUserServiceMock.Object,
             _conditionsProviderMock.Object,
             _inventoryRepositoryMock.Object);
     }
@@ -192,11 +184,15 @@ public class UpdateManufactureOrderStatusHandlerTests
 
 
     [Fact]
-    public async Task Handle_WithoutHttpContext_ShouldUseSystemAsUser()
+    public async Task Handle_UnauthenticatedUser_ShouldUseSystemAsUser()
     {
-        _httpContextAccessorMock
-            .Setup(x => x.HttpContext)
-            .Returns((HttpContext?)null);
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: null,
+                Name: null,
+                Email: null,
+                IsAuthenticated: false));
 
         var request = new UpdateManufactureOrderStatusRequest
         {
@@ -227,6 +223,53 @@ public class UpdateManufactureOrderStatusHandlerTests
 
         updatedOrder.Should().NotBeNull();
         updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+
+    [Fact]
+    public async Task Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem()
+    {
+        // Entra ID access tokens frequently omit the Name/upn claim used by Identity.Name.
+        // Before the refactor this case fell through to "System" (the bug). Per spec FR-4
+        // (Amendment 1a), the handler should now stamp "Unknown User" for an authenticated
+        // principal whose Name is null.
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "abc123",
+                Name: null,
+                Email: "user@example.com",
+                IsAuthenticated: true));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("Unknown User");
+        result.StateChangedByUser.Should().NotBe("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("Unknown User");
     }
 
     [Fact]

--- a/docs/superpowers/plans/2026-05-26-refactor-update-manufacture-order-status-handler-current-user-service.md
+++ b/docs/superpowers/plans/2026-05-26-refactor-update-manufacture-order-status-handler-current-user-service.md
@@ -1,0 +1,760 @@
+# Refactor UpdateManufactureOrderStatusHandler to use ICurrentUserService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct `IHttpContextAccessor` dependency in `UpdateManufactureOrderStatusHandler` with the existing `ICurrentUserService` abstraction so that audit fields use the same identity-resolution chain as the rest of the Application layer, stopping authenticated users from being incorrectly stamped as `"System"` when the `Identity.Name` claim is absent.
+
+**Architecture:** Surgical refactor of a single Application-layer handler. The handler stops resolving `HttpContext.User.Identity.Name` directly and instead calls `ICurrentUserService.GetCurrentUser().GetDisplayName()` once per `Handle` invocation, passing the resolved name into `WriteDownInventoryAsync` so both audit fields (`order.StateChangedByUser` and `ManufacturedProductInventoryItem.CreatedBy`) come from a single resolution. Two existing test classes swap their `IHttpContextAccessor` mock for an `ICurrentUserService` mock; one new test covers the bug-fix scenario (authenticated principal without a `Name` claim → `"Unknown User"`, not `"System"`).
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, Moq, FluentAssertions. No new packages.
+
+**Spec amendments adopted from arch-review:**
+- **Amendment 1a (FR-4):** Test asserts `"Unknown User"` (not `preferred_username`) for an authenticated principal whose `Name` is null. The existing `CurrentUserService` chain (`Identity.Name → ClaimTypes.Name → "name" → "Unknown User"`) is *not* modified in this refactor.
+- **Amendment 2 (FR-2):** The user name is resolved exactly once per `Handle` invocation and passed into `WriteDownInventoryAsync` as a parameter, so `StateChangedByUser` and `ManufacturedProductInventoryItem.CreatedBy` cannot diverge for the same transition.
+
+---
+
+## File Structure
+
+**Modified (3 files):**
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs` — swap dependency, delete `GetCurrentUserName`, resolve user once, parameterise `WriteDownInventoryAsync`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs` — swap mock, rename `Handle_WithoutHttpContext_ShouldUseSystemAsUser`, add the new FR-4 test.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs` — swap mock.
+
+**Not modified (verified):**
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — `ICurrentUserService` is already registered (line 130). `IHttpContextAccessor` registration remains, other consumers still need it.
+- `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs` — Out of scope (Amendment 1b explicitly rejected).
+- `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUserExtensions.cs` — already returns `"System"` for unauthenticated, `Name ?? "Unknown User"` for authenticated.
+
+**No DI registration changes**, no DB migrations, no frontend changes, no config flags, no new files.
+
+---
+
+## Task 1: Refactor test files to use ICurrentUserService mock + add FR-4 test (RED)
+
+> TDD anchor — write the tests against the new constructor *before* changing the handler. The solution will fail to build at the end of this task; that is the RED state we want before Task 2 makes it GREEN.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`
+
+### Step 1.1: Rewrite test class `UpdateManufactureOrderStatusHandlerTests` constructor and setup
+
+- [ ] **Replace the `using` block, field declarations, constants, and constructor in `UpdateManufactureOrderStatusHandlerTests.cs`** so the test class mocks `ICurrentUserService` instead of `IHttpContextAccessor`.
+
+In `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`:
+
+Replace lines 1-11 (the `using` block) with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+(Removed: `Microsoft.AspNetCore.Http`, `System.Security.Claims`.)
+
+Replace lines 17-67 (field declarations through the end of the constructor) with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
+    private readonly UpdateManufactureOrderStatusHandler _handler;
+
+    private const int ValidOrderId = 1;
+    private const int NonExistentOrderId = 999;
+    private const string TestUserName = "Test User";
+    private const string ValidChangeReason = "Moving to next phase";
+
+    public UpdateManufactureOrderStatusHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: TestUserName,
+                Email: "test@example.com",
+                IsAuthenticated: true));
+
+        _conditionsProviderMock
+            .Setup(x => x.GetCurrentSnapshotAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConditionsSnapshot(null, null, null, null, DateTime.UtcNow, ConditionsReadingSource.Unavailable));
+
+        _inventoryRepositoryMock
+            .Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<ManufacturedProductInventoryItem>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<ManufacturedProductInventoryItem> items, CancellationToken _) => items);
+
+        _handler = new UpdateManufactureOrderStatusHandler(
+            _repositoryMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _conditionsProviderMock.Object,
+            _inventoryRepositoryMock.Object);
+    }
+```
+
+**Notes for the implementer:**
+- The positional ordering of constructor args in the `new UpdateManufactureOrderStatusHandler(...)` call is identical to the production constructor (per Decision 3): `_currentUserServiceMock.Object` takes the slot previously occupied by `_httpContextAccessorMock.Object`.
+- `CurrentUser` is a record in `Anela.Heblo.Domain.Features.Users` (already in scope via the new `using`).
+
+### Step 1.2: Rewrite the existing "WithoutHttpContext" test as an unauthenticated-user test
+
+- [ ] **Replace the `Handle_WithoutHttpContext_ShouldUseSystemAsUser` test (lines 194-230 of the original file)** with an unauthenticated-user setup that drives the same assertion through the new abstraction.
+
+Find:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithoutHttpContext_ShouldUseSystemAsUser()
+    {
+        _httpContextAccessorMock
+            .Setup(x => x.HttpContext)
+            .Returns((HttpContext?)null);
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+```
+
+Replace with:
+
+```csharp
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_ShouldUseSystemAsUser()
+    {
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: null,
+                Name: null,
+                Email: null,
+                IsAuthenticated: false));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+```
+
+**Rationale:** `CurrentUserExtensions.GetDisplayName()` returns `"System"` exactly when `IsAuthenticated == false`. Setting up an unauthenticated `CurrentUser` is the new abstraction's analogue of the old "no HttpContext" scenario, and preserves the FR-5 acceptance criterion.
+
+### Step 1.3: Add the new FR-4 bug-fix test
+
+- [ ] **Insert a new test immediately after the renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser` test** (i.e. right before `Handle_WhenRepositoryGetThrows_ShouldReturnInternalServerError`):
+
+```csharp
+    [Fact]
+    public async Task Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem()
+    {
+        // Entra ID access tokens frequently omit the Name/upn claim used by Identity.Name.
+        // Before the refactor this case fell through to "System" (the bug). Per spec FR-4
+        // (Amendment 1a), the handler should now stamp "Unknown User" for an authenticated
+        // principal whose Name is null.
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "abc123",
+                Name: null,
+                Email: "user@example.com",
+                IsAuthenticated: true));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("Unknown User");
+        result.StateChangedByUser.Should().NotBe("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("Unknown User");
+    }
+```
+
+### Step 1.4: Rewrite test class `UpdateManufactureOrderStatusHandlerConditionsTests` to use the same mock swap
+
+- [ ] **Edit `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`** — replace the imports, mock field, constructor setup, and `CreateHandler()` body.
+
+Replace lines 1-9 (the `using` block) with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+```
+
+(Removed: `Microsoft.AspNetCore.Http`, `System.Security.Claims`.)
+
+Replace lines 15-47 (field declarations through end of `CreateHandler`) with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
+
+    public UpdateManufactureOrderStatusHandlerConditionsTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
+        _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: "Test User",
+                Email: "test@example.com",
+                IsAuthenticated: true));
+
+        _inventoryRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem item, CancellationToken _) => item);
+    }
+
+    private UpdateManufactureOrderStatusHandler CreateHandler() =>
+        new UpdateManufactureOrderStatusHandler(
+            _repositoryMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _conditionsProviderMock.Object,
+            _inventoryRepositoryMock.Object);
+```
+
+### Step 1.5: Verify the solution does NOT compile (RED)
+
+- [ ] **Run `dotnet build` from the repository root** and confirm compilation fails.
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: FAIL.
+
+Expected error symptom (one or both files):
+- `CS0246: The type or namespace name 'IHttpContextAccessor' could not be found` — only if leftover references slipped through; if you see this, re-grep and clean.
+- `CS1503: cannot convert from 'Moq.Mock<ICurrentUserService>.Object' to 'IHttpContextAccessor'` — this is the *expected* failure: the production constructor still demands `IHttpContextAccessor`. This is what proves the tests now drive a constructor change.
+
+Do **not** proceed if you see only `IHttpContextAccessor` missing-import errors — that means the test files still reference it. Re-check Step 1.1 / Step 1.4 imports.
+
+### Step 1.6: Commit the failing tests
+
+- [ ] **Commit the two test files** so the RED state is captured in history before the handler refactor.
+
+Run:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+git commit -m "test: drive UpdateManufactureOrderStatusHandler to ICurrentUserService
+
+Replace IHttpContextAccessor mock with ICurrentUserService mock in both
+handler test classes, rename the no-HttpContext test to an
+unauthenticated-user test, and add a new test covering FR-4 (authenticated
+principal without Name claim must record \"Unknown User\", not \"System\").
+
+Solution does not build yet — production handler still requires
+IHttpContextAccessor. The next commit refactors the handler to match."
+```
+
+---
+
+## Task 2: Refactor handler to use ICurrentUserService (GREEN)
+
+> Now that the tests drive the new contract, change the production code minimally to match.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+
+### Step 2.1: Swap imports and dependency field
+
+- [ ] **In `UpdateManufactureOrderStatusHandler.cs`**, replace the imports and the dependency field.
+
+Find (lines 1-7):
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+Then find (line 17):
+
+```csharp
+    private readonly IHttpContextAccessor _httpContextAccessor;
+```
+
+Replace with:
+
+```csharp
+    private readonly ICurrentUserService _currentUserService;
+```
+
+### Step 2.2: Swap constructor parameter and assignment
+
+- [ ] **Update the constructor**. Find lines 20-34:
+
+```csharp
+    public UpdateManufactureOrderStatusHandler(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider,
+        ILogger<UpdateManufactureOrderStatusHandler> logger,
+        IHttpContextAccessor httpContextAccessor,
+        IConditionsReadingProvider conditionsProvider,
+        IManufacturedProductInventoryRepository inventoryRepository)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _httpContextAccessor = httpContextAccessor;
+        _conditionsProvider = conditionsProvider;
+        _inventoryRepository = inventoryRepository;
+    }
+```
+
+Replace with:
+
+```csharp
+    public UpdateManufactureOrderStatusHandler(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider,
+        ILogger<UpdateManufactureOrderStatusHandler> logger,
+        ICurrentUserService currentUserService,
+        IConditionsReadingProvider conditionsProvider,
+        IManufacturedProductInventoryRepository inventoryRepository)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _currentUserService = currentUserService;
+        _conditionsProvider = conditionsProvider;
+        _inventoryRepository = inventoryRepository;
+    }
+```
+
+The slot position of the swapped parameter is unchanged (slot 4 of 6) per arch-review Decision 3.
+
+### Step 2.3: Resolve user name once and reuse across call sites
+
+- [ ] **Inside `Handle`, resolve the user name once after the state-transition validation and use it for both audit fields.**
+
+Find (lines 48-64 of the original — the block from `var oldState = order.State;` through `order.StateChangedByUser = GetCurrentUserName();`):
+
+```csharp
+            var oldState = order.State;
+
+            // Validate state transition (basic validation - can be extended)
+            if (!IsValidStateTransition(oldState, request.NewState))
+            {
+                return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
+                    new Dictionary<string, string>
+                    {
+                        { "oldState", oldState.ToString() },
+                        { "newState", request.NewState.ToString() }
+                    });
+            }
+
+            // Update state
+            order.State = request.NewState;
+            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+            order.StateChangedByUser = GetCurrentUserName();
+```
+
+Replace with:
+
+```csharp
+            var oldState = order.State;
+
+            // Validate state transition (basic validation - can be extended)
+            if (!IsValidStateTransition(oldState, request.NewState))
+            {
+                return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
+                    new Dictionary<string, string>
+                    {
+                        { "oldState", oldState.ToString() },
+                        { "newState", request.NewState.ToString() }
+                    });
+            }
+
+            var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
+
+            // Update state
+            order.State = request.NewState;
+            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+            order.StateChangedByUser = currentUserName;
+```
+
+**Why resolve here, not at the top of the method?** Resolving after the validation guard skips the (cheap) extension-method call for failed validations and matches the previous placement of `GetCurrentUserName()` — keeps the diff surgical.
+
+### Step 2.4: Pass the resolved user into `WriteDownInventoryAsync`
+
+- [ ] **Update the `WriteDownInventoryAsync` call site.** Find (line 135):
+
+```csharp
+                await WriteDownInventoryAsync(order, cancellationToken);
+```
+
+Replace with:
+
+```csharp
+                await WriteDownInventoryAsync(order, currentUserName, cancellationToken);
+```
+
+### Step 2.5: Update `WriteDownInventoryAsync` signature and body
+
+- [ ] **Add the `string changedByUser` parameter and remove the in-body resolution.** Find (lines 175-195 of the original):
+
+```csharp
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, CancellationToken cancellationToken)
+    {
+        var user = GetCurrentUserName();
+        var timestamp = _timeProvider.GetUtcNow().DateTime;
+
+        var items = order.Products
+            .Where(p => p.ActualQuantity is > 0)
+            .Select(p => new ManufacturedProductInventoryItem(
+                productCode: p.ProductCode,
+                productName: p.ProductName,
+                amount: p.ActualQuantity!.Value,
+                createdBy: user,
+                createdAt: timestamp,
+                lotNumber: p.LotNumber,
+                expirationDate: p.ExpirationDate,
+                manufactureOrderId: order.Id))
+            .ToList();
+
+        if (items.Count > 0)
+            await _inventoryRepository.AddRangeAsync(items, cancellationToken);
+    }
+```
+
+Replace with:
+
+```csharp
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, string changedByUser, CancellationToken cancellationToken)
+    {
+        var timestamp = _timeProvider.GetUtcNow().DateTime;
+
+        var items = order.Products
+            .Where(p => p.ActualQuantity is > 0)
+            .Select(p => new ManufacturedProductInventoryItem(
+                productCode: p.ProductCode,
+                productName: p.ProductName,
+                amount: p.ActualQuantity!.Value,
+                createdBy: changedByUser,
+                createdAt: timestamp,
+                lotNumber: p.LotNumber,
+                expirationDate: p.ExpirationDate,
+                manufactureOrderId: order.Id))
+            .ToList();
+
+        if (items.Count > 0)
+            await _inventoryRepository.AddRangeAsync(items, cancellationToken);
+    }
+```
+
+### Step 2.6: Delete the obsolete `GetCurrentUserName()` helper
+
+- [ ] **Remove the entire `GetCurrentUserName()` method.** Find (lines 169-173):
+
+```csharp
+    private string GetCurrentUserName()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        return user?.Identity?.Name ?? "System";
+    }
+```
+
+Delete those five lines plus the blank line that precedes them. After deletion, `IsValidStateTransition` should be immediately followed by `WriteDownInventoryAsync` (with one blank line between them, as in the rest of the file).
+
+### Step 2.7: Verify no stale references to `IHttpContextAccessor` or `GetCurrentUserName` remain in the handler
+
+- [ ] **Grep the handler file to confirm a clean refactor.**
+
+Run:
+
+```bash
+grep -n "IHttpContextAccessor\|_httpContextAccessor\|GetCurrentUserName\|Microsoft\.AspNetCore\.Http" \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+```
+
+Expected: no output (exit code 1). If any line matches, return to the appropriate sub-step above.
+
+### Step 2.8: Build the solution (GREEN — compile)
+
+- [ ] **Compile and confirm success.**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: PASS, zero new warnings.
+
+If the build fails:
+- **`CS0246` on `ICurrentUserService` or `CurrentUserExtensions`**: the `using Anela.Heblo.Domain.Features.Users;` import is missing in the handler. Add it.
+- **`CS1503` constructor argument mismatch in some other consumer**: there are no other consumers — `UpdateManufactureOrderStatusHandler` is only newed up via DI and in the two test classes you already updated. If you see this, you missed a test-class swap; redo Task 1.
+
+### Step 2.9: Run the affected test classes (GREEN — behavior)
+
+- [ ] **Run both targeted test classes.**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdateManufactureOrderStatusHandlerTests|FullyQualifiedName~UpdateManufactureOrderStatusHandlerConditionsTests" \
+  --no-build
+```
+
+Expected:
+- All tests in `UpdateManufactureOrderStatusHandlerTests` pass — including the new `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` and the renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser`.
+- All tests in `UpdateManufactureOrderStatusHandlerConditionsTests` pass — the conditions logic is independent of the user resolution.
+
+If a test fails:
+- `Handle_WithValidTransition_ShouldUpdateStateAndReturnResponse` asserting `TestUserName == "Test User"`: verify the constructor mock setup in Step 1.1 returns `Name: TestUserName` (not null).
+- `Handle_TransitionToCompleted_CreatesInventoryItemsForFinishedProducts` asserting `i.CreatedBy == TestUserName`: same diagnosis — the mock's `Name` must be `TestUserName`. The inventory `CreatedBy` now flows from the same resolution as `StateChangedByUser`, so the assertion still holds.
+- `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` asserting `"Unknown User"`: confirm Step 2.3 calls `GetDisplayName()` (not `currentUser.Name`). The display-name extension is what produces `"Unknown User"` for authenticated principals whose `Name` is null.
+
+### Step 2.10: Commit the handler refactor
+
+- [ ] **Commit the production change.**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+git commit -m "refactor: UpdateManufactureOrderStatusHandler uses ICurrentUserService
+
+Replace the direct IHttpContextAccessor dependency with the shared
+ICurrentUserService abstraction and resolve the user display name once
+per Handle invocation via CurrentUserExtensions.GetDisplayName(). Pass
+the resolved name into WriteDownInventoryAsync so order.StateChangedByUser
+and ManufacturedProductInventoryItem.CreatedBy share a single source.
+
+Fixes audit-trail entries that were stamped as \"System\" for authenticated
+users whose Entra ID token omits the Name/upn claim. Such users are now
+stamped \"Unknown User\" (per existing CurrentUserService fallback chain);
+truly unauthenticated callers (background jobs) continue to stamp \"System\".
+
+Removes one Application-layer consumer of IHttpContextAccessor (moves the
+broader cleanup from N to N-1; sibling consumer tracked in #1716)."
+```
+
+---
+
+## Task 3: Full validation, format, and final sweep
+
+**Files:** No code changes in this task; validation only.
+
+### Step 3.1: Apply formatting and analyzer fixes
+
+- [ ] **Run `dotnet format` over the touched files.**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+```
+
+Expected: command exits 0, no changes (or only trivial whitespace alignment).
+
+If `dotnet format` did modify files, inspect the diff with `git diff` to confirm only whitespace / import ordering changes. Then commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+git commit -m "chore: dotnet format"
+```
+
+(Skip the commit step if there were no changes.)
+
+### Step 3.2: Run the full backend test suite
+
+- [ ] **Run the entire backend test project** to confirm nothing else regressed.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build`
+
+Expected: all tests pass.
+
+If something unrelated fails, do not "fix" it inside this refactor — note it for the user and stop. Per CLAUDE.md, every changed line must trace directly to the request.
+
+### Step 3.3: Final IHttpContextAccessor consumer audit (informational)
+
+- [ ] **Grep the Application project for remaining `IHttpContextAccessor` consumers** and confirm the count dropped by exactly one.
+
+Run:
+
+```bash
+grep -rl "IHttpContextAccessor" backend/src/Anela.Heblo.Application/
+```
+
+Expected: `UpdateManufactureOrderStatusHandler.cs` no longer appears in the list. Other consumers (tracked in issue #1716) remain and are out of scope for this refactor — do not touch them.
+
+This step produces no commit; it confirms NFR-3 (`Anela.Heblo.Application` has one fewer file that imports `IHttpContextAccessor`).
+
+---
+
+## Self-review against the spec
+
+This section is a checklist run by the implementer before declaring the refactor done. Each spec requirement is matched to a task that implements it.
+
+| Spec section | Acceptance criterion | Implementing step |
+|---|---|---|
+| **FR-1** | No `IHttpContextAccessor` field/param/import in handler | Step 2.1, 2.2, 2.7 |
+| **FR-1** | Single `ICurrentUserService _currentUserService` field | Step 2.1, 2.2 |
+| **FR-1** | `GetCurrentUserName()` removed | Step 2.6 |
+| **FR-1** | `dotnet build` succeeds, no new warnings | Step 2.8 |
+| **FR-2** | All previous call sites use `GetCurrentUser().GetDisplayName()` | Step 2.3, 2.5 |
+| **FR-2** | No `_httpContextAccessor` in handler | Step 2.7 |
+| **FR-2** | `StateChangedByUser` populated from `GetDisplayName()` | Step 2.3 |
+| **FR-2** (Amendment 2) | User name resolved at most once per `Handle` invocation | Step 2.3, 2.4, 2.5 |
+| **FR-3** | Test with `Name = "user@example.com"` records that exact value | Existing `Handle_WithValidTransition_ShouldUpdateStateAndReturnResponse` (asserts `TestUserName`) — preserved via Step 1.1 mock default |
+| **FR-3** | No existing assertion loosened | All original assertions kept (Step 1.1 keeps `TestUserName`; the `CreatedBy == TestUserName` assertions in `Handle_TransitionToCompleted_...` are preserved) |
+| **FR-4** (Amendment 1a) | Authenticated principal with `Name = null` records `"Unknown User"`, not `"System"` | Step 1.3 (new test), Step 2.3 (production path) |
+| **FR-5** | Unauthenticated user → `"System"` | Step 1.2 (renamed test), Step 2.3 via `GetDisplayName()` |
+| **FR-6** | All test doubles updated to supply `ICurrentUserService` | Step 1.1, 1.4 |
+| **FR-6** | `dotnet build` succeeds across solution | Step 2.8 |
+| **FR-6** | No test mocks `IHttpContextAccessor` solely for this handler | Step 1.1, 1.4 (both swap completely) |
+| **NFR-1** | No additional async / I/O / reflection | Step 2.3 (single sync extension-method call), Step 2.5 (in-body resolution removed) |
+| **NFR-2** | No new endpoints / claims / permission checks | No code changes outside the handler & its tests |
+| **NFR-3** | One fewer Application-layer file importing `IHttpContextAccessor` | Step 2.1, 2.7, 3.3 |
+| **NFR-4** | Existing log statements still emit user identifier | The handler's `_logger.LogError` (line 150 of original) does not reference the user; observability is unchanged. No log message wired to the local user variable existed — nothing to update. |
+| **Out of scope: backfill** | Historical `"System"` rows untouched | Step 3.2 is test-only; no migration in plan |
+| **Out of scope: sibling #1716** | Other Application consumer of `IHttpContextAccessor` untouched | Step 3.3 explicitly checks for this and does not modify other files |
+
+**Type/name consistency sweep** (per writing-plans self-review):
+- Field name across handler and tests: `_currentUserService` ✓ (Step 1.1, 1.4, 2.1, 2.2)
+- Local variable inside `Handle`: `currentUserName` ✓ (Step 2.3, 2.4)
+- New parameter on `WriteDownInventoryAsync`: `changedByUser` (string) ✓ (Step 2.4, 2.5)
+- Mock field in both test classes: `_currentUserServiceMock` ✓ (Step 1.1, 1.4)
+- `CurrentUser` record positional args: `(Id, Name, Email, IsAuthenticated)` — verified against `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs` ✓ (Step 1.1, 1.2, 1.3, 1.4)
+- `CurrentUserExtensions.GetDisplayName()` returns `"System"` when `IsAuthenticated == false`, otherwise `Name ?? "Unknown User"` — verified against source ✓ (drives Step 1.2 and Step 1.3 expected values)
+
+**Placeholder scan:** no `TBD`, no `TODO`, no "implement later", no "similar to Task N", no "add appropriate error handling" — every step contains exact code or exact command output expectations.
+
+---
+
+## Done criteria
+
+- [ ] Three commits land on the branch (test refactor, handler refactor, optional format), or two if `dotnet format` was a no-op.
+- [ ] `dotnet build backend/Anela.Heblo.sln` → succeeds with no new warnings.
+- [ ] `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build` → all tests pass.
+- [ ] `dotnet format` → exit 0, no further changes.
+- [ ] Grep on `IHttpContextAccessor` in `backend/src/Anela.Heblo.Application/` no longer returns `UpdateManufactureOrderStatusHandler.cs`.
+- [ ] The new `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` test passes (FR-4, Amendment 1a).
+- [ ] The renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser` test passes (FR-5).


### PR DESCRIPTION
Users (violation in Manufacture module)

## Finding
`UpdateManufactureOrderStatusHandler` injects `IHttpContextAccessor` directly and resolves the current user itself, duplicating and diverging from the existing `ICurrentUserService` abstraction.

```csharp
// backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs, lines 17–24, 169–173
private readonly IHttpContextAccessor _httpContextAccessor;

public UpdateManufactureOrderStatusHandler(
    ...
    IHttpContextAccessor httpContextAccessor,
    ...)

private string GetCurrentUserName()
{
    var user = _httpContextAccessor.HttpContext?.User;
    return user?.Identity?.Name ?? "System";
}
```

`ICurrentUserService.GetCurrentUser()` (in `CurrentUserService.cs`) applies a chain of Entra ID claim fallbacks (`preferred_username`, `upn`, `oid`, `sub`, …). This handler reads only `Identity.Name` with no fallbacks, so in Entra ID access-token flows where `Name` is absent the stored `StateChangedByUser` will be `"System"` even for authenticated users.

## Why it matters
- Bypasses the `ICurrentUserService` abstraction that was introduced specifically to centralise Entra ID claim resolution, producing inconsistent audit trail entries.
- Adds a second direct `IHttpContextAccessor` consumer in the Application layer, worsening the coupling identified in #1716.
- The handler has an additional responsibility (HTTP identity extraction) that violates Single Responsibility.

## Suggested fix
Replace the `IHttpContextAccessor` dependency with `ICurrentUserService`:

```csharp
// Remove: private readonly IHttpContextAccessor _httpContextAccessor;
private readonly ICurrentUserService _currentUserService;

// In constructor: replace httpContextAccessor parameter with ICurrentUserService currentUserService
// Remove GetCurrentUserName() and replace its two call-sites with:
_currentUserService.GetCurrentUser().GetDisplayName()
// (using the existing CurrentUserExtensions.GetDisplayName())
```

---
_Filed by daily arch-review routine on 2026-05-26._

---

Closes #1723

### Tokens used
14026709
