### PR TITLE
fix(batch-calculator): default to MMQ from Abra Flexi and rename result labels

### DIFF
--- a/frontend/src/components/pages/ManufactureBatchCalculator.tsx
+++ b/frontend/src/components/pages/ManufactureBatchCalculator.tsx
@@ -81,9 +81,11 @@ const ManufactureBatchCalculator: React.FC = () => {
             batchSizeToUse = parseFloat(urlBatchSize);
             setDesiredBatchSize(urlBatchSize);
           } else {
-            // Use original batch size from template
-            batchSizeToUse = templateData.originalBatchSize || 0;
-            setDesiredBatchSize(templateData.originalBatchSize?.toString() || "");
+            // Default to MMQ (Abra Flexi attribute) — backend returns it as newBatchSize
+            // when no DesiredBatchSize is sent. Fall back to BOM amount if MMQ is missing.
+            const defaultBatchSize = templateData.newBatchSize || templateData.originalBatchSize || 0;
+            batchSizeToUse = defaultBatchSize;
+            setDesiredBatchSize(defaultBatchSize ? defaultBatchSize.toString() : "");
           }
           
           // Automatically calculate with the determined batch size
@@ -170,8 +172,9 @@ const ManufactureBatchCalculator: React.FC = () => {
     setCalculationResult(null);
     setDesiredIngredientAmount("");
     setSelectedIngredientCode("");
-    // Reset desired batch size to original batch size from template
-    setDesiredBatchSize(template?.originalBatchSize?.toString() || "");
+    // Reset desired batch size to MMQ (newBatchSize) or fall back to BOM amount
+    const defaultBatchSize = template?.newBatchSize || template?.originalBatchSize || 0;
+    setDesiredBatchSize(defaultBatchSize ? defaultBatchSize.toString() : "");
   };
 
   const handleIngredientClick = (productCode: string, productName: string) => {
@@ -340,7 +343,7 @@ const ManufactureBatchCalculator: React.FC = () => {
                       className="bg-gray-500 text-white px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-600 flex items-center gap-2"
                     >
                       <RotateCcw className="h-4 w-4" />
-                      Reset
+                      MMQ{template?.newBatchSize ? ` - ${template.newBatchSize}` : ""}
                     </button>
                   </div>
                 </div>
@@ -490,7 +493,7 @@ const ManufactureBatchCalculator: React.FC = () => {
               {/* Prominent display of key metrics */}
               <div className="flex gap-4 text-right flex-1">
                 <div>
-                  <div className="text-xs text-gray-500 uppercase tracking-wide">Původní dávka</div>
+                  <div className="text-xs text-gray-500 uppercase tracking-wide">Dávka - Kusovník</div>
                   <div className="text-xl font-bold text-gray-700">
                     {calculationResult.originalBatchSize}g
                   </div>
@@ -499,7 +502,7 @@ const ManufactureBatchCalculator: React.FC = () => {
                   →
                 </div>
                 <div>
-                  <div className="text-xs text-gray-500 uppercase tracking-wide">Nová dávka</div>
+                  <div className="text-xs text-gray-500 uppercase tracking-wide">Výrobní dávka</div>
                   <div className="text-xl font-bold text-indigo-600">
                     {calculationResult.newBatchSize}g
                   </div>


### PR DESCRIPTION
## Summary
- Batch Size Calculator now pre-fills the desired batch size from the **MMQ** attribute (Abra Flexi) instead of the BOM kusovnik header amount, so products like `DEO004001M` default to **6840 g** rather than **5700 g**.
- Frontend reads `templateData.newBatchSize` (already returned by the backend when no `DesiredBatchSize` is sent) and falls back to `originalBatchSize` when MMQ is 0/missing.
- UX: result labels renamed to **"Dávka - Kusovník"** and **"Výrobní dávka"**; Reset button now displays the MMQ target value (e.g. `MMQ - 6840`).

## Test plan
- [ ] Open Batch Calculator, select `DEO004001M` → input pre-fills to **6840**, result shows `5700g → 6840g, faktor 1.200×`.
- [ ] Click **Reset** → input returns to MMQ value.
- [ ] Pick a product whose FlexiBee MMQ is empty/0 → falls back to BOM amount.
- [ ] Navigation via URL `?productCode=...&batchSize=...` still honours the URL value.