### PR TITLE
feat: Remove Unimplemented Sync Scaffolding from MarketingInvoices

### DIFF
--- a/answers.md
+++ b/answers.md
@@ -1,38 +1,34 @@
 ### Question 1
-`steps` element typing. If the generated `GetArticleTraceResponse.steps` element type does not match the local `ArticleGenerationStep` interface exactly, is a single narrow cast `as ArticleGenerationStep[]` acceptable (as the brief's suggested fix uses), or should the local interface be aligned with the generated type instead?
+Which option should be implemented — A (build the sync workflow) or B (remove the scaffolding)? The brief states "Option B is cheaper now; option A is the right call only when the sync workflow is actively being built." Is the accounting-system sync on the near-term roadmap, or should we remove the scaffolding now and re-add it when the sync work is actually scheduled?
 
-**Answer:** **Neither — explicitly map each generated `ArticleGenerationStepDto` to the local `ArticleGenerationStep` shape inside the query function, mirroring the existing mapping pattern used by `useGetArticleQuery` for `sources` (`frontend/src/api/hooks/useArticles.ts:170-182`) and for `createdAt`/`generatedAt` (`...:166-167`).** Do **not** use a blanket `as ArticleGenerationStep[]` cast and do **not** modify the local `ArticleGenerationStep` interface. Concretely, the refactored hook should produce each step as:
+**Answer:** Option B — remove the scaffolding now.
 
-```typescript
-steps: (data.steps ?? []).map((step) => ({
-  id: step.id ?? '',
-  stepName: step.stepName ?? '',
-  sequence: step.sequence ?? 0,
-  status: step.status ?? '',
-  startedAt: step.startedAt?.toISOString() ?? '',
-  finishedAt: step.finishedAt?.toISOString() ?? null,
-  durationMs: step.durationMs ?? null,
-  model: step.model ?? null,
-  inputJson: step.inputJson ?? null,
-  outputJson: step.outputJson ?? null,
-  errorMessage: step.errorMessage ?? null,
-})),
-```
-
-The same mapping discipline (do not cast, project explicitly) MUST also be applied in **`useArticleFeedbackListQuery`**: the generated `GetArticleFeedbackListResponse` exposes `items` (not `articles`), each item has `createdAt` (not `generatedAt`) and `hasComment` (not `hasFeedback`), and no `feedbackComment` field at all — so `return data;` will not satisfy the consumer-facing `ArticleFeedbackListResponse` shape that `useArticleFeedbackAdapter.ts:15-25` reads. The hook MUST project the generated response into the existing local interface (`articles` ← `items`, `generatedAt` ← `createdAt.toISOString()`, `hasFeedback` ← `hasComment`, `feedbackComment` ← `null` for now), preserving FR-4 (no consumer changes).
-
-**Rationale:** Direct inspection of the generated client confirms the types genuinely differ, not just nominally: `ArticleGenerationStepDto.startedAt` is `Date | undefined` while local `ArticleGenerationStep.startedAt` is `string`; `finishedAt` is `Date | undefined` vs `string | null`; every field is optional on the generated DTO but required on the local interface (`frontend/src/api/generated/api-client.ts:13077-13151` vs `frontend/src/api/hooks/useArticleTrace.ts:4-16`). A `as ArticleGenerationStep[]` cast would lie to TypeScript about the date types and re-introduce the same "stale `as any`" class of fragility this refactor is removing — defeating NFR-2. Explicit mapping is already the codebase's established pattern (sources, createdAt, generatedAt in `useGetArticleQuery`), so this answer keeps one pattern across all Article hooks (NFR-4) and surfaces any future generated-shape drift at compile time. The local interface stays untouched because it is the consumer-facing contract and changing it would expand scope beyond FR-4. The feedback-list extension of the same answer is mandatory because returning the generated DTO directly there would silently break the existing consumer adapter (`useArticleFeedbackAdapter.ts`) which reads field names that don't exist on the generated type.
+**Rationale:** The original shared-core design (`docs/superpowers/specs/2026-04-14-marketing-invoice-import-shared-core-design.md:50`) explicitly defers the sync to a "future FlexiBee phase," and epic #609 lists "FlexiBee received invoice creation from stored transactions" under **Future Work (not in scope)**. No open issue, PR, or plan in the repo schedules that work today. Per YAGNI and the established `IssuedInvoice` precedent (which uses a richer `SyncSucceeded` / `SyncFailed` API with sync-history rows, `LastSyncTime`, and `ErrorType` — not a single `bool IsSynced` + `text ErrorMessage` pair), any future sync implementation would almost certainly redesign these fields rather than reuse them as-is, so removing now is strictly cheaper than carrying speculative scaffolding.
 
 ### Question 2
-Follow-up for `useSubmitArticleFeedbackMutation`. Should this refactor also file a tracking issue / TODO comment flagging that mutation for a future review (it still uses `(apiClient as any).baseUrl`)?
+(If Option A) Which accounting system is the sync target, and what is the transport (REST, SOAP, file drop, queue)?
 
-**Answer:** **Add a single-line `// TODO` comment at the raw-fetch site, no separate GitHub issue.** Place it immediately above the `const fullUrl = ...` line at `frontend/src/api/hooks/useArticles.ts:222`, worded: `// TODO(arch-review 2026-05-25): Uses private apiClient internals (baseUrl/http) via `as any` — same fragility as the hooks refactored in this PR. Keep raw fetch only for 409 branch; revisit when generated client exposes typed-mutation 409 handling.` Do **not** touch the mutation's behavior, do **not** change the fetch call. The TODO carries the date and the justification so future readers see why this one mutation was left as-is.
+**Answer:** Not applicable — Option B is chosen. For the record, if Option A were ever revived, the target would be **FlexiBee** (named explicitly in epic #609 and the shared-core spec) via the existing FlexiBee REST adapter that already backs `IssuedInvoice` sync — creating received-invoice documents from `ImportedMarketingTransaction` rows.
 
-**Rationale:** The project is a solo-dev workspace with AI-assisted PR review (per `CLAUDE.md` "Project facts"), so a GitHub issue adds tracking overhead with negligible discovery benefit over an in-file `// TODO` that any future reader of `useArticles.ts` will encounter the moment they look at the function. The dated TODO meets the spec's FR-5 requirement that the mutation be flagged for follow-up, satisfies the "Surgical changes" rule (one line, no behavior change), and keeps the technical-debt note co-located with the code it describes (which a GitHub issue would not).
+**Rationale:** Option B is the chosen direction (see Question 1). The target system is documented from prior artifacts only so a future implementer has a starting point.
 
 ### Question 3
-Authenticated-client accessor name. The brief uses `getAuthenticatedApiClient()`; confirm this matches the actual exported helper used by `useListArticlesQuery` in this codebase.
+(If Option A) What is the desired trigger model — scheduled background service, on-demand command, or both? And what schedule/cadence?
 
-**Answer:** **Confirmed — use `getAuthenticatedApiClient` exactly.** It is exported from `frontend/src/api/client.ts:232`, imported by `useArticleTrace.ts:2` and `useArticles.ts:2` already, and is the helper `useListArticlesQuery` calls at `useArticles.ts:129`. All three refactored hooks (`useArticleTraceQuery`, `useArticleFeedbackListQuery`, `useGetArticleQuery`) already import it; no new import is required. Do **not** use the alternative `getAuthenticatedApiClientWithProvider` (`client.ts:342`) — that variant is for callers that want to inject a custom token provider and is not the project's standard accessor.
+**Answer:** Not applicable — Option B is chosen. For the record, if Option A were ever revived, the project's established pattern is a Hangfire recurring job (mirroring `MetaAdsInvoiceImportJob` / `GoogleAdsInvoiceImportJob`, registered through the Recurring Jobs admin UI) running shortly after the import jobs (e.g., 06:30 and 18:30 daily), with an on-demand manual trigger exposed through the same admin UI.
 
-**Rationale:** Grep across `frontend/src` confirms `getAuthenticatedApiClient` is the singular accessor used by every Article hook today, including the two outliers (`useArticleTraceQuery:27`, `useArticleFeedbackListQuery:260`) that already obtain the client through it before falling back to raw fetch — so the refactor merely uses the already-obtained client's typed methods instead of poking at its private fields. The provider variant exists for a different use case (custom auth provider injection) and applying it here would expand scope beyond the brief and break FR-4's "no consumer changes" guarantee.
+**Rationale:** Option B is the chosen direction. The Hangfire-based, admin-toggleable pattern is the consistent project convention for periodic external-system writes.
+
+### Question 4
+(If Option A) What are the retry semantics for failed posts — bounded retries, indefinite retry until success, dead-letter after N attempts?
+
+**Answer:** Not applicable — Option B is chosen. For the record, if Option A were ever revived, retries should follow the `IssuedInvoice` precedent: indefinite retry on the next scheduled run while `IsSynced = false`, with a structured `ErrorType` distinguishing transient (retry) from permanent (do not retry / surface for manual review) failures, and the error string persisted on the entity for diagnostics.
+
+**Rationale:** Option B is the chosen direction. The `IssuedInvoice` model (`IsCriticalError` gated on `ErrorType != InvoicePaired`) already encodes the right precedent if revival ever happens.
+
+### Question 5
+(If Option B) Are there any pending PRs or in-flight work that already reference `GetUnsyncedAsync`, `IsSynced`, or `ErrorMessage` and would conflict with their removal? (Worth confirming before the migration is generated.)
+
+**Answer:** Yes — two open PRs touch the same module and must be sequenced. PR **#1771** (`feat-arch-review-marketinginvoices-iimportedm`) edits `IImportedMarketingTransactionRepository.AddAsync` and the concrete repository — the same interface and class this spec modifies. PR **#1766** (`feat-arch-review-marketinginvoices-marketingt`) removes `MarketingTransaction.Platform` and touches `MarketingInvoiceImportService.cs` near the entity-construction block where `IsSynced = false` is set. No other open PR, issue, or branch in the repo reads or writes `GetUnsyncedAsync`, `IsSynced`, or `ErrorMessage`.
+
+**Rationale:** `gh pr list --search "MarketingInvoice"` returns only #1771, #1766, and the long-running shared-core PR #616 (which originally introduced these fields and is irrelevant to current head). Sequence: merge whichever of #1771/#1766 lands first, then rebase this branch onto `main` before generating the EF migration so the migration is generated against the latest schema snapshot and no merge conflicts hit the interface or service files.

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/answers.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/answers.r1.md
@@ -1,0 +1,34 @@
+### Question 1
+Which option should be implemented — A (build the sync workflow) or B (remove the scaffolding)? The brief states "Option B is cheaper now; option A is the right call only when the sync workflow is actively being built." Is the accounting-system sync on the near-term roadmap, or should we remove the scaffolding now and re-add it when the sync work is actually scheduled?
+
+**Answer:** Option B — remove the scaffolding now.
+
+**Rationale:** The original shared-core design (`docs/superpowers/specs/2026-04-14-marketing-invoice-import-shared-core-design.md:50`) explicitly defers the sync to a "future FlexiBee phase," and epic #609 lists "FlexiBee received invoice creation from stored transactions" under **Future Work (not in scope)**. No open issue, PR, or plan in the repo schedules that work today. Per YAGNI and the established `IssuedInvoice` precedent (which uses a richer `SyncSucceeded` / `SyncFailed` API with sync-history rows, `LastSyncTime`, and `ErrorType` — not a single `bool IsSynced` + `text ErrorMessage` pair), any future sync implementation would almost certainly redesign these fields rather than reuse them as-is, so removing now is strictly cheaper than carrying speculative scaffolding.
+
+### Question 2
+(If Option A) Which accounting system is the sync target, and what is the transport (REST, SOAP, file drop, queue)?
+
+**Answer:** Not applicable — Option B is chosen. For the record, if Option A were ever revived, the target would be **FlexiBee** (named explicitly in epic #609 and the shared-core spec) via the existing FlexiBee REST adapter that already backs `IssuedInvoice` sync — creating received-invoice documents from `ImportedMarketingTransaction` rows.
+
+**Rationale:** Option B is the chosen direction (see Question 1). The target system is documented from prior artifacts only so a future implementer has a starting point.
+
+### Question 3
+(If Option A) What is the desired trigger model — scheduled background service, on-demand command, or both? And what schedule/cadence?
+
+**Answer:** Not applicable — Option B is chosen. For the record, if Option A were ever revived, the project's established pattern is a Hangfire recurring job (mirroring `MetaAdsInvoiceImportJob` / `GoogleAdsInvoiceImportJob`, registered through the Recurring Jobs admin UI) running shortly after the import jobs (e.g., 06:30 and 18:30 daily), with an on-demand manual trigger exposed through the same admin UI.
+
+**Rationale:** Option B is the chosen direction. The Hangfire-based, admin-toggleable pattern is the consistent project convention for periodic external-system writes.
+
+### Question 4
+(If Option A) What are the retry semantics for failed posts — bounded retries, indefinite retry until success, dead-letter after N attempts?
+
+**Answer:** Not applicable — Option B is chosen. For the record, if Option A were ever revived, retries should follow the `IssuedInvoice` precedent: indefinite retry on the next scheduled run while `IsSynced = false`, with a structured `ErrorType` distinguishing transient (retry) from permanent (do not retry / surface for manual review) failures, and the error string persisted on the entity for diagnostics.
+
+**Rationale:** Option B is the chosen direction. The `IssuedInvoice` model (`IsCriticalError` gated on `ErrorType != InvoicePaired`) already encodes the right precedent if revival ever happens.
+
+### Question 5
+(If Option B) Are there any pending PRs or in-flight work that already reference `GetUnsyncedAsync`, `IsSynced`, or `ErrorMessage` and would conflict with their removal? (Worth confirming before the migration is generated.)
+
+**Answer:** Yes — two open PRs touch the same module and must be sequenced. PR **#1771** (`feat-arch-review-marketinginvoices-iimportedm`) edits `IImportedMarketingTransactionRepository.AddAsync` and the concrete repository — the same interface and class this spec modifies. PR **#1766** (`feat-arch-review-marketinginvoices-marketingt`) removes `MarketingTransaction.Platform` and touches `MarketingInvoiceImportService.cs` near the entity-construction block where `IsSynced = false` is set. No other open PR, issue, or branch in the repo reads or writes `GetUnsyncedAsync`, `IsSynced`, or `ErrorMessage`.
+
+**Rationale:** `gh pr list --search "MarketingInvoice"` returns only #1771, #1766, and the long-running shared-core PR #616 (which originally introduced these fields and is irrelevant to current head). Sequence: merge whichever of #1771/#1766 lands first, then rebase this branch onto `main` before generating the EF migration so the migration is generated against the latest schema snapshot and no merge conflicts hit the interface or service files.

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/arch-review.r1.md
@@ -1,0 +1,213 @@
+# Architecture Review: Remove Unimplemented Sync Scaffolding from MarketingInvoices
+
+## Skip Design: true
+
+Pure backend cleanup — interface method removal, two entity property removals, EF mapping cleanup, and a column-drop migration. No new or changed UI components, screens, layouts, or visual decisions.
+
+## Architectural Fit Assessment
+
+This change is strictly subtractive and aligns perfectly with the existing Clean Architecture layering: `Domain → Persistence → Application` (no inverse coupling). The grep performed during exploration confirms the spec's claim — `GetUnsyncedAsync`, `IsSynced`, and `ErrorMessage` are referenced **only** in:
+
+- `Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs:7` (interface decl)
+- `Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:14-15` (entity props)
+- `Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs:26-28` (concrete impl)
+- `Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs:47-55` (EF mapping)
+- `Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs:75` (one assignment to `false`)
+
+The existing test suite (`MarketingInvoiceImportServiceTests.cs`) never references either property or `GetUnsyncedAsync`, so test stability is guaranteed.
+
+The integration with the codebase's broader patterns is clean:
+- `IssuedInvoice` (the eventually-richer sync precedent) lives in a different module (`Features/Invoices/`) and uses a separate sync-history persistence model. Nothing about that module touches what's being removed here.
+- The schema lives under `public` (per `ImportedMarketingTransactionConfiguration.cs:11`) — **not `dbo`** as the older 2026-04-14 migration suggests. The PascalCase plural table name (`ImportedMarketingTransactions`) is correct per the `StandardizeTableNamingToPascalCase` / `RenameSingularTablesToPluralForm` migrations.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Domain layer
+└── IImportedMarketingTransactionRepository           [−1 method: GetUnsyncedAsync]
+└── ImportedMarketingTransaction (entity)             [−2 props: IsSynced, ErrorMessage]
+
+Persistence layer
+└── ImportedMarketingTransactionRepository            [−1 method body: GetUnsyncedAsync]
+└── ImportedMarketingTransactionConfiguration         [−2 property mappings]
+└── Migrations/
+    └── <timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs   [NEW]
+
+Application layer
+└── MarketingInvoiceImportService                     [−1 line: IsSynced = false]
+
+Test layer
+└── MarketingInvoiceImportServiceTests                [unchanged — no refs]
+└── ImportMarketingInvoicesHandlerTests               [unchanged — verify no refs]
+```
+
+No new files except the migration. No file moves. No DI registration changes (the repository registration in `MarketingInvoicesModule` is interface-based and unaffected).
+
+### Key Design Decisions
+
+#### Decision 1: Keep the migration reversible (`Down` rebuilds the columns)
+**Options considered:**
+- (a) Drop-only migration with empty `Down` (matches "we'll never reuse this schema").
+- (b) Drop with a working `Down` that re-adds `IsSynced bool NOT NULL DEFAULT false` and `ErrorMessage text NULL`.
+
+**Chosen approach:** (b).
+
+**Rationale:** The repo convention (see `20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`) is that every migration has a working `Down`. Migrations are applied manually per environment, so a malformed `Down` can corner a deploy. Even though the spec notes the FlexiBee sync is unlikely to revive these exact columns, the cost of a 4-line `Down` is trivial and preserves the rollback contract.
+
+#### Decision 2: Place the migration on the `public` schema, not `dbo`
+**Options considered:**
+- (a) Use `schema: "dbo"` to match the original 2026-04-14 creation migration.
+- (b) Use `schema: "public"` to match the entity configuration's `builder.ToTable("ImportedMarketingTransactions", "public")` and the `MoveDboTablesToPublicSchema` migration from 2026-04-24.
+
+**Chosen approach:** (b).
+
+**Rationale:** The table has already been moved to `public` and renamed to `ImportedMarketingTransactions` (PascalCase plural) by the 2026-04-24 standardization migrations. Targeting `dbo` would fail at runtime against the current schema head. The most recent migration touching this table (`20260525152436_AddCurrencyDescription...`) targets `public.ImportedMarketingTransactions` — follow that precedent exactly.
+
+#### Decision 3: Remove `IsSynced = false` from the service insert path in the same PR as the entity change
+**Options considered:**
+- (a) Remove the property first (PR-A), then the service-side assignment (PR-B).
+- (b) Single PR: remove property, mapping, interface method, **and** the `IsSynced = false` line together.
+
+**Chosen approach:** (b).
+
+**Rationale:** Removing the property without removing its assignment site would leave the codebase in a non-compiling state mid-PR. The change must be atomic. The spec already groups these under FR-1 through FR-4 within a single deliverable.
+
+#### Decision 4: Do not introduce a deprecation/obsolete phase
+**Options considered:**
+- (a) Mark properties `[Obsolete]` first, ship, then remove.
+- (b) Remove directly.
+
+**Chosen approach:** (b).
+
+**Rationale:** Zero external consumers (confirmed by repo-wide grep). The OpenAPI surface does not expose `ImportedMarketingTransaction` directly — only `MarketingImportResult` is returned by `ImportMarketingInvoicesHandler`. There is no API client, frontend, or external integration relying on these fields. A deprecation phase adds ceremony with no protective value.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+All edits land in their existing files. Only one new file:
+
+```
+backend/src/Anela.Heblo.Persistence/Migrations/
+    <UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs
+    <UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs   (auto-generated)
+ApplicationDbContextModelSnapshot.cs                                                     (auto-updated)
+```
+
+The migration **must** be generated via `dotnet ef migrations add RemoveUnusedSyncColumnsFromImportedMarketingTransactions --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API`. Do not hand-write the `.Designer.cs` or model snapshot — let the tool produce them after the entity + configuration edits land.
+
+### Interfaces and Contracts
+
+**`IImportedMarketingTransactionRepository`** — final form after change:
+
+```csharp
+public interface IImportedMarketingTransactionRepository
+{
+    Task<bool> ExistsAsync(string platform, string transactionId, CancellationToken ct);
+    Task AddAsync(ImportedMarketingTransaction entity, CancellationToken ct);
+    Task<int> SaveChangesAsync(CancellationToken ct);
+}
+```
+
+**`ImportedMarketingTransaction`** — final form after change (business fields only, lines 14–15 deleted):
+
+```csharp
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public string? Description { get; set; }
+    public string? RawData { get; set; }
+}
+```
+
+**Migration `Up` / `Down` skeleton** — model on `20260525152436_AddCurrencyDescriptionRawDataToImportedMarketingTransactions.cs`:
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "ErrorMessage",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "IsSynced",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+}
+
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.AddColumn<bool>(
+        name: "IsSynced",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "boolean",
+        nullable: false,
+        defaultValue: false);
+
+    migrationBuilder.AddColumn<string>(
+        name: "ErrorMessage",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "text",
+        nullable: true);
+}
+```
+
+### Data Flow
+
+The change deletes a never-executed branch of the conceptual flow; no flow needs updating:
+
+```
+Active flow (unchanged):
+IMarketingTransactionSource → MarketingInvoiceImportService.ImportAsync
+    → ExistsAsync (per-tx dedupe) → AddAsync (staged) → SaveChangesAsync (one flush)
+    → MarketingImportResult { Imported, Skipped, Failed }
+
+Dead flow (removed):
+GetUnsyncedAsync → (no caller) → [future FlexiBee sync, never built]
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Merge order conflict with #1771 (touches same interface) and #1766 (touches same service file) | Medium | Rebase onto `main` after both merge before generating the migration. Generating the migration last guarantees the model snapshot matches schema head. Spec FR-6 already captures this. |
+| Migration generated against stale `ApplicationDbContextModelSnapshot.cs` | Medium | Run `dotnet ef migrations add` **after** rebase and **after** entity/configuration edits, so the snapshot diff captures only the column drops. Inspect the generated migration to confirm it contains only the two `DropColumn` operations on `public.ImportedMarketingTransactions`. |
+| Production deploy ships code that expects columns to be gone before the migration runs (or vice versa) | High | Migrations are applied manually per project facts. The PR description must explicitly call out the migration name and state: "apply migration before deploying this build" (column drops are backward-compatible with the old build, since the old code only wrote `IsSynced = false` and never read either column — but the new build will fail at startup model validation if the columns still exist? **No — EF Core does not fail startup if a DB column has no model mapping**; it ignores extra columns. So either order is safe. State this in the PR description.) |
+| Migration locks `ImportedMarketingTransactions` table for too long on production | Low | PostgreSQL `DROP COLUMN` is metadata-only and fast even on large tables — it does not rewrite rows. Acceptable as-is. Spec NFR-1 already flags this. |
+| Designer file / model snapshot drift if edits are partial | Medium | Do not hand-edit `.Designer.cs` or `ApplicationDbContextModelSnapshot.cs`. Always re-run `dotnet ef migrations add` after entity changes. If the generated migration looks wrong, delete it (all three files: `.cs`, `.Designer.cs`, snapshot revert) and regenerate. |
+| Hidden caller via reflection / dynamic resolution | Very Low | The grep across `backend/` returned exactly the five expected files. No reflection-based access patterns exist for these properties (they are not on any DTO contract). No mitigation needed beyond the grep already performed. |
+
+## Specification Amendments
+
+1. **Amend FR-3 / FR-4 to specify the schema as `public`, not `dbo`.** The spec currently says "drops both columns" without specifying the schema. The 2026-04-24 `MoveDboTablesToPublicSchema` migration relocated this table; the configuration confirms `public`. Hand-rolled migration code targeting `dbo` will fail.
+
+2. **Amend FR-4 acceptance criteria to explicitly require regenerating `ApplicationDbContextModelSnapshot.cs`** (it is part of the migration tool output; manual edits to the entity/configuration without re-running `dotnet ef migrations add` will leave the snapshot drifted, breaking the next migration generation in any module).
+
+3. **Add to FR-6:** when rebasing, verify the generated migration filename's UTC timestamp is later than every migration on `main` after rebase — otherwise EF Core may apply migrations out of order on `Update-Database`.
+
+4. **Strengthen NFR-3:** the `Down` migration must reproduce the original column types **exactly** — `boolean NOT NULL DEFAULT false` and `text NULL`. Inspect the regenerated `Down` against the 2026-04-14 `AddImportedMarketingTransactions` migration to confirm the type strings match.
+
+5. **Clarify in FR-2 acceptance criteria:** "repo-wide search for `IsSynced` and `ErrorMessage` in the MarketingInvoices module" — note that `ErrorMessage` is a common identifier and will appear in unrelated code (e.g., exception handling, other modules). Scope the search to `**/MarketingInvoices/**` to avoid false positives.
+
+## Prerequisites
+
+1. **PR #1771 merged to `main`** — modifies `IImportedMarketingTransactionRepository.AddAsync` and the concrete repository (same files this change edits).
+2. **PR #1766 merged to `main`** — touches `MarketingInvoiceImportService.cs` near the entity-construction block where `IsSynced = false` lives.
+3. **This branch rebased onto post-merge `main`** before generating the migration, so:
+   - Migration timestamp orders correctly relative to any other migrations that landed.
+   - `ApplicationDbContextModelSnapshot.cs` baseline reflects the latest schema.
+   - No merge conflicts in the five files this change touches.
+4. **Local DB at current schema head** when running `dotnet ef migrations add`, so the tool's diff captures only the intended column drops. If the local DB is behind, the generated migration may include unrelated diffs.
+5. **No infrastructure or config changes required.** No new packages, no DI changes, no env vars, no feature flags.
+6. **Manual deploy step documented in PR description**: list the migration filename and confirm it must be run via `dotnet ef database update` on each environment after the build ships (per project fact: migrations are not automated). Both orderings (migrate-then-deploy or deploy-then-migrate) are safe in this case because EF Core ignores unmapped DB columns at runtime and the old code never read the columns.

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/brief.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/brief.md
@@ -1,0 +1,41 @@
+## Module
+MarketingInvoices
+
+## Finding
+Three related pieces of the module exist solely as scaffolding for a sync workflow that has not been implemented:
+
+**1. `IImportedMarketingTransactionRepository.GetUnsyncedAsync` — zero callers**
+```csharp
+// Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs:7
+Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct);
+```
+A grep across the entire `src/` tree finds no call site outside the interface and its implementation.
+
+**2. `ImportedMarketingTransaction.IsSynced` — always `false`, never updated**
+```csharp
+// Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:14
+public bool IsSynced { get; set; } = false;
+```
+Set to `false` on insert (`MarketingInvoiceImportService.cs:74`). No code anywhere sets it to `true`. Every row in the database is permanently unsynced.
+
+**3. `ImportedMarketingTransaction.ErrorMessage` — always `null`, never written**
+```csharp
+// Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:15
+public string? ErrorMessage { get; set; }
+```
+The DB column is configured (`ImportedMarketingTransactionConfiguration.cs:53`), but no application code ever assigns a value. The import service logs errors via `ILogger` and updates `result.Failed`, but never stores the error string on the entity.
+
+## Why it matters
+YAGNI: these three items inflate the domain interface, the entity, and the database schema with speculative infrastructure for a future sync step. `GetUnsyncedAsync` appearing in the domain interface misleads readers into assuming it is called somewhere. `IsSynced = false` on every row makes the column queryable but useless. `ErrorMessage` occupies a `text` column that is always `NULL`.
+
+## Suggested fix
+Two options depending on intent:
+
+**A — Implement the missing sync step:** Add a use case or background service that fetches unsynced transactions, posts them to the accounting system, and sets `IsSynced = true` / `ErrorMessage` on failure. This is the intended direction.
+
+**B — Remove the scaffolding until it is needed:** Delete `GetUnsyncedAsync` from the interface and implementation, drop `IsSynced` and `ErrorMessage` from `ImportedMarketingTransaction` and its EF configuration, and add a migration to remove the columns. Re-add when the sync workflow is actually being built.
+
+Option B is cheaper now; option A is the right call only when the sync workflow is actively being built.
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/impl/main.r1.md
@@ -1,0 +1,34 @@
+This is a normal repo (GIT_DIR == GIT_COMMON) on branch `feat-arch-review-marketinginvoices-getunsynce`. Implementation complete.
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to main locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (I'll handle it later)
+4. Discard this work
+
+Which option?
+```
+
+---
+
+Here's a summary of what was implemented:
+
+**Files modified (5):**
+- `IImportedMarketingTransactionRepository.cs` — removed `GetUnsyncedAsync` declaration
+- `ImportedMarketingTransaction.cs` — removed `IsSynced` and `ErrorMessage` properties  
+- `ImportedMarketingTransactionRepository.cs` — removed `GetUnsyncedAsync` method body
+- `ImportedMarketingTransactionConfiguration.cs` — removed both EF mappings
+- `MarketingInvoiceImportService.cs` — removed `IsSynced = false` assignment
+
+**Migration created:**
+- `20260526092919_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` — drops both columns with reversible `Down` (`boolean NOT NULL DEFAULT false`; `text NULL`)
+
+**Manual deploy step required:** When this PR merges, apply the migration to each environment:
+```bash
+cd backend && dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+Both deploy-then-migrate and migrate-then-deploy orderings are safe (EF Core ignores unmapped DB columns at runtime; the old code never read these columns).

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/spec.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/spec.r1.md
@@ -1,0 +1,150 @@
+# Specification: Resolve Unimplemented Sync Scaffolding in MarketingInvoices
+
+## Summary
+The `MarketingInvoices` module contains three pieces of scaffolding (`GetUnsyncedAsync`, `IsSynced`, `ErrorMessage`) that exist solely to support a sync workflow that was never implemented. This specification covers resolving the dead scaffolding by either implementing the missing sync workflow (Option A) or removing the scaffolding until it is needed (Option B). The decision between the two options depends on whether the accounting-system sync is on the near-term roadmap.
+
+## Background
+A daily architecture review on 2026-05-26 surfaced three related YAGNI violations in `Domain/Features/MarketingInvoices/`:
+
+1. **`IImportedMarketingTransactionRepository.GetUnsyncedAsync`** — declared on the domain interface, has a concrete implementation, but has zero callers across the entire `src/` tree.
+2. **`ImportedMarketingTransaction.IsSynced`** — set to `false` on insert at `MarketingInvoiceImportService.cs:74` and never updated to `true` anywhere in the codebase. Every row in the database is permanently `IsSynced = false`.
+3. **`ImportedMarketingTransaction.ErrorMessage`** — `text` column configured at `ImportedMarketingTransactionConfiguration.cs:53`, but no application code writes to it. Errors are logged via `ILogger` and counted on `result.Failed`, but never persisted on the entity. Every row has `ErrorMessage = NULL`.
+
+The scaffolding misleads readers into assuming an active sync workflow exists, inflates the domain surface area, and adds an always-NULL `text` column to the database. Per the YAGNI principle, speculative infrastructure should be removed until the consuming feature is actively being built.
+
+## Functional Requirements
+
+The functional requirements depend on the resolution direction. Both options are specified so the architect can act on the chosen one.
+
+### Option B (default — remove scaffolding)
+
+#### FR-B1: Remove `GetUnsyncedAsync` from the repository interface and implementation
+Delete the method from `IImportedMarketingTransactionRepository` (`Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs:7`) and from its concrete implementation in the persistence layer.
+
+**Acceptance criteria:**
+- `IImportedMarketingTransactionRepository` no longer declares `GetUnsyncedAsync`.
+- The concrete repository implementation no longer defines `GetUnsyncedAsync`.
+- `dotnet build` succeeds.
+- A repo-wide search for `GetUnsyncedAsync` returns zero hits.
+
+#### FR-B2: Remove `IsSynced` and `ErrorMessage` properties from `ImportedMarketingTransaction`
+Delete both properties from `Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` (lines 14 and 15).
+
+**Acceptance criteria:**
+- `ImportedMarketingTransaction` no longer declares `IsSynced` or `ErrorMessage`.
+- `MarketingInvoiceImportService.cs:74` (the insert path) no longer references `IsSynced`.
+- `dotnet build` succeeds.
+- A repo-wide search for `IsSynced` and `ErrorMessage` in the MarketingInvoices module returns zero hits.
+
+#### FR-B3: Remove `IsSynced` and `ErrorMessage` column mappings from EF configuration
+Remove the property configurations for `IsSynced` and `ErrorMessage` from `ImportedMarketingTransactionConfiguration.cs` (around line 53 and the corresponding `IsSynced` configuration).
+
+**Acceptance criteria:**
+- The configuration class no longer references the removed properties.
+- `dotnet build` succeeds.
+
+#### FR-B4: Add an EF Core migration to drop the `IsSynced` and `ErrorMessage` columns
+Create a new EF Core migration that drops the `IsSynced` and `ErrorMessage` columns from the `ImportedMarketingTransactions` table.
+
+**Acceptance criteria:**
+- Migration is generated via `dotnet ef migrations add` with a descriptive name (e.g., `RemoveUnusedSyncColumnsFromImportedMarketingTransactions`).
+- `Up` drops both columns; `Down` re-adds them with the original types (`bool` default `false`; `text` nullable) to preserve reversibility.
+- Migration applies cleanly against a database in the current head state.
+- Migration is documented in the PR description for the manual deploy step (database migrations are not automated).
+
+#### FR-B5: Verify no callers exist for the import-service "Failed" path that depended on the entity's error storage
+Confirm that removing `ErrorMessage` does not regress any caller that reads the error text. (Brief states only `ILogger` and `result.Failed` are used; verify.)
+
+**Acceptance criteria:**
+- A repo-wide search confirms no code reads `ImportedMarketingTransaction.ErrorMessage`.
+- Existing unit tests for `MarketingInvoiceImportService` continue to pass.
+
+### Option A (alternative — implement the sync workflow)
+
+#### FR-A1: Implement a use case that fetches unsynced transactions and posts them to the accounting system
+Add a use case (MediatR handler) or hosted background service that periodically (or on-demand) reads transactions where `IsSynced = false`, posts them to the accounting system, and persists the sync outcome.
+
+**Acceptance criteria:**
+- A new command or background service exists that calls `GetUnsyncedAsync`.
+- On successful post, `IsSynced` is set to `true` and the entity is persisted.
+- On failure, `ErrorMessage` is set to a meaningful message and the entity is persisted; `IsSynced` remains `false` so the row is retried on the next run.
+- The accounting-system call is encapsulated behind an interface (testability + swappability).
+- Unit and integration tests cover the happy path, failure path, and idempotency.
+
+#### FR-A2: Define retry and idempotency semantics
+Specify whether failed transactions are retried indefinitely, capped at N attempts, or surfaced for manual intervention.
+
+**Acceptance criteria:**
+- Retry policy is documented and implemented.
+- The accounting-system post is idempotent (or the workflow guards against double-posting).
+
+> Option A requires significant additional design input (target accounting system, transport, auth, retry strategy, schedule) that is **not in the brief**. See Open Questions.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Option B: No runtime performance impact. Migration runtime depends on table row count; the columns are small (bool + text), so the drop should be fast. If the table is large (>1M rows), the migration should be reviewed for locking behavior.
+- Option A: Sync workflow should batch transactions and avoid N+1 calls to the accounting system. Targets to be defined when the workflow is specified.
+
+### NFR-2: Security
+- No new auth surface in Option B.
+- Option A introduces a credential dependency on the accounting system (out of scope here — see Open Questions).
+
+### NFR-3: Reversibility
+The Option B migration must include a working `Down` method so the columns can be restored if Option A is pursued later.
+
+### NFR-4: Backward compatibility
+There are no external consumers of `IsSynced`, `ErrorMessage`, or `GetUnsyncedAsync` (verified by the brief's grep finding). No API or client-facing contract is affected.
+
+## Data Model
+
+**Current state** (`ImportedMarketingTransaction`):
+- `Id`, business fields, plus:
+- `IsSynced : bool` (always `false`)
+- `ErrorMessage : string?` (always `null`)
+
+**After Option B:**
+- `Id`, business fields only. `IsSynced` and `ErrorMessage` are removed from the entity and the database table.
+
+**After Option A:**
+- Same shape as current, but `IsSynced` is flipped to `true` on success and `ErrorMessage` is populated on failure.
+
+## API / Interface Design
+
+### Option B
+- Domain interface `IImportedMarketingTransactionRepository` shrinks by one method (`GetUnsyncedAsync` removed).
+- No HTTP API changes.
+- No frontend changes.
+
+### Option A
+- New MediatR command or hosted service (internal — no HTTP endpoint required unless manual trigger is desired).
+- No frontend changes unless an admin "trigger sync now" UI is desired (out of scope here — see Open Questions).
+
+## Dependencies
+
+### Option B
+- EF Core migration infrastructure (already in place).
+- Manual deployment step to apply the migration (per project facts: migrations are manual).
+
+### Option A
+- Accounting system API / SDK (unspecified in brief).
+- Credentials and configuration for the accounting system.
+- Background-service or scheduler infrastructure.
+
+## Out of Scope
+
+- Refactoring the `MarketingInvoiceImportService` itself beyond removing the `IsSynced = false` line on insert (Option B) or wiring it to the sync workflow (Option A).
+- Reworking the import service's existing error-logging path (it already logs via `ILogger` and aggregates `result.Failed`).
+- Any UI changes to surface sync status or error messages to users.
+- Backfilling or migrating data in the dropped columns — they are always `false` / `NULL`, so there is no data to preserve.
+- Choosing or integrating with a specific accounting system for Option A.
+
+## Open Questions
+
+1. **Which option should be implemented — A (build the sync workflow) or B (remove the scaffolding)?** The brief states "Option B is cheaper now; option A is the right call only when the sync workflow is actively being built." Is the accounting-system sync on the near-term roadmap, or should we remove the scaffolding now and re-add it when the sync work is actually scheduled?
+2. **(If Option A)** Which accounting system is the sync target, and what is the transport (REST, SOAP, file drop, queue)?
+3. **(If Option A)** What is the desired trigger model — scheduled background service, on-demand command, or both? And what schedule/cadence?
+4. **(If Option A)** What are the retry semantics for failed posts — bounded retries, indefinite retry until success, dead-letter after N attempts?
+5. **(If Option B)** Are there any pending PRs or in-flight work that already reference `GetUnsyncedAsync`, `IsSynced`, or `ErrorMessage` and would conflict with their removal? (Worth confirming before the migration is generated.)
+
+## Status: HAS_QUESTIONS

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/spec.r2.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/spec.r2.md
@@ -1,0 +1,128 @@
+# Specification: Remove Unimplemented Sync Scaffolding from MarketingInvoices
+
+## Summary
+Three pieces of scaffolding in the `MarketingInvoices` module (`IImportedMarketingTransactionRepository.GetUnsyncedAsync`, `ImportedMarketingTransaction.IsSynced`, `ImportedMarketingTransaction.ErrorMessage`) were added to support a FlexiBee sync workflow that was never implemented and is explicitly deferred to "Future Work" in epic #609. This spec removes the scaffolding — deleting the interface method, dropping the two entity properties, removing their EF Core configuration, and adding a migration to drop the `IsSynced` and `ErrorMessage` columns.
+
+## Background
+A daily architecture review on 2026-05-26 surfaced three related YAGNI violations in `Domain/Features/MarketingInvoices/`:
+
+1. **`IImportedMarketingTransactionRepository.GetUnsyncedAsync`** (`Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs:7`) — declared on the domain interface with a concrete implementation, zero callers across the entire `src/` tree.
+2. **`ImportedMarketingTransaction.IsSynced`** (`Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:14`) — set to `false` on insert at `MarketingInvoiceImportService.cs:74` and never updated to `true` anywhere in the codebase. Every row in the database is permanently `IsSynced = false`.
+3. **`ImportedMarketingTransaction.ErrorMessage`** (`Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:15`) — `text` column configured at `ImportedMarketingTransactionConfiguration.cs:53`, but no application code writes to it. Errors are logged via `ILogger` and counted on `result.Failed`, never persisted on the entity. Every row has `ErrorMessage = NULL`.
+
+The original shared-core design (`docs/superpowers/specs/2026-04-14-marketing-invoice-import-shared-core-design.md:50`) explicitly defers the sync to a "future FlexiBee phase," and epic #609 lists "FlexiBee received invoice creation from stored transactions" under **Future Work (not in scope)**. No open issue, PR, or plan currently schedules that work.
+
+When the FlexiBee sync is eventually built, it will almost certainly follow the richer `IssuedInvoice` precedent (`SyncSucceeded` / `SyncFailed` API, sync-history rows, `LastSyncTime`, structured `ErrorType` distinguishing transient from permanent failures) rather than the single `bool IsSynced` + `text ErrorMessage` pair currently in place. Removing the speculative scaffolding now is strictly cheaper than carrying it and is unlikely to be reused as-is.
+
+## Functional Requirements
+
+### FR-1: Remove `GetUnsyncedAsync` from the repository interface and implementation
+Delete the method from `IImportedMarketingTransactionRepository` (`Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs:7`) and from its concrete implementation in the persistence layer.
+
+**Acceptance criteria:**
+- `IImportedMarketingTransactionRepository` no longer declares `GetUnsyncedAsync`.
+- The concrete repository implementation no longer defines `GetUnsyncedAsync`.
+- `dotnet build` succeeds.
+- A repo-wide search for `GetUnsyncedAsync` returns zero hits.
+
+### FR-2: Remove `IsSynced` and `ErrorMessage` properties from `ImportedMarketingTransaction`
+Delete both properties from `Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` (lines 14 and 15) and remove any assignments to them.
+
+**Acceptance criteria:**
+- `ImportedMarketingTransaction` no longer declares `IsSynced` or `ErrorMessage`.
+- `MarketingInvoiceImportService.cs:74` (the insert path) no longer sets `IsSynced = false`.
+- `dotnet build` succeeds.
+- A repo-wide search for `IsSynced` and `ErrorMessage` in the MarketingInvoices module returns zero hits.
+
+### FR-3: Remove `IsSynced` and `ErrorMessage` column mappings from EF configuration
+Remove the property configurations for both columns from `ImportedMarketingTransactionConfiguration.cs` (`IsSynced` mapping and the `ErrorMessage` `text` column at approximately line 53).
+
+**Acceptance criteria:**
+- The configuration class no longer references the removed properties.
+- `dotnet build` succeeds.
+- A repo-wide search across the `MarketingInvoices` configuration for `IsSynced` and `ErrorMessage` returns zero hits.
+
+### FR-4: Add an EF Core migration to drop the `IsSynced` and `ErrorMessage` columns
+Create a new EF Core migration that drops the `IsSynced` and `ErrorMessage` columns from the `ImportedMarketingTransactions` table.
+
+**Acceptance criteria:**
+- Migration is generated via `dotnet ef migrations add` with a descriptive name (e.g., `RemoveUnusedSyncColumnsFromImportedMarketingTransactions`).
+- `Up` drops both columns.
+- `Down` re-adds them with the original types (`bool` not null, default `false`; `text` nullable) to preserve reversibility.
+- Migration applies cleanly against a database in the current head state.
+- Migration is documented in the PR description, since database migrations are applied manually in this project (per project facts).
+
+### FR-5: Verify no callers depend on the entity-level error storage
+Confirm that removing `ErrorMessage` does not regress any caller that reads the error text. The brief states only `ILogger` and `result.Failed` are consumed; verify before removal.
+
+**Acceptance criteria:**
+- A repo-wide search confirms no code reads `ImportedMarketingTransaction.ErrorMessage` or `ImportedMarketingTransaction.IsSynced`.
+- Existing unit tests for `MarketingInvoiceImportService` continue to pass.
+
+### FR-6: Sequence this work behind two open PRs that touch the same files
+Two open PRs modify the same interface / service touched by this spec and must be merged first:
+
+- **PR #1771** (`feat-arch-review-marketinginvoices-iimportedm`) — edits `IImportedMarketingTransactionRepository.AddAsync` and the concrete repository (same interface and class FR-1 modifies).
+- **PR #1766** (`feat-arch-review-marketinginvoices-marketingt`) — removes `MarketingTransaction.Platform` and touches `MarketingInvoiceImportService.cs` near the entity-construction block where `IsSynced = false` is set (same area FR-2 modifies).
+
+PR #616 (the long-running shared-core PR that originally introduced these fields) is irrelevant to current head and does not need to be sequenced.
+
+**Acceptance criteria:**
+- Before generating the EF migration, this branch is rebased onto `main` after #1771 and #1766 have merged (or onto an `main` that already contains them), so the migration is generated against the latest schema snapshot.
+- No merge conflicts remain in `IImportedMarketingTransactionRepository.cs`, the concrete repository, `ImportedMarketingTransaction.cs`, `ImportedMarketingTransactionConfiguration.cs`, or `MarketingInvoiceImportService.cs` at PR-open time.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance impact. Migration runtime depends on table row count; the columns are small (`bool` + `text`). If the `ImportedMarketingTransactions` table exceeds ~1M rows in production, the migration's locking behavior on column drops should be reviewed before deploy; otherwise it is expected to be fast.
+
+### NFR-2: Security
+No new auth surface, no secrets, no data-classification changes. The dropped columns contain only `false` and `NULL`.
+
+### NFR-3: Reversibility
+The Option B migration must include a working `Down` method so the columns can be restored if the FlexiBee sync workflow is later built and chooses to reuse this exact schema (unlikely, but cheap to preserve).
+
+### NFR-4: Backward compatibility
+There are no external consumers of `IsSynced`, `ErrorMessage`, or `GetUnsyncedAsync` (verified by the brief's grep finding). No HTTP API, OpenAPI contract, frontend code, or external integration is affected.
+
+### NFR-5: Test coverage
+Existing tests touching `MarketingInvoiceImportService` and `ImportedMarketingTransaction` must continue to pass after removal. No new tests are required — removing dead code does not introduce new behavior to cover.
+
+## Data Model
+
+**Current state** (`ImportedMarketingTransaction`):
+- Business fields (Id, transaction identity, amounts, dates, platform linkage, etc.)
+- `IsSynced : bool` — always `false`, never updated.
+- `ErrorMessage : string?` — always `null`, never written.
+
+**After this change:**
+- Business fields only. `IsSynced` and `ErrorMessage` are removed from the entity class and the `ImportedMarketingTransactions` table.
+
+No data backfill or preservation is required — the dropped columns contain only `false` and `NULL` values that carry no information.
+
+## API / Interface Design
+
+- **Domain interface change:** `IImportedMarketingTransactionRepository` shrinks by one method (`GetUnsyncedAsync` removed).
+- **HTTP API:** no changes.
+- **OpenAPI / generated TypeScript client:** no changes (this entity is not exposed through any DTO that includes these fields; verify during FR-5).
+- **Frontend:** no changes.
+
+## Dependencies
+
+- EF Core migration infrastructure (already in place).
+- Manual deployment step to apply the migration in each environment (per project facts: migrations are not automated). PR description must call this out.
+- Merge ordering relative to PRs #1771 and #1766 (see FR-6).
+
+## Out of Scope
+
+- Building the FlexiBee sync workflow itself — explicitly deferred per epic #609 and the shared-core design doc. If/when it is built, it will be designed fresh following the `IssuedInvoice` precedent (sync-history rows, `LastSyncTime`, structured `ErrorType`), not by reviving these columns.
+- Refactoring `MarketingInvoiceImportService` beyond removing the `IsSynced = false` line on insert.
+- Reworking the existing import-error logging path (it already logs via `ILogger` and aggregates `result.Failed`).
+- Any UI changes — there is no UI that exposes `IsSynced` or `ErrorMessage`.
+- Backfilling or archiving data in the dropped columns (no information to preserve).
+- Changes to the `IssuedInvoice` sync model (separate feature, separate module).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketinginvoices-getunsynce/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketinginvoices-getunsynce/task-plan.r1.md
@@ -1,0 +1,676 @@
+# Remove Unimplemented Sync Scaffolding from MarketingInvoices — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the unused `GetUnsyncedAsync` repository method and the unused `IsSynced` / `ErrorMessage` columns on `ImportedMarketingTransaction`, including a reversible EF Core migration that drops both columns.
+
+**Architecture:** Subtractive change across the existing Clean Architecture layers — Domain (interface + entity), Persistence (concrete repo + EF configuration + new migration), Application (one line in the import service). No new abstractions, no DI changes, no API/contract changes, no frontend changes. Existing tests act as the regression harness (NFR-5: no new tests required for dead-code removal).
+
+**Tech Stack:** .NET 8, C#, EF Core 8 (Npgsql), PostgreSQL (schema `public`), xUnit + FluentAssertions for tests.
+
+---
+
+## File Structure
+
+**Files modified (5):**
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs` — remove `GetUnsyncedAsync` declaration.
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` — remove `IsSynced` and `ErrorMessage` properties.
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs` — remove `GetUnsyncedAsync` body.
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` — remove `IsSynced` and `ErrorMessage` property mappings.
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — remove `IsSynced = false` from the entity-construction block.
+
+**Files created (1, auto-generated):**
+- `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs`
+- `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs` (tool output)
+
+**Files auto-updated:**
+- `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` (tool output)
+
+**Files NOT touched:**
+- Test files — `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` and `ImportMarketingInvoicesHandlerTests.cs` have **zero** references to `IsSynced`, `ErrorMessage`, or `GetUnsyncedAsync` (verified by grep). They run as-is post-change.
+
+---
+
+## Prerequisites Check
+
+Before starting Task 1, confirm:
+
+- [ ] **PR #1771 is merged to `main`** (touches `IImportedMarketingTransactionRepository.AddAsync` and concrete repo).
+- [ ] **PR #1766 is merged to `main`** (touches `MarketingInvoiceImportService.cs` near the entity-construction block).
+- [ ] **Current branch is rebased onto post-merge `main`**, with no conflicts in the five files listed above.
+- [ ] **Local DB is at current schema head** (`dotnet ef database update --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API`), so the migration tool's diff in Task 7 captures only the intended column drops.
+
+Run to verify prerequisite #4:
+
+```bash
+cd backend
+dotnet ef migrations list \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: all migrations show as applied. If any show `(Pending)`, run `dotnet ef database update` first.
+
+If any prerequisite is unmet, **stop and resolve before continuing** — generating the migration against a stale snapshot or pre-rebase tree will produce wrong diffs (see "Risks and Mitigations" in arch-review.r1.md).
+
+---
+
+### Task 1: Remove `GetUnsyncedAsync` from the domain interface and concrete repository
+
+Removing only one of the two would leave the build broken (the interface contract would be unmet, or the concrete class would override a non-existent member). Both edits land together.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs` (line 7)
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs` (lines 26–29)
+
+- [ ] **Step 1: Edit the interface — remove the `GetUnsyncedAsync` line**
+
+Replace the content of `IImportedMarketingTransactionRepository.cs` so the final file reads exactly:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public interface IImportedMarketingTransactionRepository
+{
+    Task<bool> ExistsAsync(string platform, string transactionId, CancellationToken ct);
+    Task AddAsync(ImportedMarketingTransaction entity, CancellationToken ct);
+    Task<int> SaveChangesAsync(CancellationToken ct);
+}
+```
+
+Edit operation: delete line 7 (`Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct);`) entirely. No other changes.
+
+- [ ] **Step 2: Edit the concrete repo — remove the `GetUnsyncedAsync` method body**
+
+In `ImportedMarketingTransactionRepository.cs`, delete the entire method block (lines 26–29):
+
+```csharp
+    public async Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct)
+    {
+        return (await FindAsync(x => !x.IsSynced, ct)).ToList();
+    }
+```
+
+After deletion, the final file reads exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Anela.Heblo.Persistence.Repositories;
+
+namespace Anela.Heblo.Persistence.Features.MarketingInvoices;
+
+public class ImportedMarketingTransactionRepository
+    : BaseRepository<ImportedMarketingTransaction, int>, IImportedMarketingTransactionRepository
+{
+    public ImportedMarketingTransactionRepository(ApplicationDbContext context)
+        : base(context)
+    {
+    }
+
+    public async Task<bool> ExistsAsync(string platform, string transactionId, CancellationToken ct)
+    {
+        return await AnyAsync(
+            x => x.Platform == platform && x.TransactionId == transactionId,
+            ct);
+    }
+
+    public new async Task AddAsync(ImportedMarketingTransaction entity, CancellationToken ct)
+    {
+        await base.AddAsync(entity, ct);
+    }
+}
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run from the repo root:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+If it fails with "no callers found" for `GetUnsyncedAsync`, that's a stale build cache — rerun `dotnet build` on the whole solution. If it fails with a compilation error pointing at another file, **stop and investigate** — the spec/arch-review assert there are no other callers; an unexpected one would be a finding to report.
+
+- [ ] **Step 4: Verify no remaining references to `GetUnsyncedAsync` in the codebase**
+
+```bash
+grep -rn "GetUnsyncedAsync" backend/
+```
+
+Expected: zero hits.
+
+---
+
+### Task 2: Remove `IsSynced = false` from `MarketingInvoiceImportService`
+
+Must happen **before** Task 3 (entity property removal) — otherwise the build breaks while `IsSynced` still appears on the right-hand side of the object initializer with no matching property.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` (line 75)
+
+- [ ] **Step 1: Delete the `IsSynced = false,` line inside the entity initializer**
+
+In `MarketingInvoiceImportService.cs`, locate the entity-construction block at lines 67–78:
+
+```csharp
+                var entity = new ImportedMarketingTransaction
+                {
+                    TransactionId = transaction.TransactionId,
+                    Platform = source.Platform,
+                    Amount = transaction.Amount,
+                    Currency = transaction.Currency,
+                    TransactionDate = transaction.TransactionDate,
+                    ImportedAt = DateTime.UtcNow,
+                    IsSynced = false,
+                    Description = transaction.Description,
+                    RawData = transaction.RawData,
+                };
+```
+
+Remove the single line `                    IsSynced = false,`. The block becomes:
+
+```csharp
+                var entity = new ImportedMarketingTransaction
+                {
+                    TransactionId = transaction.TransactionId,
+                    Platform = source.Platform,
+                    Amount = transaction.Amount,
+                    Currency = transaction.Currency,
+                    TransactionDate = transaction.TransactionDate,
+                    ImportedAt = DateTime.UtcNow,
+                    Description = transaction.Description,
+                    RawData = transaction.RawData,
+                };
+```
+
+No other lines change. Match indentation (20 spaces — preserved exactly from the surrounding lines).
+
+- [ ] **Step 2: Verify build still succeeds (entity property still exists at this point)**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+---
+
+### Task 3: Remove `IsSynced` and `ErrorMessage` from the entity
+
+After this task, the build will be temporarily broken (the EF configuration still maps these properties) until Task 4 lands. That's expected — Tasks 3 and 4 together restore the build.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` (lines 14–15)
+
+- [ ] **Step 1: Delete the two property declarations**
+
+Replace the entity file content so it reads exactly:
+
+```csharp
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public string? Description { get; set; }
+    public string? RawData { get; set; }
+}
+```
+
+Delete lines 14 (`public bool IsSynced { get; set; } = false;`) and 15 (`public string? ErrorMessage { get; set; }`). No other changes.
+
+- [ ] **Step 2: Do NOT build yet — build will fail until Task 4 removes the EF configuration**
+
+Skip the verification step — proceed directly to Task 4.
+
+---
+
+### Task 4: Remove `IsSynced` and `ErrorMessage` mappings from the EF configuration
+
+Pairs with Task 3 — together they restore the build.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` (lines 47–55)
+
+- [ ] **Step 1: Delete the two property-mapping blocks**
+
+In `ImportedMarketingTransactionConfiguration.cs`, locate and delete this block (lines 47–55):
+
+```csharp
+        builder.Property(e => e.IsSynced)
+            .IsRequired()
+            .HasDefaultValue(false)
+            .HasColumnName("IsSynced")
+            .HasColumnType("boolean");
+
+        builder.Property(e => e.ErrorMessage)
+            .HasColumnName("ErrorMessage")
+            .HasColumnType("text");
+
+```
+
+The final file should read exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.MarketingInvoices;
+
+public class ImportedMarketingTransactionConfiguration : IEntityTypeConfiguration<ImportedMarketingTransaction>
+{
+    public void Configure(EntityTypeBuilder<ImportedMarketingTransaction> builder)
+    {
+        builder.ToTable("ImportedMarketingTransactions", "public");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .HasColumnType("integer")
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.TransactionId)
+            .IsRequired()
+            .HasMaxLength(255)
+            .HasColumnName("TransactionId")
+            .HasColumnType("character varying(255)");
+
+        builder.Property(e => e.Platform)
+            .IsRequired()
+            .HasMaxLength(50)
+            .HasColumnName("Platform")
+            .HasColumnType("character varying(50)");
+
+        builder.Property(e => e.Amount)
+            .IsRequired()
+            .HasColumnName("Amount")
+            .HasColumnType("numeric(18,2)");
+
+        builder.Property(e => e.TransactionDate)
+            .IsRequired()
+            .HasColumnName("TransactionDate")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.ImportedAt)
+            .IsRequired()
+            .HasColumnName("ImportedAt")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.Currency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasColumnName("Currency")
+            .HasColumnType("character varying(3)");
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500)
+            .HasColumnName("Description")
+            .HasColumnType("character varying(500)");
+
+        builder.Property(e => e.RawData)
+            .HasColumnName("RawData")
+            .HasColumnType("text");
+
+        builder.HasIndex(e => new { e.Platform, e.TransactionId })
+            .IsUnique()
+            .HasDatabaseName("IX_ImportedMarketingTransactions_Platform_TransactionId");
+    }
+}
+```
+
+---
+
+### Task 5: Verify the whole solution builds and existing tests still pass
+
+This task validates that Tasks 1–4 together leave the source tree in a fully consistent, compiling, passing state. The migration is generated in Task 7 from this clean baseline.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full solution build**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded. 0 Error(s)` across all projects.
+
+If any project fails: the most likely cause is a lingering reference to `IsSynced`, `ErrorMessage`, or `GetUnsyncedAsync` somewhere outside the five files this plan touches. The arch-review's grep was definitive, but if a build error names another file, stop and report it — do not "fix it up" silently.
+
+- [ ] **Step 2: Run the MarketingInvoices test suite**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices" \
+  --no-build
+```
+
+Expected: all tests in `MarketingInvoiceImportServiceTests` and `ImportMarketingInvoicesHandlerTests` pass. These tests do not reference the removed members (verified by grep), so they should pass without modification.
+
+- [ ] **Step 3: Verify no remaining references within the MarketingInvoices module**
+
+```bash
+grep -rn "IsSynced\|ErrorMessage" backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Application/Features/MarketingInvoices/
+```
+
+Expected: zero hits. (Scoped to the module per arch-review spec amendment #5 — searching repo-wide would surface unrelated `ErrorMessage` matches in other modules.)
+
+```bash
+grep -rn "GetUnsyncedAsync" backend/
+```
+
+Expected: zero hits.
+
+---
+
+### Task 6: Generate the EF Core migration
+
+The migration is generated **after** the entity and configuration edits are complete and the build is clean, so the tool's diff captures only the column drops.
+
+**Files (auto-generated by tool):**
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs`
+- Modify: `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`
+
+- [ ] **Step 1: Run the EF Core migration-add command**
+
+```bash
+cd backend && dotnet ef migrations add RemoveUnusedSyncColumnsFromImportedMarketingTransactions \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: tool outputs `Done.` and creates two new files in `src/Anela.Heblo.Persistence/Migrations/` plus updates `ApplicationDbContextModelSnapshot.cs`.
+
+If the tool errors with "the database operation was expected to affect X row(s)" or model-snapshot conflicts, the prerequisite local-DB-at-head check was skipped. Run `dotnet ef database update` first, then retry.
+
+- [ ] **Step 2: Inspect the generated migration's `Up` method**
+
+Open the newly created `<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` file. The `Up` method must contain **exactly** these two `DropColumn` operations targeting `schema: "public"` and `table: "ImportedMarketingTransactions"`:
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "ErrorMessage",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "IsSynced",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+}
+```
+
+The order of `DropColumn` calls may differ from the above — that's fine, both are independent.
+
+**If `Up` contains additional operations** (column adds, alters in other tables, index changes), the prerequisite "local DB at current schema head" was not met or another developer's unmigrated change is in the snapshot. Stop, investigate, and regenerate after resolving — do not commit a migration with unrelated diffs.
+
+- [ ] **Step 3: Inspect the generated migration's `Down` method**
+
+Confirm `Down` re-adds both columns with the original types (per arch-review spec amendment #4 — types must match the original `AddImportedMarketingTransactions` migration exactly):
+
+```csharp
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.AddColumn<bool>(
+        name: "IsSynced",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "boolean",
+        nullable: false,
+        defaultValue: false);
+
+    migrationBuilder.AddColumn<string>(
+        name: "ErrorMessage",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "text",
+        nullable: true);
+}
+```
+
+The EF tool generates these `AddColumn` calls automatically from the snapshot it's rolling back **to**. The expected output matches the type strings (`boolean`, `text`) and constraints (`nullable: false, defaultValue: false` for `IsSynced`; `nullable: true` for `ErrorMessage`) that match the original configuration. If the generated `Down` differs from the above, hand-edit only the differing lines to match — but it should not differ in a clean snapshot.
+
+- [ ] **Step 4: Verify the migration's UTC timestamp is later than every existing migration**
+
+```bash
+ls backend/src/Anela.Heblo.Persistence/Migrations/*.cs | sort | tail -5
+```
+
+Expected: the new `<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` is the last entry. (Per arch-review spec amendment #3.)
+
+If it isn't last, the local clock is behind another developer's migration timestamp. Delete all three generated artifacts (`.cs`, `.Designer.cs`, snapshot revert via `git checkout`) and regenerate after correcting the clock, or rebase if a newer migration was pulled in.
+
+- [ ] **Step 5: Verify the model snapshot still compiles**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+---
+
+### Task 7: Apply the migration locally to confirm it executes cleanly
+
+This is a local sanity check — the production deploy is manual per project facts and is documented in the PR description (Task 8).
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Apply the new migration to the local dev database**
+
+```bash
+cd backend && dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: tool reports `Applying migration '<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions'. Done.`
+
+- [ ] **Step 2: Verify columns are dropped in the local DB**
+
+If `psql` is available locally:
+
+```bash
+psql -h localhost -U postgres -d <dev_db_name> -c "\d public.\"ImportedMarketingTransactions\""
+```
+
+Expected: no `IsSynced` and no `ErrorMessage` columns appear in the listing. Remaining columns: `Id`, `TransactionId`, `Platform`, `Amount`, `Currency`, `TransactionDate`, `ImportedAt`, `Description`, `RawData`.
+
+If `psql` is not available, skip this step — the EF tool's success in Step 1 is sufficient.
+
+- [ ] **Step 3: Test the reversibility — apply `Down` then re-apply `Up`**
+
+```bash
+cd backend
+# Find the migration immediately preceding the new one:
+PREV_MIGRATION=$(ls src/Anela.Heblo.Persistence/Migrations/*.cs \
+  | grep -v Designer \
+  | grep -v ModelSnapshot \
+  | grep -v RemoveUnusedSyncColumnsFromImportedMarketingTransactions \
+  | sort | tail -1 | xargs basename | sed 's/\.cs$//')
+echo "Rolling back to: $PREV_MIGRATION"
+
+# Roll back the new migration
+dotnet ef database update "$PREV_MIGRATION" \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+
+# Re-apply the new migration
+dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: rollback succeeds (Down adds columns back), re-apply succeeds (Up drops them again).
+
+If the rollback fails with a column-already-exists or type-mismatch error, the `Down` method's types diverged from the original creation migration. Fix by editing `Down` to match the type strings exactly: `boolean` + `nullable: false, defaultValue: false` for `IsSynced`; `text` + `nullable: true` for `ErrorMessage`.
+
+- [ ] **Step 4: Re-run the test suite against the migrated DB**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices" \
+  --no-build
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 8: Final validation — full build, format, full test suite
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run `dotnet format`**
+
+```bash
+cd backend && dotnet format
+```
+
+Expected: no errors. Format changes (if any) get committed alongside the source edits.
+
+- [ ] **Step 2: Run `dotnet build` on the whole solution**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded. 0 Error(s) 0 Warning(s)` (or whatever the pre-existing warning baseline is — no new warnings).
+
+- [ ] **Step 3: Run the full backend test suite**
+
+```bash
+cd backend && dotnet test --no-build
+```
+
+Expected: all tests pass. The change is purely subtractive dead-code removal; no test should regress.
+
+- [ ] **Step 4: Final repo-wide grep for absent references**
+
+```bash
+grep -rn "GetUnsyncedAsync" backend/ frontend/
+```
+
+Expected: zero hits.
+
+```bash
+grep -rn "IsSynced\|\.ErrorMessage" backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Application/Features/MarketingInvoices/
+```
+
+Expected: zero hits.
+
+---
+
+### Task 9: Commit and prepare PR description
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Review the staged diff**
+
+```bash
+git status
+git diff
+```
+
+Expected files changed (no others):
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs`
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`
+- `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` (new)
+- `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs` (new)
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+If any other files appear in the diff, stop and investigate before committing.
+
+- [ ] **Step 2: Stage all changes and commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ \
+        backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ \
+        backend/src/Anela.Heblo.Persistence/Migrations/ \
+        backend/src/Anela.Heblo.Application/Features/MarketingInvoices/
+
+git commit -m "refactor(marketing-invoices): remove unimplemented sync scaffolding
+
+Remove unused GetUnsyncedAsync repository method, IsSynced and ErrorMessage
+entity properties, their EF configuration, and add a reversible migration
+dropping both columns. The FlexiBee sync workflow these columns were added
+for is explicitly deferred to Future Work per epic #609 and would not reuse
+this exact schema. Existing tests pass without modification."
+```
+
+- [ ] **Step 3: PR description must explicitly document the manual migration step**
+
+When opening the PR, include this section in the description (database migrations are not automated per project facts):
+
+```markdown
+## Manual deployment step
+
+This PR adds the migration:
+
+`<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions`
+
+It must be applied manually to each environment:
+
+```bash
+cd backend && dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Migration order is safe in either direction:
+- **migrate-then-deploy**: old code still works against the new schema (old
+  code only wrote `IsSynced = false` and never read either column).
+- **deploy-then-migrate**: new code works against the old schema (EF Core
+  ignores unmapped DB columns at runtime).
+
+`DROP COLUMN` in PostgreSQL is metadata-only and fast on any table size.
+```
+
+---
+
+## Self-Review
+
+After writing the plan, checking against spec.r2.md and arch-review.r1.md:
+
+**Spec coverage:**
+- FR-1 (remove `GetUnsyncedAsync` from interface + impl) → Task 1.
+- FR-2 (remove `IsSynced` + `ErrorMessage` from entity, remove `IsSynced = false` insert) → Tasks 2 + 3.
+- FR-3 (remove EF configuration mappings) → Task 4.
+- FR-4 (add migration with working `Up`/`Down`) → Tasks 6 + 7.
+- FR-5 (verify no callers depend on entity-level error storage) → Prerequisite grep in Task 5, Step 3 + Task 8, Step 4.
+- FR-6 (sequence behind PRs #1771 and #1766) → "Prerequisites Check" block + arch-review's risk mitigations carried into Task 6, Step 4.
+- NFR-1/2/3/4/5 (perf, security, reversibility, BC, test coverage) → covered by reversible-`Down` design in Task 6 Step 3, no test changes per NFR-5, schema is `public` per arch-review Decision 2.
+
+**Arch-review amendments applied:**
+- Amendment #1 (schema is `public`, not `dbo`) → enforced in Task 6 Step 2 verification + Task 6 Step 3.
+- Amendment #2 (regenerate `ApplicationDbContextModelSnapshot.cs`) → tool re-runs in Task 6 Step 1; manual edits forbidden.
+- Amendment #3 (timestamp must be latest) → Task 6 Step 4.
+- Amendment #4 (`Down` types match original creation migration exactly) → Task 6 Step 3 + Task 7 Step 3 reversibility test.
+- Amendment #5 (scope grep to MarketingInvoices module) → Task 5 Step 3 + Task 8 Step 4 scoped greps.
+
+**Placeholder scan:** no TBDs, no "add appropriate X", no "similar to Task N", no missing code blocks. All file paths absolute or relative-from-repo-root with explicit anchors.
+
+**Type consistency:** the interface and entity shapes in Task 1 / Task 3 final-form code blocks match the arch-review's "final form" appendix exactly. No method or property names drift between tasks.
+
+## Status: COMPLETE

--- a/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs
@@ -72,7 +72,6 @@ public class MarketingInvoiceImportService : IMarketingInvoiceImportService
                     Currency = transaction.Currency,
                     TransactionDate = transaction.TransactionDate,
                     ImportedAt = DateTime.UtcNow,
-                    IsSynced = false,
                     Description = transaction.Description,
                     RawData = transaction.RawData,
                 };

--- a/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs
@@ -4,6 +4,5 @@ public interface IImportedMarketingTransactionRepository
 {
     Task<bool> ExistsAsync(string platform, string transactionId, CancellationToken ct);
     Task AddAsync(ImportedMarketingTransaction entity, CancellationToken ct);
-    Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct);
     Task<int> SaveChangesAsync(CancellationToken ct);
 }

--- a/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs
@@ -11,8 +11,6 @@ public class ImportedMarketingTransaction : IEntity<int>
     public string Currency { get; set; } = string.Empty;
     public DateTime TransactionDate { get; set; }
     public DateTime ImportedAt { get; set; }
-    public bool IsSynced { get; set; } = false;
-    public string? ErrorMessage { get; set; }
     public string? Description { get; set; }
     public string? RawData { get; set; }
 }

--- a/backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs
@@ -44,16 +44,6 @@ public class ImportedMarketingTransactionConfiguration : IEntityTypeConfiguratio
             .HasColumnName("ImportedAt")
             .HasColumnType("timestamp without time zone");
 
-        builder.Property(e => e.IsSynced)
-            .IsRequired()
-            .HasDefaultValue(false)
-            .HasColumnName("IsSynced")
-            .HasColumnType("boolean");
-
-        builder.Property(e => e.ErrorMessage)
-            .HasColumnName("ErrorMessage")
-            .HasColumnType("text");
-
         builder.Property(e => e.Currency)
             .IsRequired()
             .HasMaxLength(3)

--- a/backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs
@@ -22,9 +22,4 @@ public class ImportedMarketingTransactionRepository
     {
         await base.AddAsync(entity, ct);
     }
-
-    public async Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct)
-    {
-        return (await FindAsync(x => !x.IsSynced, ct)).ToList();
-    }
 }

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260526092919_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260526092919_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anela.Heblo.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260526092919_RemoveUnusedSyncColumnsFromImportedMarketingTransactions")]
+    partial class RemoveUnusedSyncColumnsFromImportedMarketingTransactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Anela.Heblo.Persistence/Migrations/20260526092919_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs
+++ b/backend/src/Anela.Heblo.Persistence/Migrations/20260526092919_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anela.Heblo.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUnusedSyncColumnsFromImportedMarketingTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ErrorMessage",
+                schema: "public",
+                table: "ImportedMarketingTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "IsSynced",
+                schema: "public",
+                table: "ImportedMarketingTransactions");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ErrorMessage",
+                schema: "public",
+                table: "ImportedMarketingTransactions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSynced",
+                schema: "public",
+                table: "ImportedMarketingTransactions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-05-26-remove-unimplemented-sync-scaffolding-from-marketinginvoices.md
+++ b/docs/superpowers/plans/2026-05-26-remove-unimplemented-sync-scaffolding-from-marketinginvoices.md
@@ -1,0 +1,676 @@
+# Remove Unimplemented Sync Scaffolding from MarketingInvoices — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the unused `GetUnsyncedAsync` repository method and the unused `IsSynced` / `ErrorMessage` columns on `ImportedMarketingTransaction`, including a reversible EF Core migration that drops both columns.
+
+**Architecture:** Subtractive change across the existing Clean Architecture layers — Domain (interface + entity), Persistence (concrete repo + EF configuration + new migration), Application (one line in the import service). No new abstractions, no DI changes, no API/contract changes, no frontend changes. Existing tests act as the regression harness (NFR-5: no new tests required for dead-code removal).
+
+**Tech Stack:** .NET 8, C#, EF Core 8 (Npgsql), PostgreSQL (schema `public`), xUnit + FluentAssertions for tests.
+
+---
+
+## File Structure
+
+**Files modified (5):**
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs` — remove `GetUnsyncedAsync` declaration.
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` — remove `IsSynced` and `ErrorMessage` properties.
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs` — remove `GetUnsyncedAsync` body.
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` — remove `IsSynced` and `ErrorMessage` property mappings.
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` — remove `IsSynced = false` from the entity-construction block.
+
+**Files created (1, auto-generated):**
+- `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs`
+- `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs` (tool output)
+
+**Files auto-updated:**
+- `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs` (tool output)
+
+**Files NOT touched:**
+- Test files — `backend/test/Anela.Heblo.Tests/Features/MarketingInvoices/MarketingInvoiceImportServiceTests.cs` and `ImportMarketingInvoicesHandlerTests.cs` have **zero** references to `IsSynced`, `ErrorMessage`, or `GetUnsyncedAsync` (verified by grep). They run as-is post-change.
+
+---
+
+## Prerequisites Check
+
+Before starting Task 1, confirm:
+
+- [ ] **PR #1771 is merged to `main`** (touches `IImportedMarketingTransactionRepository.AddAsync` and concrete repo).
+- [ ] **PR #1766 is merged to `main`** (touches `MarketingInvoiceImportService.cs` near the entity-construction block).
+- [ ] **Current branch is rebased onto post-merge `main`**, with no conflicts in the five files listed above.
+- [ ] **Local DB is at current schema head** (`dotnet ef database update --project backend/src/Anela.Heblo.Persistence --startup-project backend/src/Anela.Heblo.API`), so the migration tool's diff in Task 7 captures only the intended column drops.
+
+Run to verify prerequisite #4:
+
+```bash
+cd backend
+dotnet ef migrations list \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: all migrations show as applied. If any show `(Pending)`, run `dotnet ef database update` first.
+
+If any prerequisite is unmet, **stop and resolve before continuing** — generating the migration against a stale snapshot or pre-rebase tree will produce wrong diffs (see "Risks and Mitigations" in arch-review.r1.md).
+
+---
+
+### Task 1: Remove `GetUnsyncedAsync` from the domain interface and concrete repository
+
+Removing only one of the two would leave the build broken (the interface contract would be unmet, or the concrete class would override a non-existent member). Both edits land together.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs` (line 7)
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs` (lines 26–29)
+
+- [ ] **Step 1: Edit the interface — remove the `GetUnsyncedAsync` line**
+
+Replace the content of `IImportedMarketingTransactionRepository.cs` so the final file reads exactly:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public interface IImportedMarketingTransactionRepository
+{
+    Task<bool> ExistsAsync(string platform, string transactionId, CancellationToken ct);
+    Task AddAsync(ImportedMarketingTransaction entity, CancellationToken ct);
+    Task<int> SaveChangesAsync(CancellationToken ct);
+}
+```
+
+Edit operation: delete line 7 (`Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct);`) entirely. No other changes.
+
+- [ ] **Step 2: Edit the concrete repo — remove the `GetUnsyncedAsync` method body**
+
+In `ImportedMarketingTransactionRepository.cs`, delete the entire method block (lines 26–29):
+
+```csharp
+    public async Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct)
+    {
+        return (await FindAsync(x => !x.IsSynced, ct)).ToList();
+    }
+```
+
+After deletion, the final file reads exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Anela.Heblo.Persistence.Repositories;
+
+namespace Anela.Heblo.Persistence.Features.MarketingInvoices;
+
+public class ImportedMarketingTransactionRepository
+    : BaseRepository<ImportedMarketingTransaction, int>, IImportedMarketingTransactionRepository
+{
+    public ImportedMarketingTransactionRepository(ApplicationDbContext context)
+        : base(context)
+    {
+    }
+
+    public async Task<bool> ExistsAsync(string platform, string transactionId, CancellationToken ct)
+    {
+        return await AnyAsync(
+            x => x.Platform == platform && x.TransactionId == transactionId,
+            ct);
+    }
+
+    public new async Task AddAsync(ImportedMarketingTransaction entity, CancellationToken ct)
+    {
+        await base.AddAsync(entity, ct);
+    }
+}
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run from the repo root:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+If it fails with "no callers found" for `GetUnsyncedAsync`, that's a stale build cache — rerun `dotnet build` on the whole solution. If it fails with a compilation error pointing at another file, **stop and investigate** — the spec/arch-review assert there are no other callers; an unexpected one would be a finding to report.
+
+- [ ] **Step 4: Verify no remaining references to `GetUnsyncedAsync` in the codebase**
+
+```bash
+grep -rn "GetUnsyncedAsync" backend/
+```
+
+Expected: zero hits.
+
+---
+
+### Task 2: Remove `IsSynced = false` from `MarketingInvoiceImportService`
+
+Must happen **before** Task 3 (entity property removal) — otherwise the build breaks while `IsSynced` still appears on the right-hand side of the object initializer with no matching property.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs` (line 75)
+
+- [ ] **Step 1: Delete the `IsSynced = false,` line inside the entity initializer**
+
+In `MarketingInvoiceImportService.cs`, locate the entity-construction block at lines 67–78:
+
+```csharp
+                var entity = new ImportedMarketingTransaction
+                {
+                    TransactionId = transaction.TransactionId,
+                    Platform = source.Platform,
+                    Amount = transaction.Amount,
+                    Currency = transaction.Currency,
+                    TransactionDate = transaction.TransactionDate,
+                    ImportedAt = DateTime.UtcNow,
+                    IsSynced = false,
+                    Description = transaction.Description,
+                    RawData = transaction.RawData,
+                };
+```
+
+Remove the single line `                    IsSynced = false,`. The block becomes:
+
+```csharp
+                var entity = new ImportedMarketingTransaction
+                {
+                    TransactionId = transaction.TransactionId,
+                    Platform = source.Platform,
+                    Amount = transaction.Amount,
+                    Currency = transaction.Currency,
+                    TransactionDate = transaction.TransactionDate,
+                    ImportedAt = DateTime.UtcNow,
+                    Description = transaction.Description,
+                    RawData = transaction.RawData,
+                };
+```
+
+No other lines change. Match indentation (20 spaces — preserved exactly from the surrounding lines).
+
+- [ ] **Step 2: Verify build still succeeds (entity property still exists at this point)**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+---
+
+### Task 3: Remove `IsSynced` and `ErrorMessage` from the entity
+
+After this task, the build will be temporarily broken (the EF configuration still maps these properties) until Task 4 lands. That's expected — Tasks 3 and 4 together restore the build.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs` (lines 14–15)
+
+- [ ] **Step 1: Delete the two property declarations**
+
+Replace the entity file content so it reads exactly:
+
+```csharp
+using Anela.Heblo.Xcc.Domain;
+
+namespace Anela.Heblo.Domain.Features.MarketingInvoices;
+
+public class ImportedMarketingTransaction : IEntity<int>
+{
+    public int Id { get; set; }
+    public string TransactionId { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public DateTime TransactionDate { get; set; }
+    public DateTime ImportedAt { get; set; }
+    public string? Description { get; set; }
+    public string? RawData { get; set; }
+}
+```
+
+Delete lines 14 (`public bool IsSynced { get; set; } = false;`) and 15 (`public string? ErrorMessage { get; set; }`). No other changes.
+
+- [ ] **Step 2: Do NOT build yet — build will fail until Task 4 removes the EF configuration**
+
+Skip the verification step — proceed directly to Task 4.
+
+---
+
+### Task 4: Remove `IsSynced` and `ErrorMessage` mappings from the EF configuration
+
+Pairs with Task 3 — together they restore the build.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs` (lines 47–55)
+
+- [ ] **Step 1: Delete the two property-mapping blocks**
+
+In `ImportedMarketingTransactionConfiguration.cs`, locate and delete this block (lines 47–55):
+
+```csharp
+        builder.Property(e => e.IsSynced)
+            .IsRequired()
+            .HasDefaultValue(false)
+            .HasColumnName("IsSynced")
+            .HasColumnType("boolean");
+
+        builder.Property(e => e.ErrorMessage)
+            .HasColumnName("ErrorMessage")
+            .HasColumnType("text");
+
+```
+
+The final file should read exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.MarketingInvoices;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Anela.Heblo.Persistence.Features.MarketingInvoices;
+
+public class ImportedMarketingTransactionConfiguration : IEntityTypeConfiguration<ImportedMarketingTransaction>
+{
+    public void Configure(EntityTypeBuilder<ImportedMarketingTransaction> builder)
+    {
+        builder.ToTable("ImportedMarketingTransactions", "public");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("Id")
+            .HasColumnType("integer")
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.TransactionId)
+            .IsRequired()
+            .HasMaxLength(255)
+            .HasColumnName("TransactionId")
+            .HasColumnType("character varying(255)");
+
+        builder.Property(e => e.Platform)
+            .IsRequired()
+            .HasMaxLength(50)
+            .HasColumnName("Platform")
+            .HasColumnType("character varying(50)");
+
+        builder.Property(e => e.Amount)
+            .IsRequired()
+            .HasColumnName("Amount")
+            .HasColumnType("numeric(18,2)");
+
+        builder.Property(e => e.TransactionDate)
+            .IsRequired()
+            .HasColumnName("TransactionDate")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.ImportedAt)
+            .IsRequired()
+            .HasColumnName("ImportedAt")
+            .HasColumnType("timestamp without time zone");
+
+        builder.Property(e => e.Currency)
+            .IsRequired()
+            .HasMaxLength(3)
+            .HasColumnName("Currency")
+            .HasColumnType("character varying(3)");
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500)
+            .HasColumnName("Description")
+            .HasColumnType("character varying(500)");
+
+        builder.Property(e => e.RawData)
+            .HasColumnName("RawData")
+            .HasColumnType("text");
+
+        builder.HasIndex(e => new { e.Platform, e.TransactionId })
+            .IsUnique()
+            .HasDatabaseName("IX_ImportedMarketingTransactions_Platform_TransactionId");
+    }
+}
+```
+
+---
+
+### Task 5: Verify the whole solution builds and existing tests still pass
+
+This task validates that Tasks 1–4 together leave the source tree in a fully consistent, compiling, passing state. The migration is generated in Task 7 from this clean baseline.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full solution build**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded. 0 Error(s)` across all projects.
+
+If any project fails: the most likely cause is a lingering reference to `IsSynced`, `ErrorMessage`, or `GetUnsyncedAsync` somewhere outside the five files this plan touches. The arch-review's grep was definitive, but if a build error names another file, stop and report it — do not "fix it up" silently.
+
+- [ ] **Step 2: Run the MarketingInvoices test suite**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices" \
+  --no-build
+```
+
+Expected: all tests in `MarketingInvoiceImportServiceTests` and `ImportMarketingInvoicesHandlerTests` pass. These tests do not reference the removed members (verified by grep), so they should pass without modification.
+
+- [ ] **Step 3: Verify no remaining references within the MarketingInvoices module**
+
+```bash
+grep -rn "IsSynced\|ErrorMessage" backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Application/Features/MarketingInvoices/
+```
+
+Expected: zero hits. (Scoped to the module per arch-review spec amendment #5 — searching repo-wide would surface unrelated `ErrorMessage` matches in other modules.)
+
+```bash
+grep -rn "GetUnsyncedAsync" backend/
+```
+
+Expected: zero hits.
+
+---
+
+### Task 6: Generate the EF Core migration
+
+The migration is generated **after** the entity and configuration edits are complete and the build is clean, so the tool's diff captures only the column drops.
+
+**Files (auto-generated by tool):**
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs`
+- Create: `backend/src/Anela.Heblo.Persistence/Migrations/<UTCtimestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs`
+- Modify: `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`
+
+- [ ] **Step 1: Run the EF Core migration-add command**
+
+```bash
+cd backend && dotnet ef migrations add RemoveUnusedSyncColumnsFromImportedMarketingTransactions \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: tool outputs `Done.` and creates two new files in `src/Anela.Heblo.Persistence/Migrations/` plus updates `ApplicationDbContextModelSnapshot.cs`.
+
+If the tool errors with "the database operation was expected to affect X row(s)" or model-snapshot conflicts, the prerequisite local-DB-at-head check was skipped. Run `dotnet ef database update` first, then retry.
+
+- [ ] **Step 2: Inspect the generated migration's `Up` method**
+
+Open the newly created `<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` file. The `Up` method must contain **exactly** these two `DropColumn` operations targeting `schema: "public"` and `table: "ImportedMarketingTransactions"`:
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.DropColumn(
+        name: "ErrorMessage",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+
+    migrationBuilder.DropColumn(
+        name: "IsSynced",
+        schema: "public",
+        table: "ImportedMarketingTransactions");
+}
+```
+
+The order of `DropColumn` calls may differ from the above — that's fine, both are independent.
+
+**If `Up` contains additional operations** (column adds, alters in other tables, index changes), the prerequisite "local DB at current schema head" was not met or another developer's unmigrated change is in the snapshot. Stop, investigate, and regenerate after resolving — do not commit a migration with unrelated diffs.
+
+- [ ] **Step 3: Inspect the generated migration's `Down` method**
+
+Confirm `Down` re-adds both columns with the original types (per arch-review spec amendment #4 — types must match the original `AddImportedMarketingTransactions` migration exactly):
+
+```csharp
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+    migrationBuilder.AddColumn<bool>(
+        name: "IsSynced",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "boolean",
+        nullable: false,
+        defaultValue: false);
+
+    migrationBuilder.AddColumn<string>(
+        name: "ErrorMessage",
+        schema: "public",
+        table: "ImportedMarketingTransactions",
+        type: "text",
+        nullable: true);
+}
+```
+
+The EF tool generates these `AddColumn` calls automatically from the snapshot it's rolling back **to**. The expected output matches the type strings (`boolean`, `text`) and constraints (`nullable: false, defaultValue: false` for `IsSynced`; `nullable: true` for `ErrorMessage`) that match the original configuration. If the generated `Down` differs from the above, hand-edit only the differing lines to match — but it should not differ in a clean snapshot.
+
+- [ ] **Step 4: Verify the migration's UTC timestamp is later than every existing migration**
+
+```bash
+ls backend/src/Anela.Heblo.Persistence/Migrations/*.cs | sort | tail -5
+```
+
+Expected: the new `<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` is the last entry. (Per arch-review spec amendment #3.)
+
+If it isn't last, the local clock is behind another developer's migration timestamp. Delete all three generated artifacts (`.cs`, `.Designer.cs`, snapshot revert via `git checkout`) and regenerate after correcting the clock, or rebase if a newer migration was pulled in.
+
+- [ ] **Step 5: Verify the model snapshot still compiles**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded. 0 Error(s)`.
+
+---
+
+### Task 7: Apply the migration locally to confirm it executes cleanly
+
+This is a local sanity check — the production deploy is manual per project facts and is documented in the PR description (Task 8).
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Apply the new migration to the local dev database**
+
+```bash
+cd backend && dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: tool reports `Applying migration '<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions'. Done.`
+
+- [ ] **Step 2: Verify columns are dropped in the local DB**
+
+If `psql` is available locally:
+
+```bash
+psql -h localhost -U postgres -d <dev_db_name> -c "\d public.\"ImportedMarketingTransactions\""
+```
+
+Expected: no `IsSynced` and no `ErrorMessage` columns appear in the listing. Remaining columns: `Id`, `TransactionId`, `Platform`, `Amount`, `Currency`, `TransactionDate`, `ImportedAt`, `Description`, `RawData`.
+
+If `psql` is not available, skip this step — the EF tool's success in Step 1 is sufficient.
+
+- [ ] **Step 3: Test the reversibility — apply `Down` then re-apply `Up`**
+
+```bash
+cd backend
+# Find the migration immediately preceding the new one:
+PREV_MIGRATION=$(ls src/Anela.Heblo.Persistence/Migrations/*.cs \
+  | grep -v Designer \
+  | grep -v ModelSnapshot \
+  | grep -v RemoveUnusedSyncColumnsFromImportedMarketingTransactions \
+  | sort | tail -1 | xargs basename | sed 's/\.cs$//')
+echo "Rolling back to: $PREV_MIGRATION"
+
+# Roll back the new migration
+dotnet ef database update "$PREV_MIGRATION" \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+
+# Re-apply the new migration
+dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Expected: rollback succeeds (Down adds columns back), re-apply succeeds (Up drops them again).
+
+If the rollback fails with a column-already-exists or type-mismatch error, the `Down` method's types diverged from the original creation migration. Fix by editing `Down` to match the type strings exactly: `boolean` + `nullable: false, defaultValue: false` for `IsSynced`; `text` + `nullable: true` for `ErrorMessage`.
+
+- [ ] **Step 4: Re-run the test suite against the migrated DB**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~MarketingInvoices" \
+  --no-build
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 8: Final validation — full build, format, full test suite
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run `dotnet format`**
+
+```bash
+cd backend && dotnet format
+```
+
+Expected: no errors. Format changes (if any) get committed alongside the source edits.
+
+- [ ] **Step 2: Run `dotnet build` on the whole solution**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: `Build succeeded. 0 Error(s) 0 Warning(s)` (or whatever the pre-existing warning baseline is — no new warnings).
+
+- [ ] **Step 3: Run the full backend test suite**
+
+```bash
+cd backend && dotnet test --no-build
+```
+
+Expected: all tests pass. The change is purely subtractive dead-code removal; no test should regress.
+
+- [ ] **Step 4: Final repo-wide grep for absent references**
+
+```bash
+grep -rn "GetUnsyncedAsync" backend/ frontend/
+```
+
+Expected: zero hits.
+
+```bash
+grep -rn "IsSynced\|\.ErrorMessage" backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ \
+  backend/src/Anela.Heblo.Application/Features/MarketingInvoices/
+```
+
+Expected: zero hits.
+
+---
+
+### Task 9: Commit and prepare PR description
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Review the staged diff**
+
+```bash
+git status
+git diff
+```
+
+Expected files changed (no others):
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs`
+- `backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs`
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionRepository.cs`
+- `backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ImportedMarketingTransactionConfiguration.cs`
+- `backend/src/Anela.Heblo.Persistence/Migrations/ApplicationDbContextModelSnapshot.cs`
+- `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.cs` (new)
+- `backend/src/Anela.Heblo.Persistence/Migrations/<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions.Designer.cs` (new)
+- `backend/src/Anela.Heblo.Application/Features/MarketingInvoices/Services/MarketingInvoiceImportService.cs`
+
+If any other files appear in the diff, stop and investigate before committing.
+
+- [ ] **Step 2: Stage all changes and commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/MarketingInvoices/ \
+        backend/src/Anela.Heblo.Persistence/Features/MarketingInvoices/ \
+        backend/src/Anela.Heblo.Persistence/Migrations/ \
+        backend/src/Anela.Heblo.Application/Features/MarketingInvoices/
+
+git commit -m "refactor(marketing-invoices): remove unimplemented sync scaffolding
+
+Remove unused GetUnsyncedAsync repository method, IsSynced and ErrorMessage
+entity properties, their EF configuration, and add a reversible migration
+dropping both columns. The FlexiBee sync workflow these columns were added
+for is explicitly deferred to Future Work per epic #609 and would not reuse
+this exact schema. Existing tests pass without modification."
+```
+
+- [ ] **Step 3: PR description must explicitly document the manual migration step**
+
+When opening the PR, include this section in the description (database migrations are not automated per project facts):
+
+```markdown
+## Manual deployment step
+
+This PR adds the migration:
+
+`<timestamp>_RemoveUnusedSyncColumnsFromImportedMarketingTransactions`
+
+It must be applied manually to each environment:
+
+```bash
+cd backend && dotnet ef database update \
+  --project src/Anela.Heblo.Persistence \
+  --startup-project src/Anela.Heblo.API
+```
+
+Migration order is safe in either direction:
+- **migrate-then-deploy**: old code still works against the new schema (old
+  code only wrote `IsSynced = false` and never read either column).
+- **deploy-then-migrate**: new code works against the old schema (EF Core
+  ignores unmapped DB columns at runtime).
+
+`DROP COLUMN` in PostgreSQL is metadata-only and fast on any table size.
+```
+
+---
+
+## Self-Review
+
+After writing the plan, checking against spec.r2.md and arch-review.r1.md:
+
+**Spec coverage:**
+- FR-1 (remove `GetUnsyncedAsync` from interface + impl) → Task 1.
+- FR-2 (remove `IsSynced` + `ErrorMessage` from entity, remove `IsSynced = false` insert) → Tasks 2 + 3.
+- FR-3 (remove EF configuration mappings) → Task 4.
+- FR-4 (add migration with working `Up`/`Down`) → Tasks 6 + 7.
+- FR-5 (verify no callers depend on entity-level error storage) → Prerequisite grep in Task 5, Step 3 + Task 8, Step 4.
+- FR-6 (sequence behind PRs #1771 and #1766) → "Prerequisites Check" block + arch-review's risk mitigations carried into Task 6, Step 4.
+- NFR-1/2/3/4/5 (perf, security, reversibility, BC, test coverage) → covered by reversible-`Down` design in Task 6 Step 3, no test changes per NFR-5, schema is `public` per arch-review Decision 2.
+
+**Arch-review amendments applied:**
+- Amendment #1 (schema is `public`, not `dbo`) → enforced in Task 6 Step 2 verification + Task 6 Step 3.
+- Amendment #2 (regenerate `ApplicationDbContextModelSnapshot.cs`) → tool re-runs in Task 6 Step 1; manual edits forbidden.
+- Amendment #3 (timestamp must be latest) → Task 6 Step 4.
+- Amendment #4 (`Down` types match original creation migration exactly) → Task 6 Step 3 + Task 7 Step 3 reversibility test.
+- Amendment #5 (scope grep to MarketingInvoices module) → Task 5 Step 3 + Task 8 Step 4 scoped greps.
+
+**Placeholder scan:** no TBDs, no "add appropriate X", no "similar to Task N", no missing code blocks. All file paths absolute or relative-from-repo-root with explicit anchors.
+
+**Type consistency:** the interface and entity shapes in Task 1 / Task 3 final-form code blocks match the arch-review's "final form" appendix exactly. No method or property names drift between tasks.
+
+## Status: COMPLETE


### PR DESCRIPTION
MarketingInvoices

## Finding
Three related pieces of the module exist solely as scaffolding for a sync workflow that has not been implemented:

**1. `IImportedMarketingTransactionRepository.GetUnsyncedAsync` — zero callers**
```csharp
// Domain/Features/MarketingInvoices/IImportedMarketingTransactionRepository.cs:7
Task<List<ImportedMarketingTransaction>> GetUnsyncedAsync(CancellationToken ct);
```
A grep across the entire `src/` tree finds no call site outside the interface and its implementation.

**2. `ImportedMarketingTransaction.IsSynced` — always `false`, never updated**
```csharp
// Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:14
public bool IsSynced { get; set; } = false;
```
Set to `false` on insert (`MarketingInvoiceImportService.cs:74`). No code anywhere sets it to `true`. Every row in the database is permanently unsynced.

**3. `ImportedMarketingTransaction.ErrorMessage` — always `null`, never written**
```csharp
// Domain/Features/MarketingInvoices/ImportedMarketingTransaction.cs:15
public string? ErrorMessage { get; set; }
```
The DB column is configured (`ImportedMarketingTransactionConfiguration.cs:53`), but no application code ever assigns a value. The import service logs errors via `ILogger` and updates `result.Failed`, but never stores the error string on the entity.

## Why it matters
YAGNI: these three items inflate the domain interface, the entity, and the database schema with speculative infrastructure for a future sync step. `GetUnsyncedAsync` appearing in the domain interface misleads readers into assuming it is called somewhere. `IsSynced = false` on every row makes the column queryable but useless. `ErrorMessage` occupies a `text` column that is always `NULL`.

## Suggested fix
Two options depending on intent:

**A — Implement the missing sync step:** Add a use case or background service that fetches unsynced transactions, posts them to the accounting system, and sets `IsSynced = true` / `ErrorMessage` on failure. This is the intended direction.

**B — Remove the scaffolding until it is needed:** Delete `GetUnsyncedAsync` from the interface and implementation, drop `IsSynced` and `ErrorMessage` from `ImportedMarketingTransaction` and its EF configuration, and add a migration to remove the columns. Re-add when the sync workflow is actually being built.

Option B is cheaper now; option A is the right call only when the sync workflow is actively being built.

---
_Filed by daily arch-review routine on 2026-05-26._

---

Closes #1720

### Tokens used
18732235
