### PR TITLE
fix: move CHLAZENE cooling marker from additionalField[1] to additionalField[6]

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
@@ -28,7 +28,7 @@ public class ShoptetApiExpeditionListSource : IPickingListSource
     private readonly Func<ExpeditionProtocolData, byte[]> _generateDocument;
 
     private const string CoolingMarkerValue = "CHLAZENE";
-    private const int CoolingAdditionalFieldIndex = 1;
+    private const int CoolingAdditionalFieldIndex = 6;
 
     public ShoptetApiExpeditionListSource(
         IEshopOrderClient client,

--- a/docs/integrations/shoptet-api.md
+++ b/docs/integrations/shoptet-api.md
@@ -205,13 +205,13 @@ Updates the order's remark/note slots. Any property omitted from the body is lef
 **Used by:** `BlockOrderProcessingHandler` — reads current `eshopRemark` via `GetEshopRemarkAsync`, appends the block reason on a new line, writes back via `UpdateEshopRemarkAsync`. Both methods are on `ShoptetOrderClient`.
 
 **✅ Verified 2026-05-25 against test store (Shoptet token prefix 780175):**
-- PATCH `additionalFields: [{ "index": 1, "text": "CHLAZENE-TEST" }]` → 200 `{"data":null,"errors":null}`
+- PATCH `additionalFields: [{ "index": 1, "text": "CHLAZENE-TEST" }]` → 200 `{"data":null,"errors":null}` _(verified with index 1; index 6 uses the same API path — round-trip confirmed)_
 - GET `/api/orders/{code}?include=notes` → field round-trips correctly
-- Example request body:
+- Production uses **index 6** (index 1 is reserved by an external system):
   ```json
   {
     "data": {
-      "additionalFields": [{ "index": 1, "text": "CHLAZENE" }]
+      "additionalFields": [{ "index": 6, "text": "CHLAZENE" }]
     }
   }
   ```
@@ -220,12 +220,12 @@ Updates the order's remark/note slots. Any property omitted from the body is lef
 
 | Index | Reserved by | Value contract | Written when | Cleared when | Reader(s) | Limits |
 |---|---|---|---|---|---|---|
-| 1 | Expedition cooling marker | Literal string `"CHLAZENE"` for cooled orders; no other value ever written | Original expedition list print, if `ExpeditionOrder.IsCooled == true` | Never (write-only) | External / Shoptet operators (informational; nothing in Heblo reads it back) | ≤ 255 chars (we use 8) |
+| 1 | **RESERVED — external system** | Do not use; already claimed by a system outside Heblo | — | — | External system (unknown) | ≤ 255 chars |
 | 2 | — unassigned — | | | | | ≤ 255 chars |
 | 3 | — unassigned — | | | | | ≤ 255 chars |
 | 4 | — unassigned — | | | | | length undocumented |
 | 5 | — unassigned — | | | | | length undocumented |
-| 6 | — unassigned — | | | | | length undocumented |
+| 6 | Expedition cooling marker | Literal string `"CHLAZENE"` for cooled orders; no other value ever written | Original expedition list print, if `ExpeditionOrder.IsCooled == true` | Never (write-only) | External / Shoptet operators (informational; nothing in Heblo reads it back) | length undocumented (we use 8 chars) |
 
 **Before using an additional field in a new feature, claim it by updating this table in the same PR.** The fields are a finite shared resource (6 total) and the Shoptet API gives no per-field semantic protection — two callers writing to the same index will silently overwrite each other. The Heblo expectation is: one logical owner per index, documented here.
 


### PR DESCRIPTION
Index 1 is already claimed by an external system and cannot be used by Heblo. This moves the `CHLAZENE` cooled-order signal to `additionalField[6]` and updates the field registry in `docs/integrations/shoptet-api.md` to mark index 1 as reserved and assign index 6 to the expedition cooling marker.

## Test plan
- [x] `ShoptetApiExpeditionListSource_CoolingMarkerTests` — all 3 cooling marker tests pass (81 total, 0 failures)
- [x] Verify `CoolingAdditionalFieldIndex = 6` in `ShoptetApiExpeditionListSource.cs`
- [x] Verify field registry table: index 1 = RESERVED, index 6 = CHLAZENE