### PR TITLE
feat: Remove unused `ICurrentUserService` dependency from `GridLayoutsController`

### DIFF
--- a/artifacts/feat-arch-review-users-gridlayoutscontroller-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-users-gridlayoutscontroller-/arch-review.r1.md
@@ -1,0 +1,92 @@
+# Architecture Review: Remove unused `ICurrentUserService` dependency from `GridLayoutsController`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+The change strengthens, rather than challenges, the existing architecture. The codebase follows MediatR + Vertical Slice: thin MVC controllers translate HTTP to `IRequest`/`IRequest<T>` and forward via `_mediator.Send(...)`, while identity resolution, authorization context, and persistence are owned by handlers under `Anela.Heblo.Application/Features/<Slice>/UseCases/`. Verified directly: `GetGridLayoutHandler` (lines 14, 20, 26) injects `ICurrentUserService` and reads `GetCurrentUser()` itself; the controller's field is assigned and never read. The proposed removal eliminates a constructor parameter that crosses the slice boundary unnecessarily and aligns this controller with the rest of the API surface. No integration points change — the HTTP contract, DI graph, authorization pipeline, and handler signatures are all untouched.
+
+## Proposed Architecture
+
+### Component Overview
+```
+HTTP Request
+   │
+   ▼
+[Authorize] ── GridLayoutsController (IMediator only)
+                       │  _mediator.Send(request)
+                       ▼
+              MediatR pipeline
+                       │
+                       ▼
+        Get/Save/ResetGridLayoutHandler
+            ├── ICurrentUserService  ◄── identity resolved here
+            └── IGridLayoutRepository
+                       │
+                       ▼
+                PostgreSQL (per-user layout JSON)
+```
+The only structural change is the deletion of the dotted edge `GridLayoutsController → ICurrentUserService`, which carried no behavior.
+
+### Key Design Decisions
+
+#### Decision 1: Remove the dependency rather than start using it
+**Options considered:**
+1. Remove the dead field and constructor parameter (spec proposal).
+2. Keep the field and add controller-level identity logging or pre-handler guard clauses.
+3. Move identity resolution up from handlers to the controller and pass `userId` into each request DTO.
+
+**Chosen approach:** Option 1 — remove.
+
+**Rationale:** Option 2 invents a requirement that doesn't exist (YAGNI) and would couple HTTP concerns to identity reading. Option 3 is an architectural inversion: it would force every other handler to be refactored to accept `userId` from outside, weakening encapsulation of the slice and contradicting the established pattern verified in `GetGridLayoutHandler`. Removal matches the project's "surgical changes" rule in `CLAUDE.md` and keeps the controller a pure HTTP-to-mediator adapter.
+
+#### Decision 2: Leave handlers and DI registration as-is
+**Options considered:**
+1. Touch only `GridLayoutsController.cs`.
+2. Audit and refactor the other controllers / handlers for the same pattern in this PR.
+
+**Chosen approach:** Option 1.
+
+**Rationale:** Spec explicitly scopes to one file; broader audit is listed Out of Scope and should be filed as a separate arch-review item. Bundling unrelated cleanup would violate the "surgical changes" directive and inflate review surface.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. No directory changes. Single-file edit:
+- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs`
+
+### Interfaces and Contracts
+No interface or contract changes. Specifically preserved:
+- `BaseApiController` inheritance.
+- `[ApiController]`, `[Route("api/[controller]")]`, `[Authorize]` attributes on the class.
+- Action method signatures, routes, verbs, and response types: `Get(string) → ActionResult<GridLayoutDto?>`, `Save(string, SaveGridLayoutRequest) → ActionResult`, `Reset(string) → ActionResult`.
+- `ICurrentUserService` itself, its DI registration, and all three handlers.
+
+Edits required (verified against the file at lines 1–24):
+- Delete line 5 (`using Anela.Heblo.Domain.Features.Users;`).
+- Delete line 18 (`private readonly ICurrentUserService _currentUserService;`).
+- Change constructor signature on line 20 to `public GridLayoutsController(IMediator mediator)`.
+- Delete line 23 (`_currentUserService = currentUserService;`).
+
+### Data Flow
+Unchanged at the runtime level. For each of `Get`/`Save`/`Reset`:
+1. ASP.NET Core authenticates the caller via `[Authorize]`.
+2. Controller wraps the route value into the appropriate `IRequest` and calls `_mediator.Send`.
+3. Handler reads identity via `_currentUserService.GetCurrentUser()`, derives `userId` (Id ?? Email, throws if both null — see `GetGridLayoutHandler:27`), and calls `IGridLayoutRepository`.
+4. Handler returns a response; controller maps `Success == false` to HTTP 500 (for Save/Reset) or returns the layout (for Get).
+
+## Risks and Mitigations
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Other consumers (custom DI overrides, test fixtures) construct `GridLayoutsController` with the two-arg constructor | Low | Verified via `grep` — only `GridLayoutsController.cs` references `_currentUserService` in `backend/src/Anela.Heblo.API/Controllers`; no controller tests exist. `dotnet build` will catch any straggling construction site. |
+| Stale `using` left behind triggers analyzer warnings | Low | FR-3 mandates removing the `using`; `dotnet build` and `dotnet format` validation gates will surface any residual warning. |
+| Reviewer assumes controller still enforces identity | Low | `[Authorize]` remains; identity reading lives in handlers (verified). Document in PR description that authorization surface is unchanged. |
+| Hidden reflection-based or DI-container-side resolution of the old constructor | Very Low | Project uses standard `Microsoft.Extensions.DependencyInjection` constructor injection; ASP.NET Core controller activation resolves by best-matching public constructor and will pick the new single-arg form without configuration changes. |
+
+## Specification Amendments
+None required. The spec is accurate against the current file (verified line-by-line) and correctly bounded. Status: COMPLETE is appropriate.
+
+## Prerequisites
+None. No migration, no configuration change, no infrastructure change, no new package. The change can begin immediately and is gated only by the standard validation suite in `CLAUDE.md`:
+- `dotnet build` clean (no new warnings, including no "unused using" diagnostics).
+- `dotnet format` no diff.
+- `dotnet test` green (no GridLayout-specific tests exist — confirmed via `Glob backend/test/**/GridLayout*`).

--- a/artifacts/feat-arch-review-users-gridlayoutscontroller-/brief.md
+++ b/artifacts/feat-arch-review-users-gridlayoutscontroller-/brief.md
@@ -1,0 +1,27 @@
+## Module
+Users
+
+## Finding
+`GridLayoutsController` declares and assigns `_currentUserService` in its constructor but none of its three action methods (`Get`, `Save`, `Reset`) ever call it.
+
+```csharp
+// backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs, lines 18–23
+private readonly ICurrentUserService _currentUserService;
+
+public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+{
+    _mediator = mediator;
+    _currentUserService = currentUserService;   // assigned, never read
+}
+```
+
+The actual identity resolution happens inside the MediatR handlers (`GetGridLayoutHandler`, `SaveGridLayoutHandler`, `ResetGridLayoutHandler`), each of which already injects `ICurrentUserService` directly.
+
+## Why it matters
+Dead constructor dependency. It misleads readers into thinking the controller uses it, adds an unnecessary constructor parameter, and violates YAGNI — the dependency serves no purpose at the controller boundary.
+
+## Suggested fix
+Remove the `ICurrentUserService` constructor parameter and the `_currentUserService` field from `GridLayoutsController`. No functional change needed; the handlers already have their own injection.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-users-gridlayoutscontroller-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-users-gridlayoutscontroller-/impl/main.r1.md
@@ -1,58 +1,15 @@
-# Implementation: Remove unused ICurrentUserService from GridLayoutsController
+Implementation complete. Here's the summary:
 
-## What was implemented
+**Task:** Remove unused `ICurrentUserService` from `GridLayoutsController`
 
-Surgical dead-code removal in `GridLayoutsController.cs`:
-- Removed `using Anela.Heblo.Domain.Features.Users;` (only existed to resolve `ICurrentUserService`)
-- Removed `private readonly ICurrentUserService _currentUserService;` field
-- Removed `ICurrentUserService currentUserService` constructor parameter
-- Removed `_currentUserService = currentUserService;` assignment
+**What changed:** Single file edited — `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs`. Removed the `_currentUserService` field, the `ICurrentUserService currentUserService` constructor parameter, its assignment, and the now-unused `using Anela.Heblo.Domain.Features.Users;` directive. Action methods, `[Authorize]`, and all handlers are untouched.
 
-The controller's action methods (`Get`, `Save`, `Reset`), class attributes (`[Authorize]`, `[ApiController]`, `[Route]`), and all handler files are untouched. Identity resolution continues inside `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler` which each inject `ICurrentUserService` themselves.
+**Validation:**
+- `dotnet build` — 0 errors, 0 new warnings
+- `dotnet format --verify-no-changes` — clean
+- `dotnet test` — 4,341 tests, all green
+- Diff scope — exactly 1 file, 4 deletions / 1 insertion
 
-## Files created/modified
+**Reviews:** Both spec compliance (✅ all FRs met) and code quality (✅ "Ready to merge: Yes", no issues) passed on first round.
 
-- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — removed dead dependency (4 deletions, 1 insertion net)
-
-## Tests
-
-No new tests written. The spec explicitly states no controller tests are required for this pure removal:
-- No `GridLayoutsController` tests existed before this change.
-- The existing 4,341 handler/integration tests all pass unchanged.
-
-## How to verify
-
-```bash
-cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-users-gridlayoutscontroller-
-
-# Confirm one file changed
-git diff --stat 856bdc040b83a9f5361b96a897cd9a11dae2b34b..0d0d6d0c114812c98c4785e002e5e6f612c95372
-
-# Confirm no _currentUserService reference remains
-grep -n "_currentUserService" backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs || echo "none"
-
-# Build
-dotnet build backend/Anela.Heblo.sln
-
-# Format
-dotnet format backend/Anela.Heblo.sln --verify-no-changes
-
-# Tests
-dotnet test backend/Anela.Heblo.sln --no-build
-```
-
-## Notes
-
-No deviations from spec. The implementation is exactly what FR-1 through FR-5 specify. Both spec compliance and code quality reviewers gave ✅ / "Ready to merge: Yes" with no issues found.
-
-## PR Summary
-
-Removes a dead constructor dependency from `GridLayoutsController`. The controller declared and stored an `ICurrentUserService` instance that none of its three action methods (`Get`, `Save`, `Reset`) ever read — identity resolution already lives inside `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler`, which each inject `ICurrentUserService` on their own. Keeping the unused dependency mislead readers and forced DI to resolve an unnecessary service on every controller instantiation.
-
-The fix removes the field, constructor parameter, assignment, and the now-unused `using Anela.Heblo.Domain.Features.Users;` directive. The HTTP contract, `[Authorize]` attribute, DI registration, and all handler signatures are unchanged.
-
-### Changes
-- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — removed `_currentUserService` field, constructor parameter, assignment, and unused `using` directive
-
-## Status
-DONE
+**Commit:** `0d0d6d0c` on branch `feat-arch-review-users-gridlayoutscontroller-`.

--- a/artifacts/feat-arch-review-users-gridlayoutscontroller-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-users-gridlayoutscontroller-/impl/main.r1.md
@@ -1,0 +1,58 @@
+# Implementation: Remove unused ICurrentUserService from GridLayoutsController
+
+## What was implemented
+
+Surgical dead-code removal in `GridLayoutsController.cs`:
+- Removed `using Anela.Heblo.Domain.Features.Users;` (only existed to resolve `ICurrentUserService`)
+- Removed `private readonly ICurrentUserService _currentUserService;` field
+- Removed `ICurrentUserService currentUserService` constructor parameter
+- Removed `_currentUserService = currentUserService;` assignment
+
+The controller's action methods (`Get`, `Save`, `Reset`), class attributes (`[Authorize]`, `[ApiController]`, `[Route]`), and all handler files are untouched. Identity resolution continues inside `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler` which each inject `ICurrentUserService` themselves.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — removed dead dependency (4 deletions, 1 insertion net)
+
+## Tests
+
+No new tests written. The spec explicitly states no controller tests are required for this pure removal:
+- No `GridLayoutsController` tests existed before this change.
+- The existing 4,341 handler/integration tests all pass unchanged.
+
+## How to verify
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-users-gridlayoutscontroller-
+
+# Confirm one file changed
+git diff --stat 856bdc040b83a9f5361b96a897cd9a11dae2b34b..0d0d6d0c114812c98c4785e002e5e6f612c95372
+
+# Confirm no _currentUserService reference remains
+grep -n "_currentUserService" backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs || echo "none"
+
+# Build
+dotnet build backend/Anela.Heblo.sln
+
+# Format
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+
+# Tests
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+## Notes
+
+No deviations from spec. The implementation is exactly what FR-1 through FR-5 specify. Both spec compliance and code quality reviewers gave ✅ / "Ready to merge: Yes" with no issues found.
+
+## PR Summary
+
+Removes a dead constructor dependency from `GridLayoutsController`. The controller declared and stored an `ICurrentUserService` instance that none of its three action methods (`Get`, `Save`, `Reset`) ever read — identity resolution already lives inside `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler`, which each inject `ICurrentUserService` on their own. Keeping the unused dependency mislead readers and forced DI to resolve an unnecessary service on every controller instantiation.
+
+The fix removes the field, constructor parameter, assignment, and the now-unused `using Anela.Heblo.Domain.Features.Users;` directive. The HTTP contract, `[Authorize]` attribute, DI registration, and all handler signatures are unchanged.
+
+### Changes
+- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — removed `_currentUserService` field, constructor parameter, assignment, and unused `using` directive
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-users-gridlayoutscontroller-/spec.r1.md
+++ b/artifacts/feat-arch-review-users-gridlayoutscontroller-/spec.r1.md
@@ -1,0 +1,150 @@
+# Specification: Remove unused `ICurrentUserService` dependency from `GridLayoutsController`
+
+## Summary
+`GridLayoutsController` accepts and stores an `ICurrentUserService` instance that none of its action methods ever read. This spec removes the dead constructor parameter and field so the controller's declared dependencies match its actual behavior. There is no functional change; identity resolution continues to happen inside the MediatR handlers, which inject `ICurrentUserService` directly.
+
+## Background
+The arch-review routine (filed 2026-05-25) flagged a dead constructor dependency in `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs`. The controller declares `private readonly ICurrentUserService _currentUserService;` and assigns it in the constructor, but `Get`, `Save`, and `Reset` only call `_mediator.Send(...)`. The user identity is resolved further down the stack by `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler`, each of which already injects `ICurrentUserService` on its own.
+
+Keeping the unused dependency:
+- Misleads readers into thinking the controller participates in identity resolution at the API boundary.
+- Adds an unnecessary constructor parameter that consumers (DI container, tests) must satisfy.
+- Violates YAGNI — the controller has no current or planned need for the service.
+
+This is a small surgical cleanup, not a behavior change. Authorization is still enforced by the `[Authorize]` attribute on the controller and by the handlers' own use of `ICurrentUserService`.
+
+## Functional Requirements
+
+### FR-1: Remove the `ICurrentUserService` constructor parameter
+The `GridLayoutsController` constructor must accept only `IMediator`.
+
+**Acceptance criteria:**
+- The constructor signature is `public GridLayoutsController(IMediator mediator)`.
+- The constructor body assigns only `_mediator`.
+
+### FR-2: Remove the `_currentUserService` field
+The unused private field must be removed.
+
+**Acceptance criteria:**
+- `private readonly ICurrentUserService _currentUserService;` no longer exists in the file.
+- No reference to `_currentUserService` remains in `GridLayoutsController.cs`.
+
+### FR-3: Remove the now-unused `using` directive
+The `using Anela.Heblo.Domain.Features.Users;` directive in `GridLayoutsController.cs` exists solely to resolve `ICurrentUserService`. Once the field is removed, the using must be removed too — unless another type from that namespace is still referenced in the file (none is at present).
+
+**Acceptance criteria:**
+- `using Anela.Heblo.Domain.Features.Users;` is removed from the top of `GridLayoutsController.cs`.
+- `dotnet build` succeeds with no warnings about the removed using.
+
+### FR-4: Preserve action method behavior
+The three action methods (`Get`, `Save`, `Reset`) must continue to function identically — same routes, same HTTP verbs, same request/response shapes, same status codes.
+
+**Acceptance criteria:**
+- `[HttpGet("{gridKey}")] Get(string gridKey)` returns `ActionResult<GridLayoutDto?>` via `_mediator.Send(new GetGridLayoutRequest { GridKey = gridKey })`.
+- `[HttpPut("{gridKey}")] Save(string gridKey, [FromBody] SaveGridLayoutRequest body)` sets `body.GridKey = gridKey`, sends via mediator, returns 500 on `!response.Success`, else `Ok()`.
+- `[HttpDelete("{gridKey}")] Reset(string gridKey)` returns 500 on `!response.Success`, else `Ok()`.
+- The `[Authorize]` attribute remains on the controller.
+- Routing (`api/[controller]`) is unchanged.
+
+### FR-5: Handlers remain untouched
+The three MediatR handlers (`GetGridLayoutHandler`, `SaveGridLayoutHandler`, `ResetGridLayoutHandler`) must not be modified. They continue to resolve identity via their own `ICurrentUserService` injection.
+
+**Acceptance criteria:**
+- No files under `backend/src/Anela.Heblo.Application/Features/GridLayouts/` are modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable impact. DI resolves one fewer dependency per controller instantiation, which is negligible.
+
+### NFR-2: Security
+No change. Authorization remains enforced by:
+- The `[Authorize]` attribute on `GridLayoutsController`.
+- `ICurrentUserService` consumption inside each MediatR handler.
+
+The removal does not weaken any boundary check, because the controller was not performing any check with the removed dependency.
+
+### NFR-3: Compatibility
+- The controller's public HTTP contract (routes, verbs, request/response shapes, status codes) is unchanged.
+- DI registration of `ICurrentUserService` is not modified; other consumers (the handlers) keep using it.
+- No database migration. No configuration change.
+
+### NFR-4: Validation gates
+The change must pass the standard project validation gates listed in `CLAUDE.md`:
+- `dotnet build` succeeds with no new warnings.
+- `dotnet format` produces no diff.
+- All existing tests pass.
+
+## Data Model
+No data model changes. `GridLayoutDto`, `GetGridLayoutRequest`, `SaveGridLayoutRequest`, `ResetGridLayoutRequest`, and the underlying persistence entities are all untouched.
+
+## API / Interface Design
+
+**Files modified (exactly one):**
+- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs`
+
+**Before (relevant excerpt):**
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+// ...
+public class GridLayoutsController : BaseApiController
+{
+    private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
+
+    public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
+    // action methods unchanged
+}
+```
+
+**After:**
+```csharp
+// using Anela.Heblo.Domain.Features.Users; removed
+public class GridLayoutsController : BaseApiController
+{
+    private readonly IMediator _mediator;
+
+    public GridLayoutsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+    // action methods unchanged
+}
+```
+
+**HTTP surface** — unchanged:
+- `GET    /api/GridLayouts/{gridKey}` → `GridLayoutDto?`
+- `PUT    /api/GridLayouts/{gridKey}` (body: `SaveGridLayoutRequest`) → 200 / 500
+- `DELETE /api/GridLayouts/{gridKey}` → 200 / 500
+
+## Dependencies
+- `IMediator` (retained) — already wired in DI.
+- `ICurrentUserService` (removed from this controller; still registered for handler use).
+- No new packages. No new services.
+
+## Testing
+
+### Test scope
+There are no existing tests for `GridLayoutsController` (confirmed via `backend/test/**/GridLayout*` — no matches). The change is a pure removal of unused code, so no new controller tests are required to validate the refactor itself.
+
+### Validation
+- `dotnet build` (whole solution) — must succeed cleanly.
+- `dotnet format` — must produce no diff.
+- `dotnet test` — full backend suite must remain green; integration tests that exercise the GridLayouts endpoints (if any) must continue to pass without modification, since the public surface is unchanged.
+- Optional smoke check: hit `GET /api/GridLayouts/{gridKey}` against a running instance to confirm the endpoint still resolves through DI.
+
+## Out of Scope
+- Modifying the MediatR handlers or the `ICurrentUserService` interface/implementation.
+- Auditing other controllers for the same pattern. (If a follow-up sweep is desired, it should be filed separately by the arch-review routine.)
+- Frontend changes — no client-side contract is affected.
+- Adding new tests for behavior that was not previously covered.
+- DI registration changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-users-gridlayoutscontroller-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-users-gridlayoutscontroller-/task-plan.r1.md
@@ -1,0 +1,333 @@
+# Remove unused `ICurrentUserService` dependency from `GridLayoutsController` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead `ICurrentUserService` constructor parameter, field, and unused `using` directive from `GridLayoutsController.cs`, so its declared dependencies match its actual behavior.
+
+**Architecture:** Pure removal in a single MVC controller. Identity resolution stays where it already lives — inside `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler`, which each inject `ICurrentUserService` themselves. The controller continues to be a thin HTTP-to-mediator adapter guarded by `[Authorize]`. No interface, contract, DI registration, handler, or HTTP surface changes.
+
+**Tech Stack:** .NET 8, ASP.NET Core MVC, MediatR, xUnit (existing handler tests), `dotnet build`, `dotnet format`, `dotnet test`.
+
+---
+
+## File Structure
+
+**Files modified (exactly one):**
+- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — controller class. Drop the `ICurrentUserService` constructor parameter, the `_currentUserService` field, the constructor assignment, and the now-unused `using Anela.Heblo.Domain.Features.Users;` directive. Action methods (`Get`, `Save`, `Reset`) and class-level attributes (`[ApiController]`, `[Route("api/[controller]")]`, `[Authorize]`) remain untouched.
+
+**Files NOT modified (called out so the executor does not drift):**
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs`
+- Any file under `backend/src/Anela.Heblo.Domain/Features/Users/`.
+- DI registration code (`Program.cs`, module composition).
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/` — three existing **handler** tests (`GetGridLayoutHandlerTests.cs`, `SaveGridLayoutHandlerTests.cs`, `ResetGridLayoutHandlerTests.cs`). They are not controller tests and must keep passing as-is.
+
+**No new files. No new tests.** Per spec §Testing, no controller tests exist (`grep` confirmed: `GridLayoutsController` is only referenced in its own source file), and a pure removal of unused code does not introduce new behavior worth testing. Validation is performed via the standard build/format/test gates, not by adding new assertions.
+
+---
+
+## Task 1: Remove the unused `ICurrentUserService` dependency from `GridLayoutsController`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs`
+
+**Reference — current file contents (lines 1–53, before edit):**
+
+```csharp
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class GridLayoutsController : BaseApiController
+{
+    private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
+
+    public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
+
+    [HttpGet("{gridKey}")]
+    public async Task<ActionResult<GridLayoutDto?>> Get(string gridKey)
+    {
+        var request = new GetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        return Ok(response.Layout);
+    }
+
+    [HttpPut("{gridKey}")]
+    public async Task<ActionResult> Save(string gridKey, [FromBody] SaveGridLayoutRequest body)
+    {
+        body.GridKey = gridKey;
+        var response = await _mediator.Send(body);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+
+    [HttpDelete("{gridKey}")]
+    public async Task<ActionResult> Reset(string gridKey)
+    {
+        var request = new ResetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+}
+```
+
+- [ ] **Step 1: Verify baseline build is green**
+
+Run from the worktree root (`/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-users-gridlayoutscontroller-`):
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with `0 Warning(s)` and `0 Error(s)` (or the count the executor sees pre-change — record it so any new warning introduced by the edit is detectable).
+
+If the baseline already has warnings, note the exact count. The post-edit count must not increase.
+
+- [ ] **Step 2: Remove the unused `using` directive (line 5)**
+
+Use the `Edit` tool on `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` to delete the line:
+
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+```
+
+Exact `Edit`:
+- `old_string`:
+  ```
+  using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+  using Anela.Heblo.Domain.Features.Users;
+  using MediatR;
+  ```
+- `new_string`:
+  ```
+  using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+  using MediatR;
+  ```
+
+Rationale: that `using` only exists to resolve `ICurrentUserService`. After the field removal it would be flagged by analyzers / `dotnet format` as unused. Removing it in the same step keeps the file in one consistent state.
+
+- [ ] **Step 3: Remove the `_currentUserService` field and update the constructor**
+
+Use the `Edit` tool on the same file to collapse the field, constructor parameter, and constructor assignment in a single replacement.
+
+Exact `Edit`:
+- `old_string`:
+  ```csharp
+      private readonly IMediator _mediator;
+      private readonly ICurrentUserService _currentUserService;
+
+      public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+      {
+          _mediator = mediator;
+          _currentUserService = currentUserService;
+      }
+  ```
+- `new_string`:
+  ```csharp
+      private readonly IMediator _mediator;
+
+      public GridLayoutsController(IMediator mediator)
+      {
+          _mediator = mediator;
+      }
+  ```
+
+Do not touch the three action methods, the class attributes, the namespace declaration, or the class declaration.
+
+- [ ] **Step 4: Re-read the file and confirm the post-edit shape**
+
+Read `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` end-to-end. It must now look exactly like:
+
+```csharp
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class GridLayoutsController : BaseApiController
+{
+    private readonly IMediator _mediator;
+
+    public GridLayoutsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("{gridKey}")]
+    public async Task<ActionResult<GridLayoutDto?>> Get(string gridKey)
+    {
+        var request = new GetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        return Ok(response.Layout);
+    }
+
+    [HttpPut("{gridKey}")]
+    public async Task<ActionResult> Save(string gridKey, [FromBody] SaveGridLayoutRequest body)
+    {
+        body.GridKey = gridKey;
+        var response = await _mediator.Send(body);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+
+    [HttpDelete("{gridKey}")]
+    public async Task<ActionResult> Reset(string gridKey)
+    {
+        var request = new ResetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+}
+```
+
+Checklist while reading:
+- `using Anela.Heblo.Domain.Features.Users;` is **gone**.
+- `_currentUserService` does **not** appear anywhere in the file (use `Grep` `_currentUserService` against this single file if unsure — expect zero matches).
+- Constructor signature is `public GridLayoutsController(IMediator mediator)` — single parameter.
+- `[Authorize]`, `[ApiController]`, and `[Route("api/[controller]")]` are still on the class.
+- All three action methods are byte-for-byte unchanged.
+
+If any item fails, fix it with `Edit` before continuing.
+
+- [ ] **Step 5: Confirm no other file still references the controller with two args**
+
+Run:
+
+```bash
+grep -rn "new GridLayoutsController(" backend/ || echo "no direct construction sites"
+grep -rn "_currentUserService" backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs || echo "field fully removed"
+```
+
+Expected:
+- First command prints `no direct construction sites` (controllers are activated by the framework, not constructed by hand — pre-verified by the arch-review).
+- Second command prints `field fully removed`.
+
+If either expectation fails, stop and re-read the file. Either there is a hidden construction site (rare — investigate before continuing) or the edit was not applied cleanly.
+
+- [ ] **Step 6: Build the solution and verify zero new warnings**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected:
+- `Build succeeded.` with `0 Error(s)`.
+- Warning count is `<=` the baseline from Step 1. Specifically, no new warning of category `CS8019` ("Unnecessary using directive"), `IDE0005`, or anything mentioning `Anela.Heblo.Domain.Features.Users` / `ICurrentUserService`.
+
+If build fails:
+- A "type or namespace `ICurrentUserService` could not be found" error means the field or constructor parameter was only partially removed — re-open the file and finish the removal.
+- A new `CS8019` / `IDE0005` warning means the `using` was not removed — re-apply Step 2.
+
+- [ ] **Step 7: Run `dotnet format` and verify no diff**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0`, no files reported as needing formatting.
+
+If the command reports formatting differences:
+1. Run `dotnet format backend/Anela.Heblo.sln` to apply them.
+2. `git diff backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — only whitespace / using-ordering changes inside this file are acceptable.
+3. Re-run `dotnet format backend/Anela.Heblo.sln --verify-no-changes` until it passes.
+
+Do not let `dotnet format` rewrite unrelated files. If it touches files outside `GridLayoutsController.cs`, revert those (`git checkout -- <path>`) — the surgical-changes rule from `CLAUDE.md` applies.
+
+- [ ] **Step 8: Run the backend test suite**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all tests pass. In particular, the existing handler tests under `backend/test/Anela.Heblo.Tests/Features/GridLayouts/` (`GetGridLayoutHandlerTests`, `SaveGridLayoutHandlerTests`, `ResetGridLayoutHandlerTests`) must remain green — they exercise handler behavior and do not touch the controller, so this edit cannot affect them.
+
+If any test fails:
+- If the failure is in a `GridLayouts*HandlerTests` file or any test that constructs `GridLayoutsController` directly, stop and investigate — the spec asserts no such construction sites exist, so a failure here means the assumption is wrong and the edit must be reconsidered.
+- If the failure is unrelated to GridLayouts and was already failing on `main`, capture it and confirm with the user that it predates this change. Do not "fix" unrelated test failures inside this PR.
+
+- [ ] **Step 9: Sanity-check the diff scope**
+
+Run:
+
+```bash
+git status
+git diff --stat
+git diff backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
+```
+
+Expected `git diff --stat` output: exactly one file changed — `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — with roughly `-5` / `+0` line counts (one `using`, one field, one constructor-parameter rewrite that collapses to a single-parameter form, one assignment).
+
+Expected `git diff` content: only the four removals described above; no whitespace churn elsewhere; no edits to action methods or class attributes.
+
+If the diff includes anything outside this file, revert the extra files: `git checkout -- <path>`.
+
+- [ ] **Step 10: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
+git commit -m "refactor: remove unused ICurrentUserService from GridLayoutsController
+
+The controller declared and assigned ICurrentUserService but never read it.
+Identity resolution lives in Get/Save/ResetGridLayoutHandler, which each
+inject ICurrentUserService themselves. Removing the dead constructor
+parameter, field, and the now-unused using directive aligns the controller's
+declared dependencies with its actual behavior. HTTP contract, [Authorize]
+attribute, DI registration, and handler signatures are unchanged."
+```
+
+Expected: a single commit touching exactly one file.
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Where it's covered |
+|---|---|
+| FR-1: Constructor takes only `IMediator` | Step 3 (constructor rewrite) + Step 4 (post-edit verification) |
+| FR-2: `_currentUserService` field removed | Step 3 + Step 4 + Step 5 (grep confirmation) |
+| FR-3: `using Anela.Heblo.Domain.Features.Users;` removed | Step 2 + Step 4 + Step 6 (no `CS8019`/`IDE0005`) |
+| FR-4: Action method behavior preserved | Step 4 (full-file re-read against expected shape) + Step 9 (diff scope check) |
+| FR-5: Handlers untouched | "Files NOT modified" list + Step 9 diff stat (one file only) |
+| NFR-1: Performance | No code touched that affects perf; implicit |
+| NFR-2: Security — `[Authorize]` retained, handler identity reads retained | Step 4 (attribute still present) + "Files NOT modified" |
+| NFR-3: Compatibility — routes, verbs, DTOs, DI unchanged | Step 4 (action methods byte-equal) + Step 5 (no construction sites) |
+| NFR-4: Validation gates (`dotnet build`, `dotnet format`, `dotnet test`) | Steps 6, 7, 8 |
+| Out of Scope: handlers, other controllers, frontend, DI registration, new tests | "Files NOT modified" + Step 9 diff-scope guard |

--- a/backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.GridLayouts.Contracts;
 using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
 using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
 using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
-using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -15,12 +14,10 @@ namespace Anela.Heblo.API.Controllers;
 public class GridLayoutsController : BaseApiController
 {
     private readonly IMediator _mediator;
-    private readonly ICurrentUserService _currentUserService;
 
-    public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+    public GridLayoutsController(IMediator mediator)
     {
         _mediator = mediator;
-        _currentUserService = currentUserService;
     }
 
     [HttpGet("{gridKey}")]

--- a/docs/superpowers/plans/2026-05-26-remove-currentuserservice-from-gridlayoutscontroller.md
+++ b/docs/superpowers/plans/2026-05-26-remove-currentuserservice-from-gridlayoutscontroller.md
@@ -1,0 +1,333 @@
+# Remove unused `ICurrentUserService` dependency from `GridLayoutsController` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead `ICurrentUserService` constructor parameter, field, and unused `using` directive from `GridLayoutsController.cs`, so its declared dependencies match its actual behavior.
+
+**Architecture:** Pure removal in a single MVC controller. Identity resolution stays where it already lives — inside `GetGridLayoutHandler`, `SaveGridLayoutHandler`, and `ResetGridLayoutHandler`, which each inject `ICurrentUserService` themselves. The controller continues to be a thin HTTP-to-mediator adapter guarded by `[Authorize]`. No interface, contract, DI registration, handler, or HTTP surface changes.
+
+**Tech Stack:** .NET 8, ASP.NET Core MVC, MediatR, xUnit (existing handler tests), `dotnet build`, `dotnet format`, `dotnet test`.
+
+---
+
+## File Structure
+
+**Files modified (exactly one):**
+- `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — controller class. Drop the `ICurrentUserService` constructor parameter, the `_currentUserService` field, the constructor assignment, and the now-unused `using Anela.Heblo.Domain.Features.Users;` directive. Action methods (`Get`, `Save`, `Reset`) and class-level attributes (`[ApiController]`, `[Route("api/[controller]")]`, `[Authorize]`) remain untouched.
+
+**Files NOT modified (called out so the executor does not drift):**
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs`
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs`
+- Any file under `backend/src/Anela.Heblo.Domain/Features/Users/`.
+- DI registration code (`Program.cs`, module composition).
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/` — three existing **handler** tests (`GetGridLayoutHandlerTests.cs`, `SaveGridLayoutHandlerTests.cs`, `ResetGridLayoutHandlerTests.cs`). They are not controller tests and must keep passing as-is.
+
+**No new files. No new tests.** Per spec §Testing, no controller tests exist (`grep` confirmed: `GridLayoutsController` is only referenced in its own source file), and a pure removal of unused code does not introduce new behavior worth testing. Validation is performed via the standard build/format/test gates, not by adding new assertions.
+
+---
+
+## Task 1: Remove the unused `ICurrentUserService` dependency from `GridLayoutsController`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs`
+
+**Reference — current file contents (lines 1–53, before edit):**
+
+```csharp
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class GridLayoutsController : BaseApiController
+{
+    private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
+
+    public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
+
+    [HttpGet("{gridKey}")]
+    public async Task<ActionResult<GridLayoutDto?>> Get(string gridKey)
+    {
+        var request = new GetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        return Ok(response.Layout);
+    }
+
+    [HttpPut("{gridKey}")]
+    public async Task<ActionResult> Save(string gridKey, [FromBody] SaveGridLayoutRequest body)
+    {
+        body.GridKey = gridKey;
+        var response = await _mediator.Send(body);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+
+    [HttpDelete("{gridKey}")]
+    public async Task<ActionResult> Reset(string gridKey)
+    {
+        var request = new ResetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+}
+```
+
+- [ ] **Step 1: Verify baseline build is green**
+
+Run from the worktree root (`/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-users-gridlayoutscontroller-`):
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with `0 Warning(s)` and `0 Error(s)` (or the count the executor sees pre-change — record it so any new warning introduced by the edit is detectable).
+
+If the baseline already has warnings, note the exact count. The post-edit count must not increase.
+
+- [ ] **Step 2: Remove the unused `using` directive (line 5)**
+
+Use the `Edit` tool on `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` to delete the line:
+
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+```
+
+Exact `Edit`:
+- `old_string`:
+  ```
+  using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+  using Anela.Heblo.Domain.Features.Users;
+  using MediatR;
+  ```
+- `new_string`:
+  ```
+  using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+  using MediatR;
+  ```
+
+Rationale: that `using` only exists to resolve `ICurrentUserService`. After the field removal it would be flagged by analyzers / `dotnet format` as unused. Removing it in the same step keeps the file in one consistent state.
+
+- [ ] **Step 3: Remove the `_currentUserService` field and update the constructor**
+
+Use the `Edit` tool on the same file to collapse the field, constructor parameter, and constructor assignment in a single replacement.
+
+Exact `Edit`:
+- `old_string`:
+  ```csharp
+      private readonly IMediator _mediator;
+      private readonly ICurrentUserService _currentUserService;
+
+      public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
+      {
+          _mediator = mediator;
+          _currentUserService = currentUserService;
+      }
+  ```
+- `new_string`:
+  ```csharp
+      private readonly IMediator _mediator;
+
+      public GridLayoutsController(IMediator mediator)
+      {
+          _mediator = mediator;
+      }
+  ```
+
+Do not touch the three action methods, the class attributes, the namespace declaration, or the class declaration.
+
+- [ ] **Step 4: Re-read the file and confirm the post-edit shape**
+
+Read `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` end-to-end. It must now look exactly like:
+
+```csharp
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class GridLayoutsController : BaseApiController
+{
+    private readonly IMediator _mediator;
+
+    public GridLayoutsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("{gridKey}")]
+    public async Task<ActionResult<GridLayoutDto?>> Get(string gridKey)
+    {
+        var request = new GetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        return Ok(response.Layout);
+    }
+
+    [HttpPut("{gridKey}")]
+    public async Task<ActionResult> Save(string gridKey, [FromBody] SaveGridLayoutRequest body)
+    {
+        body.GridKey = gridKey;
+        var response = await _mediator.Send(body);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+
+    [HttpDelete("{gridKey}")]
+    public async Task<ActionResult> Reset(string gridKey)
+    {
+        var request = new ResetGridLayoutRequest { GridKey = gridKey };
+        var response = await _mediator.Send(request);
+        if (!response.Success)
+            return StatusCode(500, response);
+        return Ok();
+    }
+}
+```
+
+Checklist while reading:
+- `using Anela.Heblo.Domain.Features.Users;` is **gone**.
+- `_currentUserService` does **not** appear anywhere in the file (use `Grep` `_currentUserService` against this single file if unsure — expect zero matches).
+- Constructor signature is `public GridLayoutsController(IMediator mediator)` — single parameter.
+- `[Authorize]`, `[ApiController]`, and `[Route("api/[controller]")]` are still on the class.
+- All three action methods are byte-for-byte unchanged.
+
+If any item fails, fix it with `Edit` before continuing.
+
+- [ ] **Step 5: Confirm no other file still references the controller with two args**
+
+Run:
+
+```bash
+grep -rn "new GridLayoutsController(" backend/ || echo "no direct construction sites"
+grep -rn "_currentUserService" backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs || echo "field fully removed"
+```
+
+Expected:
+- First command prints `no direct construction sites` (controllers are activated by the framework, not constructed by hand — pre-verified by the arch-review).
+- Second command prints `field fully removed`.
+
+If either expectation fails, stop and re-read the file. Either there is a hidden construction site (rare — investigate before continuing) or the edit was not applied cleanly.
+
+- [ ] **Step 6: Build the solution and verify zero new warnings**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected:
+- `Build succeeded.` with `0 Error(s)`.
+- Warning count is `<=` the baseline from Step 1. Specifically, no new warning of category `CS8019` ("Unnecessary using directive"), `IDE0005`, or anything mentioning `Anela.Heblo.Domain.Features.Users` / `ICurrentUserService`.
+
+If build fails:
+- A "type or namespace `ICurrentUserService` could not be found" error means the field or constructor parameter was only partially removed — re-open the file and finish the removal.
+- A new `CS8019` / `IDE0005` warning means the `using` was not removed — re-apply Step 2.
+
+- [ ] **Step 7: Run `dotnet format` and verify no diff**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0`, no files reported as needing formatting.
+
+If the command reports formatting differences:
+1. Run `dotnet format backend/Anela.Heblo.sln` to apply them.
+2. `git diff backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — only whitespace / using-ordering changes inside this file are acceptable.
+3. Re-run `dotnet format backend/Anela.Heblo.sln --verify-no-changes` until it passes.
+
+Do not let `dotnet format` rewrite unrelated files. If it touches files outside `GridLayoutsController.cs`, revert those (`git checkout -- <path>`) — the surgical-changes rule from `CLAUDE.md` applies.
+
+- [ ] **Step 8: Run the backend test suite**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all tests pass. In particular, the existing handler tests under `backend/test/Anela.Heblo.Tests/Features/GridLayouts/` (`GetGridLayoutHandlerTests`, `SaveGridLayoutHandlerTests`, `ResetGridLayoutHandlerTests`) must remain green — they exercise handler behavior and do not touch the controller, so this edit cannot affect them.
+
+If any test fails:
+- If the failure is in a `GridLayouts*HandlerTests` file or any test that constructs `GridLayoutsController` directly, stop and investigate — the spec asserts no such construction sites exist, so a failure here means the assumption is wrong and the edit must be reconsidered.
+- If the failure is unrelated to GridLayouts and was already failing on `main`, capture it and confirm with the user that it predates this change. Do not "fix" unrelated test failures inside this PR.
+
+- [ ] **Step 9: Sanity-check the diff scope**
+
+Run:
+
+```bash
+git status
+git diff --stat
+git diff backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
+```
+
+Expected `git diff --stat` output: exactly one file changed — `backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs` — with roughly `-5` / `+0` line counts (one `using`, one field, one constructor-parameter rewrite that collapses to a single-parameter form, one assignment).
+
+Expected `git diff` content: only the four removals described above; no whitespace churn elsewhere; no edits to action methods or class attributes.
+
+If the diff includes anything outside this file, revert the extra files: `git checkout -- <path>`.
+
+- [ ] **Step 10: Commit**
+
+Run:
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs
+git commit -m "refactor: remove unused ICurrentUserService from GridLayoutsController
+
+The controller declared and assigned ICurrentUserService but never read it.
+Identity resolution lives in Get/Save/ResetGridLayoutHandler, which each
+inject ICurrentUserService themselves. Removing the dead constructor
+parameter, field, and the now-unused using directive aligns the controller's
+declared dependencies with its actual behavior. HTTP contract, [Authorize]
+attribute, DI registration, and handler signatures are unchanged."
+```
+
+Expected: a single commit touching exactly one file.
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Where it's covered |
+|---|---|
+| FR-1: Constructor takes only `IMediator` | Step 3 (constructor rewrite) + Step 4 (post-edit verification) |
+| FR-2: `_currentUserService` field removed | Step 3 + Step 4 + Step 5 (grep confirmation) |
+| FR-3: `using Anela.Heblo.Domain.Features.Users;` removed | Step 2 + Step 4 + Step 6 (no `CS8019`/`IDE0005`) |
+| FR-4: Action method behavior preserved | Step 4 (full-file re-read against expected shape) + Step 9 (diff scope check) |
+| FR-5: Handlers untouched | "Files NOT modified" list + Step 9 diff stat (one file only) |
+| NFR-1: Performance | No code touched that affects perf; implicit |
+| NFR-2: Security — `[Authorize]` retained, handler identity reads retained | Step 4 (attribute still present) + "Files NOT modified" |
+| NFR-3: Compatibility — routes, verbs, DTOs, DI unchanged | Step 4 (action methods byte-equal) + Step 5 (no construction sites) |
+| NFR-4: Validation gates (`dotnet build`, `dotnet format`, `dotnet test`) | Steps 6, 7, 8 |
+| Out of Scope: handlers, other controllers, frontend, DI registration, new tests | "Files NOT modified" + Step 9 diff-scope guard |


### PR DESCRIPTION
Users

## Finding
`GridLayoutsController` declares and assigns `_currentUserService` in its constructor but none of its three action methods (`Get`, `Save`, `Reset`) ever call it.

```csharp
// backend/src/Anela.Heblo.API/Controllers/GridLayoutsController.cs, lines 18–23
private readonly ICurrentUserService _currentUserService;

public GridLayoutsController(IMediator mediator, ICurrentUserService currentUserService)
{
    _mediator = mediator;
    _currentUserService = currentUserService;   // assigned, never read
}
```

The actual identity resolution happens inside the MediatR handlers (`GetGridLayoutHandler`, `SaveGridLayoutHandler`, `ResetGridLayoutHandler`), each of which already injects `ICurrentUserService` directly.

## Why it matters
Dead constructor dependency. It misleads readers into thinking the controller uses it, adds an unnecessary constructor parameter, and violates YAGNI — the dependency serves no purpose at the controller boundary.

## Suggested fix
Remove the `ICurrentUserService` constructor parameter and the `_currentUserService` field from `GridLayoutsController`. No functional change needed; the handlers already have their own injection.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1715

### Tokens used
7414578
