### PR TITLE
feat: Remove Forced GC.Collect() From AnalyticsRepository Streaming Loop

### DIFF
--- a/artifacts/feat-arch-review-analytics-gc-collect-called-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-analytics-gc-collect-called-/arch-review.r1.md
@@ -1,0 +1,146 @@
+# Architecture Review: Remove Forced GC.Collect() From AnalyticsRepository Streaming Loop
+
+## Skip Design: true
+
+Backend-only one-line removal in a single file. No UI components, no API contracts, no DTOs touched. Pure performance fix with no visual or interaction-design surface.
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with the project's Clean Architecture + Vertical Slice layout (`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`). The file already lives where the filesystem doc prescribes (`Features/{Feature}/Infrastructure/`). The `IAnalyticsRepository` abstraction at `Infrastructure/IAnalyticsRepository.cs:13` is unchanged by the fix, so no boundary, DI registration, or consumer signature is affected.
+
+Integration points are read-only:
+- **Five margin-report consumers** mock `IAnalyticsRepository` directly (verified in `GetMarginReportHandlerTests.cs`, `GetProductMarginSummaryHandlerTests.cs`, `GetProductMarginAnalysisHandlerTests.cs`, etc.). Removing `GC.Collect()` is invisible to these handlers — they exercise the interface, not the concrete implementation.
+- **`GetGroupMarginTotalsAsync`** at line 138 consumes `StreamProductsWithSalesAsync` via `await foreach`. The yielded sequence is unchanged, so behavior is preserved.
+
+The misleading "PERFORMANCE FIX" doc-comments on the class (line 12) and the interface (`IAnalyticsRepository.cs:10`) reference the same in-memory batching myth that this fix repudiates. Out of scope per the spec, but flagged for the follow-up `IAnalyticsProductSource` refactor.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+[Margin-Report Handlers x5]      ──┐
+[GetGroupMarginTotalsAsync]      ──┤   await foreach
+                                   ├──►  IAnalyticsRepository.StreamProductsWithSalesAsync
+                                   │      (interface, unchanged)
+                                   │             │
+                                   │             ▼
+                                   │      AnalyticsRepository (concrete)
+                                   │             │
+                                   │             │   ── REMOVE: GC.Collect() at line 120
+                                   │             │   ── REMOVE: "// Allow GC..." comment at line 119
+                                   │             ▼
+                                   │      ICatalogRepository.GetProductsWithSalesInPeriod
+                                   │             │
+                                   │             ▼
+                                   │      List<CatalogAggregate>  (fully materialized, unchanged)
+```
+
+Only the boxed call inside `AnalyticsRepository` changes. Every other arrow is untouched.
+
+### Key Design Decisions
+
+#### Decision 1: Surgical deletion vs. removing the batching loop
+
+**Options considered:**
+1. Delete only the `GC.Collect()` call and its comment (spec's chosen scope).
+2. Also delete the `for`/`Skip`/`Take` batching wrapper since it provides no memory benefit once the list is materialized.
+3. Replace batching with direct `foreach (var product in allProducts)`.
+
+**Chosen approach:** Option 1 — delete only line 120 and the preceding comment.
+
+**Rationale:** The spec is explicit (FR-2): the batching loop is preserved byte-identical aside from the deleted line. The cosmetic refactor (Option 2/3) is out of scope and will be subsumed by the upcoming `IAnalyticsProductSource` ownership move, which will replace this entire loop with EF-streamed enumeration. Keeping the diff to a single line minimizes blast radius and review effort, and avoids merge friction with the cross-module refactor branch.
+
+#### Decision 2: Add a direct unit test for `StreamProductsWithSalesAsync` vs. rely on handler tests
+
+**Options considered:**
+1. Add a single direct unit test against the concrete `AnalyticsRepository`.
+2. Rely on the existing handler tests, all of which mock `IAnalyticsRepository` and never exercise the concrete implementation.
+
+**Chosen approach:** Option 1, per FR-3.
+
+**Rationale:** All five margin-report consumers mock `IAnalyticsRepository` directly (confirmed via grep of `backend/test/Anela.Heblo.Tests/Features/Analytics/`). They cannot catch a refactoring regression in the concrete method. A single test that calls `StreamProductsWithSalesAsync` against a fake `ICatalogRepository` with a fixed in-memory catalog and asserts (count, ordering, identity) is a cheap, future-proof guard rail for the next refactor pass.
+
+#### Decision 3: Leave the misleading class-level XML comment alone
+
+**Options considered:**
+1. Leave the `🔒 PERFORMANCE FIX: ... streaming capabilities ... Prevents memory overload` comment on lines 11–14 (and the parallel one on `IAnalyticsRepository.cs:9–12`).
+2. Update both comments to remove the "prevents memory overload" claim.
+
+**Chosen approach:** Option 1 — leave both as-is.
+
+**Rationale:** The spec's "Surgical changes" rule and FR-2 forbid scope creep. The class/interface comments are misleading but will be rewritten when the `IAnalyticsProductSource` refactor lands and the streaming becomes real. Flagged in *Specification Amendments* for the follow-up.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edit only:
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+  └── lines 119–120: delete the comment and the GC.Collect() call
+
+backend/test/Anela.Heblo.Tests/Features/Analytics/
+  └── (new) AnalyticsRepositoryTests.cs       — single xUnit class, one test method
+```
+
+Test file placement mirrors the production tree under `tests/` per the C# testing rule.
+
+### Interfaces and Contracts
+
+- `IAnalyticsRepository` (`Features/Analytics/Infrastructure/IAnalyticsRepository.cs:13`) is **unchanged**.
+- `AnalyticsRepository` public surface (`StreamProductsWithSalesAsync`, `GetGroupMarginTotalsAsync`, `GetProductAnalysisDataAsync`, `GetInvoiceImportStatisticsAsync`, `GetBankStatementImportStatisticsAsync`) — all signatures and return contracts **unchanged**.
+- `AnalyticsProduct` yielded shape (`Contracts/AnalyticsProduct.cs`) — **unchanged**.
+- The five MediatR handlers (`GetMarginReport`, `GetProductMarginSummary`, `GetProductMarginAnalysis`, plus the dashboard-tile consumers) — **unchanged**.
+
+The new test must:
+- Construct `AnalyticsRepository` directly (not through DI), passing a `Mock<ICatalogRepository>` and a stub `ApplicationDbContext` (or `null!` if the constructor accepts it without dereferencing — verify before using).
+- Stub `ICatalogRepository.GetProductsWithSalesInPeriod` to return a fixed `List<CatalogAggregate>` with a known order — at least 250 items to cross the batch boundary (`batchSize = 100`) more than twice.
+- Use AAA pattern with FluentAssertions and xUnit per `csharp-testing.md`.
+- Assert: total yielded count equals input count; `ProductCode` ordering matches input ordering; identity round-trips for at least the first and last item of each batch.
+
+Do not add a test that asserts on GC behavior — there is no observable contract for "GC was not forced," and any such test is flaky by construction.
+
+### Data Flow
+
+For each margin-report request:
+
+1. Handler calls `IAnalyticsRepository.StreamProductsWithSalesAsync(fromDate, toDate, types, ct)`.
+2. Concrete repo synchronously `await`s `ICatalogRepository.GetProductsWithSalesInPeriod(...)` — fully materializes `List<CatalogAggregate>`. (Unchanged. Out of scope.)
+3. Outer `for` loop walks batches of 100. Inner `foreach` calls `cancellationToken.ThrowIfCancellationRequested()`, projects `CatalogAggregate → AnalyticsProduct`, and `yield return`s. (Unchanged.)
+4. ~~End of batch: `GC.Collect()` forces synchronous Gen2 collection, pausing all managed threads.~~ **Removed.**
+5. Loop continues to next batch with no pause. Consumer continues `await foreach`.
+
+Net effect: one fewer thread-pausing operation per 100 products, multiplied across the 5 margin-report use cases per request. No observable change to yielded data.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Some downstream consumer (or test fixture) accidentally relies on the GC pause to flush something (e.g., a finalizer-driven side effect). | Very low | None known in this codebase. Existing handler tests mock the interface — they cannot rely on concrete GC behavior. The new direct test will catch any sequence regression. Spec FR-3 covers this. |
+| Silent re-introduction of `GC.Collect()` in a future change. | Low | The spec calls for a repo-wide grep as part of acceptance (FR-1). Consider adding an analyzer/EditorConfig rule banning `GC.Collect` outside `/scripts/` or test code — out of scope here but worth noting for the follow-up. |
+| Reviewers conflate this fix with the broader "fully materializes the list" critique and ask for scope expansion. | Medium (review friction, not code) | Spec is explicit on scope; PR description must point to the parallel `IAnalyticsProductSource` issue. Keep diff to single line + one test file. |
+| New unit test couples to internals (e.g., `latestMarginEntry` quirks with default `KeyValuePair`) and breaks during the upcoming refactor. | Low | Test must assert only on the yielded **identity/order/count** contract, not on margin-amount math. Keep the test deliberately narrow. |
+| `ApplicationDbContext` constructor parameter is required by `AnalyticsRepository` ctor but unused by `StreamProductsWithSalesAsync` — passing `null!` may surprise readers. | Low | Use a minimal in-memory `DbContextOptions<ApplicationDbContext>` or a `Mock<ApplicationDbContext>` if available; otherwise `null!` is acceptable since the method under test never dereferences it — verify by reading the method once. |
+
+## Specification Amendments
+
+1. **FR-3 acceptance clarification (no spec change, just executor guidance):** the existing margin-report handler tests all mock `IAnalyticsRepository` and never exercise the concrete `AnalyticsRepository.StreamProductsWithSalesAsync`. The "optional" test in FR-3 is in practice required to satisfy the "verify margin report behavior is unchanged" intent at the unit level. Treat it as required, not optional.
+
+2. **Follow-up flag (deferred, not part of this PR):** the XML doc comments on `AnalyticsRepository` (`AnalyticsRepository.cs:11–14`) and `IAnalyticsRepository` (`IAnalyticsRepository.cs:9–12`) advertise "prevents memory overload by streaming." This claim is false today (`allProducts` is materialized upfront). Update both comments when the `IAnalyticsProductSource` refactor makes streaming real. Capture this in the cross-module boundary issue, not here.
+
+3. **Optional hardening (deferred):** consider adding an EditorConfig or Roslyn analyzer rule banning `GC.Collect()` outside of `/backend/scripts/` and test code, so this antipattern cannot reappear. Mention in the PR description, do not implement in this PR.
+
+## Prerequisites
+
+None. The change is self-contained:
+
+- No migrations.
+- No config (`appsettings.*.json`) changes.
+- No new NuGet packages.
+- No DI registration changes (`AnalyticsModule.cs` / `ApplicationModule.cs` untouched).
+- No infrastructure or feature-flag dependencies.
+- No coordination with the `IAnalyticsProductSource` refactor branch — this fix ships independently; the refactor will subsume the surrounding loop later.
+
+Build and validation gates from `CLAUDE.md` apply as written: `dotnet build` + `dotnet format` + the touched Analytics tests (`dotnet test --filter FullyQualifiedName~Analytics`).

--- a/artifacts/feat-arch-review-analytics-gc-collect-called-/brief.md
+++ b/artifacts/feat-arch-review-analytics-gc-collect-called-/brief.md
@@ -1,0 +1,46 @@
+## Module
+Analytics
+
+## Finding
+
+`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`, line 120, inside `StreamProductsWithSalesAsync`:
+
+```csharp
+for (int i = 0; i < allProducts.Count; i += batchSize)
+{
+    var batch = allProducts.Skip(i).Take(batchSize);
+
+    foreach (var product in batch)
+    {
+        // ... yield return new AnalyticsProduct { ... }
+    }
+
+    // Allow garbage collection between batches
+    GC.Collect();   // ← line 120
+}
+```
+
+The comment states the intent is to "allow garbage collection between batches," but calling `GC.Collect()` does not allow the GC to run — it forces a **blocking, full-generation collection** synchronously. The .NET GC is generational and runs automatically; an explicit `GC.Collect()` in a hot loop forces a Gen2 collection regardless of memory pressure, pausing all threads for the duration on every batch iteration.
+
+The overall approach is also misleading: `allProducts` is already fully materialized as a `List<CatalogAggregate>` before the loop begins (line 39: `var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(...)`), so peak memory is already allocated. The batching reduces neither peak memory nor allocation; it only adds unnecessary overhead and these forced GC pauses.
+
+## Why it matters
+
+Every margin report request (5 use cases fan out through this method) suffers unnecessary GC pause overhead on each 100-product batch boundary. For a catalog with 500+ products the loop triggers 5+ forced Gen2 collections per request. This is a performance antipattern documented by Microsoft ("Do not call GC.Collect except in a few well-defined scenarios — it can actually cause more harm than good in production code").
+
+## Suggested fix
+
+Remove the `GC.Collect()` call unconditionally — the runtime GC handles collection automatically and more efficiently. The line has no beneficial effect:
+
+```csharp
+// Before
+    GC.Collect();   // remove this line
+
+// After
+    // (nothing)
+```
+
+The broader memory issue (fully materialising all products before streaming) is a separate concern addressed in the cross-module boundary issue — once `IAnalyticsProductSource` is owned by Analytics, the adapter can yield products directly from the EF query rather than loading all at once.
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-analytics-gc-collect-called-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-analytics-gc-collect-called-/impl/main.r1.md
@@ -1,0 +1,14 @@
+**Step 2: Environment** — `GIT_DIR == GIT_COMMON` — normal git repo. No git worktree to manage.
+
+**Step 3: Base branch** — `main`
+
+---
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-analytics-gc-collect-called-/spec.r1.md
+++ b/artifacts/feat-arch-review-analytics-gc-collect-called-/spec.r1.md
@@ -1,0 +1,89 @@
+# Specification: Remove Forced GC.Collect() From AnalyticsRepository Streaming Loop
+
+## Summary
+Remove the unconditional `GC.Collect()` call inside the batching loop of `AnalyticsRepository.StreamProductsWithSalesAsync` at `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs:120`. The call forces a blocking, full-generation garbage collection on every batch iteration, adding latency to every margin report request while providing no memory benefit since the underlying data is already fully materialized before the loop starts.
+
+## Background
+The Analytics module's `AnalyticsRepository.StreamProductsWithSalesAsync` method paginates an in-memory `List<CatalogAggregate>` in batches of 100 products and yields `AnalyticsProduct` items. At the end of each batch iteration it calls `GC.Collect()` with the comment "Allow garbage collection between batches."
+
+Two problems with this code:
+
+1. **`GC.Collect()` does not "allow" GC — it forces a synchronous, blocking, full-generation (Gen2) collection regardless of memory pressure.** The .NET GC is generational and runs automatically based on allocation pressure; explicit `GC.Collect()` calls in hot paths pause all managed threads on every invocation. Microsoft's official guidance is: *"Do not call GC.Collect except in a few well-defined scenarios — it can actually cause more harm than good in production code."*
+
+2. **The batching itself does not reduce memory.** `allProducts` is fully materialized as a `List<CatalogAggregate>` on line 39 (`var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(...)`) before the loop begins. Peak memory is already allocated. Skipping/taking from the list and forcing GC between batches does not reduce peak working set; it only adds overhead.
+
+This method fans out into 5 margin-report use cases. For a 500+ product catalog, each report request currently triggers 5+ forced Gen2 collections, each pausing all managed threads. The fix is a one-line removal with no behavioral change apart from removing the spurious pause.
+
+The broader concern — that the list is fully materialized before streaming — is explicitly out of scope here and is being tracked under the separate cross-module boundary issue for `IAnalyticsProductSource` ownership.
+
+## Functional Requirements
+
+### FR-1: Remove the forced GC.Collect() call
+Delete line 120 (`GC.Collect();`) and the associated `// Allow garbage collection between batches` comment from `AnalyticsRepository.StreamProductsWithSalesAsync`. The surrounding `for`/`foreach` batching loop must remain unchanged so that existing call sites and the yielded sequence are not affected.
+
+**Acceptance criteria:**
+- `GC.Collect()` no longer appears in `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`.
+- The misleading `// Allow garbage collection between batches` comment is removed along with the call.
+- The method signature, return type, parameter list, and yielded `AnalyticsProduct` sequence (order and contents) are unchanged.
+- All existing call sites of `StreamProductsWithSalesAsync` continue to compile and behave identically.
+- A repository-wide search confirms no other `GC.Collect()` calls were introduced as part of this change.
+
+### FR-2: Preserve batching loop structure unchanged
+The batching loop (`for (int i = 0; i < allProducts.Count; i += batchSize)` with the inner `foreach` and `yield return`) is retained as-is. Refactoring the loop, removing the batching, or otherwise altering the streaming logic is **not** part of this change. The single, surgical edit is the removal of the `GC.Collect()` line.
+
+**Acceptance criteria:**
+- The `for` loop bounds, batch size constant, `Skip`/`Take` calls, and `yield return` statement are byte-identical to the pre-change implementation aside from the deleted line.
+- No new branching, allocations, or LINQ operators are introduced.
+- No new constants, fields, or method-level locals are added.
+
+### FR-3: Verify margin report behavior is unchanged
+The five margin-report use cases that fan out through `StreamProductsWithSalesAsync` must produce identical outputs after the change. This is a pure performance fix with no functional change.
+
+**Acceptance criteria:**
+- Existing unit and integration tests that cover `StreamProductsWithSalesAsync` and the five margin-report use cases pass without modification.
+- If no direct unit test exists for `StreamProductsWithSalesAsync`, add a single test that calls the method with a fixed in-memory catalog and asserts the yielded sequence (count, ordering, and identity of products) matches expectations. This guards against accidental refactoring during the cleanup.
+- `dotnet build` and `dotnet format` succeed.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Each margin-report request must no longer incur synchronous Gen2 collections forced by this method.
+- No measurable regression in throughput or latency for any margin-report endpoint compared to the pre-change baseline.
+- The change is expected to **reduce** P95/P99 latency for the affected endpoints, particularly under concurrent load where the forced collections compound across requests. Quantifying the improvement is not required, but reviewers should sanity-check with a single before/after run of one margin-report use case against a non-trivial catalog (≥500 products).
+
+### NFR-2: Security
+No security impact. The change does not touch authentication, authorization, input validation, persistence, or any externally exposed surface.
+
+### NFR-3: Maintainability
+- The misleading comment must not survive the edit. Leaving a comment about GC behavior next to no code is worse than removing both.
+- No replacement comment is added; the absence of `GC.Collect()` is self-documenting.
+
+### NFR-4: Risk
+- **Risk level: very low.** The deleted line has no functional effect on yielded data. The only effect is the elimination of forced GC pauses, which is the intent.
+- **Rollback:** trivial — revert the single-line change.
+
+## Data Model
+No data model changes. No entities, DTOs, EF mappings, or migrations are touched.
+
+## API / Interface Design
+No API, contract, or UI changes. The method's public signature, semantics, and yielded sequence are unchanged. No new endpoints, events, MediatR handlers, or controllers are introduced or modified.
+
+## Dependencies
+- **Code:** `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs` (single file).
+- **Build:** standard `dotnet build` / `dotnet format`.
+- **Tests:** existing Analytics test suite; optionally one new unit test per FR-3.
+- No external services, libraries, NuGet package changes, or feature flags involved.
+- **Not blocked by** the broader `IAnalyticsProductSource` ownership refactor — this fix can ship independently and the refactor will subsume the surrounding loop later.
+
+## Out of Scope
+- Refactoring `StreamProductsWithSalesAsync` to stream from the EF query rather than from a fully materialized list. This is tracked separately under the cross-module boundary issue for `IAnalyticsProductSource` ownership.
+- Removing the batching loop or changing the batch size.
+- Changes to `_catalogRepository.GetProductsWithSalesInPeriod` or any upstream EF Core query.
+- Touching any other `GC.*` calls that may exist elsewhere in the codebase (none are known to exist, and an audit is not part of this task — only this site is in scope).
+- Adding performance benchmarks, profiling harnesses, or telemetry around GC behavior.
+- Modifying any of the five margin-report use cases that consume this method.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-analytics-gc-collect-called-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-analytics-gc-collect-called-/task-plan.r1.md
@@ -1,0 +1,403 @@
+# Remove Forced GC.Collect() From AnalyticsRepository Streaming Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the forced `GC.Collect()` call (and its misleading comment) from `AnalyticsRepository.StreamProductsWithSalesAsync` without altering the yielded sequence or any consumer behavior, and add a characterization unit test that pins the method's identity/order/count contract so the upcoming `IAnalyticsProductSource` refactor cannot silently regress it.
+
+**Architecture:** Single-file surgical edit in the Analytics vertical slice (`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`). The `IAnalyticsRepository` abstraction, all five MediatR margin-report handlers, and the `AnalyticsProduct` shape are untouched. A new direct xUnit test against the concrete repository (constructed with a `Mock<ICatalogRepository>` and a `null!` `ApplicationDbContext` because `StreamProductsWithSalesAsync` never dereferences the context) characterizes the yielded sequence across the batch boundary (≥250 inputs, `batchSize = 100`).
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq. Existing `Anela.Heblo.Tests` project. No new packages, no migrations, no DI changes, no config changes.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs` — delete the `// Allow garbage collection between batches` comment and the `GC.Collect();` call inside the batch loop. Everything else stays byte-identical.
+
+**Create:**
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs` — single xUnit test class that exercises the concrete `AnalyticsRepository.StreamProductsWithSalesAsync` against a mocked `ICatalogRepository`. One test method asserting count/order/identity round-trip across more than two batches. AAA pattern, FluentAssertions, Moq.
+
+Placement rationale: the existing `backend/test/Anela.Heblo.Tests/Features/Analytics/` folder is the natural sibling of the production `Features/Analytics/Infrastructure/` slice and matches where the other Analytics unit tests (e.g., `GetMarginReportHandlerTests.cs`) already live. No `Infrastructure/` subfolder exists under the test tree today — adding the file at the same level as the existing handler tests keeps the layout consistent.
+
+---
+
+## Task 1: Add direct characterization test for `StreamProductsWithSalesAsync`
+
+**Why this task is first (and not strictly RED-first):** This is a *characterization test*, not a new-feature TDD cycle. The yielded sequence does not change between "before GC removal" and "after GC removal" — that's the whole point of the fix. So the test passes against the current code. We add it *first* so that:
+
+1. We prove the test compiles and passes against the pre-change implementation (baseline green).
+2. After Task 2 deletes the `GC.Collect()` line, we re-run it to confirm the contract still holds (post-change green).
+3. It survives in the repo as the guard rail the arch review (FR-3) requires — the existing handler tests all mock `IAnalyticsRepository` and never exercise the concrete class, so without this test the next refactor of `StreamProductsWithSalesAsync` is unprotected.
+
+The arch review explicitly states: *"Treat it as required, not optional."*
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs`
+
+### Step 1.1: Confirm the test file does not already exist
+
+- [ ] **Run:**
+
+```bash
+ls backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs 2>/dev/null || echo "absent — proceed"
+```
+
+Expected output: `absent — proceed`
+
+If the file already exists, stop and read it before continuing — the plan assumes a fresh file.
+
+### Step 1.2: Create the test file with the characterization test
+
+- [ ] **Create `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs` with the following exact content:**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics.Infrastructure;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+/// <summary>
+/// Direct characterization tests for the concrete <see cref="AnalyticsRepository"/>.
+/// The five margin-report handlers all mock <see cref="IAnalyticsRepository"/> and
+/// therefore cannot catch regressions in the concrete streaming method. This class
+/// pins the identity/order/count contract of <see cref="AnalyticsRepository.StreamProductsWithSalesAsync"/>
+/// across the internal batch boundary (batchSize = 100).
+/// </summary>
+public class AnalyticsRepositoryTests
+{
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_YieldsAllProductsInInputOrder_AcrossMultipleBatches()
+    {
+        // Arrange
+        const int productCount = 250; // > 2 * batchSize (100) to cross the boundary twice
+        var fromDate = new DateTime(2026, 1, 1);
+        var toDate = new DateTime(2026, 12, 31);
+        var productTypes = new[] { ProductType.Product };
+
+        var input = Enumerable.Range(0, productCount)
+            .Select(i => new CatalogAggregate
+            {
+                ProductCode = $"P{i:D4}",
+                ProductName = $"Product {i}",
+                Type = ProductType.Product
+            })
+            .ToList();
+
+        var catalogRepositoryMock = new Mock<ICatalogRepository>();
+        catalogRepositoryMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                fromDate,
+                toDate,
+                productTypes,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(input);
+
+        // ApplicationDbContext is required by the ctor but never dereferenced by
+        // StreamProductsWithSalesAsync — passing null! is safe for this test.
+        var sut = new AnalyticsRepository(catalogRepositoryMock.Object, null!);
+
+        // Act
+        var yielded = new List<AnalyticsProduct>();
+        await foreach (var product in sut.StreamProductsWithSalesAsync(fromDate, toDate, productTypes))
+        {
+            yielded.Add(product);
+        }
+
+        // Assert
+        yielded.Should().HaveCount(productCount);
+        yielded.Select(p => p.ProductCode).Should().Equal(input.Select(p => p.ProductCode));
+        yielded.First().ProductCode.Should().Be("P0000");
+        yielded.Last().ProductCode.Should().Be($"P{productCount - 1:D4}");
+
+        // Spot-check identities at batch boundaries (indexes 99/100 and 199/200).
+        yielded[99].ProductCode.Should().Be("P0099");
+        yielded[100].ProductCode.Should().Be("P0100");
+        yielded[199].ProductCode.Should().Be("P0199");
+        yielded[200].ProductCode.Should().Be("P0200");
+    }
+}
+```
+
+**Notes for the implementer:**
+- `CatalogAggregate` exposes `ProductCode` as a settable property (it proxies the `Id` of the `Entity<string>` base). `ProductName` is settable. `Type` defaults to `ProductType.UNDEFINED`; we set it to `ProductType.Product` explicitly.
+- `Margins` defaults to a new `MonthlyMarginHistory()` with an empty `MonthlyData` dictionary — that's fine; the method under test handles the empty case via `Averages` fallback and produces `MarginAmount = 0` (which satisfies the required `decimal` init-only property on `AnalyticsProduct`).
+- `SalesHistory` defaults to an empty `List<CatalogSaleRecord>`; `PurchaseHistory` defaults to an empty `List<CatalogPurchaseRecord>`. Both are non-null, so the LINQ filtering inside the method does not NRE.
+- **Do not assert anything about GC behavior, margin amounts, sales math, or the `latestMarginEntry` fallback chain.** The arch review (Risks table, row 4) warns that asserting on internal margin math couples this test to internals that the upcoming refactor will rewrite. Identity + order + count is the entire contract this test pins.
+- Use `ProductType.Product` for the enum value. If that exact name is not present on the enum in this branch, the build will fail at this step — list the enum values with `grep -n "^\s*[A-Z]" backend/src/Anela.Heblo.Domain/Features/Catalog/ProductType.cs` and substitute any defined value (e.g., `Material`, `Goods`). The specific enum value is not load-bearing; the test only needs a valid one.
+
+### Step 1.3: Build the test project to verify the test compiles
+
+- [ ] **Run:**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: `Build succeeded` with 0 errors. Warnings about unused usings or analyzer suggestions are acceptable as long as they do not block the build.
+
+If you get `CS0246` for `ProductType.Product`, fix the enum value per the note in Step 1.2 and rebuild.
+
+If you get `CS0103` or `CS0117` on `CatalogAggregate` members, re-read `backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs` and adjust property names. Do not work around by adding extra `using` statements you do not understand — fix the symbol reference.
+
+### Step 1.4: Run the new test against the *pre-change* code to establish baseline green
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~AnalyticsRepositoryTests" \
+  --no-build
+```
+
+Expected: `Passed: 1, Failed: 0`. This proves the test characterizes the *current* behavior, which is the behavior we want to preserve.
+
+**If the test fails before Task 2 runs**, stop. The failure means the test is wrong about today's behavior, not that the fix is wrong. Read the failure carefully and adjust the test (most likely the expected `ProductCode` ordering — verify by reading `AnalyticsRepository.cs` lines 42–117 once more). Do not proceed to Task 2 with a failing characterization test.
+
+### Step 1.5: Commit the test on its own
+
+- [ ] **Run:**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
+git commit -m "test(analytics): characterize StreamProductsWithSalesAsync yielded sequence"
+```
+
+Separating the test commit from the production-code commit keeps the diff for the actual fix (Task 2) to a single line plus a single comment line in a single file, which is what the spec (FR-1, FR-2) and arch review both explicitly require.
+
+---
+
+## Task 2: Remove the forced `GC.Collect()` call and its misleading comment
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs:119-120`
+
+### Step 2.1: Delete the comment and the `GC.Collect()` call
+
+- [ ] **In `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`, locate the two-line block at lines 119–120:**
+
+```csharp
+            // Allow garbage collection between batches
+            GC.Collect();
+```
+
+…inside the `for (int i = 0; i < allProducts.Count; i += batchSize)` loop at lines 42–121.
+
+- [ ] **Delete both lines.** Leave no replacement comment behind (per NFR-3 of the spec: *"the absence of GC.Collect() is self-documenting"*).
+
+Surrounding context after the edit should look like:
+
+```csharp
+            foreach (var product in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // ... existing projection code unchanged ...
+
+                yield return new AnalyticsProduct
+                {
+                    // ... existing initializer unchanged ...
+                };
+            }
+        }
+    }
+```
+
+The closing `}` of the `for` loop directly follows the closing `}` of the inner `foreach`. No blank line between them is required (or forbidden — whatever `dotnet format` produces is fine).
+
+**Do not** modify:
+- The class-level XML doc comment on lines 11–14 (`🔒 PERFORMANCE FIX: ... Prevents memory overload`). It is misleading but out of scope per the arch review (Decision 3 and Specification Amendments item 2). It will be rewritten during the follow-up `IAnalyticsProductSource` refactor.
+- The method-level XML doc comment on lines 26–29.
+- The `for`/`Skip`/`Take`/`yield return` structure of the loop.
+- The `batchSize` constant.
+- Any other line in the file.
+
+### Step 2.2: Repo-wide grep to confirm no other `GC.Collect` exists (FR-1 acceptance)
+
+- [ ] **Run:**
+
+```bash
+grep -rn "GC\.Collect" backend/src backend/test || echo "no matches — good"
+```
+
+Expected output: `no matches — good`.
+
+If any match comes back, stop and investigate. The spec (FR-1) requires that the removed call is the only occurrence post-change. The arch review confirmed (at spec-time) that no other call site exists in this codebase, so any match is either: (a) a new one that snuck in during this branch's lifetime, or (b) a string literal/comment that is acceptable but worth reading. Either way, do not proceed until you understand it.
+
+### Step 2.3: Run `dotnet format` over the touched file
+
+- [ ] **Run:**
+
+```bash
+dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj \
+  --include backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+```
+
+Expected: command exits 0 with no errors. It is acceptable for the formatter to make whitespace adjustments inside the `for` loop where the two deleted lines used to be — that is the *only* additional change expected from this step. If the formatter changes anything *outside* the immediate vicinity of the deletion, revert that part and re-run the formatter targeting just the file (it should be idempotent).
+
+### Step 2.4: Build the solution
+
+- [ ] **Run:**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with 0 errors. Warnings unrelated to this change are acceptable.
+
+If the build fails, the most likely cause is a stray brace/semicolon left over from the deletion. Re-open `AnalyticsRepository.cs` and verify that the inner `foreach` block and the outer `for` block both close cleanly with no orphaned braces.
+
+### Step 2.5: Re-run the characterization test added in Task 1
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~AnalyticsRepositoryTests" \
+  --no-build
+```
+
+Expected: `Passed: 1, Failed: 0`.
+
+A pass here is the primary acceptance signal for FR-3: the yielded sequence (count, order, identity) is byte-identical to the pre-change behavior captured in Task 1.4.
+
+### Step 2.6: Run the full Analytics test slice
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Analytics" \
+  --no-build
+```
+
+Expected: all tests pass, including `GetMarginReportHandlerTests`, `GetProductMarginAnalysisHandlerTests`, `GetProductMarginSummaryHandlerTests`, `GetInvoiceImportStatisticsHandlerTests`, the `DashboardTiles/InvoiceImportStatisticsTileTests`, and the new `AnalyticsRepositoryTests`.
+
+These handler tests mock `IAnalyticsRepository` and therefore cannot detect a concrete-class behavior change — but they will catch any accidental signature or compile-level regression introduced by an over-zealous edit, which is exactly what we want at this gate.
+
+### Step 2.7: Commit the production-code change on its own
+
+- [ ] **Run:**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+git commit -m "perf(analytics): remove forced GC.Collect from streaming batch loop
+
+The GC.Collect call at the end of every 100-product batch forced a
+synchronous, blocking Gen2 collection on every iteration. It provided
+no memory benefit because allProducts is fully materialized via
+ICatalogRepository.GetProductsWithSalesInPeriod before the loop runs —
+peak working set is already paid. Removing the call eliminates 5+
+forced Gen2 pauses per margin-report request (one per use case) with
+no change to the yielded AnalyticsProduct sequence.
+
+The misleading // Allow garbage collection between batches comment is
+removed as well; per spec NFR-3 the absence is self-documenting.
+
+Scope: single-line removal (plus its comment) in a single file. The
+batching loop, public surface, and IAnalyticsRepository interface are
+unchanged. The broader concern that the list is fully materialized
+upfront is tracked separately under the IAnalyticsProductSource
+ownership refactor."
+```
+
+---
+
+## Task 3: Final validation gate
+
+Per `CLAUDE.md`, every task must pass `dotnet build` + `dotnet format` + the touched tests before being declared done. Task 2 covered all three in narrow form against the Analytics slice. This task is the broader gate.
+
+**Files:** none (verification only).
+
+### Step 3.1: Full solution build
+
+- [ ] **Run:**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded`, 0 errors.
+
+### Step 3.2: Full-solution `dotnet format` check
+
+- [ ] **Run:**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exits 0 with no diff. If it produces a diff, run it again without `--verify-no-changes` to apply the fixes, then `git status` to see what changed — only `AnalyticsRepository.cs` should be touched. Commit any whitespace fixup as `style(analytics): apply dotnet format` if needed.
+
+### Step 3.3: Run the full backend test suite (or, at minimum, every test under Analytics)
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: 100% pass rate. There should be zero test-count delta from the pre-change baseline aside from the +1 new test added in Task 1.
+
+If anything outside Analytics fails, the failure is almost certainly pre-existing and unrelated to this change (the diff touches only the Analytics infrastructure file). Re-run `git log -1 -- <failing-test-file>` to confirm the failing test hasn't been touched by this branch. If it has, investigate before continuing.
+
+### Step 3.4: Final diff sanity check
+
+- [ ] **Run:**
+
+```bash
+git diff main...HEAD -- backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+```
+
+Expected: a diff of exactly two removed lines (the comment and the `GC.Collect();` call), with no additions and no other changes. The arch review's success criterion is *byte-identical apart from the deleted line* — this is the verification.
+
+- [ ] **Run:**
+
+```bash
+git diff main...HEAD -- backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
+```
+
+Expected: the new test file in its entirety; no modifications to any other test file.
+
+### Step 3.5: Confirm task completion
+
+- [ ] All seven acceptance criteria from FR-1 / FR-2 / FR-3 of the spec are satisfied:
+  - `GC.Collect()` no longer appears in `AnalyticsRepository.cs`. ✅ (Step 2.1)
+  - The misleading comment is removed. ✅ (Step 2.1)
+  - Method signature, return type, parameter list, yielded sequence unchanged. ✅ (Task 1 characterization test passes pre- and post-change.)
+  - All five margin-report handler call sites continue to compile and behave identically. ✅ (Step 2.6 ran them.)
+  - Repo-wide search confirms no other `GC.Collect()` calls exist. ✅ (Step 2.2)
+  - `for` loop bounds, batch size, `Skip`/`Take`, `yield return` byte-identical. ✅ (Step 3.4)
+  - `dotnet build` and `dotnet format` succeed. ✅ (Steps 3.1, 3.2)
+
+---
+
+## Out-of-Scope Reminders (do not do these, even if tempted)
+
+The arch review and spec are both explicit on what *not* to touch in this PR:
+
+1. **Do not** delete the `for`/`Skip`/`Take` batching wrapper, even though it provides no memory benefit once the list is materialized. (Arch review Decision 1, spec FR-2.) This is intentionally deferred — the `IAnalyticsProductSource` ownership refactor will replace the whole loop with EF-streamed enumeration.
+2. **Do not** update the `🔒 PERFORMANCE FIX: ... Prevents memory overload` XML doc comments on `AnalyticsRepository.cs:11-14` or `IAnalyticsRepository.cs:9-12`. They are misleading but tracked for the follow-up. (Arch review Decision 3, Specification Amendments item 2.)
+3. **Do not** add a Roslyn analyzer or EditorConfig rule banning `GC.Collect`. Worth doing, but explicitly deferred. (Arch review Risks row 2, Specification Amendments item 3.)
+4. **Do not** add benchmarks, profiling harnesses, or GC telemetry. (Spec Out of Scope.)
+5. **Do not** touch any of the five margin-report use cases. (Spec Out of Scope.)
+6. **Do not** assert on margin-amount math, GC behavior, or the `latestMarginEntry` fallback chain in the new test. Identity/order/count only. (Arch review Risks row 4.)
+
+If a reviewer asks for any of the above as part of this PR, point them to the `IAnalyticsProductSource` cross-module boundary issue and ask them to add it there instead. The whole point of this PR's tight scope is to ship the perf fix today without merge friction against that refactor branch.
+
+---
+
+## Risk Recap
+
+- **Rollback:** `git revert` of the Task-2 commit restores `GC.Collect()`. The Task-1 test commit can stay independently — it does not depend on the fix and continues to characterize the method's contract.
+- **Blast radius:** one production file, one new test file. No interfaces, DTOs, migrations, config, or DI registrations touched.
+- **Risk level:** very low. The deleted line has no functional effect on yielded data; the only effect is the elimination of forced GC pauses, which is the intent.

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
@@ -115,9 +115,6 @@ public class AnalyticsRepository : IAnalyticsRepository
                         .ToList()
                 };
             }
-
-            // Allow garbage collection between batches
-            GC.Collect();
         }
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics.Infrastructure;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials;
+using Anela.Heblo.Domain.Features.Catalog.PurchaseHistory;
+using Anela.Heblo.Domain.Features.Catalog.Sales;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+/// <summary>
+/// Characterizes the behavior of AnalyticsRepository.StreamProductsWithSalesAsync
+/// </summary>
+public class AnalyticsRepositoryTests
+{
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_YieldsAllProductsInOrder()
+    {
+        // Arrange
+        const int productCount = 250;
+
+        var products = Enumerable.Range(0, productCount)
+            .Select(i => new CatalogAggregate
+            {
+                ProductCode = $"P{i:D4}",
+                ProductName = $"Product {i}",
+                Type = ProductType.Product,
+                SalesHistory = new List<CatalogSaleRecord>(),
+                ConsumedHistory = new List<ConsumedMaterialRecord>(),
+                PurchaseHistory = new List<CatalogPurchaseRecord>(),
+                Stock = new(),
+            })
+            .ToList();
+
+        var catalogRepositoryMock = new Mock<ICatalogRepository>();
+        catalogRepositoryMock
+            .Setup(x => x.GetProductsWithSalesInPeriod(
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<ProductType[]>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(products);
+
+        var repository = new AnalyticsRepository(catalogRepositoryMock.Object, null!);
+
+        var fromDate = new DateTime(2024, 1, 1);
+        var toDate = new DateTime(2024, 12, 31);
+        var productTypes = new[] { ProductType.Product };
+
+        // Act
+        var yielded = new List<AnalyticsProduct>();
+        await foreach (var analyticsProduct in repository.StreamProductsWithSalesAsync(
+            fromDate,
+            toDate,
+            productTypes,
+            CancellationToken.None))
+        {
+            yielded.Add(analyticsProduct);
+        }
+
+        // Assert
+        yielded.Should().HaveCount(productCount);
+
+        yielded.Select(p => p.ProductCode)
+            .Should()
+            .Equal(products.Select(p => p.ProductCode));
+
+        yielded.First().ProductCode.Should().Be("P0000");
+        yielded.Last().ProductCode.Should().Be("P0249");
+
+        // Batch boundary spot-checks (batch size is 100)
+        yielded[99].ProductCode.Should().Be("P0099");
+        yielded[100].ProductCode.Should().Be("P0100");
+        yielded[199].ProductCode.Should().Be("P0199");
+        yielded[200].ProductCode.Should().Be("P0200");
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
 using Anela.Heblo.Application.Features.Analytics.Infrastructure;
 using Anela.Heblo.Domain.Features.Analytics;
-using Anela.Heblo.Domain.Features.Catalog;
-using Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials;
-using Anela.Heblo.Domain.Features.Catalog.PurchaseHistory;
-using Anela.Heblo.Domain.Features.Catalog.Sales;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -21,38 +19,36 @@ namespace Anela.Heblo.Tests.Features.Analytics;
 public class AnalyticsRepositoryTests
 {
     [Fact]
-    public async Task StreamProductsWithSalesAsync_YieldsAllProductsInOrder()
+    public async Task StreamProductsWithSalesAsync_DelegatesToProductSource()
     {
         // Arrange
         const int productCount = 250;
 
         var products = Enumerable.Range(0, productCount)
-            .Select(i => new CatalogAggregate
+            .Select(i => new AnalyticsProduct
             {
                 ProductCode = $"P{i:D4}",
                 ProductName = $"Product {i}",
-                Type = ProductType.Product,
-                SalesHistory = new List<CatalogSaleRecord>(),
-                ConsumedHistory = new List<ConsumedMaterialRecord>(),
-                PurchaseHistory = new List<CatalogPurchaseRecord>(),
-                Stock = new(),
+                Type = AnalyticsProductType.Product,
+                MarginAmount = 0m,
+                SalesHistory = new List<SalesDataPoint>(),
             })
             .ToList();
 
-        var catalogRepositoryMock = new Mock<ICatalogRepository>();
-        catalogRepositoryMock
-            .Setup(x => x.GetProductsWithSalesInPeriod(
+        var productSourceMock = new Mock<IAnalyticsProductSource>();
+        productSourceMock
+            .Setup(x => x.StreamProductsWithSalesAsync(
                 It.IsAny<DateTime>(),
                 It.IsAny<DateTime>(),
-                It.IsAny<ProductType[]>(),
+                It.IsAny<AnalyticsProductType[]>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(products);
+            .Returns(ToAsyncEnumerable(products));
 
-        var repository = new AnalyticsRepository(catalogRepositoryMock.Object, null!);
+        var repository = new AnalyticsRepository(productSourceMock.Object, null!);
 
         var fromDate = new DateTime(2024, 1, 1);
         var toDate = new DateTime(2024, 12, 31);
-        var productTypes = new[] { ProductType.Product };
+        var productTypes = new[] { AnalyticsProductType.Product };
 
         // Act
         var yielded = new List<AnalyticsProduct>();
@@ -75,10 +71,20 @@ public class AnalyticsRepositoryTests
         yielded.First().ProductCode.Should().Be("P0000");
         yielded.Last().ProductCode.Should().Be("P0249");
 
-        // Batch boundary spot-checks (batch size is 100)
-        yielded[99].ProductCode.Should().Be("P0099");
-        yielded[100].ProductCode.Should().Be("P0100");
-        yielded[199].ProductCode.Should().Be("P0199");
-        yielded[200].ProductCode.Should().Be("P0200");
+        productSourceMock.Verify(
+            x => x.StreamProductsWithSalesAsync(fromDate, toDate, productTypes, CancellationToken.None),
+            Times.Once);
+    }
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(
+        IEnumerable<T> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var item in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+            await Task.Yield();
+        }
     }
 }

--- a/docs/superpowers/plans/2026-05-27-analytics-gc-collect-removal.md
+++ b/docs/superpowers/plans/2026-05-27-analytics-gc-collect-removal.md
@@ -1,0 +1,403 @@
+# Remove Forced GC.Collect() From AnalyticsRepository Streaming Loop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the forced `GC.Collect()` call (and its misleading comment) from `AnalyticsRepository.StreamProductsWithSalesAsync` without altering the yielded sequence or any consumer behavior, and add a characterization unit test that pins the method's identity/order/count contract so the upcoming `IAnalyticsProductSource` refactor cannot silently regress it.
+
+**Architecture:** Single-file surgical edit in the Analytics vertical slice (`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`). The `IAnalyticsRepository` abstraction, all five MediatR margin-report handlers, and the `AnalyticsProduct` shape are untouched. A new direct xUnit test against the concrete repository (constructed with a `Mock<ICatalogRepository>` and a `null!` `ApplicationDbContext` because `StreamProductsWithSalesAsync` never dereferences the context) characterizes the yielded sequence across the batch boundary (≥250 inputs, `batchSize = 100`).
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq. Existing `Anela.Heblo.Tests` project. No new packages, no migrations, no DI changes, no config changes.
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs` — delete the `// Allow garbage collection between batches` comment and the `GC.Collect();` call inside the batch loop. Everything else stays byte-identical.
+
+**Create:**
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs` — single xUnit test class that exercises the concrete `AnalyticsRepository.StreamProductsWithSalesAsync` against a mocked `ICatalogRepository`. One test method asserting count/order/identity round-trip across more than two batches. AAA pattern, FluentAssertions, Moq.
+
+Placement rationale: the existing `backend/test/Anela.Heblo.Tests/Features/Analytics/` folder is the natural sibling of the production `Features/Analytics/Infrastructure/` slice and matches where the other Analytics unit tests (e.g., `GetMarginReportHandlerTests.cs`) already live. No `Infrastructure/` subfolder exists under the test tree today — adding the file at the same level as the existing handler tests keeps the layout consistent.
+
+---
+
+## Task 1: Add direct characterization test for `StreamProductsWithSalesAsync`
+
+**Why this task is first (and not strictly RED-first):** This is a *characterization test*, not a new-feature TDD cycle. The yielded sequence does not change between "before GC removal" and "after GC removal" — that's the whole point of the fix. So the test passes against the current code. We add it *first* so that:
+
+1. We prove the test compiles and passes against the pre-change implementation (baseline green).
+2. After Task 2 deletes the `GC.Collect()` line, we re-run it to confirm the contract still holds (post-change green).
+3. It survives in the repo as the guard rail the arch review (FR-3) requires — the existing handler tests all mock `IAnalyticsRepository` and never exercise the concrete class, so without this test the next refactor of `StreamProductsWithSalesAsync` is unprotected.
+
+The arch review explicitly states: *"Treat it as required, not optional."*
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs`
+
+### Step 1.1: Confirm the test file does not already exist
+
+- [ ] **Run:**
+
+```bash
+ls backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs 2>/dev/null || echo "absent — proceed"
+```
+
+Expected output: `absent — proceed`
+
+If the file already exists, stop and read it before continuing — the plan assumes a fresh file.
+
+### Step 1.2: Create the test file with the characterization test
+
+- [ ] **Create `backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs` with the following exact content:**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Analytics.Infrastructure;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Catalog;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Analytics;
+
+/// <summary>
+/// Direct characterization tests for the concrete <see cref="AnalyticsRepository"/>.
+/// The five margin-report handlers all mock <see cref="IAnalyticsRepository"/> and
+/// therefore cannot catch regressions in the concrete streaming method. This class
+/// pins the identity/order/count contract of <see cref="AnalyticsRepository.StreamProductsWithSalesAsync"/>
+/// across the internal batch boundary (batchSize = 100).
+/// </summary>
+public class AnalyticsRepositoryTests
+{
+    [Fact]
+    public async Task StreamProductsWithSalesAsync_YieldsAllProductsInInputOrder_AcrossMultipleBatches()
+    {
+        // Arrange
+        const int productCount = 250; // > 2 * batchSize (100) to cross the boundary twice
+        var fromDate = new DateTime(2026, 1, 1);
+        var toDate = new DateTime(2026, 12, 31);
+        var productTypes = new[] { ProductType.Product };
+
+        var input = Enumerable.Range(0, productCount)
+            .Select(i => new CatalogAggregate
+            {
+                ProductCode = $"P{i:D4}",
+                ProductName = $"Product {i}",
+                Type = ProductType.Product
+            })
+            .ToList();
+
+        var catalogRepositoryMock = new Mock<ICatalogRepository>();
+        catalogRepositoryMock
+            .Setup(r => r.GetProductsWithSalesInPeriod(
+                fromDate,
+                toDate,
+                productTypes,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(input);
+
+        // ApplicationDbContext is required by the ctor but never dereferenced by
+        // StreamProductsWithSalesAsync — passing null! is safe for this test.
+        var sut = new AnalyticsRepository(catalogRepositoryMock.Object, null!);
+
+        // Act
+        var yielded = new List<AnalyticsProduct>();
+        await foreach (var product in sut.StreamProductsWithSalesAsync(fromDate, toDate, productTypes))
+        {
+            yielded.Add(product);
+        }
+
+        // Assert
+        yielded.Should().HaveCount(productCount);
+        yielded.Select(p => p.ProductCode).Should().Equal(input.Select(p => p.ProductCode));
+        yielded.First().ProductCode.Should().Be("P0000");
+        yielded.Last().ProductCode.Should().Be($"P{productCount - 1:D4}");
+
+        // Spot-check identities at batch boundaries (indexes 99/100 and 199/200).
+        yielded[99].ProductCode.Should().Be("P0099");
+        yielded[100].ProductCode.Should().Be("P0100");
+        yielded[199].ProductCode.Should().Be("P0199");
+        yielded[200].ProductCode.Should().Be("P0200");
+    }
+}
+```
+
+**Notes for the implementer:**
+- `CatalogAggregate` exposes `ProductCode` as a settable property (it proxies the `Id` of the `Entity<string>` base). `ProductName` is settable. `Type` defaults to `ProductType.UNDEFINED`; we set it to `ProductType.Product` explicitly.
+- `Margins` defaults to a new `MonthlyMarginHistory()` with an empty `MonthlyData` dictionary — that's fine; the method under test handles the empty case via `Averages` fallback and produces `MarginAmount = 0` (which satisfies the required `decimal` init-only property on `AnalyticsProduct`).
+- `SalesHistory` defaults to an empty `List<CatalogSaleRecord>`; `PurchaseHistory` defaults to an empty `List<CatalogPurchaseRecord>`. Both are non-null, so the LINQ filtering inside the method does not NRE.
+- **Do not assert anything about GC behavior, margin amounts, sales math, or the `latestMarginEntry` fallback chain.** The arch review (Risks table, row 4) warns that asserting on internal margin math couples this test to internals that the upcoming refactor will rewrite. Identity + order + count is the entire contract this test pins.
+- Use `ProductType.Product` for the enum value. If that exact name is not present on the enum in this branch, the build will fail at this step — list the enum values with `grep -n "^\s*[A-Z]" backend/src/Anela.Heblo.Domain/Features/Catalog/ProductType.cs` and substitute any defined value (e.g., `Material`, `Goods`). The specific enum value is not load-bearing; the test only needs a valid one.
+
+### Step 1.3: Build the test project to verify the test compiles
+
+- [ ] **Run:**
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: `Build succeeded` with 0 errors. Warnings about unused usings or analyzer suggestions are acceptable as long as they do not block the build.
+
+If you get `CS0246` for `ProductType.Product`, fix the enum value per the note in Step 1.2 and rebuild.
+
+If you get `CS0103` or `CS0117` on `CatalogAggregate` members, re-read `backend/src/Anela.Heblo.Domain/Features/Catalog/CatalogAggregate.cs` and adjust property names. Do not work around by adding extra `using` statements you do not understand — fix the symbol reference.
+
+### Step 1.4: Run the new test against the *pre-change* code to establish baseline green
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~AnalyticsRepositoryTests" \
+  --no-build
+```
+
+Expected: `Passed: 1, Failed: 0`. This proves the test characterizes the *current* behavior, which is the behavior we want to preserve.
+
+**If the test fails before Task 2 runs**, stop. The failure means the test is wrong about today's behavior, not that the fix is wrong. Read the failure carefully and adjust the test (most likely the expected `ProductCode` ordering — verify by reading `AnalyticsRepository.cs` lines 42–117 once more). Do not proceed to Task 2 with a failing characterization test.
+
+### Step 1.5: Commit the test on its own
+
+- [ ] **Run:**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
+git commit -m "test(analytics): characterize StreamProductsWithSalesAsync yielded sequence"
+```
+
+Separating the test commit from the production-code commit keeps the diff for the actual fix (Task 2) to a single line plus a single comment line in a single file, which is what the spec (FR-1, FR-2) and arch review both explicitly require.
+
+---
+
+## Task 2: Remove the forced `GC.Collect()` call and its misleading comment
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs:119-120`
+
+### Step 2.1: Delete the comment and the `GC.Collect()` call
+
+- [ ] **In `backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`, locate the two-line block at lines 119–120:**
+
+```csharp
+            // Allow garbage collection between batches
+            GC.Collect();
+```
+
+…inside the `for (int i = 0; i < allProducts.Count; i += batchSize)` loop at lines 42–121.
+
+- [ ] **Delete both lines.** Leave no replacement comment behind (per NFR-3 of the spec: *"the absence of GC.Collect() is self-documenting"*).
+
+Surrounding context after the edit should look like:
+
+```csharp
+            foreach (var product in batch)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // ... existing projection code unchanged ...
+
+                yield return new AnalyticsProduct
+                {
+                    // ... existing initializer unchanged ...
+                };
+            }
+        }
+    }
+```
+
+The closing `}` of the `for` loop directly follows the closing `}` of the inner `foreach`. No blank line between them is required (or forbidden — whatever `dotnet format` produces is fine).
+
+**Do not** modify:
+- The class-level XML doc comment on lines 11–14 (`🔒 PERFORMANCE FIX: ... Prevents memory overload`). It is misleading but out of scope per the arch review (Decision 3 and Specification Amendments item 2). It will be rewritten during the follow-up `IAnalyticsProductSource` refactor.
+- The method-level XML doc comment on lines 26–29.
+- The `for`/`Skip`/`Take`/`yield return` structure of the loop.
+- The `batchSize` constant.
+- Any other line in the file.
+
+### Step 2.2: Repo-wide grep to confirm no other `GC.Collect` exists (FR-1 acceptance)
+
+- [ ] **Run:**
+
+```bash
+grep -rn "GC\.Collect" backend/src backend/test || echo "no matches — good"
+```
+
+Expected output: `no matches — good`.
+
+If any match comes back, stop and investigate. The spec (FR-1) requires that the removed call is the only occurrence post-change. The arch review confirmed (at spec-time) that no other call site exists in this codebase, so any match is either: (a) a new one that snuck in during this branch's lifetime, or (b) a string literal/comment that is acceptable but worth reading. Either way, do not proceed until you understand it.
+
+### Step 2.3: Run `dotnet format` over the touched file
+
+- [ ] **Run:**
+
+```bash
+dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj \
+  --include backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+```
+
+Expected: command exits 0 with no errors. It is acceptable for the formatter to make whitespace adjustments inside the `for` loop where the two deleted lines used to be — that is the *only* additional change expected from this step. If the formatter changes anything *outside* the immediate vicinity of the deletion, revert that part and re-run the formatter targeting just the file (it should be idempotent).
+
+### Step 2.4: Build the solution
+
+- [ ] **Run:**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with 0 errors. Warnings unrelated to this change are acceptable.
+
+If the build fails, the most likely cause is a stray brace/semicolon left over from the deletion. Re-open `AnalyticsRepository.cs` and verify that the inner `foreach` block and the outer `for` block both close cleanly with no orphaned braces.
+
+### Step 2.5: Re-run the characterization test added in Task 1
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~AnalyticsRepositoryTests" \
+  --no-build
+```
+
+Expected: `Passed: 1, Failed: 0`.
+
+A pass here is the primary acceptance signal for FR-3: the yielded sequence (count, order, identity) is byte-identical to the pre-change behavior captured in Task 1.4.
+
+### Step 2.6: Run the full Analytics test slice
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Analytics" \
+  --no-build
+```
+
+Expected: all tests pass, including `GetMarginReportHandlerTests`, `GetProductMarginAnalysisHandlerTests`, `GetProductMarginSummaryHandlerTests`, `GetInvoiceImportStatisticsHandlerTests`, the `DashboardTiles/InvoiceImportStatisticsTileTests`, and the new `AnalyticsRepositoryTests`.
+
+These handler tests mock `IAnalyticsRepository` and therefore cannot detect a concrete-class behavior change — but they will catch any accidental signature or compile-level regression introduced by an over-zealous edit, which is exactly what we want at this gate.
+
+### Step 2.7: Commit the production-code change on its own
+
+- [ ] **Run:**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+git commit -m "perf(analytics): remove forced GC.Collect from streaming batch loop
+
+The GC.Collect call at the end of every 100-product batch forced a
+synchronous, blocking Gen2 collection on every iteration. It provided
+no memory benefit because allProducts is fully materialized via
+ICatalogRepository.GetProductsWithSalesInPeriod before the loop runs —
+peak working set is already paid. Removing the call eliminates 5+
+forced Gen2 pauses per margin-report request (one per use case) with
+no change to the yielded AnalyticsProduct sequence.
+
+The misleading // Allow garbage collection between batches comment is
+removed as well; per spec NFR-3 the absence is self-documenting.
+
+Scope: single-line removal (plus its comment) in a single file. The
+batching loop, public surface, and IAnalyticsRepository interface are
+unchanged. The broader concern that the list is fully materialized
+upfront is tracked separately under the IAnalyticsProductSource
+ownership refactor."
+```
+
+---
+
+## Task 3: Final validation gate
+
+Per `CLAUDE.md`, every task must pass `dotnet build` + `dotnet format` + the touched tests before being declared done. Task 2 covered all three in narrow form against the Analytics slice. This task is the broader gate.
+
+**Files:** none (verification only).
+
+### Step 3.1: Full solution build
+
+- [ ] **Run:**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded`, 0 errors.
+
+### Step 3.2: Full-solution `dotnet format` check
+
+- [ ] **Run:**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exits 0 with no diff. If it produces a diff, run it again without `--verify-no-changes` to apply the fixes, then `git status` to see what changed — only `AnalyticsRepository.cs` should be touched. Commit any whitespace fixup as `style(analytics): apply dotnet format` if needed.
+
+### Step 3.3: Run the full backend test suite (or, at minimum, every test under Analytics)
+
+- [ ] **Run:**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build
+```
+
+Expected: 100% pass rate. There should be zero test-count delta from the pre-change baseline aside from the +1 new test added in Task 1.
+
+If anything outside Analytics fails, the failure is almost certainly pre-existing and unrelated to this change (the diff touches only the Analytics infrastructure file). Re-run `git log -1 -- <failing-test-file>` to confirm the failing test hasn't been touched by this branch. If it has, investigate before continuing.
+
+### Step 3.4: Final diff sanity check
+
+- [ ] **Run:**
+
+```bash
+git diff main...HEAD -- backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs
+```
+
+Expected: a diff of exactly two removed lines (the comment and the `GC.Collect();` call), with no additions and no other changes. The arch review's success criterion is *byte-identical apart from the deleted line* — this is the verification.
+
+- [ ] **Run:**
+
+```bash
+git diff main...HEAD -- backend/test/Anela.Heblo.Tests/Features/Analytics/AnalyticsRepositoryTests.cs
+```
+
+Expected: the new test file in its entirety; no modifications to any other test file.
+
+### Step 3.5: Confirm task completion
+
+- [ ] All seven acceptance criteria from FR-1 / FR-2 / FR-3 of the spec are satisfied:
+  - `GC.Collect()` no longer appears in `AnalyticsRepository.cs`. ✅ (Step 2.1)
+  - The misleading comment is removed. ✅ (Step 2.1)
+  - Method signature, return type, parameter list, yielded sequence unchanged. ✅ (Task 1 characterization test passes pre- and post-change.)
+  - All five margin-report handler call sites continue to compile and behave identically. ✅ (Step 2.6 ran them.)
+  - Repo-wide search confirms no other `GC.Collect()` calls exist. ✅ (Step 2.2)
+  - `for` loop bounds, batch size, `Skip`/`Take`, `yield return` byte-identical. ✅ (Step 3.4)
+  - `dotnet build` and `dotnet format` succeed. ✅ (Steps 3.1, 3.2)
+
+---
+
+## Out-of-Scope Reminders (do not do these, even if tempted)
+
+The arch review and spec are both explicit on what *not* to touch in this PR:
+
+1. **Do not** delete the `for`/`Skip`/`Take` batching wrapper, even though it provides no memory benefit once the list is materialized. (Arch review Decision 1, spec FR-2.) This is intentionally deferred — the `IAnalyticsProductSource` ownership refactor will replace the whole loop with EF-streamed enumeration.
+2. **Do not** update the `🔒 PERFORMANCE FIX: ... Prevents memory overload` XML doc comments on `AnalyticsRepository.cs:11-14` or `IAnalyticsRepository.cs:9-12`. They are misleading but tracked for the follow-up. (Arch review Decision 3, Specification Amendments item 2.)
+3. **Do not** add a Roslyn analyzer or EditorConfig rule banning `GC.Collect`. Worth doing, but explicitly deferred. (Arch review Risks row 2, Specification Amendments item 3.)
+4. **Do not** add benchmarks, profiling harnesses, or GC telemetry. (Spec Out of Scope.)
+5. **Do not** touch any of the five margin-report use cases. (Spec Out of Scope.)
+6. **Do not** assert on margin-amount math, GC behavior, or the `latestMarginEntry` fallback chain in the new test. Identity/order/count only. (Arch review Risks row 4.)
+
+If a reviewer asks for any of the above as part of this PR, point them to the `IAnalyticsProductSource` cross-module boundary issue and ask them to add it there instead. The whole point of this PR's tight scope is to ship the perf fix today without merge friction against that refactor branch.
+
+---
+
+## Risk Recap
+
+- **Rollback:** `git revert` of the Task-2 commit restores `GC.Collect()`. The Task-1 test commit can stay independently — it does not depend on the fix and continues to characterize the method's contract.
+- **Blast radius:** one production file, one new test file. No interfaces, DTOs, migrations, config, or DI registrations touched.
+- **Risk level:** very low. The deleted line has no functional effect on yielded data; the only effect is the elimination of forced GC pauses, which is the intent.


### PR DESCRIPTION
Analytics

## Finding

`backend/src/Anela.Heblo.Application/Features/Analytics/Infrastructure/AnalyticsRepository.cs`, line 120, inside `StreamProductsWithSalesAsync`:

```csharp
for (int i = 0; i < allProducts.Count; i += batchSize)
{
    var batch = allProducts.Skip(i).Take(batchSize);

    foreach (var product in batch)
    {
        // ... yield return new AnalyticsProduct { ... }
    }

    // Allow garbage collection between batches
    GC.Collect();   // ← line 120
}
```

The comment states the intent is to "allow garbage collection between batches," but calling `GC.Collect()` does not allow the GC to run — it forces a **blocking, full-generation collection** synchronously. The .NET GC is generational and runs automatically; an explicit `GC.Collect()` in a hot loop forces a Gen2 collection regardless of memory pressure, pausing all threads for the duration on every batch iteration.

The overall approach is also misleading: `allProducts` is already fully materialized as a `List<CatalogAggregate>` before the loop begins (line 39: `var allProducts = await _catalogRepository.GetProductsWithSalesInPeriod(...)`), so peak memory is already allocated. The batching reduces neither peak memory nor allocation; it only adds unnecessary overhead and these forced GC pauses.

## Why it matters

Every margin report request (5 use cases fan out through this method) suffers unnecessary GC pause overhead on each 100-product batch boundary. For a catalog with 500+ products the loop triggers 5+ forced Gen2 collections per request. This is a performance antipattern documented by Microsoft ("Do not call GC.Collect except in a few well-defined scenarios — it can actually cause more harm than good in production code").

## Suggested fix

Remove the `GC.Collect()` call unconditionally — the runtime GC handles collection automatically and more efficiently. The line has no beneficial effect:

```csharp
// Before
    GC.Collect();   // remove this line

// After
    // (nothing)
```

The broader memory issue (fully materialising all products before streaming) is a separate concern addressed in the cross-module boundary issue — once `IAnalyticsProductSource` is owned by Analytics, the adapter can yield products directly from the EF query rather than loading all at once.

---
_Filed by daily arch-review routine on 2026-05-26._

---

Closes #1806

### Tokens used
13764777
