### PR TITLE
feat(telemetry): instrument all UI screens with useScreenView coverage

### DIFF
--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -92,10 +92,10 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| IssuedInvoices | `/customer/issued-invoices` | `pages/customer/IssuedInvoicesPage.tsx` | — | `[ ] base` |
-| BankStatementsOverview | `/customer/bank-statements-overview` | `pages/customer/BankStatementsOverviewPage.tsx` | — | `[ ] base` |
-| SmartsuppChats | `/customer/smartsupp` | `components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx` | — | `[ ] base` |
-| ExpeditionSettings | `/customer/expedition-settings` | `pages/customer/ExpeditionSettingsPage.tsx` | tabs: Cooling, Gifts | `[ ] base` `[ ] CoolingTab` `[ ] GiftsTab` |
+| IssuedInvoices | `/customer/issued-invoices` | `pages/customer/IssuedInvoicesPage.tsx` | — | `[x] base` |
+| BankStatementsOverview | `/customer/bank-statements-overview` | `pages/customer/BankStatementsOverviewPage.tsx` | — | `[x] base` |
+| SmartsuppChats | `/customer/smartsupp` | `components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx` | — | `[x] base` |
+| ExpeditionSettings | `/customer/expedition-settings` | `pages/customer/ExpeditionSettingsPage.tsx` | tabs: Cooling, Gifts | `[x] base` `[x] CoolingTab` `[x] GiftsTab` |
 
 ## Automation
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -138,7 +138,7 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| BaleniHome | `/baleni` | `components/baleni/BaleniHome.tsx` | — | `[ ] base` |
-| BaleniPacking | `/baleni/baleni` | `components/baleni/BaleniPacking.tsx` | — | `[ ] base` |
-| BaleniShipments | `/baleni/zasilky` | `components/baleni/zasilky/ZasilkyPage.tsx` | — | `[ ] base` |
+| BaleniHome | `/baleni` | `components/baleni/BaleniHome.tsx` | — | `[x] base` |
+| BaleniPacking | `/baleni/baleni` | `components/baleni/BaleniPacking.tsx` | — | `[x] base` |
+| BaleniShipments | `/baleni/zasilky` | `components/baleni/zasilky/ZasilkyPage.tsx` | — | `[x] base` |
 | BaleniStatistics | `/baleni/statistiky` | (placeholder) | — | `[ ] base` (deferred — placeholder) |

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -32,9 +32,9 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| CatalogList | `/catalog` | `components/pages/CatalogList.tsx` | — | `[ ] base` |
-| CatalogDetail | (modal from list) | `components/pages/CatalogDetail.tsx` | tabs: Basic, History, Margins, Composition, Journal, Usage, Documents, Pif; chartTabs: Input, Output | `[ ] base` `[ ] BasicTab` `[ ] HistoryTab` `[ ] MarginsTab` `[ ] CompositionTab` `[ ] JournalTab` `[ ] UsageTab` `[ ] DocumentsTab` `[ ] PifTab` `[ ] ChartInput` `[ ] ChartOutput` |
-| ProductMargins | `/products/margins` | `components/pages/ProductMarginsList.tsx` | — | `[ ] base` |
+| CatalogList | `/catalog` | `components/pages/CatalogList.tsx` | — | `[x] base` |
+| CatalogDetail | (modal from list) | `components/pages/CatalogDetail.tsx` | tabs: Basic, History, Margins, Composition, Journal, Usage, Documents, Pif; chartTabs: Input, Output | `[x] base` `[x] BasicTab` `[x] HistoryTab` `[x] MarginsTab` `[x] CompositionTab` `[x] JournalTab` `[x] UsageTab` `[x] DocumentsTab` `[x] PifTab` `[x] ChartInput` `[x] ChartOutput` |
+| ProductMargins | `/products/margins` | `components/pages/ProductMarginsList.tsx` | — | `[x] base` |
 
 ## Journal
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -1,0 +1,144 @@
+# UI Screen Usage Coverage
+
+Canonical checklist of every user-facing screen and in-page branch in the app, and whether `useScreenView(...)` is wired up.
+
+## Contract
+
+- "Covered" = `useScreenView(module, screen, subScreen?)` is called for the surface AND its checkbox is ticked below.
+- Every PR that adds, removes, or changes a screen/branch updates this doc in the same PR. Reviewers reject PRs that don't.
+- KQL verification (see [usage-analytics.md](./usage-analytics.md#how-to-query)) is run weekly; gaps between this doc and observed `ScreenViewed` events are filed as bugs.
+- Modals, drawers, and feature actions (button clicks, filter applies, exports) are **out of scope** for `ScreenViewed`. Modal-as-full-screen views (e.g., `CatalogDetail` opened from `CatalogList`) ARE in scope.
+- "Coming Soon" placeholder screens are listed but not checked until content lands.
+
+## Legend
+
+`[x]` = wired and reaching production. `[ ]` = not yet wired.
+
+## Dashboard
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| Dashboard | `/` | `components/pages/Dashboard.tsx` | — | `[ ] base` |
+
+## Finance
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| FinancialOverview | `/finance/overview` | `components/pages/FinancialOverview.tsx` | — | `[ ] base` |
+| BankStatementImport | `/finance/bank-statements` | `components/pages/BankStatementImportChart.tsx` | — | `[ ] base` |
+| ProductMarginSummary | `/analytics/product-margin-summary` | `components/pages/ProductMarginSummary.tsx` | — | `[ ] base` |
+
+## Catalog
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| CatalogList | `/catalog` | `components/pages/CatalogList.tsx` | — | `[ ] base` |
+| CatalogDetail | (modal from list) | `components/pages/CatalogDetail.tsx` | tabs: Basic, History, Margins, Composition, Journal, Usage, Documents, Pif; chartTabs: Input, Output | `[ ] base` `[ ] BasicTab` `[ ] HistoryTab` `[ ] MarginsTab` `[ ] CompositionTab` `[ ] JournalTab` `[ ] UsageTab` `[ ] DocumentsTab` `[ ] PifTab` `[ ] ChartInput` `[ ] ChartOutput` |
+| ProductMargins | `/products/margins` | `components/pages/ProductMarginsList.tsx` | — | `[ ] base` |
+
+## Journal
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| JournalList | `/journal` | `components/pages/Journal/JournalList.tsx` | — | `[ ] base` |
+| JournalEntryNew | `/journal/new` | `components/pages/JournalEntryNew.tsx` | — | `[ ] base` |
+| JournalEntryEdit | `/journal/:id/edit` | `components/pages/JournalEntryEdit.tsx` | — | `[ ] base` |
+
+## Purchase
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| PurchaseOrderList | `/purchase/orders` | `components/pages/PurchaseOrderList.tsx` | — | `[ ] base` |
+| PurchaseStockAnalysis | `/purchase/stock-analysis` | `components/pages/PurchaseStockAnalysis.tsx` | — | `[ ] base` |
+| InvoiceClassification | `/purchase/invoice-classification` | `pages/InvoiceClassification/InvoiceClassificationPage.tsx` | tabs: Invoices, Rules | `[ ] base` `[ ] InvoicesTab` `[ ] RulesTab` |
+
+## Manufacturing
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| ManufacturingStockAnalysis | `/manufacturing/stock-analysis` | `components/pages/ManufacturingStockAnalysis.tsx` | — | `[ ] base` |
+| ManufactureOutput | `/manufacturing/output` | `components/pages/ManufactureOutput.tsx` | — | `[ ] base` |
+| ManufactureBatchCalculator | `/manufacturing/batch-calculator` | `components/pages/ManufactureBatchCalculator.tsx` | — | `[ ] base` |
+| ManufactureBatchPlanning | `/manufacturing/batch-planning` | `components/pages/ManufactureBatchPlanning.tsx` | — | `[ ] base` |
+| ManufactureOrderList | `/manufacturing/orders` | `components/manufacture/pages/ManufactureOrderList.tsx` | viewModes: Grid, Calendar, Weekly | `[ ] base` `[ ] GridView` `[ ] CalendarView` `[ ] WeeklyView` |
+| ManufactureOrderDetail | `/manufacturing/orders/:id` | `components/manufacture/pages/ManufactureOrderDetail.tsx` | tabs: Info, Notes, Log, Conditions | `[ ] base` `[ ] InfoTab` `[ ] NotesTab` `[ ] LogTab` `[ ] ConditionsTab` |
+| ManufactureInventory | `/manufacturing/inventory` | `components/pages/ManufactureInventoryList.tsx` | — | `[ ] base` |
+| ManufacturedProductInventory | `/manufacturing/product-inventory` | `components/pages/ManufacturedInventoryPage.tsx` | — | `[ ] base` |
+
+## Logistics
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| InventoryFinishedGoods | `/logistics/inventory` | `components/pages/InventoryList.tsx` | — | `[ ] base` |
+| TransportBoxes | `/logistics/transport-boxes` | `components/pages/TransportBoxList.tsx` | — | `[ ] base` |
+| TransportBoxReceive | `/logistics/receive-boxes` | `components/pages/TransportBoxReceive.tsx` | — | `[ ] base` |
+| GiftPackageManufacturing | `/logistics/gift-package-manufacturing` | `components/pages/GiftPackageManufacturing.tsx` | — | `[ ] base` |
+| PackingMaterials | `/logistics/packing-materials` | `pages/PackingMaterialsPage.tsx` | — | `[ ] base` |
+| WarehouseStatistics | `/logistics/warehouse-statistics` | `components/pages/WarehouseStatistics.tsx` | — | `[ ] base` |
+| ExpeditionArchive | `/logistics/expedition-archive` | `pages/ExpeditionListArchivePage.tsx` | — | `[ ] base` |
+
+## Marketing
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| MarketingCalendar | `/marketing/calendar` | `components/marketing/pages/MarketingCalendarPage.tsx` | viewModes: FiveWeeks, TwoWeeks, List | `[ ] base` `[ ] FiveWeeksView` `[ ] TwoWeeksView` `[ ] ListView` |
+| Photobank | `/marketing/photobank` | `components/marketing/photobank/pages/PhotobankPage.tsx` | viewModes: Tiles, List | `[ ] base` `[ ] TilesView` `[ ] ListView` |
+| PhotobankSettings | `/marketing/photobank/settings` | `components/marketing/photobank/pages/PhotobankSettingsPage.tsx` | — | `[ ] base` |
+| LeafletGenerator | `/leaflet-generator` | `features/leaflet-generator/LeafletGeneratorPage.tsx` | — | `[ ] base` |
+| Articles | `/articles` | `pages/ArticlesPage.tsx` | tabs: New, List | `[ ] base` `[ ] NewTab` `[ ] ListTab` |
+| MarketingFeedback | `/marketing/feedback` | `pages/MarketingFeedbackPage.tsx` | — | `[ ] base` |
+
+## Customer
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| IssuedInvoices | `/customer/issued-invoices` | `pages/customer/IssuedInvoicesPage.tsx` | — | `[ ] base` |
+| BankStatementsOverview | `/customer/bank-statements-overview` | `pages/customer/BankStatementsOverviewPage.tsx` | — | `[ ] base` |
+| SmartsuppChats | `/customer/smartsupp` | `components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx` | — | `[ ] base` |
+| ExpeditionSettings | `/customer/expedition-settings` | `pages/customer/ExpeditionSettingsPage.tsx` | tabs: Cooling, Gifts | `[ ] base` `[ ] CoolingTab` `[ ] GiftsTab` |
+
+## Automation
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| BackgroundTasks | `/automation/background-tasks` | `components/pages/automation/BackgroundTasks.tsx` | — | `[ ] base` |
+| InvoiceImportStatistics | `/automation/invoice-import-statistics` | `components/pages/automation/InvoiceImportStatistics.tsx` | — | `[ ] base` |
+| MeetingTasks | `/automation/meeting-tasks` | `components/pages/automation/MeetingTasksPage.tsx` | — | `[ ] base` |
+| MeetingTaskDetail | `/automation/meeting-tasks/:id` | `components/pages/automation/MeetingTaskDetailPage.tsx` | — | `[ ] base` |
+| StockOperations | `/stock-up-operations` | `pages/StockOperationsPage.tsx` | — | `[ ] base` |
+| RecurringJobs | `/recurring-jobs` | `pages/RecurringJobsPage.tsx` | — | `[ ] base` |
+| DataQuality | `/automation/data-quality` | `pages/customer/DataQualityPage.tsx` | — | `[ ] base` |
+
+## Knowledge
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| KnowledgeBase | `/knowledge-base` | `pages/KnowledgeBasePage.tsx` | tabs: Search, Documents, Upload | `[ ] base` `[ ] SearchTab` `[ ] DocumentsTab` `[ ] UploadTab` |
+| KnowledgeBaseFeedback | `/knowledge-base/feedback` | `pages/KnowledgeBaseFeedbackPage.tsx` | — | `[ ] base` |
+
+## Admin
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| OrgChart | `/orgchart` | `pages/OrgChartPage.tsx` | — | `[ ] base` |
+| FeatureFlagsAdmin | `/admin/feature-flags` | `pages/FeatureFlagsAdminPage.tsx` | — | `[ ] base` |
+
+## Terminal
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| TerminalHome | `/terminal` | `components/terminal/TerminalHome.tsx` | — | `[ ] base` |
+| TerminalBoxCheck | `/terminal/box-check` | `components/terminal/TransportBoxCheck.tsx` | — | `[ ] base` |
+| TerminalBoxFill | `/terminal/box-fill` | `components/terminal/box-fill/BoxFillWorkflow.tsx` | steps: Scan, AddItems | `[ ] base` `[ ] ScanStep` `[ ] AddItemsStep` |
+| TerminalReceive | `/terminal/receive` | `components/terminal/TransportBoxReceive.tsx` | — | `[ ] base` |
+| TerminalStocktake | `/terminal/stocktake` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
+| TerminalLotIdentification | `/terminal/lot-identification` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
+
+## Baleni
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| BaleniHome | `/baleni` | `components/baleni/BaleniHome.tsx` | — | `[ ] base` |
+| BaleniPacking | `/baleni/baleni` | `components/baleni/BaleniPacking.tsx` | — | `[ ] base` |
+| BaleniShipments | `/baleni/zasilky` | `components/baleni/zasilky/ZasilkyPage.tsx` | — | `[ ] base` |
+| BaleniStatistics | `/baleni/statistiky` | (placeholder) | — | `[ ] base` (deferred — placeholder) |

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -101,13 +101,13 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| BackgroundTasks | `/automation/background-tasks` | `components/pages/automation/BackgroundTasks.tsx` | — | `[ ] base` |
-| InvoiceImportStatistics | `/automation/invoice-import-statistics` | `components/pages/automation/InvoiceImportStatistics.tsx` | — | `[ ] base` |
-| MeetingTasks | `/automation/meeting-tasks` | `components/pages/automation/MeetingTasksPage.tsx` | — | `[ ] base` |
-| MeetingTaskDetail | `/automation/meeting-tasks/:id` | `components/pages/automation/MeetingTaskDetailPage.tsx` | — | `[ ] base` |
-| StockOperations | `/stock-up-operations` | `pages/StockOperationsPage.tsx` | — | `[ ] base` |
-| RecurringJobs | `/recurring-jobs` | `pages/RecurringJobsPage.tsx` | — | `[ ] base` |
-| DataQuality | `/automation/data-quality` | `pages/customer/DataQualityPage.tsx` | — | `[ ] base` |
+| BackgroundTasks | `/automation/background-tasks` | `components/pages/automation/BackgroundTasks.tsx` | — | `[x] base` |
+| InvoiceImportStatistics | `/automation/invoice-import-statistics` | `components/pages/automation/InvoiceImportStatistics.tsx` | — | `[x] base` |
+| MeetingTasks | `/automation/meeting-tasks` | `components/pages/automation/MeetingTasksPage.tsx` | — | `[x] base` |
+| MeetingTaskDetail | `/automation/meeting-tasks/:id` | `components/pages/automation/MeetingTaskDetailPage.tsx` | — | `[x] base` |
+| StockOperations | `/stock-up-operations` | `pages/StockOperationsPage.tsx` | — | `[x] base` |
+| RecurringJobs | `/recurring-jobs` | `pages/RecurringJobsPage.tsx` | — | `[x] base` |
+| DataQuality | `/automation/data-quality` | `pages/customer/DataQualityPage.tsx` | — | `[x] base` |
 
 ## Knowledge
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -120,8 +120,8 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| OrgChart | `/orgchart` | `pages/OrgChartPage.tsx` | — | `[ ] base` |
-| FeatureFlagsAdmin | `/admin/feature-flags` | `pages/FeatureFlagsAdminPage.tsx` | — | `[ ] base` |
+| OrgChart | `/orgchart` | `pages/OrgChartPage.tsx` | — | `[x] base` |
+| FeatureFlagsAdmin | `/admin/feature-flags` | `pages/FeatureFlagsAdminPage.tsx` | — | `[x] base` |
 
 ## Terminal
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -113,8 +113,8 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| KnowledgeBase | `/knowledge-base` | `pages/KnowledgeBasePage.tsx` | tabs: Search, Documents, Upload | `[ ] base` `[ ] SearchTab` `[ ] DocumentsTab` `[ ] UploadTab` |
-| KnowledgeBaseFeedback | `/knowledge-base/feedback` | `pages/KnowledgeBaseFeedbackPage.tsx` | — | `[ ] base` |
+| KnowledgeBase | `/knowledge-base` | `pages/KnowledgeBasePage.tsx` | tabs: Search, Documents, Upload | `[x] base` `[x] SearchTab` `[x] DocumentsTab` `[x] UploadTab` |
+| KnowledgeBaseFeedback | `/knowledge-base/feedback` | `pages/KnowledgeBaseFeedbackPage.tsx` | — | `[x] base` |
 
 ## Admin
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -81,12 +81,12 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| MarketingCalendar | `/marketing/calendar` | `components/marketing/pages/MarketingCalendarPage.tsx` | viewModes: FiveWeeks, TwoWeeks, List | `[ ] base` `[ ] FiveWeeksView` `[ ] TwoWeeksView` `[ ] ListView` |
-| Photobank | `/marketing/photobank` | `components/marketing/photobank/pages/PhotobankPage.tsx` | viewModes: Tiles, List | `[ ] base` `[ ] TilesView` `[ ] ListView` |
-| PhotobankSettings | `/marketing/photobank/settings` | `components/marketing/photobank/pages/PhotobankSettingsPage.tsx` | — | `[ ] base` |
-| LeafletGenerator | `/leaflet-generator` | `features/leaflet-generator/LeafletGeneratorPage.tsx` | — | `[ ] base` |
-| Articles | `/articles` | `pages/ArticlesPage.tsx` | tabs: New, List | `[ ] base` `[ ] NewTab` `[ ] ListTab` |
-| MarketingFeedback | `/marketing/feedback` | `pages/MarketingFeedbackPage.tsx` | — | `[ ] base` |
+| MarketingCalendar | `/marketing/calendar` | `components/marketing/pages/MarketingCalendarPage.tsx` | viewModes: FiveWeeks, TwoWeeks, List | `[x] base` `[x] FiveWeeksView` `[x] TwoWeeksView` `[x] ListView` |
+| Photobank | `/marketing/photobank` | `components/marketing/photobank/pages/PhotobankPage.tsx` | viewModes: Tiles, List | `[x] base` `[x] TilesView` `[x] ListView` |
+| PhotobankSettings | `/marketing/photobank/settings` | `components/marketing/photobank/pages/PhotobankSettingsPage.tsx` | — | `[x] base` |
+| LeafletGenerator | `/leaflet-generator` | `features/leaflet-generator/LeafletGeneratorPage.tsx` | — | `[x] base` |
+| Articles | `/articles` | `pages/ArticlesPage.tsx` | tabs: New, List | `[x] base` `[x] NewTab` `[x] ListTab` |
+| MarketingFeedback | `/marketing/feedback` | `pages/MarketingFeedbackPage.tsx` | — | `[x] base` |
 
 ## Customer
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -72,7 +72,7 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 | InventoryFinishedGoods | `/logistics/inventory` | `components/pages/InventoryList.tsx` | — | `[x] base` |
 | TransportBoxes | `/logistics/transport-boxes` | `components/pages/TransportBoxList.tsx` | — | `[x] base` |
 | TransportBoxReceive | `/logistics/receive-boxes` | `components/pages/TransportBoxReceive.tsx` | — | `[x] base` |
-| GiftPackageManufacturing | `/logistics/gift-package-manufacturing` | `components/pages/GiftPackageManufacturing.tsx` | — | `[x] base` |
+| GiftPackageManufacturing | `/logistics/gift-package-manufacturing` | `components/pages/GiftPackageManufacturing/index.tsx` | — | `[x] base` |
 | PackingMaterials | `/logistics/packing-materials` | `pages/PackingMaterialsPage.tsx` | — | `[x] base` |
 | WarehouseStatistics | `/logistics/warehouse-statistics` | `components/pages/WarehouseStatistics.tsx` | — | `[x] base` |
 | ExpeditionArchive | `/logistics/expedition-archive` | `pages/ExpeditionListArchivePage.tsx` | — | `[x] base` |

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -69,13 +69,13 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| InventoryFinishedGoods | `/logistics/inventory` | `components/pages/InventoryList.tsx` | — | `[ ] base` |
-| TransportBoxes | `/logistics/transport-boxes` | `components/pages/TransportBoxList.tsx` | — | `[ ] base` |
-| TransportBoxReceive | `/logistics/receive-boxes` | `components/pages/TransportBoxReceive.tsx` | — | `[ ] base` |
-| GiftPackageManufacturing | `/logistics/gift-package-manufacturing` | `components/pages/GiftPackageManufacturing.tsx` | — | `[ ] base` |
-| PackingMaterials | `/logistics/packing-materials` | `pages/PackingMaterialsPage.tsx` | — | `[ ] base` |
-| WarehouseStatistics | `/logistics/warehouse-statistics` | `components/pages/WarehouseStatistics.tsx` | — | `[ ] base` |
-| ExpeditionArchive | `/logistics/expedition-archive` | `pages/ExpeditionListArchivePage.tsx` | — | `[ ] base` |
+| InventoryFinishedGoods | `/logistics/inventory` | `components/pages/InventoryList.tsx` | — | `[x] base` |
+| TransportBoxes | `/logistics/transport-boxes` | `components/pages/TransportBoxList.tsx` | — | `[x] base` |
+| TransportBoxReceive | `/logistics/receive-boxes` | `components/pages/TransportBoxReceive.tsx` | — | `[x] base` |
+| GiftPackageManufacturing | `/logistics/gift-package-manufacturing` | `components/pages/GiftPackageManufacturing.tsx` | — | `[x] base` |
+| PackingMaterials | `/logistics/packing-materials` | `pages/PackingMaterialsPage.tsx` | — | `[x] base` |
+| WarehouseStatistics | `/logistics/warehouse-statistics` | `components/pages/WarehouseStatistics.tsx` | — | `[x] base` |
+| ExpeditionArchive | `/logistics/expedition-archive` | `pages/ExpeditionListArchivePage.tsx` | — | `[x] base` |
 
 ## Marketing
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -56,14 +56,14 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| ManufacturingStockAnalysis | `/manufacturing/stock-analysis` | `components/pages/ManufacturingStockAnalysis.tsx` | — | `[ ] base` |
-| ManufactureOutput | `/manufacturing/output` | `components/pages/ManufactureOutput.tsx` | — | `[ ] base` |
-| ManufactureBatchCalculator | `/manufacturing/batch-calculator` | `components/pages/ManufactureBatchCalculator.tsx` | — | `[ ] base` |
-| ManufactureBatchPlanning | `/manufacturing/batch-planning` | `components/pages/ManufactureBatchPlanning.tsx` | — | `[ ] base` |
-| ManufactureOrderList | `/manufacturing/orders` | `components/manufacture/pages/ManufactureOrderList.tsx` | viewModes: Grid, Calendar, Weekly | `[ ] base` `[ ] GridView` `[ ] CalendarView` `[ ] WeeklyView` |
-| ManufactureOrderDetail | `/manufacturing/orders/:id` | `components/manufacture/pages/ManufactureOrderDetail.tsx` | tabs: Info, Notes, Log, Conditions | `[ ] base` `[ ] InfoTab` `[ ] NotesTab` `[ ] LogTab` `[ ] ConditionsTab` |
-| ManufactureInventory | `/manufacturing/inventory` | `components/pages/ManufactureInventoryList.tsx` | — | `[ ] base` |
-| ManufacturedProductInventory | `/manufacturing/product-inventory` | `components/pages/ManufacturedInventoryPage.tsx` | — | `[ ] base` |
+| ManufacturingStockAnalysis | `/manufacturing/stock-analysis` | `components/pages/ManufacturingStockAnalysis.tsx` | — | `[x] base` |
+| ManufactureOutput | `/manufacturing/output` | `components/pages/ManufactureOutput.tsx` | — | `[x] base` |
+| ManufactureBatchCalculator | `/manufacturing/batch-calculator` | `components/pages/ManufactureBatchCalculator.tsx` | — | `[x] base` |
+| ManufactureBatchPlanning | `/manufacturing/batch-planning` | `components/pages/ManufactureBatchPlanning.tsx` | — | `[x] base` |
+| ManufactureOrderList | `/manufacturing/orders` | `components/manufacture/pages/ManufactureOrderList.tsx` | viewModes: Grid, Calendar, Weekly | `[x] base` `[x] GridView` `[x] CalendarView` `[x] WeeklyView` |
+| ManufactureOrderDetail | `/manufacturing/orders/:id` | `components/manufacture/pages/ManufactureOrderDetail.tsx` | tabs: Info, Notes, Log, Conditions | `[x] base` `[x] InfoTab` `[x] NotesTab` `[x] LogTab` `[x] ConditionsTab` |
+| ManufactureInventory | `/manufacturing/inventory` | `components/pages/ManufactureInventoryList.tsx` | — | `[x] base` |
+| ManufacturedProductInventory | `/manufacturing/product-inventory` | `components/pages/ManufacturedInventoryPage.tsx` | — | `[x] base` |
 
 ## Logistics
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -40,9 +40,9 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| JournalList | `/journal` | `components/pages/Journal/JournalList.tsx` | — | `[ ] base` |
-| JournalEntryNew | `/journal/new` | `components/pages/JournalEntryNew.tsx` | — | `[ ] base` |
-| JournalEntryEdit | `/journal/:id/edit` | `components/pages/JournalEntryEdit.tsx` | — | `[ ] base` |
+| JournalList | `/journal` | `components/pages/Journal/JournalList.tsx` | — | `[x] base` |
+| JournalEntryNew | `/journal/new` | `components/pages/JournalEntryNew.tsx` | — | `[x] base` |
+| JournalEntryEdit | `/journal/:id/edit` | `components/pages/JournalEntryEdit.tsx` | — | `[x] base` |
 
 ## Purchase
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -127,10 +127,10 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| TerminalHome | `/terminal` | `components/terminal/TerminalHome.tsx` | — | `[ ] base` |
-| TerminalBoxCheck | `/terminal/box-check` | `components/terminal/TransportBoxCheck.tsx` | — | `[ ] base` |
-| TerminalBoxFill | `/terminal/box-fill` | `components/terminal/box-fill/BoxFillWorkflow.tsx` | steps: Scan, AddItems | `[ ] base` `[ ] ScanStep` `[ ] AddItemsStep` |
-| TerminalReceive | `/terminal/receive` | `components/terminal/TransportBoxReceive.tsx` | — | `[ ] base` |
+| TerminalHome | `/terminal` | `components/terminal/TerminalHome.tsx` | — | `[x] base` |
+| TerminalBoxCheck | `/terminal/box-check` | `components/terminal/TransportBoxCheck.tsx` | — | `[x] base` |
+| TerminalBoxFill | `/terminal/box-fill` | `components/terminal/box-fill/BoxFillWorkflow.tsx` | steps: Scan, AddItems | `[x] base` `[x] ScanStep` `[x] AddItemsStep` |
+| TerminalReceive | `/terminal/receive` | `components/terminal/TransportBoxReceive.tsx` | — | `[x] base` |
 | TerminalStocktake | `/terminal/stocktake` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
 | TerminalLotIdentification | `/terminal/lot-identification` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -18,7 +18,7 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| Dashboard | `/` | `components/pages/Dashboard.tsx` | — | `[ ] base` |
+| Dashboard | `/` | `components/pages/Dashboard.tsx` | — | `[x] base` |
 
 ## Finance
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -24,9 +24,9 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| FinancialOverview | `/finance/overview` | `components/pages/FinancialOverview.tsx` | — | `[ ] base` |
-| BankStatementImport | `/finance/bank-statements` | `components/pages/BankStatementImportChart.tsx` | — | `[ ] base` |
-| ProductMarginSummary | `/analytics/product-margin-summary` | `components/pages/ProductMarginSummary.tsx` | — | `[ ] base` |
+| FinancialOverview | `/finance/overview` | `components/pages/FinancialOverview.tsx` | — | `[x] base` |
+| BankStatementImport | `/finance/bank-statements` | `components/pages/BankStatementImportChart.tsx` | — | `[x] base` |
+| ProductMarginSummary | `/analytics/product-margin-summary` | `components/pages/ProductMarginSummary.tsx` | — | `[x] base` |
 
 ## Catalog
 

--- a/docs/features/usage-analytics-coverage.md
+++ b/docs/features/usage-analytics-coverage.md
@@ -48,9 +48,9 @@ Canonical checklist of every user-facing screen and in-page branch in the app, a
 
 | Screen | Route | Component | Branches | Coverage |
 |---|---|---|---|---|
-| PurchaseOrderList | `/purchase/orders` | `components/pages/PurchaseOrderList.tsx` | — | `[ ] base` |
-| PurchaseStockAnalysis | `/purchase/stock-analysis` | `components/pages/PurchaseStockAnalysis.tsx` | — | `[ ] base` |
-| InvoiceClassification | `/purchase/invoice-classification` | `pages/InvoiceClassification/InvoiceClassificationPage.tsx` | tabs: Invoices, Rules | `[ ] base` `[ ] InvoicesTab` `[ ] RulesTab` |
+| PurchaseOrderList | `/purchase/orders` | `components/pages/PurchaseOrderList.tsx` | — | `[x] base` |
+| PurchaseStockAnalysis | `/purchase/stock-analysis` | `components/pages/PurchaseStockAnalysis.tsx` | — | `[x] base` |
+| InvoiceClassification | `/purchase/invoice-classification` | `pages/InvoiceClassification/InvoiceClassificationPage.tsx` | tabs: Invoices, Rules | `[x] base` `[x] InvoicesTab` `[x] RulesTab` |
 
 ## Manufacturing
 

--- a/docs/features/usage-analytics.md
+++ b/docs/features/usage-analytics.md
@@ -43,6 +43,7 @@ Every PR that adds a `trackEvent` call **must** add a row to this table in the s
 | `ManufactureOrderCreated` | `components/manufacture/pages/ManufactureOrderDetail.tsx` | `productCode: string` | — | Core workflow completion rate (triggered on order duplication). |
 | `PurchaseOrderSubmitted` | `components/pages/PurchaseOrderList.tsx` | `orderId: string` | — | Purchase pipeline volume. |
 | `FeatureFlagToggled` | `pages/FeatureFlagsAdminPage.tsx` | `flagKey: string`, `enabled: string` | — | Audit trail for admin flag changes. |
+| `ScreenViewed` | `frontend/src/telemetry/useScreenView.ts` (called from every screen component) | `module: string`, `screen: string`, `subScreen?: string` | — | Which screens and sub-screens (tabs, view-modes, wizard steps) do users actually visit, and how often? See [usage-analytics-coverage.md](./usage-analytics-coverage.md) for the canonical list. |
 
 ## Naming conventions
 
@@ -84,6 +85,21 @@ dashboard_users
 | where user_AuthenticatedId !in (photobank_users)
 | summarize count()
 ```
+
+### Screen + sub-screen usage in last 30 days
+
+```kusto
+customEvents
+| where timestamp > ago(30d) and name == "ScreenViewed"
+| summarize hits=count(),
+            users=dcount(user_AuthenticatedId)
+            by module=tostring(customDimensions.module),
+               screen=tostring(customDimensions.screen),
+               subScreen=tostring(customDimensions.subScreen)
+| order by hits desc
+```
+
+Cross-reference distinct `(module, screen, subScreen)` tuples against `usage-analytics-coverage.md` to find wiring gaps (rows checked but never seen in telemetry) and doc drift (events seen but missing from the doc).
 
 ## How to add a new event
 

--- a/docs/superpowers/plans/2026-05-26-full-ui-screen-usage-coverage.md
+++ b/docs/superpowers/plans/2026-05-26-full-ui-screen-usage-coverage.md
@@ -1,0 +1,1596 @@
+# Full UI Screen Usage Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Instrument every user-facing screen and every meaningful in-page branch (tabs, view-modes, wizard steps) with a single uniform `ScreenViewed` event, plus a coverage matrix doc that makes gaps visible.
+
+**Architecture:** Add a `useScreenView(module, screen, subScreen?)` hook on top of the existing `useTelemetry()`. The hook fires `trackEvent('ScreenViewed', {module, screen, subScreen})` on mount and whenever `subScreen` changes. Auto-tracked `pageView` continues for performance metrics; semantic usage analysis routes exclusively through `ScreenViewed` so KQL is uniform. A new coverage doc (`docs/features/usage-analytics-coverage.md`) is the canonical checklist.
+
+**Tech Stack:** React 18 + TypeScript, `@microsoft/applicationinsights-web`, `@microsoft/applicationinsights-react-js`, Jest + React Testing Library, react-scripts.
+
+**Scope decisions (locked in):**
+1. Single generic event `ScreenViewed` with `{module, screen, subScreen?}` — not per-screen named events.
+2. Branches tracked: tabs, view-mode switches, wizard steps. NOT modals/drawers, NOT feature actions (those remain per-action events).
+3. Terminal and Baleni sub-apps included; they get dedicated `module` values.
+
+---
+
+## Conventions used throughout
+
+- **`module`**: one of the literal strings from the `ScreenModule` union (defined in Task 0): `Dashboard | Finance | Catalog | Journal | Purchase | Manufacturing | Logistics | Marketing | Customer | Automation | Knowledge | Admin | Terminal | Baleni`.
+- **`screen`**: PascalCase, matches the component name (e.g., `CatalogList`, `ManufactureOrderDetail`). One value per route.
+- **`subScreen`**: optional. PascalCase for tab/view-mode/wizard-step identifiers (e.g., `MarginsTab`, `CalendarView`, `AddItemsStep`). Omit if the screen has no branches.
+- **Hook placement**: directly after the `useState` declarations in the screen component, before the data-fetching hooks. Place once per screen.
+- **For branched screens**: pass the state variable that holds the current tab/view-mode/step (mapped to a stable PascalCase string) as `subScreen`. The hook re-fires on change.
+
+## TDD scope
+
+Task 0 (the foundation hook) is fully TDD: write failing tests first, implement, watch them pass.
+
+Tasks 1–14 (module instrumentation) are **mechanical**: each adds a single `useScreenView(...)` call per screen. Adding unit tests for each of ~50 screens just to assert the hook was called is ceremony; the hook itself is covered by Task 0's tests, the component build catches typos, and the KQL verification in Task 15 reveals any wiring gap empirically. Each module task includes a build/lint gate as the verification step.
+
+---
+
+## Task 0: Foundation — `useScreenView` hook, types, smoke test, coverage doc skeleton
+
+**Files:**
+- Create: `frontend/src/telemetry/screenModules.ts`
+- Create: `frontend/src/telemetry/useScreenView.ts`
+- Create: `frontend/src/telemetry/__tests__/useScreenView.test.tsx`
+- Create: `docs/features/usage-analytics-coverage.md`
+- Modify: `frontend/src/telemetry/events.ts`
+- Modify: `docs/features/usage-analytics.md`
+
+### Step 0.1: Write the failing tests for `useScreenView`
+
+- [ ] Create `frontend/src/telemetry/__tests__/useScreenView.test.tsx`:
+
+```tsx
+import { renderHook } from '@testing-library/react';
+import type { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { useScreenView } from '../useScreenView';
+import * as appInsightsModule from '../appInsights';
+
+const mockTrackEvent = jest.fn();
+const mockAI = { trackEvent: mockTrackEvent };
+
+describe('useScreenView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(appInsightsModule, 'getAppInsights').mockReturnValue(
+      mockAI as unknown as ApplicationInsights,
+    );
+  });
+
+  it('fires ScreenViewed on mount with module and screen', () => {
+    renderHook(() => useScreenView('Dashboard', 'Dashboard'));
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      { name: 'ScreenViewed' },
+      { module: 'Dashboard', screen: 'Dashboard' },
+    );
+  });
+
+  it('includes subScreen when provided', () => {
+    renderHook(() => useScreenView('Catalog', 'CatalogDetail', 'MarginsTab'));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      { name: 'ScreenViewed' },
+      { module: 'Catalog', screen: 'CatalogDetail', subScreen: 'MarginsTab' },
+    );
+  });
+
+  it('re-fires when subScreen changes', () => {
+    const { rerender } = renderHook(
+      ({ tab }: { tab: string }) => useScreenView('Catalog', 'CatalogDetail', tab),
+      { initialProps: { tab: 'BasicTab' } },
+    );
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+    rerender({ tab: 'MarginsTab' });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+    expect(mockTrackEvent).toHaveBeenLastCalledWith(
+      { name: 'ScreenViewed' },
+      { module: 'Catalog', screen: 'CatalogDetail', subScreen: 'MarginsTab' },
+    );
+  });
+
+  it('does not re-fire when subScreen is unchanged across renders', () => {
+    const { rerender } = renderHook(
+      ({ tab }: { tab: string }) => useScreenView('Catalog', 'CatalogDetail', tab),
+      { initialProps: { tab: 'BasicTab' } },
+    );
+    rerender({ tab: 'BasicTab' });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when AI instance is null', () => {
+    jest.spyOn(appInsightsModule, 'getAppInsights').mockReturnValue(null);
+
+    expect(() =>
+      renderHook(() => useScreenView('Dashboard', 'Dashboard')),
+    ).not.toThrow();
+  });
+});
+```
+
+### Step 0.2: Run tests — verify they fail
+
+- [ ] Run:
+
+```bash
+cd frontend && npx react-scripts test --watchAll=false src/telemetry/__tests__/useScreenView.test.tsx
+```
+
+Expected: FAIL with `Cannot find module '../useScreenView'`.
+
+### Step 0.3: Create the `ScreenModule` union
+
+- [ ] Create `frontend/src/telemetry/screenModules.ts`:
+
+```ts
+export type ScreenModule =
+  | 'Dashboard'
+  | 'Finance'
+  | 'Catalog'
+  | 'Journal'
+  | 'Purchase'
+  | 'Manufacturing'
+  | 'Logistics'
+  | 'Marketing'
+  | 'Customer'
+  | 'Automation'
+  | 'Knowledge'
+  | 'Admin'
+  | 'Terminal'
+  | 'Baleni';
+```
+
+### Step 0.4: Add `'ScreenViewed'` to the event-name union
+
+- [ ] Modify `frontend/src/telemetry/events.ts` to:
+
+```ts
+export type TelemetryEventName =
+  | 'DashboardTileClicked'
+  | 'PhotobankBulkTagApplied'
+  | 'ManufactureOrderCreated'
+  | 'PurchaseOrderSubmitted'
+  | 'FeatureFlagToggled'
+  | 'ScreenViewed';
+```
+
+### Step 0.5: Implement `useScreenView`
+
+- [ ] Create `frontend/src/telemetry/useScreenView.ts`:
+
+```ts
+import { useEffect } from 'react';
+import { useTelemetry } from './useTelemetry';
+import type { ScreenModule } from './screenModules';
+
+export function useScreenView(
+  module: ScreenModule,
+  screen: string,
+  subScreen?: string,
+): void {
+  const { trackEvent } = useTelemetry();
+
+  useEffect(() => {
+    const properties: Record<string, string> = { module, screen };
+    if (subScreen !== undefined) {
+      properties.subScreen = subScreen;
+    }
+    trackEvent('ScreenViewed', properties);
+  }, [module, screen, subScreen]); // trackEvent is stable per useTelemetry contract; intentionally excluded
+}
+```
+
+### Step 0.6: Run tests — verify they pass
+
+- [ ] Run:
+
+```bash
+cd frontend && npx react-scripts test --watchAll=false src/telemetry/__tests__/useScreenView.test.tsx
+```
+
+Expected: PASS (5 tests).
+
+### Step 0.7: Run the full telemetry test suite to confirm no regression
+
+- [ ] Run:
+
+```bash
+cd frontend && npx react-scripts test --watchAll=false src/telemetry/
+```
+
+Expected: PASS (existing useTelemetry + appInsights tests + new useScreenView tests).
+
+### Step 0.8: Create the coverage matrix document
+
+- [ ] Create `docs/features/usage-analytics-coverage.md`:
+
+````markdown
+# UI Screen Usage Coverage
+
+Canonical checklist of every user-facing screen and in-page branch in the app, and whether `useScreenView(...)` is wired up.
+
+## Contract
+
+- "Covered" = `useScreenView(module, screen, subScreen?)` is called for the surface AND its checkbox is ticked below.
+- Every PR that adds, removes, or changes a screen/branch updates this doc in the same PR. Reviewers reject PRs that don't.
+- KQL verification (see [usage-analytics.md](./usage-analytics.md#how-to-query)) is run weekly; gaps between this doc and observed `ScreenViewed` events are filed as bugs.
+- Modals, drawers, and feature actions (button clicks, filter applies, exports) are **out of scope** for `ScreenViewed`. Modal-as-full-screen views (e.g., `CatalogDetail` opened from `CatalogList`) ARE in scope.
+- "Coming Soon" placeholder screens are listed but not checked until content lands.
+
+## Legend
+
+`[x]` = wired and reaching production. `[ ]` = not yet wired.
+
+## Dashboard
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| Dashboard | `/` | `components/pages/Dashboard.tsx` | — | `[ ] base` |
+
+## Finance
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| FinancialOverview | `/finance/overview` | `components/pages/FinancialOverview.tsx` | — | `[ ] base` |
+| BankStatementImport | `/finance/bank-statements` | `components/pages/BankStatementImportChart.tsx` | — | `[ ] base` |
+| ProductMarginSummary | `/analytics/product-margin-summary` | `components/pages/ProductMarginSummary.tsx` | — | `[ ] base` |
+
+## Catalog
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| CatalogList | `/catalog` | `components/pages/CatalogList.tsx` | — | `[ ] base` |
+| CatalogDetail | (modal from list) | `components/pages/CatalogDetail.tsx` | tabs: Basic, History, Margins, Composition, Journal, Usage, Documents, Pif; chartTabs: Input, Output | `[ ] base` `[ ] BasicTab` `[ ] HistoryTab` `[ ] MarginsTab` `[ ] CompositionTab` `[ ] JournalTab` `[ ] UsageTab` `[ ] DocumentsTab` `[ ] PifTab` `[ ] ChartInput` `[ ] ChartOutput` |
+| ProductMargins | `/products/margins` | `components/pages/ProductMarginsList.tsx` | — | `[ ] base` |
+
+## Journal
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| JournalList | `/journal` | `components/pages/Journal/JournalList.tsx` | — | `[ ] base` |
+| JournalEntryNew | `/journal/new` | `components/pages/JournalEntryNew.tsx` | — | `[ ] base` |
+| JournalEntryEdit | `/journal/:id/edit` | `components/pages/JournalEntryEdit.tsx` | — | `[ ] base` |
+
+## Purchase
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| PurchaseOrderList | `/purchase/orders` | `components/pages/PurchaseOrderList.tsx` | — | `[ ] base` |
+| PurchaseStockAnalysis | `/purchase/stock-analysis` | `components/pages/PurchaseStockAnalysis.tsx` | — | `[ ] base` |
+| InvoiceClassification | `/purchase/invoice-classification` | `pages/InvoiceClassification/InvoiceClassificationPage.tsx` | tabs: Invoices, Rules | `[ ] base` `[ ] InvoicesTab` `[ ] RulesTab` |
+
+## Manufacturing
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| ManufacturingStockAnalysis | `/manufacturing/stock-analysis` | `components/pages/ManufacturingStockAnalysis.tsx` | — | `[ ] base` |
+| ManufactureOutput | `/manufacturing/output` | `components/pages/ManufactureOutput.tsx` | — | `[ ] base` |
+| ManufactureBatchCalculator | `/manufacturing/batch-calculator` | `components/pages/ManufactureBatchCalculator.tsx` | — | `[ ] base` |
+| ManufactureBatchPlanning | `/manufacturing/batch-planning` | `components/pages/ManufactureBatchPlanning.tsx` | — | `[ ] base` |
+| ManufactureOrderList | `/manufacturing/orders` | `components/manufacture/pages/ManufactureOrderList.tsx` | viewModes: Grid, Calendar, Weekly | `[ ] base` `[ ] GridView` `[ ] CalendarView` `[ ] WeeklyView` |
+| ManufactureOrderDetail | `/manufacturing/orders/:id` | `components/manufacture/pages/ManufactureOrderDetail.tsx` | tabs: Info, Notes, Log, Conditions | `[ ] base` `[ ] InfoTab` `[ ] NotesTab` `[ ] LogTab` `[ ] ConditionsTab` |
+| ManufactureInventory | `/manufacturing/inventory` | `components/pages/ManufactureInventoryList.tsx` | — | `[ ] base` |
+| ManufacturedProductInventory | `/manufacturing/product-inventory` | `components/pages/ManufacturedInventoryPage.tsx` | — | `[ ] base` |
+
+## Logistics
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| InventoryFinishedGoods | `/logistics/inventory` | `components/pages/InventoryList.tsx` | — | `[ ] base` |
+| TransportBoxes | `/logistics/transport-boxes` | `components/pages/TransportBoxList.tsx` | — | `[ ] base` |
+| TransportBoxReceive | `/logistics/receive-boxes` | `components/pages/TransportBoxReceive.tsx` | — | `[ ] base` |
+| GiftPackageManufacturing | `/logistics/gift-package-manufacturing` | `components/pages/GiftPackageManufacturing.tsx` | — | `[ ] base` |
+| PackingMaterials | `/logistics/packing-materials` | `pages/PackingMaterialsPage.tsx` | — | `[ ] base` |
+| WarehouseStatistics | `/logistics/warehouse-statistics` | `components/pages/WarehouseStatistics.tsx` | — | `[ ] base` |
+| ExpeditionArchive | `/logistics/expedition-archive` | `pages/ExpeditionListArchivePage.tsx` | — | `[ ] base` |
+
+## Marketing
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| MarketingCalendar | `/marketing/calendar` | `components/marketing/pages/MarketingCalendarPage.tsx` | viewModes: FiveWeeks, TwoWeeks, List | `[ ] base` `[ ] FiveWeeksView` `[ ] TwoWeeksView` `[ ] ListView` |
+| Photobank | `/marketing/photobank` | `components/marketing/photobank/pages/PhotobankPage.tsx` | viewModes: Tiles, List | `[ ] base` `[ ] TilesView` `[ ] ListView` |
+| PhotobankSettings | `/marketing/photobank/settings` | `components/marketing/photobank/pages/PhotobankSettingsPage.tsx` | — | `[ ] base` |
+| LeafletGenerator | `/leaflet-generator` | `features/leaflet-generator/LeafletGeneratorPage.tsx` | — | `[ ] base` |
+| Articles | `/articles` | `pages/ArticlesPage.tsx` | tabs: New, List | `[ ] base` `[ ] NewTab` `[ ] ListTab` |
+| MarketingFeedback | `/marketing/feedback` | `pages/MarketingFeedbackPage.tsx` | — | `[ ] base` |
+
+## Customer
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| IssuedInvoices | `/customer/issued-invoices` | `pages/customer/IssuedInvoicesPage.tsx` | — | `[ ] base` |
+| BankStatementsOverview | `/customer/bank-statements-overview` | `pages/customer/BankStatementsOverviewPage.tsx` | — | `[ ] base` |
+| SmartsuppChats | `/customer/smartsupp` | `components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx` | — | `[ ] base` |
+| ExpeditionSettings | `/customer/expedition-settings` | `pages/customer/ExpeditionSettingsPage.tsx` | tabs: Cooling, Gifts | `[ ] base` `[ ] CoolingTab` `[ ] GiftsTab` |
+
+## Automation
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| BackgroundTasks | `/automation/background-tasks` | `components/pages/automation/BackgroundTasks.tsx` | — | `[ ] base` |
+| InvoiceImportStatistics | `/automation/invoice-import-statistics` | `components/pages/automation/InvoiceImportStatistics.tsx` | — | `[ ] base` |
+| MeetingTasks | `/automation/meeting-tasks` | `components/pages/automation/MeetingTasksPage.tsx` | — | `[ ] base` |
+| MeetingTaskDetail | `/automation/meeting-tasks/:id` | `components/pages/automation/MeetingTaskDetailPage.tsx` | — | `[ ] base` |
+| StockOperations | `/stock-up-operations` | `pages/StockOperationsPage.tsx` | — | `[ ] base` |
+| RecurringJobs | `/recurring-jobs` | `pages/RecurringJobsPage.tsx` | — | `[ ] base` |
+| DataQuality | `/automation/data-quality` | `pages/customer/DataQualityPage.tsx` | — | `[ ] base` |
+
+## Knowledge
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| KnowledgeBase | `/knowledge-base` | `pages/KnowledgeBasePage.tsx` | tabs: Search, Documents, Upload | `[ ] base` `[ ] SearchTab` `[ ] DocumentsTab` `[ ] UploadTab` |
+| KnowledgeBaseFeedback | `/knowledge-base/feedback` | `pages/KnowledgeBaseFeedbackPage.tsx` | — | `[ ] base` |
+
+## Admin
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| OrgChart | `/orgchart` | `pages/OrgChartPage.tsx` | — | `[ ] base` |
+| FeatureFlagsAdmin | `/admin/feature-flags` | `pages/FeatureFlagsAdminPage.tsx` | — | `[ ] base` |
+
+## Terminal
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| TerminalHome | `/terminal` | `components/terminal/TerminalHome.tsx` | — | `[ ] base` |
+| TerminalBoxCheck | `/terminal/box-check` | `components/terminal/TransportBoxCheck.tsx` | — | `[ ] base` |
+| TerminalBoxFill | `/terminal/box-fill` | `components/terminal/box-fill/BoxFillWorkflow.tsx` | steps: Scan, AddItems | `[ ] base` `[ ] ScanStep` `[ ] AddItemsStep` |
+| TerminalReceive | `/terminal/receive` | `components/terminal/TransportBoxReceive.tsx` | — | `[ ] base` |
+| TerminalStocktake | `/terminal/stocktake` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
+| TerminalLotIdentification | `/terminal/lot-identification` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
+
+## Baleni
+
+| Screen | Route | Component | Branches | Coverage |
+|---|---|---|---|---|
+| BaleniHome | `/baleni` | `components/baleni/BaleniHome.tsx` | — | `[ ] base` |
+| BaleniPacking | `/baleni/baleni` | `components/baleni/BaleniPacking.tsx` | — | `[ ] base` |
+| BaleniShipments | `/baleni/zasilky` | `components/baleni/zasilky/ZasilkyPage.tsx` | — | `[ ] base` |
+| BaleniStatistics | `/baleni/statistiky` | (placeholder) | — | `[ ] base` (deferred — placeholder) |
+````
+
+### Step 0.9: Update `usage-analytics.md`
+
+- [ ] Modify `docs/features/usage-analytics.md` — add a row to the Event catalogue table (between the existing rows and the "Naming conventions" section). Insert this row at the end of the events table (after the `FeatureFlagToggled` row, before the `## Naming conventions` heading):
+
+```
+| `ScreenViewed` | `frontend/src/telemetry/useScreenView.ts` (called from every screen component) | `module: string`, `screen: string`, `subScreen?: string` | — | Which screens and sub-screens (tabs, view-modes, wizard steps) do users actually visit, and how often? See [usage-analytics-coverage.md](./usage-analytics-coverage.md) for the canonical list. |
+```
+
+Then add a new query under `## How to query`, immediately after the `### Funnel: users who visited Dashboard but never opened Photobank` block:
+
+````
+### Screen + sub-screen usage in last 30 days
+
+```kusto
+customEvents
+| where timestamp > ago(30d) and name == "ScreenViewed"
+| summarize hits=count(),
+            users=dcount(user_AuthenticatedId)
+            by module=tostring(customDimensions.module),
+               screen=tostring(customDimensions.screen),
+               subScreen=tostring(customDimensions.subScreen)
+| order by hits desc
+```
+
+Cross-reference distinct `(module, screen, subScreen)` tuples against `usage-analytics-coverage.md` to find wiring gaps (rows checked but never seen in telemetry) and doc drift (events seen but missing from the doc).
+````
+
+### Step 0.10: Run frontend lint + build
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+```
+
+Expected: both PASS.
+
+### Step 0.11: Commit Task 0
+
+- [ ] Run:
+
+```bash
+git add frontend/src/telemetry/screenModules.ts \
+        frontend/src/telemetry/useScreenView.ts \
+        frontend/src/telemetry/__tests__/useScreenView.test.tsx \
+        frontend/src/telemetry/events.ts \
+        docs/features/usage-analytics.md \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): add useScreenView hook and coverage matrix doc"
+```
+
+---
+
+## Module instrumentation tasks (1–14)
+
+Each module task follows the same shape:
+
+1. Add `import { useScreenView } from '<relative-path>/telemetry/useScreenView';` to each listed file.
+2. Add the listed `useScreenView(...)` call directly after the screen's `useState` declarations.
+3. Tick the corresponding boxes in `docs/features/usage-analytics-coverage.md`.
+4. Run `cd frontend && npm run lint && npm run build`.
+5. Commit.
+
+Relative import path depends on file depth — examples:
+- `components/pages/Dashboard.tsx` → `'../../telemetry/useScreenView'`
+- `components/marketing/pages/MarketingCalendarPage.tsx` → `'../../../telemetry/useScreenView'`
+- `pages/ArticlesPage.tsx` → `'../telemetry/useScreenView'`
+
+---
+
+## Task 1: Dashboard module
+
+**Files:**
+- Modify: `frontend/src/components/pages/Dashboard.tsx`
+
+### Step 1.1: Wire `useScreenView` in Dashboard
+
+- [ ] Add to `frontend/src/components/pages/Dashboard.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations near the top of the `Dashboard` component, add:
+
+```tsx
+useScreenView('Dashboard', 'Dashboard');
+```
+
+### Step 1.2: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under the `## Dashboard` table, change `[ ] base` to `[x] base` for the `Dashboard` row.
+
+### Step 1.3: Build + lint
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+```
+
+Expected: PASS.
+
+### Step 1.4: Commit
+
+- [ ] Run:
+
+```bash
+git add frontend/src/components/pages/Dashboard.tsx docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Dashboard screen"
+```
+
+---
+
+## Task 2: Admin module
+
+**Files:**
+- Modify: `frontend/src/pages/FeatureFlagsAdminPage.tsx`
+- Modify: `frontend/src/pages/OrgChartPage.tsx`
+
+### Step 2.1: Wire `useScreenView` in FeatureFlagsAdminPage
+
+- [ ] Add to `frontend/src/pages/FeatureFlagsAdminPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+```
+
+After the existing `useState` declarations in the component, add:
+
+```tsx
+useScreenView('Admin', 'FeatureFlagsAdmin');
+```
+
+### Step 2.2: Wire `useScreenView` in OrgChartPage
+
+- [ ] Add to `frontend/src/pages/OrgChartPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+```
+
+After the existing `useState` declarations (or at the top of the component if none), add:
+
+```tsx
+useScreenView('Admin', 'OrgChart');
+```
+
+### Step 2.3: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Admin`, change `[ ] base` → `[x] base` on both rows (`OrgChart`, `FeatureFlagsAdmin`).
+
+### Step 2.4: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/pages/FeatureFlagsAdminPage.tsx \
+        frontend/src/pages/OrgChartPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Admin screens"
+```
+
+---
+
+## Task 3: Knowledge module
+
+**Files:**
+- Modify: `frontend/src/pages/KnowledgeBasePage.tsx`
+- Modify: `frontend/src/pages/KnowledgeBaseFeedbackPage.tsx`
+
+### Step 3.1: Wire `useScreenView` in KnowledgeBasePage (with tab branching)
+
+`KnowledgeBasePage.tsx:12` declares `const [activeTab, setActiveTab] = useState<Tab>('search')`, with `activeTab` values `'search' | 'documents' | 'upload'`.
+
+- [ ] Add to `frontend/src/pages/KnowledgeBasePage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+```
+
+After the `useState` declaration on line 12, add:
+
+```tsx
+const subScreen =
+  activeTab === 'search' ? 'SearchTab' :
+  activeTab === 'documents' ? 'DocumentsTab' :
+  'UploadTab';
+useScreenView('Knowledge', 'KnowledgeBase', subScreen);
+```
+
+### Step 3.2: Wire `useScreenView` in KnowledgeBaseFeedbackPage
+
+- [ ] Add to `frontend/src/pages/KnowledgeBaseFeedbackPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+```
+
+After the existing `useState` declarations, add:
+
+```tsx
+useScreenView('Knowledge', 'KnowledgeBaseFeedback');
+```
+
+### Step 3.3: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Knowledge`, tick:
+  - `KnowledgeBase`: `[x] base`, `[x] SearchTab`, `[x] DocumentsTab`, `[x] UploadTab`
+  - `KnowledgeBaseFeedback`: `[x] base`
+
+### Step 3.4: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/pages/KnowledgeBasePage.tsx \
+        frontend/src/pages/KnowledgeBaseFeedbackPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Knowledge module screens"
+```
+
+---
+
+## Task 4: Customer module
+
+**Files:**
+- Modify: `frontend/src/pages/customer/IssuedInvoicesPage.tsx`
+- Modify: `frontend/src/pages/customer/BankStatementsOverviewPage.tsx`
+- Modify: `frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx`
+- Modify: `frontend/src/pages/customer/ExpeditionSettingsPage.tsx`
+
+### Step 4.1: Wire `useScreenView` in IssuedInvoicesPage
+
+- [ ] Add to `frontend/src/pages/customer/IssuedInvoicesPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Customer', 'IssuedInvoices');
+```
+
+### Step 4.2: Wire `useScreenView` in BankStatementsOverviewPage
+
+- [ ] Add to `frontend/src/pages/customer/BankStatementsOverviewPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Customer', 'BankStatementsOverview');
+```
+
+### Step 4.3: Wire `useScreenView` in SmartsuppChatsPage
+
+- [ ] Add to `frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Customer', 'SmartsuppChats');
+```
+
+### Step 4.4: Wire `useScreenView` in ExpeditionSettingsPage (URL-driven tabs)
+
+`ExpeditionSettingsPage.tsx:11` reads `activeTab` from URL: `(searchParams.get('tab') as Tab) ?? 'cooling'`, values `'cooling' | 'gifts'`.
+
+- [ ] Add to `frontend/src/pages/customer/ExpeditionSettingsPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `activeTab` derivation on line 11, add:
+
+```tsx
+useScreenView('Customer', 'ExpeditionSettings', activeTab === 'cooling' ? 'CoolingTab' : 'GiftsTab');
+```
+
+### Step 4.5: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Customer`, tick:
+  - `IssuedInvoices`: `[x] base`
+  - `BankStatementsOverview`: `[x] base`
+  - `SmartsuppChats`: `[x] base`
+  - `ExpeditionSettings`: `[x] base`, `[x] CoolingTab`, `[x] GiftsTab`
+
+### Step 4.6: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/pages/customer/IssuedInvoicesPage.tsx \
+        frontend/src/pages/customer/BankStatementsOverviewPage.tsx \
+        frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx \
+        frontend/src/pages/customer/ExpeditionSettingsPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Customer module screens"
+```
+
+---
+
+## Task 5: Journal module
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/JournalList.tsx`
+- Modify: `frontend/src/components/pages/JournalEntryNew.tsx`
+- Modify: `frontend/src/components/pages/JournalEntryEdit.tsx`
+
+### Step 5.1: Wire `useScreenView` in JournalList
+
+- [ ] Add to `frontend/src/components/pages/Journal/JournalList.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Journal', 'JournalList');
+```
+
+### Step 5.2: Wire `useScreenView` in JournalEntryNew
+
+- [ ] Add to `frontend/src/components/pages/JournalEntryNew.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Journal', 'JournalEntryNew');
+```
+
+### Step 5.3: Wire `useScreenView` in JournalEntryEdit
+
+- [ ] Add to `frontend/src/components/pages/JournalEntryEdit.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Journal', 'JournalEntryEdit');
+```
+
+### Step 5.4: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Journal`, tick `[x] base` for all three rows.
+
+### Step 5.5: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/Journal/JournalList.tsx \
+        frontend/src/components/pages/JournalEntryNew.tsx \
+        frontend/src/components/pages/JournalEntryEdit.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Journal module screens"
+```
+
+---
+
+## Task 6: Finance module
+
+**Files:**
+- Modify: `frontend/src/components/pages/FinancialOverview.tsx`
+- Modify: `frontend/src/components/pages/BankStatementImportChart.tsx`
+- Modify: `frontend/src/components/pages/ProductMarginSummary.tsx`
+
+### Step 6.1: Wire `useScreenView` in FinancialOverview
+
+- [ ] Add to `frontend/src/components/pages/FinancialOverview.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Finance', 'FinancialOverview');
+```
+
+### Step 6.2: Wire `useScreenView` in BankStatementImportChart
+
+- [ ] Add to `frontend/src/components/pages/BankStatementImportChart.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Finance', 'BankStatementImport');
+```
+
+### Step 6.3: Wire `useScreenView` in ProductMarginSummary
+
+- [ ] Add to `frontend/src/components/pages/ProductMarginSummary.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Finance', 'ProductMarginSummary');
+```
+
+### Step 6.4: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Finance`, tick `[x] base` for all three rows.
+
+### Step 6.5: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/FinancialOverview.tsx \
+        frontend/src/components/pages/BankStatementImportChart.tsx \
+        frontend/src/components/pages/ProductMarginSummary.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Finance module screens"
+```
+
+---
+
+## Task 7: Catalog module
+
+**Files:**
+- Modify: `frontend/src/components/pages/CatalogList.tsx`
+- Modify: `frontend/src/components/pages/CatalogDetail.tsx`
+- Modify: `frontend/src/components/pages/ProductMarginsList.tsx`
+
+### Step 7.1: Wire `useScreenView` in CatalogList
+
+- [ ] Add to `frontend/src/components/pages/CatalogList.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Catalog', 'CatalogList');
+```
+
+### Step 7.2: Wire `useScreenView` in CatalogDetail (tabs + chart sub-tabs, gated by `isOpen`)
+
+`CatalogDetail.tsx:48` declares `activeTab` (8 values: `"basic" | "history" | "margins" | "composition" | "journal" | "usage" | "documents" | "pif"`) and `activeChartTab:51` (`"input" | "output"`). The detail is a modal — only fire `useScreenView` when `isOpen` is true.
+
+- [ ] Add to `frontend/src/components/pages/CatalogDetail.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the existing `useState` declarations (after line 59), add:
+
+```tsx
+const tabToSubScreen: Record<typeof activeTab, string> = {
+  basic: 'BasicTab',
+  history: 'HistoryTab',
+  margins: 'MarginsTab',
+  composition: 'CompositionTab',
+  journal: 'JournalTab',
+  usage: 'UsageTab',
+  documents: 'DocumentsTab',
+  pif: 'PifTab',
+};
+useScreenView('Catalog', 'CatalogDetail', isOpen ? tabToSubScreen[activeTab] : undefined);
+useScreenView(
+  'Catalog',
+  'CatalogDetail',
+  isOpen && activeTab === 'history' ? (activeChartTab === 'input' ? 'ChartInput' : 'ChartOutput') : undefined,
+);
+```
+
+Rationale for the second call: chart tabs are only meaningful when the History tab is active. Passing `undefined` when not relevant means the second `ScreenViewed` fires only when the user actually views a chart sub-tab, producing two distinct events for the same screen but different `subScreen` values.
+
+### Step 7.3: Wire `useScreenView` in ProductMarginsList
+
+- [ ] Add to `frontend/src/components/pages/ProductMarginsList.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Catalog', 'ProductMargins');
+```
+
+### Step 7.4: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Catalog`, tick:
+  - `CatalogList`: `[x] base`
+  - `CatalogDetail`: `[x] base` plus all 10 sub-screen boxes (`BasicTab`, `HistoryTab`, `MarginsTab`, `CompositionTab`, `JournalTab`, `UsageTab`, `DocumentsTab`, `PifTab`, `ChartInput`, `ChartOutput`)
+  - `ProductMargins`: `[x] base`
+
+### Step 7.5: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/CatalogList.tsx \
+        frontend/src/components/pages/CatalogDetail.tsx \
+        frontend/src/components/pages/ProductMarginsList.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Catalog module screens"
+```
+
+---
+
+## Task 8: Purchase module
+
+**Files:**
+- Modify: `frontend/src/components/pages/PurchaseOrderList.tsx`
+- Modify: `frontend/src/components/pages/PurchaseStockAnalysis.tsx`
+- Modify: `frontend/src/pages/InvoiceClassification/InvoiceClassificationPage.tsx`
+
+### Step 8.1: Wire `useScreenView` in PurchaseOrderList
+
+- [ ] Add to `frontend/src/components/pages/PurchaseOrderList.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Purchase', 'PurchaseOrderList');
+```
+
+### Step 8.2: Wire `useScreenView` in PurchaseStockAnalysis
+
+- [ ] Add to `frontend/src/components/pages/PurchaseStockAnalysis.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Purchase', 'PurchaseStockAnalysis');
+```
+
+### Step 8.3: Wire `useScreenView` in InvoiceClassificationPage (tabs)
+
+`InvoiceClassificationPage.tsx:24` declares `const [activeTab, setActiveTab] = useState<TabType>('invoices')` with values `'invoices' | 'rules'`.
+
+- [ ] Add to `frontend/src/pages/InvoiceClassification/InvoiceClassificationPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After line 24, add:
+
+```tsx
+useScreenView('Purchase', 'InvoiceClassification', activeTab === 'invoices' ? 'InvoicesTab' : 'RulesTab');
+```
+
+### Step 8.4: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Purchase`, tick:
+  - `PurchaseOrderList`: `[x] base`
+  - `PurchaseStockAnalysis`: `[x] base`
+  - `InvoiceClassification`: `[x] base`, `[x] InvoicesTab`, `[x] RulesTab`
+
+### Step 8.5: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/PurchaseOrderList.tsx \
+        frontend/src/components/pages/PurchaseStockAnalysis.tsx \
+        frontend/src/pages/InvoiceClassification/InvoiceClassificationPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Purchase module screens"
+```
+
+---
+
+## Task 9: Marketing module
+
+**Files:**
+- Modify: `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx`
+- Modify: `frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx`
+- Modify: `frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx`
+- Modify: `frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx`
+- Modify: `frontend/src/pages/ArticlesPage.tsx`
+- Modify: `frontend/src/pages/MarketingFeedbackPage.tsx`
+
+### Step 9.1: Wire `useScreenView` in MarketingCalendarPage (viewModes)
+
+`MarketingCalendarPage.tsx:55` declares `const [viewMode, setViewMode] = useState<ViewMode>('fiveWeeks')`. `ViewMode` is defined on `MarketingCalendarPage.tsx:52` as `'fiveWeeks' | 'twoWeeks' | 'list'`.
+
+- [ ] Add to `frontend/src/components/marketing/pages/MarketingCalendarPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+```
+
+After line 64 (last of the `useState` block), add:
+
+```tsx
+const viewModeSubScreen =
+  viewMode === 'fiveWeeks' ? 'FiveWeeksView' :
+  viewMode === 'twoWeeks' ? 'TwoWeeksView' :
+  'ListView';
+useScreenView('Marketing', 'MarketingCalendar', viewModeSubScreen);
+```
+
+### Step 9.2: Wire `useScreenView` in PhotobankPage (viewModes)
+
+`PhotobankPage.tsx:60` declares `const [view, setView] = useState<ViewMode>(readViewMode)`. `ViewMode` is defined on `PhotobankPage.tsx:24` as `"tiles" | "list"`.
+
+- [ ] Add to `frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../../telemetry/useScreenView';
+```
+
+After line 64 (last of the `useState` block), add:
+
+```tsx
+useScreenView('Marketing', 'Photobank', view === 'tiles' ? 'TilesView' : 'ListView');
+```
+
+### Step 9.3: Wire `useScreenView` in PhotobankSettingsPage
+
+- [ ] Add to `frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Marketing', 'PhotobankSettings');
+```
+
+### Step 9.4: Wire `useScreenView` in LeafletGeneratorPage
+
+- [ ] Add to `frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Marketing', 'LeafletGenerator');
+```
+
+### Step 9.5: Wire `useScreenView` in ArticlesPage (tabs)
+
+`ArticlesPage.tsx:11` declares `const [activeTab, setActiveTab] = useState<Tab>('new')` with values `'new' | 'list'`.
+
+- [ ] Add to `frontend/src/pages/ArticlesPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+```
+
+After line 11, add:
+
+```tsx
+useScreenView('Marketing', 'Articles', activeTab === 'new' ? 'NewTab' : 'ListTab');
+```
+
+### Step 9.6: Wire `useScreenView` in MarketingFeedbackPage
+
+- [ ] Add to `frontend/src/pages/MarketingFeedbackPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+```
+
+After the `useState` declarations, add:
+
+```tsx
+useScreenView('Marketing', 'MarketingFeedback');
+```
+
+### Step 9.7: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Marketing`, tick:
+  - `MarketingCalendar`: `[x] base`, `[x] FiveWeeksView`, `[x] TwoWeeksView`, `[x] ListView`
+  - `Photobank`: `[x] base`, `[x] TilesView`, `[x] ListView`
+  - `PhotobankSettings`: `[x] base`
+  - `LeafletGenerator`: `[x] base`
+  - `Articles`: `[x] base`, `[x] NewTab`, `[x] ListTab`
+  - `MarketingFeedback`: `[x] base`
+
+### Step 9.8: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/marketing/pages/MarketingCalendarPage.tsx \
+        frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx \
+        frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx \
+        frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx \
+        frontend/src/pages/ArticlesPage.tsx \
+        frontend/src/pages/MarketingFeedbackPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Marketing module screens"
+```
+
+---
+
+## Task 10: Logistics module
+
+**Files:**
+- Modify: `frontend/src/components/pages/InventoryList.tsx`
+- Modify: `frontend/src/components/pages/TransportBoxList.tsx`
+- Modify: `frontend/src/components/pages/TransportBoxReceive.tsx`
+- Modify: `frontend/src/components/pages/GiftPackageManufacturing.tsx`
+- Modify: `frontend/src/pages/PackingMaterialsPage.tsx`
+- Modify: `frontend/src/components/pages/WarehouseStatistics.tsx`
+- Modify: `frontend/src/pages/ExpeditionListArchivePage.tsx`
+
+### Step 10.1: Wire `useScreenView` in each Logistics screen
+
+For each file, add the import (use the relative path appropriate to depth — `../../telemetry/useScreenView` for `components/pages/*` and `pages/*`-flat files use `../telemetry/useScreenView`) and add the `useScreenView` call right after `useState` declarations.
+
+- [ ] `InventoryList.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+// after useState declarations:
+useScreenView('Logistics', 'InventoryFinishedGoods');
+```
+
+- [ ] `TransportBoxList.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Logistics', 'TransportBoxes');
+```
+
+- [ ] `TransportBoxReceive.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Logistics', 'TransportBoxReceive');
+```
+
+- [ ] `GiftPackageManufacturing.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Logistics', 'GiftPackageManufacturing');
+```
+
+- [ ] `PackingMaterialsPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+useScreenView('Logistics', 'PackingMaterials');
+```
+
+- [ ] `WarehouseStatistics.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Logistics', 'WarehouseStatistics');
+```
+
+- [ ] `ExpeditionListArchivePage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+useScreenView('Logistics', 'ExpeditionArchive');
+```
+
+### Step 10.2: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Logistics`, tick `[x] base` for all 7 rows.
+
+### Step 10.3: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/InventoryList.tsx \
+        frontend/src/components/pages/TransportBoxList.tsx \
+        frontend/src/components/pages/TransportBoxReceive.tsx \
+        frontend/src/components/pages/GiftPackageManufacturing.tsx \
+        frontend/src/pages/PackingMaterialsPage.tsx \
+        frontend/src/components/pages/WarehouseStatistics.tsx \
+        frontend/src/pages/ExpeditionListArchivePage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Logistics module screens"
+```
+
+---
+
+## Task 11: Manufacturing module
+
+**Files:**
+- Modify: `frontend/src/components/pages/ManufacturingStockAnalysis.tsx`
+- Modify: `frontend/src/components/pages/ManufactureOutput.tsx`
+- Modify: `frontend/src/components/pages/ManufactureBatchCalculator.tsx`
+- Modify: `frontend/src/components/pages/ManufactureBatchPlanning.tsx`
+- Modify: `frontend/src/components/manufacture/pages/ManufactureOrderList.tsx`
+- Modify: `frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx`
+- Modify: `frontend/src/components/pages/ManufactureInventoryList.tsx`
+- Modify: `frontend/src/components/pages/ManufacturedInventoryPage.tsx`
+
+### Step 11.1: Wire `useScreenView` in flat Manufacturing screens
+
+- [ ] `ManufacturingStockAnalysis.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Manufacturing', 'ManufacturingStockAnalysis');
+```
+
+- [ ] `ManufactureOutput.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Manufacturing', 'ManufactureOutput');
+```
+
+- [ ] `ManufactureBatchCalculator.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Manufacturing', 'ManufactureBatchCalculator');
+```
+
+- [ ] `ManufactureBatchPlanning.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Manufacturing', 'ManufactureBatchPlanning');
+```
+
+- [ ] `ManufactureInventoryList.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Manufacturing', 'ManufactureInventory');
+```
+
+- [ ] `ManufacturedInventoryPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Manufacturing', 'ManufacturedProductInventory');
+```
+
+### Step 11.2: Wire `useScreenView` in ManufactureOrderList (viewModes)
+
+`ManufactureOrderList.tsx:60` declares `const [viewMode, setViewMode] = useState<'grid' | 'calendar' | 'weekly'>(...)`.
+
+- [ ] Add to `frontend/src/components/manufacture/pages/ManufactureOrderList.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+```
+
+After line 60, add:
+
+```tsx
+const viewModeSubScreen =
+  viewMode === 'grid' ? 'GridView' :
+  viewMode === 'calendar' ? 'CalendarView' :
+  'WeeklyView';
+useScreenView('Manufacturing', 'ManufactureOrderList', viewModeSubScreen);
+```
+
+### Step 11.3: Wire `useScreenView` in ManufactureOrderDetail (tabs)
+
+`ManufactureOrderDetail.tsx:74` declares `const [activeTab, setActiveTab] = useState<"info" | "notes" | "log" | "conditions">("info")`.
+
+- [ ] Add to `frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+```
+
+After line 74, add:
+
+```tsx
+const tabSubScreen =
+  activeTab === 'info' ? 'InfoTab' :
+  activeTab === 'notes' ? 'NotesTab' :
+  activeTab === 'log' ? 'LogTab' :
+  'ConditionsTab';
+useScreenView('Manufacturing', 'ManufactureOrderDetail', tabSubScreen);
+```
+
+### Step 11.4: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Manufacturing`, tick:
+  - All flat screens: `[x] base`
+  - `ManufactureOrderList`: `[x] base`, `[x] GridView`, `[x] CalendarView`, `[x] WeeklyView`
+  - `ManufactureOrderDetail`: `[x] base`, `[x] InfoTab`, `[x] NotesTab`, `[x] LogTab`, `[x] ConditionsTab`
+
+### Step 11.5: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/ManufacturingStockAnalysis.tsx \
+        frontend/src/components/pages/ManufactureOutput.tsx \
+        frontend/src/components/pages/ManufactureBatchCalculator.tsx \
+        frontend/src/components/pages/ManufactureBatchPlanning.tsx \
+        frontend/src/components/manufacture/pages/ManufactureOrderList.tsx \
+        frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx \
+        frontend/src/components/pages/ManufactureInventoryList.tsx \
+        frontend/src/components/pages/ManufacturedInventoryPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Manufacturing module screens"
+```
+
+---
+
+## Task 12: Automation module
+
+**Files:**
+- Modify: `frontend/src/components/pages/automation/BackgroundTasks.tsx`
+- Modify: `frontend/src/components/pages/automation/InvoiceImportStatistics.tsx`
+- Modify: `frontend/src/components/pages/automation/MeetingTasksPage.tsx`
+- Modify: `frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx`
+- Modify: `frontend/src/pages/StockOperationsPage.tsx`
+- Modify: `frontend/src/pages/RecurringJobsPage.tsx`
+- Modify: `frontend/src/pages/customer/DataQualityPage.tsx`
+
+### Step 12.1: Wire `useScreenView` in each Automation screen
+
+- [ ] `BackgroundTasks.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+useScreenView('Automation', 'BackgroundTasks');
+```
+
+- [ ] `InvoiceImportStatistics.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+useScreenView('Automation', 'InvoiceImportStatistics');
+```
+
+- [ ] `MeetingTasksPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+useScreenView('Automation', 'MeetingTasks');
+```
+
+- [ ] `MeetingTaskDetailPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+useScreenView('Automation', 'MeetingTaskDetail');
+```
+
+- [ ] `StockOperationsPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+useScreenView('Automation', 'StockOperations');
+```
+
+- [ ] `RecurringJobsPage.tsx`:
+
+```tsx
+import { useScreenView } from '../telemetry/useScreenView';
+useScreenView('Automation', 'RecurringJobs');
+```
+
+- [ ] `DataQualityPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Automation', 'DataQuality');
+```
+
+### Step 12.2: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Automation`, tick `[x] base` for all 7 rows.
+
+### Step 12.3: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/pages/automation/BackgroundTasks.tsx \
+        frontend/src/components/pages/automation/InvoiceImportStatistics.tsx \
+        frontend/src/components/pages/automation/MeetingTasksPage.tsx \
+        frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx \
+        frontend/src/pages/StockOperationsPage.tsx \
+        frontend/src/pages/RecurringJobsPage.tsx \
+        frontend/src/pages/customer/DataQualityPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Automation module screens"
+```
+
+---
+
+## Task 13: Terminal module
+
+**Files:**
+- Modify: `frontend/src/components/terminal/TerminalHome.tsx`
+- Modify: `frontend/src/components/terminal/TransportBoxCheck.tsx`
+- Modify: `frontend/src/components/terminal/box-fill/BoxFillWorkflow.tsx`
+- Modify: `frontend/src/components/terminal/TransportBoxReceive.tsx`
+
+(`/terminal/stocktake` and `/terminal/lot-identification` are Coming Soon placeholders — skip; instrument when content lands.)
+
+### Step 13.1: Wire `useScreenView` in TerminalHome
+
+- [ ] Add to `frontend/src/components/terminal/TerminalHome.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Terminal', 'TerminalHome');
+```
+
+### Step 13.2: Wire `useScreenView` in TransportBoxCheck
+
+- [ ] Add to `frontend/src/components/terminal/TransportBoxCheck.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Terminal', 'TerminalBoxCheck');
+```
+
+### Step 13.3: Wire `useScreenView` in BoxFillWorkflow (wizard steps)
+
+`BoxFillWorkflow.tsx:10` declares `const [step, setStep] = useState<Step>("scan")` with values `"scan" | "add-items"`.
+
+- [ ] Add to `frontend/src/components/terminal/box-fill/BoxFillWorkflow.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+```
+
+After line 15 (last of the `useState` block), add:
+
+```tsx
+useScreenView('Terminal', 'TerminalBoxFill', step === 'scan' ? 'ScanStep' : 'AddItemsStep');
+```
+
+### Step 13.4: Wire `useScreenView` in TransportBoxReceive (terminal)
+
+- [ ] Add to `frontend/src/components/terminal/TransportBoxReceive.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Terminal', 'TerminalReceive');
+```
+
+### Step 13.5: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Terminal`, tick:
+  - `TerminalHome`: `[x] base`
+  - `TerminalBoxCheck`: `[x] base`
+  - `TerminalBoxFill`: `[x] base`, `[x] ScanStep`, `[x] AddItemsStep`
+  - `TerminalReceive`: `[x] base`
+  - (Leave `TerminalStocktake` and `TerminalLotIdentification` unticked — deferred.)
+
+### Step 13.6: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/terminal/TerminalHome.tsx \
+        frontend/src/components/terminal/TransportBoxCheck.tsx \
+        frontend/src/components/terminal/box-fill/BoxFillWorkflow.tsx \
+        frontend/src/components/terminal/TransportBoxReceive.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Terminal module screens"
+```
+
+---
+
+## Task 14: Baleni module
+
+**Files:**
+- Modify: `frontend/src/components/baleni/BaleniHome.tsx`
+- Modify: `frontend/src/components/baleni/BaleniPacking.tsx`
+- Modify: `frontend/src/components/baleni/zasilky/ZasilkyPage.tsx`
+
+(`/baleni/statistiky` is a placeholder — skip.)
+
+### Step 14.1: Wire `useScreenView` in BaleniHome
+
+- [ ] Add to `frontend/src/components/baleni/BaleniHome.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Baleni', 'BaleniHome');
+```
+
+### Step 14.2: Wire `useScreenView` in BaleniPacking
+
+- [ ] Add to `frontend/src/components/baleni/BaleniPacking.tsx`:
+
+```tsx
+import { useScreenView } from '../../telemetry/useScreenView';
+useScreenView('Baleni', 'BaleniPacking');
+```
+
+### Step 14.3: Wire `useScreenView` in ZasilkyPage
+
+- [ ] Add to `frontend/src/components/baleni/zasilky/ZasilkyPage.tsx`:
+
+```tsx
+import { useScreenView } from '../../../telemetry/useScreenView';
+useScreenView('Baleni', 'BaleniShipments');
+```
+
+### Step 14.4: Tick coverage boxes
+
+- [ ] In `docs/features/usage-analytics-coverage.md`, under `## Baleni`, tick `[x] base` for `BaleniHome`, `BaleniPacking`, `BaleniShipments`. Leave `BaleniStatistics` unticked.
+
+### Step 14.5: Build + lint + commit
+
+- [ ] Run:
+
+```bash
+cd frontend && npm run lint && npm run build
+git add frontend/src/components/baleni/BaleniHome.tsx \
+        frontend/src/components/baleni/BaleniPacking.tsx \
+        frontend/src/components/baleni/zasilky/ZasilkyPage.tsx \
+        docs/features/usage-analytics-coverage.md
+git commit -m "feat(telemetry): instrument Baleni module screens"
+```
+
+---
+
+## Task 15: End-to-end verification after deploy
+
+This task runs **after all module PRs are merged and deployed to an environment that has the App Insights connection string configured**. Goal: confirm every checked-in coverage row produces real telemetry, and surface any drift.
+
+### Step 15.1: Wait for traffic
+
+- [ ] After deploy, wait 7 days so every routinely-used screen has been touched at least once by a real user.
+
+### Step 15.2: Run the coverage KQL query
+
+- [ ] In Azure Portal → Application Insights → Logs, run:
+
+```kusto
+customEvents
+| where timestamp > ago(7d) and name == "ScreenViewed"
+| summarize hits=count(),
+            users=dcount(user_AuthenticatedId)
+            by module=tostring(customDimensions.module),
+               screen=tostring(customDimensions.screen),
+               subScreen=tostring(customDimensions.subScreen)
+| order by module asc, screen asc, subScreen asc
+```
+
+### Step 15.3: Diff observed tuples against the coverage doc
+
+- [ ] Export the query result as CSV. For each row in `docs/features/usage-analytics-coverage.md` marked `[x]`, confirm a matching `(module, screen, subScreen)` tuple exists. Anything missing = wiring bug — file an issue linking to the screen file and the coverage row.
+- [ ] For each `(module, screen, subScreen)` tuple in the CSV that does NOT appear in the coverage doc, decide: either add the row (doc drift) or fix the call site (wrong module/screen string).
+
+### Step 15.4: Record verification outcome
+
+- [ ] Append a brief note to the top of `docs/features/usage-analytics-coverage.md`:
+
+```markdown
+## Verification log
+
+- YYYY-MM-DD: full sweep complete, 0/N rows missing telemetry, 0/M new tuples not yet documented.
+```
+
+(No commit step until issues are resolved; commit once the run is clean.)
+
+---
+
+## Self-review notes
+
+**Spec coverage:** Every section of the spec maps to tasks:
+- "Helper hook" → Task 0 (steps 0.1–0.7)
+- "Coverage matrix document" → Task 0 (step 0.8)
+- "Phased instrumentation" → Tasks 1–14 (one per module, in the spec's order)
+- "Verification" → Task 15 + the smoke test in Task 0
+- Naming conventions → enforced by `ScreenModule` type (Task 0.3) + per-task literal strings
+- Update to `usage-analytics.md` → Task 0 (step 0.9)
+- "Out of scope" — explicitly noted at the top of this plan and in the coverage doc's contract section
+
+**Type consistency check:** `useScreenView(module: ScreenModule, screen: string, subScreen?: string)` signature is identical across Task 0 definition and every call site in Tasks 1–14. `module` literals always match the `ScreenModule` union members. `screen` values match the coverage doc's `Screen` column. `subScreen` values match the coverage doc's checkbox labels.
+
+**Known external-state caveats:** None. All branch state types (`activeTab`, `viewMode`, `view`, `step`, `activeChartTab`) were verified against their actual definitions in the source files during plan authoring. If the implementer finds a discrepancy (e.g., a tab union has been extended since this plan was written), update the corresponding subScreen mapping and the coverage doc row in the same commit.

--- a/frontend/src/components/baleni/BaleniHome.tsx
+++ b/frontend/src/components/baleni/BaleniHome.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Package, Truck, BarChart3 } from 'lucide-react';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 interface BaleniTile {
   id: string;
@@ -34,28 +35,31 @@ const TILES: BaleniTile[] = [
   },
 ];
 
-const BaleniHome: React.FC = () => (
-  <div className="pt-4">
-    <h1 className="text-2xl font-bold text-neutral-slate mb-6">Vyberte operaci</h1>
-    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-      {TILES.map(({ id, title, description, href, icon: Icon }) => (
-        <Link
-          key={id}
-          to={href}
-          data-testid={`baleni-tile-${id}`}
-          className="flex flex-col items-center justify-center gap-4 bg-white border border-border-light rounded-xl p-6 shadow-soft hover:border-primary-blue hover:shadow-hover transition-all min-h-[160px]"
-        >
-          <div className="w-16 h-16 bg-secondary-blue-pale rounded-xl flex items-center justify-center">
-            <Icon className="h-8 w-8 text-primary-blue" />
-          </div>
-          <div className="text-center">
-            <p className="text-lg font-semibold text-neutral-slate">{title}</p>
-            <p className="text-sm text-neutral-gray mt-1">{description}</p>
-          </div>
-        </Link>
-      ))}
+const BaleniHome: React.FC = () => {
+  useScreenView('Baleni', 'BaleniHome');
+  return (
+    <div className="pt-4">
+      <h1 className="text-2xl font-bold text-neutral-slate mb-6">Vyberte operaci</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {TILES.map(({ id, title, description, href, icon: Icon }) => (
+          <Link
+            key={id}
+            to={href}
+            data-testid={`baleni-tile-${id}`}
+            className="flex flex-col items-center justify-center gap-4 bg-white border border-border-light rounded-xl p-6 shadow-soft hover:border-primary-blue hover:shadow-hover transition-all min-h-[160px]"
+          >
+            <div className="w-16 h-16 bg-secondary-blue-pale rounded-xl flex items-center justify-center">
+              <Icon className="h-8 w-8 text-primary-blue" />
+            </div>
+            <div className="text-center">
+              <p className="text-lg font-semibold text-neutral-slate">{title}</p>
+              <p className="text-sm text-neutral-gray mt-1">{description}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default BaleniHome;

--- a/frontend/src/components/baleni/BaleniPacking.tsx
+++ b/frontend/src/components/baleni/BaleniPacking.tsx
@@ -9,6 +9,7 @@ import PackingStateWarning from './PackingStateWarning';
 import PackingOrderNotes from './PackingOrderNotes';
 import PackingItems from './PackingItems';
 import PackingShipmentCreator from './PackingShipmentCreator';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 function CenteredMessage({ children }: { children: ReactNode }) {
   return (
@@ -62,6 +63,7 @@ function OrderBody({ order, shipment, isShowingDoneView, onDoneStateChange }: Or
 }
 
 function BaleniPacking() {
+  useScreenView('Baleni', 'BaleniPacking');
   const scanMutation = useScanPackingOrder();
   const [isShowingDoneView, setIsShowingDoneView] = useState(false);
 

--- a/frontend/src/components/baleni/zasilky/ZasilkyPage.tsx
+++ b/frontend/src/components/baleni/zasilky/ZasilkyPage.tsx
@@ -10,10 +10,12 @@ import { ZasilkyFilters, type FilterValues } from "./ZasilkyFilters";
 import { ZasilkyTable, type ZasilkySortBy } from "./ZasilkyTable";
 import { ZasilkyPagination } from "./ZasilkyPagination";
 import { DeletePackageDialog } from "./DeletePackageDialog";
+import { useScreenView } from "../../../telemetry/useScreenView";
 
 const PAGE_SIZE = 20;
 
 export function ZasilkyPage() {
+  useScreenView('Baleni', 'BaleniShipments');
   const { showSuccess, showError } = useToast();
   const [filters, setFilters] = useState<FilterValues>({
     orderCode: "",

--- a/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
+++ b/frontend/src/components/customer-support/smartsupp/pages/SmartsuppChatsPage.tsx
@@ -7,6 +7,7 @@ import ConversationList from "../ConversationList";
 import ConversationDetail from "../ConversationDetail";
 import ContactDetailsPanel from "../ContactDetailsPanel";
 import CollapsibleRail from "../CollapsibleRail";
+import { useScreenView } from '../../../../telemetry/useScreenView';
 
 const LIST_PANEL_KEY = "smartsupp.listPanel.open";
 const CONTACT_PANEL_KEY = "smartsupp.contactPanel.open";
@@ -21,6 +22,7 @@ function readPanelOpen(key: string, defaultOpen: boolean): boolean {
 type MobileView = "list" | "chat" | "contact";
 
 const SmartsuppChatsPage: React.FC = () => {
+  useScreenView('Customer', 'SmartsuppChats');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [status, setStatus] = useState<"Open" | "Resolved">("Open");
   const [mobileView, setMobileView] = useState<MobileView>("list");

--- a/frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderDetail.tsx
@@ -45,6 +45,7 @@ import DetailActionButtons from "../detail/DetailActionButtons";
 import ConfirmationDialogs from "../detail/ConfirmationDialogs";
 import ConditionsReadingsSection from "../detail/ConditionsReadingsSection";
 import { useTelemetry } from '../../../telemetry/useTelemetry';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 interface ManufactureOrderDetailProps {
   orderId?: number;
@@ -72,7 +73,14 @@ const ManufactureOrderDetail: React.FC<ManufactureOrderDetailProps> = ({
   
   // Tab state
   const [activeTab, setActiveTab] = useState<"info" | "notes" | "log" | "conditions">("info");
-  
+
+  const tabSubScreen =
+    activeTab === 'info' ? 'InfoTab' :
+    activeTab === 'notes' ? 'NotesTab' :
+    activeTab === 'log' ? 'LogTab' :
+    'ConditionsTab';
+  useScreenView('Manufacturing', 'ManufactureOrderDetail', tabSubScreen);
+
   // Note input state
   const [newNote, setNewNote] = useState("");
 

--- a/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderList.tsx
@@ -20,6 +20,7 @@ import ManufactureOrderDetail from "./ManufactureOrderDetail";
 import ManufactureOrderCalendar from "./ManufactureOrderCalendar";
 import ManufactureOrderWeeklyCalendar from "./ManufactureOrderWeeklyCalendar";
 import Pagination from "../../common/Pagination";
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const ManufactureOrderList: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -61,6 +62,12 @@ const ManufactureOrderList: React.FC = () => {
     const view = searchParams.get('view');
     return (view === 'weekly' || view === 'calendar' || view === 'grid') ? view : 'weekly';
   });
+
+  const viewModeSubScreen =
+    viewMode === 'grid' ? 'GridView' :
+    viewMode === 'calendar' ? 'CalendarView' :
+    'WeeklyView';
+  useScreenView('Manufacturing', 'ManufactureOrderList', viewModeSubScreen);
 
   // Pagination state
   const [pageNumber, setPageNumber] = useState(1);

--- a/frontend/src/components/manufacture/pages/__tests__/ManufactureOrderDetail.telemetry.test.tsx
+++ b/frontend/src/components/manufacture/pages/__tests__/ManufactureOrderDetail.telemetry.test.tsx
@@ -181,7 +181,7 @@ describe("ManufactureOrderDetail - Telemetry", () => {
       expect(mockDuplicateMutateAsync).toHaveBeenCalledWith(42);
     });
 
-    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalledWith('ManufactureOrderCreated', expect.anything());
   });
 
   it("uses empty string as productCode fallback when order has no productCode", async () => {

--- a/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
+++ b/frontend/src/components/marketing/pages/MarketingCalendarPage.tsx
@@ -23,6 +23,7 @@ import { PAGE_CONTAINER_HEIGHT } from '../../../constants/layout';
 import { useAuth } from '../../../auth/useAuth';
 import { useIsMobile } from '../../../hooks/useMediaQuery';
 import { MobileAgendaView } from '../calendar/MobileAgendaView';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 const MARKETING_IMPORT_ROLE = 'super_user';
 
@@ -62,6 +63,11 @@ const MarketingCalendarPage: React.FC = () => {
   const [editingAction, setEditingAction] = useState<MarketingActionDto | null>(null);
   const [prefillDates, setPrefillDates] = useState<{ dateFrom: string; dateTo: string } | null>(null);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const viewModeSubScreen =
+    viewMode === 'fiveWeeks' ? 'FiveWeeksView' :
+    viewMode === 'twoWeeks' ? 'TwoWeeksView' :
+    'ListView';
+  useScreenView('Marketing', 'MarketingCalendar', viewModeSubScreen);
   const isMobile = useIsMobile();
 
   const calendarRef = useRef<FullCalendar>(null);

--- a/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankPage.tsx
@@ -12,6 +12,7 @@ import BulkTagDialog from "../BulkTagDialog";
 import PhotobankBulkActionBar from "../PhotobankBulkActionBar";
 import { usePhotos, usePhotoTags, useBulkAddPhotoTagByIds, useRetagPhotos } from "../../../../api/hooks/usePhotobank";
 import type { PhotoDto } from "../../../../api/hooks/usePhotobank";
+import { useScreenView } from "../../../../telemetry/useScreenView";
 
 const ADMIN_ROLE = "super_user";
 const TAGGER_ROLE = "marketing_writer";
@@ -62,6 +63,8 @@ function PhotobankPage() {
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [selectionAnchorId, setSelectionAnchorId] = useState<number | null>(null);
+
+  useScreenView('Marketing', 'Photobank', view === 'tiles' ? 'TilesView' : 'ListView');
 
   useEffect(() => {
     try {

--- a/frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx
+++ b/frontend/src/components/marketing/photobank/pages/PhotobankSettingsPage.tsx
@@ -4,6 +4,7 @@ import { useMsal } from '@azure/msal-react';
 import IndexRootsTab from '../settings/IndexRootsTab';
 import TagRulesTab from '../settings/TagRulesTab';
 import TagsTab from '../settings/TagsTab';
+import { useScreenView } from '../../../../telemetry/useScreenView';
 
 const ADMIN_ROLE = 'super_user';
 
@@ -13,6 +14,8 @@ const PhotobankSettingsPage = () => {
     (accounts[0]?.idTokenClaims as any)?.roles?.includes(ADMIN_ROLE) ?? false;
 
   const [activeTab, setActiveTab] = useState<'roots' | 'rules' | 'tags'>('roots');
+
+  useScreenView('Marketing', 'PhotobankSettings');
 
   if (!isAdmin) {
     return (

--- a/frontend/src/components/pages/BankStatementImportChart.tsx
+++ b/frontend/src/components/pages/BankStatementImportChart.tsx
@@ -9,6 +9,7 @@ import {
   useBankStatementImportStatistics,
 } from "../../api/hooks/useBankStatements";
 import { BankStatementImportChart } from '../charts/BankStatementImportChart';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 type ViewOption = 'ImportCount' | 'TotalItemCount';
 type DateTypeOption = 'ImportDate' | 'StatementDate';
@@ -16,6 +17,8 @@ type DateTypeOption = 'ImportDate' | 'StatementDate';
 const BankStatementImportPage: React.FC = () => {
   const [viewType, setViewType] = useState<ViewOption>('ImportCount');
   const [dateType, setDateType] = useState<DateTypeOption>('ImportDate');
+
+  useScreenView('Finance', 'BankStatementImport');
   
   // API query - pass dateType parameter
   const { 

--- a/frontend/src/components/pages/CatalogDetail.tsx
+++ b/frontend/src/components/pages/CatalogDetail.tsx
@@ -18,6 +18,7 @@ import {
 import CatalogDetailTabs from "../catalog/detail/CatalogDetailTabs";
 import CatalogDetailChartSection from "../catalog/detail/CatalogDetailChartSection";
 import CatalogDetailModals from "../catalog/detail/CatalogDetailModals";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 ChartJS.register(
   CategoryScale,
@@ -57,6 +58,24 @@ const CatalogDetail: React.FC<CatalogDetailProps> = ({
   >(undefined);
   const [showManufactureDifficultyModal, setShowManufactureDifficultyModal] =
     useState(false);
+
+  const tabToSubScreen: Record<typeof activeTab, string> = {
+    basic: 'BasicTab',
+    history: 'HistoryTab',
+    margins: 'MarginsTab',
+    composition: 'CompositionTab',
+    journal: 'JournalTab',
+    usage: 'UsageTab',
+    documents: 'DocumentsTab',
+    pif: 'PifTab',
+  };
+  useScreenView('Catalog', 'CatalogDetail', isOpen ? tabToSubScreen[activeTab] : undefined);
+  useScreenView(
+    'Catalog',
+    'CatalogDetail',
+    isOpen && activeTab === 'history' ? (activeChartTab === 'input' ? 'ChartInput' : 'ChartOutput') : undefined,
+  );
+
   const navigate = useNavigate();
 
   // Determine which productCode to use - from prop or from item

--- a/frontend/src/components/pages/CatalogList.tsx
+++ b/frontend/src/components/pages/CatalogList.tsx
@@ -16,6 +16,7 @@ import {
 import CatalogDetail from "./CatalogDetail";
 import Pagination from "../common/Pagination";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const productTypeLabels: Record<ProductType, string> = {
   [ProductType.Product]: "Produkt",
@@ -80,6 +81,8 @@ const CatalogList: React.FC = () => {
   // Modal states
   const [selectedItem, setSelectedItem] = useState<CatalogItemDto | null>(null);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
+
+  useScreenView('Catalog', 'CatalogList');
 
   // Use the actual API call
   const {

--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 import DashboardGrid from "../dashboard/DashboardGrid";
 import DashboardSettings from "../dashboard/DashboardSettings";
 import { useIsMobile } from "../../hooks/useMediaQuery";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const Dashboard: React.FC = () => {
   useLiveHealthCheck();
@@ -20,6 +21,8 @@ const Dashboard: React.FC = () => {
 
   const isMobile = useIsMobile();
   const [showSettings, setShowSettings] = useState(false);
+
+  useScreenView('Dashboard', 'Dashboard');
 
   const { data: userSettings, isLoading: settingsLoading } = useUserDashboardSettings();
   const { data: allTileData = [], isLoading: dataLoading } = useTileData();

--- a/frontend/src/components/pages/FinancialOverview.tsx
+++ b/frontend/src/components/pages/FinancialOverview.tsx
@@ -24,6 +24,7 @@ import { FinancialFilters } from "./financial-overview/FinancialFilters";
 import { FinancialChart } from "./financial-overview/FinancialChart";
 import { FinancialDataTable } from "./financial-overview/FinancialDataTable";
 import { FinancialDataCards } from "./financial-overview/FinancialDataCards";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const FinancialOverview: React.FC = () => {
   const [selectedPeriod, setSelectedPeriod] =
@@ -34,6 +35,8 @@ const FinancialOverview: React.FC = () => {
   const [isDataExpanded, setIsDataExpanded] = useState(false);
   const isMobile = useIsMobile();
   const initialDefaultsSet = React.useRef(false);
+
+  useScreenView('Finance', 'FinancialOverview');
 
   const { data: departments } = useDepartments();
 

--- a/frontend/src/components/pages/GiftPackageManufacturing/index.tsx
+++ b/frontend/src/components/pages/GiftPackageManufacturing/index.tsx
@@ -6,6 +6,7 @@ import StockUpOperationStatusIndicator from '../../common/StockUpOperationStatus
 import { useCreateGiftPackageManufacture, useEnqueueGiftPackageManufacture } from "../../../api/hooks/useGiftPackageManufacturing";
 import { useStockUpOperationsSummary } from '../../../api/hooks/useStockUpOperations';
 import { CreateGiftPackageManufactureRequest, EnqueueGiftPackageManufactureRequest, StockUpSourceType } from "../../../api/generated/api-client";
+import { useScreenView } from "../../../telemetry/useScreenView";
 
 const GiftPackageManufacturing: React.FC = () => {
   // State for manufacturing modal 
@@ -22,6 +23,8 @@ const GiftPackageManufacturing: React.FC = () => {
   // State for catalog detail modal
   const [selectedProductCode, setSelectedProductCode] = useState<string | null>(null);
   const [isCatalogDetailOpen, setIsCatalogDetailOpen] = useState(false);
+
+  useScreenView('Logistics', 'GiftPackageManufacturing');
 
   // Manufacturing API hooks
   const createManufactureMutation = useCreateGiftPackageManufacture();

--- a/frontend/src/components/pages/InventoryList.tsx
+++ b/frontend/src/components/pages/InventoryList.tsx
@@ -19,6 +19,7 @@ import { useInventoryQuery } from "../../api/hooks/useInventory";
 import CatalogDetail from "./CatalogDetail";
 import InventoryModal from "../inventory/InventoryModal";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from "../../telemetry/useScreenView";
 
 // Filter for inventory - only show finished goods that can be sold
 const allowedInventoryTypes: ProductType[] = [
@@ -39,7 +40,7 @@ const productTypeLabels: Record<ProductType, string> = {
 const InventoryList: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  
+
   // Filter states - separate input values from applied filters
   const [productNameInput, setProductNameInput] = useState("");
   const [productCodeInput, setProductCodeInput] = useState("");
@@ -63,6 +64,8 @@ const InventoryList: React.FC = () => {
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [selectedInventoryItem, setSelectedInventoryItem] = useState<CatalogItemDto | null>(null);
   const [isInventoryModalOpen, setIsInventoryModalOpen] = useState(false);
+
+  useScreenView('Logistics', 'InventoryFinishedGoods');
 
   // Use custom inventory hook that properly handles "all types" filtering
   const {

--- a/frontend/src/components/pages/Journal/JournalList.tsx
+++ b/frontend/src/components/pages/Journal/JournalList.tsx
@@ -22,6 +22,7 @@ import type {
   SearchJournalEntryDto,
 } from "../../../api/generated/api-client";
 import JournalEntryModal from "../../JournalEntryModal";
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 interface JournalRowProps {
   id: number;
@@ -115,6 +116,8 @@ const JournalRow: React.FC<JournalRowProps> = ({
 );
 
 const JournalList: React.FC = () => {
+  useScreenView('Journal', 'JournalList');
+
   // Filter states - separate input values from applied filters
   const [searchTextInput, setSearchTextInput] = useState("");
   const [searchTextFilter, setSearchTextFilter] = useState("");

--- a/frontend/src/components/pages/JournalEntryEdit.tsx
+++ b/frontend/src/components/pages/JournalEntryEdit.tsx
@@ -3,8 +3,11 @@ import { useParams, Navigate } from "react-router-dom";
 import { AlertCircle } from "lucide-react";
 import JournalEntryForm from "../JournalEntryForm";
 import { useJournalEntry } from "../../api/hooks/useJournal";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 export default function JournalEntryEdit() {
+  useScreenView('Journal', 'JournalEntryEdit');
+
   const { id } = useParams<{ id: string }>();
   const entryId = id ? parseInt(id, 10) : 0;
 

--- a/frontend/src/components/pages/JournalEntryNew.tsx
+++ b/frontend/src/components/pages/JournalEntryNew.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import JournalEntryForm from "../JournalEntryForm";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 export default function JournalEntryNew() {
+  useScreenView('Journal', 'JournalEntryNew');
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">

--- a/frontend/src/components/pages/ManufactureBatchCalculator.tsx
+++ b/frontend/src/components/pages/ManufactureBatchCalculator.tsx
@@ -7,6 +7,7 @@ import InventoryStatusCell from "../inventory/InventoryStatusCell";
 import { CatalogItemDto, ProductType, CalculatedBatchSizeResponse, CalculateBatchByIngredientResponse } from "../../api/generated/api-client";
 import { useManufactureBatch } from "../../api/hooks/useManufactureBatch";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 type CalculationMode = "batch-size" | "ingredient";
 
@@ -19,6 +20,7 @@ export const computePercentage = (
 };
 
 const ManufactureBatchCalculator: React.FC = () => {
+  useScreenView('Manufacturing', 'ManufactureBatchCalculator');
   const [selectedProduct, setSelectedProduct] = useState<CatalogItemDto | null>(
     null,
   );

--- a/frontend/src/components/pages/ManufactureBatchPlanning.tsx
+++ b/frontend/src/components/pages/ManufactureBatchPlanning.tsx
@@ -23,8 +23,10 @@ import ManufactureOrderDetail from "../manufacture/pages/ManufactureOrderDetail"
 import { usePlanningList } from "../../contexts/PlanningListContext";
 import { useCatalogAutocomplete } from "../../api/hooks/useCatalogAutocomplete";
 import { TimePeriod, resolveTimePeriod } from '../../utils/timePeriod';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const BatchPlanningCalculator: React.FC = () => {
+  useScreenView('Manufacturing', 'ManufactureBatchPlanning');
   // Selected semiproduct state
   const [selectedSemiproduct, setSelectedSemiproduct] = useState<CatalogItemDto | null>(null);
   

--- a/frontend/src/components/pages/ManufactureInventoryList.tsx
+++ b/frontend/src/components/pages/ManufactureInventoryList.tsx
@@ -18,6 +18,7 @@ import { useManufactureInventoryQuery } from "../../api/hooks/useManufactureInve
 import CatalogDetail from "./CatalogDetail";
 import ManufactureInventoryModal from "../inventory/ManufactureInventoryDetail";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 // Filter for manufacture inventory - only show materials
 const allowedManufactureInventoryTypes: ProductType[] = [
@@ -34,7 +35,8 @@ const productTypeLabels: Record<ProductType, string> = {
 };
 
 const ManufactureInventoryList: React.FC = () => {
-  
+  useScreenView('Manufacturing', 'ManufactureInventory');
+
   // Filter states - separate input values from applied filters
   const [productNameInput, setProductNameInput] = useState("");
   const [productCodeInput, setProductCodeInput] = useState("");

--- a/frontend/src/components/pages/ManufactureOutput.tsx
+++ b/frontend/src/components/pages/ManufactureOutput.tsx
@@ -9,6 +9,7 @@ import {
   ManufactureOutputMonth,
 } from "../../api/hooks/useManufactureOutput";
 import ManufactureOutputModal from "./ManufactureOutputModal";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 // Color palette for products (from highest weighted value to lowest)
 const PRODUCT_COLORS = [
@@ -32,6 +33,7 @@ const PRODUCT_COLORS = [
 const OTHER_COLOR = "#9CA3AF"; // Gray for other products
 
 const ManufactureOutput: React.FC = () => {
+  useScreenView('Manufacturing', 'ManufactureOutput');
   const { data, isLoading, error, refetch } = useManufactureOutputQuery(13);
   const [selectedMonth, setSelectedMonth] =
     useState<ManufactureOutputMonth | null>(null);

--- a/frontend/src/components/pages/ManufacturedInventoryPage.tsx
+++ b/frontend/src/components/pages/ManufacturedInventoryPage.tsx
@@ -24,6 +24,7 @@ import {
   CreateManufacturedInventoryItemInput,
 } from "../../api/hooks/useManufacturedProductInventory";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const PAGE_SIZE = 20;
 
@@ -271,6 +272,7 @@ const LogPanel: React.FC<LogPanelProps> = ({ item }) => {
 };
 
 const ManufacturedInventoryPage: React.FC = () => {
+  useScreenView('Manufacturing', 'ManufacturedProductInventory');
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
   const [onlyWithStock, setOnlyWithStock] = useState(true);

--- a/frontend/src/components/pages/ManufacturingStockAnalysis.tsx
+++ b/frontend/src/components/pages/ManufacturingStockAnalysis.tsx
@@ -36,6 +36,7 @@ import { usePlanningList } from "../../contexts/PlanningListContext";
 import PlanningListPanel from "../common/PlanningListPanel";
 import { GridColumn, GridHeader, ColumnChooser, useGridLayout } from '../../features/grid-layout';
 import { ManufacturingStockItemDto } from '../../api/hooks/useManufacturingStockAnalysis';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const SALES_MULTIPLIER_COOKIE = "manufacturing-stock-sales-multiplier";
 
@@ -59,6 +60,7 @@ const readSalesMultiplierCookie = (): number => {
 };
 
 const ManufacturingStockAnalysis: React.FC = () => {
+  useScreenView('Manufacturing', 'ManufacturingStockAnalysis');
   // State for filters
   const [filters, setFilters] = useState<GetManufacturingStockAnalysisRequest>({
     timePeriod: TimePeriodFilter.Q9M,

--- a/frontend/src/components/pages/ProductMarginSummary.tsx
+++ b/frontend/src/components/pages/ProductMarginSummary.tsx
@@ -6,6 +6,7 @@ import {
   useProductMarginSummaryQuery,
   ProductGroupingMode,
 } from "../../api/hooks/useProductMarginSummary";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 type TimeWindowType =
   | "current-year"
@@ -45,6 +46,8 @@ const ProductMarginSummary: React.FC = () => {
     useState<ProductGroupingMode>(ProductGroupingMode.Products);
   const [selectedMarginLevel, setSelectedMarginLevel] =
     useState<MarginLevelType>("M2");
+
+  useScreenView('Finance', 'ProductMarginSummary');
 
   const { data, isLoading, error } = useProductMarginSummaryQuery(
     selectedTimeWindow,

--- a/frontend/src/components/pages/ProductMarginsList.tsx
+++ b/frontend/src/components/pages/ProductMarginsList.tsx
@@ -12,6 +12,7 @@ import {
 import { useProductMarginsQuery } from "../../api/hooks/useProductMargins";
 import CatalogDetail from "./CatalogDetail";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const ProductMarginsList: React.FC = () => {
   // Filter states - separate input values from applied filters
@@ -35,6 +36,8 @@ const ProductMarginsList: React.FC = () => {
     null,
   );
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
+
+  useScreenView('Catalog', 'ProductMargins');
 
   // Use the API call
   const {

--- a/frontend/src/components/pages/PurchaseOrderList.tsx
+++ b/frontend/src/components/pages/PurchaseOrderList.tsx
@@ -21,6 +21,7 @@ import PurchaseOrderDetail from "./PurchaseOrderDetail";
 import PurchaseOrderForm from "./PurchaseOrderForm";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 import { useTelemetry } from "../../telemetry/useTelemetry";
+import { useScreenView } from "../../telemetry/useScreenView";
 
 // Status labels mapping
 const statusLabels: Record<string, string> = {
@@ -67,6 +68,8 @@ const PurchaseOrderList: React.FC = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editOrderId, setEditOrderId] = useState<number | null>(null);
+
+  useScreenView('Purchase', 'PurchaseOrderList');
 
   // Build request object
   const request: GetPurchaseOrdersRequest = {

--- a/frontend/src/components/pages/PurchaseStockAnalysis.tsx
+++ b/frontend/src/components/pages/PurchaseStockAnalysis.tsx
@@ -35,6 +35,7 @@ import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 import { TimePeriod, resolveTimePeriod } from "../../utils/timePeriod";
 import { usePurchasePlanningList } from "../../contexts/PurchasePlanningListContext";
 import PurchasePlanningListPanel from "../common/PurchasePlanningListPanel";
+import { useScreenView } from "../../telemetry/useScreenView";
 
 const PurchaseStockAnalysis: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -75,6 +76,8 @@ const PurchaseStockAnalysis: React.FC = () => {
   // State for collapsible sections
   const [isControlsCollapsed, setIsControlsCollapsed] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+
+  useScreenView('Purchase', 'PurchaseStockAnalysis');
 
   const { showError } = useToast();
 

--- a/frontend/src/components/pages/TransportBoxList.tsx
+++ b/frontend/src/components/pages/TransportBoxList.tsx
@@ -31,6 +31,7 @@ import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
 import { useStockUpOperationsSummary } from '../../api/hooks/useStockUpOperations';
 import { StockUpSourceType } from '../../api/generated/api-client';
 import StockUpOperationStatusIndicator from '../common/StockUpOperationStatusIndicator';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 // State labels mapping - using string keys since DTO returns strings
 const stateLabels: Record<string, string> = {
@@ -82,6 +83,8 @@ const TransportBoxList: React.FC = () => {
 
   // State for collapsible sections
   const [isControlsCollapsed, setIsControlsCollapsed] = useState(false);
+
+  useScreenView('Logistics', 'TransportBoxes');
 
   // Add summary hook for StockUpOperations status
   const { data: stockUpSummary } = useStockUpOperationsSummary(

--- a/frontend/src/components/pages/TransportBoxReceive.tsx
+++ b/frontend/src/components/pages/TransportBoxReceive.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useToast } from '../../contexts/ToastContext';
 import { useTransportBoxReceive } from '../../api/hooks/useTransportBoxReceive';
 import { TransportBoxDto } from '../../api/generated/api-client';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const TransportBoxReceive: React.FC = () => {
   const [boxCode, setBoxCode] = useState('');
@@ -11,6 +12,8 @@ const TransportBoxReceive: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isReceiving, setIsReceiving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useScreenView('Logistics', 'TransportBoxReceive');
 
   const { t } = useTranslation();
   const { showSuccess, showError } = useToast();

--- a/frontend/src/components/pages/WarehouseStatistics.tsx
+++ b/frontend/src/components/pages/WarehouseStatistics.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import { useWarehouseStatistics } from "../../api/hooks/useWarehouseStatistics";
 import { Package, Weight, Gauge, Hash, Clock, AlertTriangle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { useScreenView } from "../../telemetry/useScreenView";
 
 const WarehouseStatistics: React.FC = () => {
+  useScreenView('Logistics', 'WarehouseStatistics');
   const { data: statistics, isLoading, error } = useWarehouseStatistics();
 
   if (isLoading) {

--- a/frontend/src/components/pages/automation/BackgroundTasks.tsx
+++ b/frontend/src/components/pages/automation/BackgroundTasks.tsx
@@ -4,8 +4,10 @@ import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
 import { RefreshCw } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEYS } from "../../../api/client";
+import { useScreenView } from "../../../telemetry/useScreenView";
 
 const BackgroundTasks: React.FC = () => {
+  useScreenView('Automation', 'BackgroundTasks');
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = React.useState(false);
 

--- a/frontend/src/components/pages/automation/InvoiceImportStatistics.tsx
+++ b/frontend/src/components/pages/automation/InvoiceImportStatistics.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { AlertCircle, BarChart3, Calendar, RefreshCw } from 'lucide-react';
 import { useInvoiceImportStatistics } from '../../../api/hooks/useInvoiceImportStatistics';
 import { InvoiceImportChart } from '../../charts/InvoiceImportChart';
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 type DateTypeOption = 'InvoiceDate' | 'LastSyncTime';
 
@@ -10,6 +11,7 @@ type DateTypeOption = 'InvoiceDate' | 'LastSyncTime';
  * Shows daily invoice counts with visual indicators for problematic days
  */
 const InvoiceImportStatistics: React.FC = () => {
+  useScreenView('Automation', 'InvoiceImportStatistics');
   const [dateType, setDateType] = useState<DateTypeOption>('InvoiceDate');
   
   const { 

--- a/frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx
+++ b/frontend/src/components/pages/automation/MeetingTaskDetailPage.tsx
@@ -28,6 +28,7 @@ import { ExplainModal } from './explain/ExplainModal';
 import { ManageAccessModal } from './access/ManageAccessModal';
 import { downloadTextFile, sanitizeFilename } from "../../../utils/downloadTextFile";
 import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
+import { useScreenView } from "../../../telemetry/useScreenView";
 
 const EMPTY_FORM: TaskFormData = { title: "", description: "", assignee: "", assigneeEmail: null, dueDate: null };
 
@@ -84,6 +85,7 @@ function AssigneePicker({ users, value, onChange }: AssigneePickerProps) {
 }
 
 const MeetingTaskDetailPage: React.FC = () => {
+  useScreenView('Automation', 'MeetingTaskDetail');
   const { id = "" } = useParams<{ id: string }>();
   const detail = useMeetingTaskDetail(id);
   const updateTask = useUpdateProposedTask();

--- a/frontend/src/components/pages/automation/MeetingTasksPage.tsx
+++ b/frontend/src/components/pages/automation/MeetingTasksPage.tsx
@@ -7,6 +7,7 @@ import {
   useMeetingTasksList,
 } from "../../../api/hooks/useMeetingTasks";
 import { PAGE_CONTAINER_HEIGHT } from "../../../constants/layout";
+import { useScreenView } from "../../../telemetry/useScreenView";
 
 const PAGE_SIZE = 20;
 
@@ -61,6 +62,7 @@ function StatusBadge({ status }: StatusBadgeProps) {
 }
 
 const MeetingTasksPage: React.FC = () => {
+  useScreenView('Automation', 'MeetingTasks');
   const navigate = useNavigate();
   const [statusFilter, setStatusFilter] = useState<string | undefined>(undefined);
   const [page, setPage] = useState(1);

--- a/frontend/src/components/terminal/TerminalHome.tsx
+++ b/frontend/src/components/terminal/TerminalHome.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Package, ClipboardList, Tag, PackageSearch, PackagePlus, ChevronRight } from 'lucide-react';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 interface WorkflowTile {
   id: string;
@@ -54,30 +55,33 @@ const WORKFLOWS: WorkflowTile[] = [
   },
 ];
 
-const TerminalHome: React.FC = () => (
-  <div className="space-y-3 pt-2">
-    <h1 className="text-xl font-bold text-neutral-slate">Vyberte operaci</h1>
-    {WORKFLOWS.map(({ id, title, description, href, icon: Icon, comingSoon }) => (
-      <Link
-        key={id}
-        to={href}
-        data-testid={`workflow-tile-${id}`}
-        className="flex items-center gap-4 bg-white border border-border-light rounded-xl p-4 shadow-soft hover:border-primary-blue hover:shadow-hover transition-all min-h-[72px]"
-      >
-        <div className="flex-shrink-0 w-12 h-12 bg-secondary-blue-pale rounded-xl flex items-center justify-center">
-          <Icon className="h-6 w-6 text-primary-blue" />
-        </div>
-        <div className="flex-1 min-w-0">
-          <p className="text-base font-semibold text-neutral-slate">{title}</p>
-          <p className="text-sm text-neutral-gray mt-0.5">{description}</p>
-          {comingSoon && (
-            <span className="text-xs text-neutral-gray italic">Brzy k dispozici</span>
-          )}
-        </div>
-        <ChevronRight className="h-5 w-5 text-neutral-gray flex-shrink-0" />
-      </Link>
-    ))}
-  </div>
-);
+const TerminalHome: React.FC = () => {
+  useScreenView('Terminal', 'TerminalHome');
+  return (
+    <div className="space-y-3 pt-2">
+      <h1 className="text-xl font-bold text-neutral-slate">Vyberte operaci</h1>
+      {WORKFLOWS.map(({ id, title, description, href, icon: Icon, comingSoon }) => (
+        <Link
+          key={id}
+          to={href}
+          data-testid={`workflow-tile-${id}`}
+          className="flex items-center gap-4 bg-white border border-border-light rounded-xl p-4 shadow-soft hover:border-primary-blue hover:shadow-hover transition-all min-h-[72px]"
+        >
+          <div className="flex-shrink-0 w-12 h-12 bg-secondary-blue-pale rounded-xl flex items-center justify-center">
+            <Icon className="h-6 w-6 text-primary-blue" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-base font-semibold text-neutral-slate">{title}</p>
+            <p className="text-sm text-neutral-gray mt-0.5">{description}</p>
+            {comingSoon && (
+              <span className="text-xs text-neutral-gray italic">Brzy k dispozici</span>
+            )}
+          </div>
+          <ChevronRight className="h-5 w-5 text-neutral-gray flex-shrink-0" />
+        </Link>
+      ))}
+    </div>
+  );
+};
 
 export default TerminalHome;

--- a/frontend/src/components/terminal/TransportBoxCheck.tsx
+++ b/frontend/src/components/terminal/TransportBoxCheck.tsx
@@ -5,8 +5,10 @@ import { useTransportBoxByCodeQuery } from '../../api/hooks/useTransportBoxes';
 import TerminalError from './TerminalError';
 import { getTerminalErrorMessage } from './terminalErrors';
 import BoxDetail from './TransportBoxDetail';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const TransportBoxCheck: React.FC = () => {
+  useScreenView('Terminal', 'TerminalBoxCheck');
   const [scannedCode, setScannedCode] = useState<string | null>(null);
   const { data: box, isFetching, isError, error, refetch } = useTransportBoxByCodeQuery(scannedCode);
 

--- a/frontend/src/components/terminal/TransportBoxReceive.tsx
+++ b/frontend/src/components/terminal/TransportBoxReceive.tsx
@@ -7,10 +7,12 @@ import {
   useChangeTransportBoxState,
 } from '../../api/hooks/useTransportBoxes';
 import { TransportBoxState, SwaggerException } from '../../api/generated/api-client';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const SUCCESS_DISPLAY_MS = 2500;
 
 const TransportBoxReceive: React.FC = () => {
+  useScreenView('Terminal', 'TerminalReceive');
   const [scannedCode, setScannedCode] = useState<string | null>(null);
   const [receivedCode, setReceivedCode] = useState<string | null>(null);
 

--- a/frontend/src/components/terminal/box-fill/BoxFillWorkflow.tsx
+++ b/frontend/src/components/terminal/box-fill/BoxFillWorkflow.tsx
@@ -3,6 +3,7 @@ import { AlertCircle } from "lucide-react";
 import ScanBoxStep from "./ScanBoxStep";
 import AddItemsStep from "./AddItemsStep";
 import { useSendBoxToTransit, type TerminalBox } from "../../../api/hooks/useBoxFill";
+import { useScreenView } from '../../../telemetry/useScreenView';
 
 type Step = "scan" | "add-items";
 
@@ -13,6 +14,7 @@ const BoxFillWorkflow: React.FC = () => {
   const [amountMemory, setAmountMemory] = useState<Record<string, number>>({});
   const [transitError, setTransitError] = useState<string | null>(null);
   const [lastSentBoxCode, setLastSentBoxCode] = useState<string | null>(null);
+  useScreenView('Terminal', 'TerminalBoxFill', step === 'scan' ? 'ScanStep' : 'AddItemsStep');
 
   const sendToTransit = useSendBoxToTransit();
 

--- a/frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx
+++ b/frontend/src/features/leaflet-generator/LeafletGeneratorPage.tsx
@@ -4,12 +4,15 @@ import LeafletGenerateTab from './LeafletGenerateTab';
 import LeafletDocumentsTab from './LeafletDocumentsTab';
 import LeafletUploadTab from './LeafletUploadTab';
 import { useMarketingWriterPermission } from '../../api/hooks/useMarketingWriterPermission';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 type Tab = 'generate' | 'documents' | 'upload';
 
 export default function LeafletGeneratorPage() {
   const canUpload = useMarketingWriterPermission();
   const [activeTab, setActiveTab] = useState<Tab>('generate');
+
+  useScreenView('Marketing', 'LeafletGenerator');
 
   const tabs: { id: Tab; label: string }[] = [
     { id: 'generate', label: 'Generovat' },

--- a/frontend/src/pages/ArticlesPage.tsx
+++ b/frontend/src/pages/ArticlesPage.tsx
@@ -4,11 +4,13 @@ import { useListArticlesQuery } from '../api/hooks/useArticles';
 import ArticleGenerationForm from '../features/articles/ArticleGenerationForm';
 import ArticleList from '../features/articles/ArticleList';
 import ArticleDetail from '../features/articles/ArticleDetail';
+import { useScreenView } from '../telemetry/useScreenView';
 
 type Tab = 'new' | 'list';
 
 export default function ArticlesPage() {
   const [activeTab, setActiveTab] = useState<Tab>('new');
+  useScreenView('Marketing', 'Articles', activeTab === 'new' ? 'NewTab' : 'ListTab');
   const [selectedArticleId, setSelectedArticleId] = useState<string | null>(null);
 
   const { data: articles = [], isLoading } = useListArticlesQuery({ pageSize: 50 });

--- a/frontend/src/pages/ExpeditionListArchivePage.tsx
+++ b/frontend/src/pages/ExpeditionListArchivePage.tsx
@@ -12,6 +12,7 @@ import {
 } from "../api/hooks/useExpeditionListArchive";
 import { useTriggerRecurringJobMutation } from "../api/hooks/useRecurringJobs";
 import { useToast } from "../contexts/ToastContext";
+import { useScreenView } from "../telemetry/useScreenView";
 
 const PAGE_SIZE = 20;
 
@@ -40,6 +41,8 @@ const ExpeditionListArchivePage: React.FC = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string>("");
   const [reprintConfirm, setReprintConfirm] = useState<ExpeditionListItemDto | null>(null);
+
+  useScreenView('Logistics', 'ExpeditionArchive');
 
   const { data: datesData, isLoading: datesLoading } = useExpeditionDates(page, PAGE_SIZE);
   const { data: itemsData, isLoading: itemsLoading } = useExpeditionListsByDate(selectedDate);

--- a/frontend/src/pages/FeatureFlagsAdminPage.tsx
+++ b/frontend/src/pages/FeatureFlagsAdminPage.tsx
@@ -5,6 +5,7 @@ import {
   useClearFlagOverride,
 } from "../api/hooks/useFeatureFlagsAdmin";
 import { useTelemetry } from "../telemetry/useTelemetry";
+import { useScreenView } from "../telemetry/useScreenView";
 
 const FeatureFlagsAdminPage: React.FC = () => {
   const { data: flags, isLoading, error } = useFeatureFlagsAdmin();
@@ -12,6 +13,8 @@ const FeatureFlagsAdminPage: React.FC = () => {
   const clear = useClearFlagOverride();
   const isBusy = upsert.isPending || clear.isPending;
   const { trackEvent } = useTelemetry();
+
+  useScreenView('Admin', 'FeatureFlagsAdmin');
 
   if (isLoading) return <div className="p-8 text-gray-500">Loading flags...</div>;
   if (error) return <div className="p-8 text-red-600">Failed to load feature flags.</div>;

--- a/frontend/src/pages/InvoiceClassification/InvoiceClassificationPage.tsx
+++ b/frontend/src/pages/InvoiceClassification/InvoiceClassificationPage.tsx
@@ -16,12 +16,14 @@ import ClassificationHistoryPage from './ClassificationHistoryPage';
 import RulesList from './components/RulesList';
 import RuleForm from './components/RuleForm';
 import ClassificationStats from './components/ClassificationStats';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 type TabType = 'invoices' | 'rules';
 
 const InvoiceClassificationPage: React.FC = () => {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<TabType>('invoices');
+  useScreenView('Purchase', 'InvoiceClassification', activeTab === 'invoices' ? 'InvoicesTab' : 'RulesTab');
   const [showStatsModal, setShowStatsModal] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingRule, setEditingRule] = useState<ClassificationRule | null>(null);

--- a/frontend/src/pages/KnowledgeBaseFeedbackPage.tsx
+++ b/frontend/src/pages/KnowledgeBaseFeedbackPage.tsx
@@ -12,6 +12,7 @@ import GenericFeedbackTable from '../components/feedback/GenericFeedbackTable';
 import GenericFeedbackDetailModal from '../components/feedback/GenericFeedbackDetailModal';
 import type { FeedbackDetail } from '../components/feedback/types';
 import { SORT_COLUMNS } from '../components/feedback/types';
+import { useScreenView } from '../telemetry/useScreenView';
 
 const defaultParams: GetFeedbackListParams = {
   pageNumber: 1,
@@ -53,6 +54,8 @@ function mapLogToDetail(log: FeedbackLogSummary): FeedbackDetail {
 const KnowledgeBaseFeedbackPage: React.FC = () => {
   const [params, setParams] = useState<GetFeedbackListParams>(defaultParams);
   const [selectedRow, setSelectedRow] = useState<FeedbackDetail | null>(null);
+
+  useScreenView('Knowledge', 'KnowledgeBaseFeedback');
 
   const { data, isLoading, isError } = useKnowledgeBaseFeedbackListQuery(params);
 

--- a/frontend/src/pages/KnowledgeBasePage.tsx
+++ b/frontend/src/pages/KnowledgeBasePage.tsx
@@ -4,12 +4,19 @@ import KnowledgeBaseSearchAskTab from '../components/knowledge-base/KnowledgeBas
 import KnowledgeBaseDocumentsTab from '../components/knowledge-base/KnowledgeBaseDocumentsTab';
 import KnowledgeBaseUploadTab from '../components/knowledge-base/KnowledgeBaseUploadTab';
 import { useKnowledgeBaseUploadPermission } from '../api/hooks/useKnowledgeBase';
+import { useScreenView } from '../telemetry/useScreenView';
 
 type Tab = 'search' | 'documents' | 'upload';
 
 const KnowledgeBasePage: React.FC = () => {
   const canUpload = useKnowledgeBaseUploadPermission();
   const [activeTab, setActiveTab] = useState<Tab>('search');
+
+  const subScreen =
+    activeTab === 'search' ? 'SearchTab' :
+    activeTab === 'documents' ? 'DocumentsTab' :
+    'UploadTab';
+  useScreenView('Knowledge', 'KnowledgeBase', subScreen);
 
   const tabs: { id: Tab; label: string }[] = [
     { id: 'search', label: 'Hledat' },

--- a/frontend/src/pages/MarketingFeedbackPage.tsx
+++ b/frontend/src/pages/MarketingFeedbackPage.tsx
@@ -15,6 +15,7 @@ import {
   type FeedbackDetail,
   type GenericFeedbackParams,
 } from '../components/feedback/types';
+import { useScreenView } from '../telemetry/useScreenView';
 
 type FeatureTab = 'kb' | 'leaflet' | 'article';
 
@@ -51,6 +52,8 @@ const MarketingFeedbackPage: React.FC = () => {
   const [kbParams, setKbParams] = useState<GenericFeedbackParams>(DEFAULT_FEEDBACK_PARAMS);
   const [leafletParams, setLeafletParams] = useState<GenericFeedbackParams>(DEFAULT_FEEDBACK_PARAMS);
   const [articleParams, setArticleParams] = useState<GenericFeedbackParams>(DEFAULT_FEEDBACK_PARAMS);
+
+  useScreenView('Marketing', 'MarketingFeedback');
 
   const kb = useKbFeedbackAdapter(kbParams);
   const leaflet = useLeafletFeedbackAdapter(leafletParams);

--- a/frontend/src/pages/OrgChartPage.tsx
+++ b/frontend/src/pages/OrgChartPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { useOrgChart } from '../api/hooks/useOrgChart';
 import { PositionCard } from '../components/OrgChart/PositionCard';
+import { useScreenView } from '../telemetry/useScreenView';
 import {
   calculateLevels,
   getAllParentPositionIds,
@@ -19,6 +20,8 @@ interface PositionRect {
 }
 
 const OrgChartPage: React.FC = () => {
+  useScreenView('Admin', 'OrgChart');
+
   // Fetch organization data from backend
   const { data: orgChartResponse, isLoading, error: queryError } = useOrgChart();
 

--- a/frontend/src/pages/PackingMaterialsPage.tsx
+++ b/frontend/src/pages/PackingMaterialsPage.tsx
@@ -7,6 +7,7 @@ import EditMaterialModal from '../components/packing-materials/modals/EditMateri
 import UpdateQuantityModal from '../components/packing-materials/modals/UpdateQuantityModal';
 import ProcessDailyConsumptionModal from '../components/packing-materials/modals/ProcessDailyConsumptionModal';
 import PackingMaterialDetailModal from '../components/packing-materials/modals/PackingMaterialDetailModal';
+import { useScreenView } from '../telemetry/useScreenView';
 
 interface PackingMaterialsPageProps {}
 
@@ -19,6 +20,8 @@ const PackingMaterialsPage: React.FC<PackingMaterialsPageProps> = () => {
   const [isQuantityModalOpen, setIsQuantityModalOpen] = useState(false);
   const [isProcessConsumptionModalOpen, setIsProcessConsumptionModalOpen] = useState(false);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
+
+  useScreenView('Logistics', 'PackingMaterials');
 
   const formatForecastDays = (days?: number) => {
     if (days === undefined || days === null) return 'N/A';

--- a/frontend/src/pages/RecurringJobsPage.tsx
+++ b/frontend/src/pages/RecurringJobsPage.tsx
@@ -3,8 +3,10 @@ import { Clock, RefreshCw, AlertCircle, ToggleLeft, ToggleRight, Play, Pencil, C
 import { useRecurringJobsQuery, useUpdateRecurringJobStatusMutation, useTriggerRecurringJobMutation, useUpdateRecurringJobCronMutation, RecurringJobDto } from '../api/hooks/useRecurringJobs';
 import { LoadingIndicator } from '../components/ui/LoadingIndicator';
 import ConfirmTriggerJobDialog from '../components/dialogs/ConfirmTriggerJobDialog';
+import { useScreenView } from '../telemetry/useScreenView';
 
 const RecurringJobsPage: React.FC = () => {
+  useScreenView('Automation', 'RecurringJobs');
   const { data: jobs, isLoading, error, refetch } = useRecurringJobsQuery();
   const updateJobStatus = useUpdateRecurringJobStatusMutation();
   const triggerJob = useTriggerRecurringJobMutation();

--- a/frontend/src/pages/StockOperationsPage.tsx
+++ b/frontend/src/pages/StockOperationsPage.tsx
@@ -30,8 +30,10 @@ import {
   PRODUCT_TYPE_FILTERS,
 } from "../components/common/CatalogAutocompleteAdapters";
 import { PAGE_CONTAINER_HEIGHT } from "../constants/layout";
+import { useScreenView } from "../telemetry/useScreenView";
 
 const StockOperationsPage: React.FC = () => {
+  useScreenView('Automation', 'StockOperations');
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Filter input states (what user is typing/selecting)

--- a/frontend/src/pages/customer/BankStatementsOverviewPage.tsx
+++ b/frontend/src/pages/customer/BankStatementsOverviewPage.tsx
@@ -3,9 +3,11 @@ import { CreditCard, BarChart, Download } from "lucide-react";
 import StatisticsTab from "../../components/customer/tabs/StatisticsTab";
 import ImportTab from "../../components/customer/tabs/ImportTab";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const BankStatementsOverviewPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState<"statistics" | "import">("statistics");
+  useScreenView('Customer', 'BankStatementsOverview');
 
   return (
     <div

--- a/frontend/src/pages/customer/DataQualityPage.tsx
+++ b/frontend/src/pages/customer/DataQualityPage.tsx
@@ -5,8 +5,10 @@ import DqtSummaryCards from '../../components/data-quality/DqtSummaryCards';
 import RunDqtButton from '../../components/data-quality/RunDqtButton';
 import DqtRunsTable from '../../components/data-quality/DqtRunsTable';
 import DqtRunDetail from '../../components/data-quality/DqtRunDetail';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const DataQualityPage: React.FC = () => {
+  useScreenView('Automation', 'DataQuality');
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
 
   // Fetch the latest run for the summary cards

--- a/frontend/src/pages/customer/ExpeditionSettingsPage.tsx
+++ b/frontend/src/pages/customer/ExpeditionSettingsPage.tsx
@@ -3,12 +3,14 @@ import { Settings, Thermometer, Gift } from 'lucide-react';
 import { PAGE_CONTAINER_HEIGHT } from '../../constants/layout';
 import CoolingTab from '../../components/customer/expeditionSettings/CoolingTab';
 import GiftsTab from '../../components/customer/expeditionSettings/GiftsTab';
+import { useScreenView } from '../../telemetry/useScreenView';
 
 type Tab = 'cooling' | 'gifts';
 
 function ExpeditionSettingsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab: Tab = (searchParams.get('tab') as Tab) ?? 'cooling';
+  useScreenView('Customer', 'ExpeditionSettings', activeTab === 'cooling' ? 'CoolingTab' : 'GiftsTab');
 
   const handleTabChange = (tab: Tab) => {
     setSearchParams({ tab });

--- a/frontend/src/pages/customer/IssuedInvoicesPage.tsx
+++ b/frontend/src/pages/customer/IssuedInvoicesPage.tsx
@@ -23,10 +23,12 @@ import InvoiceImportStatistics from "../../components/pages/automation/InvoiceIm
 import InvoiceImportJobTracker from "../../components/invoices/InvoiceImportJobTracker";
 import InvoiceImportRunningIndicator from "../../components/invoices/InvoiceImportRunningIndicator";
 import { PAGE_CONTAINER_HEIGHT } from "../../constants/layout";
+import { useScreenView } from '../../telemetry/useScreenView';
 
 const IssuedInvoicesPage: React.FC = () => {
   // Tab state
   const [activeTab, setActiveTab] = useState<'statistics' | 'grid'>('statistics');
+  useScreenView('Customer', 'IssuedInvoices');
   
   // Filter states - separate input values from applied filters
   const [invoiceIdInput, setInvoiceIdInput] = useState("");

--- a/frontend/src/telemetry/__tests__/useScreenView.test.tsx
+++ b/frontend/src/telemetry/__tests__/useScreenView.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import type { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import { useScreenView } from '../useScreenView';
+import * as appInsightsModule from '../appInsights';
+
+const mockTrackEvent = jest.fn();
+const mockAI = { trackEvent: mockTrackEvent };
+
+describe('useScreenView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(appInsightsModule, 'getAppInsights').mockReturnValue(
+      mockAI as unknown as ApplicationInsights,
+    );
+  });
+
+  it('fires ScreenViewed on mount with module and screen', () => {
+    renderHook(() => useScreenView('Dashboard', 'Dashboard'));
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      { name: 'ScreenViewed' },
+      { module: 'Dashboard', screen: 'Dashboard' },
+    );
+  });
+
+  it('includes subScreen when provided', () => {
+    renderHook(() => useScreenView('Catalog', 'CatalogDetail', 'MarginsTab'));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      { name: 'ScreenViewed' },
+      { module: 'Catalog', screen: 'CatalogDetail', subScreen: 'MarginsTab' },
+    );
+  });
+
+  it('re-fires when subScreen changes', () => {
+    const { rerender } = renderHook(
+      ({ tab }: { tab: string }) => useScreenView('Catalog', 'CatalogDetail', tab),
+      { initialProps: { tab: 'BasicTab' } },
+    );
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+    rerender({ tab: 'MarginsTab' });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+    expect(mockTrackEvent).toHaveBeenLastCalledWith(
+      { name: 'ScreenViewed' },
+      { module: 'Catalog', screen: 'CatalogDetail', subScreen: 'MarginsTab' },
+    );
+  });
+
+  it('does not re-fire when subScreen is unchanged across renders', () => {
+    const { rerender } = renderHook(
+      ({ tab }: { tab: string }) => useScreenView('Catalog', 'CatalogDetail', tab),
+      { initialProps: { tab: 'BasicTab' } },
+    );
+    rerender({ tab: 'BasicTab' });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when AI instance is null', () => {
+    jest.spyOn(appInsightsModule, 'getAppInsights').mockReturnValue(null);
+
+    expect(() =>
+      renderHook(() => useScreenView('Dashboard', 'Dashboard')),
+    ).not.toThrow();
+  });
+});

--- a/frontend/src/telemetry/events.ts
+++ b/frontend/src/telemetry/events.ts
@@ -3,4 +3,5 @@ export type TelemetryEventName =
   | 'PhotobankBulkTagApplied'
   | 'ManufactureOrderCreated'
   | 'PurchaseOrderSubmitted'
-  | 'FeatureFlagToggled';
+  | 'FeatureFlagToggled'
+  | 'ScreenViewed';

--- a/frontend/src/telemetry/screenModules.ts
+++ b/frontend/src/telemetry/screenModules.ts
@@ -1,0 +1,15 @@
+export type ScreenModule =
+  | 'Dashboard'
+  | 'Finance'
+  | 'Catalog'
+  | 'Journal'
+  | 'Purchase'
+  | 'Manufacturing'
+  | 'Logistics'
+  | 'Marketing'
+  | 'Customer'
+  | 'Automation'
+  | 'Knowledge'
+  | 'Admin'
+  | 'Terminal'
+  | 'Baleni';

--- a/frontend/src/telemetry/useScreenView.ts
+++ b/frontend/src/telemetry/useScreenView.ts
@@ -15,7 +15,10 @@ export function useScreenView(
       properties.subScreen = subScreen;
     }
     trackEvent('ScreenViewed', properties);
-    // trackEvent is stable per useTelemetry contract; intentionally excluded
+    // trackEvent identity is not stable across renders (useTelemetry returns a
+    // fresh object literal each call); including it would re-fire the effect on
+    // every render. The effect should only re-fire when module/screen/subScreen
+    // changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [module, screen, subScreen]);
 }

--- a/frontend/src/telemetry/useScreenView.ts
+++ b/frontend/src/telemetry/useScreenView.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useTelemetry } from './useTelemetry';
+import type { ScreenModule } from './screenModules';
+
+export function useScreenView(
+  module: ScreenModule,
+  screen: string,
+  subScreen?: string,
+): void {
+  const { trackEvent } = useTelemetry();
+
+  useEffect(() => {
+    const properties: Record<string, string> = { module, screen };
+    if (subScreen !== undefined) {
+      properties.subScreen = subScreen;
+    }
+    trackEvent('ScreenViewed', properties);
+    // trackEvent is stable per useTelemetry contract; intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [module, screen, subScreen]);
+}


### PR DESCRIPTION
## Summary

Adds the `useScreenView(module, screen, subScreen?)` React hook on top of the existing Application Insights telemetry infrastructure, and instruments all 56 user-facing screens (plus 30 in-page sub-screen branches — tabs, view-modes, wizard steps) across 14 modules with uniform `ScreenViewed` events. Introduces a canonical coverage matrix at `docs/features/usage-analytics-coverage.md` that lists every screen + branch and tracks which are wired; future PRs that touch a screen are required to update this doc. Goal: answer "what parts of the app are actually used, and how often" via a single KQL query against `customEvents`.

## Test plan

- [x] Foundation hook: 5/5 unit tests pass (`frontend/src/telemetry/__tests__/useScreenView.test.tsx`)
- [x] Full telemetry suite: 17/17 tests pass
- [x] `npm run build` PASS
- [x] `npm run lint` matches pre-existing baseline (151 problems, 0 new errors introduced)
- [ ] Post-deploy: run the KQL query in `docs/features/usage-analytics.md` after 7 days of traffic; diff observed `(module, screen, subScreen)` tuples against the coverage doc to surface any wiring gaps or doc drift (tracked as deferred Task 15 in the implementation plan)