### PR TITLE
feat: UsersModule.cs for Users Module DI Registration

### DIFF
--- a/artifacts/feat-arch-review-users-missing-usersmodule-cs/arch-review.r1.md
+++ b/artifacts/feat-arch-review-users-missing-usersmodule-cs/arch-review.r1.md
@@ -1,0 +1,140 @@
+# Architecture Review: UsersModule.cs for Users Module DI Registration
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This refactor brings the `Users` feature module into full compliance with the project's documented **Module Registration** convention (`docs/architecture/development_guidelines.md` §"Module Registration", lines 100–129). Verified state of the codebase:
+
+- **Convention is universal.** 37 sibling feature modules under `backend/src/Anela.Heblo.Application/Features/` each have a `{Feature}Module.cs` file with an `Add{Feature}Module(this IServiceCollection)` extension. `Users` is the sole exception — its folder contains only `CurrentUserService.cs`.
+- **Boundary violation confirmed.** `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130` performs an Application-layer binding (`ICurrentUserService → CurrentUserService`) from an API-layer composition-root utility. The two `using` directives on lines 9 and 11 (`Application.Features.Users`, `Domain.Features.Users`) are referenced *only* by line 130 — verified by grep — so they become unused after the move.
+- **No cross-cutting fallout.** `ICurrentUserService` has ~32+ consumers across handlers (Journal, Packaging, MeetingTasks, Catalog.Inventory, etc.). All inject the interface, none reference `CurrentUserService` directly outside tests. A pure registration move is observable to none of them.
+- **Aggregation site is unambiguous.** `ApplicationModule.AddApplicationServices` already aggregates all 37 sibling modules; adding a 38th call is a one-line insertion matching the existing block (line 86, adjacent to `AddUserManagement`).
+
+Integration points: `IHttpContextAccessor` (registered in `AddCrossCuttingServices`, line 124). This dependency relationship is the only architectural subtlety and is addressed below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Program.cs
+  └── AddApplicationServices()        [Anela.Heblo.Application/ApplicationModule.cs]
+        ├── AddJournalModule()
+        ├── AddGridLayoutsModule()
+        ├── AddUserManagement(cfg)
+        ├── AddUsersModule()          ← NEW: registers ICurrentUserService → CurrentUserService (Singleton)
+        └── ... (35 other modules)
+
+  └── AddCrossCuttingServices()       [Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs]
+        ├── AddHttpContextAccessor()  ← stays; API-layer concern (consumed by CurrentUserService)
+        ├── AddSingleton(TimeProvider.System)
+        ├── [DELETED] AddSingleton<ICurrentUserService, CurrentUserService>()
+        └── ...
+```
+
+Resolution path at request time: handler → `ICurrentUserService` (singleton resolved from `IServiceProvider`) → `CurrentUserService` constructor → `IHttpContextAccessor` (singleton, ambient `HttpContext` via `AsyncLocal<T>`).
+
+### Key Design Decisions
+
+#### Decision 1: Module file placement matches sibling layout
+**Options considered:**
+- (A) `Application/Features/Users/UsersModule.cs` — matches all 37 siblings.
+- (B) Move `CurrentUserService` to `Application/Common/` first, drop the module entirely.
+- (C) Wait until issue #1716 resolves the Users folder location, then create the module.
+
+**Chosen approach:** (A).
+**Rationale:** Option B widens scope beyond a structural compliance fix and creates a per-service exception to the module pattern. Option C blocks a trivial fix on an unrelated refactor; if #1716 later moves the folder, `UsersModule.cs` moves with it as a single file in a directory rename — zero added cost. (A) is what the spec prescribes and what every sibling does.
+
+#### Decision 2: Preserve `Singleton` lifetime verbatim
+**Options considered:**
+- (A) Keep `AddSingleton<ICurrentUserService, CurrentUserService>()` (current behavior).
+- (B) Downgrade to `Scoped` to match per-request semantics conceptually.
+
+**Chosen approach:** (A).
+**Rationale:** Behavior-parity is an explicit acceptance criterion (FR-5, NFR-1). The singleton lifetime is safe because `CurrentUserService` holds no per-request state — it captures `IHttpContextAccessor` (itself singleton, ambient context via `AsyncLocal<T>`). Changing the lifetime in this refactor would conflate two changes and break the "surgical change" constraint (NFR-3). If a future maintainer adds *new* services to `UsersModule` that hold per-request state, **they must choose `Scoped` for those services individually** — singleton is not the module-wide default and must not be assumed by future additions (see Risks table).
+
+#### Decision 3: Leave `IHttpContextAccessor` registration in the API layer
+**Options considered:**
+- (A) Keep `AddHttpContextAccessor()` in `AddCrossCuttingServices` (current state).
+- (B) Move it into `UsersModule` since `CurrentUserService` is the primary consumer.
+
+**Chosen approach:** (A).
+**Rationale:** `IHttpContextAccessor` is an ASP.NET Core HTTP-pipeline primitive — its conceptual home is the API/composition layer, not a feature module. The existing `UserManagementModule.cs:36` documents this exact convention: *"Note: HttpContextAccessor must be registered in the API layer."* Option B would introduce inconsistency for a 5-character saving. Explicitly out of scope per spec.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**New file:** `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs`
+
+**Modified files:**
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` — add 1 `using`, add 1 method call.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — delete 1 line + comment, delete 2 `using` directives (both verified unused after deletion).
+
+No other files touched.
+
+### Interfaces and Contracts
+
+**`UsersModule.cs`** — must match the exact shape of sibling modules for consistency. Use file-scoped namespace (matches `GridLayoutsModule.cs`, `UserManagementModule.cs`; `JournalModule.cs` uses block-scoped but file-scoped is the newer style and acceptable per `dotnet format` rules):
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Anela.Heblo.Domain.Features.Users;
+
+namespace Anela.Heblo.Application.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+        return services;
+    }
+}
+```
+
+**Aggregation point in `ApplicationModule.cs`:**
+- Add `using Anela.Heblo.Application.Features.Users;` to the existing import block.
+- Insert `services.AddUsersModule();` adjacent to `services.AddUserManagement(configuration);` at line 86 (logical grouping with the other identity-adjacent module).
+
+**Removal in `ServiceCollectionExtensions.cs`:**
+- Delete lines 129–130 (the `// Register Current User Service` comment + binding).
+- Delete `using Anela.Heblo.Application.Features.Users;` (line 9) — referenced only by deleted line 130.
+- Delete `using Anela.Heblo.Domain.Features.Users;` (line 11) — referenced only by deleted line 130.
+- Leave `AddHttpContextAccessor()` (line 124) untouched.
+
+### Data Flow
+
+Identical to today — no behavior change. Handler/service constructor receives `ICurrentUserService` from DI; on `GetCurrentUser()` or `IsInRole()`, the singleton reads the ambient `HttpContext` via `IHttpContextAccessor` and projects claims. Registration order in `Program.cs` (line 75 `AddApplicationServices` before line 78 `AddCrossCuttingServices`) remains correct: ASP.NET Core DI resolves at construction time, not registration time, so the order in which singletons are *declared* is irrelevant.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Duplicate registration if the API-layer deletion is missed, causing two `AddSingleton<ICurrentUserService, …>` calls — the last one wins, but it muddies the source of truth. | LOW | All three file changes are part of the single PR; CI build + `dotnet test` will catch any divergent behavior. Reviewer should grep `grep -rn "AddSingleton<ICurrentUserService" backend/src` after the change — must return exactly one hit. |
+| Stale `using` directives remain in `ServiceCollectionExtensions.cs` after deletion, causing `dotnet format` to flag warnings. | LOW | Spec FR-3 explicitly requires pruning. Verified via grep: both directives are referenced **only** at the deletion site. Run `dotnet format` after the change. |
+| Future contributor adds a *scoped* service to `UsersModule` and assumes the module's `Singleton` default applies — captive-dependency bug. | LOW | The current module body has exactly one line; the `AddSingleton` is local to that call, not a module-wide default. No mitigation needed beyond standard C# DI literacy, but a one-line comment in `UsersModule.cs` (e.g. `// CurrentUserService is singleton-safe because IHttpContextAccessor uses AsyncLocal.`) could be added if reviewer prefers — optional. |
+| `Program.cs` ordering changes in a future refactor put `AddCrossCuttingServices` before `AddApplicationServices` and someone assumes `IHttpContextAccessor` must be registered first. | NEGLIGIBLE | Ordering is irrelevant for DI resolution; only relevant for `IServiceCollection.TryAdd*` semantics, which are not used here. No action. |
+| Issue #1716 lands first and moves the Users folder, creating a merge conflict. | LOW | The conflict resolution is mechanical — the new module file follows the folder. No design-level conflict. Coordinate landing order with whoever owns #1716. |
+
+## Specification Amendments
+
+The spec (`spec.r1.md`) is complete and accurate. Minor confirmations from the codebase scan that should be noted in the PR description (not the spec itself):
+
+1. **Confirmed `using` deletions are safe.** `using Anela.Heblo.Application.Features.Users;` and `using Anela.Heblo.Domain.Features.Users;` in `ServiceCollectionExtensions.cs` are referenced **only** by line 130 (grep-verified). Both must be removed; otherwise `dotnet format` will flag them.
+2. **Namespace style suggestion.** Sibling modules are split between block-scoped (`JournalModule`) and file-scoped (`GridLayoutsModule`, `UserManagementModule`) namespaces. Use **file-scoped** for the new file — it's the newer, preferred style per modern `dotnet format` defaults and matches the two most recently created modules.
+3. **`using Anela.Heblo.Domain.Features.Users;` is required in the new module file** to reference `ICurrentUserService`. The `Anela.Heblo.Application.Features.Users` namespace doesn't need to be imported because `CurrentUserService` lives in that same namespace as `UsersModule`.
+
+No functional amendments required.
+
+## Prerequisites
+
+None. All preconditions are already met:
+
+- `Anela.Heblo.Application` project already references `Anela.Heblo.Domain` (where `ICurrentUserService` lives).
+- `Microsoft.Extensions.DependencyInjection.Abstractions` is already on the Application project's transitive graph (every sibling module uses it).
+- No NuGet packages, no project references, no migrations, no configuration changes.
+- No infrastructure or environment changes.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-users-missing-usersmodule-cs/brief.md
+++ b/artifacts/feat-arch-review-users-missing-usersmodule-cs/brief.md
@@ -1,0 +1,34 @@
+## Module
+Users
+
+## Finding
+`development_guidelines.md` requires every module to own a `{Feature}Module.cs` for DI registration. The Users module has no such file. Instead, the `ICurrentUserService → CurrentUserService` binding is wired directly in the API project:
+
+```csharp
+// backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs, line 130
+services.AddSingleton<ICurrentUserService, CurrentUserService>();
+```
+
+Every other module (e.g. `GridLayoutsModule.cs`, `JournalModule.cs`) registers its own services via a dedicated `Module.cs`. Users is the only module that breaks this convention.
+
+## Why it matters
+The module registration pattern is the project's documented mechanism for module isolation and makes each module self-describing. Embedding the binding in `ServiceCollectionExtensions` (a composition-root utility) violates that boundary and makes Users the odd one out — future developers adding Users-related services have no obvious place to put registrations.
+
+## Suggested fix
+Create `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` (or wherever the implementation ultimately lives after resolving #1716):
+
+```csharp
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+        return services;
+    }
+}
+```
+
+Then replace the inline registration in `ServiceCollectionExtensions.cs` with `.AddUsersModule()`.
+
+---
+_Filed by daily arch-review routine on 2026-05-25._

--- a/artifacts/feat-arch-review-users-missing-usersmodule-cs/impl/main.r1.md
+++ b/artifacts/feat-arch-review-users-missing-usersmodule-cs/impl/main.r1.md
@@ -1,0 +1,14 @@
+**Step 3 — Base branch:** `main`
+
+GIT_DIR == GIT_COMMON → this is a normal repo (no worktree to clean up post-merge).
+
+---
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-users-missing-usersmodule-cs/spec.r1.md
+++ b/artifacts/feat-arch-review-users-missing-usersmodule-cs/spec.r1.md
@@ -1,0 +1,104 @@
+# Specification: UsersModule.cs for Users Module DI Registration
+
+## Summary
+Create a dedicated `UsersModule.cs` for the `Users` feature module to bring it in line with the project's documented module-registration convention. Move the existing `ICurrentUserService → CurrentUserService` binding out of the API-layer composition root (`ServiceCollectionExtensions.AddCrossCuttingServices`) and into the new module, then aggregate it from `ApplicationModule.AddApplicationServices`. This is a structural refactor with no behavior change.
+
+## Background
+`docs/architecture/development_guidelines.md` (§ "Module Registration", lines 100–129) requires every feature module to expose its own `{Feature}Module.cs` with an `Add{Feature}Module(this IServiceCollection)` extension. Every feature under `backend/src/Anela.Heblo.Application/Features/` follows this pattern (e.g. `JournalModule`, `GridLayoutsModule`, `UserManagementModule`) — except `Users`, which has only `CurrentUserService.cs` and no module file.
+
+The single binding the module owns — `ICurrentUserService → CurrentUserService` — currently lives in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130` inside `AddCrossCuttingServices()`. This violates two boundaries:
+
+1. The `Users` module is no longer self-describing — a future developer adding Users-related services has no obvious place to register them.
+2. The API layer's composition-root utility owns a binding that belongs to the Application layer module.
+
+Note: the `UserManagement` module (Microsoft Graph integration) is a separate concern from `Users` (current-user identity from `HttpContext`); both can coexist after this refactor.
+
+The Users folder location may change pending resolution of issue #1716 (mentioned in the brief). That refactor is **not** in scope here — this spec targets only the missing `UsersModule.cs` at the current path.
+
+## Functional Requirements
+
+### FR-1: Create `UsersModule.cs`
+Add a new file at `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` exposing an `AddUsersModule` extension method on `IServiceCollection` and registering the `ICurrentUserService` binding.
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs`.
+- Declares a `public static class UsersModule` in namespace `Anela.Heblo.Application.Features.Users`.
+- Exposes `public static IServiceCollection AddUsersModule(this IServiceCollection services)`.
+- Method body registers `services.AddSingleton<ICurrentUserService, CurrentUserService>();` (lifetime preserved verbatim from the original).
+- Method returns `services` for fluent chaining (matches sibling modules — see `JournalModule.cs:18`).
+- File matches the structural conventions of `JournalModule.cs` and `GridLayoutsModule.cs` (single static class, no constructor logic, standard DI extension pattern).
+
+### FR-2: Aggregate `AddUsersModule()` from `ApplicationModule`
+Invoke the new module's registration from `ApplicationModule.AddApplicationServices` so it participates in the standard Application-layer aggregation.
+
+**Acceptance criteria:**
+- `backend/src/Anela.Heblo.Application/ApplicationModule.cs` imports `Anela.Heblo.Application.Features.Users`.
+- `services.AddUsersModule();` is called inside `AddApplicationServices` alongside other feature module registrations (placement near `services.AddUserManagement(configuration);` at line 86 is acceptable).
+- The call is **not** conditional on configuration — `ICurrentUserService` is unconditionally required.
+
+### FR-3: Remove the inline binding from the API composition root
+Delete the inline `services.AddSingleton<ICurrentUserService, CurrentUserService>();` call from `AddCrossCuttingServices()` so the binding lives in exactly one place.
+
+**Acceptance criteria:**
+- The line at `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130` is removed along with the adjacent `// Register Current User Service` comment.
+- Unused `using Anela.Heblo.Application.Features.Users;` and `using Anela.Heblo.Domain.Features.Users;` imports in that file are removed **only if** no other reference in the file uses them (verify by grep before deletion).
+- `services.AddHttpContextAccessor();` (the dependency `CurrentUserService` consumes) remains in `AddCrossCuttingServices()` — that is an API-layer concern and stays put.
+
+### FR-4: Preserve DI registration order semantics
+`CurrentUserService` depends on `IHttpContextAccessor`, which is registered in `AddCrossCuttingServices()` in the API layer. In the current `Program.cs` ordering (lines 74–78), `AddApplicationServices` runs **before** `AddCrossCuttingServices`. Since ASP.NET Core DI resolves dependencies at request time (not registration time), this ordering remains safe — but it must be verified.
+
+**Acceptance criteria:**
+- Application starts successfully (`dotnet run`) and `ICurrentUserService` can be resolved from any scope.
+- `Program.cs` call order is unchanged (`AddApplicationServices` then `AddCrossCuttingServices`).
+- No new explicit registration of `IHttpContextAccessor` is introduced inside `UsersModule` — that registration stays in the API layer (matching the pattern documented in `UserManagementModule.cs:36`: *"Note: HttpContextAccessor must be registered in the API layer"*).
+
+### FR-5: All existing tests pass
+`ICurrentUserService` is consumed by ~112 files (handlers, services, tests). The refactor must not change behavior observable by any consumer.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with zero warnings or errors introduced by the change.
+- `dotnet test` passes the full backend test suite (no test modifications expected).
+- `dotnet format` reports no violations on changed files.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavior parity
+No runtime behavior change. `CurrentUserService` continues to be resolved as a singleton, continues to read claims from `IHttpContextAccessor.HttpContext.User`, and continues to be available to every consumer that injects `ICurrentUserService`.
+
+### NFR-2: Convention conformance
+The result must satisfy `docs/architecture/development_guidelines.md` § "Module Registration" — i.e. the Users module is self-describing and a future developer adding e.g. `IUserPreferencesService` has an obvious file to register it in.
+
+### NFR-3: Surgical change
+Only the three files identified below are modified. No adjacent cleanup, no unrelated refactors, no comment rewording outside the immediate change site.
+
+## Data Model
+N/A — no schema, entity, or persistence change.
+
+## API / Interface Design
+N/A — no HTTP, MediatR, or contract surface change. `ICurrentUserService` interface in `Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs` is untouched.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` | **NEW** — declares `UsersModule.AddUsersModule()` and registers the singleton binding. |
+| `backend/src/Anela.Heblo.Application/ApplicationModule.cs` | Add `using Anela.Heblo.Application.Features.Users;` and `services.AddUsersModule();` call. |
+| `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | Delete `services.AddSingleton<ICurrentUserService, CurrentUserService>();` at line 130 and its comment; prune now-unused `using` directives. |
+
+## Dependencies
+- No new NuGet packages.
+- No new project references — `Anela.Heblo.Application` already references `Anela.Heblo.Domain` (where `ICurrentUserService` lives).
+- Depends on existing `IHttpContextAccessor` registration in `AddCrossCuttingServices()` remaining in place.
+
+## Out of Scope
+- **Issue #1716** (relocation of the Users module's implementation directory). This spec targets the current path `backend/src/Anela.Heblo.Application/Features/Users/`. If #1716 is resolved later, `UsersModule.cs` moves with the rest of the folder.
+- Refactoring `CurrentUserService` internals (claim resolution logic, role checks).
+- Introducing new Users-module services beyond the existing `ICurrentUserService`.
+- Changes to `UserManagementModule` (the Microsoft Graph integration is a distinct module).
+- Moving `IHttpContextAccessor` registration into the Application layer.
+- Promoting `CurrentUserService` to internal-sealed or otherwise tightening its visibility (existing tests reference it directly via the interface, but the class itself remains public for now).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-users-missing-usersmodule-cs/task-plan.r1.md
+++ b/artifacts/feat-arch-review-users-missing-usersmodule-cs/task-plan.r1.md
@@ -1,0 +1,339 @@
+# UsersModule.cs DI Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a dedicated `UsersModule.cs` for the `Users` feature module, register `ICurrentUserService → CurrentUserService` inside it, aggregate it from `ApplicationModule.AddApplicationServices`, and remove the now-duplicated binding from the API-layer composition root.
+
+**Architecture:** This is a structural refactor with zero behavior change. The single DI binding currently sitting in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130` moves into a new sibling-shaped module file at `Anela.Heblo.Application/Features/Users/UsersModule.cs`, which is invoked from `ApplicationModule.AddApplicationServices`. `IHttpContextAccessor` registration stays in the API layer (its conceptual home). Lifetime (`Singleton`) is preserved verbatim because `CurrentUserService` is stateless and the captive `IHttpContextAccessor` uses ambient `AsyncLocal<T>` context — safe across requests.
+
+**Tech Stack:** .NET 8, C#, `Microsoft.Extensions.DependencyInjection`, xUnit + FluentAssertions (existing test stack — no test additions required since this is a pure refactor with behavior parity).
+
+---
+
+## File Structure
+
+Three files in play. No new abstractions, no folder moves, no test additions.
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` | **CREATE** | Owns the `Users` feature module's DI registrations. Exposes `AddUsersModule(this IServiceCollection)`. Today registers a single binding (`ICurrentUserService → CurrentUserService`); becomes the natural home for any future Users-feature service. |
+| `backend/src/Anela.Heblo.Application/ApplicationModule.cs` | **MODIFY** | Add 1 `using` and 1 `services.AddUsersModule();` line so the new module participates in standard Application-layer aggregation. |
+| `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | **MODIFY** | Delete the now-relocated binding + comment (line 130 and the comment above it). Delete two `using` directives (lines 9 and 11) that the deletion strands. `services.AddHttpContextAccessor()` (line 124) stays. |
+
+---
+
+## Task 1: Create `UsersModule.cs`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs`
+
+**Pre-flight context (read before editing):**
+
+The conventions to mimic are visible in two sibling files. Read these first so you copy the shape exactly:
+
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutsModule.cs` — file-scoped namespace, single static class, returns `services`. This is the preferred modern style; the new file follows this layout.
+- `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs` — same pattern but block-scoped namespace; use it to confirm method-name convention (`AddJournalModule` ↔ `AddUsersModule`).
+
+The binding to register lives currently at `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130`. Copy it verbatim — same interface, same implementation type, same lifetime (`AddSingleton`). Lifetime parity is an explicit acceptance criterion (spec FR-5, NFR-1).
+
+`ICurrentUserService` lives in namespace `Anela.Heblo.Domain.Features.Users` (verified at `backend/src/Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs`). `CurrentUserService` lives in `Anela.Heblo.Application.Features.Users` (the same namespace as the new file) — so only the Domain `using` is required.
+
+- [ ] **Step 1: Create the file with the exact content below**
+
+Write the file at `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` with this content:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Anela.Heblo.Domain.Features.Users;
+
+namespace Anela.Heblo.Application.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+        return services;
+    }
+}
+```
+
+Notes:
+- File-scoped namespace matches the two most-recently authored sibling modules (`GridLayoutsModule`, `UserManagementModule`) and modern `dotnet format` defaults.
+- No XML doc comment — siblings don't have one and the spec mandates surgical changes.
+- Returns `services` for fluent chaining (matches `JournalModule.cs:18`).
+- `using Microsoft.Extensions.DependencyInjection;` is required for the `AddSingleton<,>` and `IServiceCollection` extension surfaces.
+- `using Anela.Heblo.Domain.Features.Users;` is required so the unqualified `ICurrentUserService` symbol resolves.
+
+- [ ] **Step 2: Verify the file compiles in isolation**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`.
+
+If you see a warning about an unused `using`, you've forgotten to reference `CurrentUserService` — re-check Step 1; the second `AddSingleton<ICurrentUserService, CurrentUserService>` argument is the concrete class living in the file-scoped namespace and pulls in the Domain namespace via the interface.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs
+git commit -m "feat: add UsersModule.cs for Users feature DI registration"
+```
+
+---
+
+## Task 2: Wire `AddUsersModule()` into `ApplicationModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+
+**Pre-flight context (read before editing):**
+
+Open `backend/src/Anela.Heblo.Application/ApplicationModule.cs` and confirm two things:
+1. The `using` block runs from roughly line 1 through line 46 in alphabetical-ish grouping. The line ordering is not strictly alphabetical (it groups by concept) so place the new `using` adjacent to the related `UserManagement` import (line 42) for readability.
+2. The aggregation block inside `AddApplicationServices` runs from line 72 to line 113. Each line follows the pattern `services.AddXxxModule([configuration]);`. The new call sits adjacent to `services.AddUserManagement(configuration);` (line 86) — both touch identity-adjacent surfaces and live next to each other in the diff.
+
+The new module's extension takes no `IConfiguration` parameter — it has no configuration-driven behavior today.
+
+- [ ] **Step 1: Add the `using` directive**
+
+Add the following line directly after the existing `using Anela.Heblo.Application.Features.UserManagement;` (line 42):
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Resulting block (around lines 42-43 after the edit):
+
+```csharp
+using Anela.Heblo.Application.Features.UserManagement;
+using Anela.Heblo.Application.Features.Users;
+using Anela.Heblo.Xcc.Services.Dashboard;
+```
+
+- [ ] **Step 2: Add the `services.AddUsersModule();` invocation**
+
+Add the following line directly after `services.AddUserManagement(configuration);` (line 86) inside `AddApplicationServices`:
+
+```csharp
+        services.AddUsersModule();
+```
+
+Resulting block (around lines 86-88 after the edit):
+
+```csharp
+        services.AddUserManagement(configuration);
+        services.AddUsersModule();
+        services.AddOrgChartServices(configuration);
+```
+
+Indentation: 8 spaces (matches the surrounding lines — verify by inspection that the file uses 4-space indents and the method body sits at depth 2).
+
+- [ ] **Step 3: Verify the Application project still builds**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`. The Application assembly now contains both the new module file and the wiring call.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/ApplicationModule.cs
+git commit -m "feat: wire UsersModule into ApplicationModule aggregation"
+```
+
+---
+
+## Task 3: Remove the duplicate binding from the API composition root
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+**Pre-flight context (read before editing):**
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` and locate three regions:
+
+1. **Line 9:** `using Anela.Heblo.Application.Features.Users;` — referenced only by `CurrentUserService` on line 130. Becomes unused after deletion.
+2. **Line 11:** `using Anela.Heblo.Domain.Features.Users;` — referenced only by `ICurrentUserService` on line 130. Becomes unused after deletion.
+3. **Lines 129-130:** the comment `// Register Current User Service` followed by `services.AddSingleton<ICurrentUserService, CurrentUserService>();`.
+
+Before deleting either `using`, confirm with a grep that no other line in this file uses symbols from those namespaces. The two `using`s currently appear among an 18-line import block (lines 1-26). The verified call graph (per architecture review) is: both directives are referenced *only* by line 130. Run the verification grep below before deleting them — if either grep returns a match outside line 130, do **not** delete that `using`; report the unexpected reference instead and stop.
+
+- [ ] **Step 1: Verify both `using` directives are dead after the planned deletion**
+
+Run from the repo root:
+
+```bash
+grep -n "ICurrentUserService\|CurrentUserService" backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: exactly one matching line — line 130, the binding to be deleted. If the grep returns any other line numbers, **STOP** and report the unexpected reference before continuing — the spec FR-3 acceptance criterion ("verify by grep before deletion") has been violated.
+
+Also verify nothing else in the file references the `Anela.Heblo.Application.Features.Users` or `Anela.Heblo.Domain.Features.Users` namespaces:
+
+```bash
+grep -n "Application.Features.Users\|Domain.Features.Users" backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: exactly two matches — line 9 and line 11 (the `using` directives themselves). No other matches.
+
+- [ ] **Step 2: Delete the binding and its comment (lines 129-130)**
+
+Remove these two consecutive lines from the file:
+
+```csharp
+        // Register Current User Service
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+```
+
+After the edit, the surrounding context (originally lines 126-133) should read:
+
+```csharp
+        // Register TimeProvider
+        services.AddSingleton(TimeProvider.System);
+
+        // Register HttpClient for E2E testing middleware
+        services.AddHttpClient();
+```
+
+The blank line that previously separated the `// Register Current User Service` block from `// Register HttpClient for E2E testing middleware` collapses naturally — keep exactly one blank line between `services.AddSingleton(TimeProvider.System);` and `// Register HttpClient for E2E testing middleware`.
+
+Do **not** touch `services.AddHttpContextAccessor();` on line 124 — that is an API-layer concern (per spec FR-4 and architecture review Decision 3).
+
+- [ ] **Step 3: Delete the two stranded `using` directives (lines 9 and 11)**
+
+Remove these two lines from the top of the file:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+```
+
+After the edit, lines 8-12 (originally lines 8-12) should read:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Telemetry;
+using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.OpenApi.Models;
+using Hangfire;
+```
+
+Keep `using Anela.Heblo.Domain.Features.Configuration;` (was line 10 — referenced elsewhere in the file for `ConfigurationConstants`) and `using Anela.Heblo.Domain.Features.BackgroundJobs;` (was line 12 — referenced for `IRecurringJob`).
+
+- [ ] **Step 4: Verify the API project still builds**
+
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Expected: `Build succeeded.` with `0 Error(s)` and `0 Warning(s)` introduced by the change. Pre-existing warnings elsewhere are fine, but **no new warnings** must originate from `ServiceCollectionExtensions.cs`.
+
+If the build fails with `CS0246` (type not found), one of the `using` deletions removed a symbol still in use elsewhere — restore that specific `using` and re-run Step 1's grep to identify the additional reference.
+
+If `dotnet format --verify-no-changes` flags an `IDE0005` (unused using) warning later, it means a `using` survived the deletion — recheck Step 3.
+
+- [ ] **Step 5: Verify exactly one `AddSingleton<ICurrentUserService, ...>` registration exists in the entire backend**
+
+This is the architecture-review-recommended sanity check (Risks table, row 1):
+
+```bash
+grep -rn "AddSingleton<ICurrentUserService" backend/src
+```
+
+Expected: exactly one hit — `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs`, the new file. Multiple hits indicate the API-layer deletion was incomplete and "last-registration-wins" semantics will mask a divergence.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "refactor: remove duplicate ICurrentUserService binding from API composition root"
+```
+
+---
+
+## Task 4: Full-solution build and format verification
+
+**Files:** No edits in this task — verification only.
+
+**Pre-flight context:**
+
+The refactor is structural and Application-layer, so a full-solution build is required to catch any consumer that, against expectations, references the moved binding through the API layer. The architecture review confirmed no such consumer exists, but this is the verification gate that makes that claim load-bearing.
+
+- [ ] **Step 1: Build the full backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`. Warnings count must be unchanged vs. `main` for the three affected files — pre-existing warnings elsewhere are tolerable.
+
+- [ ] **Step 2: Run `dotnet format` and confirm clean**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0`. If `dotnet format` reports `IDE0005` (unused using) or whitespace drift on any of the three changed files, fix the reported violations and re-run before continuing.
+
+If `--verify-no-changes` mode is unavailable in the local SDK, run `dotnet format backend/Anela.Heblo.sln` and confirm `git diff` shows no further changes to the three files in scope.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all existing tests pass with zero new failures. Spec FR-5 explicitly requires "no test modifications expected" — if a test fails, you have introduced a behavior delta. Roll back and investigate; do **not** modify tests to make them pass.
+
+The ~32 consumer files (handlers across Journal, Packaging, MeetingTasks, Catalog.Inventory, etc.) inject `ICurrentUserService` through the interface — none reference `CurrentUserService` directly outside of tests, and the relocated binding produces the same singleton resolution. A passing suite confirms behavior parity (NFR-1).
+
+- [ ] **Step 4: Smoke-test resolution at startup**
+
+```bash
+dotnet run --project backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Wait for the host to reach `Now listening on:` log line (typically 5-10s) and confirm no exception of the form `Unable to resolve service for type 'Anela.Heblo.Domain.Features.Users.ICurrentUserService'` appears in the console. Then `Ctrl+C` to stop.
+
+If the resolution fails at startup, the most likely cause is that `services.AddUsersModule();` is missing from `ApplicationModule.cs` — re-check Task 2 Step 2. The second-most likely cause is that `services.AddHttpContextAccessor();` has been accidentally removed from `AddCrossCuttingServices` — re-check Task 3 Step 2 (it must still be on line 124, untouched).
+
+- [ ] **Step 5: Final commit (only if Step 2 made any formatter changes)**
+
+If `dotnet format` (Step 2) modified any file, commit those changes:
+
+```bash
+git status   # confirm what changed
+git add -p   # stage only formatter-driven changes to the three files in scope
+git commit -m "chore: dotnet format pass on Users module refactor"
+```
+
+If Step 2 reported no changes, skip this step — there is nothing to commit.
+
+---
+
+## Self-Review Checklist
+
+Reviewed against `spec.r1.md`:
+
+- **FR-1** (Create `UsersModule.cs`): Task 1 creates the file with the exact namespace, class name, method signature, and binding the spec mandates. File-scoped namespace per architecture-review Decision §"Namespace style suggestion".
+- **FR-2** (Aggregate from `ApplicationModule`): Task 2 adds the `using` and the unconditional `services.AddUsersModule();` call adjacent to `AddUserManagement` (line 86), matching the spec's placement guidance.
+- **FR-3** (Remove inline binding + prune unused `using`s): Task 3 deletes line 130 and its comment, and deletes the two `using` directives confirmed dead by Step 1 grep. `AddHttpContextAccessor()` is explicitly preserved (Step 2 note).
+- **FR-4** (Preserve DI registration order semantics): Task 4 Step 4 smoke-tests startup resolution; `Program.cs` ordering is not touched in any task; `IHttpContextAccessor` stays in the API layer per architecture-review Decision 3.
+- **FR-5** (All existing tests pass): Task 4 Step 3 runs the full suite. No test modifications planned.
+- **NFR-1** (Behavior parity): Lifetime is `Singleton` verbatim (Task 1 Step 1); claim-resolution code in `CurrentUserService.cs` is untouched.
+- **NFR-2** (Convention conformance): Task 1's file shape matches `JournalModule` / `GridLayoutsModule` siblings exactly.
+- **NFR-3** (Surgical change): Only the three files listed in the spec's "Affected Files" table are touched. No adjacent cleanup, no comment rewording outside the immediate change site.
+
+Placeholder scan: no `TBD`, no "add appropriate error handling", no "similar to Task N", no untyped references. Every code-touching step includes the full code block.
+
+Type consistency: `UsersModule` ↔ `AddUsersModule` ↔ `services.AddUsersModule();` aligned across Tasks 1, 2, and 4.

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -6,9 +6,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Anela.Heblo.Xcc;
 using Anela.Heblo.Xcc.Telemetry;
 using Anela.Heblo.API.Infrastructure.Telemetry;
-using Anela.Heblo.Application.Features.Users;
 using Anela.Heblo.Domain.Features.Configuration;
-using Anela.Heblo.Domain.Features.Users;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Microsoft.OpenApi.Models;
 using Hangfire;
@@ -125,9 +123,6 @@ public static class ServiceCollectionExtensions
 
         // Register TimeProvider
         services.AddSingleton(TimeProvider.System);
-
-        // Register Current User Service
-        services.AddSingleton<ICurrentUserService, CurrentUserService>();
 
         // Register HttpClient for E2E testing middleware
         services.AddHttpClient();

--- a/backend/src/Anela.Heblo.Application/ApplicationModule.cs
+++ b/backend/src/Anela.Heblo.Application/ApplicationModule.cs
@@ -40,6 +40,7 @@ using Anela.Heblo.Application.Features.ShipmentLabels;
 using Anela.Heblo.Application.Features.ShoptetOrders;
 using Anela.Heblo.Application.Features.Packaging;
 using Anela.Heblo.Application.Features.UserManagement;
+using Anela.Heblo.Application.Features.Users;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -84,6 +85,7 @@ public static class ApplicationModule
         services.AddTransportModule();
         services.AddGiftPackageManufactureModule();
         services.AddUserManagement(configuration);
+        services.AddUsersModule();
         services.AddOrgChartServices(configuration);
         services.AddInvoiceClassificationModule();
         services.AddPackingMaterialsModule();

--- a/backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Anela.Heblo.Domain.Features.Users;
+
+namespace Anela.Heblo.Application.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+        return services;
+    }
+}

--- a/docs/superpowers/plans/2026-05-26-users-module-di-registration.md
+++ b/docs/superpowers/plans/2026-05-26-users-module-di-registration.md
@@ -1,0 +1,339 @@
+# UsersModule.cs DI Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a dedicated `UsersModule.cs` for the `Users` feature module, register `ICurrentUserService → CurrentUserService` inside it, aggregate it from `ApplicationModule.AddApplicationServices`, and remove the now-duplicated binding from the API-layer composition root.
+
+**Architecture:** This is a structural refactor with zero behavior change. The single DI binding currently sitting in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130` moves into a new sibling-shaped module file at `Anela.Heblo.Application/Features/Users/UsersModule.cs`, which is invoked from `ApplicationModule.AddApplicationServices`. `IHttpContextAccessor` registration stays in the API layer (its conceptual home). Lifetime (`Singleton`) is preserved verbatim because `CurrentUserService` is stateless and the captive `IHttpContextAccessor` uses ambient `AsyncLocal<T>` context — safe across requests.
+
+**Tech Stack:** .NET 8, C#, `Microsoft.Extensions.DependencyInjection`, xUnit + FluentAssertions (existing test stack — no test additions required since this is a pure refactor with behavior parity).
+
+---
+
+## File Structure
+
+Three files in play. No new abstractions, no folder moves, no test additions.
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` | **CREATE** | Owns the `Users` feature module's DI registrations. Exposes `AddUsersModule(this IServiceCollection)`. Today registers a single binding (`ICurrentUserService → CurrentUserService`); becomes the natural home for any future Users-feature service. |
+| `backend/src/Anela.Heblo.Application/ApplicationModule.cs` | **MODIFY** | Add 1 `using` and 1 `services.AddUsersModule();` line so the new module participates in standard Application-layer aggregation. |
+| `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` | **MODIFY** | Delete the now-relocated binding + comment (line 130 and the comment above it). Delete two `using` directives (lines 9 and 11) that the deletion strands. `services.AddHttpContextAccessor()` (line 124) stays. |
+
+---
+
+## Task 1: Create `UsersModule.cs`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs`
+
+**Pre-flight context (read before editing):**
+
+The conventions to mimic are visible in two sibling files. Read these first so you copy the shape exactly:
+
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/GridLayoutsModule.cs` — file-scoped namespace, single static class, returns `services`. This is the preferred modern style; the new file follows this layout.
+- `backend/src/Anela.Heblo.Application/Features/Journal/JournalModule.cs` — same pattern but block-scoped namespace; use it to confirm method-name convention (`AddJournalModule` ↔ `AddUsersModule`).
+
+The binding to register lives currently at `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:130`. Copy it verbatim — same interface, same implementation type, same lifetime (`AddSingleton`). Lifetime parity is an explicit acceptance criterion (spec FR-5, NFR-1).
+
+`ICurrentUserService` lives in namespace `Anela.Heblo.Domain.Features.Users` (verified at `backend/src/Anela.Heblo.Domain/Features/Users/ICurrentUserService.cs`). `CurrentUserService` lives in `Anela.Heblo.Application.Features.Users` (the same namespace as the new file) — so only the Domain `using` is required.
+
+- [ ] **Step 1: Create the file with the exact content below**
+
+Write the file at `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` with this content:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Anela.Heblo.Domain.Features.Users;
+
+namespace Anela.Heblo.Application.Features.Users;
+
+public static class UsersModule
+{
+    public static IServiceCollection AddUsersModule(this IServiceCollection services)
+    {
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+        return services;
+    }
+}
+```
+
+Notes:
+- File-scoped namespace matches the two most-recently authored sibling modules (`GridLayoutsModule`, `UserManagementModule`) and modern `dotnet format` defaults.
+- No XML doc comment — siblings don't have one and the spec mandates surgical changes.
+- Returns `services` for fluent chaining (matches `JournalModule.cs:18`).
+- `using Microsoft.Extensions.DependencyInjection;` is required for the `AddSingleton<,>` and `IServiceCollection` extension surfaces.
+- `using Anela.Heblo.Domain.Features.Users;` is required so the unqualified `ICurrentUserService` symbol resolves.
+
+- [ ] **Step 2: Verify the file compiles in isolation**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`.
+
+If you see a warning about an unused `using`, you've forgotten to reference `CurrentUserService` — re-check Step 1; the second `AddSingleton<ICurrentUserService, CurrentUserService>` argument is the concrete class living in the file-scoped namespace and pulls in the Domain namespace via the interface.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs
+git commit -m "feat: add UsersModule.cs for Users feature DI registration"
+```
+
+---
+
+## Task 2: Wire `AddUsersModule()` into `ApplicationModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/ApplicationModule.cs`
+
+**Pre-flight context (read before editing):**
+
+Open `backend/src/Anela.Heblo.Application/ApplicationModule.cs` and confirm two things:
+1. The `using` block runs from roughly line 1 through line 46 in alphabetical-ish grouping. The line ordering is not strictly alphabetical (it groups by concept) so place the new `using` adjacent to the related `UserManagement` import (line 42) for readability.
+2. The aggregation block inside `AddApplicationServices` runs from line 72 to line 113. Each line follows the pattern `services.AddXxxModule([configuration]);`. The new call sits adjacent to `services.AddUserManagement(configuration);` (line 86) — both touch identity-adjacent surfaces and live next to each other in the diff.
+
+The new module's extension takes no `IConfiguration` parameter — it has no configuration-driven behavior today.
+
+- [ ] **Step 1: Add the `using` directive**
+
+Add the following line directly after the existing `using Anela.Heblo.Application.Features.UserManagement;` (line 42):
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+Resulting block (around lines 42-43 after the edit):
+
+```csharp
+using Anela.Heblo.Application.Features.UserManagement;
+using Anela.Heblo.Application.Features.Users;
+using Anela.Heblo.Xcc.Services.Dashboard;
+```
+
+- [ ] **Step 2: Add the `services.AddUsersModule();` invocation**
+
+Add the following line directly after `services.AddUserManagement(configuration);` (line 86) inside `AddApplicationServices`:
+
+```csharp
+        services.AddUsersModule();
+```
+
+Resulting block (around lines 86-88 after the edit):
+
+```csharp
+        services.AddUserManagement(configuration);
+        services.AddUsersModule();
+        services.AddOrgChartServices(configuration);
+```
+
+Indentation: 8 spaces (matches the surrounding lines — verify by inspection that the file uses 4-space indents and the method body sits at depth 2).
+
+- [ ] **Step 3: Verify the Application project still builds**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`. The Application assembly now contains both the new module file and the wiring call.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/ApplicationModule.cs
+git commit -m "feat: wire UsersModule into ApplicationModule aggregation"
+```
+
+---
+
+## Task 3: Remove the duplicate binding from the API composition root
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`
+
+**Pre-flight context (read before editing):**
+
+Open `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` and locate three regions:
+
+1. **Line 9:** `using Anela.Heblo.Application.Features.Users;` — referenced only by `CurrentUserService` on line 130. Becomes unused after deletion.
+2. **Line 11:** `using Anela.Heblo.Domain.Features.Users;` — referenced only by `ICurrentUserService` on line 130. Becomes unused after deletion.
+3. **Lines 129-130:** the comment `// Register Current User Service` followed by `services.AddSingleton<ICurrentUserService, CurrentUserService>();`.
+
+Before deleting either `using`, confirm with a grep that no other line in this file uses symbols from those namespaces. The two `using`s currently appear among an 18-line import block (lines 1-26). The verified call graph (per architecture review) is: both directives are referenced *only* by line 130. Run the verification grep below before deleting them — if either grep returns a match outside line 130, do **not** delete that `using`; report the unexpected reference instead and stop.
+
+- [ ] **Step 1: Verify both `using` directives are dead after the planned deletion**
+
+Run from the repo root:
+
+```bash
+grep -n "ICurrentUserService\|CurrentUserService" backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: exactly one matching line — line 130, the binding to be deleted. If the grep returns any other line numbers, **STOP** and report the unexpected reference before continuing — the spec FR-3 acceptance criterion ("verify by grep before deletion") has been violated.
+
+Also verify nothing else in the file references the `Anela.Heblo.Application.Features.Users` or `Anela.Heblo.Domain.Features.Users` namespaces:
+
+```bash
+grep -n "Application.Features.Users\|Domain.Features.Users" backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: exactly two matches — line 9 and line 11 (the `using` directives themselves). No other matches.
+
+- [ ] **Step 2: Delete the binding and its comment (lines 129-130)**
+
+Remove these two consecutive lines from the file:
+
+```csharp
+        // Register Current User Service
+        services.AddSingleton<ICurrentUserService, CurrentUserService>();
+```
+
+After the edit, the surrounding context (originally lines 126-133) should read:
+
+```csharp
+        // Register TimeProvider
+        services.AddSingleton(TimeProvider.System);
+
+        // Register HttpClient for E2E testing middleware
+        services.AddHttpClient();
+```
+
+The blank line that previously separated the `// Register Current User Service` block from `// Register HttpClient for E2E testing middleware` collapses naturally — keep exactly one blank line between `services.AddSingleton(TimeProvider.System);` and `// Register HttpClient for E2E testing middleware`.
+
+Do **not** touch `services.AddHttpContextAccessor();` on line 124 — that is an API-layer concern (per spec FR-4 and architecture review Decision 3).
+
+- [ ] **Step 3: Delete the two stranded `using` directives (lines 9 and 11)**
+
+Remove these two lines from the top of the file:
+
+```csharp
+using Anela.Heblo.Application.Features.Users;
+```
+
+```csharp
+using Anela.Heblo.Domain.Features.Users;
+```
+
+After the edit, lines 8-12 (originally lines 8-12) should read:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Telemetry;
+using Anela.Heblo.Domain.Features.Configuration;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.OpenApi.Models;
+using Hangfire;
+```
+
+Keep `using Anela.Heblo.Domain.Features.Configuration;` (was line 10 — referenced elsewhere in the file for `ConfigurationConstants`) and `using Anela.Heblo.Domain.Features.BackgroundJobs;` (was line 12 — referenced for `IRecurringJob`).
+
+- [ ] **Step 4: Verify the API project still builds**
+
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Expected: `Build succeeded.` with `0 Error(s)` and `0 Warning(s)` introduced by the change. Pre-existing warnings elsewhere are fine, but **no new warnings** must originate from `ServiceCollectionExtensions.cs`.
+
+If the build fails with `CS0246` (type not found), one of the `using` deletions removed a symbol still in use elsewhere — restore that specific `using` and re-run Step 1's grep to identify the additional reference.
+
+If `dotnet format --verify-no-changes` flags an `IDE0005` (unused using) warning later, it means a `using` survived the deletion — recheck Step 3.
+
+- [ ] **Step 5: Verify exactly one `AddSingleton<ICurrentUserService, ...>` registration exists in the entire backend**
+
+This is the architecture-review-recommended sanity check (Risks table, row 1):
+
+```bash
+grep -rn "AddSingleton<ICurrentUserService" backend/src
+```
+
+Expected: exactly one hit — `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs`, the new file. Multiple hits indicate the API-layer deletion was incomplete and "last-registration-wins" semantics will mask a divergence.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "refactor: remove duplicate ICurrentUserService binding from API composition root"
+```
+
+---
+
+## Task 4: Full-solution build and format verification
+
+**Files:** No edits in this task — verification only.
+
+**Pre-flight context:**
+
+The refactor is structural and Application-layer, so a full-solution build is required to catch any consumer that, against expectations, references the moved binding through the API layer. The architecture review confirmed no such consumer exists, but this is the verification gate that makes that claim load-bearing.
+
+- [ ] **Step 1: Build the full backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`. Warnings count must be unchanged vs. `main` for the three affected files — pre-existing warnings elsewhere are tolerable.
+
+- [ ] **Step 2: Run `dotnet format` and confirm clean**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code `0`. If `dotnet format` reports `IDE0005` (unused using) or whitespace drift on any of the three changed files, fix the reported violations and re-run before continuing.
+
+If `--verify-no-changes` mode is unavailable in the local SDK, run `dotnet format backend/Anela.Heblo.sln` and confirm `git diff` shows no further changes to the three files in scope.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all existing tests pass with zero new failures. Spec FR-5 explicitly requires "no test modifications expected" — if a test fails, you have introduced a behavior delta. Roll back and investigate; do **not** modify tests to make them pass.
+
+The ~32 consumer files (handlers across Journal, Packaging, MeetingTasks, Catalog.Inventory, etc.) inject `ICurrentUserService` through the interface — none reference `CurrentUserService` directly outside of tests, and the relocated binding produces the same singleton resolution. A passing suite confirms behavior parity (NFR-1).
+
+- [ ] **Step 4: Smoke-test resolution at startup**
+
+```bash
+dotnet run --project backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Wait for the host to reach `Now listening on:` log line (typically 5-10s) and confirm no exception of the form `Unable to resolve service for type 'Anela.Heblo.Domain.Features.Users.ICurrentUserService'` appears in the console. Then `Ctrl+C` to stop.
+
+If the resolution fails at startup, the most likely cause is that `services.AddUsersModule();` is missing from `ApplicationModule.cs` — re-check Task 2 Step 2. The second-most likely cause is that `services.AddHttpContextAccessor();` has been accidentally removed from `AddCrossCuttingServices` — re-check Task 3 Step 2 (it must still be on line 124, untouched).
+
+- [ ] **Step 5: Final commit (only if Step 2 made any formatter changes)**
+
+If `dotnet format` (Step 2) modified any file, commit those changes:
+
+```bash
+git status   # confirm what changed
+git add -p   # stage only formatter-driven changes to the three files in scope
+git commit -m "chore: dotnet format pass on Users module refactor"
+```
+
+If Step 2 reported no changes, skip this step — there is nothing to commit.
+
+---
+
+## Self-Review Checklist
+
+Reviewed against `spec.r1.md`:
+
+- **FR-1** (Create `UsersModule.cs`): Task 1 creates the file with the exact namespace, class name, method signature, and binding the spec mandates. File-scoped namespace per architecture-review Decision §"Namespace style suggestion".
+- **FR-2** (Aggregate from `ApplicationModule`): Task 2 adds the `using` and the unconditional `services.AddUsersModule();` call adjacent to `AddUserManagement` (line 86), matching the spec's placement guidance.
+- **FR-3** (Remove inline binding + prune unused `using`s): Task 3 deletes line 130 and its comment, and deletes the two `using` directives confirmed dead by Step 1 grep. `AddHttpContextAccessor()` is explicitly preserved (Step 2 note).
+- **FR-4** (Preserve DI registration order semantics): Task 4 Step 4 smoke-tests startup resolution; `Program.cs` ordering is not touched in any task; `IHttpContextAccessor` stays in the API layer per architecture-review Decision 3.
+- **FR-5** (All existing tests pass): Task 4 Step 3 runs the full suite. No test modifications planned.
+- **NFR-1** (Behavior parity): Lifetime is `Singleton` verbatim (Task 1 Step 1); claim-resolution code in `CurrentUserService.cs` is untouched.
+- **NFR-2** (Convention conformance): Task 1's file shape matches `JournalModule` / `GridLayoutsModule` siblings exactly.
+- **NFR-3** (Surgical change): Only the three files listed in the spec's "Affected Files" table are touched. No adjacent cleanup, no comment rewording outside the immediate change site.
+
+Placeholder scan: no `TBD`, no "add appropriate error handling", no "similar to Task N", no untyped references. Every code-touching step includes the full code block.
+
+Type consistency: `UsersModule` ↔ `AddUsersModule` ↔ `services.AddUsersModule();` aligned across Tasks 1, 2, and 4.


### PR DESCRIPTION
Users

## Finding
`development_guidelines.md` requires every module to own a `{Feature}Module.cs` for DI registration. The Users module has no such file. Instead, the `ICurrentUserService → CurrentUserService` binding is wired directly in the API project:

```csharp
// backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs, line 130
services.AddSingleton<ICurrentUserService, CurrentUserService>();
```

Every other module (e.g. `GridLayoutsModule.cs`, `JournalModule.cs`) registers its own services via a dedicated `Module.cs`. Users is the only module that breaks this convention.

## Why it matters
The module registration pattern is the project's documented mechanism for module isolation and makes each module self-describing. Embedding the binding in `ServiceCollectionExtensions` (a composition-root utility) violates that boundary and makes Users the odd one out — future developers adding Users-related services have no obvious place to put registrations.

## Suggested fix
Create `backend/src/Anela.Heblo.Application/Features/Users/UsersModule.cs` (or wherever the implementation ultimately lives after resolving #1716):

```csharp
public static class UsersModule
{
    public static IServiceCollection AddUsersModule(this IServiceCollection services)
    {
        services.AddSingleton<ICurrentUserService, CurrentUserService>();
        return services;
    }
}
```

Then replace the inline registration in `ServiceCollectionExtensions.cs` with `.AddUsersModule()`.

---
_Filed by daily arch-review routine on 2026-05-25._

---

Closes #1717

### Tokens used
12946991
