### PR TITLE
feat: Move BackgroundJobs Request Body DTOs to Application Layer

### DIFF
--- a/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/arch-review.r1.md
@@ -1,0 +1,181 @@
+# Architecture Review: Move BackgroundJobs Request Body DTOs to Application Layer
+
+## Skip Design: true
+
+This is a backend-only mechanical relocation. No new components, screens, or visual changes.
+
+## Architectural Fit Assessment
+
+The proposed change directly enforces a rule documented in `docs/architecture/development_guidelines.md`:
+
+> *"API project never defines or owns DTOs — it only uses them"*
+> *"DTOs defined in API or Xcc — Breaks ownership, violates boundaries"*
+
+The fix aligns perfectly with the existing pattern. The target folder already exists at `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/` and already houses a sibling DTO (`RecurringJobDto.cs`) under the namespace `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`. The controller already imports that namespace (line 2 of `RecurringJobsController.cs`), so post-move type resolution is automatic.
+
+**Integration points verified:**
+- Test file `RecurringJobsControllerTests.cs` already has `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` (line 2) — unqualified references on lines 115, 153, 183, 221 will continue to resolve.
+- Frontend client (`frontend/src/api/generated/api-client.ts`) consumes only the type names (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`) — schema names are namespace-independent in NSwag output, so regeneration produces identical artifacts.
+- The `using System.ComponentModel.DataAnnotations;` directive in the controller becomes dead code after the move (only `[Required]` on `UpdateJobCronRequestBody` uses it) and must be removed.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+backend/src/Anela.Heblo.API/Controllers/
+└── RecurringJobsController.cs                         # HTTP shell only, no DTO definitions
+
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/
+├── Contracts/
+│   ├── RecurringJobDto.cs                             # (existing)
+│   ├── UpdateJobStatusRequestBody.cs                  # NEW — relocated
+│   └── UpdateJobCronRequestBody.cs                    # NEW — relocated
+├── UseCases/
+│   ├── UpdateRecurringJobStatus/                      # MediatR Request/Response/Handler
+│   └── UpdateRecurringJobCron/                        # MediatR Request/Response/Handler
+└── BackgroundJobsModule.cs
+```
+
+Data flow is unchanged:
+```
+HTTP Body → [FromBody] *RequestBody (Contracts) → Controller → MediatR Request → Handler → Response
+```
+
+### Key Design Decisions
+
+#### Decision 1: One file per DTO, mirror existing convention
+
+**Options considered:**
+- A. One file per DTO (`UpdateJobStatusRequestBody.cs`, `UpdateJobCronRequestBody.cs`).
+- B. Combined file (`UpdateRecurringJobRequestBodies.cs`).
+
+**Chosen approach:** A — one file per DTO.
+
+**Rationale:** Matches the existing convention in the same folder (`RecurringJobDto.cs` is solo) and the project-wide rule that "files [are] aligned with the primary type they define" (csharp-coding-style). Also keeps `dotnet format` diffs minimal and makes git history easier to follow when DTOs evolve independently.
+
+#### Decision 2: Keep DTOs as `public class` with mutable properties, not `record`
+
+**Options considered:**
+- A. Preserve current shape: `public class` + public mutable properties.
+- B. Convert to `record` / `init`-only.
+
+**Chosen approach:** A — preserve current shape.
+
+**Rationale:** CLAUDE.md and `development_guidelines.md` are explicit: *"DTOs are classes, never C# records"* because OpenAPI client generators (NSwag) mishandle record parameter order. The frontend depends on the generated TypeScript class shape; switching to records would silently regenerate a different client. NFR-2 also requires the DTOs to follow the same conventions as `RecurringJobDto`, which is a `public class`.
+
+#### Decision 3: Do not co-locate DTOs inside their UseCase folder
+
+**Options considered:**
+- A. Put `UpdateJobCronRequestBody` next to `UpdateRecurringJobCron` use case under `UseCases/UpdateRecurringJobCron/`.
+- B. Put both in the shared `Contracts/` folder alongside `RecurringJobDto.cs`.
+
+**Chosen approach:** B — shared `Contracts/` folder.
+
+**Rationale:** `development_guidelines.md` is explicit that DTOs live in `Contracts/` of the specific module. The `UseCases/` subfolder owns MediatR `Request`/`Response`/`Handler` triples (the internal CQRS contract); the `Contracts/` folder owns the externally consumable DTOs (the cross-boundary contract). The brief and the spec both target `Contracts/`, and this matches the precedent set by `RecurringJobDto.cs`.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create exactly two new files:**
+
+1. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs`
+2. `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs`
+
+**Modify exactly one existing file:**
+
+3. `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` — delete lines 125–146 (both DTO classes + their XML doc comments must move with them) and remove line 1 (`using System.ComponentModel.DataAnnotations;`) because no remaining symbol in the file requires it.
+
+**Do not touch:**
+- `RecurringJobsControllerTests.cs` (already correctly imports `Contracts`).
+- `useRecurringJobs.ts` (consumes regenerated client by type name).
+- Any `UseCases/` files.
+- `RecurringJobDto.cs`.
+
+### Interfaces and Contracts
+
+Both files must have this exact shape (preserving XML docs verbatim from the source):
+
+```csharp
+// UpdateJobStatusRequestBody.cs
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+```csharp
+// UpdateJobCronRequestBody.cs
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+**Critical invariants** (any deviation breaks the OpenAPI contract):
+- Type names: `UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody` — exact.
+- Property names: `IsEnabled`, `CronExpression` — exact (JSON serializer emits camelCase).
+- `[Required]` data annotation on `CronExpression` — preserved.
+- `= string.Empty` default on `CronExpression` — preserved.
+- No constructors, no `init` accessors, no `required` keyword.
+
+### Data Flow
+
+Unchanged. The HTTP request lifecycle for the two affected endpoints:
+
+```
+PUT /api/RecurringJobs/{jobName}/status
+  → ASP.NET Core model binder deserializes body into Contracts.UpdateJobStatusRequestBody
+  → RecurringJobsController.UpdateJobStatus maps to UseCases.UpdateRecurringJobStatus.UpdateRecurringJobStatusRequest
+  → MediatR dispatch → Handler → UpdateRecurringJobStatusResponse → HandleResponse → 200 OK
+
+PUT /api/RecurringJobs/{jobName}/cron
+  → ASP.NET Core model binder deserializes body into Contracts.UpdateJobCronRequestBody
+  → ModelState validation enforces [Required] CronExpression
+  → RecurringJobsController.UpdateJobCron maps to UseCases.UpdateRecurringJobCron.UpdateRecurringJobCronRequest
+  → MediatR dispatch → Handler → UpdateRecurringJobCronResponse → HandleResponse → 200 OK
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| OpenAPI schema name changes (e.g. NSwag prepends namespace prefix) — would silently break frontend types | HIGH | After build, diff `frontend/src/api/generated/api-client.ts` for the two type names and the two operation methods (`recurringJobs_UpdateJobStatus`, `recurringJobs_UpdateJobCron`). Lines 10008, 10070, 34172, 34253 must remain byte-identical except for line numbers. |
+| Forgetting to delete the in-controller class definitions → compile error from duplicate type names | LOW | Single file edit; `dotnet build` will fail loudly. |
+| Removing `using System.ComponentModel.DataAnnotations;` while another usage remains | LOW | Grep the controller for `[Required]`, `[Range]`, `[StringLength]`, etc. before removal. Current file confirms none remain after the DTOs leave. |
+| Test file relies on `Anela.Heblo.API.Controllers.UpdateJobStatusRequestBody` via FQN | LOW | Verified via grep — all four test-side references (lines 115, 153, 183, 221) are unqualified and resolve through the existing `using Contracts;`. |
+| `dotnet format` rewrites unrelated lines on the controller (because the file changed) | LOW | NFR-3 requires surgical scope. Run `dotnet format --include backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` and `--include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJob*.cs` only. |
+
+## Specification Amendments
+
+The spec is implementation-ready. Two minor reinforcements to add to the implementer's checklist:
+
+1. **FR-3 cleanup verification:** After removing `using System.ComponentModel.DataAnnotations;`, explicitly grep the controller for any remaining data-annotation attribute usage to confirm the using is truly orphan. (The current file shows none, but make this a step rather than an assumption.)
+
+2. **FR-5 OpenAPI diff check:** Add an explicit verification step that after `npm run build` (which triggers client regeneration), `git diff frontend/src/api/generated/api-client.ts` shows zero changes to the type-name lines, interface lines, and operation signatures for these two DTOs. If any shape change appears, treat it as a CRITICAL blocker — NSwag may have changed schema naming and the frontend hook will break.
+
+No other amendments. The spec correctly excludes record conversion, FluentValidation introduction, controller splitting, and frontend manual edits.
+
+## Prerequisites
+
+None. No migrations, no config, no infrastructure, no new packages, no project reference changes. The `Anela.Heblo.Application` project already has access to `System.ComponentModel.DataAnnotations` (transitive via the SDK). Implementation can start immediately.

--- a/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/brief.md
+++ b/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/brief.md
@@ -1,0 +1,24 @@
+## Module
+BackgroundJobs
+
+## Finding
+Two request-body DTO classes are defined directly inside the API layer controller file, violating the project rule that the API project must never own DTOs:
+
+- `UpdateJobStatusRequestBody` — `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` lines 128–134
+- `UpdateJobCronRequestBody` — `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` lines 136–146
+
+Both classes live in the `Anela.Heblo.API.Controllers` namespace and are defined at the bottom of the controller file.
+
+## Why it matters
+`development_guidelines.md` states explicitly: *"API project never defines or owns DTOs"* and *"DTOs defined in API or Xcc — Breaks ownership, violates boundaries."* Having DTOs in the API project couples HTTP contracts to the host layer, prevents other consumers from referencing them without taking on the API project dependency, and breaks the ownership model where each module's contracts are self-contained.
+
+## Suggested fix
+Move both classes into the existing `Contracts/` folder of the BackgroundJobs application module:
+
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs`
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs`
+
+Update the `using` in the controller accordingly. No behavioural change required.
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/impl/main.r1.md
@@ -1,0 +1,61 @@
+Final reviewer: **APPROVED**. Writing the output artifact:
+
+---
+
+# Implementation: Move BackgroundJobs Request Body DTOs to Application Layer
+
+## What was implemented
+
+Mechanical architectural fix: two request-body DTOs (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`) were relocated from the bottom of `RecurringJobsController.cs` into the BackgroundJobs module's `Contracts/` folder. This enforces the project rule that the API project must not define or own DTOs. Zero behavioural change.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` — new file: `public class` DTO with `bool IsEnabled { get; set; }`, XML doc comments preserved
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` — new file: `public class` DTO with `[Required] string CronExpression { get; set; }`, `using System.ComponentModel.DataAnnotations;`, XML doc comments preserved
+- `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` — removed both inline DTO class definitions (lines 125–146) and the now-orphan `using System.ComponentModel.DataAnnotations;` directive (line 1)
+
+## Tests
+
+- `RecurringJobsControllerTests.cs` — **unchanged** (per spec). All 5 existing tests pass. They already imported `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` and used unqualified type names — resolution is automatic.
+
+## How to verify
+
+```bash
+# Backend build
+dotnet build backend/Anela.Heblo.sln
+
+# BackgroundJobs controller tests
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTests"
+
+# Format check
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs \
+  --verify-no-changes
+
+# OpenAPI schema names (should find exactly 4 matches)
+grep -nE 'class UpdateJobStatusRequestBody|class UpdateJobCronRequestBody|recurringJobs_UpdateJobStatus|recurringJobs_UpdateJobCron' frontend/src/api/generated/api-client.ts
+```
+
+## Notes
+
+- OpenAPI schema names verified unchanged after `npm run build` — `git diff frontend/src/api/generated/api-client.ts` shows zero changes. NSwag schema naming is namespace-independent, as confirmed by the architecture review's risk assessment.
+- 151 pre-existing lint errors in the frontend test suite are unrelated to this change; no new errors were introduced.
+- Commit `40a95873`: 3 files changed, 27 insertions(+), 24 deletions(−).
+
+## PR Summary
+
+Relocates `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` from `RecurringJobsController.cs` into the BackgroundJobs module's `Contracts/` folder. This enforces the project rule that the API project never defines or owns DTOs.
+
+The controller already imported `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;`, so all consumer references (controller `[FromBody]` parameters, test file, generated TypeScript client) continue to resolve automatically without modification. The `using System.ComponentModel.DataAnnotations;` directive in the controller became orphan after the move and was removed.
+
+Wire format, OpenAPI schema names (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`), HTTP status codes, and the generated TypeScript client are byte-identical before and after the move.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` — new DTO file, relocated from controller
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` — new DTO file with `[Required]` annotation, relocated from controller
+- `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` — removed inline DTO definitions and orphan `using` directive
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/spec.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/spec.r1.md
@@ -1,0 +1,113 @@
+# Specification: Move BackgroundJobs Request Body DTOs to Application Layer
+
+## Summary
+Two request-body DTOs (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`) currently defined inside `RecurringJobsController.cs` violate the architectural rule that the API project must not own DTOs. This spec covers their relocation to the existing `BackgroundJobs` module `Contracts/` folder with no behavioural change.
+
+## Background
+The project's `development_guidelines.md` is explicit: *"API project never defines or owns DTOs"* and *"DTOs defined in API or Xcc — Breaks ownership, violates boundaries."* DTOs belong to their owning application module so contracts are self-contained and reusable by other consumers (tests, MCP, OpenAPI generation) without forcing a dependency on the API host project.
+
+A daily architecture review on 2026-05-27 flagged this violation in `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` (lines 128–134 and 136–146). The fix is mechanical: relocate the two classes to the namespace and folder where sibling DTOs already live (`RecurringJobDto` is already at `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`).
+
+## Functional Requirements
+
+### FR-1: Relocate `UpdateJobStatusRequestBody` to BackgroundJobs Contracts
+Move the class from the bottom of `RecurringJobsController.cs` into a new file owned by the application layer.
+
+**Acceptance criteria:**
+- New file exists at `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs`.
+- Class is declared in namespace `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`.
+- Class members and shape are unchanged: public class, single public property `bool IsEnabled { get; set; }`.
+- Class is no longer declared inside `RecurringJobsController.cs`.
+- The XML doc comment (`<summary>Request body for updating recurring job status</summary>` and the property summary) is preserved on the relocated class.
+
+### FR-2: Relocate `UpdateJobCronRequestBody` to BackgroundJobs Contracts
+Move the class from the bottom of `RecurringJobsController.cs` into a new file owned by the application layer.
+
+**Acceptance criteria:**
+- New file exists at `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs`.
+- Class is declared in namespace `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`.
+- Class members and shape are unchanged: public class, single public property `[Required] string CronExpression { get; set; } = string.Empty;`.
+- The `[Required]` data annotation is preserved (file must `using System.ComponentModel.DataAnnotations;`).
+- Class is no longer declared inside `RecurringJobsController.cs`.
+- The XML doc comment (`<summary>Request body for updating recurring job CRON expression</summary>` and the property summary, including the example `"0 3 * * *"`) is preserved on the relocated class.
+
+### FR-3: Update controller imports and remove orphan `using`s
+The controller file already imports `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`, so the moved types resolve through the existing using. The controller file must be cleaned up so it no longer carries usings that exist solely for the now-moved DTOs.
+
+**Acceptance criteria:**
+- `RecurringJobsController.cs` no longer contains either DTO class definition.
+- `RecurringJobsController.cs` no longer declares `using System.ComponentModel.DataAnnotations;` unless still required for other code in the file (it is not, after the move — verify and remove if unused).
+- Controller continues to reference `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` via the existing `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` directive.
+- Controller method signatures, attributes, response types, MediatR dispatch, and route templates are unchanged.
+
+### FR-4: Preserve consumer compatibility
+The existing controller test file `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTests.cs` already imports `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` and references both DTOs by their unqualified names. No source change is required there because the type names and member shapes remain identical.
+
+**Acceptance criteria:**
+- Test file is unchanged (no edits required).
+- All references to `UpdateJobStatusRequestBody` (lines 115, 153, 183, 221) compile and resolve via the new namespace through the existing using.
+- Existing `RecurringJobsControllerTests` pass with no modifications.
+
+### FR-5: Validation
+The change must be verifiable through standard project gates.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds for the full solution.
+- `dotnet format` reports no violations on the touched files.
+- `dotnet test` for the BackgroundJobs controller tests passes.
+- Generated OpenAPI client (`frontend/src/api/generated/api-client.ts`) regenerates to identical contract shapes (type names, properties, request bodies) — no frontend hook change required.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavioural Parity
+Zero runtime behavioural change. Wire-format (JSON property names), HTTP status codes, validation behaviour, and OpenAPI schema names must be byte-identical before and after the move.
+
+### NFR-2: Architectural Conformance
+After the change, the API project must contain no DTO type definitions. The relocated DTOs must live in the same `Contracts/` folder as `RecurringJobDto.cs` and follow the same conventions (public class, no `record`, public mutable properties — consistent with the project's DTO rule that DTOs are classes, never records, because OpenAPI client generators mishandle record parameter order).
+
+### NFR-3: Surgical Change Scope
+Only the controller file and the two new DTO files are touched. No reformatting, refactoring of unrelated code, or comment cleanups elsewhere.
+
+## Data Model
+
+No data model change. The two classes retain their shape:
+
+| Class                        | Property        | Type    | Attributes  |
+|------------------------------|-----------------|---------|-------------|
+| `UpdateJobStatusRequestBody` | `IsEnabled`     | `bool`  | none        |
+| `UpdateJobCronRequestBody`   | `CronExpression`| `string`| `[Required]`|
+
+Both remain public classes with public mutable properties (the project-wide DTO convention).
+
+## API / Interface Design
+
+No external interface change.
+
+- `PUT /api/RecurringJobs/{jobName}/status` continues to accept `{ "isEnabled": bool }`.
+- `PUT /api/RecurringJobs/{jobName}/cron` continues to accept `{ "cronExpression": string }`.
+- OpenAPI schema names `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` are preserved.
+- Generated TypeScript client and `frontend/src/api/hooks/useRecurringJobs.ts` need no edits because the regenerated client emits the same type names.
+
+The only namespace-level change is from `Anela.Heblo.API.Controllers` to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` on the C# side.
+
+## Dependencies
+
+- Existing `BackgroundJobs` application module (`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/`).
+- `Anela.Heblo.Application` already references `System.ComponentModel.DataAnnotations` (transitively, used elsewhere).
+- No new NuGet packages, no project reference changes.
+
+## Out of Scope
+
+- Refactoring sibling DTOs (`RecurringJobDto`) or the MediatR request/response classes under `UseCases/`.
+- Splitting the controller file further or extracting other controllers.
+- Adding FluentValidation, additional validation attributes, or changing nullability annotations on the relocated DTOs.
+- Converting the relocated DTOs to `record` types — explicitly forbidden by project rule.
+- Renaming the DTOs or changing their JSON wire shape.
+- Touching the frontend generated client manually (it will regenerate on build).
+- Any change to `RecurringJobsControllerTests.cs`.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-dtos-defined-/task-plan.r1.md
@@ -1,0 +1,407 @@
+# Relocate BackgroundJobs Request Body DTOs to Application Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` from `RecurringJobsController.cs` into the `BackgroundJobs` application module's `Contracts/` folder, with zero behavioural or wire-format change.
+
+**Architecture:** Mechanical relocation. Two new files are created in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/`, the two in-controller class definitions are deleted, and the now-orphan `using System.ComponentModel.DataAnnotations;` directive at the top of the controller is removed. The controller already imports the target `Contracts` namespace, so post-move type resolution is automatic.
+
+**Tech Stack:** .NET 8, C#, ASP.NET Core MVC, xUnit + FluentAssertions + Moq, NSwag (TypeScript client regeneration on build).
+
+---
+
+## Background & Why TDD-Lite Here
+
+The two DTOs are pure data shapes with no behaviour. The behaviour they participate in (HTTP request binding, controller dispatch, MediatR mapping, validation) is already covered by `RecurringJobsControllerTests.cs`. Those existing tests are the regression net for this move — they must continue to pass **without any edit**. There is no new code path to drive via a new RED→GREEN test; the discipline here is to make small, verifiable changes and run the existing test suite + build + OpenAPI diff at each gate.
+
+---
+
+## File Structure
+
+**Files to create (2):**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` | Request body DTO for `PUT /api/RecurringJobs/{jobName}/status` |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` | Request body DTO for `PUT /api/RecurringJobs/{jobName}/cron` |
+
+**Files to modify (1):**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` | Delete lines 125–146 (both DTO definitions + their XML doc comments). Delete line 1 (`using System.ComponentModel.DataAnnotations;`) — it is orphan after the move. |
+
+**Files explicitly NOT touched:**
+
+| Path | Reason |
+|------|--------|
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTests.cs` | Already imports `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` at line 2. The four unqualified references (`UpdateJobStatusRequestBody` on lines 115, 153, 183, 221) resolve through that using directive post-move. |
+| `frontend/src/api/hooks/useRecurringJobs.ts` | Consumes generated client types by name. NSwag schema names are namespace-independent. |
+| `frontend/src/api/generated/api-client.ts` | Auto-regenerated on `npm run build`. We **verify** it does not change (it's a checkpoint, not an edit target). |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs` | Sibling DTO; out of scope. |
+| Any file under `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/` | MediatR Request/Response/Handler triples are unchanged. |
+
+---
+
+## Task 1: Create `UpdateJobStatusRequestBody.cs` in Contracts folder
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs`
+
+- [ ] **Step 1: Verify the target folder exists and has the sibling DTO**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/
+```
+Expected output includes: `RecurringJobDto.cs`. If the folder doesn't exist, stop — the spec assumes it does.
+
+- [ ] **Step 2: Create the new DTO file**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` with this exact content (XML doc comments preserved verbatim from the source on lines 125–134 of `RecurringJobsController.cs`):
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+**Critical invariants:**
+- Type name: `UpdateJobStatusRequestBody` — exact.
+- Property name: `IsEnabled` — exact.
+- `public class` — not `record`, not `sealed`, no `init`/`required` keywords. (Project rule: DTOs are classes, never records, because NSwag mishandles record parameter order.)
+- No constructor declared.
+- File ends with newline.
+
+- [ ] **Step 3: Verify build still succeeds (duplicate type expected)**
+
+At this point both the new file AND the in-controller definition exist, so we will see a CS0101 duplicate-type compile error. That is the expected fail state — confirm it.
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: BUILD FAILED with error `CS0101: The namespace ... already contains a definition for 'UpdateJobStatusRequestBody'` **OR** `CS0436` (type conflicts between namespaces).
+
+If the build succeeds, the new file content is wrong — re-read Step 2. If it fails with any other error, stop and investigate before continuing.
+
+Note: We do not commit yet — the duplicate is resolved in Task 3.
+
+---
+
+## Task 2: Create `UpdateJobCronRequestBody.cs` in Contracts folder
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs`
+
+- [ ] **Step 1: Create the new DTO file**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` with this exact content (XML doc comments preserved verbatim from lines 136–146 of `RecurringJobsController.cs`):
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+**Critical invariants:**
+- Type name: `UpdateJobCronRequestBody` — exact.
+- Property name: `CronExpression` — exact.
+- `[Required]` attribute — preserved (uses `System.ComponentModel.DataAnnotations`).
+- Default value `= string.Empty` — preserved.
+- `public class` — not `record`, not `sealed`, no `init`/`required` keywords.
+- The `using System.ComponentModel.DataAnnotations;` directive must be at the top of the new file (not in the controller anymore — the controller's copy is removed in Task 3).
+- File ends with newline.
+
+- [ ] **Step 2: Verify build still fails with duplicate-type errors for both DTOs**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: BUILD FAILED with `CS0101`/`CS0436` errors mentioning **both** `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody`. The Application project itself should compile cleanly; the error originates from the API project, which references Application and now sees the new types alongside the in-controller copies.
+
+If only one duplicate error appears, the second file is missing a type or in the wrong namespace — re-read Step 1.
+
+No commit yet — Task 3 removes the duplicates.
+
+---
+
+## Task 3: Delete in-controller DTOs and orphan `using` directive
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs`
+
+- [ ] **Step 1: Confirm `System.ComponentModel.DataAnnotations` has no other consumer in the file**
+
+Run:
+```bash
+grep -nE '\[Required\]|\[Range\]|\[StringLength\]|\[MaxLength\]|\[MinLength\]|\[RegularExpression\]|\[EmailAddress\]|\[Phone\]|\[Url\]|\[Compare\]|\[CreditCard\]|\[DataType\]|\[EnumDataType\]|\[FileExtensions\]|\[MaxLength\]|\[MinLength\]|\[ValidationAttribute\]' backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: only the line `[Required]` inside the `UpdateJobCronRequestBody` class (line 144). After we delete that class, no usage of `System.ComponentModel.DataAnnotations` remains.
+
+If the grep shows additional attribute usage outside the DTO classes, STOP — do not remove the `using` in Step 2. Update the plan to keep the using and document why.
+
+- [ ] **Step 2: Delete the two in-controller DTO definitions (lines 125–146 of the original file)**
+
+Open `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` and delete exactly these blocks:
+
+The first block to delete (the original lines 125–134):
+```csharp
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+The second block to delete (the original lines 136–146):
+```csharp
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+Also remove the blank line between them and the trailing newline that separates them from the closing brace of the `RecurringJobsController` class. The file must end at line 123 (the closing `}` of the controller class) followed by a single trailing newline.
+
+- [ ] **Step 3: Delete the orphan `using System.ComponentModel.DataAnnotations;` directive (line 1)**
+
+Remove the first line of the file:
+```csharp
+using System.ComponentModel.DataAnnotations;
+```
+
+The remaining `using` directives must keep their existing order:
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.GetRecurringJobsList;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobStatus;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobCron;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.TriggerRecurringJob;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+```
+
+Do not reorder them. Do not add or remove other usings. The `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` line MUST remain — it is now the resolution path for both relocated DTOs.
+
+- [ ] **Step 4: Verify the controller file shape matches expectation**
+
+Run:
+```bash
+wc -l backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: 122 lines (original 146 minus the 22 deleted DTO lines minus the 1 deleted using minus 1 blank-line gap that separated the DTOs).
+
+Run:
+```bash
+grep -nE 'UpdateJobStatusRequestBody|UpdateJobCronRequestBody|System\.ComponentModel\.DataAnnotations' backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: exactly two matches, both inside `[FromBody]` parameter declarations — no class definitions, no `using` directive. Specifically:
+- One occurrence of `[FromBody] UpdateJobStatusRequestBody request` (inside `UpdateJobStatus` method).
+- One occurrence of `[FromBody] UpdateJobCronRequestBody request` (inside `UpdateJobCron` method).
+- Zero occurrences of `System.ComponentModel.DataAnnotations`.
+
+If the grep shows class definitions or the using directive, Step 2 or Step 3 was incomplete.
+
+- [ ] **Step 5: Build the solution — must now compile cleanly**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+If errors persist:
+- `CS0101` on either DTO type → an in-controller definition was not fully deleted (re-do Step 2).
+- `CS0246` "could not be found" on either DTO type → the `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` was accidentally removed (restore it).
+- `CS0246` on `Required` → the `[Required]` attribute is still in some file that no longer imports `System.ComponentModel.DataAnnotations` (verify Task 2's new file kept its `using`).
+
+---
+
+## Task 4: Verify behaviour parity (tests + format + OpenAPI diff)
+
+**Files:** No source changes. This task is verification-only and produces the artifacts we commit in Task 5.
+
+- [ ] **Step 1: Run the BackgroundJobs controller tests (existing, unmodified)**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTests" --no-build
+```
+Expected: All tests pass (zero failures, zero skipped). These tests reference `UpdateJobStatusRequestBody` unqualified on lines 115, 153, 183, 221 and resolve them via `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` (line 2 of the test file).
+
+If any test fails with a type-resolution error, the `Contracts` using in the test file is missing or the new DTO is in the wrong namespace. Investigate before continuing.
+
+- [ ] **Step 2: Run the full backend test suite to confirm no other test is affected**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: Same pass count as before the change. Any new failure means an unintended consumer (e.g. another test that referenced `Anela.Heblo.API.Controllers.UpdateJobStatusRequestBody` by FQN) — investigate and resolve before continuing. Per the architecture review, the only consumer is `RecurringJobsControllerTests.cs` and it uses unqualified names, so zero new failures is the expected outcome.
+
+- [ ] **Step 3: Run `dotnet format` scoped to the touched files only**
+
+Per NFR-3 (surgical change scope), do not let `dotnet format` rewrite unrelated files. Run:
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs \
+  --verify-no-changes
+```
+Expected: `Format complete` with exit code 0 and no files modified.
+
+If exit code is non-zero, run the same command without `--verify-no-changes` to apply the fixes, then re-run with `--verify-no-changes` to confirm clean. Inspect the resulting diff with `git diff` to make sure formatter did not change anything beyond whitespace/newlines on the three target files.
+
+- [ ] **Step 4: Regenerate the OpenAPI TypeScript client and diff it**
+
+The TypeScript client regenerates on frontend build. Run:
+```bash
+cd frontend && npm run build && cd ..
+```
+Expected: Build succeeds.
+
+Then check that the generated client did NOT change shape:
+```bash
+git diff frontend/src/api/generated/api-client.ts
+```
+Expected: **zero changes**, OR changes that are purely cosmetic (whitespace, comment ordering). Specifically verify these tokens still appear with identical signatures:
+- `class UpdateJobStatusRequestBody` and its `isEnabled` property of type `boolean`.
+- `class UpdateJobCronRequestBody` and its `cronExpression` property of type `string`.
+- `interface IUpdateJobStatusRequestBody` / `interface IUpdateJobCronRequestBody` (NSwag emits both).
+- Methods `recurringJobs_UpdateJobStatus` and `recurringJobs_UpdateJobCron` with identical request body type references.
+
+```bash
+grep -nE 'class UpdateJobStatusRequestBody|class UpdateJobCronRequestBody|recurringJobs_UpdateJobStatus|recurringJobs_UpdateJobCron' frontend/src/api/generated/api-client.ts
+```
+Expected: exactly 4 matches (one per token).
+
+If the type names changed (e.g. NSwag prepended a namespace prefix like `BackgroundJobsContractsUpdateJobStatusRequestBody`), this is a **CRITICAL** blocker per the architecture review. Revert and consult the architecture review's Risks table before proceeding — do not attempt to patch the frontend.
+
+- [ ] **Step 5: Run the frontend lint to confirm the unchanged client still compiles in TypeScript**
+
+Run:
+```bash
+cd frontend && npm run lint && cd ..
+```
+Expected: zero lint errors. If errors appear in `useRecurringJobs.ts` or files that consume it, the NSwag output changed shape and Step 4 should have caught it — go back and re-verify.
+
+---
+
+## Task 5: Commit the change
+
+**Files:** All three touched files staged together.
+
+- [ ] **Step 1: Stage exactly the three touched files**
+
+Run:
+```bash
+git add \
+  backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs
+```
+
+- [ ] **Step 2: Verify the staged diff is surgical (only these three files)**
+
+Run:
+```bash
+git status
+git diff --cached --stat
+```
+Expected:
+- `git status` shows only the three target files as staged, and no other modified files (the generated `api-client.ts` should not be in the diff — Task 4 Step 4 confirmed zero changes).
+- `git diff --cached --stat` shows two new files (the DTOs) and one modified file (the controller) with roughly `-24` lines and `+0` lines on the controller (22 DTO lines + 1 using line + 1 blank gap).
+
+If `api-client.ts` shows changes in `git status` despite Task 4 Step 4 reporting none, re-diff and revert it before continuing — committing a regenerated client with no controller-side changes is fine only when the regeneration is truly identical.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: move BackgroundJobs request body DTOs to Application layer
+
+Relocates UpdateJobStatusRequestBody and UpdateJobCronRequestBody from
+RecurringJobsController.cs into the BackgroundJobs module's Contracts/
+folder. Enforces the rule that the API project does not own DTOs.
+
+Wire format, OpenAPI schema names, and frontend generated client are
+unchanged. Existing RecurringJobsControllerTests pass without edits.
+EOF
+)"
+```
+Expected: Commit succeeds. Any pre-commit hook (build, format, test) should pass — Task 4 already verified each.
+
+If a hook fails, fix the underlying issue and create a NEW commit (do not amend per the global git policy).
+
+- [ ] **Step 4: Final post-commit sanity check**
+
+Run:
+```bash
+git log -1 --stat
+git status
+```
+Expected:
+- `git log -1 --stat` shows the commit with exactly 3 files changed: one modification, two additions.
+- `git status` shows a clean working tree.
+
+---
+
+## Self-Review Checklist
+
+This was checked against the spec before finalising:
+
+**Spec coverage:**
+- FR-1 (relocate `UpdateJobStatusRequestBody`) → Task 1 + Task 3 Step 2.
+- FR-2 (relocate `UpdateJobCronRequestBody` preserving `[Required]`) → Task 2 + Task 3 Step 2.
+- FR-3 (controller cleanup, remove orphan using) → Task 3 Steps 1, 3, 4.
+- FR-4 (consumer compatibility — test file unchanged) → Task 4 Step 1 verifies, file is explicitly in the "do not touch" list.
+- FR-5 (validation: build, format, test, OpenAPI client identical) → Task 4 Steps 2, 3, 4, 5.
+- NFR-1 (behavioural parity) → Task 4 Step 4 OpenAPI diff is the strongest check; Task 4 Step 1 covers controller behaviour.
+- NFR-2 (architectural conformance — DTOs are `public class`, live in `Contracts/`, no record conversion) → Task 1 + Task 2 invariants explicitly enforce this.
+- NFR-3 (surgical change scope — only three files touched) → Task 4 Step 3 uses `--include` scoping, Task 5 Step 2 verifies the staged diff.
+
+**Placeholder scan:** no TBDs, no "implement later", no "similar to Task N", no abstract handwaving — all code blocks are complete and copy-pasteable.
+
+**Type consistency:** type names (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`), property names (`IsEnabled`, `CronExpression`), namespace (`Anela.Heblo.Application.Features.BackgroundJobs.Contracts`), and the `[Required]` attribute are spelt identically across every task that mentions them. The architecture review's grep tokens for the OpenAPI diff match the names used in the new DTOs.
+
+No gaps. No fixes needed.

--- a/backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
 using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.GetRecurringJobsList;
 using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobStatus;
@@ -120,27 +119,4 @@ public class RecurringJobsController : BaseApiController
 
         return Accepted(response);
     }
-}
-
-/// <summary>
-/// Request body for updating recurring job status
-/// </summary>
-public class UpdateJobStatusRequestBody
-{
-    /// <summary>
-    /// Whether the job should be enabled
-    /// </summary>
-    public bool IsEnabled { get; set; }
-}
-
-/// <summary>
-/// Request body for updating recurring job CRON expression
-/// </summary>
-public class UpdateJobCronRequestBody
-{
-    /// <summary>
-    /// The new CRON expression (e.g. "0 3 * * *")
-    /// </summary>
-    [Required]
-    public string CronExpression { get; set; } = string.Empty;
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}

--- a/docs/superpowers/plans/2026-05-27-relocate-backgroundjobs-request-body-dtos.md
+++ b/docs/superpowers/plans/2026-05-27-relocate-backgroundjobs-request-body-dtos.md
@@ -1,0 +1,407 @@
+# Relocate BackgroundJobs Request Body DTOs to Application Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` from `RecurringJobsController.cs` into the `BackgroundJobs` application module's `Contracts/` folder, with zero behavioural or wire-format change.
+
+**Architecture:** Mechanical relocation. Two new files are created in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/`, the two in-controller class definitions are deleted, and the now-orphan `using System.ComponentModel.DataAnnotations;` directive at the top of the controller is removed. The controller already imports the target `Contracts` namespace, so post-move type resolution is automatic.
+
+**Tech Stack:** .NET 8, C#, ASP.NET Core MVC, xUnit + FluentAssertions + Moq, NSwag (TypeScript client regeneration on build).
+
+---
+
+## Background & Why TDD-Lite Here
+
+The two DTOs are pure data shapes with no behaviour. The behaviour they participate in (HTTP request binding, controller dispatch, MediatR mapping, validation) is already covered by `RecurringJobsControllerTests.cs`. Those existing tests are the regression net for this move — they must continue to pass **without any edit**. There is no new code path to drive via a new RED→GREEN test; the discipline here is to make small, verifiable changes and run the existing test suite + build + OpenAPI diff at each gate.
+
+---
+
+## File Structure
+
+**Files to create (2):**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` | Request body DTO for `PUT /api/RecurringJobs/{jobName}/status` |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` | Request body DTO for `PUT /api/RecurringJobs/{jobName}/cron` |
+
+**Files to modify (1):**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` | Delete lines 125–146 (both DTO definitions + their XML doc comments). Delete line 1 (`using System.ComponentModel.DataAnnotations;`) — it is orphan after the move. |
+
+**Files explicitly NOT touched:**
+
+| Path | Reason |
+|------|--------|
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTests.cs` | Already imports `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` at line 2. The four unqualified references (`UpdateJobStatusRequestBody` on lines 115, 153, 183, 221) resolve through that using directive post-move. |
+| `frontend/src/api/hooks/useRecurringJobs.ts` | Consumes generated client types by name. NSwag schema names are namespace-independent. |
+| `frontend/src/api/generated/api-client.ts` | Auto-regenerated on `npm run build`. We **verify** it does not change (it's a checkpoint, not an edit target). |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs` | Sibling DTO; out of scope. |
+| Any file under `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/` | MediatR Request/Response/Handler triples are unchanged. |
+
+---
+
+## Task 1: Create `UpdateJobStatusRequestBody.cs` in Contracts folder
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs`
+
+- [ ] **Step 1: Verify the target folder exists and has the sibling DTO**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/
+```
+Expected output includes: `RecurringJobDto.cs`. If the folder doesn't exist, stop — the spec assumes it does.
+
+- [ ] **Step 2: Create the new DTO file**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` with this exact content (XML doc comments preserved verbatim from the source on lines 125–134 of `RecurringJobsController.cs`):
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+**Critical invariants:**
+- Type name: `UpdateJobStatusRequestBody` — exact.
+- Property name: `IsEnabled` — exact.
+- `public class` — not `record`, not `sealed`, no `init`/`required` keywords. (Project rule: DTOs are classes, never records, because NSwag mishandles record parameter order.)
+- No constructor declared.
+- File ends with newline.
+
+- [ ] **Step 3: Verify build still succeeds (duplicate type expected)**
+
+At this point both the new file AND the in-controller definition exist, so we will see a CS0101 duplicate-type compile error. That is the expected fail state — confirm it.
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: BUILD FAILED with error `CS0101: The namespace ... already contains a definition for 'UpdateJobStatusRequestBody'` **OR** `CS0436` (type conflicts between namespaces).
+
+If the build succeeds, the new file content is wrong — re-read Step 2. If it fails with any other error, stop and investigate before continuing.
+
+Note: We do not commit yet — the duplicate is resolved in Task 3.
+
+---
+
+## Task 2: Create `UpdateJobCronRequestBody.cs` in Contracts folder
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs`
+
+- [ ] **Step 1: Create the new DTO file**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` with this exact content (XML doc comments preserved verbatim from lines 136–146 of `RecurringJobsController.cs`):
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+**Critical invariants:**
+- Type name: `UpdateJobCronRequestBody` — exact.
+- Property name: `CronExpression` — exact.
+- `[Required]` attribute — preserved (uses `System.ComponentModel.DataAnnotations`).
+- Default value `= string.Empty` — preserved.
+- `public class` — not `record`, not `sealed`, no `init`/`required` keywords.
+- The `using System.ComponentModel.DataAnnotations;` directive must be at the top of the new file (not in the controller anymore — the controller's copy is removed in Task 3).
+- File ends with newline.
+
+- [ ] **Step 2: Verify build still fails with duplicate-type errors for both DTOs**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: BUILD FAILED with `CS0101`/`CS0436` errors mentioning **both** `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody`. The Application project itself should compile cleanly; the error originates from the API project, which references Application and now sees the new types alongside the in-controller copies.
+
+If only one duplicate error appears, the second file is missing a type or in the wrong namespace — re-read Step 1.
+
+No commit yet — Task 3 removes the duplicates.
+
+---
+
+## Task 3: Delete in-controller DTOs and orphan `using` directive
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs`
+
+- [ ] **Step 1: Confirm `System.ComponentModel.DataAnnotations` has no other consumer in the file**
+
+Run:
+```bash
+grep -nE '\[Required\]|\[Range\]|\[StringLength\]|\[MaxLength\]|\[MinLength\]|\[RegularExpression\]|\[EmailAddress\]|\[Phone\]|\[Url\]|\[Compare\]|\[CreditCard\]|\[DataType\]|\[EnumDataType\]|\[FileExtensions\]|\[MaxLength\]|\[MinLength\]|\[ValidationAttribute\]' backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: only the line `[Required]` inside the `UpdateJobCronRequestBody` class (line 144). After we delete that class, no usage of `System.ComponentModel.DataAnnotations` remains.
+
+If the grep shows additional attribute usage outside the DTO classes, STOP — do not remove the `using` in Step 2. Update the plan to keep the using and document why.
+
+- [ ] **Step 2: Delete the two in-controller DTO definitions (lines 125–146 of the original file)**
+
+Open `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` and delete exactly these blocks:
+
+The first block to delete (the original lines 125–134):
+```csharp
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+The second block to delete (the original lines 136–146):
+```csharp
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+Also remove the blank line between them and the trailing newline that separates them from the closing brace of the `RecurringJobsController` class. The file must end at line 123 (the closing `}` of the controller class) followed by a single trailing newline.
+
+- [ ] **Step 3: Delete the orphan `using System.ComponentModel.DataAnnotations;` directive (line 1)**
+
+Remove the first line of the file:
+```csharp
+using System.ComponentModel.DataAnnotations;
+```
+
+The remaining `using` directives must keep their existing order:
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.GetRecurringJobsList;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobStatus;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobCron;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.TriggerRecurringJob;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+```
+
+Do not reorder them. Do not add or remove other usings. The `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` line MUST remain — it is now the resolution path for both relocated DTOs.
+
+- [ ] **Step 4: Verify the controller file shape matches expectation**
+
+Run:
+```bash
+wc -l backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: 122 lines (original 146 minus the 22 deleted DTO lines minus the 1 deleted using minus 1 blank-line gap that separated the DTOs).
+
+Run:
+```bash
+grep -nE 'UpdateJobStatusRequestBody|UpdateJobCronRequestBody|System\.ComponentModel\.DataAnnotations' backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: exactly two matches, both inside `[FromBody]` parameter declarations — no class definitions, no `using` directive. Specifically:
+- One occurrence of `[FromBody] UpdateJobStatusRequestBody request` (inside `UpdateJobStatus` method).
+- One occurrence of `[FromBody] UpdateJobCronRequestBody request` (inside `UpdateJobCron` method).
+- Zero occurrences of `System.ComponentModel.DataAnnotations`.
+
+If the grep shows class definitions or the using directive, Step 2 or Step 3 was incomplete.
+
+- [ ] **Step 5: Build the solution — must now compile cleanly**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+If errors persist:
+- `CS0101` on either DTO type → an in-controller definition was not fully deleted (re-do Step 2).
+- `CS0246` "could not be found" on either DTO type → the `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` was accidentally removed (restore it).
+- `CS0246` on `Required` → the `[Required]` attribute is still in some file that no longer imports `System.ComponentModel.DataAnnotations` (verify Task 2's new file kept its `using`).
+
+---
+
+## Task 4: Verify behaviour parity (tests + format + OpenAPI diff)
+
+**Files:** No source changes. This task is verification-only and produces the artifacts we commit in Task 5.
+
+- [ ] **Step 1: Run the BackgroundJobs controller tests (existing, unmodified)**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTests" --no-build
+```
+Expected: All tests pass (zero failures, zero skipped). These tests reference `UpdateJobStatusRequestBody` unqualified on lines 115, 153, 183, 221 and resolve them via `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` (line 2 of the test file).
+
+If any test fails with a type-resolution error, the `Contracts` using in the test file is missing or the new DTO is in the wrong namespace. Investigate before continuing.
+
+- [ ] **Step 2: Run the full backend test suite to confirm no other test is affected**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: Same pass count as before the change. Any new failure means an unintended consumer (e.g. another test that referenced `Anela.Heblo.API.Controllers.UpdateJobStatusRequestBody` by FQN) — investigate and resolve before continuing. Per the architecture review, the only consumer is `RecurringJobsControllerTests.cs` and it uses unqualified names, so zero new failures is the expected outcome.
+
+- [ ] **Step 3: Run `dotnet format` scoped to the touched files only**
+
+Per NFR-3 (surgical change scope), do not let `dotnet format` rewrite unrelated files. Run:
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs \
+  --verify-no-changes
+```
+Expected: `Format complete` with exit code 0 and no files modified.
+
+If exit code is non-zero, run the same command without `--verify-no-changes` to apply the fixes, then re-run with `--verify-no-changes` to confirm clean. Inspect the resulting diff with `git diff` to make sure formatter did not change anything beyond whitespace/newlines on the three target files.
+
+- [ ] **Step 4: Regenerate the OpenAPI TypeScript client and diff it**
+
+The TypeScript client regenerates on frontend build. Run:
+```bash
+cd frontend && npm run build && cd ..
+```
+Expected: Build succeeds.
+
+Then check that the generated client did NOT change shape:
+```bash
+git diff frontend/src/api/generated/api-client.ts
+```
+Expected: **zero changes**, OR changes that are purely cosmetic (whitespace, comment ordering). Specifically verify these tokens still appear with identical signatures:
+- `class UpdateJobStatusRequestBody` and its `isEnabled` property of type `boolean`.
+- `class UpdateJobCronRequestBody` and its `cronExpression` property of type `string`.
+- `interface IUpdateJobStatusRequestBody` / `interface IUpdateJobCronRequestBody` (NSwag emits both).
+- Methods `recurringJobs_UpdateJobStatus` and `recurringJobs_UpdateJobCron` with identical request body type references.
+
+```bash
+grep -nE 'class UpdateJobStatusRequestBody|class UpdateJobCronRequestBody|recurringJobs_UpdateJobStatus|recurringJobs_UpdateJobCron' frontend/src/api/generated/api-client.ts
+```
+Expected: exactly 4 matches (one per token).
+
+If the type names changed (e.g. NSwag prepended a namespace prefix like `BackgroundJobsContractsUpdateJobStatusRequestBody`), this is a **CRITICAL** blocker per the architecture review. Revert and consult the architecture review's Risks table before proceeding — do not attempt to patch the frontend.
+
+- [ ] **Step 5: Run the frontend lint to confirm the unchanged client still compiles in TypeScript**
+
+Run:
+```bash
+cd frontend && npm run lint && cd ..
+```
+Expected: zero lint errors. If errors appear in `useRecurringJobs.ts` or files that consume it, the NSwag output changed shape and Step 4 should have caught it — go back and re-verify.
+
+---
+
+## Task 5: Commit the change
+
+**Files:** All three touched files staged together.
+
+- [ ] **Step 1: Stage exactly the three touched files**
+
+Run:
+```bash
+git add \
+  backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs
+```
+
+- [ ] **Step 2: Verify the staged diff is surgical (only these three files)**
+
+Run:
+```bash
+git status
+git diff --cached --stat
+```
+Expected:
+- `git status` shows only the three target files as staged, and no other modified files (the generated `api-client.ts` should not be in the diff — Task 4 Step 4 confirmed zero changes).
+- `git diff --cached --stat` shows two new files (the DTOs) and one modified file (the controller) with roughly `-24` lines and `+0` lines on the controller (22 DTO lines + 1 using line + 1 blank gap).
+
+If `api-client.ts` shows changes in `git status` despite Task 4 Step 4 reporting none, re-diff and revert it before continuing — committing a regenerated client with no controller-side changes is fine only when the regeneration is truly identical.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: move BackgroundJobs request body DTOs to Application layer
+
+Relocates UpdateJobStatusRequestBody and UpdateJobCronRequestBody from
+RecurringJobsController.cs into the BackgroundJobs module's Contracts/
+folder. Enforces the rule that the API project does not own DTOs.
+
+Wire format, OpenAPI schema names, and frontend generated client are
+unchanged. Existing RecurringJobsControllerTests pass without edits.
+EOF
+)"
+```
+Expected: Commit succeeds. Any pre-commit hook (build, format, test) should pass — Task 4 already verified each.
+
+If a hook fails, fix the underlying issue and create a NEW commit (do not amend per the global git policy).
+
+- [ ] **Step 4: Final post-commit sanity check**
+
+Run:
+```bash
+git log -1 --stat
+git status
+```
+Expected:
+- `git log -1 --stat` shows the commit with exactly 3 files changed: one modification, two additions.
+- `git status` shows a clean working tree.
+
+---
+
+## Self-Review Checklist
+
+This was checked against the spec before finalising:
+
+**Spec coverage:**
+- FR-1 (relocate `UpdateJobStatusRequestBody`) → Task 1 + Task 3 Step 2.
+- FR-2 (relocate `UpdateJobCronRequestBody` preserving `[Required]`) → Task 2 + Task 3 Step 2.
+- FR-3 (controller cleanup, remove orphan using) → Task 3 Steps 1, 3, 4.
+- FR-4 (consumer compatibility — test file unchanged) → Task 4 Step 1 verifies, file is explicitly in the "do not touch" list.
+- FR-5 (validation: build, format, test, OpenAPI client identical) → Task 4 Steps 2, 3, 4, 5.
+- NFR-1 (behavioural parity) → Task 4 Step 4 OpenAPI diff is the strongest check; Task 4 Step 1 covers controller behaviour.
+- NFR-2 (architectural conformance — DTOs are `public class`, live in `Contracts/`, no record conversion) → Task 1 + Task 2 invariants explicitly enforce this.
+- NFR-3 (surgical change scope — only three files touched) → Task 4 Step 3 uses `--include` scoping, Task 5 Step 2 verifies the staged diff.
+
+**Placeholder scan:** no TBDs, no "implement later", no "similar to Task N", no abstract handwaving — all code blocks are complete and copy-pasteable.
+
+**Type consistency:** type names (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`), property names (`IsEnabled`, `CronExpression`), namespace (`Anela.Heblo.Application.Features.BackgroundJobs.Contracts`), and the `[Required]` attribute are spelt identically across every task that mentions them. The architecture review's grep tokens for the OpenAPI diff match the names used in the new DTOs.
+
+No gaps. No fixes needed.


### PR DESCRIPTION

Relocates `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` from `RecurringJobsController.cs` into the BackgroundJobs module's `Contracts/` folder. This enforces the project rule that the API project never defines or owns DTOs.

The controller already imported `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;`, so all consumer references (controller `[FromBody]` parameters, test file, generated TypeScript client) continue to resolve automatically without modification. The `using System.ComponentModel.DataAnnotations;` directive in the controller became orphan after the move and was removed.

Wire format, OpenAPI schema names (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`), HTTP status codes, and the generated TypeScript client are byte-identical before and after the move.

### Changes
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` — new DTO file, relocated from controller
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` — new DTO file with `[Required]` annotation, relocated from controller
- `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` — removed inline DTO definitions and orphan `using` directive

---

Closes #1832

### Tokens used
8225067
