### PR TITLE
feat: Fix Temp File Leak in ReprintExpeditionListHandler

### DIFF
--- a/artifacts/feat-arch-review-expeditionlistarchive-temp-f/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-temp-f/arch-review.r1.md
@@ -1,0 +1,101 @@
+# Architecture Review: Fix Temp File Leak in ReprintExpeditionListHandler
+
+## Skip Design: true
+
+Backend bug fix only. No UI, no API contract, no DTO change.
+
+## Architectural Fit Assessment
+
+The proposed fix aligns cleanly with patterns already established in this codebase. `Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf")` is the same idiom used in:
+
+- `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs:162` — production code building temp paths with `Path.Combine(Path.GetTempPath(), fileName)`.
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/FileSystemPrintQueueSinkTests.cs:11-12` and `CupsPrintingServiceTests.cs:14` — sibling print-pipeline tests that already use `Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())`.
+
+The handler lives in the vertical slice `Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/`. The change is localized to a single line (`ReprintExpeditionListHandler.cs:29`) inside that slice. No module boundary, no DI registration, no contract is touched. Integration points (`IBlobStorageService`, `IPrintQueueSink`, `IOptions<PrintPickingListOptions>`) are unchanged.
+
+The spec correctly defers the same-shaped bug in `PlaudCliClient.cs:29,43` to a separate sweep — that file is in a different adapter slice and its lifecycle (single-call CLI invocation) differs.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+ReprintExpeditionListRequest (MediatR)
+        │
+        ▼
+ReprintExpeditionListHandler ─────► BlobPathValidator (guard)
+        │                          
+        │ 1. allocate temp path  ◄── CHANGE: GUID-based, no pre-created file
+        │ 2. download blob ──────► IBlobStorageService
+        │ 3. write to temp file
+        │ 4. hand path to print   ► IPrintQueueSink (CUPS)
+        │ 5. DeleteTempFile (finally) — single cleanup point
+        ▼
+ReprintExpeditionListResponse
+```
+
+No structural change. Only step 1's path-allocation mechanism flips from `Path.GetTempFileName() + ".pdf"` (which creates a sibling `.tmp` file on disk) to `Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf")` (which allocates a string only).
+
+### Key Design Decisions
+
+#### Decision 1: GUID-based path vs. wrapping `Path.GetTempFileName` cleanup
+**Options considered:**
+- (a) `Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf")` — single allocation, no disk side effect.
+- (b) Keep `Path.GetTempFileName()`, capture both the original `.tmp` path and the renamed `.pdf` path, delete both.
+- (c) Switch to a stream-based pipeline that pipes blob → print sink without disk.
+
+**Chosen approach:** (a).
+
+**Rationale:** (a) matches existing codebase idiom (`ShoptetApiExpeditionListSource.cs:162`), is a one-line change, and removes one filesystem syscall per reprint. (b) doubles the cleanup surface and keeps a useless `.tmp` artifact in the success path's atomic window. (c) is the spec's "Out of Scope" item — would require redesigning `IPrintQueueSink`, which takes a path collection.
+
+#### Decision 2: Keep `.pdf` extension in temp filename
+**Chosen approach:** Preserve `.pdf` suffix.
+
+**Rationale:** `IPrintQueueSink` implementations (CUPS sink) may dispatch on extension. The spec calls this out as an acceptance criterion (FR-1). Verified that `FileSystemPrintQueueSink` and `AzureBlobPrintQueueSink` accept arbitrary paths but propagate the filename downstream — preserving `.pdf` is the safe choice.
+
+#### Decision 3: GUID `N` format (32 hex chars, no hyphens)
+**Chosen approach:** `Guid.NewGuid():N`.
+
+**Rationale:** Matches the spec. Avoids hyphens which some downstream tools handle inconsistently. Filename uniqueness is preserved (122 bits of entropy — no realistic collision under concurrent reprints).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Single edit:
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29`
+
+### Interfaces and Contracts
+None changed. `IRequestHandler<ReprintExpeditionListRequest, ReprintExpeditionListResponse>` shape, `IBlobStorageService.DownloadAsync`, and `IPrintQueueSink.SendAsync` signatures remain identical.
+
+### Data Flow
+Unchanged. Only the path-string source changes from "GetTempFileName side-effect + concat" to "pure in-memory construction."
+
+### Testing Guidance
+Existing tests in `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs` cover success and validation-failure paths with mocked dependencies but do not assert anything about the file system. The spec's leak test must be additive:
+
+1. **Add a third test** — `Handle_SuccessfulReprint_LeavesNoFilesInTempDirectory`. Snapshot the temp directory file count (or files matching `*.pdf`/`*.tmp`) before, run the handler, snapshot after, assert equality. Use a `MemoryStream` with PDF magic bytes as the blob (same as existing test).
+2. **Add a fourth test** — `Handle_BlobDownloadFails_LeavesNoFilesInTempDirectory`. Configure `_blobStorageServiceMock.Setup(...).ThrowsAsync(new IOException(...))`, then assert the same snapshot equality after the exception bubbles up.
+3. **Capture the path** passed to `IPrintQueueSink` via `Callback` and assert it ends in `.pdf` and starts with `Path.GetTempPath()`.
+
+Do **not** introduce a private temp directory or a temp-path abstraction (`ITempFileProvider`). The spec explicitly forbids broader refactoring (Out of Scope) and the existing pattern in sibling tests uses the system temp dir directly.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| New leak test is flaky because *other* code in parallel test runs writes to `Path.GetTempPath()` | MEDIUM | Snapshot only files matching a handler-specific pattern (e.g., 32-hex-char `.pdf` filenames, or capture the path returned to the sink and assert that specific path does not exist post-call). Avoid counting all temp-dir files. |
+| Hidden assumption in CUPS sink about the path being pre-existing | LOW | Code path already calls `File.OpenWrite(tempFile)` which creates the file before the sink sees it. Sink receives an existing, fully-written file in both old and new code. |
+| Race with concurrent reprints producing same path | NEGLIGIBLE | 122-bit GUID entropy. Already the assumption baked into the rest of the codebase. |
+| Reviewer asks "why not fix `PlaudCliClient.cs` too" | LOW | Spec explicitly defers that to a separate sweep. Cite the Out-of-Scope clause if asked. |
+
+## Specification Amendments
+
+The spec's Testing Strategy says "use a temp-directory snapshot (count files before/after) to verify no leak." This is fragile under parallel test execution (`xUnit` runs test classes in parallel by default). **Amend the testing approach** to: capture the path passed into `IPrintQueueSink.SendAsync` via Moq `Callback`, then assert `File.Exists(capturedPath) == false` after `Handle` returns (success path) or after the exception is caught (failure path). This is deterministic regardless of what other tests write to `Path.GetTempPath()`.
+
+## Prerequisites
+
+None. No migrations, config, or infrastructure changes. The fix is shippable in a single commit touching:
+- `ReprintExpeditionListHandler.cs:29` (production)
+- `ReprintExpeditionListHandlerTests.cs` (add two leak-regression tests)
+
+Validation gates per `CLAUDE.md`: `dotnet build` + `dotnet format` + the two new tests pass.

--- a/artifacts/feat-arch-review-expeditionlistarchive-temp-f/brief.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-temp-f/brief.md
@@ -1,0 +1,26 @@
+## Module
+ExpeditionListArchive
+
+## Finding
+`ReprintExpeditionListHandler.cs:29` constructs a temp path with:
+
+```csharp
+var tempFile = Path.GetTempFileName() + ".pdf";
+```
+
+`Path.GetTempFileName()` immediately creates a zero-byte file on disk and returns its path (e.g. `tmp1A2B.tmp`). Appending `".pdf"` produces a different string (`tmp1A2B.tmp.pdf`) — a path that does not yet exist. The handler then writes the blob into the `.pdf` path and deletes it in `DeleteTempFile`, but the original `.tmp` file created by `GetTempFileName()` is never touched again and accumulates on the server with each reprint call.
+
+## Why it matters
+Every successful or failed reprint leaks one temp file. On a busy server this fills `/tmp` silently. The `DeleteTempFile` helper already exists and the intent to clean up is clear, so the leak is purely due to the wrong API usage.
+
+## Suggested fix
+Replace the two-step approach with a single random path that is never pre-created:
+
+```csharp
+var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf");
+```
+
+This avoids creating an extra `.tmp` file and keeps the `.pdf` extension the CUPS sink may rely on.
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-expeditionlistarchive-temp-f/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-temp-f/impl/main.r1.md
@@ -1,0 +1,62 @@
+Final reviewer says **READY TO MERGE**. All three tasks are complete. Let me write the output artifact.
+
+---
+
+# Implementation: Fix Temp File Leak in ReprintExpeditionListHandler
+
+## What was implemented
+
+Eliminated the orphaned `.tmp` file that `ReprintExpeditionListHandler` leaked into the system temp directory on every reprint. `Path.GetTempFileName()` creates a zero-byte file on disk as a side effect; appending `.pdf` produced a different path, so the original `.tmp` was never cleaned up. Replaced with a pure in-memory GUID-based path that has no filesystem side effect.
+
+Two regression tests were written first (TDD RED) and then the production fix was applied (GREEN).
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs` — single-line change at line 29
+- `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs` — two new regression tests added
+
+## Tests
+
+- `Handle_SuccessfulReprint_LeavesNoTempFileBehind` — captures path via Moq Callback, asserts file exists during sink call, is gone after handler returns, and no handler-shaped files leaked in temp dir
+- `Handle_BlobDownloadFails_LeavesNoTempFileBehind` — configures blob download to throw IOException, asserts exception propagates, no leaked files, sink never called
+- Both new tests were RED before the fix and GREEN after
+- Full suite: 3985 tests pass, 3 skipped
+
+## How to verify
+
+```bash
+# Run the 4 handler tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests" --nologo
+
+# Full suite
+dotnet test backend/Anela.Heblo.sln --nologo
+
+# Build + format gates
+dotnet build backend/Anela.Heblo.sln --nologo
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+## Notes
+
+Commits (in order):
+- `b7493ec4` — test: add regression test for ReprintExpeditionListHandler temp file leak
+- `2eb92837` — test: add regression test for ReprintExpeditionListHandler temp file leak on failure
+- `e3f0f7f4` — fix: prevent temp file leak in ReprintExpeditionListHandler
+
+`PlaudCliClient.cs` has the same bug pattern but is explicitly out of scope per spec (different adapter slice, different lifecycle). Mentioned for the next sweep.
+
+## PR Summary
+
+Fixes a silent resource leak in `ReprintExpeditionListHandler` where every reprint left an orphaned zero-byte `.tmp` file in the system temp directory. Over time this fills `/tmp` with junk and degrades server health.
+
+Root cause: `Path.GetTempFileName()` atomically creates a file on disk and returns its path; appending `.pdf` produces a different path referencing a non-existent file. The handler wrote and deleted the `.pdf` path, never touching the underlying `.tmp` file.
+
+Fix: replace with `Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf")` — a pure string operation with no disk side effect, preserving the `.pdf` extension the CUPS sink depends on. One fewer syscall per reprint as a bonus.
+
+### Changes
+- `ReprintExpeditionListHandler.cs:29` — replaced path construction (single line)
+- `ReprintExpeditionListHandlerTests.cs` — added two regression tests (success path and failure path), written RED-first before the fix
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-expeditionlistarchive-temp-f/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-temp-f/spec.r1.md
@@ -1,0 +1,93 @@
+# Specification: Fix Temp File Leak in ReprintExpeditionListHandler
+
+## Summary
+`ReprintExpeditionListHandler` leaks one zero-byte temp file per invocation because `Path.GetTempFileName()` creates a file on disk that is never deleted (the handler only cleans up a different `.pdf` path it constructs by string concatenation). Replace the path construction with `Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf")` so no extra file is created and the existing cleanup logic remains effective.
+
+## Background
+The reprint flow writes a PDF blob to disk and hands the path to a CUPS print sink, then deletes the temp file via `DeleteTempFile`. The current code uses:
+
+```csharp
+var tempFile = Path.GetTempFileName() + ".pdf";
+```
+
+`Path.GetTempFileName()` has two side effects: it generates a unique name (e.g. `tmpXXXX.tmp`) **and** immediately creates a zero-byte file at that path. Appending `".pdf"` produces a new string (`tmpXXXX.tmp.pdf`) referencing a different, non-existent path. The handler subsequently writes and deletes the `.pdf` path, leaving the original `.tmp` file orphaned on disk. Over time `/tmp` fills with empty `.tmp` files — one per reprint, regardless of success or failure.
+
+The CUPS sink may rely on the `.pdf` extension, so the chosen replacement must preserve it.
+
+## Functional Requirements
+
+### FR-1: Eliminate orphaned temp file on every reprint
+Replace the temp path construction in `ReprintExpeditionListHandler` so that exactly one file is created on disk per reprint, and that file is the one the handler manages end-to-end.
+
+**Acceptance criteria:**
+- After a successful reprint, no new files remain in the system temp directory attributable to this handler.
+- After a failed reprint (exception during write or print), no new files remain in the system temp directory attributable to this handler (existing cleanup semantics preserved).
+- The path passed to the CUPS sink still ends in `.pdf`.
+- The path is unique per invocation (no collisions under concurrent reprints).
+
+### FR-2: Preserve existing cleanup behavior
+The existing `DeleteTempFile` helper must continue to be the single cleanup point. No new cleanup paths or shutdown hooks are introduced.
+
+**Acceptance criteria:**
+- `DeleteTempFile` is still invoked in the same control-flow locations (success and failure paths) as before the change.
+- No additional `try/finally` or disposal scaffolding is added beyond what already exists.
+
+### FR-3: No behavioral change to print output
+The reprint operation must continue to produce the same PDF content delivered to the same sink with the same filename semantics from the consumer's perspective. Only the path-generation mechanism changes.
+
+**Acceptance criteria:**
+- Reprint produces an identical PDF payload at the temp path.
+- The CUPS sink receives a path with a `.pdf` extension and successfully prints in manual verification.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+Negligible impact. `Guid.NewGuid()` + `Path.Combine` is faster than `Path.GetTempFileName()` (which performs a file-system create) and removes one disk I/O per reprint.
+
+### NFR-2: Security
+- Path is constructed from `Path.GetTempPath()` and a server-generated GUID — no user input flows into the path, so no path-traversal exposure is introduced.
+- Default permissions on files created in the temp directory remain unchanged (still inherits OS/process defaults).
+- Random GUID (`N` format, 32 hex chars) makes the filename unguessable, mitigating any race with a malicious local actor pre-creating the same path.
+
+### NFR-3: Reliability
+The fix removes a silent resource leak that degrades server health over time. No new failure modes are introduced; if `File.WriteAllBytes` (or equivalent) fails on the constructed path, the failure surfaces immediately just as today.
+
+## Data Model
+None. This change does not touch the domain model, database, or DTOs.
+
+## API / Interface Design
+No public API, contract, or UI change. The change is internal to `ReprintExpeditionListHandler.cs` at the temp-file allocation line (currently at `ReprintExpeditionListHandler.cs:29`).
+
+**Before:**
+```csharp
+var tempFile = Path.GetTempFileName() + ".pdf";
+```
+
+**After:**
+```csharp
+var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf");
+```
+
+## Dependencies
+- `System.IO.Path` (BCL) — already in use.
+- `System.Guid` (BCL) — already available.
+- No new packages, services, or feature flags.
+
+## Testing Strategy
+- **Unit test:** Add or update a test that invokes `ReprintExpeditionListHandler` and asserts:
+  1. The temp directory contains no leftover files matching the handler's pattern after both success and failure paths.
+  2. The path handed to the print sink ends in `.pdf`.
+  Since the handler currently depends on a CUPS sink and file system, the test should inject/stub the sink and use a temp-directory snapshot (count files before/after) to verify no leak.
+- **Manual verification:** Trigger a reprint end-to-end on a dev environment, confirm the PDF prints, and confirm no new `.tmp` or `.pdf` files remain in `/tmp` after the operation completes.
+
+## Out of Scope
+- Refactoring `DeleteTempFile` or the broader handler structure.
+- Switching to a stream-based approach that bypasses disk entirely (would require CUPS sink changes).
+- Auditing other call sites in the codebase for similar `Path.GetTempFileName()` misuse — that is a separate sweep.
+- Adding background cleanup of pre-existing orphaned temp files left by previous deployments.
+- Changing the temp directory location or introducing a configurable temp path.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-expeditionlistarchive-temp-f/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-temp-f/task-plan.r1.md
@@ -1,0 +1,324 @@
+# Fix Temp File Leak in ReprintExpeditionListHandler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the orphaned `tmpXXXX.tmp` file that `ReprintExpeditionListHandler` leaks into the system temp directory on every reprint invocation, by switching from `Path.GetTempFileName() + ".pdf"` to a pure in-memory GUID-based path.
+
+**Architecture:** Single-line production change inside the `ReprintExpeditionList` vertical slice (`backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29`). No new files, no contract changes, no DI changes — the existing `DeleteTempFile` helper remains the single cleanup point. Two regression tests are added that capture the path passed into `IPrintQueueSink.SendAsync` via Moq `Callback` and assert `File.Exists(path) == false` after the handler returns (success path) or throws (failure path).
+
+**Tech Stack:** .NET 8, C# 12, xUnit, Moq, MediatR. No new packages.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29` — production fix.
+- `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs` — add two regression tests (one success path, one failure path) verifying no temp file is left behind and the path handed to the sink ends in `.pdf` and is rooted under `Path.GetTempPath()`.
+
+**Create:** none.
+
+**Do not touch:**
+- `IPrintQueueSink`, `IBlobStorageService`, `BlobPathValidator`, `PrintPickingListOptions`, `ReprintExpeditionListRequest`/`Response`, DI registrations, or sibling adapters (`PlaudCliClient.cs` is explicitly out of scope per spec).
+
+---
+
+## Task 1: Add Regression Test — Success Path Leaves No Temp File
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs`
+
+This task adds the failing test **first** (TDD RED), before any production change. It captures the temp path passed to `IPrintQueueSink.SendAsync` and asserts the file no longer exists once `Handle` returns. With the current buggy production code, the captured path is `tmpXXXX.tmp.pdf` (deleted successfully by `DeleteTempFile` — the test on that captured path will actually PASS for the captured `.pdf` path), so to make this test actually expose the leak we must additionally assert that the *underlying* `Path.GetTempFileName()` artifact (a sibling `.tmp` file) was not left behind. The clean way to do this without coupling to internals is to assert on the **single captured path the sink received** AND on the snapshot of any handler-attributable files created during the call.
+
+After thinking through the failure-mode again: the leak is the `.tmp` file created as a side effect of `Path.GetTempFileName()`. The sink only sees the `.pdf` path. Asserting only on the captured `.pdf` path will not expose the leak. The deterministic way to expose it is to **snapshot files in `Path.GetTempPath()` matching a stable pattern before the call, run the handler, snapshot again, and assert the delta is exactly the empty set**.
+
+Per the architecture review (which warned that broad temp-dir snapshots are flaky under parallel xUnit execution), we constrain the snapshot to a narrow pattern: files created during the call window, matching either `tmp*.tmp` or `tmp*.tmp.pdf` (the two filename shapes the buggy code produces), or — after the fix — 32-hex-char `.pdf` filenames. To make this robust regardless of which side of the fix we are on, we additionally capture the path the sink received and explicitly assert that path does not exist post-call.
+
+The test:
+1. Captures the temp file path passed to `IPrintQueueSink.SendAsync` via Moq `Callback`.
+2. Snapshots the list of files currently under `Path.GetTempPath()` (full path strings) before invoking the handler.
+3. Invokes the handler.
+4. After completion, asserts: the captured path exists and ends in `.pdf` and is rooted under `Path.GetTempPath()` *during the callback* (we record this fact inside the callback because the file is deleted before the test resumes); `File.Exists(capturedPath)` is `false` after `Handle` returns; the set of files in `Path.GetTempPath()` is a subset of the pre-call snapshot (i.e., no new files attributable to this handler remain). To avoid flakiness from unrelated parallel writes, we filter the post-call delta to files whose **name** matches `tmp*.tmp` or `tmp*.tmp.pdf` — the only shapes the buggy code can produce — or any 32-hex-char `.pdf` file (the post-fix shape). Any such leftover file fails the test.
+
+- [ ] **Step 1: Write the failing test for the success path**
+
+Append this test inside `ReprintExpeditionListHandlerTests` (after the existing `Handle_InvalidBlobPath_ReturnsFailureWithoutCallingBlob` test). Also add the `System.IO` and `System.Text.RegularExpressions` `using` directives at the top of the file if they are not already present (`System.IO` is implicit, `System.Text.RegularExpressions` is needed for the filename pattern check).
+
+Add to the `using` block at the top of the file (only those not already present):
+
+```csharp
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+```
+
+Add the test method to the class:
+
+```csharp
+    [Fact]
+    public async Task Handle_SuccessfulReprint_LeavesNoTempFileBehind()
+    {
+        // Arrange
+        var blobPath = "2026-03-25/picking-list-002.pdf";
+        var pdfContent = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // PDF magic bytes
+        var blobStream = new MemoryStream(pdfContent);
+
+        _blobStorageServiceMock
+            .Setup(s => s.DownloadAsync(ContainerName, blobPath, default))
+            .ReturnsAsync(blobStream);
+
+        string? capturedPath = null;
+        bool capturedPathExistedDuringSinkCall = false;
+        bool capturedPathEndsWithPdf = false;
+        bool capturedPathRootedInTempDir = false;
+
+        _cupsSinkMock
+            .Setup(s => s.SendAsync(It.IsAny<IEnumerable<string>>(), default))
+            .Callback<IEnumerable<string>, CancellationToken>((paths, _) =>
+            {
+                capturedPath = paths.Single();
+                capturedPathExistedDuringSinkCall = File.Exists(capturedPath);
+                capturedPathEndsWithPdf = capturedPath.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+                capturedPathRootedInTempDir = capturedPath.StartsWith(Path.GetTempPath(), StringComparison.Ordinal);
+            })
+            .Returns(Task.CompletedTask);
+
+        var tempDir = Path.GetTempPath();
+        var preCallFiles = new HashSet<string>(Directory.EnumerateFiles(tempDir));
+
+        var request = new ReprintExpeditionListRequest { BlobPath = blobPath };
+
+        // Act
+        var result = await _handler.Handle(request, default);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(capturedPath);
+        Assert.True(capturedPathEndsWithPdf, "Path passed to sink must end in .pdf");
+        Assert.True(capturedPathRootedInTempDir, "Path passed to sink must be rooted under Path.GetTempPath()");
+        Assert.True(capturedPathExistedDuringSinkCall, "PDF file must exist on disk when sink is invoked");
+        Assert.False(File.Exists(capturedPath), "Temp file must be deleted after handler returns");
+
+        // Detect leaks: any *new* file in the temp dir whose name matches the
+        // shapes the handler could plausibly produce (current buggy or fixed).
+        var postCallFiles = Directory.EnumerateFiles(tempDir).ToList();
+        var handlerArtifactPattern = new Regex(@"^(tmp[^/\\]*\.tmp(\.pdf)?|[0-9a-fA-F]{32}\.pdf)$");
+        var leakedFiles = postCallFiles
+            .Where(p => !preCallFiles.Contains(p))
+            .Where(p => handlerArtifactPattern.IsMatch(Path.GetFileName(p)))
+            .ToList();
+
+        Assert.True(
+            leakedFiles.Count == 0,
+            $"Handler must not leave temp files behind. Found: {string.Join(", ", leakedFiles)}");
+    }
+```
+
+- [ ] **Step 2: Run the new test and verify it fails for the right reason**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests.Handle_SuccessfulReprint_LeavesNoTempFileBehind" \
+  --nologo
+```
+
+Expected: FAIL. The failure must be the leak-detection assertion (`"Handler must not leave temp files behind. Found: /tmp/tmpXXXXXX.tmp"`), proving the test catches the bug currently in production. If the test fails on `capturedPathEndsWithPdf` or `capturedPathExistedDuringSinkCall` instead, stop — the test instrumentation is wrong, not the production code.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
+git commit -m "test: add regression test for ReprintExpeditionListHandler temp file leak"
+```
+
+---
+
+## Task 2: Add Regression Test — Failure Path Leaves No Temp File
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs`
+
+Cover the catch-block cleanup branch: when `IBlobStorageService.DownloadAsync` throws, `DeleteTempFile` is called inside the `catch` block. We assert the same invariant: after the exception bubbles out of `Handle`, no handler-attributable file remains in the temp directory.
+
+Because the sink is never called in this scenario, we cannot capture the path via the sink. Instead, we rely solely on the temp-directory delta (filtered to handler-shaped filenames). This is the same robust pattern as Task 1's leak detection.
+
+- [ ] **Step 1: Write the failing test for the failure path**
+
+Append this test to `ReprintExpeditionListHandlerTests`:
+
+```csharp
+    [Fact]
+    public async Task Handle_BlobDownloadFails_LeavesNoTempFileBehind()
+    {
+        // Arrange
+        var blobPath = "2026-03-25/picking-list-003.pdf";
+
+        _blobStorageServiceMock
+            .Setup(s => s.DownloadAsync(ContainerName, blobPath, default))
+            .ThrowsAsync(new IOException("blob unavailable"));
+
+        var tempDir = Path.GetTempPath();
+        var preCallFiles = new HashSet<string>(Directory.EnumerateFiles(tempDir));
+
+        var request = new ReprintExpeditionListRequest { BlobPath = blobPath };
+
+        // Act
+        await Assert.ThrowsAsync<IOException>(() => _handler.Handle(request, default));
+
+        // Assert: same leak detection as the success-path test.
+        var postCallFiles = Directory.EnumerateFiles(tempDir).ToList();
+        var handlerArtifactPattern = new Regex(@"^(tmp[^/\\]*\.tmp(\.pdf)?|[0-9a-fA-F]{32}\.pdf)$");
+        var leakedFiles = postCallFiles
+            .Where(p => !preCallFiles.Contains(p))
+            .Where(p => handlerArtifactPattern.IsMatch(Path.GetFileName(p)))
+            .ToList();
+
+        Assert.True(
+            leakedFiles.Count == 0,
+            $"Handler must not leave temp files behind on failure. Found: {string.Join(", ", leakedFiles)}");
+
+        _cupsSinkMock.Verify(
+            s => s.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the new test and verify it fails for the right reason**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests.Handle_BlobDownloadFails_LeavesNoTempFileBehind" \
+  --nologo
+```
+
+Expected: FAIL with the leak-detection assertion message, listing a `tmpXXXXXX.tmp` file under `/tmp` (the artifact left by `Path.GetTempFileName()` — the `catch` block deletes the `.pdf` path but not the underlying `.tmp` file). If instead it fails because the `IOException` was not thrown, or because `SendAsync` was unexpectedly called, the test instrumentation is wrong — stop and fix.
+
+- [ ] **Step 3: Commit the second failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
+git commit -m "test: add regression test for ReprintExpeditionListHandler temp file leak on failure"
+```
+
+---
+
+## Task 3: Apply the Production Fix
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29`
+
+Replace the buggy path construction. This is the minimal change required to make both failing tests pass without altering any other handler behavior.
+
+- [ ] **Step 1: Edit the temp-path allocation line**
+
+In `ReprintExpeditionListHandler.cs`, change line 29 from:
+
+```csharp
+        var tempFile = Path.GetTempFileName() + ".pdf";
+```
+
+to:
+
+```csharp
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf");
+```
+
+No other lines in the file change. The two `try` blocks, `DeleteTempFile` calls, and exception flow stay exactly as they are.
+
+- [ ] **Step 2: Re-run both regression tests and verify they pass**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests" \
+  --nologo
+```
+
+Expected: PASS for all four tests:
+- `Handle_ValidBlobPath_DownloadsAndSendsToCupsSink` (pre-existing)
+- `Handle_InvalidBlobPath_ReturnsFailureWithoutCallingBlob` (pre-existing)
+- `Handle_SuccessfulReprint_LeavesNoTempFileBehind` (new — Task 1)
+- `Handle_BlobDownloadFails_LeavesNoTempFileBehind` (new — Task 2)
+
+- [ ] **Step 3: Run the full backend test suite to confirm no collateral damage**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --nologo
+```
+
+Expected: all tests pass. If any unrelated test fails, stop and investigate before continuing — the change is one line and should not affect any other handler, but a passing full suite is the gate per `CLAUDE.md`.
+
+- [ ] **Step 4: Run build and format gates**
+
+Per `CLAUDE.md` "Validation before completion":
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: both commands exit 0. If `dotnet format --verify-no-changes` reports diffs, run `dotnet format backend/Anela.Heblo.sln` and re-run the verify command.
+
+- [ ] **Step 5: Commit the production fix**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs
+git commit -m "fix: prevent temp file leak in ReprintExpeditionListHandler
+
+Path.GetTempFileName() creates a zero-byte file on disk as a side effect.
+The handler appended '.pdf' to that path, producing a different path that
+referenced a non-existent file, then wrote and deleted that .pdf path —
+leaving the original .tmp file orphaned in the system temp directory on
+every reprint, regardless of success or failure.
+
+Replace with Path.Combine(Path.GetTempPath(), \$\"{Guid.NewGuid():N}.pdf\"),
+which produces a unique path with no filesystem side effect and preserves
+the .pdf extension the CUPS sink relies on."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Covered by |
+|---|---|
+| FR-1: Eliminate orphaned temp file (success path) | Task 1 test + Task 3 fix |
+| FR-1: Eliminate orphaned temp file (failure path) | Task 2 test + Task 3 fix |
+| FR-1: Path ends in `.pdf` | Task 1 `capturedPathEndsWithPdf` assertion |
+| FR-1: Path uniqueness (no collisions) | Guaranteed by 122-bit `Guid.NewGuid()` entropy; no test needed |
+| FR-2: `DeleteTempFile` remains the single cleanup point | Task 3 changes only line 29; lines 30–56 untouched |
+| FR-2: No new `try/finally` scaffolding | Same — verified by surgical edit scope |
+| FR-3: Identical PDF payload at temp path | Existing `Handle_ValidBlobPath_DownloadsAndSendsToCupsSink` still passes (Task 3 Step 2) |
+| FR-3: Sink receives `.pdf` path | Task 1 `capturedPathEndsWithPdf` assertion |
+| NFR-1: Performance | One fewer syscall per reprint — automatic consequence of the fix |
+| NFR-2: Security (no user input in path) | Path components are `Path.GetTempPath()` + GUID; verified by inspection |
+| NFR-3: Reliability (no new failure modes) | Existing tests cover success/validation-failure; new tests cover I/O-failure cleanup |
+
+**Spec amendment from arch review (use Moq `Callback` to capture path, assert `File.Exists` deterministically rather than counting all temp-dir files):** Honored. Task 1 captures the sink path via `Callback` and asserts `File.Exists(capturedPath) == false`. The supplementary directory-delta check is filtered to a narrow regex of handler-shaped filenames (`tmp*.tmp`, `tmp*.tmp.pdf`, or 32-hex-char `.pdf`) to remain deterministic under parallel xUnit execution while still catching the underlying-`.tmp`-file leak that the sink-path assertion alone cannot see.
+
+**Placeholder scan:** No TBD/TODO/"add appropriate error handling"/"similar to Task N"/undefined-reference items found. Every code block is complete. Every command shows exact arguments and expected output.
+
+**Type consistency:** All identifiers used in test code (`_blobStorageServiceMock`, `_cupsSinkMock`, `_handler`, `ContainerName`, `ReprintExpeditionListRequest`, `IBlobStorageService.DownloadAsync`, `IPrintQueueSink.SendAsync`) match the fields and types established in the existing `ReprintExpeditionListHandlerTests` constructor and the production handler. Method signature `SendAsync(IEnumerable<string>, CancellationToken)` matches the existing test's `Setup`. `ReprintExpeditionListResponse.Success` matches the existing assertion. The regex pattern is consistent between Task 1 and Task 2.
+
+**Out-of-scope items confirmed untouched:** No edits to `PlaudCliClient.cs`, `DeleteTempFile`, `IPrintQueueSink`, stream-based pipeline, or any background cleanup of pre-existing orphans. Confirmed by limiting Task 3 to a single-line edit at line 29.
+
+---
+
+## Manual Verification (post-merge, optional per spec)
+
+The spec includes a manual verification step. This is not part of the automated plan but is captured here for the deploying engineer:
+
+1. Deploy to dev environment.
+2. Note current file count in `/tmp` matching `tmp*.tmp` and `[0-9a-f]{32}.pdf`.
+3. Trigger a reprint end-to-end via the UI.
+4. Confirm the PDF prints on the CUPS-attached printer.
+5. Re-list `/tmp` — the file count for both patterns should match the pre-reprint snapshot. If a single `.pdf` briefly appears mid-call, that is expected; it must be gone within ~1 second of the reprint completing.

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs
@@ -26,7 +26,7 @@ public class ReprintExpeditionListHandler : IRequestHandler<ReprintExpeditionLis
             return ReprintExpeditionListResponse.Fail("Invalid blob path.");
         }
 
-        var tempFile = Path.GetTempFileName() + ".pdf";
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf");
         try
         {
             await using var blobStream = await _blobStorageService.DownloadAsync(_containerName, request.BlobPath, cancellationToken);

--- a/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
@@ -130,4 +130,39 @@ public class ReprintExpeditionListHandlerTests
             leakedFiles.Count == 0,
             $"Handler must not leave temp files behind. Found: {string.Join(", ", leakedFiles)}");
     }
+
+    [Fact]
+    public async Task Handle_BlobDownloadFails_LeavesNoTempFileBehind()
+    {
+        // Arrange
+        var blobPath = "2026-03-25/picking-list-003.pdf";
+
+        _blobStorageServiceMock
+            .Setup(s => s.DownloadAsync(ContainerName, blobPath, default))
+            .ThrowsAsync(new IOException("blob unavailable"));
+
+        var tempDir = Path.GetTempPath();
+        var preCallFiles = new HashSet<string>(Directory.EnumerateFiles(tempDir));
+
+        var request = new ReprintExpeditionListRequest { BlobPath = blobPath };
+
+        // Act
+        await Assert.ThrowsAsync<IOException>(() => _handler.Handle(request, default));
+
+        // Assert: same leak detection as the success-path test.
+        var postCallFiles = Directory.EnumerateFiles(tempDir).ToList();
+        var handlerArtifactPattern = new Regex(@"^(tmp[^/\\]*\.tmp(\.pdf)?|[0-9a-fA-F]{32}\.pdf)$");
+        var leakedFiles = postCallFiles
+            .Where(p => !preCallFiles.Contains(p))
+            .Where(p => handlerArtifactPattern.IsMatch(Path.GetFileName(p)))
+            .ToList();
+
+        Assert.True(
+            leakedFiles.Count == 0,
+            $"Handler must not leave temp files behind on failure. Found: {string.Join(", ", leakedFiles)}");
+
+        _cupsSinkMock.Verify(
+            s => s.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Anela.Heblo.Application.Features.ExpeditionList;
 using Anela.Heblo.Application.Features.ExpeditionListArchive.UseCases.ReprintExpeditionList;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
@@ -68,5 +71,63 @@ public class ReprintExpeditionListHandlerTests
         _cupsSinkMock.Verify(
             s => s.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulReprint_LeavesNoTempFileBehind()
+    {
+        // Arrange
+        var blobPath = "2026-03-25/picking-list-002.pdf";
+        var pdfContent = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // PDF magic bytes
+        var blobStream = new MemoryStream(pdfContent);
+
+        _blobStorageServiceMock
+            .Setup(s => s.DownloadAsync(ContainerName, blobPath, default))
+            .ReturnsAsync(blobStream);
+
+        string? capturedPath = null;
+        bool capturedPathExistedDuringSinkCall = false;
+        bool capturedPathEndsWithPdf = false;
+        bool capturedPathRootedInTempDir = false;
+
+        _cupsSinkMock
+            .Setup(s => s.SendAsync(It.IsAny<IEnumerable<string>>(), default))
+            .Callback<IEnumerable<string>, CancellationToken>((paths, _) =>
+            {
+                capturedPath = paths.Single();
+                capturedPathExistedDuringSinkCall = File.Exists(capturedPath);
+                capturedPathEndsWithPdf = capturedPath.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+                capturedPathRootedInTempDir = capturedPath.StartsWith(Path.GetTempPath(), StringComparison.Ordinal);
+            })
+            .Returns(Task.CompletedTask);
+
+        var tempDir = Path.GetTempPath();
+        var preCallFiles = new HashSet<string>(Directory.EnumerateFiles(tempDir));
+
+        var request = new ReprintExpeditionListRequest { BlobPath = blobPath };
+
+        // Act
+        var result = await _handler.Handle(request, default);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(capturedPath);
+        Assert.True(capturedPathEndsWithPdf, "Path passed to sink must end in .pdf");
+        Assert.True(capturedPathRootedInTempDir, "Path passed to sink must be rooted under Path.GetTempPath()");
+        Assert.True(capturedPathExistedDuringSinkCall, "PDF file must exist on disk when sink is invoked");
+        Assert.False(File.Exists(capturedPath), "Temp file must be deleted after handler returns");
+
+        // Detect leaks: any *new* file in the temp dir whose name matches the
+        // shapes the handler could plausibly produce (current buggy or fixed).
+        var postCallFiles = Directory.EnumerateFiles(tempDir).ToList();
+        var handlerArtifactPattern = new Regex(@"^(tmp[^/\\]*\.tmp(\.pdf)?|[0-9a-fA-F]{32}\.pdf)$");
+        var leakedFiles = postCallFiles
+            .Where(p => !preCallFiles.Contains(p))
+            .Where(p => handlerArtifactPattern.IsMatch(Path.GetFileName(p)))
+            .ToList();
+
+        Assert.True(
+            leakedFiles.Count == 0,
+            $"Handler must not leave temp files behind. Found: {string.Join(", ", leakedFiles)}");
     }
 }

--- a/docs/superpowers/plans/2026-05-26-fix-reprint-expedition-list-temp-file-leak.md
+++ b/docs/superpowers/plans/2026-05-26-fix-reprint-expedition-list-temp-file-leak.md
@@ -1,0 +1,324 @@
+# Fix Temp File Leak in ReprintExpeditionListHandler — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the orphaned `tmpXXXX.tmp` file that `ReprintExpeditionListHandler` leaks into the system temp directory on every reprint invocation, by switching from `Path.GetTempFileName() + ".pdf"` to a pure in-memory GUID-based path.
+
+**Architecture:** Single-line production change inside the `ReprintExpeditionList` vertical slice (`backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29`). No new files, no contract changes, no DI changes — the existing `DeleteTempFile` helper remains the single cleanup point. Two regression tests are added that capture the path passed into `IPrintQueueSink.SendAsync` via Moq `Callback` and assert `File.Exists(path) == false` after the handler returns (success path) or throws (failure path).
+
+**Tech Stack:** .NET 8, C# 12, xUnit, Moq, MediatR. No new packages.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29` — production fix.
+- `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs` — add two regression tests (one success path, one failure path) verifying no temp file is left behind and the path handed to the sink ends in `.pdf` and is rooted under `Path.GetTempPath()`.
+
+**Create:** none.
+
+**Do not touch:**
+- `IPrintQueueSink`, `IBlobStorageService`, `BlobPathValidator`, `PrintPickingListOptions`, `ReprintExpeditionListRequest`/`Response`, DI registrations, or sibling adapters (`PlaudCliClient.cs` is explicitly out of scope per spec).
+
+---
+
+## Task 1: Add Regression Test — Success Path Leaves No Temp File
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs`
+
+This task adds the failing test **first** (TDD RED), before any production change. It captures the temp path passed to `IPrintQueueSink.SendAsync` and asserts the file no longer exists once `Handle` returns. With the current buggy production code, the captured path is `tmpXXXX.tmp.pdf` (deleted successfully by `DeleteTempFile` — the test on that captured path will actually PASS for the captured `.pdf` path), so to make this test actually expose the leak we must additionally assert that the *underlying* `Path.GetTempFileName()` artifact (a sibling `.tmp` file) was not left behind. The clean way to do this without coupling to internals is to assert on the **single captured path the sink received** AND on the snapshot of any handler-attributable files created during the call.
+
+After thinking through the failure-mode again: the leak is the `.tmp` file created as a side effect of `Path.GetTempFileName()`. The sink only sees the `.pdf` path. Asserting only on the captured `.pdf` path will not expose the leak. The deterministic way to expose it is to **snapshot files in `Path.GetTempPath()` matching a stable pattern before the call, run the handler, snapshot again, and assert the delta is exactly the empty set**.
+
+Per the architecture review (which warned that broad temp-dir snapshots are flaky under parallel xUnit execution), we constrain the snapshot to a narrow pattern: files created during the call window, matching either `tmp*.tmp` or `tmp*.tmp.pdf` (the two filename shapes the buggy code produces), or — after the fix — 32-hex-char `.pdf` filenames. To make this robust regardless of which side of the fix we are on, we additionally capture the path the sink received and explicitly assert that path does not exist post-call.
+
+The test:
+1. Captures the temp file path passed to `IPrintQueueSink.SendAsync` via Moq `Callback`.
+2. Snapshots the list of files currently under `Path.GetTempPath()` (full path strings) before invoking the handler.
+3. Invokes the handler.
+4. After completion, asserts: the captured path exists and ends in `.pdf` and is rooted under `Path.GetTempPath()` *during the callback* (we record this fact inside the callback because the file is deleted before the test resumes); `File.Exists(capturedPath)` is `false` after `Handle` returns; the set of files in `Path.GetTempPath()` is a subset of the pre-call snapshot (i.e., no new files attributable to this handler remain). To avoid flakiness from unrelated parallel writes, we filter the post-call delta to files whose **name** matches `tmp*.tmp` or `tmp*.tmp.pdf` — the only shapes the buggy code can produce — or any 32-hex-char `.pdf` file (the post-fix shape). Any such leftover file fails the test.
+
+- [ ] **Step 1: Write the failing test for the success path**
+
+Append this test inside `ReprintExpeditionListHandlerTests` (after the existing `Handle_InvalidBlobPath_ReturnsFailureWithoutCallingBlob` test). Also add the `System.IO` and `System.Text.RegularExpressions` `using` directives at the top of the file if they are not already present (`System.IO` is implicit, `System.Text.RegularExpressions` is needed for the filename pattern check).
+
+Add to the `using` block at the top of the file (only those not already present):
+
+```csharp
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+```
+
+Add the test method to the class:
+
+```csharp
+    [Fact]
+    public async Task Handle_SuccessfulReprint_LeavesNoTempFileBehind()
+    {
+        // Arrange
+        var blobPath = "2026-03-25/picking-list-002.pdf";
+        var pdfContent = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // PDF magic bytes
+        var blobStream = new MemoryStream(pdfContent);
+
+        _blobStorageServiceMock
+            .Setup(s => s.DownloadAsync(ContainerName, blobPath, default))
+            .ReturnsAsync(blobStream);
+
+        string? capturedPath = null;
+        bool capturedPathExistedDuringSinkCall = false;
+        bool capturedPathEndsWithPdf = false;
+        bool capturedPathRootedInTempDir = false;
+
+        _cupsSinkMock
+            .Setup(s => s.SendAsync(It.IsAny<IEnumerable<string>>(), default))
+            .Callback<IEnumerable<string>, CancellationToken>((paths, _) =>
+            {
+                capturedPath = paths.Single();
+                capturedPathExistedDuringSinkCall = File.Exists(capturedPath);
+                capturedPathEndsWithPdf = capturedPath.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+                capturedPathRootedInTempDir = capturedPath.StartsWith(Path.GetTempPath(), StringComparison.Ordinal);
+            })
+            .Returns(Task.CompletedTask);
+
+        var tempDir = Path.GetTempPath();
+        var preCallFiles = new HashSet<string>(Directory.EnumerateFiles(tempDir));
+
+        var request = new ReprintExpeditionListRequest { BlobPath = blobPath };
+
+        // Act
+        var result = await _handler.Handle(request, default);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(capturedPath);
+        Assert.True(capturedPathEndsWithPdf, "Path passed to sink must end in .pdf");
+        Assert.True(capturedPathRootedInTempDir, "Path passed to sink must be rooted under Path.GetTempPath()");
+        Assert.True(capturedPathExistedDuringSinkCall, "PDF file must exist on disk when sink is invoked");
+        Assert.False(File.Exists(capturedPath), "Temp file must be deleted after handler returns");
+
+        // Detect leaks: any *new* file in the temp dir whose name matches the
+        // shapes the handler could plausibly produce (current buggy or fixed).
+        var postCallFiles = Directory.EnumerateFiles(tempDir).ToList();
+        var handlerArtifactPattern = new Regex(@"^(tmp[^/\\]*\.tmp(\.pdf)?|[0-9a-fA-F]{32}\.pdf)$");
+        var leakedFiles = postCallFiles
+            .Where(p => !preCallFiles.Contains(p))
+            .Where(p => handlerArtifactPattern.IsMatch(Path.GetFileName(p)))
+            .ToList();
+
+        Assert.True(
+            leakedFiles.Count == 0,
+            $"Handler must not leave temp files behind. Found: {string.Join(", ", leakedFiles)}");
+    }
+```
+
+- [ ] **Step 2: Run the new test and verify it fails for the right reason**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests.Handle_SuccessfulReprint_LeavesNoTempFileBehind" \
+  --nologo
+```
+
+Expected: FAIL. The failure must be the leak-detection assertion (`"Handler must not leave temp files behind. Found: /tmp/tmpXXXXXX.tmp"`), proving the test catches the bug currently in production. If the test fails on `capturedPathEndsWithPdf` or `capturedPathExistedDuringSinkCall` instead, stop — the test instrumentation is wrong, not the production code.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
+git commit -m "test: add regression test for ReprintExpeditionListHandler temp file leak"
+```
+
+---
+
+## Task 2: Add Regression Test — Failure Path Leaves No Temp File
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs`
+
+Cover the catch-block cleanup branch: when `IBlobStorageService.DownloadAsync` throws, `DeleteTempFile` is called inside the `catch` block. We assert the same invariant: after the exception bubbles out of `Handle`, no handler-attributable file remains in the temp directory.
+
+Because the sink is never called in this scenario, we cannot capture the path via the sink. Instead, we rely solely on the temp-directory delta (filtered to handler-shaped filenames). This is the same robust pattern as Task 1's leak detection.
+
+- [ ] **Step 1: Write the failing test for the failure path**
+
+Append this test to `ReprintExpeditionListHandlerTests`:
+
+```csharp
+    [Fact]
+    public async Task Handle_BlobDownloadFails_LeavesNoTempFileBehind()
+    {
+        // Arrange
+        var blobPath = "2026-03-25/picking-list-003.pdf";
+
+        _blobStorageServiceMock
+            .Setup(s => s.DownloadAsync(ContainerName, blobPath, default))
+            .ThrowsAsync(new IOException("blob unavailable"));
+
+        var tempDir = Path.GetTempPath();
+        var preCallFiles = new HashSet<string>(Directory.EnumerateFiles(tempDir));
+
+        var request = new ReprintExpeditionListRequest { BlobPath = blobPath };
+
+        // Act
+        await Assert.ThrowsAsync<IOException>(() => _handler.Handle(request, default));
+
+        // Assert: same leak detection as the success-path test.
+        var postCallFiles = Directory.EnumerateFiles(tempDir).ToList();
+        var handlerArtifactPattern = new Regex(@"^(tmp[^/\\]*\.tmp(\.pdf)?|[0-9a-fA-F]{32}\.pdf)$");
+        var leakedFiles = postCallFiles
+            .Where(p => !preCallFiles.Contains(p))
+            .Where(p => handlerArtifactPattern.IsMatch(Path.GetFileName(p)))
+            .ToList();
+
+        Assert.True(
+            leakedFiles.Count == 0,
+            $"Handler must not leave temp files behind on failure. Found: {string.Join(", ", leakedFiles)}");
+
+        _cupsSinkMock.Verify(
+            s => s.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the new test and verify it fails for the right reason**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests.Handle_BlobDownloadFails_LeavesNoTempFileBehind" \
+  --nologo
+```
+
+Expected: FAIL with the leak-detection assertion message, listing a `tmpXXXXXX.tmp` file under `/tmp` (the artifact left by `Path.GetTempFileName()` — the `catch` block deletes the `.pdf` path but not the underlying `.tmp` file). If instead it fails because the `IOException` was not thrown, or because `SendAsync` was unexpectedly called, the test instrumentation is wrong — stop and fix.
+
+- [ ] **Step 3: Commit the second failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/ExpeditionListArchive/ReprintExpeditionListHandlerTests.cs
+git commit -m "test: add regression test for ReprintExpeditionListHandler temp file leak on failure"
+```
+
+---
+
+## Task 3: Apply the Production Fix
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs:29`
+
+Replace the buggy path construction. This is the minimal change required to make both failing tests pass without altering any other handler behavior.
+
+- [ ] **Step 1: Edit the temp-path allocation line**
+
+In `ReprintExpeditionListHandler.cs`, change line 29 from:
+
+```csharp
+        var tempFile = Path.GetTempFileName() + ".pdf";
+```
+
+to:
+
+```csharp
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf");
+```
+
+No other lines in the file change. The two `try` blocks, `DeleteTempFile` calls, and exception flow stay exactly as they are.
+
+- [ ] **Step 2: Re-run both regression tests and verify they pass**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ReprintExpeditionListHandlerTests" \
+  --nologo
+```
+
+Expected: PASS for all four tests:
+- `Handle_ValidBlobPath_DownloadsAndSendsToCupsSink` (pre-existing)
+- `Handle_InvalidBlobPath_ReturnsFailureWithoutCallingBlob` (pre-existing)
+- `Handle_SuccessfulReprint_LeavesNoTempFileBehind` (new — Task 1)
+- `Handle_BlobDownloadFails_LeavesNoTempFileBehind` (new — Task 2)
+
+- [ ] **Step 3: Run the full backend test suite to confirm no collateral damage**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --nologo
+```
+
+Expected: all tests pass. If any unrelated test fails, stop and investigate before continuing — the change is one line and should not affect any other handler, but a passing full suite is the gate per `CLAUDE.md`.
+
+- [ ] **Step 4: Run build and format gates**
+
+Per `CLAUDE.md` "Validation before completion":
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: both commands exit 0. If `dotnet format --verify-no-changes` reports diffs, run `dotnet format backend/Anela.Heblo.sln` and re-run the verify command.
+
+- [ ] **Step 5: Commit the production fix**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/ReprintExpeditionList/ReprintExpeditionListHandler.cs
+git commit -m "fix: prevent temp file leak in ReprintExpeditionListHandler
+
+Path.GetTempFileName() creates a zero-byte file on disk as a side effect.
+The handler appended '.pdf' to that path, producing a different path that
+referenced a non-existent file, then wrote and deleted that .pdf path —
+leaving the original .tmp file orphaned in the system temp directory on
+every reprint, regardless of success or failure.
+
+Replace with Path.Combine(Path.GetTempPath(), \$\"{Guid.NewGuid():N}.pdf\"),
+which produces a unique path with no filesystem side effect and preserves
+the .pdf extension the CUPS sink relies on."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Covered by |
+|---|---|
+| FR-1: Eliminate orphaned temp file (success path) | Task 1 test + Task 3 fix |
+| FR-1: Eliminate orphaned temp file (failure path) | Task 2 test + Task 3 fix |
+| FR-1: Path ends in `.pdf` | Task 1 `capturedPathEndsWithPdf` assertion |
+| FR-1: Path uniqueness (no collisions) | Guaranteed by 122-bit `Guid.NewGuid()` entropy; no test needed |
+| FR-2: `DeleteTempFile` remains the single cleanup point | Task 3 changes only line 29; lines 30–56 untouched |
+| FR-2: No new `try/finally` scaffolding | Same — verified by surgical edit scope |
+| FR-3: Identical PDF payload at temp path | Existing `Handle_ValidBlobPath_DownloadsAndSendsToCupsSink` still passes (Task 3 Step 2) |
+| FR-3: Sink receives `.pdf` path | Task 1 `capturedPathEndsWithPdf` assertion |
+| NFR-1: Performance | One fewer syscall per reprint — automatic consequence of the fix |
+| NFR-2: Security (no user input in path) | Path components are `Path.GetTempPath()` + GUID; verified by inspection |
+| NFR-3: Reliability (no new failure modes) | Existing tests cover success/validation-failure; new tests cover I/O-failure cleanup |
+
+**Spec amendment from arch review (use Moq `Callback` to capture path, assert `File.Exists` deterministically rather than counting all temp-dir files):** Honored. Task 1 captures the sink path via `Callback` and asserts `File.Exists(capturedPath) == false`. The supplementary directory-delta check is filtered to a narrow regex of handler-shaped filenames (`tmp*.tmp`, `tmp*.tmp.pdf`, or 32-hex-char `.pdf`) to remain deterministic under parallel xUnit execution while still catching the underlying-`.tmp`-file leak that the sink-path assertion alone cannot see.
+
+**Placeholder scan:** No TBD/TODO/"add appropriate error handling"/"similar to Task N"/undefined-reference items found. Every code block is complete. Every command shows exact arguments and expected output.
+
+**Type consistency:** All identifiers used in test code (`_blobStorageServiceMock`, `_cupsSinkMock`, `_handler`, `ContainerName`, `ReprintExpeditionListRequest`, `IBlobStorageService.DownloadAsync`, `IPrintQueueSink.SendAsync`) match the fields and types established in the existing `ReprintExpeditionListHandlerTests` constructor and the production handler. Method signature `SendAsync(IEnumerable<string>, CancellationToken)` matches the existing test's `Setup`. `ReprintExpeditionListResponse.Success` matches the existing assertion. The regex pattern is consistent between Task 1 and Task 2.
+
+**Out-of-scope items confirmed untouched:** No edits to `PlaudCliClient.cs`, `DeleteTempFile`, `IPrintQueueSink`, stream-based pipeline, or any background cleanup of pre-existing orphans. Confirmed by limiting Task 3 to a single-line edit at line 29.
+
+---
+
+## Manual Verification (post-merge, optional per spec)
+
+The spec includes a manual verification step. This is not part of the automated plan but is captured here for the deploying engineer:
+
+1. Deploy to dev environment.
+2. Note current file count in `/tmp` matching `tmp*.tmp` and `[0-9a-f]{32}.pdf`.
+3. Trigger a reprint end-to-end via the UI.
+4. Confirm the PDF prints on the CUPS-attached printer.
+5. Re-list `/tmp` — the file count for both patterns should match the pre-reprint snapshot. If a single `.pdf` briefly appears mid-call, that is expected; it must be gone within ~1 second of the reprint completing.


### PR DESCRIPTION

Fixes a silent resource leak in `ReprintExpeditionListHandler` where every reprint left an orphaned zero-byte `.tmp` file in the system temp directory. Over time this fills `/tmp` with junk and degrades server health.

Root cause: `Path.GetTempFileName()` atomically creates a file on disk and returns its path; appending `.pdf` produces a different path referencing a non-existent file. The handler wrote and deleted the `.pdf` path, never touching the underlying `.tmp` file.

Fix: replace with `Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pdf")` — a pure string operation with no disk side effect, preserving the `.pdf` extension the CUPS sink depends on. One fewer syscall per reprint as a bonus.

### Changes
- `ReprintExpeditionListHandler.cs:29` — replaced path construction (single line)
- `ReprintExpeditionListHandlerTests.cs` — added two regression tests (success path and failure path), written RED-first before the fix

---

Closes #1724

### Tokens used
8799942
