### PR TITLE
feat: Refactor GetProductMarginSummary Handler to Depend on Abstractions

### DIFF
--- a/artifacts/feat-arch-review-analytics-getproductmarginsu/arch-review.r1.md
+++ b/artifacts/feat-arch-review-analytics-getproductmarginsu/arch-review.r1.md
@@ -1,0 +1,214 @@
+# Architecture Review: Refactor GetProductMarginSummary Handler to Depend on Abstractions
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposal aligns cleanly with the codebase's established patterns. Verification of the actual code confirms:
+
+- **Clean Architecture violation is real.** `MarginCalculator` lives in `Anela.Heblo.Domain.Features.Analytics` (`backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs:1`). It contains no entity/value-object semantics — it is a stateless service that consumes `IAsyncEnumerable<AnalyticsProduct>` and produces a result DTO. It belongs in Application.
+- **Sibling pattern is well-established.** `IProductFilterService`/`ProductFilterService` and `IReportBuilderService`/`ReportBuilderService` both live in `backend/src/Anela.Heblo.Application/Features/Analytics/Services/` and are registered by interface in `AnalyticsModule.cs`. The proposed change brings `MarginCalculator` and `MonthlyBreakdownGenerator` into compliance with this pattern.
+- **One missing dependency edge in spec.** `MonthlyBreakdownGenerator` itself injects the concrete `MarginCalculator` (`MonthlyBreakdownGenerator.cs:13-18`). The spec's FR-4 says "no behavioural changes — only the implementation declaration is added," but once `MarginCalculator` is registered only by interface (FR-5), the existing concrete-constructor dependency in `MonthlyBreakdownGenerator` will fail to resolve at runtime unless its constructor is also updated to depend on `IMarginCalculator`. This is a required, not optional, change.
+- **Cross-module impact is zero.** A solution-wide search confirms only `GetProductMarginSummaryHandler`, `MonthlyBreakdownGenerator`, `AnalyticsModule`, and `GetProductMarginSummaryHandlerTests` reference the two classes. The unrelated `SafeMarginCalculator` / `IMarginCalculationService` in the Catalog feature are distinct and untouched.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Application
+└── Features/Analytics/
+    ├── Services/
+    │   ├── IMarginCalculator.cs            (NEW — interface + impl, single file)
+    │   ├── MarginCalculator.cs             (RELOCATED from Domain)
+    │   ├── IMonthlyBreakdownGenerator.cs   (NEW — interface + impl, single file)
+    │   └── MonthlyBreakdownGenerator.cs    (UPDATED: implements interface,
+    │                                                 depends on IMarginCalculator)
+    ├── UseCases/GetProductMarginSummary/
+    │   └── GetProductMarginSummaryHandler.cs
+    │       └── ctor(IAnalyticsRepository, IMarginCalculator, IMonthlyBreakdownGenerator)
+    └── AnalyticsModule.cs
+        └── services.AddScoped<IMarginCalculator, MarginCalculator>()
+        └── services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>()
+
+Anela.Heblo.Domain
+└── Features/Analytics/
+    ├── AnalyticsProduct.cs                 (unchanged — also defines MarginCalculationResult)
+    ├── AnalyticsProductType.cs             (unchanged)
+    └── ProductGroupingMode.cs              (unchanged)
+    [MarginCalculator.cs REMOVED]
+```
+
+`MarginCalculationResult` and `DateRange` remain in Domain. The Application interface returns a Domain-defined type — this is acceptable under Clean Architecture (Application depends on Domain).
+
+### Key Design Decisions
+
+#### Decision 1: Interface co-location vs. separate file
+**Options considered:**
+1. Spec's approach — interface in its own file (`IMarginCalculator.cs`) separate from `MarginCalculator.cs`.
+2. Match sibling convention — interface and implementation in the same file (`MarginCalculator.cs`), as `ProductFilterService.cs` and `ReportBuilderService.cs` already do.
+
+**Chosen approach:** Option 2. Place `IMarginCalculator` and `MarginCalculator` in the same file (`MarginCalculator.cs`); same for `IMonthlyBreakdownGenerator` and `MonthlyBreakdownGenerator`.
+
+**Rationale:** The two sibling services in the same `Services/` folder both use single-file co-location. The whole point of this refactor is to bring the two outlier classes in line with the established pattern — adopting a *different* file structure for them would re-create inconsistency in a refactor whose explicit goal is consistency. This is a spec amendment.
+
+#### Decision 2: Where `MarginCalculationResult` lives
+**Options considered:**
+1. Leave `MarginCalculationResult` in Domain (`AnalyticsProduct.cs:59`).
+2. Move it to Application alongside the relocated `MarginCalculator`.
+
+**Chosen approach:** Option 1 — leave it in Domain.
+
+**Rationale:** The spec annotates `MarginCalculationResult` as "(Application layer DTO)" but verification shows it currently lives in Domain. Moving it expands the refactor's blast radius and creates churn for an isolated structural goal. Application-layer code returning Domain-defined types is allowed under Clean Architecture. The spec's annotation is incorrect and should be amended (see Specification Amendments).
+
+#### Decision 3: `MonthlyBreakdownGenerator` constructor change
+**Options considered:**
+1. Leave `MonthlyBreakdownGenerator`'s constructor untouched (spec FR-4 as written).
+2. Update it to inject `IMarginCalculator` instead of the concrete `MarginCalculator`.
+
+**Chosen approach:** Option 2 — required, not optional.
+
+**Rationale:** Once `services.AddScoped<IMarginCalculator, MarginCalculator>()` replaces `services.AddScoped<MarginCalculator>()`, the concrete `MarginCalculator` is no longer in the DI container. `MonthlyBreakdownGenerator`'s current `ctor(MarginCalculator)` would fail to resolve at runtime. This is a correctness issue, not a style preference.
+
+#### Decision 4: Exact `CalculateAsync` signature on the interface
+**Options considered:** Preserve the existing signature verbatim, or trim.
+
+**Chosen approach:** Preserve verbatim:
+```csharp
+Task<MarginCalculationResult> CalculateAsync(
+    IAsyncEnumerable<AnalyticsProduct> products,
+    DateRange dateRange,
+    ProductGroupingMode groupingMode,
+    string marginLevel = "M2",
+    CancellationToken cancellationToken = default);
+```
+
+**Rationale:** The spec uses a placeholder. The handler's call site at `GetProductMarginSummaryHandler.cs:40` passes all five arguments; any divergence breaks compilation. Note: `dateRange` is unused inside `MarginCalculator.CalculateAsync` today — leave that alone; it's out of scope.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/Services/
+├── MarginCalculator.cs               (contains IMarginCalculator + MarginCalculator)
+├── MonthlyBreakdownGenerator.cs      (contains IMonthlyBreakdownGenerator + MonthlyBreakdownGenerator)
+├── ProductFilterService.cs           (unchanged — reference pattern)
+├── ReportBuilderService.cs           (unchanged — reference pattern)
+└── TimeWindowParser.cs               (unchanged)
+
+DELETE: backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs
+```
+
+### Interfaces and Contracts
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMarginCalculator
+{
+    Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default);
+
+    string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode);
+
+    string GetGroupDisplayName(
+        string groupKey,
+        ProductGroupingMode groupingMode,
+        List<AnalyticsProduct> products);
+
+    decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel);
+}
+
+public class MarginCalculator : IMarginCalculator { /* body unchanged */ }
+```
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs
+using System.Globalization;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMonthlyBreakdownGenerator
+{
+    List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult calculationResult,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2");
+}
+
+public class MonthlyBreakdownGenerator : IMonthlyBreakdownGenerator
+{
+    private readonly IMarginCalculator _marginCalculator;   // interface, not concrete
+
+    public MonthlyBreakdownGenerator(IMarginCalculator marginCalculator)
+    {
+        _marginCalculator = marginCalculator;
+    }
+    // remaining body unchanged
+}
+```
+
+`AnalyticsModule.cs` lines 36–38 replaced with:
+```csharp
+services.AddScoped<IMarginCalculator, MarginCalculator>();
+services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+Misleading "Legacy services" comment removed.
+
+### Data Flow
+Unchanged. The handler streams products from `IAnalyticsRepository`, hands them to `IMarginCalculator.CalculateAsync` (streaming aggregation), then `IMonthlyBreakdownGenerator.Generate` materializes the monthly view from the already-aggregated result. Both calls are now through abstractions; runtime behavior is identical.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `MonthlyBreakdownGenerator` constructor not updated → DI resolution failure at runtime | HIGH | Make the update explicit (Decision 3). Add a smoke test or integration test that resolves `IMonthlyBreakdownGenerator` from the container. |
+| `MarginCalculationResult` mis-located by spec annotation, leading implementer to move the type unnecessarily | MEDIUM | Spec amendment clarifies the type stays in Domain. |
+| Other callers of concrete classes outside the searched scope | LOW | Solution-wide grep performed: only the four expected sites match. FR-7 already covers this; PR description should confirm "no other callers found." |
+| Tests still construct concrete `new MarginCalculator()` / `new MonthlyBreakdownGenerator(...)` | LOW | Existing test in `GetProductMarginSummaryHandlerTests.cs:25-33` continues to compile (concrete class still exists, just relocated). New mockability test (FR-8) is additive. |
+| Service lifetime drift | LOW | Spec NFR mandates preserving `Scoped`. Both new registrations must use `AddScoped`. |
+| Domain assembly metadata change due to file removal (e.g., consumers reflecting over types) | LOW | No reflection-based consumers found; safe to remove. |
+
+## Specification Amendments
+
+1. **FR-2 wording — append**: `MonthlyBreakdownGenerator`'s constructor must be updated to depend on `IMarginCalculator` rather than the concrete `MarginCalculator`, because the concrete type will no longer be registered in DI after FR-5. This is required for correctness, not stylistic — treat it as part of FR-4 or as a new FR-4b. Add as acceptance criterion: "After the change, `MonthlyBreakdownGenerator` has no compile-time reference to the concrete `MarginCalculator` class."
+
+2. **FR-1/FR-2 file layout**: Change "Create a new interface `IMarginCalculator` in `…/IMarginCalculator.cs`" to "Define `IMarginCalculator` alongside the `MarginCalculator` implementation in `…/MarginCalculator.cs`" (and analogously for `IMonthlyBreakdownGenerator`). Rationale: matches the existing `ProductFilterService.cs` / `ReportBuilderService.cs` convention in the same folder.
+
+3. **FR-1 `CalculateAsync` signature**: Replace the placeholder `/* current parameter list preserved verbatim */` with the explicit signature:
+   ```csharp
+   Task<MarginCalculationResult> CalculateAsync(
+       IAsyncEnumerable<AnalyticsProduct> products,
+       DateRange dateRange,
+       ProductGroupingMode groupingMode,
+       string marginLevel = "M2",
+       CancellationToken cancellationToken = default);
+   ```
+
+4. **Data Model annotation correction**: `MarginCalculationResult` is currently defined in **Domain** (`backend/src/Anela.Heblo.Domain/Features/Analytics/AnalyticsProduct.cs:59`), not Application. The spec's "(Application layer DTO)" tag is incorrect. The refactor must **not** move this type — it stays in Domain. Update the Data Model section accordingly.
+
+5. **FR-3 acceptance criterion — strengthen**: Add "After deletion, `backend/src/Anela.Heblo.Domain/Features/Analytics/` contains only `AnalyticsProduct.cs`, `AnalyticsProductType.cs`, and `ProductGroupingMode.cs`." This makes the post-state explicit and verifiable.
+
+6. **FR-8 — be specific about the mockability test**: Add an acceptance criterion that the new test instantiates `GetProductMarginSummaryHandler` with `Mock<IMarginCalculator>` and `Mock<IMonthlyBreakdownGenerator>` (project uses Moq — confirmed via existing `GetProductMarginSummaryHandlerTests` imports) and asserts both mocks are invoked with the expected arguments for one representative request. Existing handler tests that use the real `MarginCalculator`/`MonthlyBreakdownGenerator` are fine to keep as-is — they become integration-style tests against the real services.
+
+## Prerequisites
+
+None. The refactor is self-contained:
+- No DB migration.
+- No config change.
+- No new NuGet packages.
+- No infrastructure or environment change.
+- The Domain project's existing references (used by the unchanged entities/enums) remain valid; nothing needs to be added to or removed from Domain's `.csproj`.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-analytics-getproductmarginsu/brief.md
+++ b/artifacts/feat-arch-review-analytics-getproductmarginsu/brief.md
@@ -1,0 +1,50 @@
+## Module
+Analytics
+
+## Finding
+
+`backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs:14–28`
+
+```csharp
+public class GetProductMarginSummaryHandler : IRequestHandler<...>
+{
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly MarginCalculator _marginCalculator;           // ← concrete class
+    private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;  // ← concrete class
+```
+
+`MarginCalculator` lives in the **Domain layer** (`Anela.Heblo.Domain.Features.Analytics.MarginCalculator`) while the handler is in the **Application layer** — the Application layer takes a direct dependency on a Domain layer concrete class with no interface. `MonthlyBreakdownGenerator` is in the Application layer itself but is also injected as a concrete type with no interface.
+
+Both are registered as concrete types in `AnalyticsModule.cs` (lines 37–38), labelled "Legacy services (keeping for backward compatibility)" — but they are the **active primary path** for every `GetProductMarginSummary` request; there is no newer replacement. The `IProductFilterService` and `IReportBuilderService` injected into the sibling handlers were extracted behind interfaces; `MarginCalculator` and `MonthlyBreakdownGenerator` were not.
+
+## Why it matters
+
+- **DIP**: The handler depends on concrete implementations, not abstractions. The Application layer's handler cannot be tested without constructing a real `MarginCalculator`.
+- **Inconsistency**: `IProductFilterService` and `IReportBuilderService` follow the correct interface pattern in the same module. `MarginCalculator` and `MonthlyBreakdownGenerator` are exceptions with no documented reason.
+- **Misleading label**: "Legacy services" implies they will be removed or replaced, but they are load-bearing. The comment creates confusion about whether this code path is intentional.
+
+## Suggested fix
+
+Extract interfaces for both classes in `Application/Features/Analytics/Services/`:
+
+```csharp
+public interface IMarginCalculator
+{
+    Task<MarginCalculationResult> CalculateAsync(...);
+    string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode);
+    string GetGroupDisplayName(string groupKey, ProductGroupingMode mode, List<AnalyticsProduct> products);
+    decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel);
+}
+
+public interface IMonthlyBreakdownGenerator
+{
+    List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult result, DateRange dateRange,
+        ProductGroupingMode groupingMode, string marginLevel = "M2");
+}
+```
+
+Register them behind their interfaces in `AnalyticsModule` and update the handler to inject `IMarginCalculator` and `IMonthlyBreakdownGenerator`. Remove the "Legacy services" comment, which is inaccurate. Move `MarginCalculator` from the Domain layer to the Application layer — it is an application-level calculator service with async streaming logic, not a domain entity or value object.
+
+---
+_Filed by daily arch-review routine on 2026-05-26._

--- a/artifacts/feat-arch-review-analytics-getproductmarginsu/impl/main.r1.md
+++ b/artifacts/feat-arch-review-analytics-getproductmarginsu/impl/main.r1.md
@@ -1,0 +1,88 @@
+All tasks complete. Final reviewer says **APPROVED_WITH_NOTES** — no CRITICAL or HIGH issues; medium findings are either pre-existing or intentional per spec. Now writing the output artifact.
+
+---
+
+# Implementation: Refactor GetProductMarginSummary Handler to Depend on Abstractions
+
+## What was implemented
+
+Pure structural refactor aligning the Analytics module with Clean Architecture and the established interface pattern used by sibling services (`IProductFilterService`, `IReportBuilderService`):
+
+1. **Relocated `MarginCalculator`** from `Anela.Heblo.Domain` to `Anela.Heblo.Application.Features.Analytics.Services`
+2. **Added `IMarginCalculator` interface** co-located in the same file (matches sibling convention)
+3. **Added `IMonthlyBreakdownGenerator` interface** co-located in `MonthlyBreakdownGenerator.cs`; updated its constructor to accept `IMarginCalculator` instead of the concrete type (required for DI correctness)
+4. **Updated DI registrations** in `AnalyticsModule.cs` to use interface-based `AddScoped<IInterface, Impl>()`, removed the misleading "Legacy services" comment
+5. **Updated `GetProductMarginSummaryHandler`** constructor and fields to inject `IMarginCalculator` and `IMonthlyBreakdownGenerator`
+6. **Added mockability test** demonstrating the handler is now testable in full isolation
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` — CREATED: contains `IMarginCalculator` interface + relocated `MarginCalculator` implementation
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs` — DELETED
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs` — MODIFIED: added `IMonthlyBreakdownGenerator` interface, updated constructor from `MarginCalculator` to `IMarginCalculator`
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — MODIFIED: interface-based DI registrations, misleading comment removed
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` — MODIFIED: field and constructor types changed to interfaces
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — MODIFIED: added `Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator` test
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — 6 tests total (5 original + 1 new mockability test using `Mock<IMarginCalculator>` and `Mock<IMonthlyBreakdownGenerator>` with `Times.Once` verification)
+- Full backend test suite: 4052 passed, 3 skipped, 0 failed
+
+## How to verify
+
+```bash
+cd /Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-analytics-getproductmarginsu
+
+# Build
+dotnet build backend/backend.sln
+
+# Format
+dotnet format backend/backend.sln --verify-no-changes
+
+# Handler tests (6)
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+
+# Full suite
+dotnet test backend/backend.sln
+
+# Domain folder (should have exactly 3 files)
+ls backend/src/Anela.Heblo.Domain/Features/Analytics/
+
+# Confirm no concrete-type injections remain
+grep -rn "MarginCalculator " backend/src backend/test \
+  | grep -vE "(IMarginCalculator|MarginCalculator\(|MarginCalculator\.cs|SafeMarginCalculator|IMarginCalculationService|MarginCalculationResult)"
+```
+
+## Notes
+
+**Intentional design decisions (per arch-review):**
+- Single-file co-location of interface + implementation matches the `ProductFilterService.cs` / `ReportBuilderService.cs` pattern in the same folder — this is consistent, not inconsistent.
+- `MarginCalculationResult` stays in Domain (not moved to Application) — Application returning Domain-defined types is allowed under Clean Architecture.
+
+**Pre-existing issues flagged by final reviewer (not introduced by this refactor, candidates for follow-up):**
+- `GetGroupKey` is duplicated in `AnalyticsRepository` (independent of this refactor)
+- `CalculateTotalMarginForLevel` in handler duplicates `GetMarginAmountForLevel` logic (pre-existing)
+- Existing test fixture typed as concrete `MarginCalculator` / `MonthlyBreakdownGenerator` rather than interfaces (now serves as integration-style coverage)
+
+**No other callers found:** Solution-wide search confirmed only the 4 expected sites reference `MarginCalculator` / `MonthlyBreakdownGenerator`. FR-7 satisfied.
+
+## PR Summary
+
+Extracts `IMarginCalculator` and `IMonthlyBreakdownGenerator` interfaces, relocates `MarginCalculator` from the Domain layer to Application, and switches `GetProductMarginSummaryHandler` (and `MonthlyBreakdownGenerator`) to depend on those abstractions. Aligns the two outlier services with the established pattern used by `IProductFilterService` and `IReportBuilderService` in the same `Services/` folder.
+
+The `MonthlyBreakdownGenerator` constructor was updated to accept `IMarginCalculator` (required for correctness — once `MarginCalculator` is registered only by interface, the concrete self-registration is gone and the old constructor would fail runtime DI resolution).
+
+No behavior change: same code paths, same DI lifetimes (Scoped), same HTTP API contract, same DTOs, no DB changes.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` — new file: `IMarginCalculator` interface + relocated implementation
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs` — deleted
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs` — `IMonthlyBreakdownGenerator` interface added; constructor type changed to `IMarginCalculator`
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — interface-based DI registrations; "Legacy services" comment removed
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` — field and constructor types changed to interfaces
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — mockability test added (6 tests total, all pass)
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-analytics-getproductmarginsu/spec.r1.md
+++ b/artifacts/feat-arch-review-analytics-getproductmarginsu/spec.r1.md
@@ -1,0 +1,187 @@
+# Specification: Refactor GetProductMarginSummary Handler to Depend on Abstractions
+
+## Summary
+Extract interfaces for `MarginCalculator` and `MonthlyBreakdownGenerator`, relocate `MarginCalculator` from the Domain layer to the Application layer, and update `GetProductMarginSummaryHandler` to depend on those interfaces. This aligns the handler with the Dependency Inversion Principle and the established interface pattern used by sibling services (`IProductFilterService`, `IReportBuilderService`) in the same module.
+
+## Background
+The `GetProductMarginSummaryHandler` (Application layer) currently injects two concrete classes:
+
+- `MarginCalculator` — located in the **Domain layer** (`Anela.Heblo.Domain.Features.Analytics.MarginCalculator`), violating Clean Architecture by having the Application layer depend on a concrete Domain class with no abstraction.
+- `MonthlyBreakdownGenerator` — located in the Application layer, also injected as a concrete type with no interface.
+
+Both are registered in `AnalyticsModule.cs` (lines 37–38) under a comment labelled "Legacy services (keeping for backward compatibility)". The comment is misleading: these services are the **active primary path** for every `GetProductMarginSummary` request and have no replacement. Sibling handlers in the same module already depend on `IProductFilterService` and `IReportBuilderService` via interfaces — the two services in question were simply missed during the prior extraction. The result is inconsistent abstractions across the Analytics module, untestable code paths, and incorrect documentation that creates confusion about the code's intent.
+
+## Functional Requirements
+
+### FR-1: Define `IMarginCalculator` Interface
+Create a new interface `IMarginCalculator` in `backend/src/Anela.Heblo.Application/Features/Analytics/Services/IMarginCalculator.cs` that exposes the full public surface currently consumed by `GetProductMarginSummaryHandler` and any other callers.
+
+**Acceptance criteria:**
+- Interface declares: `Task<MarginCalculationResult> CalculateAsync(...)`, `string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)`, `string GetGroupDisplayName(string groupKey, ProductGroupingMode mode, List<AnalyticsProduct> products)`, `decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel)`.
+- Signatures match the existing public methods of `MarginCalculator` exactly (parameter names, types, nullability, async patterns).
+- Interface lives under `Anela.Heblo.Application.Features.Analytics.Services` namespace.
+- All current public methods of `MarginCalculator` consumed by Application-layer code are represented; any methods only used internally remain off the interface.
+
+### FR-2: Define `IMonthlyBreakdownGenerator` Interface
+Create `IMonthlyBreakdownGenerator` in the same `Services/` folder.
+
+**Acceptance criteria:**
+- Interface declares: `List<MonthlyProductMarginDto> Generate(MarginCalculationResult result, DateRange dateRange, ProductGroupingMode groupingMode, string marginLevel = "M2")`.
+- Default parameter values preserved.
+- Lives under `Anela.Heblo.Application.Features.Analytics.Services` namespace.
+
+### FR-3: Relocate `MarginCalculator` to the Application Layer
+Move `MarginCalculator` from `Anela.Heblo.Domain.Features.Analytics` to `Anela.Heblo.Application.Features.Analytics.Services`.
+
+**Acceptance criteria:**
+- File physically moved to `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs`.
+- Namespace updated to `Anela.Heblo.Application.Features.Analytics.Services`.
+- Class implements `IMarginCalculator`.
+- All references to the old namespace are updated across the solution (handlers, tests, DI registrations).
+- The Domain project no longer contains `MarginCalculator`.
+- The Domain project's references and assembly remain unchanged otherwise; no Domain-layer entity or value object is touched.
+
+### FR-4: Make `MonthlyBreakdownGenerator` Implement `IMonthlyBreakdownGenerator`
+Update the existing `MonthlyBreakdownGenerator` class to implement the new interface.
+
+**Acceptance criteria:**
+- Class implements `IMonthlyBreakdownGenerator`.
+- No behavioural changes — only the implementation declaration is added.
+- File location unchanged.
+
+### FR-5: Update DI Registrations in `AnalyticsModule`
+In `AnalyticsModule.cs`, register both services behind their interfaces and remove the misleading comment.
+
+**Acceptance criteria:**
+- `services.AddScoped<IMarginCalculator, MarginCalculator>()` replaces the existing concrete registration.
+- `services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>()` replaces the existing concrete registration.
+- Service lifetime (`Scoped` vs `Transient` vs `Singleton`) matches the current registration to avoid behaviour change.
+- The comment `// Legacy services (keeping for backward compatibility)` is removed.
+- No other registrations in `AnalyticsModule` are altered.
+
+### FR-6: Update `GetProductMarginSummaryHandler` to Inject Interfaces
+Modify the handler constructor to depend on `IMarginCalculator` and `IMonthlyBreakdownGenerator`.
+
+**Acceptance criteria:**
+- Constructor signature uses interface types.
+- Private readonly fields renamed to reflect interface types (`_marginCalculator`, `_monthlyBreakdownGenerator` field names may remain — only types change).
+- No behavioural changes in the handler logic.
+- The handler compiles and all existing tests pass.
+
+### FR-7: Update All Other Consumers of the Concrete Classes
+Find and update any other classes that inject `MarginCalculator` or `MonthlyBreakdownGenerator` as concrete dependencies.
+
+**Acceptance criteria:**
+- A solution-wide search for `MarginCalculator` and `MonthlyBreakdownGenerator` confirms no remaining concrete-type constructor injections (excluding the DI registration itself).
+- Any callers found are updated to use the interfaces.
+- If no other callers exist, this is documented in the PR description.
+
+### FR-8: Update or Add Unit Tests
+Verify the handler is now mockable and that existing behaviour is preserved.
+
+**Acceptance criteria:**
+- Existing tests for `GetProductMarginSummaryHandler` continue to pass after the refactor.
+- At least one unit test demonstrates that `IMarginCalculator` and `IMonthlyBreakdownGenerator` can be mocked (e.g., using Moq or NSubstitute, consistent with the project's mocking convention) and injected into the handler.
+- Existing tests for `MarginCalculator` and `MonthlyBreakdownGenerator` are updated to reflect the new namespace and continue to pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change is expected or permitted. The refactor is purely structural — same code paths, same allocations, same DI lifetimes. Benchmark or response-time validation is not required, but any measurable regression in `GetProductMarginSummary` request latency is a blocker.
+
+### NFR-2: Security
+No security surface change. No new endpoints, no auth changes, no data exposure changes. Existing authorization on the `GetProductMarginSummary` endpoint remains in effect.
+
+### NFR-3: Backwards Compatibility
+- The public API contract of the `GetProductMarginSummary` endpoint is unchanged.
+- Response DTOs, error codes, and status codes are unchanged.
+- No database schema changes.
+- No breaking changes for consumers of the HTTP API.
+
+### NFR-4: Code Quality
+- `dotnet build` succeeds with zero new warnings.
+- `dotnet format` produces no diffs.
+- All existing unit tests pass.
+- Clean Architecture layering is verified: the Domain project has no reference to Application; the Application project may reference Domain.
+
+## Data Model
+No data model changes. The refactor touches only DI wiring and class organization. Entities, DTOs, persistence, and repository contracts remain identical.
+
+Affected types (for reference, not modified):
+- `MarginCalculationResult` (Application layer DTO)
+- `MonthlyProductMarginDto` (Application layer DTO)
+- `AnalyticsProduct` (Domain entity)
+- `ProductGroupingMode` (Domain enum)
+- `DateRange` (shared value object)
+
+## API / Interface Design
+
+### New Interfaces
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/Services/IMarginCalculator.cs
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMarginCalculator
+{
+    Task<MarginCalculationResult> CalculateAsync(/* current parameter list preserved verbatim */);
+    string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode);
+    string GetGroupDisplayName(string groupKey, ProductGroupingMode mode, List<AnalyticsProduct> products);
+    decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel);
+}
+```
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Analytics/Services/IMonthlyBreakdownGenerator.cs
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMonthlyBreakdownGenerator
+{
+    List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult result,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2");
+}
+```
+
+### Handler Constructor (After)
+
+```csharp
+public GetProductMarginSummaryHandler(
+    IAnalyticsRepository analyticsRepository,
+    IMarginCalculator marginCalculator,
+    IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
+{
+    _analyticsRepository = analyticsRepository;
+    _marginCalculator = marginCalculator;
+    _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+}
+```
+
+### HTTP API
+No HTTP API changes. The `GetProductMarginSummary` endpoint contract (request, response, status codes, auth) is preserved exactly.
+
+## Dependencies
+- **MediatR** — already used by handler; no version change.
+- **.NET 8 DI container** — already in use; no changes.
+- **Existing test framework** (xUnit + Moq/NSubstitute per project convention) — used to add the mockability test.
+
+No new NuGet packages. No external service dependencies.
+
+## Out of Scope
+- Refactoring `MarginCalculator` internals or splitting it into smaller services.
+- Changing the calculation algorithm or business logic for margin computation.
+- Refactoring `MonthlyBreakdownGenerator` internals.
+- Touching other handlers in the Analytics module unless they directly inject `MarginCalculator` or `MonthlyBreakdownGenerator` (FR-7).
+- Changes to `IProductFilterService` or `IReportBuilderService`.
+- Performance optimization of margin calculation.
+- Adding new functionality to either service.
+- Changes to the `GetProductMarginSummary` HTTP endpoint, request DTO, or response DTO.
+- Database schema changes.
+- Frontend changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-analytics-getproductmarginsu/task-plan.r1.md
+++ b/artifacts/feat-arch-review-analytics-getproductmarginsu/task-plan.r1.md
@@ -1,0 +1,1078 @@
+# GetProductMarginSummary — Margin Calculator Abstractions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `IMarginCalculator` and `IMonthlyBreakdownGenerator` interfaces, relocate `MarginCalculator` from Domain to Application, and switch `GetProductMarginSummaryHandler` (and `MonthlyBreakdownGenerator`) to depend on those abstractions — aligning with the sibling pattern (`IProductFilterService`, `IReportBuilderService`).
+
+**Architecture:** Pure structural refactor. No behavior change, no DTO change, no API change, no DB change. Interfaces and implementations are co-located in a single file each (matching the existing `ProductFilterService.cs` / `ReportBuilderService.cs` convention in the same folder). DI lifetimes stay `Scoped`. `MarginCalculationResult` remains in Domain — Application returning Domain-defined types is allowed under Clean Architecture.
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, Moq, FluentAssertions. No new NuGet packages.
+
+---
+
+## Context for the Implementer
+
+### Why this refactor exists
+
+`GetProductMarginSummaryHandler` currently injects two **concrete** classes:
+
+1. `MarginCalculator` — located in the **Domain** project (`Anela.Heblo.Domain.Features.Analytics`), which violates Clean Architecture (no abstraction, Domain owns a stateless service that consumes a stream and returns a DTO — it isn't an entity or value object).
+2. `MonthlyBreakdownGenerator` — already in Application but has no interface.
+
+Two sibling services in the same `Services/` folder already follow the correct pattern (interface + implementation in one file, registered by interface). The two outliers were simply missed in a prior extraction. The `AnalyticsModule.cs` comment labeling them "Legacy services (keeping for backward compatibility)" is misleading — these are the **only** path, with no replacement.
+
+### Why `MonthlyBreakdownGenerator`'s constructor MUST change
+
+`MonthlyBreakdownGenerator` itself takes a concrete `MarginCalculator` in its constructor. Once DI registration moves to `services.AddScoped<IMarginCalculator, MarginCalculator>()`, the concrete `MarginCalculator` is no longer in the container as a self-registered type — the existing `ctor(MarginCalculator)` would fail to resolve at runtime. This is a correctness requirement, not a style preference. Task 3 handles it.
+
+### Files involved (verified by solution-wide grep)
+
+The only files that touch `MarginCalculator` / `MonthlyBreakdownGenerator` are:
+
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs` (will be **deleted**)
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs` (modified)
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` (modified)
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` (modified)
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` (modified — adds mockability test)
+- New: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` (created)
+
+`SafeMarginCalculator` in the Catalog feature is **unrelated** — different type, different module. Do not touch it.
+
+### Conventions to follow
+
+- **Single-file co-location**: interface + implementation in one file, per `ProductFilterService.cs` and `ReportBuilderService.cs`.
+- **Nullable reference types enabled**: project already configured; no change needed.
+- **Service lifetimes stay `Scoped`**: NFR-1 forbids behavioral change.
+- **No comment about "legacy"**: remove the misleading line in `AnalyticsModule.cs`.
+- **Use `dotnet format`** between tasks if hooks require it; project uses `dotnet format` as part of the validation gate.
+
+### How to run the tests
+
+Run only the affected test file from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Run the full backend build:
+
+```bash
+dotnet build backend/backend.sln
+```
+
+Run a format check:
+
+```bash
+dotnet format backend/backend.sln --verify-no-changes
+```
+
+---
+
+## File Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/
+├── AnalyticsModule.cs                                          (MODIFIED — DI registrations)
+├── UseCases/GetProductMarginSummary/
+│   └── GetProductMarginSummaryHandler.cs                       (MODIFIED — inject interfaces)
+└── Services/
+    ├── MarginCalculator.cs                                     (CREATED — IMarginCalculator + impl)
+    ├── MonthlyBreakdownGenerator.cs                            (MODIFIED — implements interface, depends on IMarginCalculator)
+    ├── ProductFilterService.cs                                 (unchanged — reference pattern)
+    └── ReportBuilderService.cs                                 (unchanged — reference pattern)
+
+backend/src/Anela.Heblo.Domain/Features/Analytics/
+├── AnalyticsProduct.cs                                         (unchanged — still owns MarginCalculationResult, DateRange)
+├── AnalyticsProductType.cs                                     (unchanged)
+├── ProductGroupingMode.cs                                      (unchanged)
+└── MarginCalculator.cs                                         (DELETED)
+
+backend/test/Anela.Heblo.Tests/Features/Analytics/
+└── GetProductMarginSummaryHandlerTests.cs                      (MODIFIED — adds mockability test)
+```
+
+---
+
+### Task 1: Relocate `MarginCalculator` from Domain to Application (no interface yet, just move)
+
+**Goal:** Move the concrete class to its proper layer. Existing tests must still pass with concrete construction. This isolates the relocation from the interface change so each step is bisectable.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs`
+- Delete: `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs`
+- No source/test edits needed yet — namespace imports already cover both layers in every consumer (verified).
+
+- [ ] **Step 1.1: Create the new file with the relocated class**
+
+Create `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` with the **exact** body of the original (copy verbatim), only the namespace changes:
+
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+/// <summary>
+/// 🔒 PERFORMANCE FIX: Extracted margin calculation logic from handler
+/// Implements single responsibility principle and improves testability
+/// </summary>
+public class MarginCalculator
+{
+    /// <summary>
+    /// Calculates margin data using streaming approach to minimize memory usage
+    /// </summary>
+    public async Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default)
+    {
+        var groupTotals = new Dictionary<string, decimal>();
+        var groupProducts = new Dictionary<string, List<AnalyticsProduct>>();
+        var totalMargin = 0m;
+
+        await foreach (var product in products.WithCancellation(cancellationToken))
+        {
+            if (product.MarginAmount <= 0)
+                continue;
+
+            var groupKey = GetGroupKey(product, groupingMode);
+
+            // Calculate total units sold in the period
+            var totalSold = product.SalesHistory.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = (decimal)totalSold * GetMarginAmountForLevel(product, marginLevel);
+
+            // Update group totals
+            if (!groupTotals.ContainsKey(groupKey))
+            {
+                groupTotals[groupKey] = 0;
+                groupProducts[groupKey] = new List<AnalyticsProduct>();
+            }
+
+            groupTotals[groupKey] += marginContribution;
+            groupProducts[groupKey].Add(product);
+            totalMargin += marginContribution;
+        }
+
+        return new MarginCalculationResult
+        {
+            GroupTotals = groupTotals,
+            GroupProducts = groupProducts,
+            TotalMargin = totalMargin
+        };
+    }
+
+    /// <summary>
+    /// Gets the group key based on grouping mode
+    /// </summary>
+    public string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => product.ProductCode,
+            ProductGroupingMode.ProductFamily => product.ProductFamily ?? "Unknown",
+            ProductGroupingMode.ProductCategory => product.ProductCategory ?? "Unknown",
+            _ => product.ProductCode
+        };
+    }
+
+    /// <summary>
+    /// Gets display name for a group
+    /// </summary>
+    public string GetGroupDisplayName(string groupKey, ProductGroupingMode groupingMode, List<AnalyticsProduct> products)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => products.FirstOrDefault(p => p.ProductCode == groupKey)?.ProductName ?? groupKey,
+            ProductGroupingMode.ProductFamily => $"Rodina {groupKey}",
+            ProductGroupingMode.ProductCategory => $"Kategorie {groupKey}",
+            _ => groupKey
+        };
+    }
+
+    /// <summary>
+    /// Gets the margin amount for a specific margin level
+    /// </summary>
+    public decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel)
+    {
+        return marginLevel.ToUpperInvariant() switch
+        {
+            "M0" => product.M0Amount,
+            "M1" => product.M1Amount,
+            "M2" => product.M2Amount,
+            _ => product.M2Amount // Default to M2
+        };
+    }
+}
+```
+
+- [ ] **Step 1.2: Delete the old Domain-layer file**
+
+Delete `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs`.
+
+After deletion, `backend/src/Anela.Heblo.Domain/Features/Analytics/` must contain only:
+- `AnalyticsProduct.cs`
+- `AnalyticsProductType.cs`
+- `ProductGroupingMode.cs`
+
+Verify with:
+
+```bash
+ls backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected output:
+```
+AnalyticsProduct.cs
+AnalyticsProductType.cs
+ProductGroupingMode.cs
+```
+
+- [ ] **Step 1.3: Build the solution to verify type resolution**
+
+Run:
+```bash
+dotnet build backend/backend.sln
+```
+
+Expected: **Build succeeded** with 0 errors and 0 new warnings.
+
+Why this works without source edits: every consumer (`MonthlyBreakdownGenerator.cs`, `GetProductMarginSummaryHandler.cs`, `AnalyticsModule.cs`, `GetProductMarginSummaryHandlerTests.cs`) already has both `using Anela.Heblo.Application.Features.Analytics.Services;` and `using Anela.Heblo.Domain.Features.Analytics;` (or sits inside one of those namespaces). The unqualified `MarginCalculator` token now resolves to the new Application namespace because the Domain one is gone.
+
+- [ ] **Step 1.4: Run the affected tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **All 5 existing test cases pass** (`Handle_ValidRequest_ReturnsCorrectResponse`, three `Handle_DifferentTimeWindows_ParsesCorrectly` theory rows, `Handle_EmptyProductList_ReturnsZeroMargin`).
+
+- [ ] **Step 1.5: Format check**
+
+Run:
+```bash
+dotnet format backend/backend.sln --verify-no-changes
+```
+
+If it reports diffs, run `dotnet format backend/backend.sln` to apply, then re-verify.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs \
+        backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs
+git commit -m "refactor: relocate MarginCalculator from Domain to Application layer"
+```
+
+---
+
+### Task 2: Add `IMarginCalculator` interface alongside the relocated `MarginCalculator`
+
+**Goal:** Expose the public surface as an interface in the same file. Class implements it. No behavior change.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs`
+
+- [ ] **Step 2.1: Add the interface and have the class implement it**
+
+Replace the file content with the version below. The interface declares the four public methods currently consumed; the class body is unchanged.
+
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMarginCalculator
+{
+    Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default);
+
+    string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode);
+
+    string GetGroupDisplayName(
+        string groupKey,
+        ProductGroupingMode groupingMode,
+        List<AnalyticsProduct> products);
+
+    decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel);
+}
+
+/// <summary>
+/// 🔒 PERFORMANCE FIX: Extracted margin calculation logic from handler
+/// Implements single responsibility principle and improves testability
+/// </summary>
+public class MarginCalculator : IMarginCalculator
+{
+    /// <summary>
+    /// Calculates margin data using streaming approach to minimize memory usage
+    /// </summary>
+    public async Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default)
+    {
+        var groupTotals = new Dictionary<string, decimal>();
+        var groupProducts = new Dictionary<string, List<AnalyticsProduct>>();
+        var totalMargin = 0m;
+
+        await foreach (var product in products.WithCancellation(cancellationToken))
+        {
+            if (product.MarginAmount <= 0)
+                continue;
+
+            var groupKey = GetGroupKey(product, groupingMode);
+
+            // Calculate total units sold in the period
+            var totalSold = product.SalesHistory.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = (decimal)totalSold * GetMarginAmountForLevel(product, marginLevel);
+
+            // Update group totals
+            if (!groupTotals.ContainsKey(groupKey))
+            {
+                groupTotals[groupKey] = 0;
+                groupProducts[groupKey] = new List<AnalyticsProduct>();
+            }
+
+            groupTotals[groupKey] += marginContribution;
+            groupProducts[groupKey].Add(product);
+            totalMargin += marginContribution;
+        }
+
+        return new MarginCalculationResult
+        {
+            GroupTotals = groupTotals,
+            GroupProducts = groupProducts,
+            TotalMargin = totalMargin
+        };
+    }
+
+    /// <summary>
+    /// Gets the group key based on grouping mode
+    /// </summary>
+    public string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => product.ProductCode,
+            ProductGroupingMode.ProductFamily => product.ProductFamily ?? "Unknown",
+            ProductGroupingMode.ProductCategory => product.ProductCategory ?? "Unknown",
+            _ => product.ProductCode
+        };
+    }
+
+    /// <summary>
+    /// Gets display name for a group
+    /// </summary>
+    public string GetGroupDisplayName(string groupKey, ProductGroupingMode groupingMode, List<AnalyticsProduct> products)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => products.FirstOrDefault(p => p.ProductCode == groupKey)?.ProductName ?? groupKey,
+            ProductGroupingMode.ProductFamily => $"Rodina {groupKey}",
+            ProductGroupingMode.ProductCategory => $"Kategorie {groupKey}",
+            _ => groupKey
+        };
+    }
+
+    /// <summary>
+    /// Gets the margin amount for a specific margin level
+    /// </summary>
+    public decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel)
+    {
+        return marginLevel.ToUpperInvariant() switch
+        {
+            "M0" => product.M0Amount,
+            "M1" => product.M1Amount,
+            "M2" => product.M2Amount,
+            _ => product.M2Amount // Default to M2
+        };
+    }
+}
+```
+
+- [ ] **Step 2.2: Build and test**
+
+```bash
+dotnet build backend/backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **Build succeeded**, **all 5 tests pass**.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
+git commit -m "refactor: introduce IMarginCalculator interface"
+```
+
+---
+
+### Task 3: Add `IMonthlyBreakdownGenerator`, implement it, and switch its dependency to `IMarginCalculator`
+
+**Goal:** Add the interface to the existing `MonthlyBreakdownGenerator.cs` file. Make the class implement it. **Crucial:** change the constructor parameter from concrete `MarginCalculator` to `IMarginCalculator` — Task 4 will swap the DI registration, after which the concrete self-registration is gone, so the existing concrete-typed constructor would break runtime resolution.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs`
+
+- [ ] **Step 3.1: Add interface and update constructor**
+
+Replace the file with the version below. Only three things change vs. the original:
+1. A new `IMonthlyBreakdownGenerator` interface declared at the top of the file.
+2. Class declaration changes to `public class MonthlyBreakdownGenerator : IMonthlyBreakdownGenerator`.
+3. The field and constructor parameter types change from `MarginCalculator` to `IMarginCalculator`. Field name `_marginCalculator` preserved.
+
+Everything else is byte-for-byte identical.
+
+```csharp
+using System.Globalization;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMonthlyBreakdownGenerator
+{
+    List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult calculationResult,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2");
+}
+
+/// <summary>
+/// 🔒 PERFORMANCE FIX: Extracted monthly breakdown logic from handler
+/// Implements single responsibility principle and reduces handler complexity
+/// </summary>
+public class MonthlyBreakdownGenerator : IMonthlyBreakdownGenerator
+{
+    private readonly IMarginCalculator _marginCalculator;
+
+    public MonthlyBreakdownGenerator(IMarginCalculator marginCalculator)
+    {
+        _marginCalculator = marginCalculator;
+    }
+
+    /// <summary>
+    /// Generates monthly breakdown efficiently by processing products once per month
+    /// </summary>
+    public List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult calculationResult,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2")
+    {
+        var monthlyData = new List<MonthlyProductMarginDto>();
+
+        // Generate all months in the date range
+        var current = new DateTime(dateRange.FromDate.Year, dateRange.FromDate.Month, 1);
+        var end = new DateTime(dateRange.ToDate.Year, dateRange.ToDate.Month, 1);
+
+        while (current <= end)
+        {
+            var monthStart = current;
+            var monthEnd = monthStart.AddMonths(1).AddDays(-1);
+
+            var monthlySegments = GenerateMonthlySegments(
+                calculationResult.GroupProducts,
+                monthStart,
+                monthEnd,
+                groupingMode,
+                marginLevel);
+
+            monthlyData.Add(new MonthlyProductMarginDto
+            {
+                Year = current.Year,
+                Month = current.Month,
+                MonthDisplay = current.ToString("MMM yyyy", CultureInfo.CreateSpecificCulture("cs-CZ")),
+                ProductSegments = monthlySegments.segments,
+                TotalMonthMargin = monthlySegments.totalMargin
+            });
+
+            current = current.AddMonths(1);
+        }
+
+        return monthlyData;
+    }
+
+    /// <summary>
+    /// Generates segments for a specific month, processing each group's products efficiently
+    /// </summary>
+    private (List<ProductMarginSegmentDto> segments, decimal totalMargin) GenerateMonthlySegments(
+        Dictionary<string, List<AnalyticsProduct>> groupProducts,
+        DateTime monthStart,
+        DateTime monthEnd,
+        ProductGroupingMode groupingMode,
+        string marginLevel)
+    {
+        var segments = new List<ProductMarginSegmentDto>();
+        var totalMonthMargin = 0m;
+
+        foreach (var (groupKey, products) in groupProducts)
+        {
+            var groupData = ProcessGroupForMonth(products, monthStart, monthEnd, marginLevel);
+
+            if (groupData.totalMargin <= 0)
+                continue;
+
+            totalMonthMargin += groupData.totalMargin;
+
+            var displayName = _marginCalculator.GetGroupDisplayName(groupKey, groupingMode, products);
+
+            segments.Add(new ProductMarginSegmentDto
+            {
+                GroupKey = groupKey,
+                DisplayName = displayName,
+                MarginContribution = groupData.totalMargin,
+                ColorCode = "", // Color assigned by frontend
+                AverageMarginPerPiece = groupData.avgMarginPerPiece,
+                UnitsSold = groupData.totalUnitsSold,
+                AverageSellingPriceWithoutVat = groupData.avgSellingPrice,
+                AverageMaterialCosts = groupData.avgMaterialCosts,
+                AverageLaborCosts = groupData.avgLaborCosts,
+                ProductCount = groupData.productCount,
+                IsOther = false
+            });
+        }
+
+        // Sort by margin contribution (highest first)
+        segments = segments.OrderByDescending(s => s.MarginContribution).ToList();
+
+        // Calculate percentages
+        if (totalMonthMargin > 0)
+        {
+            foreach (var segment in segments)
+            {
+                segment.Percentage = (segment.MarginContribution / totalMonthMargin) * 100;
+            }
+        }
+
+        return (segments, totalMonthMargin);
+    }
+
+    /// <summary>
+    /// Processes a group of products for a specific month
+    /// </summary>
+    private (decimal totalMargin, int totalUnitsSold, decimal avgMarginPerPiece,
+             decimal avgSellingPrice, decimal avgMaterialCosts, decimal avgLaborCosts,
+             int productCount) ProcessGroupForMonth(
+        List<AnalyticsProduct> products,
+        DateTime monthStart,
+        DateTime monthEnd,
+        string marginLevel)
+    {
+        var totalMargin = 0m;
+        var totalUnitsSold = 0;
+        var productCount = 0;
+        var totalMarginPerPiece = 0m;
+        var totalSellingPrice = 0m;
+        var totalMaterialCosts = 0m;
+        var totalLaborCosts = 0m;
+
+        foreach (var product in products)
+        {
+            var salesInMonth = product.SalesHistory
+                .Where(s => s.Date >= monthStart && s.Date <= monthEnd)
+                .ToList();
+
+            var marginAmount = _marginCalculator.GetMarginAmountForLevel(product, marginLevel);
+
+            if (!salesInMonth.Any() || marginAmount <= 0)
+                continue;
+
+            var unitsSold = (int)salesInMonth.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = unitsSold * marginAmount;
+
+            totalMargin += marginContribution;
+            totalUnitsSold += unitsSold;
+            productCount++;
+
+            // Accumulate for averages
+            totalMarginPerPiece += marginAmount;
+            totalSellingPrice += product.EshopPriceWithoutVat ?? 0;
+            totalMaterialCosts += product.MaterialCost;
+            totalLaborCosts += product.HandlingCost;
+        }
+
+        return (
+            totalMargin,
+            totalUnitsSold,
+            productCount > 0 ? totalMarginPerPiece / productCount : 0,
+            productCount > 0 ? totalSellingPrice / productCount : 0,
+            productCount > 0 ? totalMaterialCosts / productCount : 0,
+            productCount > 0 ? totalLaborCosts / productCount : 0,
+            productCount
+        );
+    }
+}
+```
+
+- [ ] **Step 3.2: Build and test**
+
+```bash
+dotnet build backend/backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **Build succeeded** (the test file constructs `new MonthlyBreakdownGenerator(_marginCalculator)` where `_marginCalculator` is the concrete `MarginCalculator`; since `MarginCalculator` implements `IMarginCalculator`, this assignment is valid). **All 5 tests pass.**
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs
+git commit -m "refactor: introduce IMonthlyBreakdownGenerator, depend on IMarginCalculator"
+```
+
+---
+
+### Task 4: Switch DI registrations to interface-based and drop the misleading comment
+
+**Goal:** Register both services by their interfaces with `AddScoped` (preserving lifetime per NFR-1). Remove the "Legacy services" comment.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs`
+
+- [ ] **Step 4.1: Update the registration block**
+
+Replace lines 36–38 of `AnalyticsModule.cs`:
+
+**Before:**
+```csharp
+        // Legacy services (keeping for backward compatibility)
+        services.AddScoped<MarginCalculator>();
+        services.AddScoped<MonthlyBreakdownGenerator>();
+```
+
+**After:**
+```csharp
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+
+Do not change any other registration in the file. The full updated file (for reference):
+
+```csharp
+using Anela.Heblo.Application.Features.Analytics.DashboardTiles;
+using Anela.Heblo.Application.Features.Analytics.Infrastructure;
+using Anela.Heblo.Application.Features.Analytics.Services;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginAnalysis;
+using Anela.Heblo.Application.Features.Analytics.Validators;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Analytics;
+
+/// <summary>
+/// Enhanced analytics module with refactored services and validation
+/// Registers new services for better separation of concerns and testability
+/// </summary>
+public static class AnalyticsModule
+{
+    public static IServiceCollection AddAnalyticsModule(this IServiceCollection services)
+    {
+        // MediatR handlers are automatically registered by AddMediatR scan
+
+        // Register repository
+        services.AddScoped<IAnalyticsRepository, AnalyticsRepository>();
+
+        // Register refactored services for clean separation of concerns
+        // Note: IMarginCalculationService is registered by CatalogModule and injected here
+        services.AddScoped<IProductFilterService, ProductFilterService>();
+        services.AddScoped<IReportBuilderService, ReportBuilderService>();
+
+        // Register validators for FluentValidation
+        services.AddScoped<IValidator<GetMarginReportRequest>, GetMarginReportRequestValidator>();
+        services.AddScoped<IValidator<GetProductMarginAnalysisRequest>, GetProductMarginAnalysisRequestValidator>();
+
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+
+        // Register dashboard tiles
+        services.RegisterTile<InvoiceImportStatisticsTile>();
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 4.2: Build**
+
+```bash
+dotnet build backend/backend.sln
+```
+
+Expected: **Build succeeded.** The handler still references the concrete classes (Task 5 fixes that), but since the concrete classes still exist and the test file uses them directly via `new`, the build remains green.
+
+Note: at this checkpoint, **a runtime DI resolution of `GetProductMarginSummaryHandler` would fail** because the handler's constructor still asks for `MarginCalculator` (concrete) and `MonthlyBreakdownGenerator` (concrete), which are no longer self-registered. The fix lands in Task 5. Existing **unit tests** still pass because they wire the handler manually with `new`, not via DI.
+
+- [ ] **Step 4.3: Run unit tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **All 5 tests pass.**
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+git commit -m "refactor: register margin calculator services by interface"
+```
+
+---
+
+### Task 5: Update `GetProductMarginSummaryHandler` to inject the interfaces
+
+**Goal:** Switch handler fields and constructor parameters to interface types. Field names preserved. No behavioral change.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs`
+
+- [ ] **Step 5.1: Change field and constructor parameter types**
+
+Apply this targeted edit to `GetProductMarginSummaryHandler.cs` lines 15–27.
+
+**Before:**
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly MarginCalculator _marginCalculator;
+    private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        MarginCalculator marginCalculator,
+        MonthlyBreakdownGenerator monthlyBreakdownGenerator)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+    }
+```
+
+**After:**
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+    }
+```
+
+Do not touch any other line in the file. The `Handle` method, `GenerateTopProducts`, `CalculateGroupMarginData`, `ApplySorting`, and `CalculateTotalMarginForLevel` are unchanged — they call methods that exist on `IMarginCalculator` (`GetGroupDisplayName`, etc.) so the body still compiles.
+
+- [ ] **Step 5.2: Build the full solution and run all backend tests**
+
+```bash
+dotnet build backend/backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **Build succeeded**, **all 5 tests pass.** (The existing tests pass `_marginCalculator` and `_monthlyBreakdownGenerator` to the constructor; both concrete fields satisfy the new interface parameters via implicit upcast.)
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+git commit -m "refactor: GetProductMarginSummaryHandler depends on margin calculator abstractions"
+```
+
+---
+
+### Task 6: Add a mockability test demonstrating the handler is now testable in isolation (FR-8)
+
+**Goal:** Add one new test that constructs `GetProductMarginSummaryHandler` with `Mock<IMarginCalculator>` and `Mock<IMonthlyBreakdownGenerator>` and asserts both mocks are invoked. This is the verification test for the refactor's success criterion. Existing tests that use the real `MarginCalculator` / `MonthlyBreakdownGenerator` stay as-is — they now serve as integration-style coverage against the real services.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs`
+
+- [ ] **Step 6.1: Add the test method**
+
+Insert this new test method into `GetProductMarginSummaryHandlerTests` (e.g. after `Handle_EmptyProductList_ReturnsZeroMargin`, before the closing brace of the class). It uses the existing mocking convention (`Moq`) and `FluentAssertions`, both already imported at the top of the file.
+
+```csharp
+    [Fact]
+    public async Task Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator()
+    {
+        // Arrange
+        var marginCalculatorMock = new Mock<IMarginCalculator>();
+        var monthlyBreakdownGeneratorMock = new Mock<IMonthlyBreakdownGenerator>();
+
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products,
+            MarginLevel = "M2"
+        };
+
+        var today = DateTime.Today;
+        var fromDate = new DateTime(today.Year, 1, 1);
+        var toDate = today;
+
+        var calculationResult = new MarginCalculationResult
+        {
+            GroupTotals = new Dictionary<string, decimal> { ["PROD001"] = 500m },
+            GroupProducts = new Dictionary<string, List<AnalyticsProduct>>
+            {
+                ["PROD001"] = new List<AnalyticsProduct>
+                {
+                    new AnalyticsProduct
+                    {
+                        ProductCode = "PROD001",
+                        ProductName = "Product 1",
+                        Type = AnalyticsProductType.Product,
+                        MarginAmount = 50m,
+                        M0Amount = 50m,
+                        M1Amount = 50m,
+                        M2Amount = 50m,
+                        SellingPrice = 100m,
+                        PurchasePrice = 50m,
+                        SalesHistory = new List<SalesDataPoint>
+                        {
+                            new() { Date = new DateTime(today.Year, 3, 1), AmountB2B = 5, AmountB2C = 5 }
+                        }
+                    }
+                }
+            },
+            TotalMargin = 500m
+        };
+
+        var monthlyData = new List<MonthlyProductMarginDto>
+        {
+            new MonthlyProductMarginDto
+            {
+                Year = today.Year,
+                Month = 3,
+                MonthDisplay = "Mar",
+                ProductSegments = new List<ProductMarginSegmentDto>(),
+                TotalMonthMargin = 500m
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        marginCalculatorMock
+            .Setup(x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(calculationResult);
+
+        marginCalculatorMock
+            .Setup(x => x.GetGroupDisplayName(
+                It.IsAny<string>(),
+                It.IsAny<ProductGroupingMode>(),
+                It.IsAny<List<AnalyticsProduct>>()))
+            .Returns<string, ProductGroupingMode, List<AnalyticsProduct>>((key, _, _) => key);
+
+        monthlyBreakdownGeneratorMock
+            .Setup(x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2"))
+            .Returns(monthlyData);
+
+        var handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            marginCalculatorMock.Object,
+            monthlyBreakdownGeneratorMock.Object);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMargin.Should().Be(500m);
+        result.MonthlyData.Should().BeSameAs(monthlyData);
+
+        marginCalculatorMock.Verify(
+            x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        monthlyBreakdownGeneratorMock.Verify(
+            x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2"),
+            Times.Once);
+    }
+```
+
+Notes for the implementer:
+- `_analyticsRepositoryMock` is already a field on the test class — reuse it.
+- The handler's `Handle` calls `_marginCalculator.GetGroupDisplayName` from inside `GenerateTopProducts` when iterating `calculationResult.GroupTotals`. The mock setup for `GetGroupDisplayName` above covers that call.
+- `MarginLevel` default in `GetProductMarginSummaryRequest` is unknown at this layer; setting it explicitly to `"M2"` matches the test's mock setup. If `GetProductMarginSummaryRequest.MarginLevel` is non-nullable and has a different default, set it to whatever value the request uses by default — but match it in the `.Setup(...)` calls. (Check `GetProductMarginSummaryRequest.cs` in the same UseCases folder if uncertain.)
+
+- [ ] **Step 6.2: Run the new test alone to confirm it passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator"
+```
+
+Expected: **1 test passed.**
+
+- [ ] **Step 6.3: Run the full handler test class**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **6 tests passed** (5 original + 1 new).
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+git commit -m "test: add mockability test for GetProductMarginSummaryHandler"
+```
+
+---
+
+### Task 7: Full verification gate
+
+**Goal:** Confirm the refactor is complete, clean-architecture-compliant, and ready to ship. Verifies the CLAUDE.md completion gates (build + format + tests).
+
+- [ ] **Step 7.1: Full backend build**
+
+```bash
+dotnet build backend/backend.sln
+```
+
+Expected: **Build succeeded. 0 Warning(s), 0 Error(s).** (Zero **new** warnings — pre-existing warnings unrelated to this change are tolerable but should not increase in count.)
+
+- [ ] **Step 7.2: Format check**
+
+```bash
+dotnet format backend/backend.sln --verify-no-changes
+```
+
+Expected: **Format complete** (no diffs). If diffs are reported, run `dotnet format backend/backend.sln`, then re-verify, then amend the most recent commit only if the diffs are formatting-only.
+
+- [ ] **Step 7.3: Full backend test run**
+
+```bash
+dotnet test backend/backend.sln
+```
+
+Expected: **All tests pass.** Pay attention to:
+- All 6 `GetProductMarginSummaryHandlerTests` cases pass.
+- No other test broke (cross-module impact should be zero — `SafeMarginCalculator` etc. are unrelated).
+
+- [ ] **Step 7.4: Manual grep — confirm no concrete-type injections remain (FR-7)**
+
+Run a grep for stale concrete references:
+
+```bash
+grep -rn "MarginCalculator " backend/src backend/test \
+  | grep -vE "(IMarginCalculator|MarginCalculator\(|MarginCalculator\.cs|SafeMarginCalculator|IMarginCalculationService|MarginCalculationResult|MarginCalculationService)"
+```
+
+Expected output: **no lines**, OR only lines that are clearly:
+- The interface↔class registration in `AnalyticsModule.cs` (e.g. `IMarginCalculator, MarginCalculator>`).
+- The `new MarginCalculator()` construction in the existing test setup (`GetProductMarginSummaryHandlerTests.cs:32`).
+- The `public class MarginCalculator : IMarginCalculator` declaration in the implementation file.
+
+Anything else (e.g. a constructor parameter typed `MarginCalculator` somewhere) is a bug — fix before proceeding.
+
+Same check for `MonthlyBreakdownGenerator`:
+
+```bash
+grep -rn "MonthlyBreakdownGenerator " backend/src backend/test \
+  | grep -vE "(IMonthlyBreakdownGenerator|MonthlyBreakdownGenerator\(|MonthlyBreakdownGenerator\.cs)"
+```
+
+Expected output: **no lines**, OR only the registration and test instantiation.
+
+- [ ] **Step 7.5: Confirm Domain folder is clean (FR-3 strengthened acceptance)**
+
+```bash
+ls backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected output exactly:
+```
+AnalyticsProduct.cs
+AnalyticsProductType.cs
+ProductGroupingMode.cs
+```
+
+If `MarginCalculator.cs` still appears: it was not deleted in Task 1. Delete it now and amend the Task 1 commit only if no other tasks have been pushed.
+
+- [ ] **Step 7.6: Final commit if any formatting changes accumulated**
+
+If Steps 7.1–7.5 produced any auto-format diffs:
+
+```bash
+git status
+# If there are formatting-only diffs:
+git add -A
+git commit -m "chore: dotnet format pass"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Spec Coverage Check
+
+| Requirement | Covered by |
+|---|---|
+| FR-1: Define `IMarginCalculator` interface | Task 2 |
+| FR-2: Define `IMonthlyBreakdownGenerator` interface | Task 3 |
+| FR-3: Relocate `MarginCalculator` to Application layer | Task 1 (+ Task 7.5 verification) |
+| FR-4: `MonthlyBreakdownGenerator` implements `IMonthlyBreakdownGenerator` | Task 3 |
+| FR-4b (arch-review amendment): `MonthlyBreakdownGenerator` ctor depends on `IMarginCalculator` | Task 3 |
+| FR-5: Update DI registrations + remove misleading comment | Task 4 |
+| FR-6: Handler injects interfaces | Task 5 |
+| FR-7: Update other concrete consumers (none expected) | Task 7.4 grep verification |
+| FR-8: Existing tests pass + mockability test added | Task 6 |
+| NFR-1: No performance change (same lifetimes preserved) | Task 4 (uses `AddScoped`) |
+| NFR-2: No security change | n/a — no surface change |
+| NFR-3: Backwards compatible (no API/DTO/DB changes) | n/a — not touched |
+| NFR-4: Build clean, format clean, tests pass | Task 7 gates |
+
+Arch-review amendments incorporated:
+1. ✅ `MonthlyBreakdownGenerator` constructor switch made explicit (Task 3).
+2. ✅ Single-file interface co-location (Tasks 2, 3 — both interfaces declared in the same file as their implementations).
+3. ✅ Explicit `CalculateAsync` signature (Task 2).
+4. ✅ `MarginCalculationResult` stays in Domain (verified — no task moves it).
+5. ✅ Post-state of Domain folder verified explicitly (Task 7.5).
+6. ✅ Mockability test uses `Mock<IMarginCalculator>` and `Mock<IMonthlyBreakdownGenerator>` with invocation verification (Task 6).

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
@@ -33,9 +33,8 @@ public static class AnalyticsModule
         services.AddScoped<IValidator<GetMarginReportRequest>, GetMarginReportRequestValidator>();
         services.AddScoped<IValidator<GetProductMarginAnalysisRequest>, GetProductMarginAnalysisRequestValidator>();
 
-        // Legacy services (keeping for backward compatibility)
-        services.AddScoped<MarginCalculator>();
-        services.AddScoped<MonthlyBreakdownGenerator>();
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
 
         // Register dashboard tiles
         services.RegisterTile<InvoiceImportStatisticsTile>();

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
@@ -1,4 +1,6 @@
-namespace Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
 
 /// <summary>
 /// 🔒 PERFORMANCE FIX: Extracted margin calculation logic from handler

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
@@ -2,11 +2,30 @@ using Anela.Heblo.Domain.Features.Analytics;
 
 namespace Anela.Heblo.Application.Features.Analytics.Services;
 
+public interface IMarginCalculator
+{
+    Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default);
+
+    string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode);
+
+    string GetGroupDisplayName(
+        string groupKey,
+        ProductGroupingMode groupingMode,
+        List<AnalyticsProduct> products);
+
+    decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel);
+}
+
 /// <summary>
 /// 🔒 PERFORMANCE FIX: Extracted margin calculation logic from handler
 /// Implements single responsibility principle and improves testability
 /// </summary>
-public class MarginCalculator
+public class MarginCalculator : IMarginCalculator
 {
     /// <summary>
     /// Calculates margin data using streaming approach to minimize memory usage

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs
@@ -4,15 +4,24 @@ using Anela.Heblo.Domain.Features.Analytics;
 
 namespace Anela.Heblo.Application.Features.Analytics.Services;
 
+public interface IMonthlyBreakdownGenerator
+{
+    List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult calculationResult,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2");
+}
+
 /// <summary>
 /// 🔒 PERFORMANCE FIX: Extracted monthly breakdown logic from handler
 /// Implements single responsibility principle and reduces handler complexity
 /// </summary>
-public class MonthlyBreakdownGenerator
+public class MonthlyBreakdownGenerator : IMonthlyBreakdownGenerator
 {
-    private readonly MarginCalculator _marginCalculator;
+    private readonly IMarginCalculator _marginCalculator;
 
-    public MonthlyBreakdownGenerator(MarginCalculator marginCalculator)
+    public MonthlyBreakdownGenerator(IMarginCalculator marginCalculator)
     {
         _marginCalculator = marginCalculator;
     }

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
@@ -13,13 +13,13 @@ namespace Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginSu
 public class GetProductMarginSummaryHandler : IRequestHandler<GetProductMarginSummaryRequest, GetProductMarginSummaryResponse>
 {
     private readonly IAnalyticsRepository _analyticsRepository;
-    private readonly MarginCalculator _marginCalculator;
-    private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
 
     public GetProductMarginSummaryHandler(
         IAnalyticsRepository analyticsRepository,
-        MarginCalculator marginCalculator,
-        MonthlyBreakdownGenerator monthlyBreakdownGenerator)
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
     {
         _analyticsRepository = analyticsRepository;
         _marginCalculator = marginCalculator;

--- a/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
@@ -161,6 +161,124 @@ public class GetProductMarginSummaryHandlerTests
         result.TopProducts.Should().BeEmpty();
         result.MonthlyData.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator()
+    {
+        // Arrange
+        var marginCalculatorMock = new Mock<IMarginCalculator>();
+        var monthlyBreakdownGeneratorMock = new Mock<IMonthlyBreakdownGenerator>();
+
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products,
+            MarginLevel = "M2"
+        };
+
+        var today = DateTime.Today;
+        var fromDate = new DateTime(today.Year, 1, 1);
+        var toDate = today;
+
+        var calculationResult = new MarginCalculationResult
+        {
+            GroupTotals = new Dictionary<string, decimal> { ["PROD001"] = 500m },
+            GroupProducts = new Dictionary<string, List<AnalyticsProduct>>
+            {
+                ["PROD001"] = new List<AnalyticsProduct>
+                {
+                    new AnalyticsProduct
+                    {
+                        ProductCode = "PROD001",
+                        ProductName = "Product 1",
+                        Type = AnalyticsProductType.Product,
+                        MarginAmount = 50m,
+                        M0Amount = 50m,
+                        M1Amount = 50m,
+                        M2Amount = 50m,
+                        SellingPrice = 100m,
+                        PurchasePrice = 50m,
+                        SalesHistory = new List<SalesDataPoint>
+                        {
+                            new() { Date = new DateTime(today.Year, 3, 1), AmountB2B = 5, AmountB2C = 5 }
+                        }
+                    }
+                }
+            },
+            TotalMargin = 500m
+        };
+
+        var monthlyData = new List<MonthlyProductMarginDto>
+        {
+            new MonthlyProductMarginDto
+            {
+                Year = today.Year,
+                Month = 3,
+                MonthDisplay = "Mar",
+                ProductSegments = new List<ProductMarginSegmentDto>(),
+                TotalMonthMargin = 500m
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        marginCalculatorMock
+            .Setup(x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(calculationResult);
+
+        marginCalculatorMock
+            .Setup(x => x.GetGroupDisplayName(
+                It.IsAny<string>(),
+                It.IsAny<ProductGroupingMode>(),
+                It.IsAny<List<AnalyticsProduct>>()))
+            .Returns<string, ProductGroupingMode, List<AnalyticsProduct>>((key, _, _) => key);
+
+        monthlyBreakdownGeneratorMock
+            .Setup(x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2"))
+            .Returns(monthlyData);
+
+        var handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            marginCalculatorMock.Object,
+            monthlyBreakdownGeneratorMock.Object);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMargin.Should().Be(500m);
+        result.MonthlyData.Should().BeSameAs(monthlyData);
+
+        marginCalculatorMock.Verify(
+            x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        monthlyBreakdownGeneratorMock.Verify(
+            x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2"),
+            Times.Once);
+    }
 }
 
 // Extension method to convert list to IAsyncEnumerable for testing

--- a/docs/superpowers/plans/2026-05-27-margin-calculator-abstractions.md
+++ b/docs/superpowers/plans/2026-05-27-margin-calculator-abstractions.md
@@ -1,0 +1,1078 @@
+# GetProductMarginSummary — Margin Calculator Abstractions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `IMarginCalculator` and `IMonthlyBreakdownGenerator` interfaces, relocate `MarginCalculator` from Domain to Application, and switch `GetProductMarginSummaryHandler` (and `MonthlyBreakdownGenerator`) to depend on those abstractions — aligning with the sibling pattern (`IProductFilterService`, `IReportBuilderService`).
+
+**Architecture:** Pure structural refactor. No behavior change, no DTO change, no API change, no DB change. Interfaces and implementations are co-located in a single file each (matching the existing `ProductFilterService.cs` / `ReportBuilderService.cs` convention in the same folder). DI lifetimes stay `Scoped`. `MarginCalculationResult` remains in Domain — Application returning Domain-defined types is allowed under Clean Architecture.
+
+**Tech Stack:** .NET 8, C#, MediatR, xUnit, Moq, FluentAssertions. No new NuGet packages.
+
+---
+
+## Context for the Implementer
+
+### Why this refactor exists
+
+`GetProductMarginSummaryHandler` currently injects two **concrete** classes:
+
+1. `MarginCalculator` — located in the **Domain** project (`Anela.Heblo.Domain.Features.Analytics`), which violates Clean Architecture (no abstraction, Domain owns a stateless service that consumes a stream and returns a DTO — it isn't an entity or value object).
+2. `MonthlyBreakdownGenerator` — already in Application but has no interface.
+
+Two sibling services in the same `Services/` folder already follow the correct pattern (interface + implementation in one file, registered by interface). The two outliers were simply missed in a prior extraction. The `AnalyticsModule.cs` comment labeling them "Legacy services (keeping for backward compatibility)" is misleading — these are the **only** path, with no replacement.
+
+### Why `MonthlyBreakdownGenerator`'s constructor MUST change
+
+`MonthlyBreakdownGenerator` itself takes a concrete `MarginCalculator` in its constructor. Once DI registration moves to `services.AddScoped<IMarginCalculator, MarginCalculator>()`, the concrete `MarginCalculator` is no longer in the container as a self-registered type — the existing `ctor(MarginCalculator)` would fail to resolve at runtime. This is a correctness requirement, not a style preference. Task 3 handles it.
+
+### Files involved (verified by solution-wide grep)
+
+The only files that touch `MarginCalculator` / `MonthlyBreakdownGenerator` are:
+
+- `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs` (will be **deleted**)
+- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs` (modified)
+- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` (modified)
+- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` (modified)
+- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` (modified — adds mockability test)
+- New: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` (created)
+
+`SafeMarginCalculator` in the Catalog feature is **unrelated** — different type, different module. Do not touch it.
+
+### Conventions to follow
+
+- **Single-file co-location**: interface + implementation in one file, per `ProductFilterService.cs` and `ReportBuilderService.cs`.
+- **Nullable reference types enabled**: project already configured; no change needed.
+- **Service lifetimes stay `Scoped`**: NFR-1 forbids behavioral change.
+- **No comment about "legacy"**: remove the misleading line in `AnalyticsModule.cs`.
+- **Use `dotnet format`** between tasks if hooks require it; project uses `dotnet format` as part of the validation gate.
+
+### How to run the tests
+
+Run only the affected test file from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Run the full backend build:
+
+```bash
+dotnet build backend/backend.sln
+```
+
+Run a format check:
+
+```bash
+dotnet format backend/backend.sln --verify-no-changes
+```
+
+---
+
+## File Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Analytics/
+├── AnalyticsModule.cs                                          (MODIFIED — DI registrations)
+├── UseCases/GetProductMarginSummary/
+│   └── GetProductMarginSummaryHandler.cs                       (MODIFIED — inject interfaces)
+└── Services/
+    ├── MarginCalculator.cs                                     (CREATED — IMarginCalculator + impl)
+    ├── MonthlyBreakdownGenerator.cs                            (MODIFIED — implements interface, depends on IMarginCalculator)
+    ├── ProductFilterService.cs                                 (unchanged — reference pattern)
+    └── ReportBuilderService.cs                                 (unchanged — reference pattern)
+
+backend/src/Anela.Heblo.Domain/Features/Analytics/
+├── AnalyticsProduct.cs                                         (unchanged — still owns MarginCalculationResult, DateRange)
+├── AnalyticsProductType.cs                                     (unchanged)
+├── ProductGroupingMode.cs                                      (unchanged)
+└── MarginCalculator.cs                                         (DELETED)
+
+backend/test/Anela.Heblo.Tests/Features/Analytics/
+└── GetProductMarginSummaryHandlerTests.cs                      (MODIFIED — adds mockability test)
+```
+
+---
+
+### Task 1: Relocate `MarginCalculator` from Domain to Application (no interface yet, just move)
+
+**Goal:** Move the concrete class to its proper layer. Existing tests must still pass with concrete construction. This isolates the relocation from the interface change so each step is bisectable.
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs`
+- Delete: `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs`
+- No source/test edits needed yet — namespace imports already cover both layers in every consumer (verified).
+
+- [ ] **Step 1.1: Create the new file with the relocated class**
+
+Create `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` with the **exact** body of the original (copy verbatim), only the namespace changes:
+
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+/// <summary>
+/// 🔒 PERFORMANCE FIX: Extracted margin calculation logic from handler
+/// Implements single responsibility principle and improves testability
+/// </summary>
+public class MarginCalculator
+{
+    /// <summary>
+    /// Calculates margin data using streaming approach to minimize memory usage
+    /// </summary>
+    public async Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default)
+    {
+        var groupTotals = new Dictionary<string, decimal>();
+        var groupProducts = new Dictionary<string, List<AnalyticsProduct>>();
+        var totalMargin = 0m;
+
+        await foreach (var product in products.WithCancellation(cancellationToken))
+        {
+            if (product.MarginAmount <= 0)
+                continue;
+
+            var groupKey = GetGroupKey(product, groupingMode);
+
+            // Calculate total units sold in the period
+            var totalSold = product.SalesHistory.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = (decimal)totalSold * GetMarginAmountForLevel(product, marginLevel);
+
+            // Update group totals
+            if (!groupTotals.ContainsKey(groupKey))
+            {
+                groupTotals[groupKey] = 0;
+                groupProducts[groupKey] = new List<AnalyticsProduct>();
+            }
+
+            groupTotals[groupKey] += marginContribution;
+            groupProducts[groupKey].Add(product);
+            totalMargin += marginContribution;
+        }
+
+        return new MarginCalculationResult
+        {
+            GroupTotals = groupTotals,
+            GroupProducts = groupProducts,
+            TotalMargin = totalMargin
+        };
+    }
+
+    /// <summary>
+    /// Gets the group key based on grouping mode
+    /// </summary>
+    public string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => product.ProductCode,
+            ProductGroupingMode.ProductFamily => product.ProductFamily ?? "Unknown",
+            ProductGroupingMode.ProductCategory => product.ProductCategory ?? "Unknown",
+            _ => product.ProductCode
+        };
+    }
+
+    /// <summary>
+    /// Gets display name for a group
+    /// </summary>
+    public string GetGroupDisplayName(string groupKey, ProductGroupingMode groupingMode, List<AnalyticsProduct> products)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => products.FirstOrDefault(p => p.ProductCode == groupKey)?.ProductName ?? groupKey,
+            ProductGroupingMode.ProductFamily => $"Rodina {groupKey}",
+            ProductGroupingMode.ProductCategory => $"Kategorie {groupKey}",
+            _ => groupKey
+        };
+    }
+
+    /// <summary>
+    /// Gets the margin amount for a specific margin level
+    /// </summary>
+    public decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel)
+    {
+        return marginLevel.ToUpperInvariant() switch
+        {
+            "M0" => product.M0Amount,
+            "M1" => product.M1Amount,
+            "M2" => product.M2Amount,
+            _ => product.M2Amount // Default to M2
+        };
+    }
+}
+```
+
+- [ ] **Step 1.2: Delete the old Domain-layer file**
+
+Delete `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs`.
+
+After deletion, `backend/src/Anela.Heblo.Domain/Features/Analytics/` must contain only:
+- `AnalyticsProduct.cs`
+- `AnalyticsProductType.cs`
+- `ProductGroupingMode.cs`
+
+Verify with:
+
+```bash
+ls backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected output:
+```
+AnalyticsProduct.cs
+AnalyticsProductType.cs
+ProductGroupingMode.cs
+```
+
+- [ ] **Step 1.3: Build the solution to verify type resolution**
+
+Run:
+```bash
+dotnet build backend/backend.sln
+```
+
+Expected: **Build succeeded** with 0 errors and 0 new warnings.
+
+Why this works without source edits: every consumer (`MonthlyBreakdownGenerator.cs`, `GetProductMarginSummaryHandler.cs`, `AnalyticsModule.cs`, `GetProductMarginSummaryHandlerTests.cs`) already has both `using Anela.Heblo.Application.Features.Analytics.Services;` and `using Anela.Heblo.Domain.Features.Analytics;` (or sits inside one of those namespaces). The unqualified `MarginCalculator` token now resolves to the new Application namespace because the Domain one is gone.
+
+- [ ] **Step 1.4: Run the affected tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **All 5 existing test cases pass** (`Handle_ValidRequest_ReturnsCorrectResponse`, three `Handle_DifferentTimeWindows_ParsesCorrectly` theory rows, `Handle_EmptyProductList_ReturnsZeroMargin`).
+
+- [ ] **Step 1.5: Format check**
+
+Run:
+```bash
+dotnet format backend/backend.sln --verify-no-changes
+```
+
+If it reports diffs, run `dotnet format backend/backend.sln` to apply, then re-verify.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs \
+        backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs
+git commit -m "refactor: relocate MarginCalculator from Domain to Application layer"
+```
+
+---
+
+### Task 2: Add `IMarginCalculator` interface alongside the relocated `MarginCalculator`
+
+**Goal:** Expose the public surface as an interface in the same file. Class implements it. No behavior change.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs`
+
+- [ ] **Step 2.1: Add the interface and have the class implement it**
+
+Replace the file content with the version below. The interface declares the four public methods currently consumed; the class body is unchanged.
+
+```csharp
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMarginCalculator
+{
+    Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default);
+
+    string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode);
+
+    string GetGroupDisplayName(
+        string groupKey,
+        ProductGroupingMode groupingMode,
+        List<AnalyticsProduct> products);
+
+    decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel);
+}
+
+/// <summary>
+/// 🔒 PERFORMANCE FIX: Extracted margin calculation logic from handler
+/// Implements single responsibility principle and improves testability
+/// </summary>
+public class MarginCalculator : IMarginCalculator
+{
+    /// <summary>
+    /// Calculates margin data using streaming approach to minimize memory usage
+    /// </summary>
+    public async Task<MarginCalculationResult> CalculateAsync(
+        IAsyncEnumerable<AnalyticsProduct> products,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2",
+        CancellationToken cancellationToken = default)
+    {
+        var groupTotals = new Dictionary<string, decimal>();
+        var groupProducts = new Dictionary<string, List<AnalyticsProduct>>();
+        var totalMargin = 0m;
+
+        await foreach (var product in products.WithCancellation(cancellationToken))
+        {
+            if (product.MarginAmount <= 0)
+                continue;
+
+            var groupKey = GetGroupKey(product, groupingMode);
+
+            // Calculate total units sold in the period
+            var totalSold = product.SalesHistory.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = (decimal)totalSold * GetMarginAmountForLevel(product, marginLevel);
+
+            // Update group totals
+            if (!groupTotals.ContainsKey(groupKey))
+            {
+                groupTotals[groupKey] = 0;
+                groupProducts[groupKey] = new List<AnalyticsProduct>();
+            }
+
+            groupTotals[groupKey] += marginContribution;
+            groupProducts[groupKey].Add(product);
+            totalMargin += marginContribution;
+        }
+
+        return new MarginCalculationResult
+        {
+            GroupTotals = groupTotals,
+            GroupProducts = groupProducts,
+            TotalMargin = totalMargin
+        };
+    }
+
+    /// <summary>
+    /// Gets the group key based on grouping mode
+    /// </summary>
+    public string GetGroupKey(AnalyticsProduct product, ProductGroupingMode groupingMode)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => product.ProductCode,
+            ProductGroupingMode.ProductFamily => product.ProductFamily ?? "Unknown",
+            ProductGroupingMode.ProductCategory => product.ProductCategory ?? "Unknown",
+            _ => product.ProductCode
+        };
+    }
+
+    /// <summary>
+    /// Gets display name for a group
+    /// </summary>
+    public string GetGroupDisplayName(string groupKey, ProductGroupingMode groupingMode, List<AnalyticsProduct> products)
+    {
+        return groupingMode switch
+        {
+            ProductGroupingMode.Products => products.FirstOrDefault(p => p.ProductCode == groupKey)?.ProductName ?? groupKey,
+            ProductGroupingMode.ProductFamily => $"Rodina {groupKey}",
+            ProductGroupingMode.ProductCategory => $"Kategorie {groupKey}",
+            _ => groupKey
+        };
+    }
+
+    /// <summary>
+    /// Gets the margin amount for a specific margin level
+    /// </summary>
+    public decimal GetMarginAmountForLevel(AnalyticsProduct product, string marginLevel)
+    {
+        return marginLevel.ToUpperInvariant() switch
+        {
+            "M0" => product.M0Amount,
+            "M1" => product.M1Amount,
+            "M2" => product.M2Amount,
+            _ => product.M2Amount // Default to M2
+        };
+    }
+}
+```
+
+- [ ] **Step 2.2: Build and test**
+
+```bash
+dotnet build backend/backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **Build succeeded**, **all 5 tests pass**.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs
+git commit -m "refactor: introduce IMarginCalculator interface"
+```
+
+---
+
+### Task 3: Add `IMonthlyBreakdownGenerator`, implement it, and switch its dependency to `IMarginCalculator`
+
+**Goal:** Add the interface to the existing `MonthlyBreakdownGenerator.cs` file. Make the class implement it. **Crucial:** change the constructor parameter from concrete `MarginCalculator` to `IMarginCalculator` — Task 4 will swap the DI registration, after which the concrete self-registration is gone, so the existing concrete-typed constructor would break runtime resolution.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs`
+
+- [ ] **Step 3.1: Add interface and update constructor**
+
+Replace the file with the version below. Only three things change vs. the original:
+1. A new `IMonthlyBreakdownGenerator` interface declared at the top of the file.
+2. Class declaration changes to `public class MonthlyBreakdownGenerator : IMonthlyBreakdownGenerator`.
+3. The field and constructor parameter types change from `MarginCalculator` to `IMarginCalculator`. Field name `_marginCalculator` preserved.
+
+Everything else is byte-for-byte identical.
+
+```csharp
+using System.Globalization;
+using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Domain.Features.Analytics;
+
+namespace Anela.Heblo.Application.Features.Analytics.Services;
+
+public interface IMonthlyBreakdownGenerator
+{
+    List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult calculationResult,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2");
+}
+
+/// <summary>
+/// 🔒 PERFORMANCE FIX: Extracted monthly breakdown logic from handler
+/// Implements single responsibility principle and reduces handler complexity
+/// </summary>
+public class MonthlyBreakdownGenerator : IMonthlyBreakdownGenerator
+{
+    private readonly IMarginCalculator _marginCalculator;
+
+    public MonthlyBreakdownGenerator(IMarginCalculator marginCalculator)
+    {
+        _marginCalculator = marginCalculator;
+    }
+
+    /// <summary>
+    /// Generates monthly breakdown efficiently by processing products once per month
+    /// </summary>
+    public List<MonthlyProductMarginDto> Generate(
+        MarginCalculationResult calculationResult,
+        DateRange dateRange,
+        ProductGroupingMode groupingMode,
+        string marginLevel = "M2")
+    {
+        var monthlyData = new List<MonthlyProductMarginDto>();
+
+        // Generate all months in the date range
+        var current = new DateTime(dateRange.FromDate.Year, dateRange.FromDate.Month, 1);
+        var end = new DateTime(dateRange.ToDate.Year, dateRange.ToDate.Month, 1);
+
+        while (current <= end)
+        {
+            var monthStart = current;
+            var monthEnd = monthStart.AddMonths(1).AddDays(-1);
+
+            var monthlySegments = GenerateMonthlySegments(
+                calculationResult.GroupProducts,
+                monthStart,
+                monthEnd,
+                groupingMode,
+                marginLevel);
+
+            monthlyData.Add(new MonthlyProductMarginDto
+            {
+                Year = current.Year,
+                Month = current.Month,
+                MonthDisplay = current.ToString("MMM yyyy", CultureInfo.CreateSpecificCulture("cs-CZ")),
+                ProductSegments = monthlySegments.segments,
+                TotalMonthMargin = monthlySegments.totalMargin
+            });
+
+            current = current.AddMonths(1);
+        }
+
+        return monthlyData;
+    }
+
+    /// <summary>
+    /// Generates segments for a specific month, processing each group's products efficiently
+    /// </summary>
+    private (List<ProductMarginSegmentDto> segments, decimal totalMargin) GenerateMonthlySegments(
+        Dictionary<string, List<AnalyticsProduct>> groupProducts,
+        DateTime monthStart,
+        DateTime monthEnd,
+        ProductGroupingMode groupingMode,
+        string marginLevel)
+    {
+        var segments = new List<ProductMarginSegmentDto>();
+        var totalMonthMargin = 0m;
+
+        foreach (var (groupKey, products) in groupProducts)
+        {
+            var groupData = ProcessGroupForMonth(products, monthStart, monthEnd, marginLevel);
+
+            if (groupData.totalMargin <= 0)
+                continue;
+
+            totalMonthMargin += groupData.totalMargin;
+
+            var displayName = _marginCalculator.GetGroupDisplayName(groupKey, groupingMode, products);
+
+            segments.Add(new ProductMarginSegmentDto
+            {
+                GroupKey = groupKey,
+                DisplayName = displayName,
+                MarginContribution = groupData.totalMargin,
+                ColorCode = "", // Color assigned by frontend
+                AverageMarginPerPiece = groupData.avgMarginPerPiece,
+                UnitsSold = groupData.totalUnitsSold,
+                AverageSellingPriceWithoutVat = groupData.avgSellingPrice,
+                AverageMaterialCosts = groupData.avgMaterialCosts,
+                AverageLaborCosts = groupData.avgLaborCosts,
+                ProductCount = groupData.productCount,
+                IsOther = false
+            });
+        }
+
+        // Sort by margin contribution (highest first)
+        segments = segments.OrderByDescending(s => s.MarginContribution).ToList();
+
+        // Calculate percentages
+        if (totalMonthMargin > 0)
+        {
+            foreach (var segment in segments)
+            {
+                segment.Percentage = (segment.MarginContribution / totalMonthMargin) * 100;
+            }
+        }
+
+        return (segments, totalMonthMargin);
+    }
+
+    /// <summary>
+    /// Processes a group of products for a specific month
+    /// </summary>
+    private (decimal totalMargin, int totalUnitsSold, decimal avgMarginPerPiece,
+             decimal avgSellingPrice, decimal avgMaterialCosts, decimal avgLaborCosts,
+             int productCount) ProcessGroupForMonth(
+        List<AnalyticsProduct> products,
+        DateTime monthStart,
+        DateTime monthEnd,
+        string marginLevel)
+    {
+        var totalMargin = 0m;
+        var totalUnitsSold = 0;
+        var productCount = 0;
+        var totalMarginPerPiece = 0m;
+        var totalSellingPrice = 0m;
+        var totalMaterialCosts = 0m;
+        var totalLaborCosts = 0m;
+
+        foreach (var product in products)
+        {
+            var salesInMonth = product.SalesHistory
+                .Where(s => s.Date >= monthStart && s.Date <= monthEnd)
+                .ToList();
+
+            var marginAmount = _marginCalculator.GetMarginAmountForLevel(product, marginLevel);
+
+            if (!salesInMonth.Any() || marginAmount <= 0)
+                continue;
+
+            var unitsSold = (int)salesInMonth.Sum(s => s.AmountB2B + s.AmountB2C);
+            var marginContribution = unitsSold * marginAmount;
+
+            totalMargin += marginContribution;
+            totalUnitsSold += unitsSold;
+            productCount++;
+
+            // Accumulate for averages
+            totalMarginPerPiece += marginAmount;
+            totalSellingPrice += product.EshopPriceWithoutVat ?? 0;
+            totalMaterialCosts += product.MaterialCost;
+            totalLaborCosts += product.HandlingCost;
+        }
+
+        return (
+            totalMargin,
+            totalUnitsSold,
+            productCount > 0 ? totalMarginPerPiece / productCount : 0,
+            productCount > 0 ? totalSellingPrice / productCount : 0,
+            productCount > 0 ? totalMaterialCosts / productCount : 0,
+            productCount > 0 ? totalLaborCosts / productCount : 0,
+            productCount
+        );
+    }
+}
+```
+
+- [ ] **Step 3.2: Build and test**
+
+```bash
+dotnet build backend/backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **Build succeeded** (the test file constructs `new MonthlyBreakdownGenerator(_marginCalculator)` where `_marginCalculator` is the concrete `MarginCalculator`; since `MarginCalculator` implements `IMarginCalculator`, this assignment is valid). **All 5 tests pass.**
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs
+git commit -m "refactor: introduce IMonthlyBreakdownGenerator, depend on IMarginCalculator"
+```
+
+---
+
+### Task 4: Switch DI registrations to interface-based and drop the misleading comment
+
+**Goal:** Register both services by their interfaces with `AddScoped` (preserving lifetime per NFR-1). Remove the "Legacy services" comment.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs`
+
+- [ ] **Step 4.1: Update the registration block**
+
+Replace lines 36–38 of `AnalyticsModule.cs`:
+
+**Before:**
+```csharp
+        // Legacy services (keeping for backward compatibility)
+        services.AddScoped<MarginCalculator>();
+        services.AddScoped<MonthlyBreakdownGenerator>();
+```
+
+**After:**
+```csharp
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+```
+
+Do not change any other registration in the file. The full updated file (for reference):
+
+```csharp
+using Anela.Heblo.Application.Features.Analytics.DashboardTiles;
+using Anela.Heblo.Application.Features.Analytics.Infrastructure;
+using Anela.Heblo.Application.Features.Analytics.Services;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetMarginReport;
+using Anela.Heblo.Application.Features.Analytics.UseCases.GetProductMarginAnalysis;
+using Anela.Heblo.Application.Features.Analytics.Validators;
+using Anela.Heblo.Domain.Features.Analytics;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.Analytics;
+
+/// <summary>
+/// Enhanced analytics module with refactored services and validation
+/// Registers new services for better separation of concerns and testability
+/// </summary>
+public static class AnalyticsModule
+{
+    public static IServiceCollection AddAnalyticsModule(this IServiceCollection services)
+    {
+        // MediatR handlers are automatically registered by AddMediatR scan
+
+        // Register repository
+        services.AddScoped<IAnalyticsRepository, AnalyticsRepository>();
+
+        // Register refactored services for clean separation of concerns
+        // Note: IMarginCalculationService is registered by CatalogModule and injected here
+        services.AddScoped<IProductFilterService, ProductFilterService>();
+        services.AddScoped<IReportBuilderService, ReportBuilderService>();
+
+        // Register validators for FluentValidation
+        services.AddScoped<IValidator<GetMarginReportRequest>, GetMarginReportRequestValidator>();
+        services.AddScoped<IValidator<GetProductMarginAnalysisRequest>, GetProductMarginAnalysisRequestValidator>();
+
+        services.AddScoped<IMarginCalculator, MarginCalculator>();
+        services.AddScoped<IMonthlyBreakdownGenerator, MonthlyBreakdownGenerator>();
+
+        // Register dashboard tiles
+        services.RegisterTile<InvoiceImportStatisticsTile>();
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 4.2: Build**
+
+```bash
+dotnet build backend/backend.sln
+```
+
+Expected: **Build succeeded.** The handler still references the concrete classes (Task 5 fixes that), but since the concrete classes still exist and the test file uses them directly via `new`, the build remains green.
+
+Note: at this checkpoint, **a runtime DI resolution of `GetProductMarginSummaryHandler` would fail** because the handler's constructor still asks for `MarginCalculator` (concrete) and `MonthlyBreakdownGenerator` (concrete), which are no longer self-registered. The fix lands in Task 5. Existing **unit tests** still pass because they wire the handler manually with `new`, not via DI.
+
+- [ ] **Step 4.3: Run unit tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **All 5 tests pass.**
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs
+git commit -m "refactor: register margin calculator services by interface"
+```
+
+---
+
+### Task 5: Update `GetProductMarginSummaryHandler` to inject the interfaces
+
+**Goal:** Switch handler fields and constructor parameters to interface types. Field names preserved. No behavioral change.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs`
+
+- [ ] **Step 5.1: Change field and constructor parameter types**
+
+Apply this targeted edit to `GetProductMarginSummaryHandler.cs` lines 15–27.
+
+**Before:**
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly MarginCalculator _marginCalculator;
+    private readonly MonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        MarginCalculator marginCalculator,
+        MonthlyBreakdownGenerator monthlyBreakdownGenerator)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+    }
+```
+
+**After:**
+```csharp
+    private readonly IAnalyticsRepository _analyticsRepository;
+    private readonly IMarginCalculator _marginCalculator;
+    private readonly IMonthlyBreakdownGenerator _monthlyBreakdownGenerator;
+
+    public GetProductMarginSummaryHandler(
+        IAnalyticsRepository analyticsRepository,
+        IMarginCalculator marginCalculator,
+        IMonthlyBreakdownGenerator monthlyBreakdownGenerator)
+    {
+        _analyticsRepository = analyticsRepository;
+        _marginCalculator = marginCalculator;
+        _monthlyBreakdownGenerator = monthlyBreakdownGenerator;
+    }
+```
+
+Do not touch any other line in the file. The `Handle` method, `GenerateTopProducts`, `CalculateGroupMarginData`, `ApplySorting`, and `CalculateTotalMarginForLevel` are unchanged — they call methods that exist on `IMarginCalculator` (`GetGroupDisplayName`, etc.) so the body still compiles.
+
+- [ ] **Step 5.2: Build the full solution and run all backend tests**
+
+```bash
+dotnet build backend/backend.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **Build succeeded**, **all 5 tests pass.** (The existing tests pass `_marginCalculator` and `_monthlyBreakdownGenerator` to the constructor; both concrete fields satisfy the new interface parameters via implicit upcast.)
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs
+git commit -m "refactor: GetProductMarginSummaryHandler depends on margin calculator abstractions"
+```
+
+---
+
+### Task 6: Add a mockability test demonstrating the handler is now testable in isolation (FR-8)
+
+**Goal:** Add one new test that constructs `GetProductMarginSummaryHandler` with `Mock<IMarginCalculator>` and `Mock<IMonthlyBreakdownGenerator>` and asserts both mocks are invoked. This is the verification test for the refactor's success criterion. Existing tests that use the real `MarginCalculator` / `MonthlyBreakdownGenerator` stay as-is — they now serve as integration-style coverage against the real services.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs`
+
+- [ ] **Step 6.1: Add the test method**
+
+Insert this new test method into `GetProductMarginSummaryHandlerTests` (e.g. after `Handle_EmptyProductList_ReturnsZeroMargin`, before the closing brace of the class). It uses the existing mocking convention (`Moq`) and `FluentAssertions`, both already imported at the top of the file.
+
+```csharp
+    [Fact]
+    public async Task Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator()
+    {
+        // Arrange
+        var marginCalculatorMock = new Mock<IMarginCalculator>();
+        var monthlyBreakdownGeneratorMock = new Mock<IMonthlyBreakdownGenerator>();
+
+        var request = new GetProductMarginSummaryRequest
+        {
+            TimeWindow = "current-year",
+            GroupingMode = ProductGroupingMode.Products,
+            MarginLevel = "M2"
+        };
+
+        var today = DateTime.Today;
+        var fromDate = new DateTime(today.Year, 1, 1);
+        var toDate = today;
+
+        var calculationResult = new MarginCalculationResult
+        {
+            GroupTotals = new Dictionary<string, decimal> { ["PROD001"] = 500m },
+            GroupProducts = new Dictionary<string, List<AnalyticsProduct>>
+            {
+                ["PROD001"] = new List<AnalyticsProduct>
+                {
+                    new AnalyticsProduct
+                    {
+                        ProductCode = "PROD001",
+                        ProductName = "Product 1",
+                        Type = AnalyticsProductType.Product,
+                        MarginAmount = 50m,
+                        M0Amount = 50m,
+                        M1Amount = 50m,
+                        M2Amount = 50m,
+                        SellingPrice = 100m,
+                        PurchasePrice = 50m,
+                        SalesHistory = new List<SalesDataPoint>
+                        {
+                            new() { Date = new DateTime(today.Year, 3, 1), AmountB2B = 5, AmountB2C = 5 }
+                        }
+                    }
+                }
+            },
+            TotalMargin = 500m
+        };
+
+        var monthlyData = new List<MonthlyProductMarginDto>
+        {
+            new MonthlyProductMarginDto
+            {
+                Year = today.Year,
+                Month = 3,
+                MonthDisplay = "Mar",
+                ProductSegments = new List<ProductMarginSegmentDto>(),
+                TotalMonthMargin = 500m
+            }
+        };
+
+        _analyticsRepositoryMock
+            .Setup(x => x.StreamProductsWithSalesAsync(fromDate, toDate,
+                It.IsAny<AnalyticsProductType[]>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<AnalyticsProduct>().ToAsyncEnumerable());
+
+        marginCalculatorMock
+            .Setup(x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(calculationResult);
+
+        marginCalculatorMock
+            .Setup(x => x.GetGroupDisplayName(
+                It.IsAny<string>(),
+                It.IsAny<ProductGroupingMode>(),
+                It.IsAny<List<AnalyticsProduct>>()))
+            .Returns<string, ProductGroupingMode, List<AnalyticsProduct>>((key, _, _) => key);
+
+        monthlyBreakdownGeneratorMock
+            .Setup(x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2"))
+            .Returns(monthlyData);
+
+        var handler = new GetProductMarginSummaryHandler(
+            _analyticsRepositoryMock.Object,
+            marginCalculatorMock.Object,
+            monthlyBreakdownGeneratorMock.Object);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.TotalMargin.Should().Be(500m);
+        result.MonthlyData.Should().BeSameAs(monthlyData);
+
+        marginCalculatorMock.Verify(
+            x => x.CalculateAsync(
+                It.IsAny<IAsyncEnumerable<AnalyticsProduct>>(),
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        monthlyBreakdownGeneratorMock.Verify(
+            x => x.Generate(
+                calculationResult,
+                It.IsAny<DateRange>(),
+                ProductGroupingMode.Products,
+                "M2"),
+            Times.Once);
+    }
+```
+
+Notes for the implementer:
+- `_analyticsRepositoryMock` is already a field on the test class — reuse it.
+- The handler's `Handle` calls `_marginCalculator.GetGroupDisplayName` from inside `GenerateTopProducts` when iterating `calculationResult.GroupTotals`. The mock setup for `GetGroupDisplayName` above covers that call.
+- `MarginLevel` default in `GetProductMarginSummaryRequest` is unknown at this layer; setting it explicitly to `"M2"` matches the test's mock setup. If `GetProductMarginSummaryRequest.MarginLevel` is non-nullable and has a different default, set it to whatever value the request uses by default — but match it in the `.Setup(...)` calls. (Check `GetProductMarginSummaryRequest.cs` in the same UseCases folder if uncertain.)
+
+- [ ] **Step 6.2: Run the new test alone to confirm it passes**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WithMockedDependencies_InvokesCalculatorAndBreakdownGenerator"
+```
+
+Expected: **1 test passed.**
+
+- [ ] **Step 6.3: Run the full handler test class**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetProductMarginSummaryHandlerTests"
+```
+
+Expected: **6 tests passed** (5 original + 1 new).
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs
+git commit -m "test: add mockability test for GetProductMarginSummaryHandler"
+```
+
+---
+
+### Task 7: Full verification gate
+
+**Goal:** Confirm the refactor is complete, clean-architecture-compliant, and ready to ship. Verifies the CLAUDE.md completion gates (build + format + tests).
+
+- [ ] **Step 7.1: Full backend build**
+
+```bash
+dotnet build backend/backend.sln
+```
+
+Expected: **Build succeeded. 0 Warning(s), 0 Error(s).** (Zero **new** warnings — pre-existing warnings unrelated to this change are tolerable but should not increase in count.)
+
+- [ ] **Step 7.2: Format check**
+
+```bash
+dotnet format backend/backend.sln --verify-no-changes
+```
+
+Expected: **Format complete** (no diffs). If diffs are reported, run `dotnet format backend/backend.sln`, then re-verify, then amend the most recent commit only if the diffs are formatting-only.
+
+- [ ] **Step 7.3: Full backend test run**
+
+```bash
+dotnet test backend/backend.sln
+```
+
+Expected: **All tests pass.** Pay attention to:
+- All 6 `GetProductMarginSummaryHandlerTests` cases pass.
+- No other test broke (cross-module impact should be zero — `SafeMarginCalculator` etc. are unrelated).
+
+- [ ] **Step 7.4: Manual grep — confirm no concrete-type injections remain (FR-7)**
+
+Run a grep for stale concrete references:
+
+```bash
+grep -rn "MarginCalculator " backend/src backend/test \
+  | grep -vE "(IMarginCalculator|MarginCalculator\(|MarginCalculator\.cs|SafeMarginCalculator|IMarginCalculationService|MarginCalculationResult|MarginCalculationService)"
+```
+
+Expected output: **no lines**, OR only lines that are clearly:
+- The interface↔class registration in `AnalyticsModule.cs` (e.g. `IMarginCalculator, MarginCalculator>`).
+- The `new MarginCalculator()` construction in the existing test setup (`GetProductMarginSummaryHandlerTests.cs:32`).
+- The `public class MarginCalculator : IMarginCalculator` declaration in the implementation file.
+
+Anything else (e.g. a constructor parameter typed `MarginCalculator` somewhere) is a bug — fix before proceeding.
+
+Same check for `MonthlyBreakdownGenerator`:
+
+```bash
+grep -rn "MonthlyBreakdownGenerator " backend/src backend/test \
+  | grep -vE "(IMonthlyBreakdownGenerator|MonthlyBreakdownGenerator\(|MonthlyBreakdownGenerator\.cs)"
+```
+
+Expected output: **no lines**, OR only the registration and test instantiation.
+
+- [ ] **Step 7.5: Confirm Domain folder is clean (FR-3 strengthened acceptance)**
+
+```bash
+ls backend/src/Anela.Heblo.Domain/Features/Analytics/
+```
+
+Expected output exactly:
+```
+AnalyticsProduct.cs
+AnalyticsProductType.cs
+ProductGroupingMode.cs
+```
+
+If `MarginCalculator.cs` still appears: it was not deleted in Task 1. Delete it now and amend the Task 1 commit only if no other tasks have been pushed.
+
+- [ ] **Step 7.6: Final commit if any formatting changes accumulated**
+
+If Steps 7.1–7.5 produced any auto-format diffs:
+
+```bash
+git status
+# If there are formatting-only diffs:
+git add -A
+git commit -m "chore: dotnet format pass"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Spec Coverage Check
+
+| Requirement | Covered by |
+|---|---|
+| FR-1: Define `IMarginCalculator` interface | Task 2 |
+| FR-2: Define `IMonthlyBreakdownGenerator` interface | Task 3 |
+| FR-3: Relocate `MarginCalculator` to Application layer | Task 1 (+ Task 7.5 verification) |
+| FR-4: `MonthlyBreakdownGenerator` implements `IMonthlyBreakdownGenerator` | Task 3 |
+| FR-4b (arch-review amendment): `MonthlyBreakdownGenerator` ctor depends on `IMarginCalculator` | Task 3 |
+| FR-5: Update DI registrations + remove misleading comment | Task 4 |
+| FR-6: Handler injects interfaces | Task 5 |
+| FR-7: Update other concrete consumers (none expected) | Task 7.4 grep verification |
+| FR-8: Existing tests pass + mockability test added | Task 6 |
+| NFR-1: No performance change (same lifetimes preserved) | Task 4 (uses `AddScoped`) |
+| NFR-2: No security change | n/a — no surface change |
+| NFR-3: Backwards compatible (no API/DTO/DB changes) | n/a — not touched |
+| NFR-4: Build clean, format clean, tests pass | Task 7 gates |
+
+Arch-review amendments incorporated:
+1. ✅ `MonthlyBreakdownGenerator` constructor switch made explicit (Task 3).
+2. ✅ Single-file interface co-location (Tasks 2, 3 — both interfaces declared in the same file as their implementations).
+3. ✅ Explicit `CalculateAsync` signature (Task 2).
+4. ✅ `MarginCalculationResult` stays in Domain (verified — no task moves it).
+5. ✅ Post-state of Domain folder verified explicitly (Task 7.5).
+6. ✅ Mockability test uses `Mock<IMarginCalculator>` and `Mock<IMonthlyBreakdownGenerator>` with invocation verification (Task 6).


### PR DESCRIPTION

Extracts `IMarginCalculator` and `IMonthlyBreakdownGenerator` interfaces, relocates `MarginCalculator` from the Domain layer to Application, and switches `GetProductMarginSummaryHandler` (and `MonthlyBreakdownGenerator`) to depend on those abstractions. Aligns the two outlier services with the established pattern used by `IProductFilterService` and `IReportBuilderService` in the same `Services/` folder.

The `MonthlyBreakdownGenerator` constructor was updated to accept `IMarginCalculator` (required for correctness — once `MarginCalculator` is registered only by interface, the concrete self-registration is gone and the old constructor would fail runtime DI resolution).

No behavior change: same code paths, same DI lifetimes (Scoped), same HTTP API contract, same DTOs, no DB changes.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MarginCalculator.cs` — new file: `IMarginCalculator` interface + relocated implementation
- `backend/src/Anela.Heblo.Domain/Features/Analytics/MarginCalculator.cs` — deleted
- `backend/src/Anela.Heblo.Application/Features/Analytics/Services/MonthlyBreakdownGenerator.cs` — `IMonthlyBreakdownGenerator` interface added; constructor type changed to `IMarginCalculator`
- `backend/src/Anela.Heblo.Application/Features/Analytics/AnalyticsModule.cs` — interface-based DI registrations; "Legacy services" comment removed
- `backend/src/Anela.Heblo.Application/Features/Analytics/UseCases/GetProductMarginSummary/GetProductMarginSummaryHandler.cs` — field and constructor types changed to interfaces
- `backend/test/Anela.Heblo.Tests/Features/Analytics/GetProductMarginSummaryHandlerTests.cs` — mockability test added (6 tests total, all pass)

---

Closes #1807

### Tokens used
18374885
