### PR TITLE
feat: Refactor GetAvailableRuleTypes to MediatR Handler

### DIFF
--- a/artifacts/feat-arch-review-invoiceclassification-getava/answers.r1.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/answers.r1.md
@@ -1,0 +1,38 @@
+### Question 1
+`steps` element typing. If the generated `GetArticleTraceResponse.steps` element type does not match the local `ArticleGenerationStep` interface exactly, is a single narrow cast `as ArticleGenerationStep[]` acceptable (as the brief's suggested fix uses), or should the local interface be aligned with the generated type instead?
+
+**Answer:** **Neither — explicitly map each generated `ArticleGenerationStepDto` to the local `ArticleGenerationStep` shape inside the query function, mirroring the existing mapping pattern used by `useGetArticleQuery` for `sources` (`frontend/src/api/hooks/useArticles.ts:170-182`) and for `createdAt`/`generatedAt` (`...:166-167`).** Do **not** use a blanket `as ArticleGenerationStep[]` cast and do **not** modify the local `ArticleGenerationStep` interface. Concretely, the refactored hook should produce each step as:
+
+```typescript
+steps: (data.steps ?? []).map((step) => ({
+  id: step.id ?? '',
+  stepName: step.stepName ?? '',
+  sequence: step.sequence ?? 0,
+  status: step.status ?? '',
+  startedAt: step.startedAt?.toISOString() ?? '',
+  finishedAt: step.finishedAt?.toISOString() ?? null,
+  durationMs: step.durationMs ?? null,
+  model: step.model ?? null,
+  inputJson: step.inputJson ?? null,
+  outputJson: step.outputJson ?? null,
+  errorMessage: step.errorMessage ?? null,
+})),
+```
+
+The same mapping discipline (do not cast, project explicitly) MUST also be applied in **`useArticleFeedbackListQuery`**: the generated `GetArticleFeedbackListResponse` exposes `items` (not `articles`), each item has `createdAt` (not `generatedAt`) and `hasComment` (not `hasFeedback`), and no `feedbackComment` field at all — so `return data;` will not satisfy the consumer-facing `ArticleFeedbackListResponse` shape that `useArticleFeedbackAdapter.ts:15-25` reads. The hook MUST project the generated response into the existing local interface (`articles` ← `items`, `generatedAt` ← `createdAt.toISOString()`, `hasFeedback` ← `hasComment`, `feedbackComment` ← `null` for now), preserving FR-4 (no consumer changes).
+
+**Rationale:** Direct inspection of the generated client confirms the types genuinely differ, not just nominally: `ArticleGenerationStepDto.startedAt` is `Date | undefined` while local `ArticleGenerationStep.startedAt` is `string`; `finishedAt` is `Date | undefined` vs `string | null`; every field is optional on the generated DTO but required on the local interface (`frontend/src/api/generated/api-client.ts:13077-13151` vs `frontend/src/api/hooks/useArticleTrace.ts:4-16`). A `as ArticleGenerationStep[]` cast would lie to TypeScript about the date types and re-introduce the same "stale `as any`" class of fragility this refactor is removing — defeating NFR-2. Explicit mapping is already the codebase's established pattern (sources, createdAt, generatedAt in `useGetArticleQuery`), so this answer keeps one pattern across all Article hooks (NFR-4) and surfaces any future generated-shape drift at compile time. The local interface stays untouched because it is the consumer-facing contract and changing it would expand scope beyond FR-4. The feedback-list extension of the same answer is mandatory because returning the generated DTO directly there would silently break the existing consumer adapter (`useArticleFeedbackAdapter.ts`) which reads field names that don't exist on the generated type.
+
+### Question 2
+Follow-up for `useSubmitArticleFeedbackMutation`. Should this refactor also file a tracking issue / TODO comment flagging that mutation for a future review (it still uses `(apiClient as any).baseUrl`)?
+
+**Answer:** **Add a single-line `// TODO` comment at the raw-fetch site, no separate GitHub issue.** Place it immediately above the `const fullUrl = ...` line at `frontend/src/api/hooks/useArticles.ts:222`, worded: `// TODO(arch-review 2026-05-25): Uses private apiClient internals (baseUrl/http) via `as any` — same fragility as the hooks refactored in this PR. Keep raw fetch only for 409 branch; revisit when generated client exposes typed-mutation 409 handling.` Do **not** touch the mutation's behavior, do **not** change the fetch call. The TODO carries the date and the justification so future readers see why this one mutation was left as-is.
+
+**Rationale:** The project is a solo-dev workspace with AI-assisted PR review (per `CLAUDE.md` "Project facts"), so a GitHub issue adds tracking overhead with negligible discovery benefit over an in-file `// TODO` that any future reader of `useArticles.ts` will encounter the moment they look at the function. The dated TODO meets the spec's FR-5 requirement that the mutation be flagged for follow-up, satisfies the "Surgical changes" rule (one line, no behavior change), and keeps the technical-debt note co-located with the code it describes (which a GitHub issue would not).
+
+### Question 3
+Authenticated-client accessor name. The brief uses `getAuthenticatedApiClient()`; confirm this matches the actual exported helper used by `useListArticlesQuery` in this codebase.
+
+**Answer:** **Confirmed — use `getAuthenticatedApiClient` exactly.** It is exported from `frontend/src/api/client.ts:232`, imported by `useArticleTrace.ts:2` and `useArticles.ts:2` already, and is the helper `useListArticlesQuery` calls at `useArticles.ts:129`. All three refactored hooks (`useArticleTraceQuery`, `useArticleFeedbackListQuery`, `useGetArticleQuery`) already import it; no new import is required. Do **not** use the alternative `getAuthenticatedApiClientWithProvider` (`client.ts:342`) — that variant is for callers that want to inject a custom token provider and is not the project's standard accessor.
+
+**Rationale:** Grep across `frontend/src` confirms `getAuthenticatedApiClient` is the singular accessor used by every Article hook today, including the two outliers (`useArticleTraceQuery:27`, `useArticleFeedbackListQuery:260`) that already obtain the client through it before falling back to raw fetch — so the refactor merely uses the already-obtained client's typed methods instead of poking at its private fields. The provider variant exists for a different use case (custom auth provider injection) and applying it here would expand scope beyond the brief and break FR-4's "no consumer changes" guarantee.

--- a/artifacts/feat-arch-review-invoiceclassification-getava/arch-review.r1.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/arch-review.r1.md
@@ -1,0 +1,245 @@
+# Architecture Review: Refactor GetAvailableRuleTypes to MediatR Handler
+
+## Skip Design: true
+
+Backend-only structural refactor — no UI/UX work, no new visual components, no design decisions.
+
+## Architectural Fit Assessment
+
+The spec aligns precisely with established conventions in this codebase. Verified against the actual code:
+
+- **MediatR + Vertical Slice is the established pattern** in `Features/InvoiceClassification/UseCases/*`. Every other action in `InvoiceClassificationController` dispatches via `IMediator` (lines 31, 39, 46, 53, 61, 69, 89, 97, 120, 132). The target action (line 75–86) is the lone exception.
+- **MediatR handler scan is global** — `ApplicationModule.cs:61` does `AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(ApplicationModule).Assembly))`, so a new handler is picked up with no DI changes (confirmed against sibling module comments such as `CatalogModule.cs:38`).
+- **`IClassificationRule` is in Domain** (`backend/src/Anela.Heblo.Domain/Features/InvoiceClassification/IClassificationRule.cs`) — controller currently couples API → Domain, bypassing Application. This violates the dependency direction defined in `docs/architecture/development_guidelines.md` and the "no business logic in controllers" rule (line 37 of that doc).
+- **Sibling response/request shape is uniform**: empty `...Request : IRequest<...Response>` (see `GetAccountingTemplatesRequest.cs`), `...Response : BaseResponse` with `(ErrorCodes, Dictionary<string,string>?)` overload (see `GetAccountingTemplatesResponse.cs`). The spec mirrors this exactly.
+- **`ClassificationRuleTypeDto` is already a `class`** (`Application/Features/InvoiceClassification/Contracts/ClassificationRuleTypeDto.cs`), satisfying the project's "DTOs never records" rule.
+- **DI registration of `IClassificationRule` is in `InvoiceClassificationModule.cs:16–20`** as 5 scoped implementations. The handler receives them via `IEnumerable<IClassificationRule>` — same lifetime as sibling handlers (scoped). No DI changes required.
+
+Integration points: (a) the controller constructor (drops the Domain dependency), (b) one new use case folder, (c) one new test file. Surface area is small and contained.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/
+├── src/Anela.Heblo.API/Controllers/
+│   └── InvoiceClassificationController.cs        ── EDIT: drop IClassificationRule dep,
+│                                                          inject IMediator only,
+│                                                          rewrite action as MediatR dispatch
+│
+├── src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/
+│   └── GetClassificationRuleTypes/               ── NEW folder
+│       ├── GetClassificationRuleTypesRequest.cs    ── NEW: empty IRequest<...Response>
+│       ├── GetClassificationRuleTypesResponse.cs   ── NEW: BaseResponse + List<DTO> RuleTypes
+│       └── GetClassificationRuleTypesHandler.cs    ── NEW: ctor-inject IEnumerable<IClassificationRule>,
+│                                                          project to DTOs
+│
+└── test/Anela.Heblo.Tests/Features/InvoiceClassification/
+    └── GetClassificationRuleTypesHandlerTests.cs ── NEW: xUnit + FluentAssertions + Moq
+
+Layer dependency (after refactor):
+  API ──► Application ──► Domain
+  (controller depends only on Application use case namespace + IMediator)
+```
+
+Runtime call path:
+
+```
+HTTP GET /api/InvoiceClassification/rule-types
+        │
+        ▼
+Controller.GetAvailableRuleTypes(ct)
+        │  await _mediator.Send(new GetClassificationRuleTypesRequest(), ct)
+        ▼
+MediatR pipeline ──► GetClassificationRuleTypesHandler.Handle(...)
+        │           uses IEnumerable<IClassificationRule> from DI (5 registrations)
+        │           projects to List<ClassificationRuleTypeDto>
+        ▼
+GetClassificationRuleTypesResponse { RuleTypes = [...] }
+        │
+        ▼
+Controller returns Ok(response.RuleTypes)   ← UNWRAP to preserve bare-array HTTP contract
+```
+
+### Key Design Decisions
+
+#### Decision 1: Return bare array from controller (unwrap response envelope)
+
+**Options considered:**
+- **A.** Controller returns `Ok(response)` (envelope, matching all sibling controllers).
+- **B.** Controller returns `Ok(response.RuleTypes)` (bare array, matching the pre-refactor contract).
+
+**Chosen approach:** B — unwrap in the controller.
+
+**Rationale:** The current HTTP response is a bare JSON array, while every other action returns an envelope object. Switching to A would break the OpenAPI schema and the generated TypeScript client in `frontend/src/api/generated/`. FR-4 of the spec (and the brief itself) treats this as a structural refactor with no consumer impact — preserving the array is the contract guarantee. Internal consistency (handler returns `BaseResponse`-derived envelope, sibling handler convention) is preserved; the deviation is one line in the controller and is the smallest possible departure. **Add a code comment in the controller action body** explaining the one-line unwrap so future contributors don't "fix it" to match siblings.
+
+#### Decision 2: `Task.FromResult` over `async`/`await` in handler
+
+**Options considered:**
+- **A.** `public Task<...> Handle(...) => Task.FromResult(new Response { ... });`
+- **B.** `public async Task<...> Handle(...) { /* no await */ return new Response { ... }; }`
+
+**Chosen approach:** A — synchronous body wrapped in `Task.FromResult`.
+
+**Rationale:** No I/O is performed (DI-resolved in-memory collection). `async` with no `await` causes a CS1998 warning and adds state-machine overhead for no benefit. `Task.FromResult` is the idiomatic C# choice for genuinely-sync MediatR handlers. Accept `CancellationToken` in the signature (required by `IRequestHandler`) but it can be safely ignored — there's nothing to cancel.
+
+#### Decision 3: Inject `IEnumerable<IClassificationRule>` directly into the handler
+
+**Options considered:**
+- **A.** Handler depends on `IEnumerable<IClassificationRule>` (the Domain abstraction).
+- **B.** Introduce an Application-layer `IClassificationRuleCatalog` service that wraps the enumeration.
+
+**Chosen approach:** A.
+
+**Rationale:** The Application layer is *allowed* to reference Domain (per the dependency rule API → Application → Domain). The whole point of moving the projection out of the controller is that it's now in the layer that *should* depend on Domain. Introducing a wrapper interface adds an abstraction with no second consumer (YAGNI). `GetAccountingTemplatesHandler` and `GetClassificationRulesHandler` both depend directly on Domain abstractions (`IInvoiceClassificationsClient`, `IClassificationRuleRepository`) — this matches the local pattern.
+
+#### Decision 4: No AutoMapper for this projection
+
+**Options considered:**
+- **A.** Inline `Select(...)` projection in the handler.
+- **B.** Add an AutoMapper profile entry mapping `IClassificationRule` → `ClassificationRuleTypeDto`.
+
+**Chosen approach:** A.
+
+**Rationale:** Three fields, all strings, name-aligned. Inline projection is shorter, debuggable without reflection, and avoids polluting `InvoiceClassificationMappingProfile.cs` with a mapping for a DI-resolved metadata interface (AutoMapper profiles in this codebase are used for persistence entity → DTO mappings, not service interface → DTO).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/
+    GetClassificationRuleTypesRequest.cs
+    GetClassificationRuleTypesResponse.cs
+    GetClassificationRuleTypesHandler.cs
+
+backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/
+    GetClassificationRuleTypesHandlerTests.cs
+```
+
+Mirror the **exact** file layout and namespace of `GetAccountingTemplates/`. Namespace: `Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes`.
+
+### Interfaces and Contracts
+
+**Request (empty marker):**
+```csharp
+public class GetClassificationRuleTypesRequest : IRequest<GetClassificationRuleTypesResponse>
+{
+}
+```
+
+**Response (BaseResponse-derived, dual constructor matching siblings):**
+```csharp
+public class GetClassificationRuleTypesResponse : BaseResponse
+{
+    public List<ClassificationRuleTypeDto> RuleTypes { get; set; } = new();
+
+    public GetClassificationRuleTypesResponse() : base() { }
+
+    public GetClassificationRuleTypesResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters) { }
+}
+```
+
+**Handler:**
+```csharp
+public class GetClassificationRuleTypesHandler
+    : IRequestHandler<GetClassificationRuleTypesRequest, GetClassificationRuleTypesResponse>
+{
+    private readonly IEnumerable<IClassificationRule> _classificationRules;
+
+    public GetClassificationRuleTypesHandler(IEnumerable<IClassificationRule> classificationRules)
+    {
+        _classificationRules = classificationRules;
+    }
+
+    public Task<GetClassificationRuleTypesResponse> Handle(
+        GetClassificationRuleTypesRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ruleTypes = _classificationRules
+            .Select(rule => new ClassificationRuleTypeDto
+            {
+                Identifier = rule.Identifier,
+                DisplayName = rule.DisplayName,
+                Description = rule.Description
+            })
+            .ToList();
+
+        return Task.FromResult(new GetClassificationRuleTypesResponse { RuleTypes = ruleTypes });
+    }
+}
+```
+
+**Controller action (note the one-line unwrap to preserve HTTP contract):**
+```csharp
+[HttpGet("rule-types")]
+public async Task<ActionResult<List<ClassificationRuleTypeDto>>> GetAvailableRuleTypes(
+    CancellationToken cancellationToken)
+{
+    var response = await _mediator.Send(new GetClassificationRuleTypesRequest(), cancellationToken);
+    // Unwrap to preserve bare-array JSON contract; envelope kept internally for sibling consistency.
+    return Ok(response.RuleTypes);
+}
+```
+
+**Controller constructor:**
+```csharp
+private readonly IMediator _mediator;
+
+public InvoiceClassificationController(IMediator mediator)
+{
+    _mediator = mediator;
+}
+```
+
+Required `using` adjustments to `InvoiceClassificationController.cs`:
+- **Add:** `using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;`
+- **Remove:** `using Anela.Heblo.Domain.Features.InvoiceClassification;` (line 12) — verify no other reference to it remains in the file before deleting (grep the file after edits).
+
+### Data Flow
+
+1. Client `GET /api/InvoiceClassification/rule-types`.
+2. ASP.NET Core resolves `InvoiceClassificationController` with `IMediator` only.
+3. Action constructs an empty `GetClassificationRuleTypesRequest` and `Send`s it with the request `CancellationToken`.
+4. MediatR resolves `GetClassificationRuleTypesHandler` (scoped — same scope as the controller).
+5. Handler's `IEnumerable<IClassificationRule>` is materialized from DI (5 scoped instances per `InvoiceClassificationModule.cs:16–20`, in registration order).
+6. Handler projects each rule to a `ClassificationRuleTypeDto`, wraps in `GetClassificationRuleTypesResponse`, returns synchronously via `Task.FromResult`.
+7. Controller unwraps `response.RuleTypes` and returns `Ok(...)`.
+8. ASP.NET serializes as a JSON array. Element order is the DI-registration order from `InvoiceClassificationModule.cs` — identical to today.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Contributor "fixes" the controller to `return Ok(response)` for consistency with siblings, breaking the bare-array contract. | Medium | Inline comment in the action explaining the unwrap. Add a controller integration test (or assert in an existing test) that the response body is a JSON array, not an object. |
+| OpenAPI regeneration alters the operation's response type (e.g., from `ClassificationRuleTypeDto[]` to a generated `GetClassificationRuleTypesResponse`) because Swashbuckle infers from the `Send` envelope rather than the controller return type. | Medium | Controller action signature already declares `ActionResult<List<ClassificationRuleTypeDto>>` — Swashbuckle uses the declared return type, so the OpenAPI schema should be unchanged. **Verify** by running the OpenAPI generator and diffing `frontend/src/api/generated/` after the refactor; if the generated TypeScript client changes, treat that as a regression and adjust the action's response type attribute. |
+| Element ordering changes if DI resolution order differs from today. | Low | DI order is deterministic given identical registrations; no registration changes are in scope. Spec NFR-3 test case 3 (`Handle_PreservesEnumerationOrder`) locks this in. |
+| `IEnumerable<IClassificationRule>` is enumerated multiple times by accident (it's lazy). | Low | The handler enumerates exactly once via `Select(...).ToList()`. Test case 1 (empty collection) also exercises the enumeration. |
+| `dotnet format` rewrites `using` order in the controller, producing a noisy diff. | Low | Run `dotnet format` after edits and commit the formatted result; review the diff to confirm only intentional changes. |
+| Hidden test or DI consumer relies on the controller's `IEnumerable<IClassificationRule>` field (reflection, internals-visible-to). | Very Low | `grep` the solution for `_classificationRules` and `IEnumerable<IClassificationRule>` references in API and test projects before merging. |
+
+## Specification Amendments
+
+The spec (`spec.r2.md`) is internally consistent, accurately reflects the codebase, and resolves its prior open questions correctly. Two small clarifications worth folding into the spec:
+
+1. **Mandate a comment on the controller unwrap.** FR-3 should explicitly require an inline comment such as `// Unwrap to preserve bare-array JSON contract; envelope kept internally for sibling consistency.` This is a deliberate deviation from sibling pattern and needs a guardrail against well-meaning "consistency" edits. (This satisfies the WHY-only comment rule from the project's coding behavior — the comment is non-obvious context, not redundant narration.)
+
+2. **Add OpenAPI verification to the validation steps.** NFR-4 currently asks for `dotnet build`, `dotnet format`, and tests-green. Add: *"The OpenAPI document regenerates with no diff to the `/api/InvoiceClassification/rule-types` operation schema (response type still `ClassificationRuleTypeDto[]`). The generated TypeScript client (`frontend/src/api/generated/`) produces no diff for `getAvailableRuleTypes`."* This makes FR-5's existing contract claim a concrete, checkable step.
+
+3. **Pick `Task.FromResult` explicitly.** FR-2 currently leaves the choice between `async`-no-`await` and `Task.FromResult` open. Decide on `Task.FromResult` (no CS1998 warning, clearer intent). Minor; either works functionally.
+
+No other amendments needed.
+
+## Prerequisites
+
+None. All required infrastructure exists:
+
+- **MediatR is registered globally** via `ApplicationModule.cs:61` (`AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(ApplicationModule).Assembly))`). The new handler is auto-discovered with zero DI changes.
+- **`IClassificationRule` implementations are already registered** (`InvoiceClassificationModule.cs:16–20`) — five scoped registrations. Handler scope (scoped via MediatR) matches.
+- **`BaseResponse`, `ErrorCodes`, and `ClassificationRuleTypeDto` already exist** in their canonical locations.
+- **Test project** (`Anela.Heblo.Tests`) already references xUnit, FluentAssertions, and Moq (per `ClassifyInvoicesHandlerTests.cs:5–7`); no new test dependencies needed.
+- **No database migration, configuration entry, environment variable, or infrastructure change** is required.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-invoiceclassification-getava/brief.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/brief.md
@@ -1,0 +1,19 @@
+## Module
+InvoiceClassification
+
+## Finding
+`InvoiceClassificationController.GetAvailableRuleTypes()` (lines 76–86 of `backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs`) does not dispatch via MediatR. Instead, the controller:
+
+1. Declares a second constructor dependency on `IEnumerable<IClassificationRule>` — a Domain interface — injected directly into the API layer.
+2. Iterates over `_classificationRules`, projects each to a `ClassificationRuleTypeDto`, and returns the list from the action method itself.
+
+No handler exists for this operation; it is the only endpoint in the module that bypasses MediatR entirely.
+
+## Why it matters
+`development_guidelines.md` forbids business logic in controllers: _"Business logic must be in MediatR handlers, NOT in controllers"_. Projecting domain rule metadata to a DTO is business logic. Additionally, the controller taking a direct dependency on `IEnumerable<IClassificationRule>` creates a Domain→API layer dependency that bypasses the Application layer entirely, violating Clean Architecture's dependency rule. It also makes this operation untestable via handler unit tests.
+
+## Suggested fix
+Create a `GetClassificationRuleTypesHandler` in `Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/` that accepts the `IEnumerable<IClassificationRule>` dependency and maps to `ClassificationRuleTypeDto`. The controller action becomes a one-liner dispatching to MediatR, matching all other actions in the same controller. Remove `IEnumerable<IClassificationRule>` from the controller constructor.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-invoiceclassification-getava/impl/main.r1.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/impl/main.r1.md
@@ -1,67 +1,18 @@
-# Implementation: Refactor GetAvailableRuleTypes to MediatR Handler
+Implementation complete. Here's a summary of what was done:
 
-## What was implemented
+---
 
-Purely structural refactor of the `InvoiceClassification` module. Moved the DTO projection logic out of `InvoiceClassificationController.GetAvailableRuleTypes()` into a new MediatR handler `GetClassificationRuleTypesHandler`. Removed the direct Domain dependency (`IEnumerable<IClassificationRule>`) from the API controller, restoring the correct API → Application → Domain dependency direction.
+## Implementation: Refactor GetAvailableRuleTypes to MediatR Handler
 
-No behavior change. HTTP contract (route, verb, status code, JSON array shape) is identical.
+**Two commits landed on `feat-arch-review-invoiceclassification-getava`:**
 
-## Files created/modified
+1. `afb3d6c` — `feat: add GetClassificationRuleTypes MediatR handler and tests`
+   - Created 3 Application layer files (`Request`, `Response`, `Handler`) in the new `GetClassificationRuleTypes/` use case folder
+   - Created `GetClassificationRuleTypesHandlerTests.cs` with 3 passing tests
 
-- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesRequest.cs` — empty MediatR IRequest marker class
-- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesResponse.cs` — BaseResponse subclass carrying `List<ClassificationRuleTypeDto> RuleTypes`
-- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesHandler.cs` — handler that ctor-injects `IEnumerable<IClassificationRule>` and projects to DTOs via `Task.FromResult`
-- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs` — 3 xUnit tests (empty collection, multi-rule projection, order preservation)
-- `backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs` — removed `IClassificationRule` field/constructor param/Domain using; added GetClassificationRuleTypes using; updated action to async MediatR dispatch with RuleTypes unwrap
+2. `fec4445` — `refactor: remove IClassificationRule dependency from InvoiceClassificationController`
+   - Removed `IEnumerable<IClassificationRule>` constructor param and field from controller
+   - Removed `using Anela.Heblo.Domain.Features.InvoiceClassification;`
+   - Updated `GetAvailableRuleTypes()` to async MediatR dispatch, returning `Ok(response.RuleTypes)` to preserve the bare-array JSON contract
 
-## Tests
-
-`backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs`:
-- `Handle_WithEmptyRuleCollection_ReturnsEmptyList` — verifies empty input → empty RuleTypes, Success=true
-- `Handle_WithMultipleRules_ProjectsEachToDto` — 3 mocked rules → 3 DTOs with correct Identifier/DisplayName/Description
-- `Handle_PreservesEnumerationOrder` — order of input rules preserved in output DTOs
-
-All 3985 tests in the test suite pass.
-
-## How to verify
-
-```bash
-cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-invoiceclassification-getava
-
-# Build
-dotnet build backend/Anela.Heblo.sln
-
-# Handler tests
-dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~GetClassificationRuleTypesHandlerTests"
-
-# Full test suite
-dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
-
-# Confirm no Domain reference remains in controller
-grep -n "IClassificationRule\|_classificationRules\|Domain.Features.InvoiceClassification" \
-  backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs
-# Expected: no output
-```
-
-## Notes
-
-The controller action returns `Ok(response.RuleTypes)` (bare array) rather than `Ok(response)` (envelope object) — an intentional deviation from sibling actions. This preserves the existing HTTP contract. A comment in the action body explains the reason. The handler itself follows sibling conventions (returns `BaseResponse`-derived envelope).
-
-No DI registration changes required — the new handler is auto-discovered via MediatR's `AddMediatR(cfg => cfg.RegisterServicesFromAssembly(...))` assembly scan in `ApplicationModule.cs`.
-
-## PR Summary
-
-Structural refactor eliminating the one remaining API → Domain layering violation in `InvoiceClassificationController`. The `GetAvailableRuleTypes` action was the only action in the file not using MediatR — it held a direct constructor dependency on `IEnumerable<IClassificationRule>` (a Domain interface) and performed DTO projection inline. This change moves the projection into a new `GetClassificationRuleTypesHandler` in the Application layer, making the controller a thin dispatcher consistent with all sibling actions.
-
-The HTTP contract is unchanged: the controller unwraps `response.RuleTypes` to return the same bare JSON array as before (documented with an inline comment). The handler returns a `BaseResponse`-derived envelope internally, matching sibling handler conventions.
-
-### Changes
-- `GetClassificationRuleTypesRequest.cs` — new empty IRequest marker
-- `GetClassificationRuleTypesResponse.cs` — new BaseResponse subclass with List<ClassificationRuleTypeDto> RuleTypes
-- `GetClassificationRuleTypesHandler.cs` — new handler projecting IEnumerable<IClassificationRule> → DTOs via Task.FromResult
-- `GetClassificationRuleTypesHandlerTests.cs` — 3 unit tests (empty, multi-rule, order)
-- `InvoiceClassificationController.cs` — removed Domain dependency, updated action to MediatR dispatch
-
-## Status
-DONE
+**Results:** `dotnet build` ✅ zero errors — all 3985 tests pass — `dotnet format` no-diff.

--- a/artifacts/feat-arch-review-invoiceclassification-getava/impl/main.r1.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/impl/main.r1.md
@@ -1,0 +1,67 @@
+# Implementation: Refactor GetAvailableRuleTypes to MediatR Handler
+
+## What was implemented
+
+Purely structural refactor of the `InvoiceClassification` module. Moved the DTO projection logic out of `InvoiceClassificationController.GetAvailableRuleTypes()` into a new MediatR handler `GetClassificationRuleTypesHandler`. Removed the direct Domain dependency (`IEnumerable<IClassificationRule>`) from the API controller, restoring the correct API → Application → Domain dependency direction.
+
+No behavior change. HTTP contract (route, verb, status code, JSON array shape) is identical.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesRequest.cs` — empty MediatR IRequest marker class
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesResponse.cs` — BaseResponse subclass carrying `List<ClassificationRuleTypeDto> RuleTypes`
+- `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesHandler.cs` — handler that ctor-injects `IEnumerable<IClassificationRule>` and projects to DTOs via `Task.FromResult`
+- `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs` — 3 xUnit tests (empty collection, multi-rule projection, order preservation)
+- `backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs` — removed `IClassificationRule` field/constructor param/Domain using; added GetClassificationRuleTypes using; updated action to async MediatR dispatch with RuleTypes unwrap
+
+## Tests
+
+`backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs`:
+- `Handle_WithEmptyRuleCollection_ReturnsEmptyList` — verifies empty input → empty RuleTypes, Success=true
+- `Handle_WithMultipleRules_ProjectsEachToDto` — 3 mocked rules → 3 DTOs with correct Identifier/DisplayName/Description
+- `Handle_PreservesEnumerationOrder` — order of input rules preserved in output DTOs
+
+All 3985 tests in the test suite pass.
+
+## How to verify
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-invoiceclassification-getava
+
+# Build
+dotnet build backend/Anela.Heblo.sln
+
+# Handler tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetClassificationRuleTypesHandlerTests"
+
+# Full test suite
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+
+# Confirm no Domain reference remains in controller
+grep -n "IClassificationRule\|_classificationRules\|Domain.Features.InvoiceClassification" \
+  backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs
+# Expected: no output
+```
+
+## Notes
+
+The controller action returns `Ok(response.RuleTypes)` (bare array) rather than `Ok(response)` (envelope object) — an intentional deviation from sibling actions. This preserves the existing HTTP contract. A comment in the action body explains the reason. The handler itself follows sibling conventions (returns `BaseResponse`-derived envelope).
+
+No DI registration changes required — the new handler is auto-discovered via MediatR's `AddMediatR(cfg => cfg.RegisterServicesFromAssembly(...))` assembly scan in `ApplicationModule.cs`.
+
+## PR Summary
+
+Structural refactor eliminating the one remaining API → Domain layering violation in `InvoiceClassificationController`. The `GetAvailableRuleTypes` action was the only action in the file not using MediatR — it held a direct constructor dependency on `IEnumerable<IClassificationRule>` (a Domain interface) and performed DTO projection inline. This change moves the projection into a new `GetClassificationRuleTypesHandler` in the Application layer, making the controller a thin dispatcher consistent with all sibling actions.
+
+The HTTP contract is unchanged: the controller unwraps `response.RuleTypes` to return the same bare JSON array as before (documented with an inline comment). The handler returns a `BaseResponse`-derived envelope internally, matching sibling handler conventions.
+
+### Changes
+- `GetClassificationRuleTypesRequest.cs` — new empty IRequest marker
+- `GetClassificationRuleTypesResponse.cs` — new BaseResponse subclass with List<ClassificationRuleTypeDto> RuleTypes
+- `GetClassificationRuleTypesHandler.cs` — new handler projecting IEnumerable<IClassificationRule> → DTOs via Task.FromResult
+- `GetClassificationRuleTypesHandlerTests.cs` — 3 unit tests (empty, multi-rule, order)
+- `InvoiceClassificationController.cs` — removed Domain dependency, updated action to MediatR dispatch
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-invoiceclassification-getava/spec.r1.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/spec.r1.md
@@ -1,0 +1,139 @@
+# Specification: Refactor GetAvailableRuleTypes to MediatR Handler
+
+## Summary
+The `InvoiceClassificationController.GetAvailableRuleTypes()` endpoint currently bypasses MediatR and contains business logic in the controller, violating Clean Architecture's dependency rule and the project's development guidelines. This refactor moves the rule-type projection logic into a new `GetClassificationRuleTypesHandler` in the Application layer, making the controller action a thin MediatR dispatch matching the rest of the module.
+
+## Background
+The `InvoiceClassification` module follows a consistent MediatR + Vertical Slice pattern: every other endpoint in `InvoiceClassificationController` dispatches a request through `IMediator` to a feature-scoped handler under `Application/Features/InvoiceClassification/UseCases/`. The `GetAvailableRuleTypes()` action is the lone exception. It was implemented with two issues:
+
+1. **Layering violation** — The controller takes an `IEnumerable<IClassificationRule>` dependency directly. `IClassificationRule` is a Domain abstraction, and Domain interfaces should not be wired into the API layer. The Application layer is the correct seam for orchestrating Domain types and projecting them to DTOs.
+2. **Business logic in controller** — Iterating the rules and projecting each to `ClassificationRuleTypeDto` is application logic. Per `docs/architecture/development_guidelines.md`, controllers must not contain business logic. They dispatch via MediatR; handlers do the work.
+
+The current shape also blocks unit testing the projection via handler tests (today it can only be exercised through controller/integration tests).
+
+This refactor is purely structural — no behavior or contract change. The HTTP response shape, status codes, and route remain identical. Only the internal wiring moves.
+
+## Functional Requirements
+
+### FR-1: New MediatR Query and Handler
+Introduce a query/handler pair that returns the list of available classification rule types.
+
+**Acceptance criteria:**
+- A new query class `GetClassificationRuleTypesRequest` (or matching project naming convention, e.g. `GetClassificationRuleTypesQuery`) exists under `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/`.
+- The query implements `IRequest<GetClassificationRuleTypesResponse>` (or returns `List<ClassificationRuleTypeDto>` consistently with the module's existing handler return-type convention — see Open Questions).
+- A new handler class `GetClassificationRuleTypesHandler` exists in the same folder and implements `IRequestHandler<...>`.
+- The handler accepts `IEnumerable<IClassificationRule>` via constructor injection.
+- The handler iterates the injected rules and projects each into `ClassificationRuleTypeDto`, preserving the exact projection logic that exists today in the controller (same property mapping, same ordering).
+- The handler returns the projected list synchronously-completed `Task` (no I/O involved).
+- The handler is registered automatically via the existing MediatR assembly-scan registration in the Application layer (no manual `services.AddScoped` needed unless other handlers in the module require it).
+
+### FR-2: Controller Action Becomes One-Line Dispatch
+Refactor `InvoiceClassificationController.GetAvailableRuleTypes()` to dispatch through MediatR exactly like every other action in the file.
+
+**Acceptance criteria:**
+- The action body is a single `await _mediator.Send(new GetClassificationRuleTypesRequest(), cancellationToken)` call (or equivalent), wrapped in the same `Ok(...)` return pattern used by the other actions in the controller.
+- The action accepts a `CancellationToken` parameter consistent with the rest of the controller.
+- The HTTP route, verb, response DTO shape, and status codes (200 OK + JSON body) are unchanged.
+- Action-level attributes (`[HttpGet]`, route, `[ProducesResponseType]`, etc.) match what is currently declared on the action.
+
+### FR-3: Remove Domain Dependency From Controller
+Strip the direct `IEnumerable<IClassificationRule>` dependency from the API layer.
+
+**Acceptance criteria:**
+- `InvoiceClassificationController`'s constructor no longer declares `IEnumerable<IClassificationRule>` as a parameter.
+- Any backing field that held the rules (e.g. `_classificationRules`) is removed.
+- `using` statements that referenced the Domain rule interface are removed from the controller file if no longer used.
+- The API project's compilation graph no longer reaches `IClassificationRule` from this controller; the Domain dependency is isolated to the new Application-layer handler.
+
+### FR-4: Behavior Parity
+The externally visible behavior of the endpoint is identical before and after the refactor.
+
+**Acceptance criteria:**
+- A request to the existing route returns a JSON array with the same number of elements and same DTO content as before the change, given identical DI registrations of `IClassificationRule` implementations.
+- Element ordering is preserved (matches whatever DI resolution order produces today — no new sort is introduced).
+- No new query string parameters, headers, or response fields are added.
+- The OpenAPI document re-generates without breaking changes to consumers; the generated TypeScript client requires no manual fixups beyond regeneration.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change. The work is in-process enumeration of a DI-resolved collection (typically <20 items). Response time and throughput are unchanged.
+
+### NFR-2: Security
+No change. The endpoint's authorization attributes, if any, are preserved exactly as they are on the existing action.
+
+### NFR-3: Testability
+The projection logic must be unit-testable without spinning up the API.
+
+**Acceptance criteria:**
+- A unit test class for `GetClassificationRuleTypesHandler` exists under `backend/test/Anela.Heblo.Tests/` (or the project's standard handler-test location — see Open Questions on test project path).
+- Tests cover: (a) empty rule collection returns empty list, (b) a collection of fakes is projected correctly, (c) projection field mapping (each `ClassificationRuleTypeDto` property is populated from the expected source on `IClassificationRule`).
+- Tests use plain fakes/mocks of `IClassificationRule`; no DI container needed.
+
+### NFR-4: Architectural Compliance
+The refactor must satisfy the project's stated layering rules.
+
+**Acceptance criteria:**
+- API → Application → Domain dependency direction is preserved. The API project does not reference `IClassificationRule` directly through this controller after the change.
+- The handler resides in the Application layer's `InvoiceClassification` feature folder, matching the Vertical Slice organization used by sibling use cases.
+- No business logic (projection, filtering, mapping) remains in the controller action.
+
+## Data Model
+
+No persistence changes. The relevant types are:
+
+- `IClassificationRule` (Domain) — existing interface, unchanged. Provides the metadata being projected (rule type identifier, display name, and whatever other fields the current projection reads).
+- `ClassificationRuleTypeDto` (Application/Contracts) — existing DTO returned by the endpoint, unchanged. Per project rules, this remains a **class**, not a record.
+- `GetClassificationRuleTypesRequest` — new MediatR request marker; carries no payload.
+- `GetClassificationRuleTypesResponse` — optional wrapper if the module's convention is to wrap list returns in a response envelope; otherwise the handler returns `List<ClassificationRuleTypeDto>` directly. (See Open Questions.)
+
+Relationships: the handler depends on `IEnumerable<IClassificationRule>` resolved by DI; the request/response live alongside the handler in the feature folder.
+
+## API / Interface Design
+
+**Endpoint (unchanged externally):**
+- Route, verb, and response shape as currently defined on `InvoiceClassificationController.GetAvailableRuleTypes()`.
+- Response body: JSON array of `ClassificationRuleTypeDto`.
+
+**Internal interface (new):**
+```
+GetClassificationRuleTypesRequest  -->  GetClassificationRuleTypesHandler  -->  List<ClassificationRuleTypeDto>
+                                              ^
+                                              | ctor-injected
+                                       IEnumerable<IClassificationRule>
+```
+
+**Controller after change (illustrative):**
+```csharp
+[HttpGet("rule-types")]  // exact attributes preserved from current action
+public async Task<IActionResult> GetAvailableRuleTypes(CancellationToken cancellationToken)
+{
+    var result = await _mediator.Send(new GetClassificationRuleTypesRequest(), cancellationToken);
+    return Ok(result);
+}
+```
+
+## Dependencies
+
+- **MediatR** — already in use across the module; no version change.
+- **Existing DI registrations of `IClassificationRule` implementations** — must remain registered so the handler can receive them via `IEnumerable<IClassificationRule>`. The refactor does not modify these registrations.
+- **OpenAPI client generation** — runs on build; consumers (frontend TypeScript client) regenerate automatically. No manual frontend changes expected because the response contract is unchanged.
+
+## Out of Scope
+
+- Changing the response DTO (`ClassificationRuleTypeDto`) shape, fields, or naming.
+- Changing the HTTP route, verb, or status codes.
+- Adding pagination, filtering, sorting, or query parameters to the endpoint.
+- Refactoring other actions in `InvoiceClassificationController` (they already use MediatR correctly).
+- Touching `IClassificationRule`, its implementations, or their DI registration.
+- Frontend changes beyond the automatic OpenAPI client regeneration.
+- Adding new authorization policies or modifying existing ones.
+- Performance optimizations or caching of the rule list.
+
+## Open Questions
+
+1. **Response wrapper convention.** Does the `InvoiceClassification` module's existing handler return convention use a dedicated response class (e.g. `GetClassificationRuleTypesResponse { List<ClassificationRuleTypeDto> Items }`) or return the list directly as `List<ClassificationRuleTypeDto>`? Inspect a sibling handler in `Application/Features/InvoiceClassification/UseCases/` and match it. **Assumption if unanswered:** match the closest existing sibling handler's pattern; if mixed, return `List<ClassificationRuleTypeDto>` directly for simplicity.
+2. **Query vs. Request naming.** Does the project name MediatR read operations `...Query` or `...Request`? **Assumption if unanswered:** mirror the naming used by sibling handlers in the same module.
+3. **Test project location.** Confirm whether handler unit tests go in `backend/test/Anela.Heblo.Application.Tests/` or another path used by sibling InvoiceClassification handler tests. **Assumption if unanswered:** match the existing pattern of other InvoiceClassification handler tests in the repo.
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-arch-review-invoiceclassification-getava/spec.r2.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/spec.r2.md
@@ -1,0 +1,222 @@
+# Specification: Refactor GetAvailableRuleTypes to MediatR Handler
+
+## Summary
+The `InvoiceClassificationController.GetAvailableRuleTypes()` endpoint currently bypasses MediatR, performs DTO projection inside the controller, and takes a direct dependency on the Domain interface `IEnumerable<IClassificationRule>`. This refactor moves the projection into a new `GetClassificationRuleTypesHandler` in the Application layer, making the controller action a thin MediatR dispatch consistent with every other action in the file. The HTTP contract is unchanged.
+
+## Background
+The `InvoiceClassification` module follows a consistent MediatR + Vertical Slice pattern (see `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/`): every endpoint in `InvoiceClassificationController` dispatches a `...Request` through `IMediator` to a feature-scoped handler that returns a `...Response` class. The `GetAvailableRuleTypes()` action (lines 75–86 of `backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs`) is the lone exception:
+
+```csharp
+[HttpGet("rule-types")]
+public ActionResult<List<ClassificationRuleTypeDto>> GetAvailableRuleTypes()
+{
+    var ruleTypes = _classificationRules.Select(rule => new ClassificationRuleTypeDto
+    {
+        Identifier = rule.Identifier,
+        DisplayName = rule.DisplayName,
+        Description = rule.Description
+    }).ToList();
+
+    return Ok(ruleTypes);
+}
+```
+
+Two issues:
+
+1. **Layering violation** — The controller takes `IEnumerable<IClassificationRule>` directly (`InvoiceClassificationController.cs:22, 24`). `IClassificationRule` lives in `Anela.Heblo.Domain.Features.InvoiceClassification`, so the API project depends on a Domain abstraction without going through Application. Per `docs/architecture/development_guidelines.md`, the dependency direction must be API → Application → Domain.
+2. **Business logic in controller** — Iterating rules and projecting them to `ClassificationRuleTypeDto` is application logic. The same guideline document states: *"Business logic must be in MediatR handlers, NOT in controllers."*
+
+The shape also blocks handler-level unit testing of the projection (today only controller/integration tests can cover it).
+
+This refactor is purely structural — no behavior or contract change. Route, verb, status codes, response JSON shape, and element ordering remain identical. Only the internal wiring moves.
+
+### Conventions confirmed by codebase inspection
+
+The previously-open questions in `spec.r1.md` are resolved by direct inspection of sibling handlers (the `answers.r1.md` artifact provided addressed a different feature and is not applicable here):
+
+- **Request vs. Query naming.** Sibling handlers in the module use `...Request` (e.g. `GetAccountingTemplatesRequest`, `GetClassificationRulesRequest`, `GetClassificationHistoryRequest`). This refactor uses `GetClassificationRuleTypesRequest`.
+- **Response wrapper convention.** Every sibling handler returns a dedicated `...Response` class extending `Anela.Heblo.Application.Shared.BaseResponse` (e.g. `GetAccountingTemplatesResponse { List<AccountingTemplateDto> Templates }`, `GetClassificationRulesResponse { List<ClassificationRuleDto> Rules }`). This refactor uses `GetClassificationRuleTypesResponse { List<ClassificationRuleTypeDto> RuleTypes }`.
+- **Test project location.** Existing handler tests for this module live at `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/` (e.g. `ClassifyInvoicesHandlerTests.cs`). New tests go there.
+
+### Important caveat — HTTP response shape
+
+Because the existing action returns the bare list (`return Ok(ruleTypes)` where `ruleTypes` is `List<ClassificationRuleTypeDto>`) while sibling actions return their `...Response` envelope object, this refactor faces a tension:
+
+- **Follow sibling convention strictly** → wrap result in `GetClassificationRuleTypesResponse` → **breaking change** to the JSON shape (consumers would now see `{ ruleTypes: [...] }` instead of `[...]`).
+- **Preserve HTTP contract** (FR-4) → controller must unwrap the response envelope before returning `Ok(...)`.
+
+This spec takes the second path: the **handler returns the envelope** (matches sibling convention internally) and the **controller unwraps it** to keep the external JSON shape identical. This preserves FR-4 (no consumer impact, no OpenAPI break) while keeping the Application layer consistent with siblings.
+
+## Functional Requirements
+
+### FR-1: New MediatR Request and Response
+
+**Acceptance criteria:**
+- New file `backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesRequest.cs` defines `public class GetClassificationRuleTypesRequest : IRequest<GetClassificationRuleTypesResponse>` with no properties.
+- New file `.../GetClassificationRuleTypes/GetClassificationRuleTypesResponse.cs` defines `public class GetClassificationRuleTypesResponse : BaseResponse` with a single property `public List<ClassificationRuleTypeDto> RuleTypes { get; set; } = new();` and a parameterless constructor plus the `(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)` constructor matching the `BaseResponse` convention used by siblings (see `GetAccountingTemplatesResponse.cs`).
+- Both files declare namespace `Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes`.
+- Per project rule, both types are `class`, not `record`.
+
+### FR-2: New MediatR Handler
+
+**Acceptance criteria:**
+- New file `.../GetClassificationRuleTypes/GetClassificationRuleTypesHandler.cs` defines `public class GetClassificationRuleTypesHandler : IRequestHandler<GetClassificationRuleTypesRequest, GetClassificationRuleTypesResponse>`.
+- Handler constructor takes a single parameter: `IEnumerable<IClassificationRule> classificationRules`, stored in a `private readonly` field.
+- `Handle(GetClassificationRuleTypesRequest request, CancellationToken cancellationToken)` projects each rule into a `ClassificationRuleTypeDto` with the same three field mappings as the current controller (`Identifier`, `DisplayName`, `Description`), returns a populated `GetClassificationRuleTypesResponse`.
+- The method body is `Task.FromResult(...)` (no async I/O is needed), or the method is `async` with no `await` and a suppression — the project's other simple handlers may guide which is preferred, but functional correctness is the only hard requirement.
+- The handler is picked up automatically by the existing MediatR assembly-scan registration in the Application layer; no manual `services.AddScoped<...>` is required.
+
+### FR-3: Refactor Controller Action
+
+**Acceptance criteria:**
+- `InvoiceClassificationController.GetAvailableRuleTypes()` becomes:
+  ```csharp
+  [HttpGet("rule-types")]
+  public async Task<ActionResult<List<ClassificationRuleTypeDto>>> GetAvailableRuleTypes(CancellationToken cancellationToken)
+  {
+      var response = await _mediator.Send(new GetClassificationRuleTypesRequest(), cancellationToken);
+      return Ok(response.RuleTypes);
+  }
+  ```
+- The action signature changes from synchronous `ActionResult<List<ClassificationRuleTypeDto>>` to `Task<ActionResult<List<ClassificationRuleTypeDto>>>` and accepts a `CancellationToken`, matching the other actions in the file (e.g. lines 31, 39, 46, 53, 61, 69, 89, 97, 120, 132).
+- The HTTP route (`"rule-types"`), verb (`HttpGet`), `ActionResult<T>` envelope, response JSON shape (bare array of `ClassificationRuleTypeDto`), and status code (200 OK) are unchanged.
+- A `using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;` directive is added to the controller file.
+
+### FR-4: Remove Domain Dependency From Controller
+
+**Acceptance criteria:**
+- The constructor parameter `IEnumerable<IClassificationRule> classificationRules` is removed from `InvoiceClassificationController`.
+- The field `private readonly IEnumerable<IClassificationRule> _classificationRules;` is removed.
+- The controller constructor is updated to take only `IMediator mediator`.
+- The `using Anela.Heblo.Domain.Features.InvoiceClassification;` directive (line 12) is removed from the controller file (no other reference to the Domain namespace exists in this file).
+- Building the API project does not produce a compile-time reference from `InvoiceClassificationController` to `IClassificationRule`.
+
+### FR-5: Behavior Parity
+
+**Acceptance criteria:**
+- A GET to `/api/InvoiceClassification/rule-types` returns a JSON array (not an object) with the same number of elements and the same per-element shape (`{ identifier, displayName, description }`) as before the change, given identical DI registrations of `IClassificationRule` implementations.
+- Element ordering matches the DI-resolution order produced today — no new sort is introduced.
+- No new query string parameters, headers, or response fields are added or removed.
+- The OpenAPI document regenerates without breaking changes to consumers. The generated TypeScript client (`frontend/src/api/generated/`) requires no manual fixups beyond automatic regeneration.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change. The work is in-process enumeration of a DI-resolved collection (typically <20 items). Latency and throughput are unchanged. An extra MediatR pipeline dispatch is introduced but its overhead is negligible relative to network and serialization costs already present in every other endpoint in the controller.
+
+### NFR-2: Security
+No change. The endpoint has no `[Authorize]` attribute at the action level today; if a class-level policy applies, it continues to apply unchanged. No new data is exposed, no input is accepted from the client.
+
+### NFR-3: Testability
+
+**Acceptance criteria:**
+- New file `backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs` is created.
+- Tests use xUnit + FluentAssertions + Moq/NSubstitute consistent with `ClassifyInvoicesHandlerTests.cs` in the same folder.
+- Test cases at minimum:
+  1. `Handle_WithEmptyRuleCollection_ReturnsEmptyList` — empty `IEnumerable<IClassificationRule>` → response with empty `RuleTypes`, `Success == true`.
+  2. `Handle_WithMultipleRules_ProjectsEachToDto` — three fake rules → response contains three DTOs in the same order, each with `Identifier`/`DisplayName`/`Description` matching the source.
+  3. `Handle_PreservesEnumerationOrder` — explicit order check on a multi-element list.
+- Tests construct fake `IClassificationRule` implementations (mocked stubs returning the three properties) without spinning up a DI container or the API host.
+
+### NFR-4: Architectural Compliance
+
+**Acceptance criteria:**
+- The API project no longer references `IClassificationRule` from `InvoiceClassificationController`. (It may still reference the Domain namespace elsewhere in the project; this requirement is scoped to the controller file.)
+- The new handler resides in `Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/`, matching the Vertical Slice convention used by all sibling use cases.
+- No business logic (projection, mapping, filtering, ordering) remains in `GetAvailableRuleTypes()`. The action body is exactly two statements: dispatch and `Ok(...)`.
+- `dotnet build` succeeds, `dotnet format` reports no diff on the changed files, and existing tests remain green.
+
+## Data Model
+
+No persistence changes. Types involved:
+
+| Type | Layer | Status | Purpose |
+|------|-------|--------|---------|
+| `IClassificationRule` | Domain | Unchanged | Provides `Identifier`, `DisplayName`, `Description` properties. |
+| `ClassificationRuleTypeDto` | Application/Contracts | Unchanged | `class` (not `record`); shape is `{ Identifier, DisplayName, Description }`. |
+| `GetClassificationRuleTypesRequest` | Application/UseCases | **New** | Empty marker; `IRequest<GetClassificationRuleTypesResponse>`. |
+| `GetClassificationRuleTypesResponse` | Application/UseCases | **New** | Extends `BaseResponse`; carries `List<ClassificationRuleTypeDto> RuleTypes`. |
+
+DI relationships: the new handler depends on `IEnumerable<IClassificationRule>` resolved by the existing DI registrations (untouched). The request/response types live alongside the handler in the feature folder.
+
+## API / Interface Design
+
+### External (HTTP) — unchanged
+
+```
+GET /api/InvoiceClassification/rule-types
+→ 200 OK
+[
+  { "identifier": "...", "displayName": "...", "description": "..." },
+  ...
+]
+```
+
+### Internal (process)
+
+```
+Controller.GetAvailableRuleTypes(ct)
+    │
+    ▼
+IMediator.Send(GetClassificationRuleTypesRequest, ct)
+    │
+    ▼
+GetClassificationRuleTypesHandler.Handle(...)
+    │ uses
+    ▼
+IEnumerable<IClassificationRule>   ◄── ctor-injected
+    │ projects to
+    ▼
+GetClassificationRuleTypesResponse { RuleTypes: List<ClassificationRuleTypeDto> }
+    │
+    ▼
+Controller returns Ok(response.RuleTypes)   ← unwraps to keep external array shape
+```
+
+### Controller after refactor (illustrative, full action body)
+
+```csharp
+[HttpGet("rule-types")]
+public async Task<ActionResult<List<ClassificationRuleTypeDto>>> GetAvailableRuleTypes(CancellationToken cancellationToken)
+{
+    var response = await _mediator.Send(new GetClassificationRuleTypesRequest(), cancellationToken);
+    return Ok(response.RuleTypes);
+}
+```
+
+### Controller constructor after refactor
+
+```csharp
+private readonly IMediator _mediator;
+
+public InvoiceClassificationController(IMediator mediator)
+{
+    _mediator = mediator;
+}
+```
+
+## Dependencies
+
+- **MediatR** — already in use across the module; no version change.
+- **Existing DI registrations of `IClassificationRule` implementations** — must remain registered (likely in `InvoiceClassificationModule.cs`) so the handler receives them via `IEnumerable<IClassificationRule>`. The refactor does not modify these registrations.
+- **`Anela.Heblo.Application.Shared.BaseResponse`** — base class for the new response, already used by every sibling response in the module.
+- **OpenAPI client generation** — runs on build; consumer (frontend TypeScript client) regenerates automatically. No manual frontend changes expected because the response contract is unchanged.
+
+## Out of Scope
+
+- Changing the `ClassificationRuleTypeDto` shape, fields, or naming.
+- Changing the HTTP route, verb, response status codes, or external JSON shape.
+- Adding pagination, filtering, sorting, or query parameters to the endpoint.
+- Refactoring other actions in `InvoiceClassificationController` (they already use MediatR correctly).
+- Touching `IClassificationRule`, its concrete implementations, or their DI registration.
+- Frontend changes beyond automatic OpenAPI client regeneration.
+- Adding or modifying authorization policies.
+- Performance optimizations or caching of the rule list.
+- Reorganizing or renaming the `IClassificationRule` interface across layers.
+- Mapping via AutoMapper — this projection is small and explicit; sibling handlers use AutoMapper only when the source/target are persistence entities, not DI-resolved metadata.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-invoiceclassification-getava/task-plan.r1.md
+++ b/artifacts/feat-arch-review-invoiceclassification-getava/task-plan.r1.md
@@ -1,0 +1,760 @@
+# Refactor UpdateManufactureOrderStatusHandler to use ICurrentUserService Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct `IHttpContextAccessor` dependency in `UpdateManufactureOrderStatusHandler` with the existing `ICurrentUserService` abstraction so that audit fields use the same identity-resolution chain as the rest of the Application layer, stopping authenticated users from being incorrectly stamped as `"System"` when the `Identity.Name` claim is absent.
+
+**Architecture:** Surgical refactor of a single Application-layer handler. The handler stops resolving `HttpContext.User.Identity.Name` directly and instead calls `ICurrentUserService.GetCurrentUser().GetDisplayName()` once per `Handle` invocation, passing the resolved name into `WriteDownInventoryAsync` so both audit fields (`order.StateChangedByUser` and `ManufacturedProductInventoryItem.CreatedBy`) come from a single resolution. Two existing test classes swap their `IHttpContextAccessor` mock for an `ICurrentUserService` mock; one new test covers the bug-fix scenario (authenticated principal without a `Name` claim → `"Unknown User"`, not `"System"`).
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, Moq, FluentAssertions. No new packages.
+
+**Spec amendments adopted from arch-review:**
+- **Amendment 1a (FR-4):** Test asserts `"Unknown User"` (not `preferred_username`) for an authenticated principal whose `Name` is null. The existing `CurrentUserService` chain (`Identity.Name → ClaimTypes.Name → "name" → "Unknown User"`) is *not* modified in this refactor.
+- **Amendment 2 (FR-2):** The user name is resolved exactly once per `Handle` invocation and passed into `WriteDownInventoryAsync` as a parameter, so `StateChangedByUser` and `ManufacturedProductInventoryItem.CreatedBy` cannot diverge for the same transition.
+
+---
+
+## File Structure
+
+**Modified (3 files):**
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs` — swap dependency, delete `GetCurrentUserName`, resolve user once, parameterise `WriteDownInventoryAsync`.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs` — swap mock, rename `Handle_WithoutHttpContext_ShouldUseSystemAsUser`, add the new FR-4 test.
+- `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs` — swap mock.
+
+**Not modified (verified):**
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — `ICurrentUserService` is already registered (line 130). `IHttpContextAccessor` registration remains, other consumers still need it.
+- `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs` — Out of scope (Amendment 1b explicitly rejected).
+- `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUserExtensions.cs` — already returns `"System"` for unauthenticated, `Name ?? "Unknown User"` for authenticated.
+
+**No DI registration changes**, no DB migrations, no frontend changes, no config flags, no new files.
+
+---
+
+## Task 1: Refactor test files to use ICurrentUserService mock + add FR-4 test (RED)
+
+> TDD anchor — write the tests against the new constructor *before* changing the handler. The solution will fail to build at the end of this task; that is the RED state we want before Task 2 makes it GREEN.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`
+
+### Step 1.1: Rewrite test class `UpdateManufactureOrderStatusHandlerTests` constructor and setup
+
+- [ ] **Replace the `using` block, field declarations, constants, and constructor in `UpdateManufactureOrderStatusHandlerTests.cs`** so the test class mocks `ICurrentUserService` instead of `IHttpContextAccessor`.
+
+In `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs`:
+
+Replace lines 1-11 (the `using` block) with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+(Removed: `Microsoft.AspNetCore.Http`, `System.Security.Claims`.)
+
+Replace lines 17-67 (field declarations through the end of the constructor) with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
+    private readonly UpdateManufactureOrderStatusHandler _handler;
+
+    private const int ValidOrderId = 1;
+    private const int NonExistentOrderId = 999;
+    private const string TestUserName = "Test User";
+    private const string ValidChangeReason = "Moving to next phase";
+
+    public UpdateManufactureOrderStatusHandlerTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+        _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: TestUserName,
+                Email: "test@example.com",
+                IsAuthenticated: true));
+
+        _conditionsProviderMock
+            .Setup(x => x.GetCurrentSnapshotAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConditionsSnapshot(null, null, null, null, DateTime.UtcNow, ConditionsReadingSource.Unavailable));
+
+        _inventoryRepositoryMock
+            .Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<ManufacturedProductInventoryItem>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<ManufacturedProductInventoryItem> items, CancellationToken _) => items);
+
+        _handler = new UpdateManufactureOrderStatusHandler(
+            _repositoryMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _conditionsProviderMock.Object,
+            _inventoryRepositoryMock.Object);
+    }
+```
+
+**Notes for the implementer:**
+- The positional ordering of constructor args in the `new UpdateManufactureOrderStatusHandler(...)` call is identical to the production constructor (per Decision 3): `_currentUserServiceMock.Object` takes the slot previously occupied by `_httpContextAccessorMock.Object`.
+- `CurrentUser` is a record in `Anela.Heblo.Domain.Features.Users` (already in scope via the new `using`).
+
+### Step 1.2: Rewrite the existing "WithoutHttpContext" test as an unauthenticated-user test
+
+- [ ] **Replace the `Handle_WithoutHttpContext_ShouldUseSystemAsUser` test (lines 194-230 of the original file)** with an unauthenticated-user setup that drives the same assertion through the new abstraction.
+
+Find:
+
+```csharp
+    [Fact]
+    public async Task Handle_WithoutHttpContext_ShouldUseSystemAsUser()
+    {
+        _httpContextAccessorMock
+            .Setup(x => x.HttpContext)
+            .Returns((HttpContext?)null);
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+```
+
+Replace with:
+
+```csharp
+    [Fact]
+    public async Task Handle_UnauthenticatedUser_ShouldUseSystemAsUser()
+    {
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: null,
+                Name: null,
+                Email: null,
+                IsAuthenticated: false));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("System");
+    }
+```
+
+**Rationale:** `CurrentUserExtensions.GetDisplayName()` returns `"System"` exactly when `IsAuthenticated == false`. Setting up an unauthenticated `CurrentUser` is the new abstraction's analogue of the old "no HttpContext" scenario, and preserves the FR-5 acceptance criterion.
+
+### Step 1.3: Add the new FR-4 bug-fix test
+
+- [ ] **Insert a new test immediately after the renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser` test** (i.e. right before `Handle_WhenRepositoryGetThrows_ShouldReturnInternalServerError`):
+
+```csharp
+    [Fact]
+    public async Task Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem()
+    {
+        // Entra ID access tokens frequently omit the Name/upn claim used by Identity.Name.
+        // Before the refactor this case fell through to "System" (the bug). Per spec FR-4
+        // (Amendment 1a), the handler should now stamp "Unknown User" for an authenticated
+        // principal whose Name is null.
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "abc123",
+                Name: null,
+                Email: "user@example.com",
+                IsAuthenticated: true));
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Planned
+        };
+
+        var existingOrder = CreateOrderInState(ManufactureOrderState.Draft);
+        ManufactureOrder? updatedOrder = null;
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingOrder);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder order, CancellationToken ct) =>
+            {
+                updatedOrder = order;
+                return order;
+            });
+
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue();
+        result.StateChangedByUser.Should().Be("Unknown User");
+        result.StateChangedByUser.Should().NotBe("System");
+
+        updatedOrder.Should().NotBeNull();
+        updatedOrder!.StateChangedByUser.Should().Be("Unknown User");
+    }
+```
+
+### Step 1.4: Rewrite test class `UpdateManufactureOrderStatusHandlerConditionsTests` to use the same mock swap
+
+- [ ] **Edit `backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs`** — replace the imports, mock field, constructor setup, and `CreateHandler()` body.
+
+Replace lines 1-9 (the `using` block) with:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+```
+
+(Removed: `Microsoft.AspNetCore.Http`, `System.Security.Claims`.)
+
+Replace lines 15-47 (field declarations through end of `CreateHandler`) with:
+
+```csharp
+    private readonly Mock<IManufactureOrderRepository> _repositoryMock;
+    private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+    private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
+    private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
+
+    public UpdateManufactureOrderStatusHandlerConditionsTests()
+    {
+        _repositoryMock = new Mock<IManufactureOrderRepository>();
+        _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
+        _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+        _currentUserServiceMock = new Mock<ICurrentUserService>();
+
+        _currentUserServiceMock
+            .Setup(x => x.GetCurrentUser())
+            .Returns(new CurrentUser(
+                Id: "test-id",
+                Name: "Test User",
+                Email: "test@example.com",
+                IsAuthenticated: true));
+
+        _inventoryRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufacturedProductInventoryItem item, CancellationToken _) => item);
+    }
+
+    private UpdateManufactureOrderStatusHandler CreateHandler() =>
+        new UpdateManufactureOrderStatusHandler(
+            _repositoryMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object,
+            _currentUserServiceMock.Object,
+            _conditionsProviderMock.Object,
+            _inventoryRepositoryMock.Object);
+```
+
+### Step 1.5: Verify the solution does NOT compile (RED)
+
+- [ ] **Run `dotnet build` from the repository root** and confirm compilation fails.
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: FAIL.
+
+Expected error symptom (one or both files):
+- `CS0246: The type or namespace name 'IHttpContextAccessor' could not be found` — only if leftover references slipped through; if you see this, re-grep and clean.
+- `CS1503: cannot convert from 'Moq.Mock<ICurrentUserService>.Object' to 'IHttpContextAccessor'` — this is the *expected* failure: the production constructor still demands `IHttpContextAccessor`. This is what proves the tests now drive a constructor change.
+
+Do **not** proceed if you see only `IHttpContextAccessor` missing-import errors — that means the test files still reference it. Re-check Step 1.1 / Step 1.4 imports.
+
+### Step 1.6: Commit the failing tests
+
+- [ ] **Commit the two test files** so the RED state is captured in history before the handler refactor.
+
+Run:
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+git commit -m "test: drive UpdateManufactureOrderStatusHandler to ICurrentUserService
+
+Replace IHttpContextAccessor mock with ICurrentUserService mock in both
+handler test classes, rename the no-HttpContext test to an
+unauthenticated-user test, and add a new test covering FR-4 (authenticated
+principal without Name claim must record \"Unknown User\", not \"System\").
+
+Solution does not build yet — production handler still requires
+IHttpContextAccessor. The next commit refactors the handler to match."
+```
+
+---
+
+## Task 2: Refactor handler to use ICurrentUserService (GREEN)
+
+> Now that the tests drive the new contract, change the production code minimally to match.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+
+### Step 2.1: Swap imports and dependency field
+
+- [ ] **In `UpdateManufactureOrderStatusHandler.cs`**, replace the imports and the dependency field.
+
+Find (lines 1-7):
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Manufacture;
+using Anela.Heblo.Domain.Features.Manufacture.Conditions;
+using Anela.Heblo.Domain.Features.Manufacture.Inventory;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+```
+
+Then find (line 17):
+
+```csharp
+    private readonly IHttpContextAccessor _httpContextAccessor;
+```
+
+Replace with:
+
+```csharp
+    private readonly ICurrentUserService _currentUserService;
+```
+
+### Step 2.2: Swap constructor parameter and assignment
+
+- [ ] **Update the constructor**. Find lines 20-34:
+
+```csharp
+    public UpdateManufactureOrderStatusHandler(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider,
+        ILogger<UpdateManufactureOrderStatusHandler> logger,
+        IHttpContextAccessor httpContextAccessor,
+        IConditionsReadingProvider conditionsProvider,
+        IManufacturedProductInventoryRepository inventoryRepository)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _httpContextAccessor = httpContextAccessor;
+        _conditionsProvider = conditionsProvider;
+        _inventoryRepository = inventoryRepository;
+    }
+```
+
+Replace with:
+
+```csharp
+    public UpdateManufactureOrderStatusHandler(
+        IManufactureOrderRepository repository,
+        TimeProvider timeProvider,
+        ILogger<UpdateManufactureOrderStatusHandler> logger,
+        ICurrentUserService currentUserService,
+        IConditionsReadingProvider conditionsProvider,
+        IManufacturedProductInventoryRepository inventoryRepository)
+    {
+        _repository = repository;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _currentUserService = currentUserService;
+        _conditionsProvider = conditionsProvider;
+        _inventoryRepository = inventoryRepository;
+    }
+```
+
+The slot position of the swapped parameter is unchanged (slot 4 of 6) per arch-review Decision 3.
+
+### Step 2.3: Resolve user name once and reuse across call sites
+
+- [ ] **Inside `Handle`, resolve the user name once after the state-transition validation and use it for both audit fields.**
+
+Find (lines 48-64 of the original — the block from `var oldState = order.State;` through `order.StateChangedByUser = GetCurrentUserName();`):
+
+```csharp
+            var oldState = order.State;
+
+            // Validate state transition (basic validation - can be extended)
+            if (!IsValidStateTransition(oldState, request.NewState))
+            {
+                return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
+                    new Dictionary<string, string>
+                    {
+                        { "oldState", oldState.ToString() },
+                        { "newState", request.NewState.ToString() }
+                    });
+            }
+
+            // Update state
+            order.State = request.NewState;
+            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+            order.StateChangedByUser = GetCurrentUserName();
+```
+
+Replace with:
+
+```csharp
+            var oldState = order.State;
+
+            // Validate state transition (basic validation - can be extended)
+            if (!IsValidStateTransition(oldState, request.NewState))
+            {
+                return new UpdateManufactureOrderStatusResponse(Application.Shared.ErrorCodes.InvalidOperation,
+                    new Dictionary<string, string>
+                    {
+                        { "oldState", oldState.ToString() },
+                        { "newState", request.NewState.ToString() }
+                    });
+            }
+
+            var currentUserName = _currentUserService.GetCurrentUser().GetDisplayName();
+
+            // Update state
+            order.State = request.NewState;
+            order.StateChangedAt = _timeProvider.GetUtcNow().DateTime;
+            order.StateChangedByUser = currentUserName;
+```
+
+**Why resolve here, not at the top of the method?** Resolving after the validation guard skips the (cheap) extension-method call for failed validations and matches the previous placement of `GetCurrentUserName()` — keeps the diff surgical.
+
+### Step 2.4: Pass the resolved user into `WriteDownInventoryAsync`
+
+- [ ] **Update the `WriteDownInventoryAsync` call site.** Find (line 135):
+
+```csharp
+                await WriteDownInventoryAsync(order, cancellationToken);
+```
+
+Replace with:
+
+```csharp
+                await WriteDownInventoryAsync(order, currentUserName, cancellationToken);
+```
+
+### Step 2.5: Update `WriteDownInventoryAsync` signature and body
+
+- [ ] **Add the `string changedByUser` parameter and remove the in-body resolution.** Find (lines 175-195 of the original):
+
+```csharp
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, CancellationToken cancellationToken)
+    {
+        var user = GetCurrentUserName();
+        var timestamp = _timeProvider.GetUtcNow().DateTime;
+
+        var items = order.Products
+            .Where(p => p.ActualQuantity is > 0)
+            .Select(p => new ManufacturedProductInventoryItem(
+                productCode: p.ProductCode,
+                productName: p.ProductName,
+                amount: p.ActualQuantity!.Value,
+                createdBy: user,
+                createdAt: timestamp,
+                lotNumber: p.LotNumber,
+                expirationDate: p.ExpirationDate,
+                manufactureOrderId: order.Id))
+            .ToList();
+
+        if (items.Count > 0)
+            await _inventoryRepository.AddRangeAsync(items, cancellationToken);
+    }
+```
+
+Replace with:
+
+```csharp
+    private async Task WriteDownInventoryAsync(ManufactureOrder order, string changedByUser, CancellationToken cancellationToken)
+    {
+        var timestamp = _timeProvider.GetUtcNow().DateTime;
+
+        var items = order.Products
+            .Where(p => p.ActualQuantity is > 0)
+            .Select(p => new ManufacturedProductInventoryItem(
+                productCode: p.ProductCode,
+                productName: p.ProductName,
+                amount: p.ActualQuantity!.Value,
+                createdBy: changedByUser,
+                createdAt: timestamp,
+                lotNumber: p.LotNumber,
+                expirationDate: p.ExpirationDate,
+                manufactureOrderId: order.Id))
+            .ToList();
+
+        if (items.Count > 0)
+            await _inventoryRepository.AddRangeAsync(items, cancellationToken);
+    }
+```
+
+### Step 2.6: Delete the obsolete `GetCurrentUserName()` helper
+
+- [ ] **Remove the entire `GetCurrentUserName()` method.** Find (lines 169-173):
+
+```csharp
+    private string GetCurrentUserName()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        return user?.Identity?.Name ?? "System";
+    }
+```
+
+Delete those five lines plus the blank line that precedes them. After deletion, `IsValidStateTransition` should be immediately followed by `WriteDownInventoryAsync` (with one blank line between them, as in the rest of the file).
+
+### Step 2.7: Verify no stale references to `IHttpContextAccessor` or `GetCurrentUserName` remain in the handler
+
+- [ ] **Grep the handler file to confirm a clean refactor.**
+
+Run:
+
+```bash
+grep -n "IHttpContextAccessor\|_httpContextAccessor\|GetCurrentUserName\|Microsoft\.AspNetCore\.Http" \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+```
+
+Expected: no output (exit code 1). If any line matches, return to the appropriate sub-step above.
+
+### Step 2.8: Build the solution (GREEN — compile)
+
+- [ ] **Compile and confirm success.**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: PASS, zero new warnings.
+
+If the build fails:
+- **`CS0246` on `ICurrentUserService` or `CurrentUserExtensions`**: the `using Anela.Heblo.Domain.Features.Users;` import is missing in the handler. Add it.
+- **`CS1503` constructor argument mismatch in some other consumer**: there are no other consumers — `UpdateManufactureOrderStatusHandler` is only newed up via DI and in the two test classes you already updated. If you see this, you missed a test-class swap; redo Task 1.
+
+### Step 2.9: Run the affected test classes (GREEN — behavior)
+
+- [ ] **Run both targeted test classes.**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~UpdateManufactureOrderStatusHandlerTests|FullyQualifiedName~UpdateManufactureOrderStatusHandlerConditionsTests" \
+  --no-build
+```
+
+Expected:
+- All tests in `UpdateManufactureOrderStatusHandlerTests` pass — including the new `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` and the renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser`.
+- All tests in `UpdateManufactureOrderStatusHandlerConditionsTests` pass — the conditions logic is independent of the user resolution.
+
+If a test fails:
+- `Handle_WithValidTransition_ShouldUpdateStateAndReturnResponse` asserting `TestUserName == "Test User"`: verify the constructor mock setup in Step 1.1 returns `Name: TestUserName` (not null).
+- `Handle_TransitionToCompleted_CreatesInventoryItemsForFinishedProducts` asserting `i.CreatedBy == TestUserName`: same diagnosis — the mock's `Name` must be `TestUserName`. The inventory `CreatedBy` now flows from the same resolution as `StateChangedByUser`, so the assertion still holds.
+- `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` asserting `"Unknown User"`: confirm Step 2.3 calls `GetDisplayName()` (not `currentUser.Name`). The display-name extension is what produces `"Unknown User"` for authenticated principals whose `Name` is null.
+
+### Step 2.10: Commit the handler refactor
+
+- [ ] **Commit the production change.**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+git commit -m "refactor: UpdateManufactureOrderStatusHandler uses ICurrentUserService
+
+Replace the direct IHttpContextAccessor dependency with the shared
+ICurrentUserService abstraction and resolve the user display name once
+per Handle invocation via CurrentUserExtensions.GetDisplayName(). Pass
+the resolved name into WriteDownInventoryAsync so order.StateChangedByUser
+and ManufacturedProductInventoryItem.CreatedBy share a single source.
+
+Fixes audit-trail entries that were stamped as \"System\" for authenticated
+users whose Entra ID token omits the Name/upn claim. Such users are now
+stamped \"Unknown User\" (per existing CurrentUserService fallback chain);
+truly unauthenticated callers (background jobs) continue to stamp \"System\".
+
+Removes one Application-layer consumer of IHttpContextAccessor (moves the
+broader cleanup from N to N-1; sibling consumer tracked in #1716)."
+```
+
+---
+
+## Task 3: Full validation, format, and final sweep
+
+**Files:** No code changes in this task; validation only.
+
+### Step 3.1: Apply formatting and analyzer fixes
+
+- [ ] **Run `dotnet format` over the touched files.**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include \
+  backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+```
+
+Expected: command exits 0, no changes (or only trivial whitespace alignment).
+
+If `dotnet format` did modify files, inspect the diff with `git diff` to confirm only whitespace / import ordering changes. Then commit:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+git commit -m "chore: dotnet format"
+```
+
+(Skip the commit step if there were no changes.)
+
+### Step 3.2: Run the full backend test suite
+
+- [ ] **Run the entire backend test project** to confirm nothing else regressed.
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build`
+
+Expected: all tests pass.
+
+If something unrelated fails, do not "fix" it inside this refactor — note it for the user and stop. Per CLAUDE.md, every changed line must trace directly to the request.
+
+### Step 3.3: Final IHttpContextAccessor consumer audit (informational)
+
+- [ ] **Grep the Application project for remaining `IHttpContextAccessor` consumers** and confirm the count dropped by exactly one.
+
+Run:
+
+```bash
+grep -rl "IHttpContextAccessor" backend/src/Anela.Heblo.Application/
+```
+
+Expected: `UpdateManufactureOrderStatusHandler.cs` no longer appears in the list. Other consumers (tracked in issue #1716) remain and are out of scope for this refactor — do not touch them.
+
+This step produces no commit; it confirms NFR-3 (`Anela.Heblo.Application` has one fewer file that imports `IHttpContextAccessor`).
+
+---
+
+## Self-review against the spec
+
+This section is a checklist run by the implementer before declaring the refactor done. Each spec requirement is matched to a task that implements it.
+
+| Spec section | Acceptance criterion | Implementing step |
+|---|---|---|
+| **FR-1** | No `IHttpContextAccessor` field/param/import in handler | Step 2.1, 2.2, 2.7 |
+| **FR-1** | Single `ICurrentUserService _currentUserService` field | Step 2.1, 2.2 |
+| **FR-1** | `GetCurrentUserName()` removed | Step 2.6 |
+| **FR-1** | `dotnet build` succeeds, no new warnings | Step 2.8 |
+| **FR-2** | All previous call sites use `GetCurrentUser().GetDisplayName()` | Step 2.3, 2.5 |
+| **FR-2** | No `_httpContextAccessor` in handler | Step 2.7 |
+| **FR-2** | `StateChangedByUser` populated from `GetDisplayName()` | Step 2.3 |
+| **FR-2** (Amendment 2) | User name resolved at most once per `Handle` invocation | Step 2.3, 2.4, 2.5 |
+| **FR-3** | Test with `Name = "user@example.com"` records that exact value | Existing `Handle_WithValidTransition_ShouldUpdateStateAndReturnResponse` (asserts `TestUserName`) — preserved via Step 1.1 mock default |
+| **FR-3** | No existing assertion loosened | All original assertions kept (Step 1.1 keeps `TestUserName`; the `CreatedBy == TestUserName` assertions in `Handle_TransitionToCompleted_...` are preserved) |
+| **FR-4** (Amendment 1a) | Authenticated principal with `Name = null` records `"Unknown User"`, not `"System"` | Step 1.3 (new test), Step 2.3 (production path) |
+| **FR-5** | Unauthenticated user → `"System"` | Step 1.2 (renamed test), Step 2.3 via `GetDisplayName()` |
+| **FR-6** | All test doubles updated to supply `ICurrentUserService` | Step 1.1, 1.4 |
+| **FR-6** | `dotnet build` succeeds across solution | Step 2.8 |
+| **FR-6** | No test mocks `IHttpContextAccessor` solely for this handler | Step 1.1, 1.4 (both swap completely) |
+| **NFR-1** | No additional async / I/O / reflection | Step 2.3 (single sync extension-method call), Step 2.5 (in-body resolution removed) |
+| **NFR-2** | No new endpoints / claims / permission checks | No code changes outside the handler & its tests |
+| **NFR-3** | One fewer Application-layer file importing `IHttpContextAccessor` | Step 2.1, 2.7, 3.3 |
+| **NFR-4** | Existing log statements still emit user identifier | The handler's `_logger.LogError` (line 150 of original) does not reference the user; observability is unchanged. No log message wired to the local user variable existed — nothing to update. |
+| **Out of scope: backfill** | Historical `"System"` rows untouched | Step 3.2 is test-only; no migration in plan |
+| **Out of scope: sibling #1716** | Other Application consumer of `IHttpContextAccessor` untouched | Step 3.3 explicitly checks for this and does not modify other files |
+
+**Type/name consistency sweep** (per writing-plans self-review):
+- Field name across handler and tests: `_currentUserService` ✓ (Step 1.1, 1.4, 2.1, 2.2)
+- Local variable inside `Handle`: `currentUserName` ✓ (Step 2.3, 2.4)
+- New parameter on `WriteDownInventoryAsync`: `changedByUser` (string) ✓ (Step 2.4, 2.5)
+- Mock field in both test classes: `_currentUserServiceMock` ✓ (Step 1.1, 1.4)
+- `CurrentUser` record positional args: `(Id, Name, Email, IsAuthenticated)` — verified against `backend/src/Anela.Heblo.Domain/Features/Users/CurrentUser.cs` ✓ (Step 1.1, 1.2, 1.3, 1.4)
+- `CurrentUserExtensions.GetDisplayName()` returns `"System"` when `IsAuthenticated == false`, otherwise `Name ?? "Unknown User"` — verified against source ✓ (drives Step 1.2 and Step 1.3 expected values)
+
+**Placeholder scan:** no `TBD`, no `TODO`, no "implement later", no "similar to Task N", no "add appropriate error handling" — every step contains exact code or exact command output expectations.
+
+---
+
+## Done criteria
+
+- [ ] Three commits land on the branch (test refactor, handler refactor, optional format), or two if `dotnet format` was a no-op.
+- [ ] `dotnet build backend/Anela.Heblo.sln` → succeeds with no new warnings.
+- [ ] `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build` → all tests pass.
+- [ ] `dotnet format` → exit 0, no further changes.
+- [ ] Grep on `IHttpContextAccessor` in `backend/src/Anela.Heblo.Application/` no longer returns `UpdateManufactureOrderStatusHandler.cs`.
+- [ ] The new `Handle_AuthenticatedUserWithoutNameClaim_ShouldRecordUnknownUserNotSystem` test passes (FR-4, Amendment 1a).
+- [ ] The renamed `Handle_UnauthenticatedUser_ShouldUseSystemAsUser` test passes (FR-5).

--- a/backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs
@@ -9,7 +9,7 @@ using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.ClassifyIn
 using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetAccountingTemplates;
 using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationHistory;
 using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetInvoiceDetails;
-using Anela.Heblo.Domain.Features.InvoiceClassification;
+using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;
 using Anela.Heblo.Application.Features.InvoiceClassification.Contracts;
 
 namespace Anela.Heblo.API.Controllers;
@@ -19,12 +19,10 @@ namespace Anela.Heblo.API.Controllers;
 public class InvoiceClassificationController : ControllerBase
 {
     private readonly IMediator _mediator;
-    private readonly IEnumerable<IClassificationRule> _classificationRules;
 
-    public InvoiceClassificationController(IMediator mediator, IEnumerable<IClassificationRule> classificationRules)
+    public InvoiceClassificationController(IMediator mediator)
     {
         _mediator = mediator;
-        _classificationRules = classificationRules;
     }
 
     [HttpGet("rules")]
@@ -73,16 +71,12 @@ public class InvoiceClassificationController : ControllerBase
     }
 
     [HttpGet("rule-types")]
-    public ActionResult<List<ClassificationRuleTypeDto>> GetAvailableRuleTypes()
+    public async Task<ActionResult<List<ClassificationRuleTypeDto>>> GetAvailableRuleTypes(
+        CancellationToken cancellationToken)
     {
-        var ruleTypes = _classificationRules.Select(rule => new ClassificationRuleTypeDto
-        {
-            Identifier = rule.Identifier,
-            DisplayName = rule.DisplayName,
-            Description = rule.Description
-        }).ToList();
-
-        return Ok(ruleTypes);
+        var response = await _mediator.Send(new GetClassificationRuleTypesRequest(), cancellationToken);
+        // Unwrap to preserve bare-array JSON contract; envelope kept internally for sibling consistency.
+        return Ok(response.RuleTypes);
     }
 
     [HttpGet("accounting-templates")]

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesHandler.cs
@@ -1,0 +1,32 @@
+using Anela.Heblo.Application.Features.InvoiceClassification.Contracts;
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;
+
+public class GetClassificationRuleTypesHandler
+    : IRequestHandler<GetClassificationRuleTypesRequest, GetClassificationRuleTypesResponse>
+{
+    private readonly IEnumerable<IClassificationRule> _classificationRules;
+
+    public GetClassificationRuleTypesHandler(IEnumerable<IClassificationRule> classificationRules)
+    {
+        _classificationRules = classificationRules;
+    }
+
+    public Task<GetClassificationRuleTypesResponse> Handle(
+        GetClassificationRuleTypesRequest request,
+        CancellationToken cancellationToken)
+    {
+        var ruleTypes = _classificationRules
+            .Select(rule => new ClassificationRuleTypeDto
+            {
+                Identifier = rule.Identifier,
+                DisplayName = rule.DisplayName,
+                Description = rule.Description
+            })
+            .ToList();
+
+        return Task.FromResult(new GetClassificationRuleTypesResponse { RuleTypes = ruleTypes });
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesRequest.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;
+
+public class GetClassificationRuleTypesRequest : IRequest<GetClassificationRuleTypesResponse>
+{
+}

--- a/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesResponse.cs
+++ b/backend/src/Anela.Heblo.Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/GetClassificationRuleTypesResponse.cs
@@ -1,0 +1,14 @@
+using Anela.Heblo.Application.Features.InvoiceClassification.Contracts;
+using Anela.Heblo.Application.Shared;
+
+namespace Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;
+
+public class GetClassificationRuleTypesResponse : BaseResponse
+{
+    public List<ClassificationRuleTypeDto> RuleTypes { get; set; } = new();
+
+    public GetClassificationRuleTypesResponse() : base() { }
+
+    public GetClassificationRuleTypesResponse(ErrorCodes errorCode, Dictionary<string, string>? parameters = null)
+        : base(errorCode, parameters) { }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/InvoiceClassification/GetClassificationRuleTypesHandlerTests.cs
@@ -1,0 +1,81 @@
+using Anela.Heblo.Application.Features.InvoiceClassification.UseCases.GetClassificationRuleTypes;
+using Anela.Heblo.Domain.Features.InvoiceClassification;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.InvoiceClassification;
+
+public class GetClassificationRuleTypesHandlerTests
+{
+    private static Mock<IClassificationRule> CreateRuleMock(string identifier, string displayName, string description)
+    {
+        var mock = new Mock<IClassificationRule>();
+        mock.Setup(r => r.Identifier).Returns(identifier);
+        mock.Setup(r => r.DisplayName).Returns(displayName);
+        mock.Setup(r => r.Description).Returns(description);
+        return mock;
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyRuleCollection_ReturnsEmptyList()
+    {
+        // Arrange
+        var handler = new GetClassificationRuleTypesHandler(Enumerable.Empty<IClassificationRule>());
+        var request = new GetClassificationRuleTypesRequest();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Should().NotBeNull();
+        response.Success.Should().BeTrue();
+        response.RuleTypes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithMultipleRules_ProjectsEachToDto()
+    {
+        // Arrange
+        var rules = new[]
+        {
+            CreateRuleMock("rule-1", "Rule One", "Description one").Object,
+            CreateRuleMock("rule-2", "Rule Two", "Description two").Object,
+            CreateRuleMock("rule-3", "Rule Three", "Description three").Object
+        };
+        var handler = new GetClassificationRuleTypesHandler(rules);
+        var request = new GetClassificationRuleTypesRequest();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeTrue();
+        response.RuleTypes.Should().HaveCount(3);
+        response.RuleTypes[0].Identifier.Should().Be("rule-1");
+        response.RuleTypes[0].DisplayName.Should().Be("Rule One");
+        response.RuleTypes[0].Description.Should().Be("Description one");
+        response.RuleTypes[1].Identifier.Should().Be("rule-2");
+        response.RuleTypes[2].Identifier.Should().Be("rule-3");
+    }
+
+    [Fact]
+    public async Task Handle_PreservesEnumerationOrder()
+    {
+        // Arrange
+        var rules = new[]
+        {
+            CreateRuleMock("alpha", "Alpha", "First").Object,
+            CreateRuleMock("beta", "Beta", "Second").Object,
+            CreateRuleMock("gamma", "Gamma", "Third").Object
+        };
+        var handler = new GetClassificationRuleTypesHandler(rules);
+        var request = new GetClassificationRuleTypesRequest();
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.RuleTypes.Select(r => r.Identifier).Should().ContainInOrder("alpha", "beta", "gamma");
+    }
+}


### PR DESCRIPTION
InvoiceClassification

## Finding
`InvoiceClassificationController.GetAvailableRuleTypes()` (lines 76–86 of `backend/src/Anela.Heblo.API/Controllers/InvoiceClassificationController.cs`) does not dispatch via MediatR. Instead, the controller:

1. Declares a second constructor dependency on `IEnumerable<IClassificationRule>` — a Domain interface — injected directly into the API layer.
2. Iterates over `_classificationRules`, projects each to a `ClassificationRuleTypeDto`, and returns the list from the action method itself.

No handler exists for this operation; it is the only endpoint in the module that bypasses MediatR entirely.

## Why it matters
`development_guidelines.md` forbids business logic in controllers: _"Business logic must be in MediatR handlers, NOT in controllers"_. Projecting domain rule metadata to a DTO is business logic. Additionally, the controller taking a direct dependency on `IEnumerable<IClassificationRule>` creates a Domain→API layer dependency that bypasses the Application layer entirely, violating Clean Architecture's dependency rule. It also makes this operation untestable via handler unit tests.

## Suggested fix
Create a `GetClassificationRuleTypesHandler` in `Application/Features/InvoiceClassification/UseCases/GetClassificationRuleTypes/` that accepts the `IEnumerable<IClassificationRule>` dependency and maps to `ClassificationRuleTypeDto`. The controller action becomes a one-liner dispatching to MediatR, matching all other actions in the same controller. Remove `IEnumerable<IClassificationRule>` from the controller constructor.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1695

### Tokens used
16473596
