### PR TITLE
feat: Remove Analytics → Catalog Direct Cross-Module Dependency

### DIFF
--- a/artifacts/feat-arch-review-analytics-direct-cross-modul/arch-review.r1.md
+++ b/artifacts/feat-arch-review-analytics-direct-cross-modul/arch-review.r1.md
@@ -1,0 +1,264 @@
+# Architecture Review: Remove Analytics → Catalog Direct Cross-Module Dependency
+
+## Skip Design: true
+
+Backend-only refactor with no UI/UX work — internal contract changes only, no HTTP API surface or DTO changes, no new screens or visual components.
+
+## Architectural Fit Assessment
+
+The proposed refactor aligns precisely with the canonical pattern already established in this codebase. Two existing exemplars validate the approach:
+
+- **Leaflet → KnowledgeBase**: `ILeafletKnowledgeSource` (Leaflet-owned contract) implemented by `KnowledgeBaseLeafletSourceAdapter` (KnowledgeBase-owned adapter), registered in `KnowledgeBaseModule`.
+- **Purchase → Catalog**: `IMaterialCatalogService` (Purchase-owned contract) implemented by `PurchaseMaterialCatalogAdapter` (Catalog-owned adapter), registered in `CatalogModule` (line 45 of `CatalogModule.cs`).
+
+The same wiring shape applies here. The reflection-based test in `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` is the canonical guardrail and **must be extended** with an `Analytics → Catalog` rule — the spec does not call this out explicitly, but the existing rules for Leaflet, Article, Logistics, PackingMaterials, Purchase, and ExpeditionListArchive set the precedent.
+
+**Key gap in the spec:** The spec describes refactoring `AnalyticsRepository.cs` (impl) but does not mention `IAnalyticsRepository.cs` (interface, lines 18–22, 28–32), which itself imports `Anela.Heblo.Domain.Features.Catalog` and exposes `ProductType[] productTypes` on `StreamProductsWithSalesAsync` and `GetGroupMarginTotalsAsync`. The interface must change too — otherwise `GetMarginReportHandler` and `GetProductMarginSummaryHandler` (which call these methods with `new[] { ProductType.Product, ProductType.Goods }` at line 57 and line 37 respectively) cannot stop importing Catalog.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Anela.Heblo.Application.Features.Analytics                         │
+│                                                                     │
+│  ┌─────────────────────────────────────────┐                        │
+│  │ UseCases/                               │                        │
+│  │   GetMarginReportHandler                │ ← injects              │
+│  │   GetProductMarginSummaryHandler        │   IAnalyticsRepository │
+│  │   GetProductMarginAnalysisHandler       │                        │
+│  └────────────────────┬────────────────────┘                        │
+│                       │                                             │
+│  ┌────────────────────▼────────────────────┐                        │
+│  │ Infrastructure/                         │                        │
+│  │   IAnalyticsRepository  (Analytics-owned, NO Catalog types)      │
+│  │   AnalyticsRepository                   │ ← injects              │
+│  └────────────────────┬────────────────────┘   IAnalyticsProductSource│
+│                       │                                             │
+│  ┌────────────────────▼────────────────────┐                        │
+│  │ Contracts/                              │                        │
+│  │   IAnalyticsProductSource  (NEW)        │                        │
+│  └────────────────────▲────────────────────┘                        │
+└───────────────────────┼─────────────────────────────────────────────┘
+                        │  implemented by (DI)
+┌───────────────────────┼─────────────────────────────────────────────┐
+│  Anela.Heblo.Application.Features.Catalog                           │
+│                       │                                             │
+│  ┌────────────────────┴────────────────────┐                        │
+│  │ Infrastructure/                         │                        │
+│  │   CatalogAnalyticsSourceAdapter  (NEW)  │ ← injects              │
+│  └────────────────────┬────────────────────┘   ICatalogRepository   │
+│                       │                                             │
+│  ┌────────────────────▼────────────────────┐                        │
+│  │ CatalogModule.cs                        │                        │
+│  │   AddScoped<IAnalyticsProductSource,    │                        │
+│  │             CatalogAnalyticsSourceAdapter>()                     │
+│  └─────────────────────────────────────────┘                        │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│  Anela.Heblo.Domain.Features.Analytics                              │
+│    AnalyticsProduct  (Type retyped: AnalyticsProductType)           │
+│    AnalyticsProductType  (NEW enum, mirrors used Catalog values)    │
+│    MarginCalculator, SalesDataPoint, DateRange, ...                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Interface lives in `Contracts/`, not `Infrastructure/`
+
+**Options considered:**
+- (A) Place `IAnalyticsProductSource` in `Application/Features/Analytics/Contracts/` (consumer-owned contract folder, per spec FR-1).
+- (B) Place it in `Application/Features/Analytics/Infrastructure/` next to `IAnalyticsRepository`.
+
+**Chosen approach:** (A) — `Contracts/`.
+
+**Rationale:** Both exemplars (`ILeafletKnowledgeSource`, `IMaterialCatalogService`) live in their consumer module's `Contracts/`. `Infrastructure/` is for the consumer's own data-access concerns (e.g., `IAnalyticsRepository`/`AnalyticsRepository` accessing `ApplicationDbContext`). A cross-module contract that the consumer owns and the provider implements belongs in `Contracts/`.
+
+#### Decision 2: `IAnalyticsRepository` must also be detoxified
+
+**Options considered:**
+- (A) Change only `AnalyticsRepository` impl; leave the interface signature with `ProductType[]`.
+- (B) Change the interface to take `AnalyticsProductType[]` and update all callers.
+
+**Chosen approach:** (B).
+
+**Rationale:** If the interface still exposes `Catalog.ProductType`, the handlers must still import Catalog to call it — defeating FR-6's acceptance criterion ("Neither file imports from `Anela.Heblo.Domain.Features.Catalog`"). The architectural fence (NFR-2's grep test) will fail at the handler level. This is an addition to the spec, not a contradiction.
+
+#### Decision 3: `CatalogAnalyticsSourceAdapter` lifetime
+
+**Options considered:**
+- (A) `AddScoped` (per spec FR-4).
+- (B) `AddTransient` (matches `ICatalogRepository` registration at `CatalogModule.cs:41`).
+
+**Chosen approach:** (B) — `AddTransient`.
+
+**Rationale:** The adapter is stateless and merely delegates. Its dependency (`ICatalogRepository`) is registered Transient. Using Scoped here introduces a lifetime mismatch (Transient inside Scoped is fine, but the inverse can produce captive-dependency warnings if anything ever changes). Match the dependency's lifetime; the spec's "lifetime to match existing Catalog repository registrations" wording supports this — `ICatalogRepository` is Transient, not Scoped.
+
+#### Decision 4: Add `Analytics → Catalog` rule to `ModuleBoundariesTests`
+
+**Options considered:**
+- (A) Add a new `ModuleBoundaryRule` entry to the `Rules()` `TheoryData` in `ModuleBoundariesTests.cs`.
+- (B) Rely on manual grep (per spec NFR-2) without a CI guard.
+
+**Chosen approach:** (A).
+
+**Rationale:** Every other module decoupling in this repo (Leaflet, Article, Logistics, PackingMaterials, Purchase, ExpeditionListArchive) is enforced by a reflection-based rule in this test. Without one, regressions are inevitable. The new rule must also include a check against `Anela.Heblo.Domain.Features.Analytics → Anela.Heblo.Domain.Features.Catalog` (the domain entity `AnalyticsProduct.cs` is the original violation site — the current test only inspects the Application assembly). Either extend the existing test to also load `Anela.Heblo.Domain`, or add a parallel test scoped to the Domain assembly.
+
+#### Decision 5: Preserve current materialization semantics; do not claim "streaming"
+
+**Options considered:**
+- (A) Document the adapter as streaming (per spec NFR-1).
+- (B) Acknowledge that the underlying `ICatalogRepository.GetProductsWithSalesInPeriod` returns `Task<List<CatalogAggregate>>` (eager) and that `IAsyncEnumerable` is a façade over an already-materialized list.
+
+**Chosen approach:** (B) — be honest about current behavior.
+
+**Rationale:** `AnalyticsRepository.cs:39` calls `await _catalogRepository.GetProductsWithSalesInPeriod(...)` which returns a fully materialized `List<CatalogAggregate>`. The `IAsyncEnumerable` yield loop and `GC.Collect()` calls (line 120) are theater over a list that is already in memory. The refactor must **preserve** this semantics (FR-7 behavior preservation), but the spec should not claim we are protecting streaming we don't have. True streaming is out of scope (it would require pushing changes into `ICatalogRepository` and the underlying provider).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/
+  Contracts/
+    IAnalyticsProductSource.cs              ← NEW (cross-module contract)
+  Infrastructure/
+    IAnalyticsRepository.cs                 ← MODIFIED (drop ProductType[])
+    AnalyticsRepository.cs                  ← MODIFIED (drop ICatalogRepository,
+                                              mapping moves to adapter)
+
+backend/src/Anela.Heblo.Domain/Features/Analytics/
+  AnalyticsProductType.cs                   ← NEW
+  AnalyticsProduct.cs                       ← MODIFIED (Type: AnalyticsProductType)
+
+backend/src/Anela.Heblo.Application/Features/Catalog/
+  Infrastructure/
+    CatalogAnalyticsSourceAdapter.cs        ← NEW (internal sealed, like
+                                              PurchaseMaterialCatalogAdapter)
+  CatalogModule.cs                          ← MODIFIED (register binding)
+
+backend/test/Anela.Heblo.Tests/
+  Architecture/
+    ModuleBoundariesTests.cs                ← MODIFIED (add Analytics→Catalog rule
+                                              spanning Domain + Application)
+  Features/Catalog/Infrastructure/
+    CatalogAnalyticsSourceAdapterTests.cs   ← NEW (per NFR-3 — mapping was
+                                              previously untested)
+```
+
+### Interfaces and Contracts
+
+**`IAnalyticsProductSource`** (Analytics-owned, in `Contracts/`):
+```csharp
+namespace Anela.Heblo.Application.Features.Analytics.Contracts;
+
+public interface IAnalyticsProductSource
+{
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default);
+
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**`AnalyticsProductType`** (Analytics-owned, in `Domain.Features.Analytics`):
+```csharp
+namespace Anela.Heblo.Domain.Features.Analytics;
+
+public enum AnalyticsProductType
+{
+    Product,
+    Goods,
+}
+```
+
+Mirror only the values Analytics actually consumes today. Inspection of all Analytics call sites (`GetMarginReportHandler.cs:57` and `GetProductMarginSummaryHandler.cs:37`) shows only `ProductType.Product` and `ProductType.Goods` are passed. Do **not** mirror `Material`, `SemiProduct`, `Set`, `UNDEFINED` — they are unused in Analytics and including them is speculative.
+
+**`IAnalyticsRepository`** (signature change):
+```csharp
+IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+    DateTime fromDate, DateTime toDate,
+    AnalyticsProductType[] productTypes,            // was ProductType[]
+    CancellationToken cancellationToken = default);
+
+Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
+    DateTime fromDate, DateTime toDate,
+    AnalyticsProductType[] productTypes,            // was ProductType[]
+    ProductGroupingMode groupingMode,
+    CancellationToken cancellationToken = default);
+```
+
+**`CatalogAnalyticsSourceAdapter`** (Catalog-owned, mirrors `PurchaseMaterialCatalogAdapter` shape):
+- `internal sealed class CatalogAnalyticsSourceAdapter : IAnalyticsProductSource`
+- Constructor takes `ICatalogRepository` only
+- Private `MapToAnalyticsProduct(CatalogAggregate, DateTime fromDate, DateTime toDate)` extracts the duplicated mapping at lines 80–116 and 196–231 of `AnalyticsRepository.cs` into a single helper (the current code violates DRY across the streaming and single-product paths). **Note on the single-product path**: line 223 of `AnalyticsRepository.cs` does not filter `SalesHistory` by the period — preserve that asymmetry verbatim (FR-7) or document it as a follow-up bug.
+- Private `MapProductType(AnalyticsProductType) → Catalog.ProductType` at the adapter boundary
+
+### Data Flow
+
+```
+Handler (e.g., GetMarginReportHandler)
+  ↓ passes new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods }
+  ↓
+AnalyticsRepository.StreamProductsWithSalesAsync
+  ↓ delegates (no mapping, no ProductType conversion here)
+  ↓
+IAnalyticsProductSource.StreamProductsWithSalesAsync       ← module boundary
+  ↓
+CatalogAnalyticsSourceAdapter
+  ↓ MapProductType: AnalyticsProductType[] → ProductType[]
+  ↓
+ICatalogRepository.GetProductsWithSalesInPeriod
+  ↓ returns List<CatalogAggregate>
+  ↓
+CatalogAnalyticsSourceAdapter.MapToAnalyticsProduct (per item, yield return)
+  ↓ returns AnalyticsProduct
+  ↓
+Handler consumes AnalyticsProduct stream
+```
+
+`AnalyticsRepository` becomes a thin pass-through for the two product-source methods. Consider whether `StreamProductsWithSalesAsync` and `GetProductAnalysisDataAsync` should remain on `IAnalyticsRepository` at all, or whether handlers should inject `IAnalyticsProductSource` directly. **Recommendation:** keep them on `IAnalyticsRepository` to minimize blast radius and preserve handler/test signatures; only the inner delegation changes. This is the conservative path per FR-7.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec omits `IAnalyticsRepository` interface signature — refactor leaves handlers still importing Catalog | HIGH | Amend spec FR-5 to include the interface; update handler call sites in same PR. |
+| `ModuleBoundariesTests` not extended → silent regression two weeks later | HIGH | Mandatory rule addition; rule must cover both `Anela.Heblo.Domain.Features.Analytics` and `Anela.Heblo.Application.Features.Analytics` namespaces. |
+| Existing `AnalyticsRepository` test mocks of `ICatalogRepository` break en masse | MEDIUM | Replace mocks of `ICatalogRepository` with mocks of `IAnalyticsProductSource` in `GetProductMarginAnalysisHandlerTests`, `GetMarginReportHandlerTests`, `GetProductMarginSummaryHandlerTests`. Verify all six test files in `backend/test/Anela.Heblo.Tests/Features/Analytics/`. |
+| `AnalyticsProductType` enum drift (Catalog adds a value Analytics needs later) | LOW | Document in `AnalyticsProductType.cs` xmldoc that this is an Analytics-owned subset; if Analytics needs a new value, mirror it and update `MapProductType` in the adapter. No runtime conversion safety net needed since the adapter owns both sides of the mapping. |
+| Single-product path (`GetProductAnalysisDataAsync`) does not filter `SalesHistory` by period (line 223 of current code), unlike streaming path (line 107) | LOW | Preserve verbatim per FR-7; file a separate ticket if this is actually a bug. Do **not** "fix" it during this refactor (surgical changes rule). |
+| DI lifetime mismatch | LOW | Register adapter as `AddTransient` to match `ICatalogRepository` lifetime, not `AddScoped`. |
+| `Catalog.CatalogAggregate` evolves after refactor, breaking adapter mapping silently | LOW | The new `CatalogAnalyticsSourceAdapterTests` (NFR-3) covers the mapping. This is a net improvement — currently no test exercises the mapping at all. |
+
+## Specification Amendments
+
+1. **FR-5 expansion:** Extend FR-5 to include `IAnalyticsRepository` (the interface, not just `AnalyticsRepository`). The two methods `StreamProductsWithSalesAsync` and `GetGroupMarginTotalsAsync` must take `AnalyticsProductType[]` instead of `ProductType[]`, and the file must drop `using Anela.Heblo.Domain.Features.Catalog;`.
+
+2. **FR-6 expansion:** Add `GetProductMarginAnalysisHandler` to the scope. While it does not import `ProductType` today, it consumes `IAnalyticsRepository.GetProductAnalysisDataAsync` and its tests will need adapter mocking updates (NFR-3 implies this but the spec lists only two handlers in FR-6).
+
+3. **New FR-8 — Architecture test rule:** Add an `Analytics → Catalog` `ModuleBoundaryRule` to `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. The rule must inspect both `Anela.Heblo.Application.Features.Analytics` (currently the test only loads the Application assembly) and `Anela.Heblo.Domain.Features.Analytics` (the `AnalyticsProduct.Type` violation lives in the Domain assembly — this requires loading `Anela.Heblo.Domain` as well). Empty allowlist.
+
+4. **FR-4 lifetime correction:** Register `CatalogAnalyticsSourceAdapter` as `AddTransient`, not `AddScoped`. This matches `ICatalogRepository` (`CatalogModule.cs:41`) and avoids captive-dependency risk.
+
+5. **NFR-1 wording correction:** Drop the claim about "preserving streaming." The current code is not streaming under the hood — `ICatalogRepository.GetProductsWithSalesInPeriod` returns a materialized `List<CatalogAggregate>`. Replace with: "The adapter must invoke the same `ICatalogRepository` methods and yield the same items in the same order; no new SQL queries; memory profile unchanged."
+
+6. **Mapping consolidation (clarification):** The current `AnalyticsRepository.cs` duplicates the `CatalogAggregate → AnalyticsProduct` mapping across two methods (lines 80–116 and 196–231) with one subtle difference (sales filter applied in streaming path only). The adapter should extract a single private mapping helper and preserve the asymmetry as-is. Add this to FR-3.
+
+7. **`AnalyticsModule.cs` cleanup (advisory):** Line 28's comment "`IMarginCalculationService` is registered by CatalogModule and injected here" is stale — no Analytics class injects it. No change required for this spec, but flag in a follow-up.
+
+## Prerequisites
+
+- **None blocking.** No migrations, no infrastructure, no config, no external dependencies.
+- **Module wiring order verified:** `CatalogModule.AddCatalogModule()` must be called before any Analytics handler resolves `IAnalyticsProductSource`. Confirm `Program.cs` invokes `AddCatalogModule()` before `AddAnalyticsModule()` (it currently does, and Catalog has no inverse dependency on Analytics, so this is structurally sound).
+- **Recommend bundling in one PR:** contract + adapter + DI registration + handler/interface changes + test updates + architecture rule. Splitting risks an intermediate state that fails the new architecture rule.

--- a/artifacts/feat-arch-review-analytics-direct-cross-modul/brief.md
+++ b/artifacts/feat-arch-review-analytics-direct-cross-modul/brief.md
@@ -1,0 +1,70 @@
+## Module
+Analytics
+
+## Finding
+
+Two files in the Analytics module take direct compile-time dependencies on Catalog-owned types:
+
+**1. `AnalyticsProduct` (Domain layer) imports `ProductType` from Catalog domain**
+`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs:1–13`
+```csharp
+using Anela.Heblo.Domain.Features.Catalog;   // ← cross-module domain import
+
+public class AnalyticsProduct
+{
+    public required ProductType Type { get; init; }  // ← Catalog's enum
+```
+The Analytics domain entity carries a hard dependency on a type owned by the Catalog domain.
+
+**2. `AnalyticsRepository` (Analytics Application layer) injects `ICatalogRepository` directly**
+`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs:5–21`
+```csharp
+using Anela.Heblo.Domain.Features.Catalog;        // ← Catalog domain
+...
+public class AnalyticsRepository : IAnalyticsRepository
+{
+    private readonly ICatalogRepository _catalogRepository;  // ← Catalog's repository
+
+    public AnalyticsRepository(ICatalogRepository catalogRepository, ...)
+```
+`AnalyticsRepository` delegates every product data fetch to `ICatalogRepository.GetProductsWithSalesInPeriod()` and `GetByIdAsync()`, calling these on `CatalogAggregate` objects directly.
+
+Both `GetMarginReportHandler` (line 7, line 57) and `GetProductMarginSummaryHandler` (line 5, line 37) also import `ProductType` from Catalog as a downstream consequence.
+
+## Why it matters
+
+`development_guidelines.md` explicitly forbids:
+- **"Direct access to another module's entities"**
+- **"Shared repositories across modules"**
+
+Analytics can never be deployed or tested in isolation; it is tightly coupled to Catalog's internal data model (`CatalogAggregate`, `MarginData`, `PurchaseHistory`, etc.). Any internal refactoring of the `CatalogAggregate` structure silently breaks the Analytics repository's manual field mappings (lines 52–116 of `AnalyticsRepository.cs`).
+
+## Suggested fix
+
+Apply the adapter pattern documented in `development_guidelines.md` (§ *Cross-Module Communication*):
+
+1. **Analytics owns the contract.** Add `IAnalyticsProductSource` to `Application/Features/Analytics/Contracts/`:
+```csharp
+public interface IAnalyticsProductSource
+{
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime from, DateTime to, AnalyticsProductType[] types,
+        CancellationToken ct = default);
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId, DateTime from, DateTime to,
+        CancellationToken ct = default);
+}
+```
+Define `AnalyticsProductType` as an Analytics-owned enum (mirroring the values currently borrowed from Catalog).
+
+2. **Catalog implements the adapter.** Move the existing `CatalogAggregate → AnalyticsProduct` mapping code from `AnalyticsRepository` into a new `CatalogAnalyticsSourceAdapter` class inside `Application/Features/Catalog/Infrastructure/`.
+
+3. **Catalog registers the binding.** In `CatalogModule.AddCatalogModule()`:
+```csharp
+services.AddScoped<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
+```
+
+4. **`AnalyticsRepository` drops `ICatalogRepository`.** It now depends only on `IAnalyticsProductSource` (Analytics-owned) and `ApplicationDbContext` (already correct).
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-analytics-direct-cross-modul/impl/main.r1.md
+++ b/artifacts/feat-arch-review-analytics-direct-cross-modul/impl/main.r1.md
@@ -1,0 +1,8 @@
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-analytics-direct-cross-modul/spec.r1.md
+++ b/artifacts/feat-arch-review-analytics-direct-cross-modul/spec.r1.md
@@ -1,0 +1,186 @@
+# Specification: Remove Analytics → Catalog Direct Cross-Module Dependency
+
+## Summary
+The Analytics module currently violates the project's module-boundary rules by depending directly on Catalog's domain types (`ProductType`) and repository (`ICatalogRepository`). This work introduces an Analytics-owned contract (`IAnalyticsProductSource`) implemented by a Catalog-side adapter, removes all Catalog imports from Analytics, and aligns the module with the adapter pattern documented in `development_guidelines.md`.
+
+## Background
+`docs/architecture/development_guidelines.md` explicitly forbids cross-module direct entity access and shared repositories. Two files violate this rule today:
+
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs` imports `Anela.Heblo.Domain.Features.Catalog.ProductType` and exposes it as a property (`Type`).
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs` injects `ICatalogRepository` and consumes `CatalogAggregate` (with its `MarginData`, `PurchaseHistory`, and other nested types) directly, performing field-level mapping inline.
+
+Downstream consumers `GetMarginReportHandler` and `GetProductMarginSummaryHandler` re-import Catalog's `ProductType` because the public Analytics surface leaks it.
+
+Consequences:
+- Analytics cannot be built, tested, or evolved in isolation from Catalog.
+- Internal refactors of `CatalogAggregate` silently break the manual mappings on lines 52–116 of `AnalyticsRepository.cs`.
+- The dependency is hidden from architectural review because it is bidirectional in spirit (Analytics pulls Catalog data) but unidirectional in code (Analytics depends on Catalog).
+
+The fix follows the canonical Cross-Module Communication pattern: Analytics owns the contract, Catalog implements the adapter, the DI registration lives in Catalog's composition root.
+
+## Functional Requirements
+
+### FR-1: Analytics-owned contract `IAnalyticsProductSource`
+Introduce a new interface owned by the Analytics module that exposes only the data Analytics needs, expressed entirely in Analytics-owned types.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs`
+
+**Shape (informative, may be adjusted during implementation):**
+```csharp
+public interface IAnalyticsProductSource
+{
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime from,
+        DateTime to,
+        AnalyticsProductType[] types,
+        CancellationToken cancellationToken = default);
+
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime from,
+        DateTime to,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**Acceptance criteria:**
+- Interface lives under `Application/Features/Analytics/Contracts/`.
+- Interface references no Catalog-owned types in its signature.
+- All current call sites in Analytics that today hit `ICatalogRepository.GetProductsWithSalesInPeriod` and `ICatalogRepository.GetByIdAsync` for analytics purposes go through this interface.
+- Method names and parameter shapes preserve the semantics of the current Analytics queries (period filter, optional product-type filter, single-product lookup).
+
+### FR-2: Analytics-owned `AnalyticsProductType` enum
+Mirror the values from `Catalog.ProductType` that Analytics consumes today, as an Analytics-owned enum.
+
+**Location:** `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs`
+
+**Acceptance criteria:**
+- Enum exists in the Analytics domain namespace.
+- Enum contains exactly the set of values Analytics currently uses from `Catalog.ProductType` (no extras, no omissions — see Open Questions for confirmation).
+- `AnalyticsProduct.Type` is retyped to `AnalyticsProductType`.
+- `GetMarginReportHandler` and `GetProductMarginSummaryHandler` no longer import from `Anela.Heblo.Domain.Features.Catalog`.
+
+### FR-3: Catalog-side adapter `CatalogAnalyticsSourceAdapter`
+Implement `IAnalyticsProductSource` inside the Catalog application layer. The adapter owns the `CatalogAggregate → AnalyticsProduct` mapping that currently lives in `AnalyticsRepository`.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs`
+
+**Acceptance criteria:**
+- Class implements `IAnalyticsProductSource`.
+- Adapter consumes `ICatalogRepository` (legitimate, same-module access).
+- Mapping logic from `AnalyticsRepository.cs` lines 52–116 (and the equivalent single-product mapping) moves verbatim into the adapter, behavior-preserving.
+- The `AnalyticsProductType[] types` filter is translated to the Catalog-side `ProductType[]` at the adapter boundary.
+- Adapter has no knowledge of MediatR handlers, controllers, or other Analytics application code.
+
+### FR-4: Catalog module registers the binding
+The DI registration for `IAnalyticsProductSource → CatalogAnalyticsSourceAdapter` must live in Catalog's module wiring, not Analytics'.
+
+**Location:** `CatalogModule.AddCatalogModule()` (or equivalent extension method in the Catalog module composition root).
+
+**Acceptance criteria:**
+- Registration is `services.AddScoped<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();` (lifetime to match existing Catalog repository registrations).
+- Analytics module wiring contains no reference to the adapter implementation.
+- Application boots and resolves `IAnalyticsProductSource` correctly via DI.
+
+### FR-5: `AnalyticsRepository` drops `ICatalogRepository`
+Refactor `AnalyticsRepository` to depend only on `IAnalyticsProductSource` and `ApplicationDbContext`.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`
+
+**Acceptance criteria:**
+- No `using Anela.Heblo.Domain.Features.Catalog;` in the file.
+- Constructor signature replaces `ICatalogRepository` with `IAnalyticsProductSource`.
+- The previous mapping code (lines 52–116) is removed from this file (it now lives in the adapter).
+- `GetProductsWithSalesInPeriod`-style calls go through `StreamProductsWithSalesAsync`.
+- `GetByIdAsync`-style calls go through `GetProductAnalysisDataAsync`.
+- Streaming semantics: if `StreamProductsWithSalesAsync` returns `IAsyncEnumerable`, the repository materializes only what each handler needs (do not regress memory usage by always `ToListAsync()`-ing if the prior code was already streaming; preserve current behavior).
+
+### FR-6: Downstream handler cleanup
+Remove Catalog imports from `GetMarginReportHandler` and `GetProductMarginSummaryHandler`.
+
+**Acceptance criteria:**
+- Neither file imports from `Anela.Heblo.Domain.Features.Catalog`.
+- Any `ProductType` references become `AnalyticsProductType`.
+- Handler unit/integration tests still pass.
+
+### FR-7: Behavior preservation
+The end-to-end behavior of every Analytics endpoint must remain identical before and after the refactor.
+
+**Acceptance criteria:**
+- All existing Analytics unit and integration tests pass without modification to assertions (only injection/mocking targets change).
+- For each affected endpoint, response payloads for an identical request are byte-equivalent (or semantically identical if ordering is unspecified) before and after the change.
+- No new SQL queries are introduced (the adapter performs the same underlying repository calls).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- No regression in query count, query shape, or memory profile for `GetMarginReportHandler` and `GetProductMarginSummaryHandler`.
+- If the current code streams via `IAsyncEnumerable` or paged enumeration, the adapter preserves streaming. If it currently materializes a full list, that is acceptable to preserve.
+- Adapter mapping must remain O(n) over the input set with no additional allocations beyond what the current mapping does.
+
+### NFR-2: Architecture compliance
+- After the change, `grep -r "Anela.Heblo.Domain.Features.Catalog" backend/src/Anela.Heblo.Application/Features/Analytics/` and the same against `backend/src/Anela.Heblo.Domain/Features/Analytics/` return zero matches.
+- No Analytics file references `CatalogAggregate`, `MarginData`, `PurchaseHistory`, `ProductType`, or `ICatalogRepository`.
+
+### NFR-3: Test isolation
+- Analytics tests no longer need a Catalog test double for `ICatalogRepository`; they mock `IAnalyticsProductSource` instead.
+- A new adapter test verifies the `CatalogAggregate → AnalyticsProduct` mapping in isolation (this is the highest-risk surface, since it was previously untested at the mapper level).
+
+### NFR-4: Backwards compatibility
+- Public HTTP API surface of Analytics endpoints is unchanged (request/response DTOs identical).
+- Internal contract changes only — no API client regeneration required, no frontend changes.
+
+## Data Model
+
+**New types (Analytics-owned):**
+- `AnalyticsProductType` (enum) — values mirror current usage of `Catalog.ProductType` within Analytics.
+- `IAnalyticsProductSource` (interface) — contract for product-with-sales data, expressed entirely in Analytics types.
+
+**Modified types:**
+- `AnalyticsProduct.Type` retyped from `Catalog.ProductType` to `AnalyticsProductType`.
+
+**New types (Catalog-owned):**
+- `CatalogAnalyticsSourceAdapter` (class) — implements `IAnalyticsProductSource` using `ICatalogRepository` internally; owns the `CatalogAggregate → AnalyticsProduct` mapping.
+
+**Unchanged:**
+- `CatalogAggregate`, `MarginData`, `PurchaseHistory`, `Catalog.ProductType`, `ICatalogRepository` — no changes to Catalog's internal model.
+- Database schema — no migrations.
+
+## API / Interface Design
+
+**Internal interface (new):** `IAnalyticsProductSource` (see FR-1).
+
+**Dependency injection wiring:**
+- Catalog module: `services.AddScoped<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();`
+- Analytics module: no change (the framework resolves the interface from the Catalog registration).
+
+**HTTP endpoints:** No changes. All existing Analytics controllers/handlers continue to expose the same routes, requests, and responses.
+
+**Module wiring order:** `CatalogModule.AddCatalogModule()` must be invoked before any code resolves `IAnalyticsProductSource`. Confirm the current `Program.cs` / module composition already invokes Catalog registration before Analytics consumption (it should — Catalog has no dependency on Analytics).
+
+## Dependencies
+
+**Internal:**
+- Catalog module (`ICatalogRepository`, `CatalogAggregate`, and related types remain the data source — only the access path changes).
+- Existing Analytics MediatR handlers (`GetMarginReportHandler`, `GetProductMarginSummaryHandler`) and their unit/integration tests.
+
+**External:** None. No new NuGet packages, no infrastructure changes, no migrations.
+
+**Documentation:**
+- `docs/architecture/development_guidelines.md` § *Cross-Module Communication* is the canonical reference for the pattern being applied.
+
+## Out of Scope
+
+- Refactoring of `CatalogAggregate`, `MarginData`, `PurchaseHistory`, or any other Catalog-owned type.
+- Splitting Analytics into its own deployable assembly or solution.
+- Introducing message-bus / async communication between modules; this is an in-process adapter only.
+- Changes to Analytics endpoints' HTTP surface, request/response DTOs, or frontend code.
+- Auditing other modules for similar violations (a separate arch-review pass).
+- Performance optimizations beyond preserving current behavior.
+- Database migrations of any kind.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-analytics-direct-cross-modul/task-plan.r1.md
+++ b/artifacts/feat-arch-review-analytics-direct-cross-modul/task-plan.r1.md
@@ -1,0 +1,1263 @@
+# Decouple Analytics from Catalog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate Analytics's direct dependency on Catalog (`ProductType`, `ICatalogRepository`, `CatalogAggregate`, `MarginData`, `PurchaseHistory`) by introducing an Analytics-owned `IAnalyticsProductSource` contract implemented by a Catalog-side adapter, and lock the new boundary with an architectural test that covers both the Application and Domain assemblies.
+
+**Architecture:** Apply the consumer-owns-contract / provider-owns-adapter pattern documented in `docs/architecture/development_guidelines.md` §"Cross-Module Communication Example" and already used by Leaflet→KnowledgeBase (2026-05-15), Logistics→Manufacture (2026-05-16), PackingMaterials→Invoices (2026-05-21), Purchase→Catalog (2026-05-24), Article→KnowledgeBase (2026-05-25), and ExpeditionListArchive→ExpeditionList (2026-05-26). Analytics declares `IAnalyticsProductSource` in `Application/Features/Analytics/Contracts/` and `AnalyticsProductType` in `Domain/Features/Analytics/`; Catalog provides an `internal sealed CatalogAnalyticsSourceAdapter` in `Application/Features/Catalog/Infrastructure/` that owns the `CatalogAggregate → AnalyticsProduct` mapping previously duplicated across two methods of `AnalyticsRepository`. `CatalogModule.AddCatalogModule` registers the binding (Transient, to match `ICatalogRepository`). The architectural test extends `ModuleBoundaryRule` with an optional `InspectedAssembly` field so the new rule can also catch the `AnalyticsProduct.Type` violation that lives in the Domain assembly. No HTTP API, DTO, or schema changes.
+
+**Tech Stack:** .NET 8, C# (nullable enabled), xUnit, FluentAssertions, Moq, MediatR, `Microsoft.Extensions.DependencyInjection`. No new NuGet packages, no migrations.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs` | Analytics-owned enum mirroring exactly the two `Catalog.ProductType` values Analytics consumes today (`Product`, `Goods`). |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs` | Cross-module contract — two methods (`StreamProductsWithSalesAsync`, `GetProductAnalysisDataAsync`) that expose only Analytics-owned types. |
+| `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs` | `internal sealed` adapter — depends on `ICatalogRepository`, owns the `CatalogAggregate → AnalyticsProduct` mapping (extracted into a single private helper), translates `AnalyticsProductType[] → ProductType[]` at the boundary. |
+| `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs` | xUnit + Moq tests for the adapter — first-ever coverage of the previously-untested mapping. |
+
+**Files to modify:**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Retype `Type` from `ProductType` to `AnalyticsProductType`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Change `ProductType[] productTypes` → `AnalyticsProductType[] productTypes` on `StreamProductsWithSalesAsync` and `GetGroupMarginTotalsAsync`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Replace `ICatalogRepository _catalogRepository` ctor dependency with `IAnalyticsProductSource _productSource`. Delete the mapping bodies of `StreamProductsWithSalesAsync` (lines 30–122) and `GetProductAnalysisDataAsync` (lines 156–232) and delegate to the contract. Retype `productTypes` to `AnalyticsProductType[]`. `GetGroupMarginTotalsAsync`, `GetInvoiceImportStatisticsAsync`, `GetBankStatementImportStatisticsAsync` are kept; only the `productTypes` parameter type changes on `GetGroupMarginTotalsAsync`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Change `new[] { ProductType.Product, ProductType.Goods }` → `new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods }`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Same enum array replacement. |
+| `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` | Add `using Anela.Heblo.Application.Features.Analytics.Contracts;`. Register `services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();` immediately after the existing `IMaterialCatalogService` registration (line 45). |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Extend `ModuleBoundaryRule` record with optional `string InspectedAssembly = "Anela.Heblo.Application"`. Replace the hard-coded `Assembly.Load("Anela.Heblo.Application")` call with `Assembly.Load(rule.InspectedAssembly)`. Add two new theory rows: `Analytics (Application) -> Catalog` and `Analytics (Domain) -> Catalog`. Empty allowlists. |
+| `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Every `Type = ProductType.Product` (10 occurrences at lines 128, 141, 280, 293, 337, 350, 395, 408, 450, 463) → `Type = AnalyticsProductType.Product`. |
+| `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` | Same — `using Catalog` removed; `Type = ProductType.Product` (lines 61, 75) → `AnalyticsProductType.Product`. |
+| `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs` | Same — `using Catalog` removed; `Type = ProductType.Product` (lines 55, 196, 236, 279) → `AnalyticsProductType.Product`. |
+
+**Files NOT touched:**
+
+- `backend/src/Anela.Heblo.Domain/Features/Catalog/*` — Catalog domain types (`CatalogAggregate`, `ProductType`, `MarginData`, `ICatalogRepository`, …) remain unchanged.
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — the analytics binding is not registered here; the provider (Catalog) owns the registration per the documented pattern. The stale comment on line 28 ("`IMarginCalculationService` is registered by CatalogModule and injected here") is out of scope per arch-review §"Specification Amendments" item 7.
+- `GetBankStatementImportStatistics`, `GetInvoiceImportStatistics` handlers — already independent of Catalog.
+- Frontend, OpenAPI clients, controllers — no public API change.
+
+---
+
+## Task 1: Add the failing architecture-test rules for Analytics → Catalog
+
+This locks the boundary in place before any source changes. Subsequent tasks turn it green. Two theory rows are needed because the existing `AnalyticsProduct.Type` violation lives in `Anela.Heblo.Domain` (the current test inspects only the Application assembly). The rule record gains an optional `InspectedAssembly` field so existing rules keep their default behavior with no churn.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Extend `ModuleBoundaryRule` with an `InspectedAssembly` field**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Replace the `public sealed record ModuleBoundaryRule(...)` declaration (currently lines 15–19) with:
+
+```csharp
+    public sealed record ModuleBoundaryRule(
+        string Name,
+        string InspectedNamespacePrefix,
+        IReadOnlyList<string> ForbiddenNamespacePrefixes,
+        IReadOnlySet<string> Allowlist,
+        string InspectedAssembly = "Anela.Heblo.Application");
+```
+
+- [ ] **Step 2: Use `rule.InspectedAssembly` in the theory method**
+
+Locate the line that reads:
+
+```csharp
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+```
+
+inside `Consumer_types_should_not_reference_provider_owned_namespaces` (around line 167). Replace it with:
+
+```csharp
+        var assembly = Assembly.Load(rule.InspectedAssembly);
+```
+
+Leave the other `Assembly.Load("Anela.Heblo.Application")` calls in `Logistics_types_should_not_reference_Purchase_owned_namespaces` and `Application_types_should_not_reference_AspNetCore_namespaces` unchanged — only the theory method becomes data-driven on `InspectedAssembly`.
+
+- [ ] **Step 3: Append the two new theory rows to `Rules()`**
+
+Inside the `Rules()` method, after the `ExpeditionListArchive -> ExpeditionList` row (currently lines 152–161) and before the closing `};` of the TheoryData initializer, append:
+
+```csharp
+        new ModuleBoundaryRule(
+            Name: "Analytics (Application) -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Analytics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+
+        new ModuleBoundaryRule(
+            Name: "Analytics (Domain) -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Domain.Features.Analytics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal),
+            InspectedAssembly: "Anela.Heblo.Domain"),
+```
+
+- [ ] **Step 4: Verify the new theory cases currently fail**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: the two new theory cases FAIL with violations including (non-exhaustive):
+
+`Analytics (Application) -> Catalog`:
+- `…AnalyticsRepository -> Anela.Heblo.Domain.Features.Catalog.ICatalogRepository`
+- `…AnalyticsRepository -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+- `…IAnalyticsRepository -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+- `…GetMarginReportHandler -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+- `…GetProductMarginSummaryHandler -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+
+`Analytics (Domain) -> Catalog`:
+- `…AnalyticsProduct -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+
+All other existing theory cases (Leaflet, Article, Logistics, PackingMaterials, Purchase, ExpeditionListArchive) and the two `[Fact]` tests must still PASS.
+
+- [ ] **Step 5: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test(arch): add failing Analytics -> Catalog boundary rules"
+```
+
+---
+
+## Task 2: Create the `AnalyticsProductType` enum
+
+Pure type declaration in Analytics's Domain namespace. Mirrors exactly the two `Catalog.ProductType` values used by Analytics today (`Product`, `Goods`) — `Material`, `SemiProduct`, `Set`, `UNDEFINED` are intentionally omitted because Analytics never passes them (verified at `GetMarginReportHandler.cs:57` and `GetProductMarginSummaryHandler.cs:37`). No tests for an inert enum.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs`
+
+- [ ] **Step 1: Create the enum**
+
+Write the file exactly:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Analytics;
+
+/// <summary>
+/// Analytics-owned classification of products that margin reporting cares about.
+/// Mirrors the subset of <c>Anela.Heblo.Domain.Features.Catalog.ProductType</c>
+/// that Analytics consumes today (Product, Goods). If Analytics ever needs
+/// another value, mirror it here and update the AnalyticsProductType ->
+/// ProductType translation in CatalogAnalyticsSourceAdapter.
+/// </summary>
+public enum AnalyticsProductType
+{
+    Product,
+    Goods,
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj --no-restore
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs
+git commit -m "feat(analytics): add AnalyticsProductType enum"
+```
+
+---
+
+## Task 3: Create the `IAnalyticsProductSource` contract
+
+Pure interface declaration in Analytics's Contracts folder, expressed entirely in Analytics-owned types (`AnalyticsProduct`, `AnalyticsProductType`). No tests — this is an inert abstraction; behavior is covered by the adapter tests in Task 4.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs`
+
+- [ ] **Step 1: Create the interface**
+
+Write the file exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Contracts;
+
+/// <summary>
+/// Analytics-owned read abstraction over catalog data. Implemented by the
+/// Catalog module via <c>CatalogAnalyticsSourceAdapter</c> per the cross-module
+/// communication pattern in <c>docs/architecture/development_guidelines.md</c>.
+/// All inputs and outputs are Analytics-owned types; the adapter owns the
+/// translation between <see cref="AnalyticsProductType"/> and Catalog's ProductType
+/// and the projection from CatalogAggregate to <see cref="AnalyticsProduct"/>.
+/// </summary>
+public interface IAnalyticsProductSource
+{
+    /// <summary>
+    /// Streams products of the requested types that have sales in the given
+    /// period, projected to <see cref="AnalyticsProduct"/>. Items are yielded
+    /// one by one; the underlying call still materialises a list internally,
+    /// but the iteration boundary preserves the surface that callers rely on.
+    /// </summary>
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a single product projected to <see cref="AnalyticsProduct"/>,
+    /// or <c>null</c> if the product is unknown. Matches the soft-fallback
+    /// semantics of <c>ICatalogRepository.GetByIdAsync</c>.
+    /// </summary>
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --no-restore
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs
+git commit -m "feat(analytics): add IAnalyticsProductSource contract"
+```
+
+---
+
+## Task 4: Create `CatalogAnalyticsSourceAdapter` and its tests (TDD)
+
+The adapter owns the entire `CatalogAggregate → AnalyticsProduct` mapping that currently lives duplicated across two methods of `AnalyticsRepository` (streaming path at lines 52–116, single-product path at lines 168–231 of the original `AnalyticsRepository.cs`). The two paths differ in exactly one place: the streaming path filters `SalesHistory` by the request period, while the single-product path does not (line 223 — preserve as-is per FR-7; the asymmetry is acknowledged in the spec's "Out of Scope" and arch-review §"Mapping consolidation"). The adapter consolidates the M0/M1/M2 mapping into a single helper and keeps the sales-filter difference visible at the two call sites. The `AnalyticsProductType[] → ProductType[]` conversion happens at the entry point.
+
+This task writes the tests FIRST (RED), then the adapter (GREEN), per project TDD convention.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs`
+
+- [ ] **Step 1: Write the failing adapter tests**
+
+Write `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs` exactly:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using Anela.Heblo.Domain.Features.Catalog.PurchaseHistory;
+using Anela.Heblo.Domain.Features.Catalog.Sales;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class CatalogAnalyticsSourceAdapterTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private CatalogAnalyticsSourceAdapter CreateAdapter() => new(_repository.Object);
+
+    private static CatalogAggregate MakeAggregate(
+        string productCode = "P1",
+        string productName = "Product 1",
+        ProductType type = ProductType.Product,
+        string? family = "FamA",
+        string? category = "CatA",
+        decimal eshopPriceWithoutVat = 200m,
+        IEnumerable<CatalogSaleRecord>? sales = null,
+        IEnumerable<CatalogPurchaseRecord>? purchases = null,
+        IEnumerable<KeyValuePair<DateTime, MarginData>>? monthlyMargins = null,
+        MarginAverages? averages = null)
+    {
+        var aggregate = new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productName,
+            Type = type,
+            ProductFamily = family,
+            ProductCategory = category,
+            EshopPrice = new ProductPriceEshop { PriceWithoutVat = eshopPriceWithoutVat },
+            SalesHistory = sales?.ToList() ?? new List<CatalogSaleRecord>(),
+            PurchaseHistory = purchases?.ToList() ?? new List<CatalogPurchaseRecord>(),
+        };
+
+        aggregate.Margins = new MarginAggregate
+        {
+            MonthlyData = monthlyMargins?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+                ?? new Dictionary<DateTime, MarginData>(),
+            Averages = averages ?? new MarginAverages
+            {
+                M0 = new MarginAmount { Amount = 0m, Percentage = 0m, CostLevel = 0m },
+                M1 = new MarginAmount(),
+                M1_A = new MarginAmount(),
+                M2 = new MarginAmount(),
+            },
+        };
+
+        return aggregate;
+    }
+
+    private static MarginData MarginAt(decimal m0Amount, decimal m1Amount, decimal m2Amount, decimal m0Cost = 0m, decimal m1aCost = 0m)
+    {
+        return new MarginData
+        {
+            M0 = new MarginAmount { Amount = m0Amount, Percentage = m0Amount, CostLevel = m0Cost },
+            M1 = new MarginAmount { Amount = m1Amount, Percentage = m1Amount },
+            M1_A = new MarginAmount { CostLevel = m1aCost },
+            M2 = new MarginAmount { Amount = m2Amount, Percentage = m2Amount },
+        };
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_translates_AnalyticsProductType_array_to_Catalog_ProductType_array_at_boundary()
+    {
+        ProductType[]? captured = null;
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DateTime, DateTime, ProductType[], CancellationToken>((_, _, t, _) => captured = t)
+            .ReturnsAsync(new List<CatalogAggregate>());
+
+        var adapter = CreateAdapter();
+
+        await foreach (var _ in adapter.StreamProductsWithSalesAsync(
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods },
+            CancellationToken.None))
+        {
+            // drain
+        }
+
+        captured.Should().BeEquivalentTo(new[] { ProductType.Product, ProductType.Goods });
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_maps_M0_M1_M2_amounts_and_percentages_from_latest_margin_entry_in_period()
+    {
+        var from = new DateTime(2024, 1, 1);
+        var to = new DateTime(2024, 12, 31);
+        var aggregate = MakeAggregate(
+            monthlyMargins: new[]
+            {
+                new KeyValuePair<DateTime, MarginData>(new DateTime(2024, 3, 1), MarginAt(10m, 20m, 30m, m0Cost: 5m, m1aCost: 7m)),
+                new KeyValuePair<DateTime, MarginData>(new DateTime(2024, 10, 1), MarginAt(11m, 21m, 31m, m0Cost: 6m, m1aCost: 8m)),
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(from, to, It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(from, to, new[] { AnalyticsProductType.Product }, CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results.Should().HaveCount(1);
+        var p = results[0];
+        p.M0Amount.Should().Be(11m);
+        p.M1Amount.Should().Be(21m);
+        p.M2Amount.Should().Be(31m);
+        p.M0Percentage.Should().Be(11m);
+        p.M1Percentage.Should().Be(21m);
+        p.M2Percentage.Should().Be(31m);
+        p.MarginAmount.Should().Be(11m);
+        p.MaterialCost.Should().Be(6m);
+        p.HandlingCost.Should().Be(8m);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_falls_back_to_averages_when_no_monthly_margin_data_present()
+    {
+        var aggregate = MakeAggregate(
+            monthlyMargins: Array.Empty<KeyValuePair<DateTime, MarginData>>(),
+            averages: new MarginAverages
+            {
+                M0 = new MarginAmount { Amount = 42m, Percentage = 0m, CostLevel = 0m },
+                M1 = new MarginAmount(),
+                M1_A = new MarginAmount(),
+                M2 = new MarginAmount(),
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            new[] { AnalyticsProductType.Product },
+            CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results[0].MarginAmount.Should().Be(42m);
+        results[0].M0Amount.Should().Be(0m);
+        results[0].MaterialCost.Should().Be(0m);
+        results[0].HandlingCost.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_filters_SalesHistory_to_the_requested_period()
+    {
+        var from = new DateTime(2024, 6, 1);
+        var to = new DateTime(2024, 8, 31);
+        var aggregate = MakeAggregate(
+            sales: new[]
+            {
+                new CatalogSaleRecord { Date = new DateTime(2024, 1, 15), AmountB2B = 1, AmountB2C = 2 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 7, 15), AmountB2B = 3, AmountB2C = 4 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 11, 15), AmountB2B = 5, AmountB2C = 6 },
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(from, to, It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(from, to, new[] { AnalyticsProductType.Product }, CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results[0].SalesHistory.Should().HaveCount(1);
+        results[0].SalesHistory[0].Date.Should().Be(new DateTime(2024, 7, 15));
+        results[0].SalesHistory[0].AmountB2B.Should().Be(3);
+        results[0].SalesHistory[0].AmountB2C.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_takes_latest_purchase_price_from_purchase_history()
+    {
+        var aggregate = MakeAggregate(
+            purchases: new[]
+            {
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 3, 1), PricePerPiece = 100m },
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 9, 1), PricePerPiece = 150m },
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 5, 1), PricePerPiece = 120m },
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            new[] { AnalyticsProductType.Product },
+            CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results[0].PurchasePrice.Should().Be(150m);
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_returns_null_when_repository_returns_null()
+    {
+        _repository
+            .Setup(r => r.GetByIdAsync("MISSING", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogAggregate?)null);
+
+        var adapter = CreateAdapter();
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "MISSING",
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_preserves_unfiltered_SalesHistory_for_single_product_path()
+    {
+        // FR-7 / arch-review Risk row: the single-product path historically does NOT filter
+        // SalesHistory by the requested period (line 223 of original AnalyticsRepository.cs),
+        // unlike the streaming path. Preserve this asymmetry verbatim — fixing it is out of scope.
+        var aggregate = MakeAggregate(
+            productCode: "P1",
+            sales: new[]
+            {
+                new CatalogSaleRecord { Date = new DateTime(2024, 1, 15), AmountB2B = 1, AmountB2C = 2 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 7, 15), AmountB2B = 3, AmountB2C = 4 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 11, 15), AmountB2B = 5, AmountB2C = 6 },
+            });
+
+        _repository
+            .Setup(r => r.GetByIdAsync("P1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aggregate);
+
+        var adapter = CreateAdapter();
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "P1",
+            new DateTime(2024, 6, 1),
+            new DateTime(2024, 8, 31),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.SalesHistory.Should().HaveCount(3); // all three preserved, not filtered
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_maps_pricing_purchase_price_and_margin_fields()
+    {
+        var aggregate = MakeAggregate(
+            productCode: "P1",
+            productName: "Single Product",
+            family: "Fam",
+            category: "Cat",
+            eshopPriceWithoutVat: 333m,
+            purchases: new[]
+            {
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 4, 1), PricePerPiece = 50m },
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 9, 1), PricePerPiece = 75m },
+            },
+            monthlyMargins: new[]
+            {
+                new KeyValuePair<DateTime, MarginData>(new DateTime(2024, 7, 1), MarginAt(10m, 20m, 30m, m0Cost: 4m, m1aCost: 6m)),
+            });
+
+        _repository
+            .Setup(r => r.GetByIdAsync("P1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aggregate);
+
+        var adapter = CreateAdapter();
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "P1",
+            new DateTime(2024, 6, 1),
+            new DateTime(2024, 8, 31),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ProductCode.Should().Be("P1");
+        result.ProductName.Should().Be("Single Product");
+        result.ProductFamily.Should().Be("Fam");
+        result.ProductCategory.Should().Be("Cat");
+        result.SellingPrice.Should().Be(333m);
+        result.EshopPriceWithoutVat.Should().Be(333m);
+        result.PurchasePrice.Should().Be(75m);
+        result.MarginAmount.Should().Be(10m);
+        result.M0Amount.Should().Be(10m);
+        result.M1Amount.Should().Be(20m);
+        result.M2Amount.Should().Be(30m);
+        result.MaterialCost.Should().Be(4m);
+        result.HandlingCost.Should().Be(6m);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail to compile**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-restore
+```
+
+Expected: build FAILS with `CS0246` style errors — `CatalogAnalyticsSourceAdapter` does not exist yet.
+
+If field names on existing Catalog types (`CatalogAggregate`, `MarginData`, `MarginAverages`, `MarginAmount`, `CatalogSaleRecord`, `CatalogPurchaseRecord`, `ProductPriceEshop`) differ from what's used above, fix the **test** to use the real type members (read the actual files under `backend/src/Anela.Heblo.Domain/Features/Catalog/`). Do **not** invent fields on production code to make the test compile.
+
+- [ ] **Step 3: Implement the adapter**
+
+Write `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs` exactly:
+
+```csharp
+using System.Runtime.CompilerServices;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogAnalyticsSourceAdapter : IAnalyticsProductSource
+{
+    private const int BatchSize = 100;
+
+    private readonly ICatalogRepository _catalogRepository;
+
+    public CatalogAnalyticsSourceAdapter(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public async IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var catalogProductTypes = MapProductTypes(productTypes);
+
+        var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(
+            fromDate, toDate, catalogProductTypes, cancellationToken);
+
+        for (int i = 0; i < allProducts.Count; i += BatchSize)
+        {
+            var batch = allProducts.Skip(i).Take(BatchSize);
+
+            foreach (var product in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var filteredSales = product.SalesHistory
+                    .Where(s => s.Date >= fromDate && s.Date <= toDate)
+                    .Select(s => new SalesDataPoint
+                    {
+                        Date = s.Date,
+                        AmountB2B = s.AmountB2B,
+                        AmountB2C = s.AmountB2C,
+                    })
+                    .ToList();
+
+                yield return MapToAnalyticsProduct(product, fromDate, toDate, filteredSales);
+            }
+
+            GC.Collect();
+        }
+    }
+
+    public async Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default)
+    {
+        var product = await _catalogRepository.GetByIdAsync(productId, cancellationToken);
+        if (product == null)
+            return null;
+
+        // Preserve verbatim from original AnalyticsRepository.GetProductAnalysisDataAsync (line 223):
+        // single-product path does NOT filter SalesHistory by period, unlike the streaming path.
+        var unfilteredSales = product.SalesHistory
+            .Select(s => new SalesDataPoint
+            {
+                Date = s.Date,
+                AmountB2B = s.AmountB2B,
+                AmountB2C = s.AmountB2C,
+            })
+            .ToList();
+
+        return MapToAnalyticsProduct(product, fromDate, toDate, unfilteredSales);
+    }
+
+    private static AnalyticsProduct MapToAnalyticsProduct(
+        CatalogAggregate product,
+        DateTime fromDate,
+        DateTime toDate,
+        List<SalesDataPoint> salesHistory)
+    {
+        var marginData = product.Margins;
+
+        var relevantMargins = marginData.MonthlyData
+            .Where(m => m.Key >= fromDate && m.Key <= toDate)
+            .ToList();
+
+        var latestMarginEntry = relevantMargins.LastOrDefault();
+        if (latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)))
+        {
+            latestMarginEntry = marginData.MonthlyData.LastOrDefault();
+        }
+
+        bool hasMargin = !latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>));
+
+        var marginAmount = hasMargin
+            ? latestMarginEntry.Value.M0.Amount
+            : marginData.Averages.M0.Amount;
+        var materialCost = hasMargin ? latestMarginEntry.Value.M0.CostLevel : 0m;
+        var handlingCost = hasMargin ? latestMarginEntry.Value.M1_A.CostLevel : 0m;
+
+        var latestPurchase = product.PurchaseHistory?.OrderByDescending(p => p.Date).FirstOrDefault();
+        var purchasePrice = latestPurchase?.PricePerPiece ?? 0m;
+
+        return new AnalyticsProduct
+        {
+            ProductCode = product.ProductCode,
+            ProductName = product.ProductName,
+            Type = MapProductType(product.Type),
+            ProductFamily = product.ProductFamily,
+            ProductCategory = product.ProductCategory,
+            MarginAmount = marginAmount,
+
+            M0Amount = hasMargin ? latestMarginEntry.Value.M0.Amount : 0m,
+            M1Amount = hasMargin ? latestMarginEntry.Value.M1.Amount : 0m,
+            M2Amount = hasMargin ? latestMarginEntry.Value.M2.Amount : 0m,
+
+            M0Percentage = hasMargin ? latestMarginEntry.Value.M0.Percentage : 0m,
+            M1Percentage = hasMargin ? latestMarginEntry.Value.M1.Percentage : 0m,
+            M2Percentage = hasMargin ? latestMarginEntry.Value.M2.Percentage : 0m,
+
+            SellingPrice = product.EshopPrice?.PriceWithoutVat ?? 0m,
+            EshopPriceWithoutVat = product.EshopPrice?.PriceWithoutVat,
+            PurchasePrice = purchasePrice,
+
+            MaterialCost = materialCost,
+            HandlingCost = handlingCost,
+            SalesHistory = salesHistory,
+        };
+    }
+
+    private static ProductType[] MapProductTypes(AnalyticsProductType[] types) =>
+        types.Select(MapProductTypeToCatalog).ToArray();
+
+    private static ProductType MapProductTypeToCatalog(AnalyticsProductType type) => type switch
+    {
+        AnalyticsProductType.Product => ProductType.Product,
+        AnalyticsProductType.Goods => ProductType.Goods,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(type),
+            type,
+            "AnalyticsProductType has no Catalog.ProductType counterpart. " +
+            "Mirror the value in AnalyticsProductType.cs and extend this switch."),
+    };
+
+    private static AnalyticsProductType MapProductType(ProductType type) => type switch
+    {
+        ProductType.Product => AnalyticsProductType.Product,
+        ProductType.Goods => AnalyticsProductType.Goods,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(type),
+            type,
+            "Adapter only projects Product and Goods. " +
+            "ICatalogRepository.GetProductsWithSalesInPeriod filtering must ensure no other types are returned."),
+    };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~CatalogAnalyticsSourceAdapterTests" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: all 8 adapter tests PASS.
+
+If a test fails because a referenced Catalog type/field name in the test differs from production (e.g., `CatalogSaleRecord.AmountB2B` vs. another name), correct the **test** — the adapter mapping mirrors the original `AnalyticsRepository.cs` lines 52–116 and 168–231 exactly, so the production mapping is correct by construction.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs \
+        backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs
+git commit -m "feat(catalog): add CatalogAnalyticsSourceAdapter implementing IAnalyticsProductSource"
+```
+
+---
+
+## Task 5: Register the adapter binding in `CatalogModule`
+
+Single-line DI registration. The lifetime is **Transient**, matching `ICatalogRepository` (`CatalogModule.cs:41`) — the adapter is stateless and merely delegates, so its lifetime should match the dependency it wraps (per arch-review Decision 3). Spec FR-4's wording "lifetime to match existing Catalog repository registrations" supports Transient over Scoped.
+
+The application still doesn't use `IAnalyticsProductSource` after this task — Analytics's `AnalyticsRepository` still injects `ICatalogRepository` directly. The arch test still fails. This task is intentionally small to keep DI changes reviewable in isolation.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+
+- [ ] **Step 1: Add the using directive**
+
+At the top of `CatalogModule.cs`, add `using Anela.Heblo.Application.Features.Analytics.Contracts;` to the import block (alphabetical placement: between `Anela.Heblo.Application.Features.Catalog.Validators;` and `Anela.Heblo.Domain.Features.Catalog;`).
+
+- [ ] **Step 2: Register the binding**
+
+Locate the existing line (currently line 45):
+
+```csharp
+        services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
+```
+
+Immediately after it, add:
+
+```csharp
+        services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
+```
+
+- [ ] **Step 3: Verify build succeeds**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --no-restore
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "feat(catalog): register CatalogAnalyticsSourceAdapter binding"
+```
+
+---
+
+## Task 6: Switch Analytics consumers to the new contract (the type-swap commit)
+
+This is the cohesive refactor that flips Analytics off Catalog. All of the following must move together because they form one compile-unit:
+
+- `AnalyticsProduct.Type` is retyped from `Catalog.ProductType` to `AnalyticsProductType`.
+- `IAnalyticsRepository`'s `productTypes` parameter type changes on two methods.
+- `AnalyticsRepository`'s constructor replaces `ICatalogRepository` with `IAnalyticsProductSource`; the duplicated mapping bodies (originally lines 30–122 and 156–232) are deleted and replaced with delegation; `productTypes` parameter type updated on the two methods that take it.
+- Both handlers (`GetMarginReportHandler`, `GetProductMarginSummaryHandler`) replace their `new[] { ProductType.Product, ProductType.Goods }` arrays with `new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods }`.
+- Three handler test files update their `Type = ProductType.Product` initialisers to `Type = AnalyticsProductType.Product`.
+
+Existing handler tests already mock `IAnalyticsRepository` (verified — no test mocks `ICatalogRepository` in the Analytics test folder), so the test surface changes are limited to the enum rename. No new mocks are needed for handler tests — `IAnalyticsProductSource` is only consumed inside `AnalyticsRepository`, which is mocked at the `IAnalyticsRepository` level above.
+
+After this commit:
+- `dotnet build` passes
+- The `Analytics (Application) -> Catalog` and `Analytics (Domain) -> Catalog` arch theory rows turn GREEN
+- All existing Analytics tests still pass with assertion text unchanged (only enum type changed)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs`
+
+- [ ] **Step 1: Update `AnalyticsProduct.cs`**
+
+Remove the line `using Anela.Heblo.Domain.Features.Catalog;` at the top. Change the `Type` property:
+
+From:
+
+```csharp
+    public required ProductType Type { get; init; }
+```
+
+To:
+
+```csharp
+    public required AnalyticsProductType Type { get; init; }
+```
+
+No other changes — `SalesHistory`, `SalesDataPoint`, `DateRange`, `MarginCalculationResult` keep their current shape (already Analytics-owned).
+
+- [ ] **Step 2: Update `IAnalyticsRepository.cs`**
+
+Remove the line `using Anela.Heblo.Domain.Features.Catalog;` at the top. In both `StreamProductsWithSalesAsync` and `GetGroupMarginTotalsAsync`, change the parameter `ProductType[] productTypes` to `AnalyticsProductType[] productTypes`. The full file becomes:
+
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Infrastructure;
+
+/// <summary>
+/// Analytics-specific repository with streaming capabilities
+/// Prevents memory issues by avoiding loading all data at once
+/// </summary>
+public interface IAnalyticsRepository
+{
+    /// <summary>
+    /// Streams products with sales data to avoid memory overload
+    /// </summary>
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets aggregated margin data directly from repository (optimized query)
+    /// </summary>
+    Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        ProductGroupingMode groupingMode,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets detailed product analysis data for a specific product
+    /// </summary>
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets daily invoice import statistics for monitoring purposes
+    /// </summary>
+    Task<List<DailyInvoiceCount>> GetInvoiceImportStatisticsAsync(
+        DateTime startDate,
+        DateTime endDate,
+        ImportDateType dateType,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets daily bank statement import statistics for monitoring purposes
+    /// </summary>
+    Task<List<DailyBankStatementStatistics>> GetBankStatementImportStatisticsAsync(
+        DateTime startDate,
+        DateTime endDate,
+        BankStatementDateType dateType,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 3: Update `AnalyticsRepository.cs`**
+
+Rewrite the top of the file (replacing the mapping bodies with delegation) so it looks exactly like this (the invoice/bank-statement methods at the bottom are unchanged — only their `using` declarations and the top three Analytics methods change):
+
+Replace **everything from line 1 through line 244** (i.e., everything up to and including `private string GetGroupKey(...)` method) of the current `AnalyticsRepository.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Application.Features.Analytics.Infrastructure;
+
+/// <summary>
+/// Analytics repository — delegates product/sales lookups to the Catalog-side
+/// adapter via <see cref="IAnalyticsProductSource"/> and owns the EF-backed
+/// invoice/bank-statement statistics queries.
+/// </summary>
+public class AnalyticsRepository : IAnalyticsRepository
+{
+    private readonly IAnalyticsProductSource _productSource;
+    private readonly ApplicationDbContext _dbContext;
+
+    public AnalyticsRepository(IAnalyticsProductSource productSource, ApplicationDbContext dbContext)
+    {
+        _productSource = productSource;
+        _dbContext = dbContext;
+    }
+
+    public IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default)
+    {
+        return _productSource.StreamProductsWithSalesAsync(fromDate, toDate, productTypes, cancellationToken);
+    }
+
+    public async Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        ProductGroupingMode groupingMode,
+        CancellationToken cancellationToken = default)
+    {
+        var groupTotals = new Dictionary<string, decimal>();
+
+        await foreach (var product in StreamProductsWithSalesAsync(fromDate, toDate, productTypes, cancellationToken))
+        {
+            if (product.MarginAmount <= 0)
+                continue;
+
+            var groupKey = GetGroupKey(product, groupingMode);
+            var totalSold = product.SalesHistory.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = (decimal)totalSold * product.MarginAmount;
+
+            if (!groupTotals.ContainsKey(groupKey))
+                groupTotals[groupKey] = 0;
+
+            groupTotals[groupKey] += marginContribution;
+        }
+
+        return groupTotals;
+    }
+
+    public Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default)
+    {
+        return _productSource.GetProductAnalysisDataAsync(productId, fromDate, toDate, cancellationToken);
+    }
+
+    private string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => product.ProductCode,
+            ProductGroupingMode.ProductFamily => product.ProductFamily ?? "Unknown",
+            ProductGroupingMode.ProductCategory => product.ProductCategory ?? "Unknown",
+            _ => product.ProductCode
+        };
+    }
+```
+
+Keep the existing closing brace of the class and the two remaining methods (`GetInvoiceImportStatisticsAsync`, `GetBankStatementImportStatisticsAsync`) **exactly as they are** — they don't reference Catalog and require no changes.
+
+- [ ] **Step 4: Update `GetMarginReportHandler.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Locate line 57:
+
+```csharp
+            var productTypes = new[] { ProductType.Product, ProductType.Goods };
+```
+
+Replace with:
+
+```csharp
+            var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
+```
+
+- [ ] **Step 5: Update `GetProductMarginSummaryHandler.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Locate line 37:
+
+```csharp
+        var productTypes = new[] { ProductType.Product, ProductType.Goods };
+```
+
+Replace with:
+
+```csharp
+        var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
+```
+
+- [ ] **Step 6: Update `GetMarginReportHandlerTests.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Use the Edit tool with `replace_all: true` to replace every occurrence of `Type = ProductType.Product,` with `Type = AnalyticsProductType.Product,` (10 occurrences — lines 128, 141, 280, 293, 337, 350, 395, 408, 450, 463).
+
+- [ ] **Step 7: Update `GetProductMarginSummaryHandlerTests.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Replace every `Type = ProductType.Product,` with `Type = AnalyticsProductType.Product,` (2 occurrences — lines 61, 75).
+
+- [ ] **Step 8: Update `GetProductMarginAnalysisHandlerTests.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Replace every `Type = ProductType.Product,` with `Type = AnalyticsProductType.Product,` (4 occurrences — lines 55, 196, 236, 279).
+
+- [ ] **Step 9: Build and verify**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --no-restore
+```
+
+Expected: solution builds with zero errors and no new warnings.
+
+If a `using Anela.Heblo.Domain.Features.Catalog;` remains needed in any Analytics file because it is genuinely consumed for an unrelated reason (e.g., an `ImportDateType` reference that happens to live under Catalog — verify with the actual file), keep it and note the case here. But based on inspection (`Grep "Anela.Heblo.Domain.Features.Catalog" backend/src/Anela.Heblo.Application/Features/Analytics`), the only consumers are the four files listed above, all touched by this task.
+
+- [ ] **Step 10: Run the full Analytics test suite**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Analytics" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: all Analytics tests PASS, including the four handler test files and the new adapter test file. No assertions should need to change.
+
+- [ ] **Step 11: Run the architecture tests**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: all theory cases PASS, including both `Analytics (Application) -> Catalog` and `Analytics (Domain) -> Catalog`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs
+git commit -m "refactor(analytics): consume IAnalyticsProductSource instead of Catalog types"
+```
+
+---
+
+## Task 7: Final validation and format pass
+
+The change is functionally complete after Task 6. This task runs the project's mandated validation gates (per `CLAUDE.md` "Validation before completion") and applies `dotnet format` to pick up any stylistic drift.
+
+**Files:**
+- (no new files; may touch any of the above for `dotnet format` whitespace fixes only)
+
+- [ ] **Step 1: `dotnet build` on the full solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: solution builds with zero errors and no new warnings.
+
+- [ ] **Step 2: `dotnet format` on the solution**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Apply any whitespace/style fixes the formatter produces. If the formatter modifies files **outside** the eight files listed in Task 6, stop and inspect — surgical-change rule: don't bundle unrelated formatting.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build --logger "console;verbosity=normal"
+```
+
+Expected: all tests PASS. Pay attention to:
+- All eight `CatalogAnalyticsSourceAdapterTests` cases.
+- All Analytics handler tests (`GetMarginReportHandlerTests`, `GetProductMarginSummaryHandlerTests`, `GetProductMarginAnalysisHandlerTests`, `GetInvoiceImportStatisticsHandlerTests`, `DashboardTiles/InvoiceImportStatisticsTileTests`).
+- All `ModuleBoundariesTests` theory rows and facts.
+- `PurchaseMaterialCatalogAdapterTests` (Task 5 added a binding in the same module — make sure nothing regressed).
+
+- [ ] **Step 4: Spec NFR-2 verification — zero Catalog references in Analytics namespaces**
+
+Run:
+
+```bash
+grep -r "Anela.Heblo.Domain.Features.Catalog" \
+  backend/src/Anela.Heblo.Application/Features/Analytics/ \
+  backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected: no output (zero matches).
+
+Also confirm no Analytics file references the specific Catalog types listed in spec NFR-2:
+
+```bash
+grep -rE "CatalogAggregate|\bMarginData\b|PurchaseHistory|\bProductType\b|ICatalogRepository" \
+  backend/src/Anela.Heblo.Application/Features/Analytics/ \
+  backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected: no output. (`AnalyticsProductType` references are fine — the search uses `\bProductType\b` to avoid matching `AnalyticsProductType`.)
+
+- [ ] **Step 5: If `dotnet format` produced changes, commit them**
+
+```bash
+git status
+# If any modified files appear:
+git add <changed files>
+git commit -m "style: apply dotnet format after analytics decoupling"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Scope Boundary
+
+The following are explicitly out of scope (per spec "Out of Scope" and arch-review §"Specification Amendments"):
+
+- Refactoring `CatalogAggregate`, `MarginData`, `PurchaseHistory`, or any Catalog-owned type.
+- Fixing the asymmetric `SalesHistory` filtering between streaming and single-product paths (preserved verbatim per FR-7).
+- Removing the stale comment in `AnalyticsModule.cs:28` about `IMarginCalculationService` (flag in a follow-up).
+- Auditing other modules for similar violations.
+- True streaming (the underlying `ICatalogRepository.GetProductsWithSalesInPeriod` returns a materialised `List<CatalogAggregate>`; the `IAsyncEnumerable` façade is preserved as-is).
+- Frontend, OpenAPI client, or HTTP-surface changes.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 `IAnalyticsProductSource` interface — Task 3.
+- FR-2 `AnalyticsProductType` enum (`Product`, `Goods` only) and `AnalyticsProduct.Type` retyping — Tasks 2 and 6 Step 1.
+- FR-3 `CatalogAnalyticsSourceAdapter` with consolidated mapping helper and adapter-boundary type translation — Task 4.
+- FR-4 DI registration in `CatalogModule` (Transient, per arch-review Decision 3 / spec amendment item 4) — Task 5.
+- FR-5 `AnalyticsRepository` drops `ICatalogRepository`, and (per arch-review amendment item 1) `IAnalyticsRepository` interface signature also drops `ProductType[]` — Task 6 Steps 2–3.
+- FR-6 `GetMarginReportHandler` and `GetProductMarginSummaryHandler` lose Catalog imports — Task 6 Steps 4–5. `GetProductMarginAnalysisHandler` already does not import Catalog; its test file is updated in Task 6 Step 8 per arch-review amendment item 2.
+- FR-7 Behavior preservation — mapping moves verbatim, sales-filter asymmetry preserved, `GC.Collect()` batching loop preserved; verified by Task 6 Step 10 (all existing assertions unchanged) and Task 7 Steps 3–4.
+- FR-8 (arch-review amendment 3) `ModuleBoundariesTests` rule(s) covering both Application and Domain assemblies — Task 1.
+- NFR-1 (with arch-review amendment 5 wording) — same underlying `ICatalogRepository` calls, no new SQL, no allocation change in mapping — by-construction from Task 4 implementation.
+- NFR-2 grep returns zero matches — verified by Task 7 Step 4.
+- NFR-3 test isolation + new adapter mapping tests — Task 4 Step 1.
+- NFR-4 backwards compatibility — no HTTP/DTO/schema changes; verified by Task 7 Step 3.
+
+**Placeholder scan:** no TODO/TBD/"implement later"; every step has actual file contents, commands, and expected output. The only "if X then …" branches are honest failure paths (Task 4 Step 2 if Catalog field names differ from the test fixture; Task 6 Step 9 if an unexpected `using Catalog` lingers; Task 7 Step 5 conditional commit).
+
+**Type consistency:** `IAnalyticsProductSource` method signatures in Task 3 match the implementation in Task 4 and the call sites in Task 6 Step 3. `AnalyticsProductType` is referenced consistently as the Domain-namespace enum. `MapProductType` and `MapProductTypes` (plural) are both defined in Task 4 Step 3.

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs
@@ -1,0 +1,37 @@
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Contracts;
+
+/// <summary>
+/// Analytics-owned read abstraction over catalog data. Implemented by the
+/// Catalog module via <c>CatalogAnalyticsSourceAdapter</c> per the cross-module
+/// communication pattern in <c>docs/architecture/development_guidelines.md</c>.
+/// All inputs and outputs are Analytics-owned types; the adapter owns the
+/// translation between <see cref="AnalyticsProductType"/> and Catalog's ProductType
+/// and the projection from CatalogAggregate to <see cref="AnalyticsProduct"/>.
+/// </summary>
+public interface IAnalyticsProductSource
+{
+    /// <summary>
+    /// Streams products of the requested types that have sales in the given
+    /// period, projected to <see cref="AnalyticsProduct"/>. Items are yielded
+    /// one by one; the underlying call still materialises a list internally,
+    /// but the iteration boundary preserves the surface that callers rely on.
+    /// </summary>
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a single product projected to <see cref="AnalyticsProduct"/>,
+    /// or <c>null</c> if the product is unknown. Matches the soft-fallback
+    /// semantics of <c>ICatalogRepository.GetByIdAsync</c>.
+    /// </summary>
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Analytics.Contracts;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,124 +9,39 @@ namespace Anela.Heblo.Application.Features.Analytics.Infrastructure;
 
 /// <summary>
 /// 🔒 PERFORMANCE FIX: Analytics repository with streaming capabilities
-/// Prevents memory overload by streaming data instead of loading everything at once
+/// Prevents memory overload by delegating to IAnalyticsProductSource
 /// </summary>
 public class AnalyticsRepository : IAnalyticsRepository
 {
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IAnalyticsProductSource _productSource;
     private readonly ApplicationDbContext _dbContext;
 
-    public AnalyticsRepository(ICatalogRepository catalogRepository, ApplicationDbContext dbContext)
+    public AnalyticsRepository(IAnalyticsProductSource productSource, ApplicationDbContext dbContext)
     {
-        _catalogRepository = catalogRepository;
+        _productSource = productSource;
         _dbContext = dbContext;
     }
 
     /// <summary>
     /// Streams products with sales to avoid memory overload
-    /// Converts heavy CatalogAggregate to lightweight AnalyticsProduct
+    /// Delegates to the product source implementation
     /// </summary>
-    public async IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+    public IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
         DateTime fromDate,
         DateTime toDate,
-        ProductType[] productTypes,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default)
     {
-        const int batchSize = 100;
-
-        // Get total count for batching
-        var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(fromDate, toDate, productTypes, cancellationToken);
-
-        // Process in batches to reduce memory usage
-        for (int i = 0; i < allProducts.Count; i += batchSize)
-        {
-            var batch = allProducts.Skip(i).Take(batchSize);
-
-            foreach (var product in batch)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // Convert to lightweight analytics model
-                // Use pre-calculated margin data from CatalogAggregate.Margins
-                var marginData = product.Margins;
-
-                // Filter monthly data by date range
-                var relevantMargins = marginData.MonthlyData
-                    .Where(m => m.Key >= fromDate && m.Key <= toDate)
-                    .ToList();
-
-                // Use latest margin data or fallback to averages
-                var latestMarginEntry = relevantMargins.LastOrDefault();
-                if (latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)))
-                {
-                    latestMarginEntry = marginData.MonthlyData.LastOrDefault();
-                }
-
-                var marginAmount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>))
-                    ? marginData.Averages.M0.Amount
-                    : latestMarginEntry.Value.M0.Amount;
-                var materialCost = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>))
-                    ? 0
-                    : latestMarginEntry.Value.M0.CostLevel;
-                var handlingCost = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>))
-                    ? 0
-                    : latestMarginEntry.Value.M1_A.CostLevel;
-
-                // Get latest purchase price from purchase history
-                var latestPurchase = product.PurchaseHistory?.OrderByDescending(p => p.Date).FirstOrDefault();
-                var purchasePrice = latestPurchase?.PricePerPiece ?? 0;
-
-                yield return new AnalyticsProduct
-                {
-                    ProductCode = product.ProductCode,
-                    ProductName = product.ProductName,
-                    Type = product.Type,
-                    ProductFamily = product.ProductFamily,
-                    ProductCategory = product.ProductCategory,
-                    MarginAmount = marginAmount,
-
-                    // M0-M2 margin amounts
-                    M0Amount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M0.Amount,
-                    M1Amount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M1.Amount,
-                    M2Amount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M2.Amount,
-
-                    // M0-M2 margin percentages
-                    M0Percentage = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M0.Percentage,
-                    M1Percentage = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M1.Percentage,
-                    M2Percentage = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M2.Percentage,
-
-                    // Pricing
-                    SellingPrice = product.EshopPrice?.PriceWithoutVat ?? 0,
-                    EshopPriceWithoutVat = product.EshopPrice?.PriceWithoutVat,
-                    PurchasePrice = purchasePrice,
-
-                    // Cost components
-                    MaterialCost = materialCost,
-                    HandlingCost = handlingCost,
-                    SalesHistory = product.SalesHistory
-                        .Where(s => s.Date >= fromDate && s.Date <= toDate)
-                        .Select(s => new SalesDataPoint
-                        {
-                            Date = s.Date,
-                            AmountB2B = s.AmountB2B,
-                            AmountB2C = s.AmountB2C
-                        })
-                        .ToList()
-                };
-            }
-
-            // Allow garbage collection between batches
-            GC.Collect();
-        }
+        return _productSource.StreamProductsWithSalesAsync(fromDate, toDate, productTypes, cancellationToken);
     }
 
     /// <summary>
-    /// Gets aggregated margin data with optimized query (future implementation)
+    /// Gets aggregated margin data with optimized query
     /// </summary>
     public async Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
         DateTime fromDate,
         DateTime toDate,
-        ProductType[] productTypes,
+        AnalyticsProductType[] productTypes,
         ProductGroupingMode groupingMode,
         CancellationToken cancellationToken = default)
     {
@@ -153,82 +67,13 @@ public class AnalyticsRepository : IAnalyticsRepository
         return groupTotals;
     }
 
-    public async Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+    public Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
         string productId,
         DateTime fromDate,
         DateTime toDate,
         CancellationToken cancellationToken = default)
     {
-        var product = await _catalogRepository.GetByIdAsync(productId, cancellationToken);
-        if (product == null)
-            return null;
-
-        // Convert to analytics product with filtered sales data
-        // Use pre-calculated margin data from CatalogAggregate.Margins
-        var marginData = product.Margins;
-
-        // Filter monthly data by date range
-        var relevantMargins = marginData.MonthlyData
-            .Where(m => m.Key >= fromDate && m.Key <= toDate)
-            .ToList();
-
-        // Use latest margin data or fallback to averages
-        var latestMarginEntry = relevantMargins.LastOrDefault();
-        if (latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)))
-        {
-            latestMarginEntry = marginData.MonthlyData.LastOrDefault();
-        }
-
-        var marginAmount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>))
-            ? marginData.Averages.M0.Amount
-            : latestMarginEntry.Value.M0.Amount;
-        var materialCost = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>))
-            ? 0
-            : latestMarginEntry.Value.M0.CostLevel;
-        var handlingCost = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>))
-            ? 0
-            : latestMarginEntry.Value.M1_A.CostLevel;
-
-        // Get latest purchase price from purchase history
-        var latestPurchase = product.PurchaseHistory?.OrderByDescending(p => p.Date).FirstOrDefault();
-        var purchasePrice = latestPurchase?.PricePerPiece ?? 0;
-
-        return new AnalyticsProduct
-        {
-            ProductCode = product.ProductCode,
-            ProductName = product.ProductName,
-            Type = product.Type,
-            ProductFamily = product.ProductFamily,
-            ProductCategory = product.ProductCategory,
-            MarginAmount = marginAmount,
-
-            // M0-M2 margin amounts
-            M0Amount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M0.Amount,
-            M1Amount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M1.Amount,
-            M2Amount = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M2.Amount,
-
-            // M0-M2 margin percentages
-            M0Percentage = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M0.Percentage,
-            M1Percentage = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M1.Percentage,
-            M2Percentage = latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)) ? 0 : latestMarginEntry.Value.M2.Percentage,
-
-            // Pricing
-            SellingPrice = product.EshopPrice?.PriceWithoutVat ?? 0,
-            EshopPriceWithoutVat = product.EshopPrice?.PriceWithoutVat,
-            PurchasePrice = purchasePrice,
-
-            // Cost components
-            MaterialCost = materialCost,
-            HandlingCost = handlingCost,
-            SalesHistory = product.SalesHistory
-                .Select(s => new SalesDataPoint
-                {
-                    Date = s.Date,
-                    AmountB2B = s.AmountB2B,
-                    AmountB2C = s.AmountB2C
-                })
-                .ToList()
-        };
+        return _productSource.GetProductAnalysisDataAsync(productId, fromDate, toDate, cancellationToken);
     }
 
     private string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Analytics.Contracts;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
 
 namespace Anela.Heblo.Application.Features.Analytics.Infrastructure;
 
@@ -18,7 +17,7 @@ public interface IAnalyticsRepository
     IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
         DateTime fromDate,
         DateTime toDate,
-        ProductType[] productTypes,
+        AnalyticsProductType[] productTypes,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -27,7 +26,7 @@ public interface IAnalyticsRepository
     Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
         DateTime fromDate,
         DateTime toDate,
-        ProductType[] productTypes,
+        AnalyticsProductType[] productTypes,
         ProductGroupingMode groupingMode,
         CancellationToken cancellationToken = default);
 

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs
@@ -3,7 +3,7 @@ using Anela.Heblo.Application.Features.Analytics.Infrastructure;
 using Anela.Heblo.Application.Features.Analytics.Models;
 using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Analytics;
 using MediatR;
 
 namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
@@ -54,7 +54,7 @@ public class GetMarginReportHandler : IRequestHandler<GetMarginReportRequest, Ge
         try
         {
             // Get products stream from repository
-            var productTypes = new[] { ProductType.Product, ProductType.Goods };
+            var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
             var productsStream = _analyticsRepository.StreamProductsWithSalesAsync(
                 request.StartDate,
                 request.EndDate,

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Analytics.Contracts;
 using Anela.Heblo.Application.Features.Analytics.Infrastructure;
 using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
 using MediatR;
 
 namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
@@ -33,8 +32,8 @@ public class GetProductMarginSummaryHandler : IRequestHandler<GetProductMarginSu
         var (fromDate, toDate) = TimeWindowParser.ParseTimeWindow(request.TimeWindow);
         var dateRange = new DateRange(fromDate, toDate);
 
-        // 2. Stream products with Product/Goods types that have sales in the period  
-        var productTypes = new[] { ProductType.Product, ProductType.Goods };
+        // 2. Stream products with Product/Goods types that have sales in the period
+        var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
         var productStream = _analyticsRepository.StreamProductsWithSalesAsync(fromDate, toDate, productTypes, cancellationToken);
 
         // 3. Calculate margin data using streaming approach (reduces memory usage)

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -15,6 +15,7 @@ using Anela.Heblo.Application.Features.Catalog.UseCases.RecalculateProductWeight
 using Anela.Heblo.Application.Features.Catalog.UseCases.SubmitStockTaking;
 using Anela.Heblo.Application.Features.Catalog.UseCases.UpdateManufactureDifficulty;
 using Anela.Heblo.Application.Features.Catalog.Validators;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Cache;
 using Anela.Heblo.Domain.Features.Catalog.CostProviders;
@@ -43,6 +44,7 @@ public static class CatalogModule
 
         // Register adapter to expose catalog services to Purchase module
         services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
+        services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
 
         // Register cost repositories
         services.AddTransient<IMaterialCostProvider, ManufactureBasedMaterialCostProvider>(); // Product type-based: manufacture history for Set/Product/SemiProduct, purchase price for others

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs
@@ -99,7 +99,7 @@ internal sealed class CatalogAnalyticsSourceAdapter : IAnalyticsProductSource
         {
             ProductCode = product.ProductCode,
             ProductName = product.ProductName,
-            Type = product.Type,
+            Type = MapProductType(product.Type),
             ProductFamily = product.ProductFamily,
             ProductCategory = product.ProductCategory,
             MarginAmount = marginAmount,

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs
@@ -1,0 +1,140 @@
+using System.Runtime.CompilerServices;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Sales;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogAnalyticsSourceAdapter : IAnalyticsProductSource
+{
+    private const int BatchSize = 100;
+    private readonly ICatalogRepository _catalogRepository;
+
+    public CatalogAnalyticsSourceAdapter(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public async IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var catalogProductTypes = MapProductTypes(productTypes);
+        var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(
+            fromDate, toDate, catalogProductTypes, cancellationToken);
+
+        for (int i = 0; i < allProducts.Count; i += BatchSize)
+        {
+            var batch = allProducts.Skip(i).Take(BatchSize);
+            foreach (var product in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var filteredSales = product.SalesHistory
+                    .Where(s => s.Date >= fromDate && s.Date <= toDate)
+                    .Select(s => new SalesDataPoint
+                    {
+                        Date = s.Date,
+                        AmountB2B = s.AmountB2B,
+                        AmountB2C = s.AmountB2C
+                    })
+                    .ToList();
+                yield return MapToAnalyticsProduct(product, fromDate, toDate, filteredSales);
+            }
+            GC.Collect();
+        }
+    }
+
+    public async Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default)
+    {
+        var product = await _catalogRepository.GetByIdAsync(productId, cancellationToken);
+        if (product == null)
+            return null;
+
+        // Preserve verbatim from original AnalyticsRepository: single-product path does NOT
+        // filter SalesHistory by period, unlike the streaming path.
+        var unfilteredSales = product.SalesHistory
+            .Select(s => new SalesDataPoint
+            {
+                Date = s.Date,
+                AmountB2B = s.AmountB2B,
+                AmountB2C = s.AmountB2C
+            })
+            .ToList();
+
+        return MapToAnalyticsProduct(product, fromDate, toDate, unfilteredSales);
+    }
+
+    private static AnalyticsProduct MapToAnalyticsProduct(
+        CatalogAggregate product,
+        DateTime fromDate,
+        DateTime toDate,
+        List<SalesDataPoint> salesHistory)
+    {
+        var marginData = product.Margins;
+        var relevantMargins = marginData.MonthlyData
+            .Where(m => m.Key >= fromDate && m.Key <= toDate)
+            .ToList();
+
+        var latestMarginEntry = relevantMargins.LastOrDefault();
+        if (latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)))
+            latestMarginEntry = marginData.MonthlyData.LastOrDefault();
+
+        bool hasMargin = !latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>));
+
+        var marginAmount = hasMargin ? latestMarginEntry.Value.M0.Amount : marginData.Averages.M0.Amount;
+        var materialCost = hasMargin ? latestMarginEntry.Value.M0.CostLevel : 0m;
+        var handlingCost = hasMargin ? latestMarginEntry.Value.M1_A.CostLevel : 0m;
+
+        var latestPurchase = product.PurchaseHistory?.OrderByDescending(p => p.Date).FirstOrDefault();
+        var purchasePrice = latestPurchase?.PricePerPiece ?? 0m;
+
+        return new AnalyticsProduct
+        {
+            ProductCode = product.ProductCode,
+            ProductName = product.ProductName,
+            Type = product.Type,
+            ProductFamily = product.ProductFamily,
+            ProductCategory = product.ProductCategory,
+            MarginAmount = marginAmount,
+            M0Amount = hasMargin ? latestMarginEntry.Value.M0.Amount : 0m,
+            M1Amount = hasMargin ? latestMarginEntry.Value.M1_A.Amount : 0m,
+            M2Amount = hasMargin ? latestMarginEntry.Value.M2.Amount : 0m,
+            M0Percentage = hasMargin ? latestMarginEntry.Value.M0.Percentage : 0m,
+            M1Percentage = hasMargin ? latestMarginEntry.Value.M1_A.Percentage : 0m,
+            M2Percentage = hasMargin ? latestMarginEntry.Value.M2.Percentage : 0m,
+            SellingPrice = product.EshopPrice?.PriceWithoutVat ?? 0m,
+            EshopPriceWithoutVat = product.EshopPrice?.PriceWithoutVat,
+            PurchasePrice = purchasePrice,
+            MaterialCost = materialCost,
+            HandlingCost = handlingCost,
+            SalesHistory = salesHistory,
+        };
+    }
+
+    private static ProductType[] MapProductTypes(AnalyticsProductType[] types) =>
+        types.Select(MapProductTypeToCatalog).ToArray();
+
+    private static ProductType MapProductTypeToCatalog(AnalyticsProductType type) => type switch
+    {
+        AnalyticsProductType.Product => ProductType.Product,
+        AnalyticsProductType.Goods => ProductType.Goods,
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type,
+            "AnalyticsProductType has no Catalog.ProductType counterpart. Mirror the value in AnalyticsProductType and extend this switch."),
+    };
+
+    // Will be called in Task 6 when AnalyticsProduct.Type changes to AnalyticsProductType
+    private static AnalyticsProductType MapProductType(ProductType type) => type switch
+    {
+        ProductType.Product => AnalyticsProductType.Product,
+        ProductType.Goods => AnalyticsProductType.Goods,
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type,
+            "Adapter only projects Product and Goods."),
+    };
+}

--- a/backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs
@@ -1,5 +1,3 @@
-using Anela.Heblo.Domain.Features.Catalog;
-
 namespace Anela.Heblo.Domain.Features.Analytics;
 
 /// <summary>
@@ -10,7 +8,7 @@ public class AnalyticsProduct
 {
     public required string ProductCode { get; init; }
     public required string ProductName { get; init; }
-    public required ProductType Type { get; init; }
+    public required AnalyticsProductType Type { get; init; }
     public string? ProductFamily { get; init; }
     public string? ProductCategory { get; init; }
     public required decimal MarginAmount { get; init; }

--- a/backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs
@@ -1,0 +1,14 @@
+namespace Anela.Heblo.Domain.Features.Analytics;
+
+/// <summary>
+/// Analytics-owned classification of products that margin reporting cares about.
+/// Mirrors the subset of <c>Anela.Heblo.Domain.Features.Catalog.ProductType</c>
+/// that Analytics consumes today (Product, Goods). If Analytics ever needs
+/// another value, mirror it here and update the AnalyticsProductType ->
+/// ProductType translation in CatalogAnalyticsSourceAdapter.
+/// </summary>
+public enum AnalyticsProductType
+{
+    Product,
+    Goods,
+}

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -16,7 +16,8 @@ public class ModuleBoundariesTests
         string Name,
         string InspectedNamespacePrefix,
         IReadOnlyList<string> ForbiddenNamespacePrefixes,
-        IReadOnlySet<string> Allowlist);
+        IReadOnlySet<string> Allowlist,
+        string InspectedAssembly = "Anela.Heblo.Application");
 
     // Pre-existing allowlist for Leaflet → KnowledgeBase. Each entry needs a comment with the
     // justification. Entries should be removed as the underlying violations are fixed.
@@ -158,13 +159,36 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.ExpeditionList",
             },
             Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+
+        new ModuleBoundaryRule(
+            Name: "Analytics (Application) -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Analytics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+
+        new ModuleBoundaryRule(
+            Name: "Analytics (Domain) -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Domain.Features.Analytics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal),
+            InspectedAssembly: "Anela.Heblo.Domain"),
     };
 
     [Theory]
     [MemberData(nameof(Rules))]
     public void Consumer_types_should_not_reference_provider_owned_namespaces(ModuleBoundaryRule rule)
     {
-        var assembly = Assembly.Load("Anela.Heblo.Application");
+        var assembly = Assembly.Load(rule.InspectedAssembly);
         var consumerTypes = assembly.GetTypes()
             .Where(t => t.Namespace is not null
                 && t.Namespace.StartsWith(rule.InspectedNamespacePrefix, StringComparison.Ordinal))

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs
@@ -11,7 +11,6 @@ using Anela.Heblo.Application.Features.Analytics.Models;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -125,7 +124,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD001",
                 ProductName = "Product 1",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Electronics",
                 MarginAmount = 100m,
                 SellingPrice = 150m,
@@ -138,7 +137,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD002",
                 ProductName = "Product 2",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Books",
                 MarginAmount = 50m,
                 SellingPrice = 80m,
@@ -152,7 +151,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(analyticsProducts.ToAsyncEnumerable());
 
         // Act
@@ -245,7 +244,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
 
         // Act
@@ -277,7 +276,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD001",
                 ProductName = "Product 1",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Electronics",
                 MarginAmount = 100m,
                 SellingPrice = 150m,
@@ -290,7 +289,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD002",
                 ProductName = "Different Product",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Books",
                 MarginAmount = 50m,
                 SellingPrice = 80m,
@@ -303,7 +302,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(analyticsProducts.ToAsyncEnumerable());
 
         // Act
@@ -334,7 +333,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD001",
                 ProductName = "Product 1",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Electronics",
                 MarginAmount = 100m,
                 SellingPrice = 150m,
@@ -347,7 +346,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD002",
                 ProductName = "Product 2",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Books",
                 MarginAmount = 50m,
                 SellingPrice = 80m,
@@ -360,7 +359,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(analyticsProducts.ToAsyncEnumerable());
 
         // Act
@@ -392,7 +391,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD001",
                 ProductName = "Product 1",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Electronics",
                 MarginAmount = 100m,
                 SellingPrice = 150m,
@@ -405,7 +404,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD002",
                 ProductName = "Product 2",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Books",
                 MarginAmount = 50m,
                 SellingPrice = 80m,
@@ -418,7 +417,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(analyticsProducts.ToAsyncEnumerable());
 
         // Act
@@ -447,7 +446,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD001",
                 ProductName = "Product with Sales",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Electronics",
                 MarginAmount = 100m,
                 SellingPrice = 150m,
@@ -460,7 +459,7 @@ public class GetMarginReportHandlerTests
             {
                 ProductCode = "PROD002",
                 ProductName = "Product with Zero Sales",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 ProductCategory = "Books",
                 MarginAmount = 50m,
                 SellingPrice = 80m,
@@ -473,7 +472,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(analyticsProducts.ToAsyncEnumerable());
 
         // Act
@@ -500,7 +499,7 @@ public class GetMarginReportHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(request.StartDate, request.EndDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(ThrowAsync<AnalyticsProduct>(new Exception("Database connection failed")));
 
         // Act

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs
@@ -10,7 +10,6 @@ using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginAnalysis;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -52,7 +51,7 @@ public class GetProductMarginAnalysisHandlerTests
         {
             ProductCode = "PROD001",
             ProductName = "Test Product",
-            Type = ProductType.Product,
+            Type = AnalyticsProductType.Product,
             MarginAmount = 100m,
             SellingPrice = 150m,
             SalesHistory = new List<SalesDataPoint>
@@ -193,7 +192,7 @@ public class GetProductMarginAnalysisHandlerTests
         {
             ProductCode = "PROD001",
             ProductName = "Test Product",
-            Type = ProductType.Product,
+            Type = AnalyticsProductType.Product,
             MarginAmount = 100m,
             SellingPrice = 150m,
             SalesHistory = new List<SalesDataPoint>
@@ -233,7 +232,7 @@ public class GetProductMarginAnalysisHandlerTests
         {
             ProductCode = "PROD001",
             ProductName = "Test Product",
-            Type = ProductType.Product,
+            Type = AnalyticsProductType.Product,
             MarginAmount = 100m,
             SellingPrice = 150m,
             SalesHistory = new List<SalesDataPoint>
@@ -276,7 +275,7 @@ public class GetProductMarginAnalysisHandlerTests
         {
             ProductCode = "PROD001",
             ProductName = "Test Product",
-            Type = ProductType.Product,
+            Type = AnalyticsProductType.Product,
             MarginAmount = 100m,
             SellingPrice = 150m,
             SalesHistory = new List<SalesDataPoint>

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
@@ -9,7 +9,6 @@ using Anela.Heblo.Application.Features.Analytics.Infrastructure;
 using Anela.Heblo.Application.Features.Analytics.Services;
 using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSummary;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -58,7 +57,7 @@ public class GetProductMarginSummaryHandlerTests
             {
                 ProductCode = "PROD001",
                 ProductName = "Product 1",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 MarginAmount = 100m,
                 M0Amount = 100m,
                 M1Amount = 100m,
@@ -72,7 +71,7 @@ public class GetProductMarginSummaryHandlerTests
             {
                 ProductCode = "PROD002",
                 ProductName = "Product 2",
-                Type = ProductType.Product,
+                Type = AnalyticsProductType.Product,
                 MarginAmount = 50m,
                 M0Amount = 50m,
                 M1Amount = 50m,
@@ -87,7 +86,7 @@ public class GetProductMarginSummaryHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(analyticsProducts.ToAsyncEnumerable());
 
         // Act
@@ -122,7 +121,7 @@ public class GetProductMarginSummaryHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
 
         // Act
@@ -151,7 +150,7 @@ public class GetProductMarginSummaryHandlerTests
 
         _analyticsRepositoryMock
             .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
-                It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
             .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
 
         // Act

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs
@@ -320,7 +320,7 @@ public sealed class CatalogAnalyticsSourceAdapterTests
         result.Should().NotBeNull();
         result!.ProductCode.Should().Be("PROD001");
         result.ProductName.Should().Be("Test Product");
-        result.Type.Should().Be(ProductType.Goods);
+        result.Type.Should().Be(AnalyticsProductType.Goods);
         result.SellingPrice.Should().Be(100m);
         result.EshopPriceWithoutVat.Should().Be(100m);
         result.PurchasePrice.Should().Be(50m);

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs
@@ -1,0 +1,332 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using Anela.Heblo.Domain.Features.Catalog.PurchaseHistory;
+using Anela.Heblo.Domain.Features.Catalog.Sales;
+using FluentAssertions;
+using Moq;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public sealed class CatalogAnalyticsSourceAdapterTests
+{
+    private static CatalogAggregate CreateCatalogAggregate(
+        string productCode = "TEST001",
+        string productName = "Test Product",
+        ProductType type = ProductType.Product)
+    {
+        return new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productName,
+            Type = type,
+            SalesHistory = new List<CatalogSaleRecord>(),
+            PurchaseHistory = new List<CatalogPurchaseRecord>(),
+            Margins = new MonthlyMarginHistory(),
+            EshopPrice = null
+        };
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_TranslatesAnalyticsProductTypeToCatalogProductTypeAtBoundary()
+    {
+        // Arrange
+        var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
+        var product = CreateCatalogAggregate("PROD001", "Test", ProductType.Product);
+
+        var repoMock = new Mock<ICatalogRepository>();
+        ProductType[]? capturedProductTypes = null;
+        repoMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DateTime, DateTime, ProductType[], CancellationToken>(
+                (_, _, types, _) => capturedProductTypes = types)
+            .ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        // Act
+        var result = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(fromDate, toDate, productTypes))
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        capturedProductTypes.Should().NotBeNull();
+        capturedProductTypes.Should().HaveCount(2);
+        capturedProductTypes.Should().Contain(new[] { ProductType.Product, ProductType.Goods });
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_MapsM0M1M2AmountsFromLatestMarginEntryInPeriod()
+    {
+        // Arrange
+        var product = CreateCatalogAggregate("PROD001", "Test", ProductType.Product);
+        product.Margins.MonthlyData = new Dictionary<DateTime, MarginData>
+        {
+            [new DateTime(2024, 1, 1)] = new MarginData
+            {
+                M0 = new MarginLevel(10m, 10m, 0m, 5m),
+                M1_A = new MarginLevel(15m, 20m, 0m, 7m),
+                M2 = new MarginLevel(20m, 30m, 0m, 0m)
+            },
+            [new DateTime(2024, 6, 1)] = new MarginData
+            {
+                M0 = new MarginLevel(12m, 12m, 0m, 6m),
+                M1_A = new MarginLevel(18m, 22m, 0m, 8m),
+                M2 = new MarginLevel(22m, 32m, 0m, 0m)
+            }
+        };
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        // Act
+        var result = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            fromDate, toDate, new[] { AnalyticsProductType.Product }))
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].M0Amount.Should().Be(12m); // Latest entry
+        result[0].M1Amount.Should().Be(22m); // M1_A.Amount
+        result[0].M2Amount.Should().Be(32m);
+        result[0].MaterialCost.Should().Be(6m); // M0.CostLevel
+        result[0].HandlingCost.Should().Be(8m); // M1_A.CostLevel
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_FallsBackToAveragesWhenNoMonthlyMarginDataInPeriod()
+    {
+        // Arrange
+        var product = CreateCatalogAggregate("PROD001", "Test", ProductType.Product);
+        product.Margins = new MonthlyMarginHistory { MonthlyData = new Dictionary<DateTime, MarginData>() };
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        // Act
+        var result = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            fromDate, toDate, new[] { AnalyticsProductType.Product }))
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].MarginAmount.Should().Be(0m); // Empty Averages returns Zero
+        result[0].M0Amount.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_FiltersSalesHistoryToTheRequestedPeriod()
+    {
+        // Arrange
+        var product = CreateCatalogAggregate("PROD001", "Test", ProductType.Product);
+        product.SalesHistory = new List<CatalogSaleRecord>
+        {
+            new CatalogSaleRecord { Date = new DateTime(2023, 12, 31), AmountB2B = 5, AmountB2C = 3, SumB2B = 50, SumB2C = 30 },
+            new CatalogSaleRecord { Date = new DateTime(2024, 6, 15), AmountB2B = 10, AmountB2C = 8, SumB2B = 100, SumB2C = 80 },
+            new CatalogSaleRecord { Date = new DateTime(2025, 1, 1), AmountB2B = 2, AmountB2C = 1, SumB2B = 20, SumB2C = 10 }
+        };
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        // Act
+        var result = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            fromDate, toDate, new[] { AnalyticsProductType.Product }))
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].SalesHistory.Should().HaveCount(1);
+        result[0].SalesHistory[0].Date.Should().Be(new DateTime(2024, 6, 15));
+        result[0].SalesHistory[0].AmountB2B.Should().Be(10);
+        result[0].SalesHistory[0].AmountB2C.Should().Be(8);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_TakesLatestPurchasePrice()
+    {
+        // Arrange
+        var product = CreateCatalogAggregate("PROD001", "Test", ProductType.Product);
+        product.PurchaseHistory = new List<CatalogPurchaseRecord>
+        {
+            new CatalogPurchaseRecord { Date = new DateTime(2024, 1, 1), PricePerPiece = 10m, Amount = 100, PriceTotal = 1000 },
+            new CatalogPurchaseRecord { Date = new DateTime(2024, 6, 15), PricePerPiece = 15m, Amount = 50, PriceTotal = 750 },
+            new CatalogPurchaseRecord { Date = new DateTime(2024, 12, 1), PricePerPiece = 12m, Amount = 75, PriceTotal = 900 }
+        };
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { product });
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        // Act
+        var result = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            fromDate, toDate, new[] { AnalyticsProductType.Product }))
+        {
+            result.Add(item);
+        }
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].PurchasePrice.Should().Be(12m); // Latest date
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_ReturnsNullWhenRepositoryReturnsNull()
+    {
+        // Arrange
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogAggregate?)null);
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+
+        // Act
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "NONEXISTENT",
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31));
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_PreservesUnfilteredSalesHistory()
+    {
+        // Arrange
+        var product = CreateCatalogAggregate("PROD001", "Test", ProductType.Product);
+        product.SalesHistory = new List<CatalogSaleRecord>
+        {
+            new CatalogSaleRecord { Date = new DateTime(2023, 6, 15), AmountB2B = 5, AmountB2C = 3, SumB2B = 50, SumB2C = 30 },
+            new CatalogSaleRecord { Date = new DateTime(2024, 6, 15), AmountB2B = 10, AmountB2C = 8, SumB2B = 100, SumB2C = 80 },
+            new CatalogSaleRecord { Date = new DateTime(2025, 6, 15), AmountB2B = 2, AmountB2C = 1, SumB2B = 20, SumB2C = 10 }
+        };
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetByIdAsync("PROD001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+
+        // Act
+        var result = await adapter.GetProductAnalysisDataAsync("PROD001", fromDate, toDate);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.SalesHistory.Should().HaveCount(3); // All 3 records, not filtered by period
+        result.SalesHistory.Should().Satisfy(
+            s => s.Date == new DateTime(2023, 6, 15),
+            s => s.Date == new DateTime(2024, 6, 15),
+            s => s.Date == new DateTime(2025, 6, 15));
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_MapsPricingAndMarginFields()
+    {
+        // Arrange
+        var product = CreateCatalogAggregate("PROD001", "Test Product", ProductType.Goods);
+        product.EshopPrice = new ProductPriceEshop { PriceWithoutVat = 100m };
+        product.PurchaseHistory = new List<CatalogPurchaseRecord>
+        {
+            new CatalogPurchaseRecord { Date = new DateTime(2024, 6, 15), PricePerPiece = 50m, Amount = 10, PriceTotal = 500 }
+        };
+        product.Margins.MonthlyData = new Dictionary<DateTime, MarginData>
+        {
+            [new DateTime(2024, 6, 1)] = new MarginData
+            {
+                M0 = new MarginLevel(20m, 20m, 0m, 25m),
+                M1_A = new MarginLevel(25m, 25m, 0m, 30m),
+                M2 = new MarginLevel(30m, 30m, 0m, 0m)
+            }
+        };
+
+        var repoMock = new Mock<ICatalogRepository>();
+        repoMock
+            .Setup(r => r.GetByIdAsync("PROD001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+
+        var adapter = new CatalogAnalyticsSourceAdapter(repoMock.Object);
+
+        // Act
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "PROD001",
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31));
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.ProductCode.Should().Be("PROD001");
+        result.ProductName.Should().Be("Test Product");
+        result.Type.Should().Be(ProductType.Goods);
+        result.SellingPrice.Should().Be(100m);
+        result.EshopPriceWithoutVat.Should().Be(100m);
+        result.PurchasePrice.Should().Be(50m);
+        result.MarginAmount.Should().Be(20m);
+        result.M0Amount.Should().Be(20m);
+        result.M1Amount.Should().Be(25m);
+        result.M2Amount.Should().Be(30m);
+    }
+}

--- a/docs/superpowers/plans/2026-05-27-decouple-analytics-from-catalog.md
+++ b/docs/superpowers/plans/2026-05-27-decouple-analytics-from-catalog.md
@@ -1,0 +1,1263 @@
+# Decouple Analytics from Catalog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate Analytics's direct dependency on Catalog (`ProductType`, `ICatalogRepository`, `CatalogAggregate`, `MarginData`, `PurchaseHistory`) by introducing an Analytics-owned `IAnalyticsProductSource` contract implemented by a Catalog-side adapter, and lock the new boundary with an architectural test that covers both the Application and Domain assemblies.
+
+**Architecture:** Apply the consumer-owns-contract / provider-owns-adapter pattern documented in `docs/architecture/development_guidelines.md` §"Cross-Module Communication Example" and already used by Leaflet→KnowledgeBase (2026-05-15), Logistics→Manufacture (2026-05-16), PackingMaterials→Invoices (2026-05-21), Purchase→Catalog (2026-05-24), Article→KnowledgeBase (2026-05-25), and ExpeditionListArchive→ExpeditionList (2026-05-26). Analytics declares `IAnalyticsProductSource` in `Application/Features/Analytics/Contracts/` and `AnalyticsProductType` in `Domain/Features/Analytics/`; Catalog provides an `internal sealed CatalogAnalyticsSourceAdapter` in `Application/Features/Catalog/Infrastructure/` that owns the `CatalogAggregate → AnalyticsProduct` mapping previously duplicated across two methods of `AnalyticsRepository`. `CatalogModule.AddCatalogModule` registers the binding (Transient, to match `ICatalogRepository`). The architectural test extends `ModuleBoundaryRule` with an optional `InspectedAssembly` field so the new rule can also catch the `AnalyticsProduct.Type` violation that lives in the Domain assembly. No HTTP API, DTO, or schema changes.
+
+**Tech Stack:** .NET 8, C# (nullable enabled), xUnit, FluentAssertions, Moq, MediatR, `Microsoft.Extensions.DependencyInjection`. No new NuGet packages, no migrations.
+
+---
+
+## File Structure
+
+**Files to create:**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs` | Analytics-owned enum mirroring exactly the two `Catalog.ProductType` values Analytics consumes today (`Product`, `Goods`). |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs` | Cross-module contract — two methods (`StreamProductsWithSalesAsync`, `GetProductAnalysisDataAsync`) that expose only Analytics-owned types. |
+| `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs` | `internal sealed` adapter — depends on `ICatalogRepository`, owns the `CatalogAggregate → AnalyticsProduct` mapping (extracted into a single private helper), translates `AnalyticsProductType[] → ProductType[]` at the boundary. |
+| `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs` | xUnit + Moq tests for the adapter — first-ever coverage of the previously-untested mapping. |
+
+**Files to modify:**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Retype `Type` from `ProductType` to `AnalyticsProductType`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Change `ProductType[] productTypes` → `AnalyticsProductType[] productTypes` on `StreamProductsWithSalesAsync` and `GetGroupMarginTotalsAsync`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Replace `ICatalogRepository _catalogRepository` ctor dependency with `IAnalyticsProductSource _productSource`. Delete the mapping bodies of `StreamProductsWithSalesAsync` (lines 30–122) and `GetProductAnalysisDataAsync` (lines 156–232) and delegate to the contract. Retype `productTypes` to `AnalyticsProductType[]`. `GetGroupMarginTotalsAsync`, `GetInvoiceImportStatisticsAsync`, `GetBankStatementImportStatisticsAsync` are kept; only the `productTypes` parameter type changes on `GetGroupMarginTotalsAsync`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Change `new[] { ProductType.Product, ProductType.Goods }` → `new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods }`. |
+| `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Same enum array replacement. |
+| `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` | Add `using Anela.Heblo.Application.Features.Analytics.Contracts;`. Register `services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();` immediately after the existing `IMaterialCatalogService` registration (line 45). |
+| `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` | Extend `ModuleBoundaryRule` record with optional `string InspectedAssembly = "Anela.Heblo.Application"`. Replace the hard-coded `Assembly.Load("Anela.Heblo.Application")` call with `Assembly.Load(rule.InspectedAssembly)`. Add two new theory rows: `Analytics (Application) -> Catalog` and `Analytics (Domain) -> Catalog`. Empty allowlists. |
+| `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs` | Drop `using Anela.Heblo.Domain.Features.Catalog;`. Every `Type = ProductType.Product` (10 occurrences at lines 128, 141, 280, 293, 337, 350, 395, 408, 450, 463) → `Type = AnalyticsProductType.Product`. |
+| `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` | Same — `using Catalog` removed; `Type = ProductType.Product` (lines 61, 75) → `AnalyticsProductType.Product`. |
+| `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs` | Same — `using Catalog` removed; `Type = ProductType.Product` (lines 55, 196, 236, 279) → `AnalyticsProductType.Product`. |
+
+**Files NOT touched:**
+
+- `backend/src/Anela.Heblo.Domain/Features/Catalog/*` — Catalog domain types (`CatalogAggregate`, `ProductType`, `MarginData`, `ICatalogRepository`, …) remain unchanged.
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — the analytics binding is not registered here; the provider (Catalog) owns the registration per the documented pattern. The stale comment on line 28 ("`IMarginCalculationService` is registered by CatalogModule and injected here") is out of scope per arch-review §"Specification Amendments" item 7.
+- `GetBankStatementImportStatistics`, `GetInvoiceImportStatistics` handlers — already independent of Catalog.
+- Frontend, OpenAPI clients, controllers — no public API change.
+
+---
+
+## Task 1: Add the failing architecture-test rules for Analytics → Catalog
+
+This locks the boundary in place before any source changes. Subsequent tasks turn it green. Two theory rows are needed because the existing `AnalyticsProduct.Type` violation lives in `Anela.Heblo.Domain` (the current test inspects only the Application assembly). The rule record gains an optional `InspectedAssembly` field so existing rules keep their default behavior with no churn.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Extend `ModuleBoundaryRule` with an `InspectedAssembly` field**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Replace the `public sealed record ModuleBoundaryRule(...)` declaration (currently lines 15–19) with:
+
+```csharp
+    public sealed record ModuleBoundaryRule(
+        string Name,
+        string InspectedNamespacePrefix,
+        IReadOnlyList<string> ForbiddenNamespacePrefixes,
+        IReadOnlySet<string> Allowlist,
+        string InspectedAssembly = "Anela.Heblo.Application");
+```
+
+- [ ] **Step 2: Use `rule.InspectedAssembly` in the theory method**
+
+Locate the line that reads:
+
+```csharp
+        var assembly = Assembly.Load("Anela.Heblo.Application");
+```
+
+inside `Consumer_types_should_not_reference_provider_owned_namespaces` (around line 167). Replace it with:
+
+```csharp
+        var assembly = Assembly.Load(rule.InspectedAssembly);
+```
+
+Leave the other `Assembly.Load("Anela.Heblo.Application")` calls in `Logistics_types_should_not_reference_Purchase_owned_namespaces` and `Application_types_should_not_reference_AspNetCore_namespaces` unchanged — only the theory method becomes data-driven on `InspectedAssembly`.
+
+- [ ] **Step 3: Append the two new theory rows to `Rules()`**
+
+Inside the `Rules()` method, after the `ExpeditionListArchive -> ExpeditionList` row (currently lines 152–161) and before the closing `};` of the TheoryData initializer, append:
+
+```csharp
+        new ModuleBoundaryRule(
+            Name: "Analytics (Application) -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Analytics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+
+        new ModuleBoundaryRule(
+            Name: "Analytics (Domain) -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Domain.Features.Analytics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal),
+            InspectedAssembly: "Anela.Heblo.Domain"),
+```
+
+- [ ] **Step 4: Verify the new theory cases currently fail**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: the two new theory cases FAIL with violations including (non-exhaustive):
+
+`Analytics (Application) -> Catalog`:
+- `…AnalyticsRepository -> Anela.Heblo.Domain.Features.Catalog.ICatalogRepository`
+- `…AnalyticsRepository -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+- `…IAnalyticsRepository -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+- `…GetMarginReportHandler -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+- `…GetProductMarginSummaryHandler -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+
+`Analytics (Domain) -> Catalog`:
+- `…AnalyticsProduct -> Anela.Heblo.Domain.Features.Catalog.ProductType`
+
+All other existing theory cases (Leaflet, Article, Logistics, PackingMaterials, Purchase, ExpeditionListArchive) and the two `[Fact]` tests must still PASS.
+
+- [ ] **Step 5: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test(arch): add failing Analytics -> Catalog boundary rules"
+```
+
+---
+
+## Task 2: Create the `AnalyticsProductType` enum
+
+Pure type declaration in Analytics's Domain namespace. Mirrors exactly the two `Catalog.ProductType` values used by Analytics today (`Product`, `Goods`) — `Material`, `SemiProduct`, `Set`, `UNDEFINED` are intentionally omitted because Analytics never passes them (verified at `GetMarginReportHandler.cs:57` and `GetProductMarginSummaryHandler.cs:37`). No tests for an inert enum.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs`
+
+- [ ] **Step 1: Create the enum**
+
+Write the file exactly:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Analytics;
+
+/// <summary>
+/// Analytics-owned classification of products that margin reporting cares about.
+/// Mirrors the subset of <c>Anela.Heblo.Domain.Features.Catalog.ProductType</c>
+/// that Analytics consumes today (Product, Goods). If Analytics ever needs
+/// another value, mirror it here and update the AnalyticsProductType ->
+/// ProductType translation in CatalogAnalyticsSourceAdapter.
+/// </summary>
+public enum AnalyticsProductType
+{
+    Product,
+    Goods,
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj --no-restore
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProductType.cs
+git commit -m "feat(analytics): add AnalyticsProductType enum"
+```
+
+---
+
+## Task 3: Create the `IAnalyticsProductSource` contract
+
+Pure interface declaration in Analytics's Contracts folder, expressed entirely in Analytics-owned types (`AnalyticsProduct`, `AnalyticsProductType`). No tests — this is an inert abstraction; behavior is covered by the adapter tests in Task 4.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs`
+
+- [ ] **Step 1: Create the interface**
+
+Write the file exactly:
+
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Contracts;
+
+/// <summary>
+/// Analytics-owned read abstraction over catalog data. Implemented by the
+/// Catalog module via <c>CatalogAnalyticsSourceAdapter</c> per the cross-module
+/// communication pattern in <c>docs/architecture/development_guidelines.md</c>.
+/// All inputs and outputs are Analytics-owned types; the adapter owns the
+/// translation between <see cref="AnalyticsProductType"/> and Catalog's ProductType
+/// and the projection from CatalogAggregate to <see cref="AnalyticsProduct"/>.
+/// </summary>
+public interface IAnalyticsProductSource
+{
+    /// <summary>
+    /// Streams products of the requested types that have sales in the given
+    /// period, projected to <see cref="AnalyticsProduct"/>. Items are yielded
+    /// one by one; the underlying call still materialises a list internally,
+    /// but the iteration boundary preserves the surface that callers rely on.
+    /// </summary>
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns a single product projected to <see cref="AnalyticsProduct"/>,
+    /// or <c>null</c> if the product is unknown. Matches the soft-fallback
+    /// semantics of <c>ICatalogRepository.GetByIdAsync</c>.
+    /// </summary>
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --no-restore
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Contracts/IAnalyticsProductSource.cs
+git commit -m "feat(analytics): add IAnalyticsProductSource contract"
+```
+
+---
+
+## Task 4: Create `CatalogAnalyticsSourceAdapter` and its tests (TDD)
+
+The adapter owns the entire `CatalogAggregate → AnalyticsProduct` mapping that currently lives duplicated across two methods of `AnalyticsRepository` (streaming path at lines 52–116, single-product path at lines 168–231 of the original `AnalyticsRepository.cs`). The two paths differ in exactly one place: the streaming path filters `SalesHistory` by the request period, while the single-product path does not (line 223 — preserve as-is per FR-7; the asymmetry is acknowledged in the spec's "Out of Scope" and arch-review §"Mapping consolidation"). The adapter consolidates the M0/M1/M2 mapping into a single helper and keeps the sales-filter difference visible at the two call sites. The `AnalyticsProductType[] → ProductType[]` conversion happens at the entry point.
+
+This task writes the tests FIRST (RED), then the adapter (GREEN), per project TDD convention.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs`
+
+- [ ] **Step 1: Write the failing adapter tests**
+
+Write `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs` exactly:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using Anela.Heblo.Domain.Features.Catalog.PurchaseHistory;
+using Anela.Heblo.Domain.Features.Catalog.Sales;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class CatalogAnalyticsSourceAdapterTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private CatalogAnalyticsSourceAdapter CreateAdapter() => new(_repository.Object);
+
+    private static CatalogAggregate MakeAggregate(
+        string productCode = "P1",
+        string productName = "Product 1",
+        ProductType type = ProductType.Product,
+        string? family = "FamA",
+        string? category = "CatA",
+        decimal eshopPriceWithoutVat = 200m,
+        IEnumerable<CatalogSaleRecord>? sales = null,
+        IEnumerable<CatalogPurchaseRecord>? purchases = null,
+        IEnumerable<KeyValuePair<DateTime, MarginData>>? monthlyMargins = null,
+        MarginAverages? averages = null)
+    {
+        var aggregate = new CatalogAggregate
+        {
+            ProductCode = productCode,
+            ProductName = productName,
+            Type = type,
+            ProductFamily = family,
+            ProductCategory = category,
+            EshopPrice = new ProductPriceEshop { PriceWithoutVat = eshopPriceWithoutVat },
+            SalesHistory = sales?.ToList() ?? new List<CatalogSaleRecord>(),
+            PurchaseHistory = purchases?.ToList() ?? new List<CatalogPurchaseRecord>(),
+        };
+
+        aggregate.Margins = new MarginAggregate
+        {
+            MonthlyData = monthlyMargins?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+                ?? new Dictionary<DateTime, MarginData>(),
+            Averages = averages ?? new MarginAverages
+            {
+                M0 = new MarginAmount { Amount = 0m, Percentage = 0m, CostLevel = 0m },
+                M1 = new MarginAmount(),
+                M1_A = new MarginAmount(),
+                M2 = new MarginAmount(),
+            },
+        };
+
+        return aggregate;
+    }
+
+    private static MarginData MarginAt(decimal m0Amount, decimal m1Amount, decimal m2Amount, decimal m0Cost = 0m, decimal m1aCost = 0m)
+    {
+        return new MarginData
+        {
+            M0 = new MarginAmount { Amount = m0Amount, Percentage = m0Amount, CostLevel = m0Cost },
+            M1 = new MarginAmount { Amount = m1Amount, Percentage = m1Amount },
+            M1_A = new MarginAmount { CostLevel = m1aCost },
+            M2 = new MarginAmount { Amount = m2Amount, Percentage = m2Amount },
+        };
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_translates_AnalyticsProductType_array_to_Catalog_ProductType_array_at_boundary()
+    {
+        ProductType[]? captured = null;
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<DateTime, DateTime, ProductType[], CancellationToken>((_, _, t, _) => captured = t)
+            .ReturnsAsync(new List<CatalogAggregate>());
+
+        var adapter = CreateAdapter();
+
+        await foreach (var _ in adapter.StreamProductsWithSalesAsync(
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods },
+            CancellationToken.None))
+        {
+            // drain
+        }
+
+        captured.Should().BeEquivalentTo(new[] { ProductType.Product, ProductType.Goods });
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_maps_M0_M1_M2_amounts_and_percentages_from_latest_margin_entry_in_period()
+    {
+        var from = new DateTime(2024, 1, 1);
+        var to = new DateTime(2024, 12, 31);
+        var aggregate = MakeAggregate(
+            monthlyMargins: new[]
+            {
+                new KeyValuePair<DateTime, MarginData>(new DateTime(2024, 3, 1), MarginAt(10m, 20m, 30m, m0Cost: 5m, m1aCost: 7m)),
+                new KeyValuePair<DateTime, MarginData>(new DateTime(2024, 10, 1), MarginAt(11m, 21m, 31m, m0Cost: 6m, m1aCost: 8m)),
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(from, to, It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(from, to, new[] { AnalyticsProductType.Product }, CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results.Should().HaveCount(1);
+        var p = results[0];
+        p.M0Amount.Should().Be(11m);
+        p.M1Amount.Should().Be(21m);
+        p.M2Amount.Should().Be(31m);
+        p.M0Percentage.Should().Be(11m);
+        p.M1Percentage.Should().Be(21m);
+        p.M2Percentage.Should().Be(31m);
+        p.MarginAmount.Should().Be(11m);
+        p.MaterialCost.Should().Be(6m);
+        p.HandlingCost.Should().Be(8m);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_falls_back_to_averages_when_no_monthly_margin_data_present()
+    {
+        var aggregate = MakeAggregate(
+            monthlyMargins: Array.Empty<KeyValuePair<DateTime, MarginData>>(),
+            averages: new MarginAverages
+            {
+                M0 = new MarginAmount { Amount = 42m, Percentage = 0m, CostLevel = 0m },
+                M1 = new MarginAmount(),
+                M1_A = new MarginAmount(),
+                M2 = new MarginAmount(),
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            new[] { AnalyticsProductType.Product },
+            CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results[0].MarginAmount.Should().Be(42m);
+        results[0].M0Amount.Should().Be(0m);
+        results[0].MaterialCost.Should().Be(0m);
+        results[0].HandlingCost.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_filters_SalesHistory_to_the_requested_period()
+    {
+        var from = new DateTime(2024, 6, 1);
+        var to = new DateTime(2024, 8, 31);
+        var aggregate = MakeAggregate(
+            sales: new[]
+            {
+                new CatalogSaleRecord { Date = new DateTime(2024, 1, 15), AmountB2B = 1, AmountB2C = 2 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 7, 15), AmountB2B = 3, AmountB2C = 4 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 11, 15), AmountB2B = 5, AmountB2C = 6 },
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(from, to, It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(from, to, new[] { AnalyticsProductType.Product }, CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results[0].SalesHistory.Should().HaveCount(1);
+        results[0].SalesHistory[0].Date.Should().Be(new DateTime(2024, 7, 15));
+        results[0].SalesHistory[0].AmountB2B.Should().Be(3);
+        results[0].SalesHistory[0].AmountB2C.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_takes_latest_purchase_price_from_purchase_history()
+    {
+        var aggregate = MakeAggregate(
+            purchases: new[]
+            {
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 3, 1), PricePerPiece = 100m },
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 9, 1), PricePerPiece = 150m },
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 5, 1), PricePerPiece = 120m },
+            });
+
+        _repository
+            .Setup(r => r.GetProductsWithSalesInPeriod(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<ProductType[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogAggregate> { aggregate });
+
+        var adapter = CreateAdapter();
+        var results = new List<AnalyticsProduct>();
+        await foreach (var item in adapter.StreamProductsWithSalesAsync(
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            new[] { AnalyticsProductType.Product },
+            CancellationToken.None))
+        {
+            results.Add(item);
+        }
+
+        results[0].PurchasePrice.Should().Be(150m);
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_returns_null_when_repository_returns_null()
+    {
+        _repository
+            .Setup(r => r.GetByIdAsync("MISSING", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CatalogAggregate?)null);
+
+        var adapter = CreateAdapter();
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "MISSING",
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 12, 31),
+            CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_preserves_unfiltered_SalesHistory_for_single_product_path()
+    {
+        // FR-7 / arch-review Risk row: the single-product path historically does NOT filter
+        // SalesHistory by the requested period (line 223 of original AnalyticsRepository.cs),
+        // unlike the streaming path. Preserve this asymmetry verbatim — fixing it is out of scope.
+        var aggregate = MakeAggregate(
+            productCode: "P1",
+            sales: new[]
+            {
+                new CatalogSaleRecord { Date = new DateTime(2024, 1, 15), AmountB2B = 1, AmountB2C = 2 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 7, 15), AmountB2B = 3, AmountB2C = 4 },
+                new CatalogSaleRecord { Date = new DateTime(2024, 11, 15), AmountB2B = 5, AmountB2C = 6 },
+            });
+
+        _repository
+            .Setup(r => r.GetByIdAsync("P1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aggregate);
+
+        var adapter = CreateAdapter();
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "P1",
+            new DateTime(2024, 6, 1),
+            new DateTime(2024, 8, 31),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.SalesHistory.Should().HaveCount(3); // all three preserved, not filtered
+    }
+
+    [Fact]
+    public async Task GetProductAnalysisDataAsync_maps_pricing_purchase_price_and_margin_fields()
+    {
+        var aggregate = MakeAggregate(
+            productCode: "P1",
+            productName: "Single Product",
+            family: "Fam",
+            category: "Cat",
+            eshopPriceWithoutVat: 333m,
+            purchases: new[]
+            {
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 4, 1), PricePerPiece = 50m },
+                new CatalogPurchaseRecord { Date = new DateTime(2024, 9, 1), PricePerPiece = 75m },
+            },
+            monthlyMargins: new[]
+            {
+                new KeyValuePair<DateTime, MarginData>(new DateTime(2024, 7, 1), MarginAt(10m, 20m, 30m, m0Cost: 4m, m1aCost: 6m)),
+            });
+
+        _repository
+            .Setup(r => r.GetByIdAsync("P1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aggregate);
+
+        var adapter = CreateAdapter();
+        var result = await adapter.GetProductAnalysisDataAsync(
+            "P1",
+            new DateTime(2024, 6, 1),
+            new DateTime(2024, 8, 31),
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ProductCode.Should().Be("P1");
+        result.ProductName.Should().Be("Single Product");
+        result.ProductFamily.Should().Be("Fam");
+        result.ProductCategory.Should().Be("Cat");
+        result.SellingPrice.Should().Be(333m);
+        result.EshopPriceWithoutVat.Should().Be(333m);
+        result.PurchasePrice.Should().Be(75m);
+        result.MarginAmount.Should().Be(10m);
+        result.M0Amount.Should().Be(10m);
+        result.M1Amount.Should().Be(20m);
+        result.M2Amount.Should().Be(30m);
+        result.MaterialCost.Should().Be(4m);
+        result.HandlingCost.Should().Be(6m);
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail to compile**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-restore
+```
+
+Expected: build FAILS with `CS0246` style errors — `CatalogAnalyticsSourceAdapter` does not exist yet.
+
+If field names on existing Catalog types (`CatalogAggregate`, `MarginData`, `MarginAverages`, `MarginAmount`, `CatalogSaleRecord`, `CatalogPurchaseRecord`, `ProductPriceEshop`) differ from what's used above, fix the **test** to use the real type members (read the actual files under `backend/src/Anela.Heblo.Domain/Features/Catalog/`). Do **not** invent fields on production code to make the test compile.
+
+- [ ] **Step 3: Implement the adapter**
+
+Write `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs` exactly:
+
+```csharp
+using System.Runtime.CompilerServices;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogAnalyticsSourceAdapter : IAnalyticsProductSource
+{
+    private const int BatchSize = 100;
+
+    private readonly ICatalogRepository _catalogRepository;
+
+    public CatalogAnalyticsSourceAdapter(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public async IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var catalogProductTypes = MapProductTypes(productTypes);
+
+        var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(
+            fromDate, toDate, catalogProductTypes, cancellationToken);
+
+        for (int i = 0; i < allProducts.Count; i += BatchSize)
+        {
+            var batch = allProducts.Skip(i).Take(BatchSize);
+
+            foreach (var product in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var filteredSales = product.SalesHistory
+                    .Where(s => s.Date >= fromDate && s.Date <= toDate)
+                    .Select(s => new SalesDataPoint
+                    {
+                        Date = s.Date,
+                        AmountB2B = s.AmountB2B,
+                        AmountB2C = s.AmountB2C,
+                    })
+                    .ToList();
+
+                yield return MapToAnalyticsProduct(product, fromDate, toDate, filteredSales);
+            }
+
+            GC.Collect();
+        }
+    }
+
+    public async Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default)
+    {
+        var product = await _catalogRepository.GetByIdAsync(productId, cancellationToken);
+        if (product == null)
+            return null;
+
+        // Preserve verbatim from original AnalyticsRepository.GetProductAnalysisDataAsync (line 223):
+        // single-product path does NOT filter SalesHistory by period, unlike the streaming path.
+        var unfilteredSales = product.SalesHistory
+            .Select(s => new SalesDataPoint
+            {
+                Date = s.Date,
+                AmountB2B = s.AmountB2B,
+                AmountB2C = s.AmountB2C,
+            })
+            .ToList();
+
+        return MapToAnalyticsProduct(product, fromDate, toDate, unfilteredSales);
+    }
+
+    private static AnalyticsProduct MapToAnalyticsProduct(
+        CatalogAggregate product,
+        DateTime fromDate,
+        DateTime toDate,
+        List<SalesDataPoint> salesHistory)
+    {
+        var marginData = product.Margins;
+
+        var relevantMargins = marginData.MonthlyData
+            .Where(m => m.Key >= fromDate && m.Key <= toDate)
+            .ToList();
+
+        var latestMarginEntry = relevantMargins.LastOrDefault();
+        if (latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>)))
+        {
+            latestMarginEntry = marginData.MonthlyData.LastOrDefault();
+        }
+
+        bool hasMargin = !latestMarginEntry.Equals(default(KeyValuePair<DateTime, MarginData>));
+
+        var marginAmount = hasMargin
+            ? latestMarginEntry.Value.M0.Amount
+            : marginData.Averages.M0.Amount;
+        var materialCost = hasMargin ? latestMarginEntry.Value.M0.CostLevel : 0m;
+        var handlingCost = hasMargin ? latestMarginEntry.Value.M1_A.CostLevel : 0m;
+
+        var latestPurchase = product.PurchaseHistory?.OrderByDescending(p => p.Date).FirstOrDefault();
+        var purchasePrice = latestPurchase?.PricePerPiece ?? 0m;
+
+        return new AnalyticsProduct
+        {
+            ProductCode = product.ProductCode,
+            ProductName = product.ProductName,
+            Type = MapProductType(product.Type),
+            ProductFamily = product.ProductFamily,
+            ProductCategory = product.ProductCategory,
+            MarginAmount = marginAmount,
+
+            M0Amount = hasMargin ? latestMarginEntry.Value.M0.Amount : 0m,
+            M1Amount = hasMargin ? latestMarginEntry.Value.M1.Amount : 0m,
+            M2Amount = hasMargin ? latestMarginEntry.Value.M2.Amount : 0m,
+
+            M0Percentage = hasMargin ? latestMarginEntry.Value.M0.Percentage : 0m,
+            M1Percentage = hasMargin ? latestMarginEntry.Value.M1.Percentage : 0m,
+            M2Percentage = hasMargin ? latestMarginEntry.Value.M2.Percentage : 0m,
+
+            SellingPrice = product.EshopPrice?.PriceWithoutVat ?? 0m,
+            EshopPriceWithoutVat = product.EshopPrice?.PriceWithoutVat,
+            PurchasePrice = purchasePrice,
+
+            MaterialCost = materialCost,
+            HandlingCost = handlingCost,
+            SalesHistory = salesHistory,
+        };
+    }
+
+    private static ProductType[] MapProductTypes(AnalyticsProductType[] types) =>
+        types.Select(MapProductTypeToCatalog).ToArray();
+
+    private static ProductType MapProductTypeToCatalog(AnalyticsProductType type) => type switch
+    {
+        AnalyticsProductType.Product => ProductType.Product,
+        AnalyticsProductType.Goods => ProductType.Goods,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(type),
+            type,
+            "AnalyticsProductType has no Catalog.ProductType counterpart. " +
+            "Mirror the value in AnalyticsProductType.cs and extend this switch."),
+    };
+
+    private static AnalyticsProductType MapProductType(ProductType type) => type switch
+    {
+        ProductType.Product => AnalyticsProductType.Product,
+        ProductType.Goods => AnalyticsProductType.Goods,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(type),
+            type,
+            "Adapter only projects Product and Goods. " +
+            "ICatalogRepository.GetProductsWithSalesInPeriod filtering must ensure no other types are returned."),
+    };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~CatalogAnalyticsSourceAdapterTests" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: all 8 adapter tests PASS.
+
+If a test fails because a referenced Catalog type/field name in the test differs from production (e.g., `CatalogSaleRecord.AmountB2B` vs. another name), correct the **test** — the adapter mapping mirrors the original `AnalyticsRepository.cs` lines 52–116 and 168–231 exactly, so the production mapping is correct by construction.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapter.cs \
+        backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogAnalyticsSourceAdapterTests.cs
+git commit -m "feat(catalog): add CatalogAnalyticsSourceAdapter implementing IAnalyticsProductSource"
+```
+
+---
+
+## Task 5: Register the adapter binding in `CatalogModule`
+
+Single-line DI registration. The lifetime is **Transient**, matching `ICatalogRepository` (`CatalogModule.cs:41`) — the adapter is stateless and merely delegates, so its lifetime should match the dependency it wraps (per arch-review Decision 3). Spec FR-4's wording "lifetime to match existing Catalog repository registrations" supports Transient over Scoped.
+
+The application still doesn't use `IAnalyticsProductSource` after this task — Analytics's `AnalyticsRepository` still injects `ICatalogRepository` directly. The arch test still fails. This task is intentionally small to keep DI changes reviewable in isolation.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+
+- [ ] **Step 1: Add the using directive**
+
+At the top of `CatalogModule.cs`, add `using Anela.Heblo.Application.Features.Analytics.Contracts;` to the import block (alphabetical placement: between `Anela.Heblo.Application.Features.Catalog.Validators;` and `Anela.Heblo.Domain.Features.Catalog;`).
+
+- [ ] **Step 2: Register the binding**
+
+Locate the existing line (currently line 45):
+
+```csharp
+        services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
+```
+
+Immediately after it, add:
+
+```csharp
+        services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
+```
+
+- [ ] **Step 3: Verify build succeeds**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj --no-restore
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "feat(catalog): register CatalogAnalyticsSourceAdapter binding"
+```
+
+---
+
+## Task 6: Switch Analytics consumers to the new contract (the type-swap commit)
+
+This is the cohesive refactor that flips Analytics off Catalog. All of the following must move together because they form one compile-unit:
+
+- `AnalyticsProduct.Type` is retyped from `Catalog.ProductType` to `AnalyticsProductType`.
+- `IAnalyticsRepository`'s `productTypes` parameter type changes on two methods.
+- `AnalyticsRepository`'s constructor replaces `ICatalogRepository` with `IAnalyticsProductSource`; the duplicated mapping bodies (originally lines 30–122 and 156–232) are deleted and replaced with delegation; `productTypes` parameter type updated on the two methods that take it.
+- Both handlers (`GetMarginReportHandler`, `GetProductMarginSummaryHandler`) replace their `new[] { ProductType.Product, ProductType.Goods }` arrays with `new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods }`.
+- Three handler test files update their `Type = ProductType.Product` initialisers to `Type = AnalyticsProductType.Product`.
+
+Existing handler tests already mock `IAnalyticsRepository` (verified — no test mocks `ICatalogRepository` in the Analytics test folder), so the test surface changes are limited to the enum rename. No new mocks are needed for handler tests — `IAnalyticsProductSource` is only consumed inside `AnalyticsRepository`, which is mocked at the `IAnalyticsRepository` level above.
+
+After this commit:
+- `dotnet build` passes
+- The `Analytics (Application) -> Catalog` and `Analytics (Domain) -> Catalog` arch theory rows turn GREEN
+- All existing Analytics tests still pass with assertion text unchanged (only enum type changed)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs`
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs`
+
+- [ ] **Step 1: Update `AnalyticsProduct.cs`**
+
+Remove the line `using Anela.Heblo.Domain.Features.Catalog;` at the top. Change the `Type` property:
+
+From:
+
+```csharp
+    public required ProductType Type { get; init; }
+```
+
+To:
+
+```csharp
+    public required AnalyticsProductType Type { get; init; }
+```
+
+No other changes — `SalesHistory`, `SalesDataPoint`, `DateRange`, `MarginCalculationResult` keep their current shape (already Analytics-owned).
+
+- [ ] **Step 2: Update `IAnalyticsRepository.cs`**
+
+Remove the line `using Anela.Heblo.Domain.Features.Catalog;` at the top. In both `StreamProductsWithSalesAsync` and `GetGroupMarginTotalsAsync`, change the parameter `ProductType[] productTypes` to `AnalyticsProductType[] productTypes`. The full file becomes:
+
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Infrastructure;
+
+/// <summary>
+/// Analytics-specific repository with streaming capabilities
+/// Prevents memory issues by avoiding loading all data at once
+/// </summary>
+public interface IAnalyticsRepository
+{
+    /// <summary>
+    /// Streams products with sales data to avoid memory overload
+    /// </summary>
+    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets aggregated margin data directly from repository (optimized query)
+    /// </summary>
+    Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        ProductGroupingMode groupingMode,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets detailed product analysis data for a specific product
+    /// </summary>
+    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets daily invoice import statistics for monitoring purposes
+    /// </summary>
+    Task<List<DailyInvoiceCount>> GetInvoiceImportStatisticsAsync(
+        DateTime startDate,
+        DateTime endDate,
+        ImportDateType dateType,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets daily bank statement import statistics for monitoring purposes
+    /// </summary>
+    Task<List<DailyBankStatementStatistics>> GetBankStatementImportStatisticsAsync(
+        DateTime startDate,
+        DateTime endDate,
+        BankStatementDateType dateType,
+        CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 3: Update `AnalyticsRepository.cs`**
+
+Rewrite the top of the file (replacing the mapping bodies with delegation) so it looks exactly like this (the invoice/bank-statement methods at the bottom are unchanged — only their `using` declarations and the top three Analytics methods change):
+
+Replace **everything from line 1 through line 244** (i.e., everything up to and including `private string GetGroupKey(...)` method) of the current `AnalyticsRepository.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetInvoiceImportStatistics;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetBankStatementImportStatistics;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Application.Features.Analytics.Infrastructure;
+
+/// <summary>
+/// Analytics repository — delegates product/sales lookups to the Catalog-side
+/// adapter via <see cref="IAnalyticsProductSource"/> and owns the EF-backed
+/// invoice/bank-statement statistics queries.
+/// </summary>
+public class AnalyticsRepository : IAnalyticsRepository
+{
+    private readonly IAnalyticsProductSource _productSource;
+    private readonly ApplicationDbContext _dbContext;
+
+    public AnalyticsRepository(IAnalyticsProductSource productSource, ApplicationDbContext dbContext)
+    {
+        _productSource = productSource;
+        _dbContext = dbContext;
+    }
+
+    public IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        CancellationToken cancellationToken = default)
+    {
+        return _productSource.StreamProductsWithSalesAsync(fromDate, toDate, productTypes, cancellationToken);
+    }
+
+    public async Task<Dictionary<string, decimal>> GetGroupMarginTotalsAsync(
+        DateTime fromDate,
+        DateTime toDate,
+        AnalyticsProductType[] productTypes,
+        ProductGroupingMode groupingMode,
+        CancellationToken cancellationToken = default)
+    {
+        var groupTotals = new Dictionary<string, decimal>();
+
+        await foreach (var product in StreamProductsWithSalesAsync(fromDate, toDate, productTypes, cancellationToken))
+        {
+            if (product.MarginAmount <= 0)
+                continue;
+
+            var groupKey = GetGroupKey(product, groupingMode);
+            var totalSold = product.SalesHistory.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = (decimal)totalSold * product.MarginAmount;
+
+            if (!groupTotals.ContainsKey(groupKey))
+                groupTotals[groupKey] = 0;
+
+            groupTotals[groupKey] += marginContribution;
+        }
+
+        return groupTotals;
+    }
+
+    public Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
+        string productId,
+        DateTime fromDate,
+        DateTime toDate,
+        CancellationToken cancellationToken = default)
+    {
+        return _productSource.GetProductAnalysisDataAsync(productId, fromDate, toDate, cancellationToken);
+    }
+
+    private string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => product.ProductCode,
+            ProductGroupingMode.ProductFamily => product.ProductFamily ?? "Unknown",
+            ProductGroupingMode.ProductCategory => product.ProductCategory ?? "Unknown",
+            _ => product.ProductCode
+        };
+    }
+```
+
+Keep the existing closing brace of the class and the two remaining methods (`GetInvoiceImportStatisticsAsync`, `GetBankStatementImportStatisticsAsync`) **exactly as they are** — they don't reference Catalog and require no changes.
+
+- [ ] **Step 4: Update `GetMarginReportHandler.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Locate line 57:
+
+```csharp
+            var productTypes = new[] { ProductType.Product, ProductType.Goods };
+```
+
+Replace with:
+
+```csharp
+            var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
+```
+
+- [ ] **Step 5: Update `GetProductMarginSummaryHandler.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Locate line 37:
+
+```csharp
+        var productTypes = new[] { ProductType.Product, ProductType.Goods };
+```
+
+Replace with:
+
+```csharp
+        var productTypes = new[] { AnalyticsProductType.Product, AnalyticsProductType.Goods };
+```
+
+- [ ] **Step 6: Update `GetMarginReportHandlerTests.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Use the Edit tool with `replace_all: true` to replace every occurrence of `Type = ProductType.Product,` with `Type = AnalyticsProductType.Product,` (10 occurrences — lines 128, 141, 280, 293, 337, 350, 395, 408, 450, 463).
+
+- [ ] **Step 7: Update `GetProductMarginSummaryHandlerTests.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Replace every `Type = ProductType.Product,` with `Type = AnalyticsProductType.Product,` (2 occurrences — lines 61, 75).
+
+- [ ] **Step 8: Update `GetProductMarginAnalysisHandlerTests.cs`**
+
+Remove `using Anela.Heblo.Domain.Features.Catalog;` at the top.
+
+Replace every `Type = ProductType.Product,` with `Type = AnalyticsProductType.Product,` (4 occurrences — lines 55, 196, 236, 279).
+
+- [ ] **Step 9: Build and verify**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln --no-restore
+```
+
+Expected: solution builds with zero errors and no new warnings.
+
+If a `using Anela.Heblo.Domain.Features.Catalog;` remains needed in any Analytics file because it is genuinely consumed for an unrelated reason (e.g., an `ImportDateType` reference that happens to live under Catalog — verify with the actual file), keep it and note the case here. But based on inspection (`Grep "Anela.Heblo.Domain.Features.Catalog" backend/src/Anela.Heblo.Application/Features/Analytics`), the only consumers are the four files listed above, all touched by this task.
+
+- [ ] **Step 10: Run the full Analytics test suite**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Analytics" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: all Analytics tests PASS, including the four handler test files and the new adapter test file. No assertions should need to change.
+
+- [ ] **Step 11: Run the architecture tests**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests" \
+  --no-restore --logger "console;verbosity=normal"
+```
+
+Expected: all theory cases PASS, including both `Analytics (Application) -> Catalog` and `Analytics (Domain) -> Catalog`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/IAnalyticsRepository.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetMarginReport/GetMarginReportHandler.cs \
+        backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/Analytics/GetMarginReportHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginAnalysisHandlerTests.cs
+git commit -m "refactor(analytics): consume IAnalyticsProductSource instead of Catalog types"
+```
+
+---
+
+## Task 7: Final validation and format pass
+
+The change is functionally complete after Task 6. This task runs the project's mandated validation gates (per `CLAUDE.md` "Validation before completion") and applies `dotnet format` to pick up any stylistic drift.
+
+**Files:**
+- (no new files; may touch any of the above for `dotnet format` whitespace fixes only)
+
+- [ ] **Step 1: `dotnet build` on the full solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: solution builds with zero errors and no new warnings.
+
+- [ ] **Step 2: `dotnet format` on the solution**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Apply any whitespace/style fixes the formatter produces. If the formatter modifies files **outside** the eight files listed in Task 6, stop and inspect — surgical-change rule: don't bundle unrelated formatting.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build --logger "console;verbosity=normal"
+```
+
+Expected: all tests PASS. Pay attention to:
+- All eight `CatalogAnalyticsSourceAdapterTests` cases.
+- All Analytics handler tests (`GetMarginReportHandlerTests`, `GetProductMarginSummaryHandlerTests`, `GetProductMarginAnalysisHandlerTests`, `GetInvoiceImportStatisticsHandlerTests`, `DashboardTiles/InvoiceImportStatisticsTileTests`).
+- All `ModuleBoundariesTests` theory rows and facts.
+- `PurchaseMaterialCatalogAdapterTests` (Task 5 added a binding in the same module — make sure nothing regressed).
+
+- [ ] **Step 4: Spec NFR-2 verification — zero Catalog references in Analytics namespaces**
+
+Run:
+
+```bash
+grep -r "Anela.Heblo.Domain.Features.Catalog" \
+  backend/src/Anela.Heblo.Application/Features/Analytics/ \
+  backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected: no output (zero matches).
+
+Also confirm no Analytics file references the specific Catalog types listed in spec NFR-2:
+
+```bash
+grep -rE "CatalogAggregate|\bMarginData\b|PurchaseHistory|\bProductType\b|ICatalogRepository" \
+  backend/src/Anela.Heblo.Application/Features/Analytics/ \
+  backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected: no output. (`AnalyticsProductType` references are fine — the search uses `\bProductType\b` to avoid matching `AnalyticsProductType`.)
+
+- [ ] **Step 5: If `dotnet format` produced changes, commit them**
+
+```bash
+git status
+# If any modified files appear:
+git add <changed files>
+git commit -m "style: apply dotnet format after analytics decoupling"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Scope Boundary
+
+The following are explicitly out of scope (per spec "Out of Scope" and arch-review §"Specification Amendments"):
+
+- Refactoring `CatalogAggregate`, `MarginData`, `PurchaseHistory`, or any Catalog-owned type.
+- Fixing the asymmetric `SalesHistory` filtering between streaming and single-product paths (preserved verbatim per FR-7).
+- Removing the stale comment in `AnalyticsModule.cs:28` about `IMarginCalculationService` (flag in a follow-up).
+- Auditing other modules for similar violations.
+- True streaming (the underlying `ICatalogRepository.GetProductsWithSalesInPeriod` returns a materialised `List<CatalogAggregate>`; the `IAsyncEnumerable` façade is preserved as-is).
+- Frontend, OpenAPI client, or HTTP-surface changes.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 `IAnalyticsProductSource` interface — Task 3.
+- FR-2 `AnalyticsProductType` enum (`Product`, `Goods` only) and `AnalyticsProduct.Type` retyping — Tasks 2 and 6 Step 1.
+- FR-3 `CatalogAnalyticsSourceAdapter` with consolidated mapping helper and adapter-boundary type translation — Task 4.
+- FR-4 DI registration in `CatalogModule` (Transient, per arch-review Decision 3 / spec amendment item 4) — Task 5.
+- FR-5 `AnalyticsRepository` drops `ICatalogRepository`, and (per arch-review amendment item 1) `IAnalyticsRepository` interface signature also drops `ProductType[]` — Task 6 Steps 2–3.
+- FR-6 `GetMarginReportHandler` and `GetProductMarginSummaryHandler` lose Catalog imports — Task 6 Steps 4–5. `GetProductMarginAnalysisHandler` already does not import Catalog; its test file is updated in Task 6 Step 8 per arch-review amendment item 2.
+- FR-7 Behavior preservation — mapping moves verbatim, sales-filter asymmetry preserved, `GC.Collect()` batching loop preserved; verified by Task 6 Step 10 (all existing assertions unchanged) and Task 7 Steps 3–4.
+- FR-8 (arch-review amendment 3) `ModuleBoundariesTests` rule(s) covering both Application and Domain assemblies — Task 1.
+- NFR-1 (with arch-review amendment 5 wording) — same underlying `ICatalogRepository` calls, no new SQL, no allocation change in mapping — by-construction from Task 4 implementation.
+- NFR-2 grep returns zero matches — verified by Task 7 Step 4.
+- NFR-3 test isolation + new adapter mapping tests — Task 4 Step 1.
+- NFR-4 backwards compatibility — no HTTP/DTO/schema changes; verified by Task 7 Step 3.
+
+**Placeholder scan:** no TODO/TBD/"implement later"; every step has actual file contents, commands, and expected output. The only "if X then …" branches are honest failure paths (Task 4 Step 2 if Catalog field names differ from the test fixture; Task 6 Step 9 if an unexpected `using Catalog` lingers; Task 7 Step 5 conditional commit).
+
+**Type consistency:** `IAnalyticsProductSource` method signatures in Task 3 match the implementation in Task 4 and the call sites in Task 6 Step 3. `AnalyticsProductType` is referenced consistently as the Domain-namespace enum. `MapProductType` and `MapProductTypes` (plural) are both defined in Task 4 Step 3.


### PR DESCRIPTION
Analytics

## Finding

Two files in the Analytics module take direct compile-time dependencies on Catalog-owned types:

**1. `AnalyticsProduct` (Domain layer) imports `ProductType` from Catalog domain**
`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs:1–13`
```csharp
using Anela.Heblo.Domain.Features.Catalog;   // ← cross-module domain import

public class AnalyticsProduct
{
    public required ProductType Type { get; init; }  // ← Catalog's enum
```
The Analytics domain entity carries a hard dependency on a type owned by the Catalog domain.

**2. `AnalyticsRepository` (Analytics Application layer) injects `ICatalogRepository` directly**
`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs:5–21`
```csharp
using Anela.Heblo.Domain.Features.Catalog;        // ← Catalog domain
...
public class AnalyticsRepository : IAnalyticsRepository
{
    private readonly ICatalogRepository _catalogRepository;  // ← Catalog's repository

    public AnalyticsRepository(ICatalogRepository catalogRepository, ...)
```
`AnalyticsRepository` delegates every product data fetch to `ICatalogRepository.GetProductsWithSalesInPeriod()` and `GetByIdAsync()`, calling these on `CatalogAggregate` objects directly.

Both `GetMarginReportHandler` (line 7, line 57) and `GetProductMarginSummaryHandler` (line 5, line 37) also import `ProductType` from Catalog as a downstream consequence.

## Why it matters

`development_guidelines.md` explicitly forbids:
- **"Direct access to another module's entities"**
- **"Shared repositories across modules"**

Analytics can never be deployed or tested in isolation; it is tightly coupled to Catalog's internal data model (`CatalogAggregate`, `MarginData`, `PurchaseHistory`, etc.). Any internal refactoring of the `CatalogAggregate` structure silently breaks the Analytics repository's manual field mappings (lines 52–116 of `AnalyticsRepository.cs`).

## Suggested fix

Apply the adapter pattern documented in `development_guidelines.md` (§ *Cross-Module Communication*):

1. **Analytics owns the contract.** Add `IAnalyticsProductSource` to `Application/Features/Analytics/Contracts/`:
```csharp
public interface IAnalyticsProductSource
{
    IAsyncEnumerable<AnalyticsProduct> StreamProductsWithSalesAsync(
        DateTime from, DateTime to, AnalyticsProductType[] types,
        CancellationToken ct = default);
    Task<AnalyticsProduct?> GetProductAnalysisDataAsync(
        string productId, DateTime from, DateTime to,
        CancellationToken ct = default);
}
```
Define `AnalyticsProductType` as an Analytics-owned enum (mirroring the values currently borrowed from Catalog).

2. **Catalog implements the adapter.** Move the existing `CatalogAggregate → AnalyticsProduct` mapping code from `AnalyticsRepository` into a new `CatalogAnalyticsSourceAdapter` class inside `Application/Features/Catalog/Infrastructure/`.

3. **Catalog registers the binding.** In `CatalogModule.AddCatalogModule()`:
```csharp
services.AddScoped<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
```

4. **`AnalyticsRepository` drops `ICatalogRepository`.** It now depends only on `IAnalyticsProductSource` (Analytics-owned) and `ApplicationDbContext` (already correct).

---
_Filed by daily arch-review routine on 2026-05-26._

---

Closes #1805

### Tokens used
34286310
