### PR TITLE
feat: Relocate CurrentUserService Out of Application Layer

### DIFF
--- a/artifacts/feat-arch-review-users-currentuserservice-liv/arch-review.r1.md
+++ b/artifacts/feat-arch-review-users-currentuserservice-liv/arch-review.r1.md
@@ -1,0 +1,162 @@
+# Architecture Review: Relocate `CurrentUserService` Out of Application Layer
+
+## Skip Design: true
+
+Pure backend structural refactor — no UI, no API contracts, no visual components.
+
+## Architectural Fit Assessment
+
+The spec aligns cleanly with the project's documented Clean Architecture and Vertical Slice conventions (`docs/architecture/development_guidelines.md`, `docs/architecture/filesystem.md`). Two things make the work straightforward:
+
+- The contract `ICurrentUserService` and its DTO `CurrentUser` already live in `Anela.Heblo.Domain/Features/Users/` (verified — see `ICurrentUserService.cs:3`, `CurrentUser.cs:3`). FR-1 is therefore satisfied by the current code; no interface move is required.
+- The "implementation in the outer ring, registered via per-module composition root" pattern is established: `Anela.Heblo.API/Features/ExpeditionList/CombinedPrintQueueSink.cs` already demonstrates an API-layer feature folder, and every Application feature has a `{Feature}Module.cs` (verified across 30+ modules).
+
+Two integration concerns surface from the exploration:
+
+1. **`Anela.Heblo.Application.csproj` declares `Microsoft.AspNetCore.Http.Abstractions` 2.2.0** (line 21). Moving `CurrentUserService` is necessary but not sufficient — the package reference must also be removed for NFR-3 (zero ASP.NET Core in source) to hold. After the move, `Application/Features/UserManagement/UserManagementModule.cs:6` still has `using Microsoft.AspNetCore.Http;` but only for a comment-style hint; that import is dead and must be deleted as part of this work, otherwise removing the package reference breaks the build.
+2. The current registration is **`AddSingleton<ICurrentUserService, CurrentUserService>()`** (`ServiceCollectionExtensions.cs:130`). Singleton + `IHttpContextAccessor` works (the accessor uses `AsyncLocal<HttpContext>`), but it is an unusual choice. Spec FR-3 says "match the current lifetime exactly" — we will keep it Singleton and call out the surprise rather than change it.
+
+A naming collision risk exists: there is already an `Anela.Heblo.Application.Features.UserManagement` namespace (Graph-backed user lookup). The new module is `Users` (current-request identity), so the names do not collide — but the proximity is real, and the new module's purpose should be obvious from the file name.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Domain/Features/Users/        (unchanged — referenced by Application consumers)
+├── ICurrentUserService.cs                  contract
+├── CurrentUser.cs                          DTO record
+└── CurrentUserExtensions.cs
+
+Anela.Heblo.Application/                  (no ASP.NET Core anywhere after this change)
+└── Features/**/...Handler.cs               consumers inject ICurrentUserService (unchanged)
+
+Anela.Heblo.API/Features/Users/           (NEW — outer-ring implementation + composition)
+├── CurrentUserService.cs                   moved from Application; behavior verbatim
+└── UsersModule.cs                          AddUsersModule() extension
+                                            └── AddHttpContextAccessor()
+                                            └── AddSingleton<ICurrentUserService, CurrentUserService>()
+
+Anela.Heblo.API/Program.cs                (one line added: services.AddUsersModule())
+Anela.Heblo.API/Extensions/
+ └── ServiceCollectionExtensions.cs        (remove inline registration; AddHttpContextAccessor()
+                                            stays only if other API-layer code calls it before
+                                            UsersModule registration runs)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Implementation lands in `Anela.Heblo.API/Features/Users/`, not in `Application/Features/Users/Infrastructure/`
+
+**Options considered:**
+- (A) `Anela.Heblo.API/Features/Users/CurrentUserService.cs`
+- (B) `Anela.Heblo.Application/Features/Users/Infrastructure/CurrentUserService.cs`
+
+**Chosen approach:** (A) API project.
+
+**Rationale:** Option (B) keeps `Microsoft.AspNetCore.Http.Abstractions` in the Application csproj, which violates NFR-3 ("Application project has zero references — direct or transitive package-level — to `Microsoft.AspNetCore.*` types in source code"). The whole point of the refactor is to delete that package reference. Option (A) is also the brief's preferred placement and matches existing precedent (`API/Features/ExpeditionList/`). The Application project becomes a pure use-case layer that depends only on Domain and framework-neutral abstractions.
+
+#### Decision 2: `UsersModule.cs` lives in `Anela.Heblo.API/Features/Users/`, not in Application
+
+**Options considered:**
+- (A) `Anela.Heblo.API/Features/Users/UsersModule.cs`
+- (B) `Anela.Heblo.Application/Features/Users/UsersModule.cs` (matching the other 30 modules)
+
+**Chosen approach:** (A) Same project as the implementation it composes.
+
+**Rationale:** A composition root that references types it doesn't own is a smell. The implementation type (`CurrentUserService`) and its framework dependency (`AddHttpContextAccessor`) both live in the API project; the module that wires them belongs there too. Other modules in `Anela.Heblo.Application` register Application-layer services — the Users feature is the exception because its only registration is an API-layer adapter. Locating `UsersModule.cs` in API makes that boundary visible.
+
+#### Decision 3: Preserve Singleton lifetime; do not change to Scoped
+
+**Options considered:**
+- (A) Keep `AddSingleton<ICurrentUserService, CurrentUserService>()`
+- (B) Quietly upgrade to Scoped
+
+**Chosen approach:** (A) Verbatim preservation.
+
+**Rationale:** FR-3 mandates exact lifetime preservation. Singleton + `IHttpContextAccessor` is safe because the accessor reads `AsyncLocal<HttpContext>` per call, not constructor-captured state. Changing it would be an undocumented behavior change in a "structural-only" refactor. The risk is captured below; cleanup belongs to a separate change.
+
+#### Decision 4: Remove `Microsoft.AspNetCore.Http.Abstractions` from `Anela.Heblo.Application.csproj` as part of this refactor
+
+**Options considered:**
+- (A) Remove the package reference now
+- (B) Leave it for a follow-up
+
+**Chosen approach:** (A) Remove immediately.
+
+**Rationale:** NFR-3 names "transitive package-level" references explicitly. If the package stays, the boundary is not actually enforced — a future commit could re-introduce a `using Microsoft.AspNetCore.Http;` in Application without breaking the build. Removing it converts the architectural rule into a compile-time gate. The only other `using Microsoft.AspNetCore.Http;` in the Application project is in `UserManagement/UserManagementModule.cs:6`, where it is unused — delete it as part of this change (small surgical fix, not scope creep).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` — moved verbatim. Namespace: `Anela.Heblo.API.Features.Users`.
+- `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` — namespace: `Anela.Heblo.API.Features.Users`.
+
+**Delete:**
+- `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs`
+- The (now empty) directory `backend/src/Anela.Heblo.Application/Features/Users/` if no other files land in it.
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — remove `<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" .../>` (line 21).
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — remove the unused `using Microsoft.AspNetCore.Http;` (line 6).
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — remove `using Anela.Heblo.Application.Features.Users;` (line 9), remove the inline `AddHttpContextAccessor()` and `AddSingleton<ICurrentUserService, CurrentUserService>()` (lines 123–130) from `AddCrossCuttingServices`. Both moves go into `UsersModule.AddUsersModule()`.
+- `backend/src/Anela.Heblo.API/Program.cs` — add `builder.Services.AddUsersModule();` before `AddCrossCuttingServices()` (so other code that may consume `IHttpContextAccessor` during DI build still finds it; ordering is conservative).
+- `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs:2` and `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs:2` — update `using Anela.Heblo.Application.Features.Users;` → `using Anela.Heblo.API.Features.Users;`. No logic changes.
+
+### Interfaces and Contracts
+
+No public contract changes. Specifically:
+
+- **`Anela.Heblo.Domain.Features.Users.ICurrentUserService`** — unchanged, still owns `CurrentUser GetCurrentUser()` and `bool IsInRole(string role)`.
+- **`Anela.Heblo.Domain.Features.Users.CurrentUser`** — unchanged record.
+- **`AddUsersModule` extension** (new):
+  ```csharp
+  namespace Anela.Heblo.API.Features.Users;
+
+  public static class UsersModule
+  {
+      public static IServiceCollection AddUsersModule(this IServiceCollection services)
+      {
+          services.AddHttpContextAccessor();
+          services.AddSingleton<ICurrentUserService, CurrentUserService>();
+          return services;
+      }
+  }
+  ```
+
+### Data Flow
+
+Unchanged. Per HTTP request: ASP.NET Core middleware sets `HttpContext` on `IHttpContextAccessor` → any MediatR handler that injects `ICurrentUserService` calls `GetCurrentUser()` → implementation reads `HttpContext.User.Claims` and returns a `CurrentUser` record. The only thing that moves is which assembly hosts the implementation type — the call graph and per-request semantics are identical.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Removing `Microsoft.AspNetCore.Http.Abstractions` breaks a hidden Application-layer use of `Microsoft.AspNetCore.Http.*` not surfaced by grep | Medium | Run `dotnet build` on the whole solution after the package removal — the compiler will flag every remaining symbol. Also run `grep -r "Microsoft.AspNetCore" backend/src/Anela.Heblo.Application` before committing. |
+| Singleton lifetime is preserved but is a known smell with `IHttpContextAccessor` | Low | Out of scope per FR-3. Document the choice with a one-line comment on the registration: `// Lifetime preserved from prior registration; HttpContextAccessor uses AsyncLocal so per-request reads remain correct.` File a separate follow-up ticket if cleanup is desired. |
+| Tests in `backend/test/Anela.Heblo.Tests/Application/Users/` reside under an `Application/` folder but will reference an API-layer type after the move — confusing structure | Low | Acceptable for this PR (FR-5 covers the using-directive update). Optional follow-up: physically relocate the test files under `backend/test/Anela.Heblo.Tests/Api/Users/` to mirror the production layout. Not required for spec acceptance. |
+| Future regressions reintroduce ASP.NET types in Application without a compile error (e.g., via a different transitive package) | Medium | Extend `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` with a new rule that scans every type in `Anela.Heblo.Application` for namespace references starting with `Microsoft.AspNetCore.`. The existing reflection-based pattern there (lines 13–100+) covers this idiom; one new `ModuleBoundaryRule` entry is sufficient. |
+| `AddCrossCuttingServices()` runs before `AddUsersModule()` and something inside it needs `IHttpContextAccessor` during the build phase | Low | None observed in the current code. Call `AddUsersModule()` immediately before `AddCrossCuttingServices()` in `Program.cs` (`builder.Services.AddUsersModule(); builder.Services.AddCrossCuttingServices();`) so the order is deterministic. |
+
+## Specification Amendments
+
+The spec is implementable as written, with three small clarifications worth incorporating:
+
+1. **FR-1 (interface placement) is already satisfied.** `ICurrentUserService` and `CurrentUser` already live in `Anela.Heblo.Domain/Features/Users/`. The spec implies the interface "may need to remain" or "be moved to Domain" — neither is needed. Update the FR-1 status to "already met; verify no regression."
+2. **Add an explicit task: remove `Microsoft.AspNetCore.Http.Abstractions` from `Anela.Heblo.Application.csproj`.** Without this, NFR-3 ("zero package-level references to Microsoft.AspNetCore.*") is not actually met. Currently FR/NFR text targets source-code imports but the package stays.
+3. **Add an explicit task: delete the unused `using Microsoft.AspNetCore.Http;` from `Application/Features/UserManagement/UserManagementModule.cs:6`.** This is the only other ASP.NET Core import in the Application project; without removing it, the package removal in (2) breaks the build.
+4. **Add a recommended (not required) follow-up:** extend `ModuleBoundariesTests.cs` with a `Application -> Microsoft.AspNetCore.*` boundary rule to lock in NFR-3 as a CI gate.
+
+## Prerequisites
+
+None. The work is in-process source-only refactoring:
+
+- No database migrations.
+- No configuration (`appsettings.*.json`) changes.
+- No infrastructure changes (Docker, CI/CD, Azure).
+- No API contract changes — the OpenAPI client does not need regeneration.
+- No frontend impact.
+
+Validation per `CLAUDE.md`: `dotnet build`, `dotnet format`, and the existing test suite under `backend/test/` (especially `Tests/Features/Users/CurrentUserServiceTests.cs` and `Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs`) cover the refactor's correctness.

--- a/artifacts/feat-arch-review-users-currentuserservice-liv/brief.md
+++ b/artifacts/feat-arch-review-users-currentuserservice-liv/brief.md
@@ -1,0 +1,29 @@
+## Module
+Users
+
+## Finding
+`CurrentUserService` is placed in `Anela.Heblo.Application` but takes a direct dependency on `IHttpContextAccessor` from `Microsoft.AspNetCore.Http` — a web-framework type.
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs, lines 1–14
+using Microsoft.AspNetCore.Http;   // web infrastructure in Application layer
+
+public class CurrentUserService : ICurrentUserService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    ...
+}
+```
+
+The Application layer is intended to be independent of the web host. The DI registration in `ServiceCollectionExtensions.cs:130` also sits in the API project rather than in a dedicated `UsersModule.cs`, which is where any infrastructure wiring for this module belongs.
+
+## Why it matters
+Violates the Clean Architecture rule that Application must not depend on Infrastructure/framework types. It couples the Application project to the ASP.NET Core web host, making it harder to test in isolation and preventing future reuse outside a web context (e.g. background workers, console tools, integration tests).
+
+## Suggested fix
+Move `CurrentUserService` to the API project (e.g. `Anela.Heblo.API/Features/Users/`) or to an `Infrastructure/` subfolder within `Anela.Heblo.Application/Features/Users/`. The interface `ICurrentUserService` stays in Domain. The DI binding moves with the implementation (see companion issue about missing `UsersModule.cs`).
+
+This is the same adapter pattern already documented in `development_guidelines.md` under *Cross-Module Communication* — infrastructure adapters live in the outer ring, not in Application.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-users-currentuserservice-liv/impl/main.r1.md
+++ b/artifacts/feat-arch-review-users-currentuserservice-liv/impl/main.r1.md
@@ -1,0 +1,61 @@
+All 7 tasks complete. Writing the output artifact:
+
+---
+
+# Implementation: Relocate CurrentUserService Out of Application Layer
+
+## What was implemented
+
+A structural Clean Architecture refactoring that moves the `CurrentUserService` implementation from the Application layer (where it violated boundaries by importing ASP.NET Core types) to the API layer. The Application project's dependency on `Microsoft.AspNetCore.Http.Abstractions` was removed, and the boundary is now enforced at compile time via a new architecture test.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` — moved verbatim from Application; namespace changed to `Anela.Heblo.API.Features.Users`
+- `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` — new composition root exposing `AddUsersModule()` (registers `AddHttpContextAccessor` + `AddSingleton<ICurrentUserService, CurrentUserService>`)
+- `backend/src/Anela.Heblo.API/Program.cs` — added `builder.Services.AddUsersModule()` before `AddCrossCuttingServices()`
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed inline `AddHttpContextAccessor()` and `AddSingleton<ICurrentUserService, ...>()` from `AddCrossCuttingServices()`; removed stale using directives
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — removed `Microsoft.AspNetCore.Http.Abstractions` package reference
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — removed dead `using Microsoft.AspNetCore.Http;`
+- `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs` — updated using to `Anela.Heblo.API.Features.Users`
+- `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs` — updated using to `Anela.Heblo.API.Features.Users`
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — added `Application_types_should_not_reference_AspNetCore_namespaces` [Fact] as CI gate
+- **Deleted:** `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs`
+
+## Tests
+
+- `CurrentUserServiceTests.cs` — 8 tests covering claim extraction (sub, oid, NameIdentifier, email, preferred_username, upn, anonymous) — all pass
+- `CurrentUserServiceIsInRoleTests.cs` — 3 tests covering role membership — all pass
+- `ModuleBoundariesTests.cs` — 7 rules total (6 existing + 1 new AspNetCore boundary rule) — all pass
+- Full suite: 3981 passed, 3 skipped, 0 failed
+
+## How to verify
+
+```bash
+cd backend
+dotnet build                                          # 0 errors
+dotnet test test/Anela.Heblo.Tests --no-build         # 3981 pass
+grep -rn "Microsoft.AspNetCore" src/Anela.Heblo.Application  # 0 results
+ls src/Anela.Heblo.API/Features/Users/               # CurrentUserService.cs + UsersModule.cs
+```
+
+## Notes
+
+- `ICurrentUserService` and `CurrentUser` already resided in `Anela.Heblo.Domain.Features.Users` — no interface relocation was needed (FR-1 was pre-satisfied).
+- Singleton lifetime preserved verbatim per FR-3; the comment in `UsersModule.cs` explains why `IHttpContextAccessor` is safe under a singleton (uses `AsyncLocal<HttpContext>` per-request).
+- Commits: `3334f67c` (move), `49651d60` (UsersModule DI), `9dbf136c` (remove unused import), `a400f80d` (remove package ref), `ee9fabd5` (architecture test)
+
+## PR Summary
+
+Moves `CurrentUserService` from the Application layer to `Anela.Heblo.API/Features/Users/` to fix a Clean Architecture boundary violation where the Application project imported `Microsoft.AspNetCore.Http`. Creates a `UsersModule.cs` composition root following the project's existing vertical-slice module pattern. Removes the now-unnecessary `Microsoft.AspNetCore.Http.Abstractions` package reference from the Application csproj, converting the architectural rule into a compile-time gate. Adds a reflection-based architecture test that asserts no Application type references `Microsoft.AspNetCore.*` namespaces, locking the boundary in CI.
+
+### Changes
+- `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` — moved from Application; namespace updated
+- `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` — new composition root with `AddUsersModule()`
+- `backend/src/Anela.Heblo.API/Program.cs` — wires `AddUsersModule()` before `AddCrossCuttingServices()`
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed inline user service DI
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — dropped `Microsoft.AspNetCore.Http.Abstractions` package ref
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — removed dead using
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — new boundary test as CI gate
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-users-currentuserservice-liv/spec.r1.md
+++ b/artifacts/feat-arch-review-users-currentuserservice-liv/spec.r1.md
@@ -1,0 +1,103 @@
+# Specification: Relocate CurrentUserService Out of Application Layer
+
+## Summary
+The `CurrentUserService` implementation currently resides in the Application layer but takes a direct dependency on `IHttpContextAccessor`, a web-framework type from `Microsoft.AspNetCore.Http`. This refactoring moves the implementation to an appropriate outer ring (API or Infrastructure), keeps the `ICurrentUserService` abstraction accessible to Application code, and consolidates the module's DI wiring into a dedicated `UsersModule.cs` to align with the project's Clean Architecture and Vertical Slice conventions.
+
+## Background
+The codebase follows Clean Architecture: the Application layer holds use cases and orchestration logic and must not depend on web-host or other infrastructure types. The current placement of `CurrentUserService` in `Anela.Heblo.Application/Features/Users/CurrentUserService.cs` violates that boundary because it imports `Microsoft.AspNetCore.Http` and depends on `IHttpContextAccessor`.
+
+Consequences of the current placement:
+- The Application project transitively pulls in ASP.NET Core types, blocking reuse from background workers, console tools, and pure unit-test contexts.
+- The DI registration lives in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` rather than a per-module composition root, so the Users module lacks a self-contained registration surface and diverges from the pattern already used by other modules.
+- The same adapter pattern is documented in `docs/architecture/development_guidelines.md` under *Cross-Module Communication* and is not being followed for this module.
+
+This issue was identified by the daily arch-review routine on 2026-05-25.
+
+## Functional Requirements
+
+### FR-1: Keep `ICurrentUserService` accessible to Application code
+The abstraction `ICurrentUserService` must remain in a layer that the Application project can reference without violating Clean Architecture (Domain or Application). The interface defines the contract the Application layer relies on to retrieve the current user.
+**Acceptance criteria:**
+- `ICurrentUserService` resides in a layer at or below Application (Domain preferred per the brief's suggested fix; Application is acceptable if no Domain dependency exists today).
+- All existing Application-layer call sites (e.g., `MediatR` handlers) continue to compile and resolve the dependency unchanged.
+- No file in the Application project imports `Microsoft.AspNetCore.Http` after the change.
+
+### FR-2: Relocate the `CurrentUserService` implementation out of the Application layer
+The concrete `CurrentUserService` class (which depends on `IHttpContextAccessor`) must move out of `Anela.Heblo.Application` into an outer ring that is permitted to reference ASP.NET Core types.
+**Acceptance criteria:**
+- The file `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs` no longer exists.
+- The implementation lives in `Anela.Heblo.API/Features/Users/` (preferred per the brief) or, if more consistent with sibling modules, in an `Infrastructure/` subfolder accessible from the composition root.
+- Namespace of the relocated class matches its new physical location and the conventions in `docs/architecture/filesystem.md`.
+- Behavior (claims read, null-handling, exceptions) is preserved verbatim — no logic changes.
+
+### FR-3: Consolidate Users-module DI wiring into a `UsersModule.cs`
+The DI registration for `ICurrentUserService → CurrentUserService` currently inlined in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (around line 130) must move to a dedicated `UsersModule.cs` composition root, matching how other modules are wired.
+**Acceptance criteria:**
+- A new file (e.g., `Anela.Heblo.API/Features/Users/UsersModule.cs` or the matching infrastructure folder) contains an extension method such as `AddUsersModule(this IServiceCollection services)`.
+- The `ICurrentUserService` registration and any `AddHttpContextAccessor()` call required by it are inside that module method.
+- `ServiceCollectionExtensions.cs` invokes `services.AddUsersModule()` in place of the inline registration; no other inline Users wiring remains there.
+- Service lifetime (Scoped/Transient/Singleton) matches the current registration exactly.
+
+### FR-4: Preserve runtime behavior end-to-end
+The refactor is structural only. The values returned by `ICurrentUserService` (user id, email, claims, authenticated flag, etc.) must be identical for the same HTTP request before and after the change.
+**Acceptance criteria:**
+- All existing unit and integration tests that exercise `ICurrentUserService` (directly or transitively) pass without modification beyond namespace/using updates.
+- A manual smoke test of an authenticated endpoint that surfaces the current user (e.g., any handler resolving `ICurrentUserService`) returns the same user identity as before.
+- `dotnet build` and `dotnet format` pass cleanly on the backend solution.
+
+### FR-5: Update affected `using` directives and references
+All consumers of `CurrentUserService` (production code and tests) must reference the relocated implementation and the (possibly relocated) interface from their new namespaces.
+**Acceptance criteria:**
+- A repository-wide search for the old namespace of `CurrentUserService` returns no results after the change.
+- A repository-wide search for `Microsoft.AspNetCore.Http` inside `Anela.Heblo.Application` returns no results.
+- The project compiles with no new warnings introduced by the move.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. DI resolution path and per-request claim lookup remain unchanged. No new allocations or framework calls introduced.
+
+### NFR-2: Security
+- The change must not alter how user identity is read from `HttpContext` (claims, authentication scheme, anonymous fallback).
+- No new logging of user identity, tokens, or claims is introduced.
+- Existing authorization behavior (anywhere `ICurrentUserService` is consulted) must be byte-identical.
+
+### NFR-3: Architectural Conformance
+- After the change, the Application project has zero references — direct or transitive package-level — to `Microsoft.AspNetCore.*` types in source code.
+- The Users module follows the same `XxxModule.cs` composition-root pattern as other modules in the repository.
+- The placement matches the *Cross-Module Communication* adapter pattern in `docs/architecture/development_guidelines.md`.
+
+### NFR-4: Testability
+- The relocated implementation remains substitutable: unit tests in Application can use a fake/stub `ICurrentUserService` without referencing ASP.NET Core types.
+- The relocation does not require any test to start an HTTP host that did not previously require one.
+
+## Data Model
+No data model changes. This is a structural/architectural refactor of in-process service composition only. No database schema, DTOs, contracts, or persisted entities are touched.
+
+## API / Interface Design
+No external API changes. The public method surface of `ICurrentUserService` is unchanged.
+
+Internal composition changes:
+- **Interface placement (preferred):** `Anela.Heblo.Domain` (or remain in `Anela.Heblo.Application` if it currently lives there and no Domain-side consumer needs it). The interface itself has no framework dependency.
+- **Implementation placement:** `Anela.Heblo.API/Features/Users/CurrentUserService.cs` (preferred per brief) — the API project is already permitted to depend on ASP.NET Core.
+- **Composition root:** `Anela.Heblo.API/Features/Users/UsersModule.cs` exposing `IServiceCollection AddUsersModule(this IServiceCollection services)`.
+- **API project bootstrap:** `ServiceCollectionExtensions.cs` calls `services.AddUsersModule()` in place of the inline registration; the surrounding ordering of module registrations is preserved.
+
+## Dependencies
+- `Microsoft.AspNetCore.Http.IHttpContextAccessor` — remains a dependency of the relocated implementation; no longer leaks into the Application project.
+- Existing MediatR handlers and any other consumers that inject `ICurrentUserService` — must continue to resolve through DI unchanged.
+- Companion arch-review issue: introduction of `UsersModule.cs` for the Users module's composition root (this spec implements that consolidation as part of FR-3).
+
+## Out of Scope
+- Adding new functionality to `ICurrentUserService` (e.g., new claims, new methods).
+- Changing authentication or authorization mechanisms.
+- Renaming `ICurrentUserService` or its members.
+- Refactoring other modules that may have similar boundary violations — those are addressed by their own arch-review issues.
+- Introducing new abstractions over `HttpContext` beyond what already exists.
+- Database, DTO, or OpenAPI client changes.
+- Frontend changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-users-currentuserservice-liv/task-plan.r1.md
+++ b/artifacts/feat-arch-review-users-currentuserservice-liv/task-plan.r1.md
@@ -1,0 +1,635 @@
+# Relocate `CurrentUserService` Out of Application Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the `CurrentUserService` implementation out of the Application layer to the API layer, consolidate Users DI wiring into a `UsersModule.cs`, and remove the `Microsoft.AspNetCore.Http.Abstractions` package reference from the Application csproj so the Clean Architecture boundary is enforced at compile time.
+
+**Architecture:** The interface `ICurrentUserService` already lives in `Anela.Heblo.Domain.Features.Users` (no change). The concrete implementation moves verbatim to `Anela.Heblo.API/Features/Users/CurrentUserService.cs` (namespace `Anela.Heblo.API.Features.Users`). A new `UsersModule.cs` in the same folder exposes `AddUsersModule()` that registers `IHttpContextAccessor` + `AddSingleton<ICurrentUserService, CurrentUserService>()`. Program.cs invokes `AddUsersModule()` immediately before `AddCrossCuttingServices()`. The `Microsoft.AspNetCore.Http.Abstractions` package reference is removed from `Anela.Heblo.Application.csproj`, and a new architecture test locks the rule in.
+
+**Tech Stack:** .NET 8, ASP.NET Core, xUnit, FluentAssertions, Moq, MediatR (handlers consume `ICurrentUserService` unchanged).
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` — moved verbatim from Application; new namespace `Anela.Heblo.API.Features.Users`.
+- `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` — composition root for the Users module; exposes `AddUsersModule(this IServiceCollection)`.
+
+**Delete:**
+- `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs` — moved.
+- `backend/src/Anela.Heblo.Application/Features/Users/` directory if it becomes empty.
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — remove `Microsoft.AspNetCore.Http.Abstractions` package reference (line 21).
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — remove unused `using Microsoft.AspNetCore.Http;` (line 6).
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — remove inline `AddHttpContextAccessor()` and `AddSingleton<ICurrentUserService, CurrentUserService>()` from `AddCrossCuttingServices()`; remove now-unused usings.
+- `backend/src/Anela.Heblo.API/Program.cs` — add `builder.Services.AddUsersModule();` before `AddCrossCuttingServices()`.
+- `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs` — update `using Anela.Heblo.Application.Features.Users;` → `using Anela.Heblo.API.Features.Users;`.
+- `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs` — same using update.
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — add an `Application_should_not_reference_AspNetCore` test (locks in NFR-3 as a CI gate).
+
+---
+
+## Task 1: Establish green baseline
+
+**Files:** none modified — pure verification before changes.
+
+- [ ] **Step 1: Build the backend solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` (or pre-existing warnings only).
+
+- [ ] **Step 2: Run the existing `CurrentUserService` tests to confirm they currently pass**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~CurrentUserService" --no-build
+```
+Expected: All tests in `CurrentUserServiceTests` (8 tests) and `CurrentUserServiceIsInRoleTests` (3 tests) PASS — 11 total green.
+
+- [ ] **Step 3: Run the existing module-boundary architecture tests**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ModuleBoundariesTests" --no-build
+```
+Expected: All existing rules PASS.
+
+- [ ] **Step 4: Confirm baseline grep state**
+
+Run:
+```bash
+grep -rn "Microsoft.AspNetCore" backend/src/Anela.Heblo.Application
+```
+Expected output (exactly two lines): the `using Microsoft.AspNetCore.Http;` at `Features/UserManagement/UserManagementModule.cs:6` and the source file `Features/Users/CurrentUserService.cs:3`. The csproj `PackageReference` should also be visible if you grep the csproj — that's the package we will remove.
+
+- [ ] **Step 5: No commit — this task is verification only.**
+
+---
+
+## Task 2: Move `CurrentUserService` from Application to API project
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs`
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (update `using` for the relocated type)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs` (`using` only)
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs` (`using` only)
+
+- [ ] **Step 1: Create the new file with the implementation verbatim under the API namespace**
+
+Create `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` with this exact content:
+
+```csharp
+using System.Security.Claims;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.AspNetCore.Http;
+
+namespace Anela.Heblo.API.Features.Users;
+
+public class CurrentUserService : ICurrentUserService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public CurrentUser GetCurrentUser()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        var isAuthenticated = user?.Identity?.IsAuthenticated ?? false;
+
+        var name = user?.Identity?.Name
+                   ?? user?.FindFirst(ClaimTypes.Name)?.Value
+                   ?? user?.FindFirst("name")?.Value
+                   ?? (isAuthenticated ? "Unknown User" : "Anonymous");
+
+        var id = user?.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                 ?? user?.FindFirst("sub")?.Value
+                 ?? user?.FindFirst("oid")?.Value;
+
+        // Entra ID access tokens omit the `email` claim by default; the user's
+        // email/UPN lives in `preferred_username` (and sometimes `upn`).
+        // ClaimTypes.Upn covers the legacy JwtSecurityTokenHandler claim remap.
+        var email = user?.FindFirst(ClaimTypes.Email)?.Value
+                    ?? user?.FindFirst("email")?.Value
+                    ?? user?.FindFirst("preferred_username")?.Value
+                    ?? user?.FindFirst(ClaimTypes.Upn)?.Value
+                    ?? user?.FindFirst("upn")?.Value;
+
+        return new CurrentUser(
+            Id: id,
+            Name: name,
+            Email: email,
+            IsAuthenticated: isAuthenticated
+        );
+    }
+
+    public bool IsInRole(string role)
+    {
+        return _httpContextAccessor.HttpContext?.User?.IsInRole(role) ?? false;
+    }
+}
+```
+
+- [ ] **Step 2: Delete the old implementation file**
+
+Run:
+```bash
+rm backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs
+```
+
+Then check whether the directory is now empty and delete it if so:
+```bash
+rmdir backend/src/Anela.Heblo.Application/Features/Users 2>/dev/null || true
+```
+Expected: directory removed if empty; the command silently no-ops if not.
+
+- [ ] **Step 3: Update the `using` in `ServiceCollectionExtensions.cs` to the new namespace**
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Find line 9:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+Leave the rest of the file unchanged for this task; the inline DI registration on line 130 will be removed in Task 3.
+
+- [ ] **Step 4: Update the `using` in `CurrentUserServiceTests.cs`**
+
+Open `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs`. Find line 2:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+- [ ] **Step 5: Update the `using` in `CurrentUserServiceIsInRoleTests.cs`**
+
+Open `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs`. Find line 2:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+- [ ] **Step 6: Add a project reference from the test project to the API project if it does not already exist**
+
+The test project must be able to resolve `Anela.Heblo.API.Features.Users.CurrentUserService`. Inspect:
+
+```bash
+cat backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj | grep -i ProjectReference
+```
+
+Expected: an entry like `<ProjectReference Include="..\..\src\Anela.Heblo.API\Anela.Heblo.API.csproj" />` already exists (the tests already reference API). If — and only if — no such reference exists, add it inside the existing `<ItemGroup>` containing other `ProjectReference` entries:
+
+```xml
+<ProjectReference Include="..\..\src\Anela.Heblo.API\Anela.Heblo.API.csproj" />
+```
+
+Do not add the reference if it is already present.
+
+- [ ] **Step 7: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no new warnings or errors.
+
+- [ ] **Step 8: Run the relocated tests to confirm they still pass**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~CurrentUserService" --no-build
+```
+Expected: same 11 tests PASS — behavior is unchanged.
+
+- [ ] **Step 9: Confirm no stale references to the old namespace remain**
+
+Run:
+```bash
+grep -rn "Anela\.Heblo\.Application\.Features\.Users" backend/
+```
+Expected: zero results. (The only files that referenced the old namespace were the three updated in Steps 3–5.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs \
+        backend/src/Anela.Heblo.Application/Features/Users \
+        backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs \
+        backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs \
+        backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs
+git commit -m "refactor: move CurrentUserService implementation from Application to API layer"
+```
+
+---
+
+## Task 3: Create `UsersModule.cs` and re-route DI through it
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs`
+- Modify: `backend/src/Anela.Heblo.API/Program.cs` (add `AddUsersModule()` call)
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (remove inline registration + now-unused usings)
+
+- [ ] **Step 1: Create `UsersModule.cs` exposing `AddUsersModule()`**
+
+Create `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.API.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddHttpContextAccessor();
+
+        // Lifetime preserved from prior registration; HttpContextAccessor uses AsyncLocal
+        // so per-request reads remain correct under a singleton.
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Wire `AddUsersModule()` into `Program.cs` immediately before `AddCrossCuttingServices()`**
+
+Open `backend/src/Anela.Heblo.API/Program.cs`. Find this block (around lines 76–78):
+
+```csharp
+        builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+        builder.Services.AddXccServices(builder.Configuration); // Cross-cutting concerns (audit, telemetry, etc.)
+        builder.Services.AddCrossCuttingServices(); // Cross-cutting services from API layer
+```
+
+Replace with:
+
+```csharp
+        builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+        builder.Services.AddXccServices(builder.Configuration); // Cross-cutting concerns (audit, telemetry, etc.)
+        builder.Services.AddUsersModule(); // Users feature composition root (API-layer adapter for ICurrentUserService)
+        builder.Services.AddCrossCuttingServices(); // Cross-cutting services from API layer
+```
+
+You will also need a `using` directive for the new module at the top of `Program.cs`. Find the existing using block and add (alphabetically grouped with the other `Anela.Heblo.API.*` usings; the file already uses `using Anela.Heblo.API.MCP;`):
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+- [ ] **Step 3: Remove the inline DI registrations from `AddCrossCuttingServices`**
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Find lines 121–131 inside `AddCrossCuttingServices`:
+
+```csharp
+    public static IServiceCollection AddCrossCuttingServices(this IServiceCollection services)
+    {
+        // Register HttpContextAccessor for user service
+        services.AddHttpContextAccessor();
+
+        // Register TimeProvider
+        services.AddSingleton(TimeProvider.System);
+
+        // Register Current User Service
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+
+        // Register HttpClient for E2E testing middleware
+```
+
+Replace with (removes the `AddHttpContextAccessor()` and the `AddSingleton<ICurrentUserService, ...>` registration; keeps `TimeProvider` and `AddHttpClient`):
+
+```csharp
+    public static IServiceCollection AddCrossCuttingServices(this IServiceCollection services)
+    {
+        // Register TimeProvider
+        services.AddSingleton(TimeProvider.System);
+
+        // Register HttpClient for E2E testing middleware
+```
+
+- [ ] **Step 4: Remove the now-unused usings from `ServiceCollectionExtensions.cs`**
+
+`ServiceCollectionExtensions.cs` previously imported `Anela.Heblo.API.Features.Users` (after Task 2) and `Anela.Heblo.Domain.Features.Users` (existing) only because of the line you just deleted. Verify by reading the file — if no other reference to either namespace remains, remove both `using` directives.
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Lines 9 and 11 (currently `using Anela.Heblo.API.Features.Users;` and `using Anela.Heblo.Domain.Features.Users;`) — delete them.
+
+If `dotnet build` (Step 5) reports either namespace as still needed, restore that single using and proceed.
+
+- [ ] **Step 5: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no new warnings or errors. If a `CS0246` or `CS0103` surfaces for `ICurrentUserService` or `CurrentUserService` inside `ServiceCollectionExtensions.cs`, restore the deleted `using` for whichever namespace the compiler asks for.
+
+- [ ] **Step 6: Run `CurrentUserService` tests**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~CurrentUserService" --no-build
+```
+Expected: 11 tests PASS.
+
+- [ ] **Step 7: Run full backend test suite to confirm no regression in handlers that depend on `ICurrentUserService`**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --no-build
+```
+Expected: all tests PASS (baseline count unchanged). Pay attention to handler tests under `Features/Manufacture`, `Features/Purchase`, `Features/Marketing`, `Features/Journal`, `Features/GridLayouts`, and `Features/Logistics` — those handlers all inject `ICurrentUserService` and resolve through the DI container in integration paths.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs \
+        backend/src/Anela.Heblo.API/Program.cs \
+        backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "refactor: consolidate Users-module DI into UsersModule.cs composition root"
+```
+
+---
+
+## Task 4: Remove the unused `Microsoft.AspNetCore.Http` import from `UserManagementModule.cs`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`
+
+This is the only other `using Microsoft.AspNetCore.Http;` left in the Application project. Removing it is a prerequisite for removing the package reference in Task 5.
+
+- [ ] **Step 1: Delete the unused import**
+
+Open `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`. Find line 6:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+```
+
+Delete this single line. Leave the rest of the file (including the `// Note: HttpContextAccessor must be registered in the API layer` comment on line 36) untouched.
+
+- [ ] **Step 2: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` — the import was dead, so removing it cannot break anything.
+
+- [ ] **Step 3: Confirm there are no other `using Microsoft.AspNetCore.*` imports in the Application project**
+
+Run:
+```bash
+grep -rn "using Microsoft\.AspNetCore" backend/src/Anela.Heblo.Application
+```
+Expected: zero results.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
+git commit -m "chore: remove unused Microsoft.AspNetCore.Http import from UserManagementModule"
+```
+
+---
+
+## Task 5: Remove the `Microsoft.AspNetCore.Http.Abstractions` package reference from the Application csproj
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+
+This converts the architectural rule into a compile-time gate. Without this, a future commit could re-introduce `using Microsoft.AspNetCore.Http;` in Application without breaking the build.
+
+- [ ] **Step 1: Remove the package reference**
+
+Open `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`. Find line 21:
+
+```xml
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+```
+
+Delete this single line. Leave the surrounding `<ItemGroup>` and other `<PackageReference>` entries untouched.
+
+- [ ] **Step 2: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no new errors. If the build fails with `CS0246` for any `Microsoft.AspNetCore.Http.*` symbol inside `Anela.Heblo.Application`, that is a hidden reference the grep did not catch — investigate the failing file, decide whether to relocate the offending code (preferred) or restore the package reference (last resort), and only proceed with the build green.
+
+- [ ] **Step 3: Confirm no `Microsoft.AspNetCore` source references remain in the Application project**
+
+Run:
+```bash
+grep -rn "Microsoft\.AspNetCore" backend/src/Anela.Heblo.Application
+```
+Expected: zero results. (No `using` directives, no fully-qualified usages, no csproj entries.)
+
+- [ ] **Step 4: Run the full backend test suite**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --no-build
+```
+Expected: all tests PASS — no behavioral change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+git commit -m "refactor: drop Microsoft.AspNetCore.Http.Abstractions from Application csproj"
+```
+
+---
+
+## Task 6: Lock the boundary in with an architecture test
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+Per the arch-review's recommended follow-up (and to make NFR-3 a CI gate that survives future refactors), add a test that asserts no type in the `Anela.Heblo.Application` assembly references any namespace starting with `Microsoft.AspNetCore.`.
+
+- [ ] **Step 1: Write the new architecture test**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Find the end of the existing `Logistics_types_should_not_reference_Purchase_owned_namespaces` method (around line 266, the closing `}` before the `private static bool IsForbidden(...)` helper). Add this new `[Fact]` method directly after that closing brace and before the `IsForbidden` helper:
+
+```csharp
+    [Fact]
+    public void Application_types_should_not_reference_AspNetCore_namespaces()
+    {
+        // NFR-3 from spec 2026-05-26: the Application layer must remain free of any
+        // Microsoft.AspNetCore.* type references. CurrentUserService was relocated to
+        // the API project to enforce this. This test prevents regression.
+        const string ApplicationNamespacePrefix = "Anela.Heblo.Application";
+        const string ForbiddenPrefix = "Microsoft.AspNetCore";
+
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var applicationTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                && t.Namespace.StartsWith(ApplicationNamespacePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var applicationType in applicationTypes)
+        {
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(applicationType))
+            {
+                if (referencedType.Namespace is null)
+                    continue;
+
+                if (!referencedType.Namespace.Equals(ForbiddenPrefix, StringComparison.Ordinal)
+                    && !referencedType.Namespace.StartsWith(ForbiddenPrefix + ".", StringComparison.Ordinal))
+                    continue;
+
+                violations.Add($"{applicationType.FullName} -> {referencedType.FullName} (via {memberDescription})");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "Application layer must not reference Microsoft.AspNetCore.* types. " +
+            "Move ASP.NET Core-dependent code to the API or Infrastructure layer and " +
+            "expose it through a framework-neutral abstraction in Domain or Application. " +
+            "Found:\n  " + string.Join("\n  ", violations));
+    }
+```
+
+- [ ] **Step 2: Build to make sure the new test compiles**
+
+Run:
+```bash
+cd backend && dotnet build test/Anela.Heblo.Tests
+```
+Expected: `Build succeeded.`
+
+- [ ] **Step 3: Run the new test**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~Application_types_should_not_reference_AspNetCore_namespaces" --no-build
+```
+Expected: PASS. If it fails, the failure message lists every type/member combination that still pulls in `Microsoft.AspNetCore.*` — investigate the offending file, relocate the code or its abstraction, and rerun. Do not work around the test by adding an allowlist; the whole point is to ban this dependency outright.
+
+- [ ] **Step 4: Run the full module-boundary suite to make sure the new test does not break existing rules**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ModuleBoundariesTests" --no-build
+```
+Expected: all rules PASS, including the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test: lock in Application -> Microsoft.AspNetCore.* boundary via architecture test"
+```
+
+---
+
+## Task 7: Final validation
+
+**Files:** none modified beyond formatting that `dotnet format` may apply.
+
+- [ ] **Step 1: Run `dotnet format` and verify there are no changes**
+
+Run:
+```bash
+cd backend && dotnet format --verify-no-changes
+```
+Expected: exit code 0. If `dotnet format` reports issues, run `dotnet format` (without `--verify-no-changes`) to fix them, then re-run with `--verify-no-changes` to confirm clean.
+
+- [ ] **Step 2: Full backend build**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no warnings/errors.
+
+- [ ] **Step 3: Full backend test suite**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --no-build
+```
+Expected: all tests PASS — baseline count preserved + the new boundary test added in Task 6.
+
+- [ ] **Step 4: Final invariant grep**
+
+Run:
+```bash
+grep -rn "Microsoft\.AspNetCore" backend/src/Anela.Heblo.Application
+grep -rn "Anela\.Heblo\.Application\.Features\.Users" backend/
+```
+Expected: both commands return zero matches.
+
+- [ ] **Step 5: Verify file layout matches the plan**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.API/Features/Users/
+ls backend/src/Anela.Heblo.Application/Features/Users/ 2>&1 || echo "old directory removed: OK"
+```
+Expected: the API folder contains `CurrentUserService.cs` and `UsersModule.cs`. The Application folder either doesn't exist (preferred) or is empty.
+
+- [ ] **Step 6: Commit any format-only changes (if produced by Step 1)**
+
+If `dotnet format` modified files in earlier steps, capture them now:
+
+```bash
+git status
+# If files were changed by dotnet format, stage and commit them:
+git add -u backend/
+git commit -m "chore: apply dotnet format"
+```
+
+If nothing changed, skip this step — do not create an empty commit.
+
+---
+
+## Acceptance Criteria Map (Spec → Plan)
+
+| Spec | Where it is satisfied |
+|------|-----------------------|
+| FR-1 (interface accessible to Application) | Already satisfied — `ICurrentUserService` lives in `Anela.Heblo.Domain.Features.Users`. Verified in Task 1 (baseline) and protected by Task 2 (no namespace renames). |
+| FR-2 (relocate implementation) | Task 2 |
+| FR-3 (consolidate DI into `UsersModule.cs`) | Task 3 |
+| FR-4 (preserve runtime behavior end-to-end) | Task 2 Step 8, Task 3 Step 7, Task 5 Step 4, Task 7 Step 3 — every existing test must pass at each checkpoint. |
+| FR-5 (update affected usings + zero remaining old-namespace hits) | Task 2 Steps 3–5 + Step 9; final grep in Task 7 Step 4. |
+| NFR-1 (no perf impact) | No code-path changes; lifetimes unchanged; verified by passing test suite. |
+| NFR-2 (security — identical identity reads) | Implementation moved verbatim in Task 2 Step 1; tests for claim selection (`Email`/`preferred_username`/`upn`, `sub`/`oid`/`NameIdentifier`) re-run in Task 2 Step 8 and Task 3 Step 6. |
+| NFR-3 (Application has zero ASP.NET Core source or package refs) | Source removed in Task 2 + Task 4. Package reference removed in Task 5. Locked in by Task 6 architecture test. Final grep in Task 7 Step 4. |
+| NFR-4 (testability preserved) | Test files updated only by `using` directive in Task 2; no production fakes/mocks change. |
+| Arch-review amendment 1 (FR-1 already met) | Documented above; Task 1 Step 4 confirms. |
+| Arch-review amendment 2 (delete package reference) | Task 5 |
+| Arch-review amendment 3 (delete unused `using` in `UserManagementModule.cs:6`) | Task 4 |
+| Arch-review amendment 4 (architecture test follow-up) | Task 6 |

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -6,9 +6,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Anela.Heblo.Xcc;
 using Anela.Heblo.Xcc.Telemetry;
 using Anela.Heblo.API.Infrastructure.Telemetry;
-using Anela.Heblo.API.Features.Users;
 using Anela.Heblo.Domain.Features.Configuration;
-using Anela.Heblo.Domain.Features.Users;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Microsoft.OpenApi.Models;
 using Hangfire;
@@ -120,14 +118,8 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddCrossCuttingServices(this IServiceCollection services)
     {
-        // Register HttpContextAccessor for user service
-        services.AddHttpContextAccessor();
-
         // Register TimeProvider
         services.AddSingleton(TimeProvider.System);
-
-        // Register Current User Service
-        services.AddSingleton<ICurrentUserService, CurrentUserService>();
 
         // Register HttpClient for E2E testing middleware
         services.AddHttpClient();

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Anela.Heblo.Xcc;
 using Anela.Heblo.Xcc.Telemetry;
 using Anela.Heblo.API.Infrastructure.Telemetry;
-using Anela.Heblo.Application.Features.Users;
+using Anela.Heblo.API.Features.Users;
 using Anela.Heblo.Domain.Features.Configuration;
 using Anela.Heblo.Domain.Features.Users;
 using Anela.Heblo.Domain.Features.BackgroundJobs;

--- a/backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs
+++ b/backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs
@@ -2,7 +2,7 @@ using System.Security.Claims;
 using Anela.Heblo.Domain.Features.Users;
 using Microsoft.AspNetCore.Http;
 
-namespace Anela.Heblo.Application.Features.Users;
+namespace Anela.Heblo.API.Features.Users;
 
 public class CurrentUserService : ICurrentUserService
 {

--- a/backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs
+++ b/backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs
@@ -1,0 +1,18 @@
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.API.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddHttpContextAccessor();
+
+        // Lifetime preserved from prior registration; HttpContextAccessor uses AsyncLocal
+        // so per-request reads remain correct under a singleton.
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+
+        return services;
+    }
+}

--- a/backend/src/Anela.Heblo.API/Program.cs
+++ b/backend/src/Anela.Heblo.API/Program.cs
@@ -15,6 +15,7 @@ using Anela.Heblo.Adapters.Shoptet;
 using Anela.Heblo.Adapters.ShoptetApi;
 using Anela.Heblo.Adapters.ShoptetApi.IssuedInvoices;
 using Anela.Heblo.API.Extensions;
+using Anela.Heblo.API.Features.Users;
 using Anela.Heblo.API.MCP;
 using Anela.Heblo.API.Webhooks.Smartsupp;
 using Anela.Heblo.Application;
@@ -75,6 +76,7 @@ public partial class Program
         builder.Services.AddApplicationServices(builder.Configuration, builder.Environment); // Vertical slice modules from Application layer
         builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
         builder.Services.AddXccServices(builder.Configuration); // Cross-cutting concerns (audit, telemetry, etc.)
+        builder.Services.AddUsersModule(); // Users feature composition root (API-layer adapter for ICurrentUserService)
         builder.Services.AddCrossCuttingServices(); // Cross-cutting services from API layer
         builder.Services.AddSpaServices();
 

--- a/backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+++ b/backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />

--- a/backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Anela.Heblo.Domain.Features.Configuration;
 using Microsoft.Graph;
-using Microsoft.AspNetCore.Http;
 
 namespace Anela.Heblo.Application.Features.UserManagement;
 

--- a/backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs
@@ -1,5 +1,5 @@
 using System.Security.Claims;
-using Anela.Heblo.Application.Features.Users;
+using Anela.Heblo.API.Features.Users;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Moq;

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -265,6 +265,45 @@ public class ModuleBoundariesTests
             "Found:\n  " + string.Join("\n  ", violations));
     }
 
+    [Fact]
+    public void Application_types_should_not_reference_AspNetCore_namespaces()
+    {
+        // NFR-3 from spec 2026-05-26: the Application layer must remain free of any
+        // Microsoft.AspNetCore.* type references. CurrentUserService was relocated to
+        // the API project to enforce this. This test prevents regression.
+        const string ApplicationNamespacePrefix = "Anela.Heblo.Application";
+        const string ForbiddenPrefix = "Microsoft.AspNetCore";
+
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var applicationTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                && t.Namespace.StartsWith(ApplicationNamespacePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var applicationType in applicationTypes)
+        {
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(applicationType))
+            {
+                if (referencedType.Namespace is null)
+                    continue;
+
+                if (!referencedType.Namespace.Equals(ForbiddenPrefix, StringComparison.Ordinal)
+                    && !referencedType.Namespace.StartsWith(ForbiddenPrefix + ".", StringComparison.Ordinal))
+                    continue;
+
+                violations.Add($"{applicationType.FullName} -> {referencedType.FullName} (via {memberDescription})");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "Application layer must not reference Microsoft.AspNetCore.* types. " +
+            "Move ASP.NET Core-dependent code to the API or Infrastructure layer and " +
+            "expose it through a framework-neutral abstraction in Domain or Application. " +
+            "Found:\n  " + string.Join("\n  ", violations));
+    }
+
     private static bool IsForbidden(Type type, IReadOnlyList<string> forbiddenPrefixes)
     {
         if (type.Namespace is null)

--- a/backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs
@@ -1,5 +1,5 @@
 using System.Security.Claims;
-using Anela.Heblo.Application.Features.Users;
+using Anela.Heblo.API.Features.Users;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;

--- a/docs/superpowers/plans/2026-05-26-relocate-currentuserservice-out-of-application.md
+++ b/docs/superpowers/plans/2026-05-26-relocate-currentuserservice-out-of-application.md
@@ -1,0 +1,635 @@
+# Relocate `CurrentUserService` Out of Application Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the `CurrentUserService` implementation out of the Application layer to the API layer, consolidate Users DI wiring into a `UsersModule.cs`, and remove the `Microsoft.AspNetCore.Http.Abstractions` package reference from the Application csproj so the Clean Architecture boundary is enforced at compile time.
+
+**Architecture:** The interface `ICurrentUserService` already lives in `Anela.Heblo.Domain.Features.Users` (no change). The concrete implementation moves verbatim to `Anela.Heblo.API/Features/Users/CurrentUserService.cs` (namespace `Anela.Heblo.API.Features.Users`). A new `UsersModule.cs` in the same folder exposes `AddUsersModule()` that registers `IHttpContextAccessor` + `AddSingleton<ICurrentUserService, CurrentUserService>()`. Program.cs invokes `AddUsersModule()` immediately before `AddCrossCuttingServices()`. The `Microsoft.AspNetCore.Http.Abstractions` package reference is removed from `Anela.Heblo.Application.csproj`, and a new architecture test locks the rule in.
+
+**Tech Stack:** .NET 8, ASP.NET Core, xUnit, FluentAssertions, Moq, MediatR (handlers consume `ICurrentUserService` unchanged).
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` — moved verbatim from Application; new namespace `Anela.Heblo.API.Features.Users`.
+- `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` — composition root for the Users module; exposes `AddUsersModule(this IServiceCollection)`.
+
+**Delete:**
+- `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs` — moved.
+- `backend/src/Anela.Heblo.Application/Features/Users/` directory if it becomes empty.
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — remove `Microsoft.AspNetCore.Http.Abstractions` package reference (line 21).
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — remove unused `using Microsoft.AspNetCore.Http;` (line 6).
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — remove inline `AddHttpContextAccessor()` and `AddSingleton<ICurrentUserService, CurrentUserService>()` from `AddCrossCuttingServices()`; remove now-unused usings.
+- `backend/src/Anela.Heblo.API/Program.cs` — add `builder.Services.AddUsersModule();` before `AddCrossCuttingServices()`.
+- `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs` — update `using Anela.Heblo.Application.Features.Users;` → `using Anela.Heblo.API.Features.Users;`.
+- `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs` — same using update.
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — add an `Application_should_not_reference_AspNetCore` test (locks in NFR-3 as a CI gate).
+
+---
+
+## Task 1: Establish green baseline
+
+**Files:** none modified — pure verification before changes.
+
+- [ ] **Step 1: Build the backend solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)` (or pre-existing warnings only).
+
+- [ ] **Step 2: Run the existing `CurrentUserService` tests to confirm they currently pass**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~CurrentUserService" --no-build
+```
+Expected: All tests in `CurrentUserServiceTests` (8 tests) and `CurrentUserServiceIsInRoleTests` (3 tests) PASS — 11 total green.
+
+- [ ] **Step 3: Run the existing module-boundary architecture tests**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ModuleBoundariesTests" --no-build
+```
+Expected: All existing rules PASS.
+
+- [ ] **Step 4: Confirm baseline grep state**
+
+Run:
+```bash
+grep -rn "Microsoft.AspNetCore" backend/src/Anela.Heblo.Application
+```
+Expected output (exactly two lines): the `using Microsoft.AspNetCore.Http;` at `Features/UserManagement/UserManagementModule.cs:6` and the source file `Features/Users/CurrentUserService.cs:3`. The csproj `PackageReference` should also be visible if you grep the csproj — that's the package we will remove.
+
+- [ ] **Step 5: No commit — this task is verification only.**
+
+---
+
+## Task 2: Move `CurrentUserService` from Application to API project
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs`
+- Delete: `backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs`
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (update `using` for the relocated type)
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs` (`using` only)
+- Modify: `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs` (`using` only)
+
+- [ ] **Step 1: Create the new file with the implementation verbatim under the API namespace**
+
+Create `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` with this exact content:
+
+```csharp
+using System.Security.Claims;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.AspNetCore.Http;
+
+namespace Anela.Heblo.API.Features.Users;
+
+public class CurrentUserService : ICurrentUserService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public CurrentUser GetCurrentUser()
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        var isAuthenticated = user?.Identity?.IsAuthenticated ?? false;
+
+        var name = user?.Identity?.Name
+                   ?? user?.FindFirst(ClaimTypes.Name)?.Value
+                   ?? user?.FindFirst("name")?.Value
+                   ?? (isAuthenticated ? "Unknown User" : "Anonymous");
+
+        var id = user?.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                 ?? user?.FindFirst("sub")?.Value
+                 ?? user?.FindFirst("oid")?.Value;
+
+        // Entra ID access tokens omit the `email` claim by default; the user's
+        // email/UPN lives in `preferred_username` (and sometimes `upn`).
+        // ClaimTypes.Upn covers the legacy JwtSecurityTokenHandler claim remap.
+        var email = user?.FindFirst(ClaimTypes.Email)?.Value
+                    ?? user?.FindFirst("email")?.Value
+                    ?? user?.FindFirst("preferred_username")?.Value
+                    ?? user?.FindFirst(ClaimTypes.Upn)?.Value
+                    ?? user?.FindFirst("upn")?.Value;
+
+        return new CurrentUser(
+            Id: id,
+            Name: name,
+            Email: email,
+            IsAuthenticated: isAuthenticated
+        );
+    }
+
+    public bool IsInRole(string role)
+    {
+        return _httpContextAccessor.HttpContext?.User?.IsInRole(role) ?? false;
+    }
+}
+```
+
+- [ ] **Step 2: Delete the old implementation file**
+
+Run:
+```bash
+rm backend/src/Anela.Heblo.Application/Features/Users/CurrentUserService.cs
+```
+
+Then check whether the directory is now empty and delete it if so:
+```bash
+rmdir backend/src/Anela.Heblo.Application/Features/Users 2>/dev/null || true
+```
+Expected: directory removed if empty; the command silently no-ops if not.
+
+- [ ] **Step 3: Update the `using` in `ServiceCollectionExtensions.cs` to the new namespace**
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Find line 9:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+Leave the rest of the file unchanged for this task; the inline DI registration on line 130 will be removed in Task 3.
+
+- [ ] **Step 4: Update the `using` in `CurrentUserServiceTests.cs`**
+
+Open `backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs`. Find line 2:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+- [ ] **Step 5: Update the `using` in `CurrentUserServiceIsInRoleTests.cs`**
+
+Open `backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs`. Find line 2:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Replace with:
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+- [ ] **Step 6: Add a project reference from the test project to the API project if it does not already exist**
+
+The test project must be able to resolve `Anela.Heblo.API.Features.Users.CurrentUserService`. Inspect:
+
+```bash
+cat backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj | grep -i ProjectReference
+```
+
+Expected: an entry like `<ProjectReference Include="..\..\src\Anela.Heblo.API\Anela.Heblo.API.csproj" />` already exists (the tests already reference API). If — and only if — no such reference exists, add it inside the existing `<ItemGroup>` containing other `ProjectReference` entries:
+
+```xml
+<ProjectReference Include="..\..\src\Anela.Heblo.API\Anela.Heblo.API.csproj" />
+```
+
+Do not add the reference if it is already present.
+
+- [ ] **Step 7: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no new warnings or errors.
+
+- [ ] **Step 8: Run the relocated tests to confirm they still pass**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~CurrentUserService" --no-build
+```
+Expected: same 11 tests PASS — behavior is unchanged.
+
+- [ ] **Step 9: Confirm no stale references to the old namespace remain**
+
+Run:
+```bash
+grep -rn "Anela\.Heblo\.Application\.Features\.Users" backend/
+```
+Expected: zero results. (The only files that referenced the old namespace were the three updated in Steps 3–5.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs \
+        backend/src/Anela.Heblo.Application/Features/Users \
+        backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs \
+        backend/test/Anela.Heblo.Tests/Features/Users/CurrentUserServiceTests.cs \
+        backend/test/Anela.Heblo.Tests/Application/Users/CurrentUserServiceIsInRoleTests.cs
+git commit -m "refactor: move CurrentUserService implementation from Application to API layer"
+```
+
+---
+
+## Task 3: Create `UsersModule.cs` and re-route DI through it
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs`
+- Modify: `backend/src/Anela.Heblo.API/Program.cs` (add `AddUsersModule()` call)
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (remove inline registration + now-unused usings)
+
+- [ ] **Step 1: Create `UsersModule.cs` exposing `AddUsersModule()`**
+
+Create `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.API.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddHttpContextAccessor();
+
+        // Lifetime preserved from prior registration; HttpContextAccessor uses AsyncLocal
+        // so per-request reads remain correct under a singleton.
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 2: Wire `AddUsersModule()` into `Program.cs` immediately before `AddCrossCuttingServices()`**
+
+Open `backend/src/Anela.Heblo.API/Program.cs`. Find this block (around lines 76–78):
+
+```csharp
+        builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+        builder.Services.AddXccServices(builder.Configuration); // Cross-cutting concerns (audit, telemetry, etc.)
+        builder.Services.AddCrossCuttingServices(); // Cross-cutting services from API layer
+```
+
+Replace with:
+
+```csharp
+        builder.Services.AddScoped<ISmartsuppWebhookMetrics, SmartsuppWebhookMetrics>();
+        builder.Services.AddXccServices(builder.Configuration); // Cross-cutting concerns (audit, telemetry, etc.)
+        builder.Services.AddUsersModule(); // Users feature composition root (API-layer adapter for ICurrentUserService)
+        builder.Services.AddCrossCuttingServices(); // Cross-cutting services from API layer
+```
+
+You will also need a `using` directive for the new module at the top of `Program.cs`. Find the existing using block and add (alphabetically grouped with the other `Anela.Heblo.API.*` usings; the file already uses `using Anela.Heblo.API.MCP;`):
+
+```csharp
+using Anela.Heblo.API.Features.Users;
+```
+
+- [ ] **Step 3: Remove the inline DI registrations from `AddCrossCuttingServices`**
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Find lines 121–131 inside `AddCrossCuttingServices`:
+
+```csharp
+    public static IServiceCollection AddCrossCuttingServices(this IServiceCollection services)
+    {
+        // Register HttpContextAccessor for user service
+        services.AddHttpContextAccessor();
+
+        // Register TimeProvider
+        services.AddSingleton(TimeProvider.System);
+
+        // Register Current User Service
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+
+        // Register HttpClient for E2E testing middleware
+```
+
+Replace with (removes the `AddHttpContextAccessor()` and the `AddSingleton<ICurrentUserService, ...>` registration; keeps `TimeProvider` and `AddHttpClient`):
+
+```csharp
+    public static IServiceCollection AddCrossCuttingServices(this IServiceCollection services)
+    {
+        // Register TimeProvider
+        services.AddSingleton(TimeProvider.System);
+
+        // Register HttpClient for E2E testing middleware
+```
+
+- [ ] **Step 4: Remove the now-unused usings from `ServiceCollectionExtensions.cs`**
+
+`ServiceCollectionExtensions.cs` previously imported `Anela.Heblo.API.Features.Users` (after Task 2) and `Anela.Heblo.Domain.Features.Users` (existing) only because of the line you just deleted. Verify by reading the file — if no other reference to either namespace remains, remove both `using` directives.
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`. Lines 9 and 11 (currently `using Anela.Heblo.API.Features.Users;` and `using Anela.Heblo.Domain.Features.Users;`) — delete them.
+
+If `dotnet build` (Step 5) reports either namespace as still needed, restore that single using and proceed.
+
+- [ ] **Step 5: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no new warnings or errors. If a `CS0246` or `CS0103` surfaces for `ICurrentUserService` or `CurrentUserService` inside `ServiceCollectionExtensions.cs`, restore the deleted `using` for whichever namespace the compiler asks for.
+
+- [ ] **Step 6: Run `CurrentUserService` tests**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~CurrentUserService" --no-build
+```
+Expected: 11 tests PASS.
+
+- [ ] **Step 7: Run full backend test suite to confirm no regression in handlers that depend on `ICurrentUserService`**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --no-build
+```
+Expected: all tests PASS (baseline count unchanged). Pay attention to handler tests under `Features/Manufacture`, `Features/Purchase`, `Features/Marketing`, `Features/Journal`, `Features/GridLayouts`, and `Features/Logistics` — those handlers all inject `ICurrentUserService` and resolve through the DI container in integration paths.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs \
+        backend/src/Anela.Heblo.API/Program.cs \
+        backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "refactor: consolidate Users-module DI into UsersModule.cs composition root"
+```
+
+---
+
+## Task 4: Remove the unused `Microsoft.AspNetCore.Http` import from `UserManagementModule.cs`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`
+
+This is the only other `using Microsoft.AspNetCore.Http;` left in the Application project. Removing it is a prerequisite for removing the package reference in Task 5.
+
+- [ ] **Step 1: Delete the unused import**
+
+Open `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`. Find line 6:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+```
+
+Delete this single line. Leave the rest of the file (including the `// Note: HttpContextAccessor must be registered in the API layer` comment on line 36) untouched.
+
+- [ ] **Step 2: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` — the import was dead, so removing it cannot break anything.
+
+- [ ] **Step 3: Confirm there are no other `using Microsoft.AspNetCore.*` imports in the Application project**
+
+Run:
+```bash
+grep -rn "using Microsoft\.AspNetCore" backend/src/Anela.Heblo.Application
+```
+Expected: zero results.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
+git commit -m "chore: remove unused Microsoft.AspNetCore.Http import from UserManagementModule"
+```
+
+---
+
+## Task 5: Remove the `Microsoft.AspNetCore.Http.Abstractions` package reference from the Application csproj
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`
+
+This converts the architectural rule into a compile-time gate. Without this, a future commit could re-introduce `using Microsoft.AspNetCore.Http;` in Application without breaking the build.
+
+- [ ] **Step 1: Remove the package reference**
+
+Open `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj`. Find line 21:
+
+```xml
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+```
+
+Delete this single line. Leave the surrounding `<ItemGroup>` and other `<PackageReference>` entries untouched.
+
+- [ ] **Step 2: Build the solution**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no new errors. If the build fails with `CS0246` for any `Microsoft.AspNetCore.Http.*` symbol inside `Anela.Heblo.Application`, that is a hidden reference the grep did not catch — investigate the failing file, decide whether to relocate the offending code (preferred) or restore the package reference (last resort), and only proceed with the build green.
+
+- [ ] **Step 3: Confirm no `Microsoft.AspNetCore` source references remain in the Application project**
+
+Run:
+```bash
+grep -rn "Microsoft\.AspNetCore" backend/src/Anela.Heblo.Application
+```
+Expected: zero results. (No `using` directives, no fully-qualified usages, no csproj entries.)
+
+- [ ] **Step 4: Run the full backend test suite**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --no-build
+```
+Expected: all tests PASS — no behavioral change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+git commit -m "refactor: drop Microsoft.AspNetCore.Http.Abstractions from Application csproj"
+```
+
+---
+
+## Task 6: Lock the boundary in with an architecture test
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+Per the arch-review's recommended follow-up (and to make NFR-3 a CI gate that survives future refactors), add a test that asserts no type in the `Anela.Heblo.Application` assembly references any namespace starting with `Microsoft.AspNetCore.`.
+
+- [ ] **Step 1: Write the new architecture test**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Find the end of the existing `Logistics_types_should_not_reference_Purchase_owned_namespaces` method (around line 266, the closing `}` before the `private static bool IsForbidden(...)` helper). Add this new `[Fact]` method directly after that closing brace and before the `IsForbidden` helper:
+
+```csharp
+    [Fact]
+    public void Application_types_should_not_reference_AspNetCore_namespaces()
+    {
+        // NFR-3 from spec 2026-05-26: the Application layer must remain free of any
+        // Microsoft.AspNetCore.* type references. CurrentUserService was relocated to
+        // the API project to enforce this. This test prevents regression.
+        const string ApplicationNamespacePrefix = "Anela.Heblo.Application";
+        const string ForbiddenPrefix = "Microsoft.AspNetCore";
+
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var applicationTypes = assembly.GetTypes()
+            .Where(t => t.Namespace is not null
+                && t.Namespace.StartsWith(ApplicationNamespacePrefix, StringComparison.Ordinal))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var applicationType in applicationTypes)
+        {
+            foreach (var (referencedType, memberDescription) in EnumerateReferencedTypes(applicationType))
+            {
+                if (referencedType.Namespace is null)
+                    continue;
+
+                if (!referencedType.Namespace.Equals(ForbiddenPrefix, StringComparison.Ordinal)
+                    && !referencedType.Namespace.StartsWith(ForbiddenPrefix + ".", StringComparison.Ordinal))
+                    continue;
+
+                violations.Add($"{applicationType.FullName} -> {referencedType.FullName} (via {memberDescription})");
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "Application layer must not reference Microsoft.AspNetCore.* types. " +
+            "Move ASP.NET Core-dependent code to the API or Infrastructure layer and " +
+            "expose it through a framework-neutral abstraction in Domain or Application. " +
+            "Found:\n  " + string.Join("\n  ", violations));
+    }
+```
+
+- [ ] **Step 2: Build to make sure the new test compiles**
+
+Run:
+```bash
+cd backend && dotnet build test/Anela.Heblo.Tests
+```
+Expected: `Build succeeded.`
+
+- [ ] **Step 3: Run the new test**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~Application_types_should_not_reference_AspNetCore_namespaces" --no-build
+```
+Expected: PASS. If it fails, the failure message lists every type/member combination that still pulls in `Microsoft.AspNetCore.*` — investigate the offending file, relocate the code or its abstraction, and rerun. Do not work around the test by adding an allowlist; the whole point is to ban this dependency outright.
+
+- [ ] **Step 4: Run the full module-boundary suite to make sure the new test does not break existing rules**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --filter "FullyQualifiedName~ModuleBoundariesTests" --no-build
+```
+Expected: all rules PASS, including the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test: lock in Application -> Microsoft.AspNetCore.* boundary via architecture test"
+```
+
+---
+
+## Task 7: Final validation
+
+**Files:** none modified beyond formatting that `dotnet format` may apply.
+
+- [ ] **Step 1: Run `dotnet format` and verify there are no changes**
+
+Run:
+```bash
+cd backend && dotnet format --verify-no-changes
+```
+Expected: exit code 0. If `dotnet format` reports issues, run `dotnet format` (without `--verify-no-changes`) to fix them, then re-run with `--verify-no-changes` to confirm clean.
+
+- [ ] **Step 2: Full backend build**
+
+Run:
+```bash
+cd backend && dotnet build
+```
+Expected: `Build succeeded.` with no warnings/errors.
+
+- [ ] **Step 3: Full backend test suite**
+
+Run:
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests --no-build
+```
+Expected: all tests PASS — baseline count preserved + the new boundary test added in Task 6.
+
+- [ ] **Step 4: Final invariant grep**
+
+Run:
+```bash
+grep -rn "Microsoft\.AspNetCore" backend/src/Anela.Heblo.Application
+grep -rn "Anela\.Heblo\.Application\.Features\.Users" backend/
+```
+Expected: both commands return zero matches.
+
+- [ ] **Step 5: Verify file layout matches the plan**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.API/Features/Users/
+ls backend/src/Anela.Heblo.Application/Features/Users/ 2>&1 || echo "old directory removed: OK"
+```
+Expected: the API folder contains `CurrentUserService.cs` and `UsersModule.cs`. The Application folder either doesn't exist (preferred) or is empty.
+
+- [ ] **Step 6: Commit any format-only changes (if produced by Step 1)**
+
+If `dotnet format` modified files in earlier steps, capture them now:
+
+```bash
+git status
+# If files were changed by dotnet format, stage and commit them:
+git add -u backend/
+git commit -m "chore: apply dotnet format"
+```
+
+If nothing changed, skip this step — do not create an empty commit.
+
+---
+
+## Acceptance Criteria Map (Spec → Plan)
+
+| Spec | Where it is satisfied |
+|------|-----------------------|
+| FR-1 (interface accessible to Application) | Already satisfied — `ICurrentUserService` lives in `Anela.Heblo.Domain.Features.Users`. Verified in Task 1 (baseline) and protected by Task 2 (no namespace renames). |
+| FR-2 (relocate implementation) | Task 2 |
+| FR-3 (consolidate DI into `UsersModule.cs`) | Task 3 |
+| FR-4 (preserve runtime behavior end-to-end) | Task 2 Step 8, Task 3 Step 7, Task 5 Step 4, Task 7 Step 3 — every existing test must pass at each checkpoint. |
+| FR-5 (update affected usings + zero remaining old-namespace hits) | Task 2 Steps 3–5 + Step 9; final grep in Task 7 Step 4. |
+| NFR-1 (no perf impact) | No code-path changes; lifetimes unchanged; verified by passing test suite. |
+| NFR-2 (security — identical identity reads) | Implementation moved verbatim in Task 2 Step 1; tests for claim selection (`Email`/`preferred_username`/`upn`, `sub`/`oid`/`NameIdentifier`) re-run in Task 2 Step 8 and Task 3 Step 6. |
+| NFR-3 (Application has zero ASP.NET Core source or package refs) | Source removed in Task 2 + Task 4. Package reference removed in Task 5. Locked in by Task 6 architecture test. Final grep in Task 7 Step 4. |
+| NFR-4 (testability preserved) | Test files updated only by `using` directive in Task 2; no production fakes/mocks change. |
+| Arch-review amendment 1 (FR-1 already met) | Documented above; Task 1 Step 4 confirms. |
+| Arch-review amendment 2 (delete package reference) | Task 5 |
+| Arch-review amendment 3 (delete unused `using` in `UserManagementModule.cs:6`) | Task 4 |
+| Arch-review amendment 4 (architecture test follow-up) | Task 6 |


### PR DESCRIPTION

Moves `CurrentUserService` from the Application layer to `Anela.Heblo.API/Features/Users/` to fix a Clean Architecture boundary violation where the Application project imported `Microsoft.AspNetCore.Http`. Creates a `UsersModule.cs` composition root following the project's existing vertical-slice module pattern. Removes the now-unnecessary `Microsoft.AspNetCore.Http.Abstractions` package reference from the Application csproj, converting the architectural rule into a compile-time gate. Adds a reflection-based architecture test that asserts no Application type references `Microsoft.AspNetCore.*` namespaces, locking the boundary in CI.

### Changes
- `backend/src/Anela.Heblo.API/Features/Users/CurrentUserService.cs` — moved from Application; namespace updated
- `backend/src/Anela.Heblo.API/Features/Users/UsersModule.cs` — new composition root with `AddUsersModule()`
- `backend/src/Anela.Heblo.API/Program.cs` — wires `AddUsersModule()` before `AddCrossCuttingServices()`
- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed inline user service DI
- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — dropped `Microsoft.AspNetCore.Http.Abstractions` package ref
- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — removed dead using
- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — new boundary test as CI gate

---

Closes #1716

### Tokens used
18804780
