### PR TITLE
fix: exclude semiproducts from automatic manufacture store write

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Anela.Heblo.Domain.Features.Manufacture.Inventory;
@@ -12,6 +13,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
 {
     private readonly IManufactureOrderRepository _repository;
     private readonly IManufacturedProductInventoryRepository _inventoryRepository;
+    private readonly ICatalogRepository _catalogRepository;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<UpdateManufactureOrderStatusHandler> _logger;
     private readonly ICurrentUserService _currentUserService;
@@ -23,7 +25,8 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
         ILogger<UpdateManufactureOrderStatusHandler> logger,
         ICurrentUserService currentUserService,
         IConditionsReadingProvider conditionsProvider,
-        IManufacturedProductInventoryRepository inventoryRepository)
+        IManufacturedProductInventoryRepository inventoryRepository,
+        ICatalogRepository catalogRepository)
     {
         _repository = repository;
         _timeProvider = timeProvider;
@@ -31,6 +34,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
         _currentUserService = currentUserService;
         _conditionsProvider = conditionsProvider;
         _inventoryRepository = inventoryRepository;
+        _catalogRepository = catalogRepository;
     }
 
     public async Task<UpdateManufactureOrderStatusResponse> Handle(UpdateManufactureOrderStatusRequest request, CancellationToken cancellationToken)
@@ -172,8 +176,18 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
     {
         var timestamp = _timeProvider.GetUtcNow().DateTime;
 
-        var items = order.Products
+        var productsWithQuantity = order.Products
             .Where(p => p.ActualQuantity is > 0)
+            .ToList();
+
+        if (productsWithQuantity.Count == 0)
+            return;
+
+        var productCodes = productsWithQuantity.Select(p => p.ProductCode).ToList();
+        var catalogEntries = await _catalogRepository.GetByIdsAsync(productCodes, cancellationToken);
+
+        var items = productsWithQuantity
+            .Where(p => !catalogEntries.TryGetValue(p.ProductCode, out var entry) || entry.Type != ProductType.SemiProduct)
             .Select(p => new ManufacturedProductInventoryItem(
                 productCode: p.ProductCode,
                 productName: p.ProductName,

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
+using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Anela.Heblo.Domain.Features.Manufacture.Inventory;
@@ -13,6 +14,7 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
     private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
@@ -21,6 +23,7 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
     {
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _catalogRepositoryMock = new Mock<ICatalogRepository>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
         _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
@@ -36,6 +39,10 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
         _inventoryRepositoryMock
             .Setup(r => r.AddAsync(It.IsAny<ManufacturedProductInventoryItem>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ManufacturedProductInventoryItem item, CancellationToken _) => item);
+
+        _catalogRepositoryMock
+            .Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, CatalogAggregate>());
     }
 
     private UpdateManufactureOrderStatusHandler CreateHandler() =>
@@ -45,7 +52,8 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
             _loggerMock.Object,
             _currentUserServiceMock.Object,
             _conditionsProviderMock.Object,
-            _inventoryRepositoryMock.Object);
+            _inventoryRepositoryMock.Object,
+            _catalogRepositoryMock.Object);
 
     private ManufactureOrder CreateOrderInState(ManufactureOrderState state) =>
         new ManufactureOrder

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
 using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Manufacture.Conditions;
 using Anela.Heblo.Domain.Features.Manufacture.Inventory;
@@ -15,6 +16,7 @@ public class UpdateManufactureOrderStatusHandlerTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
+    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
     private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
@@ -29,9 +31,14 @@ public class UpdateManufactureOrderStatusHandlerTests
     {
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
+        _catalogRepositoryMock = new Mock<ICatalogRepository>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
+
+        _catalogRepositoryMock
+            .Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, CatalogAggregate>());
 
         _currentUserServiceMock
             .Setup(x => x.GetCurrentUser())
@@ -55,7 +62,8 @@ public class UpdateManufactureOrderStatusHandlerTests
             _loggerMock.Object,
             _currentUserServiceMock.Object,
             _conditionsProviderMock.Object,
-            _inventoryRepositoryMock.Object);
+            _inventoryRepositoryMock.Object,
+            _catalogRepositoryMock.Object);
     }
 
     [Fact]

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
@@ -645,6 +645,112 @@ public class UpdateManufactureOrderStatusHandlerTests
     }
 
     [Fact]
+    public async Task Handle_TransitionToCompleted_ExcludesSemiProductsFromInventory()
+    {
+        // Arrange
+        var order = CreateOrderInState(ManufactureOrderState.SemiProductManufactured);
+        order.Products = new List<ManufactureOrderProduct>
+        {
+            new ManufactureOrderProduct
+            {
+                ProductCode = "SEMI-001",
+                ProductName = "Semi Product",
+                ActualQuantity = 8m,
+                ManufactureOrderId = ValidOrderId
+            }
+        };
+
+        _catalogRepositoryMock
+            .Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, CatalogAggregate>
+            {
+                ["SEMI-001"] = new CatalogAggregate { ProductCode = "SEMI-001", Type = ProductType.SemiProduct }
+            });
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder o, CancellationToken _) => o);
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Completed
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        _inventoryRepositoryMock.Verify(
+            r => r.AddRangeAsync(It.IsAny<IEnumerable<ManufacturedProductInventoryItem>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_TransitionToCompleted_IncludesOnlyNonSemiProductsWhenMixed()
+    {
+        // Arrange
+        var order = CreateOrderInState(ManufactureOrderState.SemiProductManufactured);
+        order.Products = new List<ManufactureOrderProduct>
+        {
+            new ManufactureOrderProduct
+            {
+                ProductCode = "SEMI-001",
+                ProductName = "Semi Product",
+                ActualQuantity = 8m,
+                ManufactureOrderId = ValidOrderId
+            },
+            new ManufactureOrderProduct
+            {
+                ProductCode = "PROD-001",
+                ProductName = "Regular Product",
+                ActualQuantity = 5m,
+                ManufactureOrderId = ValidOrderId
+            }
+        };
+
+        _catalogRepositoryMock
+            .Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, CatalogAggregate>
+            {
+                ["SEMI-001"] = new CatalogAggregate { ProductCode = "SEMI-001", Type = ProductType.SemiProduct }
+            });
+
+        _repositoryMock
+            .Setup(x => x.GetOrderByIdAsync(ValidOrderId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(order);
+
+        _repositoryMock
+            .Setup(x => x.UpdateOrderAsync(It.IsAny<ManufactureOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ManufactureOrder o, CancellationToken _) => o);
+
+        var request = new UpdateManufactureOrderStatusRequest
+        {
+            Id = ValidOrderId,
+            NewState = ManufactureOrderState.Completed
+        };
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        _inventoryRepositoryMock.Verify(
+            r => r.AddRangeAsync(
+                It.Is<IEnumerable<ManufacturedProductInventoryItem>>(items =>
+                    items.Single().ProductCode == "PROD-001"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task Handle_TransitionFromCompleted_DoesNotTouchInventory()
     {
         // Arrange


### PR DESCRIPTION
When a manufacture order transitions to `Completed`, `WriteDownInventoryAsync` now bulk-fetches catalog product types and skips any `ManufactureOrderProduct` whose catalog type is `SemiProduct` before writing to the manufactured inventory (Sklad výroby). Products not found in the catalog are allowed through unchanged. Test mocks updated to pass the new `ICatalogRepository` dependency.