### PR TITLE
fix(smartsupp): use /close action endpoint and stop masking 4xx as unavailable

### DIFF
--- a/backend/src/Adapters/Anela.Heblo.Adapters.Smartsupp/SmartsuppApiClient.cs
+++ b/backend/src/Adapters/Anela.Heblo.Adapters.Smartsupp/SmartsuppApiClient.cs
@@ -604,17 +604,13 @@ public class SmartsuppApiClient : ISmartsuppApiClient
         if (string.IsNullOrEmpty(_options.ApiToken))
             throw new InvalidOperationException("Smartsupp:ApiToken is not configured.");
 
-        var body = new CloseConversationApiRequest { Status = "closed" };
-        var json = JsonSerializer.Serialize(body, JsonOptions);
-
         await _pipeline.ExecuteAsync(async ct =>
         {
             var client = _httpClientFactory.CreateClient("Smartsupp");
             using var request = new HttpRequestMessage(
                 HttpMethod.Patch,
-                $"{_options.BaseUrl}conversations/{conversationId}");
+                $"{_options.BaseUrl}conversations/{conversationId}/close");
             request.Headers.Add("Authorization", $"Bearer {_options.ApiToken}");
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
             var response = await client.SendAsync(request, ct);
 
@@ -630,10 +626,5 @@ public class SmartsuppApiClient : ISmartsuppApiClient
                 throw ex;
             }
         }, cancellationToken);
-    }
-
-    private sealed class CloseConversationApiRequest
-    {
-        public required string Status { get; init; }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/CloseConversation/CloseConversationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Smartsupp/UseCases/CloseConversation/CloseConversationHandler.cs
@@ -33,11 +33,10 @@ public class CloseConversationHandler : IRequestHandler<CloseConversationRequest
         {
             await _apiClient.CloseConversationAsync(request.ConversationId, cancellationToken);
         }
-        // Only absorb cancellations that originated inside the API client (e.g. HttpClient timeouts),
-        // not cancellations requested by the caller.
-        catch (Exception ex) when (ex is HttpRequestException or TimeoutException
-                                       or ObjectDisposedException
-                                       || (ex is TaskCanceledException tce && tce.CancellationToken != cancellationToken))
+        // Map only true availability problems (5xx, network, timeout, client-side cancellation)
+        // to "unavailable". A 4xx from Smartsupp indicates a contract bug on our side and must
+        // surface as a real failure so it does not hide behind a benign "service unavailable" toast.
+        catch (Exception ex) when (IsUnavailable(ex, cancellationToken))
         {
             _logger.LogWarning(ex, "Smartsupp API unavailable while closing conversation {ConversationId}",
                 request.ConversationId);
@@ -46,4 +45,14 @@ public class CloseConversationHandler : IRequestHandler<CloseConversationRequest
 
         return new CloseConversationResponse();
     }
+
+    private static bool IsUnavailable(Exception ex, CancellationToken cancellationToken) =>
+        ex switch
+        {
+            HttpRequestException http => http.StatusCode is null || (int)http.StatusCode >= 500,
+            TimeoutException => true,
+            ObjectDisposedException => true,
+            TaskCanceledException tce => tce.CancellationToken != cancellationToken,
+            _ => false,
+        };
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/CloseConversationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/CloseConversationHandlerTests.cs
@@ -78,6 +78,24 @@ public class CloseConversationHandlerTests
     }
 
     [Fact]
+    public async Task Handle_DoesNotReturnUnavailable_When4xxFromApi()
+    {
+        // A 4xx from Smartsupp indicates a contract bug, not a transient unavailability.
+        // It must propagate instead of being masked as SmartsuppCloseConversationUnavailable.
+        SetupConversation();
+        _apiClient.Setup(a => a.CloseConversationAsync("conv-1", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Smartsupp API 422", null,
+                System.Net.HttpStatusCode.UnprocessableEntity));
+
+        var act = () => CreateHandler().Handle(
+            new CloseConversationRequest { ConversationId = "conv-1" },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .Where(ex => ex.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
     public async Task Handle_ReturnsUnavailable_WhenApiThrowsTimeout()
     {
         // Arrange

--- a/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppApiClientTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Smartsupp/SmartsuppApiClientTests.cs
@@ -438,12 +438,12 @@ public class SmartsuppApiClientTests
     }
 
     [Fact]
-    public async Task CloseConversationAsync_SendsPatchWithClosedStatus()
+    public async Task CloseConversationAsync_SendsPatchToCloseSubresource()
     {
         // Arrange
         string? capturedUrl = null;
         string? capturedMethod = null;
-        string? capturedBody = null;
+        HttpContent? capturedContent = null;
         string? capturedAuth = null;
 
         var handler = new Mock<HttpMessageHandler>();
@@ -451,11 +451,11 @@ public class SmartsuppApiClientTests
             .Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
             {
                 capturedUrl = req.RequestUri?.ToString();
                 capturedMethod = req.Method.Method;
-                capturedBody = await req.Content!.ReadAsStringAsync();
+                capturedContent = req.Content;
                 capturedAuth = req.Headers.Authorization?.ToString();
             })
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
@@ -469,9 +469,9 @@ public class SmartsuppApiClientTests
         await client.CloseConversationAsync("conv-abc", CancellationToken.None);
 
         // Assert
-        capturedUrl.Should().Contain("conversations/conv-abc");
+        capturedUrl.Should().EndWith("conversations/conv-abc/close");
         capturedMethod.Should().Be("PATCH");
-        capturedBody.Should().Contain("closed");
+        capturedContent.Should().BeNull();
         capturedAuth.Should().StartWith("Bearer test-token");
     }
 

--- a/docs/integrations/smartsupp-api.md
+++ b/docs/integrations/smartsupp-api.md
@@ -103,43 +103,37 @@ Not polled on startup — first request to `GetConversation` triggers the fetch.
 
 ---
 
-### PATCH /conversations/{id}
+### PATCH /conversations/{id}/close
 
 **Close (resolve) a conversation.**
 
-**Status:** Inferred from API overview + payload mapper evidence (2026-05-26). Not directly verified against the live API — the Smartsupp docs site is a JavaScript SPA that cannot be scraped. Verify on first use and update this entry.
+**Status:** Verified against the live OpenAPI spec at `https://api.smartsupp.com/v2/specs/open-api.json` (2026-05-27).
 
-**Rationale:**
-- The Smartsupp overview docs state that `PATCH` is used for partial updates.
-- `SmartsuppPayloadMapper.cs` (line 17) proves the API uses `"closed"` (not `"resolved"`) as the conversation status string for resolved conversations: `"closed" => SmartsuppConversationStatus.Resolved`.
-- `PATCH /conversations/{id}` with `{ "status": "closed" }` is the standard REST pattern for this operation.
+**Background:** The first implementation used `PATCH /conversations/{id}` with body `{ "status": "closed" }`. That endpoint exists for partial updates (group_id, variables, virtual_agent) and does not accept a `status` field, so it returned `422 { "code": "invalid_parameters", "message": "Not provided any valid data" }`. The dedicated action endpoint below is the correct one.
 
 **Request:**
 ```http
-PATCH https://app.smartsupp.com/api/v2/conversations/{id}
+PATCH https://api.smartsupp.com/v2/conversations/{id}/close
 Authorization: Bearer {token}
-Content-Type: application/json
-
-{
-  "status": "closed"
-}
 ```
 
-**Known status values (from search filter + payload mapper):**
-- `"open"` — open conversation
-- `"served"` — conversation being served by an agent
-- `"pending"` — pending (waiting for agent)
-- `"closed"` — closed/resolved (maps to `SmartsuppConversationStatus.Resolved` in our domain)
+No body. No `Content-Type` header (no content).
 
-**Success response (expected):** The updated conversation object, same shape as `GET /conversations/{id}`. HTTP 200.
+**Success response:** HTTP 200. The conversation transitions to `"closed"` status (mapped to `SmartsuppConversationStatus.Resolved` in our domain via `SmartsuppPayloadMapper.cs:17`).
 
 **Error codes:**
 - `401` — missing or invalid Bearer token
 - `404` — conversation not found
-- `422` — unprocessable entity (invalid status value or transition not allowed)
+- `422` — unprocessable entity (rare for this action endpoint; would indicate an invalid state transition)
 - `429` — rate limited (Polly `RetryAfter` header handled by `SmartsuppApiClient`)
 
-**Implementation note:** Use `PATCH` via `HttpMethod.Patch`. The `SmartsuppApiClient` pattern: serialize `{ "status": "closed" }` as snake_case JSON, send with Bearer auth, treat `404` as `null` / not-found result, throw `HttpRequestException` on other non-2xx.
+**Implementation note:** Use `PATCH` via `HttpMethod.Patch` against `conversations/{id}/close` with no request content. Treat any non-2xx as `HttpRequestException`. `CloseConversationHandler` maps only 5xx / network / timeout failures to `SmartsuppCloseConversationUnavailable`; 4xx propagates so contract regressions surface immediately.
+
+**Known conversation status values** (returned in `GET /conversations/{id}` and used in search filters):
+- `"open"` — open conversation
+- `"served"` — conversation being served by an agent
+- `"pending"` — pending (waiting for agent)
+- `"closed"` — closed/resolved
 
 ---
 


### PR DESCRIPTION
## Summary

- `SmartsuppApiClient.CloseConversationAsync` now PATCHes the dedicated `/conversations/{id}/close` action endpoint with no body. The previous `PATCH /conversations/{id}` + `{"status":"closed"}` was rejected by Smartsupp with `422 "Not provided any valid data"` because that endpoint only accepts `group_id`/`variables`/`virtual_agent` (verified against `api.smartsupp.com/v2/specs/open-api.json`).
- `CloseConversationHandler` no longer catches every `HttpRequestException` as `SmartsuppCloseConversationUnavailable`; only 5xx / null status / timeout / network failures map to "unavailable", so 4xx contract regressions stop hiding behind a benign 503 toast.
- Updated `docs/integrations/smartsupp-api.md` with the verified contract and the failure history, plus adapter test (asserts URL ends with `/close`, method `PATCH`, no body) and handler test (asserts 422 propagates).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test --filter "FullyQualifiedName~Smartsupp"` — 173 passed, 0 failed
- [x] `dotnet format --verify-no-changes` on changed files — clean
- [ ] Deploy to Staging, close a real conversation, confirm App Insights shows `PATCH /v2/conversations/{id}/close` returning 200 and no `Smartsupp close conversation failed` traces