### PR TITLE
feat: Remove Unused `Platform` Field from `MarketingTransaction`

### DIFF
--- a/artifacts/feat-arch-review-marketinginvoices-marketingt/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-marketingt/arch-review.r1.md
@@ -1,0 +1,143 @@
+```markdown
+# Architecture Review: Remove Unused `Platform` Field from `MarketingTransaction`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with the existing layering and reinforces the intended invariant of the MarketingInvoices module:
+
+- **Adapter pattern with platform-at-source authority.** `IMarketingTransactionSource` (Domain) exposes a single `Platform` property at the *source* level. `MarketingInvoiceImportService.ImportAsync` (Application) reads `source.Platform` exclusively when persisting (`MarketingInvoiceImportService.cs:70`) and when logging/exists-checking. Per-transaction `Platform` is dead data that contradicts this invariant.
+- **Layer separation preserved.** The removed field is internal to the Domain layer's in-memory transfer object; it never crosses an HTTP, MediatR, or OpenAPI contract. No client regeneration, no migration.
+- **Persistence is unaffected.** `ImportedMarketingTransaction.Platform` (the persisted column with `IX_ImportedMarketingTransactions_Platform_TransactionId` index) remains, populated from `source.Platform` — that contract does not change.
+
+Verdict: the refactor is purely a YAGNI cleanup that improves the contract honesty of the domain model. No architectural risks.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Domain  (Anela.Heblo.Domain.Features.MarketingInvoices)        │
+│                                                                 │
+│   IMarketingTransactionSource         MarketingTransaction      │
+│     ├─ string Platform   (KEEP)         ├─ TransactionId        │
+│     └─ GetTransactionsAsync()           ├─ Platform  ← REMOVE   │
+│                                         ├─ Amount              │
+│                                         ├─ TransactionDate     │
+│                                         ├─ Description         │
+│                                         ├─ Currency            │
+│                                         └─ RawData             │
+└─────────────────────────────────────────────────────────────────┘
+        │ implements                              ▲ produces
+        ▼                                         │
+┌────────────────────────────┐         ┌──────────────────────────┐
+│ Adapters (Meta / Google)   │────────▶│ Application Service      │
+│  MetaAdsTransactionSource  │         │ MarketingInvoiceImport-  │
+│  GoogleAdsTransactionSource│         │ Service.ImportAsync      │
+│   (drop `Platform = ...`)  │         │  uses source.Platform    │
+└────────────────────────────┘         │  to persist Imported-    │
+                                       │  MarketingTransaction    │
+                                       └──────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Remove the field outright (not deprecate)
+**Options considered:**
+- (A) Delete the `Platform` property and all initializers immediately.
+- (B) Mark `[Obsolete]`, ship across releases, delete later.
+
+**Chosen approach:** (A) Delete outright.
+
+**Rationale:** `MarketingTransaction` is an internal Domain DTO with zero external consumers (no API contract, no persisted column, no OpenAPI client). It is not a `record` so OpenAPI parameter ordering is not a concern (per the project's DTO rules). The codebase is a solo-dev workspace with no downstream binary consumers. Obsolete annotations add noise for no benefit here.
+
+#### Decision 2: Do not change `IMarketingTransactionSource.Platform`
+**Options considered:**
+- (A) Keep the source-level `Platform` on the interface.
+- (B) Remove it and have the service receive `Platform` as a separate argument.
+
+**Chosen approach:** (A) Keep it.
+
+**Rationale:** The service reads `source.Platform` for logging, the duplicate-staging guard, the `ExistsAsync` query, and the persisted entity. It is also referenced by the MediatR handler (`ImportMarketingInvoicesHandler.cs:29` matches sources by platform). Touching this surface is out of scope for the cleanup and would broaden the blast radius unnecessarily.
+
+#### Decision 3: Update adapter unit-test assertions on `tx.Platform`
+**Options considered:**
+- (A) Delete the two `tx.Platform.Should().Be(...)` assertions in `MetaAdsTransactionSourceTests` and `GoogleAdsTransactionSourceTests`.
+- (B) Replace them with assertions on `source.Platform`.
+
+**Chosen approach:** (A) Delete.
+
+**Rationale:** `source.Platform` is a trivial constant (`PlatformName`) and already exercised implicitly via the import-service tests and adapter wiring tests. Asserting a constant returned by a property getter adds no coverage. The spec already permits trivial assertion removal.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edit only the following:
+
+| Path | Change |
+|---|---|
+| `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs` | Delete the `Platform` property. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` | Remove `Platform = Platform,` initializer at line 68. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs` | Remove `Platform = Platform,` initializer at line 39. |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Remove all `Platform = "TestPlatform",` initializer entries in `MarketingTransaction` object initializers (≈10 sites at lines 38–39, 74, 103–104, 139–140, 197–198, 237, 289, 342). |
+| `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs` | Delete the `tx.Platform.Should().Be("MetaAds");` assertion at line 72. |
+| `backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs` | Delete the `tx.Platform.Should().Be("GoogleAds");` assertion at line 28. |
+
+Do **not** touch:
+- `IMarketingTransactionSource` interface — `Platform` property stays.
+- `ImportedMarketingTransaction` entity and its `ImportedMarketingTransactionConfiguration` — DB column and index unchanged.
+- `MarketingInvoiceImportService.cs` — already uses `source.Platform`; verify by reading after edit but no edit required.
+- Adapter `Platform => PlatformName` properties on `MetaAdsTransactionSource` / `GoogleAdsTransactionSource` — these implement the interface and remain.
+
+### Interfaces and Contracts
+
+- `IMarketingTransactionSource.Platform` — unchanged.
+- `MarketingTransaction` — narrowed (one fewer property). This is a Domain-internal POCO; not a wire contract, not persisted, not exposed via OpenAPI. No DTO/contract rules violated.
+- `ImportedMarketingTransaction` — unchanged (entity + EF configuration + index unchanged).
+- `MarketingImportResult`, `ImportMarketingInvoicesRequest/Response` — unchanged.
+
+### Data Flow
+
+For each platform import (Meta or Google), unchanged in observable behavior:
+
+```
+Job → Handler → Service.ImportAsync(source, from, to)
+   1. transactions = source.GetTransactionsAsync(from, to)
+        // adapter constructs MarketingTransaction WITHOUT Platform
+   2. for each tx:
+        skip if Currency empty
+        skip if (source.Platform, tx.TransactionId) already staged or persisted
+        new ImportedMarketingTransaction { Platform = source.Platform, ... }
+        repo.AddAsync(entity)
+   3. repo.SaveChangesAsync()
+```
+
+The Platform written into `ImportedMarketingTransaction` is byte-identical before and after the change because `source.Platform` (interface getter returning `PlatformName` constant) was already the authoritative source.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| A consumer outside the explored set reads `MarketingTransaction.Platform`. | Low | Grep verified zero non-initializer reads. Compiler will catch any miss when the property is deleted — fail-fast. |
+| Adapter unit tests that assert `tx.Platform` fail after delete. | Low (known) | Drop the two assertions in `MetaAdsTransactionSourceTests` and `GoogleAdsTransactionSourceTests` listed above. |
+| EF Core entity `ImportedMarketingTransaction` accidentally edited and triggers a migration. | Low | Limit edits to the files listed in the table. Run `dotnet ef migrations list` after build to confirm no model snapshot change is required (none should be — only Domain DTO is touched). |
+| Hidden serialization of `MarketingTransaction` to JSON (e.g., diagnostics) drops the field silently. | Low | None found via grep (`MarketingTransaction` is never serialized — only `RawData` payloads are). Acceptable. |
+
+## Specification Amendments
+
+The spec is correct as written. Two small clarifications worth recording in the implementation commit message:
+
+1. **FR-4 scope is concrete.** The only test project with `MarketingTransaction { Platform = ... }` initializers is `MarketingInvoiceImportServiceTests.cs` (≈10 sites). All others reference `Platform` on different types (`ImportMarketingInvoicesRequest`, `ImportMarketingInvoicesResponse`, `ImportedMarketingTransaction`) and are out of scope.
+2. **Two adapter-test assertions exist** on `tx.Platform` (`MetaAdsTransactionSourceTests.cs:72`, `GoogleAdsTransactionSourceTests.cs:28`). Delete them — they assert a property that no longer exists. The spec's FR-2/FR-3 escape hatch ("trivial removal of assertions … if present") covers this; calling it out explicitly avoids ambiguity during review.
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure changes, no feature flags. The change can be implemented and validated entirely with:
+
+- `dotnet build` on the solution
+- `dotnet test` on `Anela.Heblo.Tests`
+- `dotnet format` on the touched files
+```

--- a/artifacts/feat-arch-review-marketinginvoices-marketingt/brief.md
+++ b/artifacts/feat-arch-review-marketinginvoices-marketingt/brief.md
@@ -1,0 +1,39 @@
+## Module
+MarketingInvoices
+
+## Finding
+`MarketingTransaction.Platform` (`Domain/Features/MarketingInvoices/MarketingTransaction.cs:6`) is populated by both source adapters but never consumed by the import service.
+
+Both adapters set it:
+- `MetaAdsTransactionSource.cs:68`: `Platform = Platform`
+- `GoogleAdsTransactionSource.cs:39`: `Platform = Platform`
+
+But `MarketingInvoiceImportService.ImportAsync` always uses `source.Platform` when constructing `ImportedMarketingTransaction` (`Services/MarketingInvoiceImportService.cs:70`):
+```csharp
+Platform = source.Platform,   // transaction.Platform is never read
+```
+
+`transaction.Platform` has zero read sites in the entire codebase. Test data populates it, but no assertion ever checks it.
+
+## Why it matters
+The field creates a false impression that platform can vary per transaction (rather than being authoritative from the source), and suggests that the service validates or reconciles per-transaction vs source platform. A future developer could reasonably add logic that reads `transaction.Platform` expecting the service to honor it — silently getting no effect. It's YAGNI code in the domain contract.
+
+## Suggested fix
+Remove `Platform` from `MarketingTransaction`:
+```csharp
+// Domain/Features/MarketingInvoices/MarketingTransaction.cs
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    // Remove: public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+Remove the `Platform = Platform` initializer line from both adapter source files.
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-marketinginvoices-marketingt/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-marketingt/impl/main.r1.md
@@ -1,0 +1,10 @@
+Tests were verified in Task 6 — 3980 passed, 0 failed. This is a standalone clone under `.worktrees/` with `GIT_DIR == GIT_COMMON` (normal repo behavior, no linked worktree to clean up).
+
+Implementation complete. What would you like to do?
+
+1. Merge back to `main` locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?

--- a/artifacts/feat-arch-review-marketinginvoices-marketingt/spec.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-marketingt/spec.r1.md
@@ -1,0 +1,130 @@
+# Specification: Remove Unused `Platform` Field from `MarketingTransaction`
+
+## Summary
+The `Platform` property on the domain entity `MarketingTransaction` is written by every source adapter but never read by any consumer. This specification removes the dead field from the domain contract and the corresponding initializer code in both adapters, eliminating a misleading affordance in the MarketingInvoices module.
+
+## Background
+`MarketingTransaction` (`backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`) is the domain record produced by source adapters (`MetaAdsTransactionSource`, `GoogleAdsTransactionSource`) and consumed by `MarketingInvoiceImportService.ImportAsync` to construct `ImportedMarketingTransaction` rows.
+
+Audit findings:
+- Both adapters set `transaction.Platform = Platform` (the adapter's own `Platform` property).
+- `MarketingInvoiceImportService.ImportAsync` always uses `source.Platform` (the adapter-level platform) — line 70 in `Services/MarketingInvoiceImportService.cs` — to populate the imported row.
+- No production code or test assertion reads `MarketingTransaction.Platform`. Test data populates it, but only as part of object construction.
+
+The field is therefore dead weight in the domain contract. It implies semantics that do not exist: that a single fetch could mix platforms per transaction, or that the service reconciles a per-transaction platform with the source's platform. Neither is true — the platform is authoritative at the source level. Leaving this field invites a future contributor to write logic that depends on it and silently get no effect.
+
+This is a YAGNI cleanup motivated by the daily architecture review routine on 2026-05-26.
+
+## Functional Requirements
+
+### FR-1: Remove `Platform` property from `MarketingTransaction`
+Delete the `Platform` property from the `MarketingTransaction` class at `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`.
+
+**Acceptance criteria:**
+- `MarketingTransaction` no longer declares a `Platform` property.
+- `dotnet build` succeeds for the whole solution without warnings related to this change.
+- Grepping the repository for `MarketingTransaction.*Platform` (and `transaction.Platform` within MarketingInvoices contexts) returns no remaining references to the removed property.
+
+### FR-2: Remove `Platform` initializer from `MetaAdsTransactionSource`
+Remove the `Platform = Platform,` line in the `MarketingTransaction` initializer in `MetaAdsTransactionSource` (around `MetaAdsTransactionSource.cs:68`).
+
+**Acceptance criteria:**
+- Adapter no longer references the removed property.
+- Adapter still compiles and continues to expose its own source-level `Platform` value (consumed by `MarketingInvoiceImportService` via `source.Platform`).
+- Any existing tests for `MetaAdsTransactionSource` pass without modification — except for trivial removal of assertions/initializers referencing the removed field, if present.
+
+### FR-3: Remove `Platform` initializer from `GoogleAdsTransactionSource`
+Remove the `Platform = Platform,` line in the `MarketingTransaction` initializer in `GoogleAdsTransactionSource` (around `GoogleAdsTransactionSource.cs:39`).
+
+**Acceptance criteria:**
+- Adapter no longer references the removed property.
+- Adapter still compiles and continues to expose its own source-level `Platform` value.
+- Any existing tests for `GoogleAdsTransactionSource` pass without modification — except for trivial removal of assertions/initializers referencing the removed field, if present.
+
+### FR-4: Clean up test data that sets the removed property
+Any test fixtures, mocks, or in-test object initializers that set `MarketingTransaction.Platform` must be updated to remove the assignment. No assertions need to be added or modified because no assertion currently reads the field.
+
+**Acceptance criteria:**
+- `dotnet test` for all MarketingInvoices-related test projects passes.
+- No test fixture references the removed property.
+
+### FR-5: Preserve import behavior end-to-end
+The behavior of `MarketingInvoiceImportService.ImportAsync` must be identical before and after the change. It already reads `source.Platform` (the adapter-level value), so the `ImportedMarketingTransaction.Platform` output must remain the same for every input.
+
+**Acceptance criteria:**
+- Existing import tests pass with no changes to their assertions on `ImportedMarketingTransaction.Platform`.
+- Manual or automated regression of an end-to-end import flow (Meta Ads source → service → imported rows) yields the same `Platform` values as before.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change is expected or required. The removal eliminates one string property assignment per transaction during import — a negligible improvement.
+
+### NFR-2: Security
+No security implications. The property holds no sensitive data and no access control depends on it.
+
+### NFR-3: Maintainability
+The change improves maintainability by removing a misleading affordance from the domain contract. The domain model now reflects the actual invariant: platform is a source-level attribute, not a per-transaction one.
+
+### NFR-4: Backwards compatibility
+`MarketingTransaction` is an internal domain entity, not part of any public API or persisted schema (it is mapped into `ImportedMarketingTransaction` for persistence). No database migration, API client regeneration, or external contract update is required. This should be verified during implementation — see Open Questions if any DTO inadvertently exposes the field.
+
+## Data Model
+
+**Before:**
+```csharp
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;   // removed
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+**After:**
+```csharp
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+`ImportedMarketingTransaction` (the persisted entity) is **unchanged** — it continues to carry `Platform`, populated from the adapter-level `source.Platform`.
+
+## API / Interface Design
+
+No public API changes. No HTTP endpoints, MediatR requests, MVC controllers, or OpenAPI clients are affected. The adapter contract (`IMarketingTransactionSource` or equivalent) retains its source-level `Platform` property, which is what `MarketingInvoiceImportService.ImportAsync` actually reads.
+
+## Dependencies
+
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs` — domain entity to modify
+- `backend/src/Anela.Heblo.../MetaAdsTransactionSource.cs` — adapter to update
+- `backend/src/Anela.Heblo.../GoogleAdsTransactionSource.cs` — adapter to update
+- `backend/src/Anela.Heblo.../Services/MarketingInvoiceImportService.cs` — already uses `source.Platform`, no change required (but verify after refactor)
+- Test projects covering MarketingInvoices (unit tests for adapters and the import service)
+
+No external services, packages, or feature flags are involved.
+
+## Out of Scope
+
+- Refactoring the broader MarketingInvoices module or its data flow.
+- Renaming or restructuring `MarketingTransaction` or `ImportedMarketingTransaction`.
+- Changes to `source.Platform` or the adapter interface.
+- Adding new tests beyond updating fixtures that set the removed property.
+- Database migrations — `ImportedMarketingTransaction` schema is untouched.
+- Any frontend changes — this is a purely server-side domain cleanup.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketinginvoices-marketingt/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-marketingt/task-plan.r1.md
@@ -1,0 +1,531 @@
+# Remove Unused `Platform` Field from `MarketingTransaction` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead `Platform` property from the `MarketingTransaction` domain DTO and every write/read site, eliminating a misleading affordance from the MarketingInvoices module while keeping import behavior byte-identical.
+
+**Architecture:** Compiler-driven dead-code removal in the Domain layer's in-memory DTO. The persisted entity `ImportedMarketingTransaction.Platform` is unchanged — it is populated from `source.Platform` (interface-level value), which remains authoritative. No migration, no API contract change, no frontend impact.
+
+**Tech Stack:** C# / .NET 8, xUnit, FluentAssertions, EF Core (read-only impact verification).
+
+**TDD note:** This is a refactor with **no behavior change**, so there is no new failing test to write. The existing test suite is the safety net — every task validates by running the suite and confirming it still passes (green → green). The change progresses from leaves to root (writes → property declaration) so the build stays green between every step.
+
+---
+
+## File Touch Map
+
+| Path | Change |
+|---|---|
+| `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` | Remove `Platform = Platform,` initializer line. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs` | Remove `Platform = Platform,` initializer line. |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Remove `Platform = "TestPlatform",` from 12 `MarketingTransaction` initializer sites. |
+| `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs` | Delete `tx.Platform.Should().Be("MetaAds");` assertion. |
+| `backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs` | Delete `tx.Platform.Should().Be("GoogleAds");` assertion. |
+| `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs` | Delete `Platform` property declaration. |
+
+**Do NOT touch:**
+- `IMarketingTransactionSource` — interface-level `Platform` property stays (`source.Platform` is what the service actually reads).
+- `ImportedMarketingTransaction` and `ImportedMarketingTransactionConfiguration` — DB column and index unchanged.
+- `MarketingInvoiceImportService.cs` — already uses `source.Platform`; verify, don't edit.
+- Adapter `Platform => PlatformName` properties on `MetaAdsTransactionSource` / `GoogleAdsTransactionSource` — these implement the interface and stay.
+- `ImportMarketingInvoicesHandlerTests.cs`, `MetaAdsInvoiceImportJobTests.cs`, `GoogleAdsInvoiceImportJobTests.cs` — their `Platform =` references are on `ImportMarketingInvoicesRequest`/`Response`, not `MarketingTransaction`.
+
+---
+
+## Task 0: Verify Baseline
+
+Establish that the suite is green on the current branch before changing anything.
+
+**Files:** None.
+
+- [ ] **Step 1: Build the backend solution**
+
+Run from repo root:
+
+```bash
+dotnet build backend/Anela.Heblo.sln -warnaserror
+```
+
+Expected: build succeeds with zero errors/warnings. If warnings exist already on the branch, note them — they are pre-existing and not in scope.
+
+- [ ] **Step 2: Run the targeted test slice**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices|FullyQualifiedName~MetaAds|FullyQualifiedName~GoogleAds" \
+  --no-build
+```
+
+Expected: all tests pass. Record the count of passing tests (e.g., "N passed, 0 failed, 0 skipped") so you can confirm it does not regress after the refactor.
+
+- [ ] **Step 3: Verify no pending EF model changes**
+
+```bash
+dotnet ef migrations has-pending-model-changes \
+  --project backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj \
+  --startup-project backend/src/Anela.Heblo/Anela.Heblo.csproj
+```
+
+Expected: "No model changes detected." (or equivalent). This sets a baseline so the post-change check is meaningful.
+
+> If `dotnet ef` is not installed in the environment, fall back to `dotnet ef migrations list ...` and record the most-recent migration name. The relevant check is that this name does not change after the refactor.
+
+---
+
+## Task 1: Remove `Platform` Initializer from `MetaAdsTransactionSource`
+
+Strip the write site in the Meta adapter. The domain property still exists, so the build stays green.
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs:68`
+
+- [ ] **Step 1: Edit the file**
+
+Remove the single line at position 68 inside the `new MarketingTransaction { ... }` initializer.
+
+**Before** (lines 65–74):
+
+```csharp
+results.Add(new MarketingTransaction
+{
+    TransactionId = item.Id,
+    Platform = Platform,
+    Amount = item.Amount / 100m,
+    TransactionDate = txDate,
+    Currency = item.Currency,
+    Description = item.PaymentType,
+    RawData = JsonSerializer.Serialize(item, JsonOptions),
+});
+```
+
+**After**:
+
+```csharp
+results.Add(new MarketingTransaction
+{
+    TransactionId = item.Id,
+    Amount = item.Amount / 100m,
+    TransactionDate = txDate,
+    Currency = item.Currency,
+    Description = item.PaymentType,
+    RawData = JsonSerializer.Serialize(item, JsonOptions),
+});
+```
+
+> The adapter-level `Platform => PlatformName` property (member of the class, implementing `IMarketingTransactionSource.Platform`) is untouched — keep it.
+
+- [ ] **Step 2: Verify file compiles**
+
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Run adapter tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MetaAds" --no-build
+```
+
+Expected: all tests pass. (The `tx.Platform.Should().Be("MetaAds")` assertion still passes because the property is still on the class with its default value of `string.Empty`... wait — it asserts `"MetaAds"`, not the default. The assertion will now FAIL after this step because the initializer no longer sets it.)
+
+> **Expected failure at this step:** the test `GetTransactionsAsync_Amount_ConvertedFromCentsToDecimal` (or whichever test contains the line 72 assertion) will fail with FluentAssertions reporting `Expected tx.Platform to be "MetaAds", but found ""`. **This is intentional and will be fixed in Task 4.** Do not commit yet.
+
+---
+
+## Task 2: Remove `Platform` Initializer from `GoogleAdsTransactionSource`
+
+Mirror Task 1 for the Google adapter.
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs:39`
+
+- [ ] **Step 1: Edit the file**
+
+Remove the single line at position 39 inside the `new MarketingTransaction { ... }` initializer.
+
+**Before** (lines 36–45):
+
+```csharp
+var transactions = rows.Select(r => new MarketingTransaction
+{
+    TransactionId = r.Id,
+    Platform = Platform,
+    Amount = r.AmountServedMicros / 1_000_000m,
+    TransactionDate = r.StartDate,
+    Currency = r.CurrencyCode,
+    Description = r.Name ?? "Google Ads billing period",
+    RawData = JsonSerializer.Serialize(r),
+}).ToList();
+```
+
+**After**:
+
+```csharp
+var transactions = rows.Select(r => new MarketingTransaction
+{
+    TransactionId = r.Id,
+    Amount = r.AmountServedMicros / 1_000_000m,
+    TransactionDate = r.StartDate,
+    Currency = r.CurrencyCode,
+    Description = r.Name ?? "Google Ads billing period",
+    RawData = JsonSerializer.Serialize(r),
+}).ToList();
+```
+
+> The class-level `Platform => PlatformName` property is untouched.
+
+- [ ] **Step 2: Verify file compiles**
+
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Note expected adapter test failure**
+
+The Google adapter test on line 28 (`tx.Platform.Should().Be("GoogleAds");`) will now fail for the same reason as the Meta one. Do not run tests separately here — they will be fixed in Task 4 and validated then.
+
+---
+
+## Task 3: Clean Up `MarketingInvoiceImportServiceTests` Initializers
+
+Remove every `Platform = "TestPlatform",` site in the service unit tests. There are 12 sites: 9 inline initializers and 3 multi-line block initializers (verified by grep).
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+Lines affected (per grep `Platform\s*=` against the file):
+- Lines 38, 39, 74, 103, 104, 139, 140, 197, 198 — inline `new() { ..., Platform = "TestPlatform", ... }` literals (delete the substring `Platform = "TestPlatform", ` from each).
+- Lines 237, 289, 342 — multi-line `new() { ... Platform = "TestPlatform", ... }` (delete the entire line plus its trailing newline).
+
+- [ ] **Step 1: Edit inline sites (lines 38, 39, 74, 103, 104, 139, 140, 197, 198)**
+
+For each of these lines the substring `Platform = "TestPlatform", ` (including the trailing comma + space) appears exactly once between `TransactionId = ...,` and `Amount = ...,`. Use Edit with `replace_all` against the exact substring to delete it in one operation.
+
+**Exact substring to remove** (appears in 9 sites):
+
+```
+Platform = "TestPlatform", 
+```
+
+(Note the single trailing space before `Amount`.)
+
+After the edit, each affected line should read:
+
+```csharp
+new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+```
+
+…and similarly for the other transaction IDs (`"TX-002"`, `"TX-DUP"`).
+
+- [ ] **Step 2: Edit multi-line initializers (lines 237, 289, 342)**
+
+Each of these sites is a property line of its own within a `new() { ... }` initializer. Delete the full line, including the leading whitespace and trailing comma+newline.
+
+For line 237 — before:
+
+```csharp
+            {
+                TransactionId = "TX-EUR-001",
+                Platform = "TestPlatform",
+                Amount = 123.45m,
+                ...
+            },
+```
+
+After:
+
+```csharp
+            {
+                TransactionId = "TX-EUR-001",
+                Amount = 123.45m,
+                ...
+            },
+```
+
+Apply the same deletion for the multi-line initializers around lines 289 (`TransactionId = "TX-BAD-001"`) and 342 (`TransactionId = "TX-WS-001"`).
+
+- [ ] **Step 3: Verify the file is clean**
+
+Run from repo root:
+
+```bash
+grep -n "Platform" backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs || echo "no matches"
+```
+
+Expected matches are limited to references on **other types**:
+- `_mockRepository.Setup(x => x.ExistsAsync("TestPlatform", ...))` — argument string, not a property assignment. **Keep.**
+- `v.ToString()!.Contains("TestPlatform")` inside a logger Verify — keep.
+- `Mock<IMarketingTransactionSource>` setup where `source.Platform` is mocked (e.g., `_mockSource.Setup(x => x.Platform).Returns("TestPlatform")` if present) — keep.
+
+There must be **zero** remaining occurrences of `Platform = "TestPlatform"` (the property-assignment form). If grep still shows any, repeat Step 1/Step 2 against the missed line.
+
+- [ ] **Step 4: Build the test project**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds.
+
+---
+
+## Task 4: Remove Adapter-Test Assertions on `tx.Platform`
+
+Delete the two assertions that read `MarketingTransaction.Platform`. They assert a constant (`"MetaAds"` / `"GoogleAds"`) that is already exercised indirectly via `IMarketingTransactionSource.Platform` and adds no coverage.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs:72`
+- Modify: `backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs:28`
+
+- [ ] **Step 1: Delete the Meta assertion**
+
+In `MetaAdsTransactionSourceTests.cs`, remove the entire line 72:
+
+```csharp
+        tx.Platform.Should().Be("MetaAds");
+```
+
+The surrounding assertions (`tx.TransactionId`, `tx.Amount`, `tx.Currency`, `tx.Description`, `tx.TransactionDate`) stay.
+
+- [ ] **Step 2: Delete the Google assertion**
+
+In `GoogleAdsTransactionSourceTests.cs`, remove the entire line 28:
+
+```csharp
+        tx.Platform.Should().Be("GoogleAds");
+```
+
+The surrounding assertions (`tx.TransactionId`, `tx.Amount`, `tx.Currency`, `tx.Description`, `tx.TransactionDate`) stay.
+
+- [ ] **Step 3: Build the test project**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Run the targeted test slice**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices|FullyQualifiedName~MetaAds|FullyQualifiedName~GoogleAds" \
+  --no-build
+```
+
+Expected: all tests pass. **The count must match the Task 0 baseline minus zero** — no tests should be missing; the only changes were deletions of assertion lines, not whole tests.
+
+> If a test fails here with `Platform` in the message, you missed a reference. Re-grep with `grep -n "tx\.Platform\|\.Platform\.Should" backend/test/Anela.Heblo.Tests/...` and clean up.
+
+---
+
+## Task 5: Delete the `Platform` Property from `MarketingTransaction`
+
+With all writes and reads removed, deleting the property declaration is safe. The compiler will fail-fast on any stragglers.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`
+
+- [ ] **Step 1: Edit the file**
+
+**Before:**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+**After:**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+(Single-line deletion: `    public string Platform { get; set; } = string.Empty;`.)
+
+- [ ] **Step 2: Build the whole solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln -warnaserror
+```
+
+Expected: build succeeds with zero errors. If you see any `CS0117: 'MarketingTransaction' does not contain a definition for 'Platform'`, the failing site was missed in Task 1–4 — fix it in the file pointed to by the compiler and rerun.
+
+- [ ] **Step 3: Confirm `MarketingInvoiceImportService` still uses `source.Platform` (no edit required)**
+
+Open `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` and read around line 70. Verify that the assignment to `ImportedMarketingTransaction.Platform` reads `source.Platform`, not `tx.Platform` (it should already, per the spec and arch review). No edit; this is a sanity check.
+
+If somehow `tx.Platform` is referenced anywhere in this file, the build in Step 2 would have failed — so a passing build is the actual proof. Step 3 just documents the invariant for the reviewer.
+
+---
+
+## Task 6: Final Validation, Format, Commit
+
+Comprehensive validation against the spec's acceptance criteria.
+
+**Files:** All changes from Tasks 1–5.
+
+- [ ] **Step 1: Format touched files**
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs \
+            backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs \
+            backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs \
+            backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs \
+            backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs \
+            backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+```
+
+Expected: no output (or "Format complete"). If the formatter rewrites any of the touched files, `git diff` should still show only the property/initializer/assertion deletions plus, at worst, whitespace normalization.
+
+- [ ] **Step 2: Full backend build with warnings as errors**
+
+```bash
+dotnet build backend/Anela.Heblo.sln -warnaserror
+```
+
+Expected: build succeeds, zero warnings introduced by this change.
+
+- [ ] **Step 3: Full test run (all backend tests)**
+
+```bash
+dotnet test backend/Anela.Heblo.Tests --no-build
+```
+
+Or, more targeted but still comprehensive:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests pass. Count must equal the Task 0 baseline (we removed two adapter-test assertions but no `[Fact]`/`[Theory]` declarations, so the test count is unchanged).
+
+- [ ] **Step 4: Verify no EF migration is pending**
+
+```bash
+dotnet ef migrations has-pending-model-changes \
+  --project backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj \
+  --startup-project backend/src/Anela.Heblo/Anela.Heblo.csproj
+```
+
+Expected: "No model changes detected." — matches Task 0, confirms the persisted `ImportedMarketingTransaction` schema is untouched.
+
+- [ ] **Step 5: Grep for leftover references to the removed property**
+
+```bash
+grep -rn "MarketingTransaction.*Platform\|tx\.Platform\|transaction\.Platform" \
+  backend/src backend/test --include="*.cs"
+```
+
+Expected: no matches in production code or tests for `tx.Platform` / `transaction.Platform`. The `MarketingTransaction.*Platform` pattern may still match incidentally on unrelated whitespace (e.g. comments mentioning the change in commit history aren't grepped from source — only `.cs` files); inspect any hits and confirm they're false positives (e.g. references to `ImportMarketingInvoicesRequest.Platform` or `ImportMarketingInvoicesResponse.Platform`, which are different types).
+
+- [ ] **Step 6: Inspect the staged diff**
+
+```bash
+git diff --stat
+git diff
+```
+
+Expected diff scope (6 files, ~17 line deletions, 0 additions outside whitespace):
+
+| File | Approx. line delta |
+|---|---|
+| `MarketingTransaction.cs` | −1 |
+| `MetaAdsTransactionSource.cs` | −1 |
+| `GoogleAdsTransactionSource.cs` | −1 |
+| `MarketingInvoiceImportServiceTests.cs` | −12 (9 inline edits + 3 line deletions) |
+| `MetaAdsTransactionSourceTests.cs` | −1 |
+| `GoogleAdsTransactionSourceTests.cs` | −1 |
+
+If any other file is modified, investigate: was `dotnet format` overly aggressive, or did an edit slip into the wrong file?
+
+- [ ] **Step 7: Commit**
+
+Single atomic commit — the changes form one logical refactor.
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs \
+        backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs \
+        backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs \
+        backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs \
+        backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs \
+        backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: remove unused Platform field from MarketingTransaction
+
+The per-transaction Platform property on MarketingTransaction was written
+by both adapters (MetaAds, GoogleAds) but never read by any consumer.
+MarketingInvoiceImportService.ImportAsync uses source.Platform
+(IMarketingTransactionSource.Platform) when persisting
+ImportedMarketingTransaction — that path is unchanged.
+
+- Drop the Platform property from the domain DTO.
+- Drop Platform = Platform initializers in MetaAds and GoogleAds adapters.
+- Drop Platform = "TestPlatform" initializers in MarketingInvoiceImportServiceTests.
+- Drop tx.Platform assertions in MetaAds/GoogleAds adapter tests (they
+  asserted a constant already covered by source.Platform).
+
+No public API, persisted schema, or OpenAPI client is affected. The
+ImportedMarketingTransaction column and its Platform/TransactionId index
+remain unchanged.
+EOF
+)"
+```
+
+- [ ] **Step 8: Confirm commit and clean tree**
+
+```bash
+git status
+git log -1 --stat
+```
+
+Expected: clean working tree, the new commit lists the six files above.
+
+---
+
+## Acceptance Criteria Cross-Check
+
+Mapping each spec requirement to the task that implements it:
+
+| Spec | Task |
+|---|---|
+| FR-1: Remove `Platform` property from `MarketingTransaction` | Task 5 |
+| FR-2: Remove `Platform` initializer from `MetaAdsTransactionSource` | Task 1 |
+| FR-3: Remove `Platform` initializer from `GoogleAdsTransactionSource` | Task 2 |
+| FR-4: Clean up test data that sets the removed property | Tasks 3, 4 |
+| FR-5: Preserve import behavior end-to-end | Task 6, Steps 3–6 (passing test suite + diff inspection) |
+| NFR-4: Backwards compatibility (no migration, no API change) | Task 6, Steps 4–5 |
+
+## Risks (from arch review) — Mitigation Status
+
+- *A consumer outside the explored set reads `MarketingTransaction.Platform`.* → Task 5 Step 2 fails the build fast on any missed read; the grep in Task 6 Step 5 confirms zero stragglers.
+- *Adapter unit-tests assert `tx.Platform` and would fail.* → Known; addressed in Task 4.
+- *Accidental EF model change* → Task 6 Step 4 explicitly checks for pending model changes.
+- *Hidden serialization of `MarketingTransaction`* → Arch review's grep showed none; passing tests in Task 6 are the runtime check.

--- a/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs
@@ -36,7 +36,6 @@ public class GoogleAdsTransactionSource : IMarketingTransactionSource
         var transactions = rows.Select(r => new MarketingTransaction
         {
             TransactionId = r.Id,
-            Platform = Platform,
             Amount = r.AmountServedMicros / 1_000_000m,
             TransactionDate = r.StartDate,
             Currency = r.CurrencyCode,

--- a/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs
@@ -65,7 +65,6 @@ public class MetaAdsTransactionSource : IMarketingTransactionSource
                     results.Add(new MarketingTransaction
                     {
                         TransactionId = item.Id,
-                        Platform = Platform,
                         Amount = item.Amount / 100m,
                         TransactionDate = txDate,
                         Currency = item.Currency,

--- a/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs
@@ -3,7 +3,6 @@ namespace Anela.Heblo.Domain.Features.MarketingInvoices;
 public class MarketingTransaction
 {
     public string TransactionId { get; set; } = string.Empty;
-    public string Platform { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public DateTime TransactionDate { get; set; }
     public string Description { get; set; } = string.Empty;

--- a/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
@@ -25,7 +25,6 @@ public class GoogleAdsTransactionSourceTests
         transactions.Should().HaveCount(1);
         var tx = transactions[0];
         tx.TransactionId.Should().Be("budget-001");
-        tx.Platform.Should().Be("GoogleAds");
         tx.Amount.Should().Be(15m); // 15_000_000 micros / 1_000_000
         tx.Currency.Should().Be("CZK");
         tx.Description.Should().Be("Spring Campaign Budget");

--- a/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs
@@ -69,7 +69,6 @@ public class MetaAdsTransactionSourceTests
         tx.Amount.Should().Be(1500.00m);
         tx.Currency.Should().Be("CZK");
         tx.Description.Should().Be("THRESHOLD");
-        tx.Platform.Should().Be("MetaAds");
         tx.TransactionDate.Should().Be(DateTimeOffset.FromUnixTimeSeconds(1744300800).UtcDateTime);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs
@@ -35,8 +35,8 @@ public class MarketingInvoiceImportServiceTests
 
         var transactions = new List<MarketingTransaction>
         {
-            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
-            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
         };
 
         _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -71,7 +71,7 @@ public class MarketingInvoiceImportServiceTests
 
         var transactions = new List<MarketingTransaction>
         {
-            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
         };
 
         _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -100,8 +100,8 @@ public class MarketingInvoiceImportServiceTests
 
         var transactions = new List<MarketingTransaction>
         {
-            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
-            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
         };
 
         _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -136,8 +136,8 @@ public class MarketingInvoiceImportServiceTests
 
         var transactions = new List<MarketingTransaction>
         {
-            new() { TransactionId = "TX-001", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
-            new() { TransactionId = "TX-002", Platform = "TestPlatform", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-002", Amount = 200m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
         };
 
         _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -194,8 +194,8 @@ public class MarketingInvoiceImportServiceTests
         // Same TransactionId returned twice by the source in one run
         var transactions = new List<MarketingTransaction>
         {
-            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
-            new() { TransactionId = "TX-DUP", Platform = "TestPlatform", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-DUP", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+            new() { TransactionId = "TX-DUP", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
         };
 
         _mockSource.Setup(x => x.GetTransactionsAsync(from, to, It.IsAny<CancellationToken>()))
@@ -234,7 +234,6 @@ public class MarketingInvoiceImportServiceTests
             new()
             {
                 TransactionId = "TX-EUR-001",
-                Platform = "TestPlatform",
                 Amount = 123.45m,
                 TransactionDate = from,
                 Description = "campaign X",
@@ -286,7 +285,6 @@ public class MarketingInvoiceImportServiceTests
             new()
             {
                 TransactionId = "TX-BAD-001",
-                Platform = "TestPlatform",
                 Amount = 100m,
                 TransactionDate = from,
                 Description = "missing currency",
@@ -339,7 +337,6 @@ public class MarketingInvoiceImportServiceTests
             new()
             {
                 TransactionId = "TX-WS-001",
-                Platform = "TestPlatform",
                 Amount = 50m,
                 TransactionDate = from,
                 Description = "whitespace currency",

--- a/docs/superpowers/plans/2026-05-26-remove-marketingtransaction-platform.md
+++ b/docs/superpowers/plans/2026-05-26-remove-marketingtransaction-platform.md
@@ -1,0 +1,531 @@
+# Remove Unused `Platform` Field from `MarketingTransaction` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the dead `Platform` property from the `MarketingTransaction` domain DTO and every write/read site, eliminating a misleading affordance from the MarketingInvoices module while keeping import behavior byte-identical.
+
+**Architecture:** Compiler-driven dead-code removal in the Domain layer's in-memory DTO. The persisted entity `ImportedMarketingTransaction.Platform` is unchanged — it is populated from `source.Platform` (interface-level value), which remains authoritative. No migration, no API contract change, no frontend impact.
+
+**Tech Stack:** C# / .NET 8, xUnit, FluentAssertions, EF Core (read-only impact verification).
+
+**TDD note:** This is a refactor with **no behavior change**, so there is no new failing test to write. The existing test suite is the safety net — every task validates by running the suite and confirming it still passes (green → green). The change progresses from leaves to root (writes → property declaration) so the build stays green between every step.
+
+---
+
+## File Touch Map
+
+| Path | Change |
+|---|---|
+| `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs` | Remove `Platform = Platform,` initializer line. |
+| `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs` | Remove `Platform = Platform,` initializer line. |
+| `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` | Remove `Platform = "TestPlatform",` from 12 `MarketingTransaction` initializer sites. |
+| `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs` | Delete `tx.Platform.Should().Be("MetaAds");` assertion. |
+| `backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs` | Delete `tx.Platform.Should().Be("GoogleAds");` assertion. |
+| `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs` | Delete `Platform` property declaration. |
+
+**Do NOT touch:**
+- `IMarketingTransactionSource` — interface-level `Platform` property stays (`source.Platform` is what the service actually reads).
+- `ImportedMarketingTransaction` and `ImportedMarketingTransactionConfiguration` — DB column and index unchanged.
+- `MarketingInvoiceImportService.cs` — already uses `source.Platform`; verify, don't edit.
+- Adapter `Platform => PlatformName` properties on `MetaAdsTransactionSource` / `GoogleAdsTransactionSource` — these implement the interface and stay.
+- `ImportMarketingInvoicesHandlerTests.cs`, `MetaAdsInvoiceImportJobTests.cs`, `GoogleAdsInvoiceImportJobTests.cs` — their `Platform =` references are on `ImportMarketingInvoicesRequest`/`Response`, not `MarketingTransaction`.
+
+---
+
+## Task 0: Verify Baseline
+
+Establish that the suite is green on the current branch before changing anything.
+
+**Files:** None.
+
+- [ ] **Step 1: Build the backend solution**
+
+Run from repo root:
+
+```bash
+dotnet build backend/Anela.Heblo.sln -warnaserror
+```
+
+Expected: build succeeds with zero errors/warnings. If warnings exist already on the branch, note them — they are pre-existing and not in scope.
+
+- [ ] **Step 2: Run the targeted test slice**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices|FullyQualifiedName~MetaAds|FullyQualifiedName~GoogleAds" \
+  --no-build
+```
+
+Expected: all tests pass. Record the count of passing tests (e.g., "N passed, 0 failed, 0 skipped") so you can confirm it does not regress after the refactor.
+
+- [ ] **Step 3: Verify no pending EF model changes**
+
+```bash
+dotnet ef migrations has-pending-model-changes \
+  --project backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj \
+  --startup-project backend/src/Anela.Heblo/Anela.Heblo.csproj
+```
+
+Expected: "No model changes detected." (or equivalent). This sets a baseline so the post-change check is meaningful.
+
+> If `dotnet ef` is not installed in the environment, fall back to `dotnet ef migrations list ...` and record the most-recent migration name. The relevant check is that this name does not change after the refactor.
+
+---
+
+## Task 1: Remove `Platform` Initializer from `MetaAdsTransactionSource`
+
+Strip the write site in the Meta adapter. The domain property still exists, so the build stays green.
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs:68`
+
+- [ ] **Step 1: Edit the file**
+
+Remove the single line at position 68 inside the `new MarketingTransaction { ... }` initializer.
+
+**Before** (lines 65–74):
+
+```csharp
+results.Add(new MarketingTransaction
+{
+    TransactionId = item.Id,
+    Platform = Platform,
+    Amount = item.Amount / 100m,
+    TransactionDate = txDate,
+    Currency = item.Currency,
+    Description = item.PaymentType,
+    RawData = JsonSerializer.Serialize(item, JsonOptions),
+});
+```
+
+**After**:
+
+```csharp
+results.Add(new MarketingTransaction
+{
+    TransactionId = item.Id,
+    Amount = item.Amount / 100m,
+    TransactionDate = txDate,
+    Currency = item.Currency,
+    Description = item.PaymentType,
+    RawData = JsonSerializer.Serialize(item, JsonOptions),
+});
+```
+
+> The adapter-level `Platform => PlatformName` property (member of the class, implementing `IMarketingTransactionSource.Platform`) is untouched — keep it.
+
+- [ ] **Step 2: Verify file compiles**
+
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/Anela.Heblo.Adapters.MetaAds.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Run adapter tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MetaAds" --no-build
+```
+
+Expected: all tests pass. (The `tx.Platform.Should().Be("MetaAds")` assertion still passes because the property is still on the class with its default value of `string.Empty`... wait — it asserts `"MetaAds"`, not the default. The assertion will now FAIL after this step because the initializer no longer sets it.)
+
+> **Expected failure at this step:** the test `GetTransactionsAsync_Amount_ConvertedFromCentsToDecimal` (or whichever test contains the line 72 assertion) will fail with FluentAssertions reporting `Expected tx.Platform to be "MetaAds", but found ""`. **This is intentional and will be fixed in Task 4.** Do not commit yet.
+
+---
+
+## Task 2: Remove `Platform` Initializer from `GoogleAdsTransactionSource`
+
+Mirror Task 1 for the Google adapter.
+
+**Files:**
+- Modify: `backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs:39`
+
+- [ ] **Step 1: Edit the file**
+
+Remove the single line at position 39 inside the `new MarketingTransaction { ... }` initializer.
+
+**Before** (lines 36–45):
+
+```csharp
+var transactions = rows.Select(r => new MarketingTransaction
+{
+    TransactionId = r.Id,
+    Platform = Platform,
+    Amount = r.AmountServedMicros / 1_000_000m,
+    TransactionDate = r.StartDate,
+    Currency = r.CurrencyCode,
+    Description = r.Name ?? "Google Ads billing period",
+    RawData = JsonSerializer.Serialize(r),
+}).ToList();
+```
+
+**After**:
+
+```csharp
+var transactions = rows.Select(r => new MarketingTransaction
+{
+    TransactionId = r.Id,
+    Amount = r.AmountServedMicros / 1_000_000m,
+    TransactionDate = r.StartDate,
+    Currency = r.CurrencyCode,
+    Description = r.Name ?? "Google Ads billing period",
+    RawData = JsonSerializer.Serialize(r),
+}).ToList();
+```
+
+> The class-level `Platform => PlatformName` property is untouched.
+
+- [ ] **Step 2: Verify file compiles**
+
+```bash
+dotnet build backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/Anela.Heblo.Adapters.GoogleAds.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Note expected adapter test failure**
+
+The Google adapter test on line 28 (`tx.Platform.Should().Be("GoogleAds");`) will now fail for the same reason as the Meta one. Do not run tests separately here — they will be fixed in Task 4 and validated then.
+
+---
+
+## Task 3: Clean Up `MarketingInvoiceImportServiceTests` Initializers
+
+Remove every `Platform = "TestPlatform",` site in the service unit tests. There are 12 sites: 9 inline initializers and 3 multi-line block initializers (verified by grep).
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs`
+
+Lines affected (per grep `Platform\s*=` against the file):
+- Lines 38, 39, 74, 103, 104, 139, 140, 197, 198 — inline `new() { ..., Platform = "TestPlatform", ... }` literals (delete the substring `Platform = "TestPlatform", ` from each).
+- Lines 237, 289, 342 — multi-line `new() { ... Platform = "TestPlatform", ... }` (delete the entire line plus its trailing newline).
+
+- [ ] **Step 1: Edit inline sites (lines 38, 39, 74, 103, 104, 139, 140, 197, 198)**
+
+For each of these lines the substring `Platform = "TestPlatform", ` (including the trailing comma + space) appears exactly once between `TransactionId = ...,` and `Amount = ...,`. Use Edit with `replace_all` against the exact substring to delete it in one operation.
+
+**Exact substring to remove** (appears in 9 sites):
+
+```
+Platform = "TestPlatform", 
+```
+
+(Note the single trailing space before `Amount`.)
+
+After the edit, each affected line should read:
+
+```csharp
+new() { TransactionId = "TX-001", Amount = 100m, TransactionDate = from, Description = "Ad charge", Currency = "CZK" },
+```
+
+…and similarly for the other transaction IDs (`"TX-002"`, `"TX-DUP"`).
+
+- [ ] **Step 2: Edit multi-line initializers (lines 237, 289, 342)**
+
+Each of these sites is a property line of its own within a `new() { ... }` initializer. Delete the full line, including the leading whitespace and trailing comma+newline.
+
+For line 237 — before:
+
+```csharp
+            {
+                TransactionId = "TX-EUR-001",
+                Platform = "TestPlatform",
+                Amount = 123.45m,
+                ...
+            },
+```
+
+After:
+
+```csharp
+            {
+                TransactionId = "TX-EUR-001",
+                Amount = 123.45m,
+                ...
+            },
+```
+
+Apply the same deletion for the multi-line initializers around lines 289 (`TransactionId = "TX-BAD-001"`) and 342 (`TransactionId = "TX-WS-001"`).
+
+- [ ] **Step 3: Verify the file is clean**
+
+Run from repo root:
+
+```bash
+grep -n "Platform" backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs || echo "no matches"
+```
+
+Expected matches are limited to references on **other types**:
+- `_mockRepository.Setup(x => x.ExistsAsync("TestPlatform", ...))` — argument string, not a property assignment. **Keep.**
+- `v.ToString()!.Contains("TestPlatform")` inside a logger Verify — keep.
+- `Mock<IMarketingTransactionSource>` setup where `source.Platform` is mocked (e.g., `_mockSource.Setup(x => x.Platform).Returns("TestPlatform")` if present) — keep.
+
+There must be **zero** remaining occurrences of `Platform = "TestPlatform"` (the property-assignment form). If grep still shows any, repeat Step 1/Step 2 against the missed line.
+
+- [ ] **Step 4: Build the test project**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds.
+
+---
+
+## Task 4: Remove Adapter-Test Assertions on `tx.Platform`
+
+Delete the two assertions that read `MarketingTransaction.Platform`. They assert a constant (`"MetaAds"` / `"GoogleAds"`) that is already exercised indirectly via `IMarketingTransactionSource.Platform` and adds no coverage.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs:72`
+- Modify: `backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs:28`
+
+- [ ] **Step 1: Delete the Meta assertion**
+
+In `MetaAdsTransactionSourceTests.cs`, remove the entire line 72:
+
+```csharp
+        tx.Platform.Should().Be("MetaAds");
+```
+
+The surrounding assertions (`tx.TransactionId`, `tx.Amount`, `tx.Currency`, `tx.Description`, `tx.TransactionDate`) stay.
+
+- [ ] **Step 2: Delete the Google assertion**
+
+In `GoogleAdsTransactionSourceTests.cs`, remove the entire line 28:
+
+```csharp
+        tx.Platform.Should().Be("GoogleAds");
+```
+
+The surrounding assertions (`tx.TransactionId`, `tx.Amount`, `tx.Currency`, `tx.Description`, `tx.TransactionDate`) stay.
+
+- [ ] **Step 3: Build the test project**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Run the targeted test slice**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices|FullyQualifiedName~MetaAds|FullyQualifiedName~GoogleAds" \
+  --no-build
+```
+
+Expected: all tests pass. **The count must match the Task 0 baseline minus zero** — no tests should be missing; the only changes were deletions of assertion lines, not whole tests.
+
+> If a test fails here with `Platform` in the message, you missed a reference. Re-grep with `grep -n "tx\.Platform\|\.Platform\.Should" backend/test/Anela.Heblo.Tests/...` and clean up.
+
+---
+
+## Task 5: Delete the `Platform` Property from `MarketingTransaction`
+
+With all writes and reads removed, deleting the property declaration is safe. The compiler will fail-fast on any stragglers.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs`
+
+- [ ] **Step 1: Edit the file**
+
+**Before:**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+**After:**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class MarketingTransaction
+{
+    public string TransactionId { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime TransactionDate { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string Currency { get; set; } = string.Empty;
+    public string? RawData { get; set; }
+}
+```
+
+(Single-line deletion: `    public string Platform { get; set; } = string.Empty;`.)
+
+- [ ] **Step 2: Build the whole solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln -warnaserror
+```
+
+Expected: build succeeds with zero errors. If you see any `CS0117: 'MarketingTransaction' does not contain a definition for 'Platform'`, the failing site was missed in Task 1–4 — fix it in the file pointed to by the compiler and rerun.
+
+- [ ] **Step 3: Confirm `MarketingInvoiceImportService` still uses `source.Platform` (no edit required)**
+
+Open `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` and read around line 70. Verify that the assignment to `ImportedMarketingTransaction.Platform` reads `source.Platform`, not `tx.Platform` (it should already, per the spec and arch review). No edit; this is a sanity check.
+
+If somehow `tx.Platform` is referenced anywhere in this file, the build in Step 2 would have failed — so a passing build is the actual proof. Step 3 just documents the invariant for the reviewer.
+
+---
+
+## Task 6: Final Validation, Format, Commit
+
+Comprehensive validation against the spec's acceptance criteria.
+
+**Files:** All changes from Tasks 1–5.
+
+- [ ] **Step 1: Format touched files**
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs \
+            backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs \
+            backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs \
+            backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs \
+            backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs \
+            backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+```
+
+Expected: no output (or "Format complete"). If the formatter rewrites any of the touched files, `git diff` should still show only the property/initializer/assertion deletions plus, at worst, whitespace normalization.
+
+- [ ] **Step 2: Full backend build with warnings as errors**
+
+```bash
+dotnet build backend/Anela.Heblo.sln -warnaserror
+```
+
+Expected: build succeeds, zero warnings introduced by this change.
+
+- [ ] **Step 3: Full test run (all backend tests)**
+
+```bash
+dotnet test backend/Anela.Heblo.Tests --no-build
+```
+
+Or, more targeted but still comprehensive:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: all tests pass. Count must equal the Task 0 baseline (we removed two adapter-test assertions but no `[Fact]`/`[Theory]` declarations, so the test count is unchanged).
+
+- [ ] **Step 4: Verify no EF migration is pending**
+
+```bash
+dotnet ef migrations has-pending-model-changes \
+  --project backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj \
+  --startup-project backend/src/Anela.Heblo/Anela.Heblo.csproj
+```
+
+Expected: "No model changes detected." — matches Task 0, confirms the persisted `ImportedMarketingTransaction` schema is untouched.
+
+- [ ] **Step 5: Grep for leftover references to the removed property**
+
+```bash
+grep -rn "MarketingTransaction.*Platform\|tx\.Platform\|transaction\.Platform" \
+  backend/src backend/test --include="*.cs"
+```
+
+Expected: no matches in production code or tests for `tx.Platform` / `transaction.Platform`. The `MarketingTransaction.*Platform` pattern may still match incidentally on unrelated whitespace (e.g. comments mentioning the change in commit history aren't grepped from source — only `.cs` files); inspect any hits and confirm they're false positives (e.g. references to `ImportMarketingInvoicesRequest.Platform` or `ImportMarketingInvoicesResponse.Platform`, which are different types).
+
+- [ ] **Step 6: Inspect the staged diff**
+
+```bash
+git diff --stat
+git diff
+```
+
+Expected diff scope (6 files, ~17 line deletions, 0 additions outside whitespace):
+
+| File | Approx. line delta |
+|---|---|
+| `MarketingTransaction.cs` | −1 |
+| `MetaAdsTransactionSource.cs` | −1 |
+| `GoogleAdsTransactionSource.cs` | −1 |
+| `MarketingInvoiceImportServiceTests.cs` | −12 (9 inline edits + 3 line deletions) |
+| `MetaAdsTransactionSourceTests.cs` | −1 |
+| `GoogleAdsTransactionSourceTests.cs` | −1 |
+
+If any other file is modified, investigate: was `dotnet format` overly aggressive, or did an edit slip into the wrong file?
+
+- [ ] **Step 7: Commit**
+
+Single atomic commit — the changes form one logical refactor.
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/MarketingTransaction.cs \
+        backend/src/Adapters/Anela.Heblo.Adapters.MetaAds/MetaAdsTransactionSource.cs \
+        backend/src/Adapters/Anela.Heblo.Adapters.GoogleAds/GoogleAdsTransactionSource.cs \
+        backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs \
+        backend/test/Anela.Heblo.Tests/Adapters/MetaAds/MetaAdsTransactionSourceTests.cs \
+        backend/test/Anela.Heblo.Tests/Adapters/GoogleAds/GoogleAdsTransactionSourceTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: remove unused Platform field from MarketingTransaction
+
+The per-transaction Platform property on MarketingTransaction was written
+by both adapters (MetaAds, GoogleAds) but never read by any consumer.
+MarketingInvoiceImportService.ImportAsync uses source.Platform
+(IMarketingTransactionSource.Platform) when persisting
+ImportedMarketingTransaction — that path is unchanged.
+
+- Drop the Platform property from the domain DTO.
+- Drop Platform = Platform initializers in MetaAds and GoogleAds adapters.
+- Drop Platform = "TestPlatform" initializers in MarketingInvoiceImportServiceTests.
+- Drop tx.Platform assertions in MetaAds/GoogleAds adapter tests (they
+  asserted a constant already covered by source.Platform).
+
+No public API, persisted schema, or OpenAPI client is affected. The
+ImportedMarketingTransaction column and its Platform/TransactionId index
+remain unchanged.
+EOF
+)"
+```
+
+- [ ] **Step 8: Confirm commit and clean tree**
+
+```bash
+git status
+git log -1 --stat
+```
+
+Expected: clean working tree, the new commit lists the six files above.
+
+---
+
+## Acceptance Criteria Cross-Check
+
+Mapping each spec requirement to the task that implements it:
+
+| Spec | Task |
+|---|---|
+| FR-1: Remove `Platform` property from `MarketingTransaction` | Task 5 |
+| FR-2: Remove `Platform` initializer from `MetaAdsTransactionSource` | Task 1 |
+| FR-3: Remove `Platform` initializer from `GoogleAdsTransactionSource` | Task 2 |
+| FR-4: Clean up test data that sets the removed property | Tasks 3, 4 |
+| FR-5: Preserve import behavior end-to-end | Task 6, Steps 3–6 (passing test suite + diff inspection) |
+| NFR-4: Backwards compatibility (no migration, no API change) | Task 6, Steps 4–5 |
+
+## Risks (from arch review) — Mitigation Status
+
+- *A consumer outside the explored set reads `MarketingTransaction.Platform`.* → Task 5 Step 2 fails the build fast on any missed read; the grep in Task 6 Step 5 confirms zero stragglers.
+- *Adapter unit-tests assert `tx.Platform` and would fail.* → Known; addressed in Task 4.
+- *Accidental EF model change* → Task 6 Step 4 explicitly checks for pending model changes.
+- *Hidden serialization of `MarketingTransaction`* → Arch review's grep showed none; passing tests in Task 6 are the runtime check.


### PR DESCRIPTION
MarketingInvoices

## Finding
`MarketingTransaction.Platform` (`Domain/Features/MarketingInvoices/MarketingTransaction.cs:6`) is populated by both source adapters but never consumed by the import service.

Both adapters set it:
- `MetaAdsTransactionSource.cs:68`: `Platform = Platform`
- `GoogleAdsTransactionSource.cs:39`: `Platform = Platform`

But `MarketingInvoiceImportService.ImportAsync` always uses `source.Platform` when constructing `ImportedMarketingTransaction` (`Services/MarketingInvoiceImportService.cs:70`):
```csharp
Platform = source.Platform,   // transaction.Platform is never read
```

`transaction.Platform` has zero read sites in the entire codebase. Test data populates it, but no assertion ever checks it.

## Why it matters
The field creates a false impression that platform can vary per transaction (rather than being authoritative from the source), and suggests that the service validates or reconciles per-transaction vs source platform. A future developer could reasonably add logic that reads `transaction.Platform` expecting the service to honor it — silently getting no effect. It's YAGNI code in the domain contract.

## Suggested fix
Remove `Platform` from `MarketingTransaction`:
```csharp
// Domain/Features/MarketingInvoices/MarketingTransaction.cs
public class MarketingTransaction
{
    public string TransactionId { get; set; } = string.Empty;
    // Remove: public string Platform { get; set; } = string.Empty;
    public decimal Amount { get; set; }
    public DateTime TransactionDate { get; set; }
    public string Description { get; set; } = string.Empty;
    public string Currency { get; set; } = string.Empty;
    public string? RawData { get; set; }
}
```
Remove the `Platform = Platform` initializer line from both adapter source files.

---
_Filed by daily arch-review routine on 2026-05-26._

---

Closes #1718

### Tokens used
20221910
