### PR TITLE
feat: Decouple Purchase.RecalculatePurchasePrice from Catalog Domain

### DIFF
--- a/artifacts/feat-arch-review-purchase-recalculatepurchase/arch-review.r1.md
+++ b/artifacts/feat-arch-review-purchase-recalculatepurchase/arch-review.r1.md
@@ -1,0 +1,194 @@
+# Architecture Review: Decouple Purchase.RecalculatePurchasePrice from Catalog Domain
+
+## Skip Design: true
+
+This is a backend-only architectural refactor. No UI components, screens, layouts, or visual design decisions are involved. The HTTP API surface, MediatR contracts, and OpenAPI client output are explicitly unchanged.
+
+## Architectural Fit Assessment
+
+The proposed design is an **exact replication of the existing, documented pattern** in this codebase. The verification is concrete:
+
+- **`IMaterialCatalogService`** (Purchase-owned contract at `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IMaterialCatalogService.cs`) is implemented by **`PurchaseMaterialCatalogAdapter`** (`internal sealed`, in `Application/Features/Catalog/Infrastructure/`), registered in `CatalogModule.cs:46` as `Scoped`. The Catalog module already imports `Anela.Heblo.Application.Features.Purchase.Contracts` (`CatalogModule.cs:10`), so the new adapter introduces zero new project-level dependencies.
+- **`PurchaseAllowlist`** in `ModuleBoundariesTests.cs:84-93` contains exactly one entry — the `RecalculatePurchasePriceHandler → IProductPriceErpClient` coupling — and that entry's own comment explicitly tracks this work as the follow-up. Eliminating it makes the set empty, matching `PackingMaterials`, `ExpeditionListArchive`, and both `Analytics` allowlists.
+- The handler at `RecalculatePurchasePriceHandler.cs:83` performs a single, side-effect-only invocation of `_productPriceClient.RecalculatePurchasePrice(bom.BoMId, cancellationToken)` — there is no return value, no state transfer, no transformation. The boundary is trivially narrow and adapts cleanly through a pure delegation method.
+
+Integration points are limited to: (1) Purchase Contracts folder (add interface), (2) Catalog Infrastructure folder (add adapter), (3) `CatalogModule` DI registration, (4) `RecalculatePurchasePriceHandler` constructor + one call site, (5) two test files. No persistence, no API surface, no cross-assembly references change.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────── Purchase module ────────────────────────────────┐
+│                                                                                  │
+│   RecalculatePurchasePriceHandler                                                │
+│         │                                                                        │
+│         │ depends on (constructor injection)                                     │
+│         ▼                                                                        │
+│   IPurchasePriceRecalculationService     ◄── new contract (Purchase-owned)       │
+│         (Contracts/)                                                             │
+└─────────┬────────────────────────────────────────────────────────────────────────┘
+          │ DI binding registered in CatalogModule
+          ▼
+┌─────────┴──────────────────────── Catalog module ───────────────────────────────┐
+│                                                                                  │
+│   CatalogPurchasePriceRecalculationAdapter  ◄── new adapter (internal sealed)    │
+│         (Infrastructure/)                                                        │
+│         │                                                                        │
+│         │ delegates to                                                           │
+│         ▼                                                                        │
+│   IProductPriceErpClient                                                         │
+│         (Domain/Features/Catalog/Price/) — unchanged                             │
+└──────────────────────────────────────────────────────────────────────────────────┘
+          │
+          ▼
+   FlexiProductPriceErpClient (Adapters layer) — unchanged
+```
+
+### Key Design Decisions
+
+#### Decision 1: Contract Naming
+**Options considered:**
+- `IPurchasePriceRecalculationService` (spec choice)
+- `IPurchasePriceRecalculator` (suggested in brief and in the allowlist's tracking comment)
+
+**Chosen approach:** `IPurchasePriceRecalculationService`, as in the spec.
+
+**Rationale:** Matches the existing sibling contract `IMaterialCatalogService` in the same Contracts/ folder. The `*Service` suffix is established convention here; introducing a `*Recalculator` suffix would create an inconsistency at the same boundary. Naming is a one-way door once consumers reference the interface.
+
+#### Decision 2: Async Suffix on the New Method
+**Options considered:**
+- Match the existing `IProductPriceErpClient.RecalculatePurchasePrice` (no suffix)
+- Use `RecalculatePurchasePriceAsync` (spec choice)
+
+**Chosen approach:** `RecalculatePurchasePriceAsync`.
+
+**Rationale:** New code follows the project's documented Async naming convention. The legacy `IProductPriceErpClient` symbol is explicitly out of scope (see spec "Out of Scope" §3). The adapter absorbs the rename mismatch — that is precisely what adapters exist to do.
+
+#### Decision 3: Provider-Side DI Registration
+**Options considered:**
+- Register binding in `CatalogModule.AddCatalogModule` (spec choice)
+- Register in `PurchaseModule.AddPurchaseModule`
+- Register in a composition root
+
+**Chosen approach:** `CatalogModule`.
+
+**Rationale:** The provider owns the implementation; the consumer owns the contract. This is the rule established for `IMaterialCatalogService` and is what makes Purchase compile without referencing any Catalog implementation symbol. Putting the binding in Purchase would force Purchase to know about `CatalogPurchasePriceRecalculationAdapter`, defeating the entire point of the refactor.
+
+#### Decision 4: Adapter Visibility
+**Options considered:**
+- `internal sealed` (spec choice)
+- `public sealed`
+
+**Chosen approach:** `internal sealed`.
+
+**Rationale:** Matches `PurchaseMaterialCatalogAdapter` exactly. The DI container can resolve internal types because `CatalogModule` lives in the same assembly. No external code needs to reference the adapter directly. Sealing prevents accidental subclassing of a pure-delegation type.
+
+#### Decision 5: Service Lifetime
+**Options considered:**
+- `Scoped` (spec choice, matches `IMaterialCatalogService`)
+- `Transient` (matches the underlying `ICatalogRepository`)
+- `Singleton` (the adapter is stateless)
+
+**Chosen approach:** `Scoped`.
+
+**Rationale:** Consistency with the sibling adapter. The adapter is stateless so any lifetime is functionally correct, but uniformity reduces cognitive load when reading `CatalogModule`. Scoped also matches the lifetime ceiling implied by handler scopes in the MediatR pipeline.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Files to create:
+- `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IPurchasePriceRecalculationService.cs`
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapter.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapterTests.cs`
+
+Files to modify:
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` (add one `AddScoped` line near line 46)
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs` (swap dependency)
+- `backend/test/Anela.Heblo.Tests/Application/Purchase/RecalculatePurchasePriceHandlerTests.cs` (swap mock)
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (empty the `PurchaseAllowlist`)
+
+No files to delete. No project-level reference changes.
+
+### Interfaces and Contracts
+
+```csharp
+// New — Purchase-owned
+namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+public interface IPurchasePriceRecalculationService
+{
+    Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken);
+}
+```
+
+```csharp
+// New — Catalog-implemented adapter
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogPurchasePriceRecalculationAdapter : IPurchasePriceRecalculationService
+{
+    private readonly IProductPriceErpClient _productPriceErpClient;
+
+    public CatalogPurchasePriceRecalculationAdapter(IProductPriceErpClient productPriceErpClient)
+    {
+        _productPriceErpClient = productPriceErpClient;
+    }
+
+    public Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken) =>
+        _productPriceErpClient.RecalculatePurchasePrice(bomId, cancellationToken);
+}
+```
+
+Developer rules:
+- The adapter MUST be pure delegation. No logging, retry, transformation, or null-checks. Existing semantics (including any exceptions thrown by `IProductPriceErpClient`) propagate verbatim — `RecalculatePurchasePriceHandler`'s try/catch at line 78–113 already handles them.
+- The handler's exception/error-code surface (`ErrorCodes.InvalidValue`, `ErrorCodes.CatalogItemNotFound`, `ErrorCodes.Exception`) MUST remain bit-identical. This is asserted by the existing nine `[Fact]` tests in `RecalculatePurchasePriceHandlerTests` — keep them all passing.
+
+### Data Flow
+
+For the recalculate-single-product use case:
+
+1. HTTP → `RecalculatePurchasePriceController` → MediatR → `RecalculatePurchasePriceHandler.Handle`
+2. Handler validates → calls `IMaterialCatalogService.GetByIdAsync` (existing contract) → builds `bomReferences` list
+3. Per BoM reference, handler calls **`IPurchasePriceRecalculationService.RecalculatePurchasePriceAsync(bomId, ct)`** (new line replacing line 83)
+4. DI resolves to `CatalogPurchasePriceRecalculationAdapter` → forwards to `IProductPriceErpClient.RecalculatePurchasePrice(bomId, ct)`
+5. DI resolves `IProductPriceErpClient` to `FlexiProductPriceErpClient` → calls the ERP
+
+Compared to the current flow, only step 4 is new. All other behavior — including iteration semantics, exception handling, response shape, and logging — is preserved.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Adapter lifetime mismatch with `IProductPriceErpClient` registration (e.g., the ERP client is Singleton while the adapter is Scoped) | Low | Verify in `FlexiAdapterServiceCollectionExtensions` before committing. Captive dependency is harmless for a stateless adapter, but worth a one-line confirmation that lifetimes compose cleanly. |
+| Other Purchase types (handlers, services, controllers) still reference Catalog symbols, causing `Consumer_types_should_not_reference_provider_owned_namespaces` to fail after the allowlist is emptied | Low | Run `dotnet test --filter ModuleBoundariesTests` locally after the change. If new violations surface, they were latent under the original allowlist scope and need to be addressed under their own tickets — **do not expand the allowlist**. |
+| Test file path drift: spec suggests `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapterTests.cs` but mentions following "the existing test folder convention" | Low | Confirmed convention by inspection: `PurchaseMaterialCatalogAdapterTests.cs` and `CatalogAnalyticsSourceAdapterTests.cs` both live in `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/`. Use that exact directory. |
+| Adapter changes inadvertently break the `FinancialOverview` consumers (`StockValueService`, `FinancialOverviewModule`) that also reference `IProductPriceErpClient` | Low | The refactor adds a new binding; it does not modify, replace, or unregister `IProductPriceErpClient`. Other consumers continue to inject `IProductPriceErpClient` directly. Verify by running their existing tests (`StockValueServiceTests`, `FinancialOverviewModuleTests`). |
+| Internal adapter not resolvable by DI | Negligible | Identical to `PurchaseMaterialCatalogAdapter` which is already `internal sealed` and DI-registered in the same module — pattern is proven. |
+
+## Specification Amendments
+
+The spec is well-grounded and aligns with existing patterns. Three minor amendments recommended:
+
+1. **FR-2 acceptance criterion (test directory):** Replace the parenthetical "(or follow the existing test folder convention for Catalog infrastructure adapters)" with the explicit, verified path `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapterTests.cs`. The convention is unambiguous; the hedge is unnecessary.
+
+2. **FR-3 add an implicit check:** After implementing, run a grep verifying no type under `Anela.Heblo.Application.Features.Purchase.*` references `Anela.Heblo.Domain.Features.Catalog.*` or `Anela.Heblo.Application.Features.Catalog.*`. Concretely: `grep -r "Anela.Heblo.\(Application\|Domain\)\.Features\.Catalog" backend/src/Anela.Heblo.Application/Features/Purchase/` should return no matches. This is the operational equivalent of NFR-4 and provides a fast pre-test signal.
+
+3. **FR-7 cleanup:** Spec says "comment block describing the violation MUST be removed; if the set is empty, the descriptive comment about the allowlist's purpose can be reduced to one line." To match the empty-allowlist style used by `PackingMaterials`, `ExpeditionListArchive`, and `Analytics` rules (which inline `new HashSet<string>(StringComparer.Ordinal)` directly into the `Rules()` `TheoryData`), consider deleting the `PurchaseAllowlist` field entirely and inlining an empty `HashSet` in the rule definition. This removes a now-pointless named field. (Optional cleanup — does not affect correctness.)
+
+No functional or non-functional requirements need to be added or removed. No data model, API, or persistence amendments.
+
+## Prerequisites
+
+None. Specifically:
+
+- No NuGet package additions.
+- No project reference changes (Catalog already references Purchase's Contracts namespace at `CatalogModule.cs:10`).
+- No database migration.
+- No configuration change (`appsettings.*.json`, environment variables).
+- No infrastructure or deployment change.
+- No frontend rebuild (OpenAPI client surface is bit-identical, per spec NFR-3).
+- No coordinated work in adjacent modules. The `FinancialOverview` violation referenced in spec "Out of Scope" §1 is independent and untouched.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-purchase-recalculatepurchase/brief.md
+++ b/artifacts/feat-arch-review-purchase-recalculatepurchase/brief.md
@@ -1,0 +1,34 @@
+## Module
+Purchase
+
+## Finding
+`RecalculatePurchasePriceHandler` imports and directly injects `IProductPriceErpClient` from the **Catalog module's domain layer**:
+
+- File: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs`
+- Line 4: `using Anela.Heblo.Domain.Features.Catalog.Price;`
+- Lines 13–14: `IProductPriceErpClient` injected as a constructor dependency
+
+`IProductPriceErpClient` is defined at `backend/src/Anela.Heblo.Domain/Features/Catalog/Price/IProductPriceErpClient.cs` — it is owned by the Catalog module's domain.
+
+## Why it matters
+This violates the module isolation rule from `development_guidelines.md`: modules must communicate **only through the consuming module's own contracts**, never by reaching into another module's domain or application types. The Purchase module now has a hard compile-time dependency on Catalog's domain layer, which prevents future extraction of either module and defeats the contract-based decoupling architecture.
+
+The established pattern in this codebase (see `ILeafletKnowledgeSource` example in the guidelines) is:
+1. **Consumer (Purchase)** defines an interface in `Purchase/Contracts/` (e.g. `IPurchasePriceRecalculationService`)
+2. **Provider (Catalog)** implements an adapter in `Catalog/Infrastructure/` that delegates to `IProductPriceErpClient`
+3. **Catalog's module** registers the DI binding
+
+## Suggested fix
+1. Add `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IPurchasePriceRecalculationService.cs`:
+   ```csharp
+   public interface IPurchasePriceRecalculationService
+   {
+       Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken);
+   }
+   ```
+2. Add an adapter in Catalog (e.g. `Catalog/Infrastructure/CatalogPurchasePriceAdapter.cs`) that implements the new interface by delegating to `IProductPriceErpClient`.
+3. Update `CatalogModule.cs` to register `services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceAdapter>()`.
+4. Replace the `IProductPriceErpClient` dependency in `RecalculatePurchasePriceHandler` with `IPurchasePriceRecalculationService`.
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-purchase-recalculatepurchase/impl/main.r1.md
+++ b/artifacts/feat-arch-review-purchase-recalculatepurchase/impl/main.r1.md
@@ -1,0 +1,12 @@
+This is a named branch (`feat-arch-review-purchase-recalculatepurchase`) in what appears to be a standalone repo (GIT_DIR == GIT_COMMON). Base branch is `main`. 4 commits of implementation work on top of 4 agent-uploaded artifact commits.
+
+---
+
+Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-purchase-recalculatepurchase/spec.r1.md
+++ b/artifacts/feat-arch-review-purchase-recalculatepurchase/spec.r1.md
@@ -1,0 +1,212 @@
+# Specification: Decouple Purchase.RecalculatePurchasePrice from Catalog Domain
+
+## Summary
+The `RecalculatePurchasePriceHandler` in the Purchase module directly injects `IProductPriceErpClient`, an interface owned by the Catalog domain. This violates the project's module isolation rule and is currently tolerated via an explicit allowlist entry in `ModuleBoundariesTests`. This specification defines the work required to lift that dependency behind a Purchase-owned contract implemented by an adapter in the Catalog module, mirroring the established `IMaterialCatalogService` / `PurchaseMaterialCatalogAdapter` pattern.
+
+## Background
+The codebase follows a Vertical Slice / Clean Architecture where each feature module (Purchase, Catalog, Logistics, etc.) is intended to be independently deployable. The governing rule in `docs/architecture/development_guidelines.md` is:
+
+> Communication between modules **exclusively through `contracts/`** … When module A needs data from module B: define the interface in **module A's contracts**, implement it in module B, never access module B's domain or infrastructure directly.
+
+The `RecalculatePurchasePriceHandler` currently breaks this rule at two locations:
+
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs:3` — `using Anela.Heblo.Domain.Features.Catalog.Price;`
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs:12,17` — `IProductPriceErpClient` is a constructor dependency
+
+The violation is already tracked: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs:84-93` contains a `PurchaseAllowlist` entry permitting this single coupling pending decoupling work. The allowlist comment explicitly notes that the fix is "out of scope for the 2026-05-24 Purchase ↔ Catalog decoupling" and tracks it as a follow-up. This specification IS that follow-up.
+
+The pattern to apply is already proven in this codebase by two precedents:
+
+1. `IMaterialCatalogService` (Purchase contract) implemented by `PurchaseMaterialCatalogAdapter` (Catalog infrastructure), registered in `CatalogModule.AddCatalogModule()` at line 46.
+2. `ILeafletKnowledgeSource` (Leaflet contract) implemented by `KnowledgeBaseLeafletSourceAdapter` (KnowledgeBase infrastructure) — the canonical example in the architecture docs.
+
+Beyond restoring architectural conformance, this also reduces blast radius for the planned Phase-2 split into per-module DbContexts and microservices.
+
+## Functional Requirements
+
+### FR-1: Introduce Purchase-owned recalculation contract
+A new interface, `IPurchasePriceRecalculationService`, MUST be added to the Purchase module's contracts folder. It exposes only the single operation the handler currently consumes.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IPurchasePriceRecalculationService.cs`
+
+**Signature:**
+```csharp
+namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+public interface IPurchasePriceRecalculationService
+{
+    Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken);
+}
+```
+
+**Acceptance criteria:**
+- File exists in the path above with the namespace `Anela.Heblo.Application.Features.Purchase.Contracts`.
+- The interface declares exactly one method matching the signature above (preserving the existing `bomId` parameter type and the cancellation token contract).
+- The method name uses the `Async` suffix to match repository naming conventions (existing client uses `RecalculatePurchasePrice` without suffix; the new contract aligns with `IMaterialCatalogService` naming).
+- No other operations are added speculatively — YAGNI applies.
+
+### FR-2: Implement Catalog-owned adapter
+A new adapter, `CatalogPurchasePriceRecalculationAdapter`, MUST be added to the Catalog module's infrastructure folder. It implements `IPurchasePriceRecalculationService` by delegating to the existing `IProductPriceErpClient`.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapter.cs`
+
+**Structure:** Sealed `internal` class with a constructor accepting `IProductPriceErpClient`. The single method delegates straight through; no business logic is added.
+
+**Acceptance criteria:**
+- Implementation lives in namespace `Anela.Heblo.Application.Features.Catalog.Infrastructure`, mirroring `PurchaseMaterialCatalogAdapter`.
+- The adapter is `internal sealed` (matches the existing `PurchaseMaterialCatalogAdapter` visibility/sealing).
+- `RecalculatePurchasePriceAsync(bomId, ct)` forwards the call verbatim to `_productPriceErpClient.RecalculatePurchasePrice(bomId, ct)`.
+- No error handling, retry, logging, or transformation is added in the adapter — semantics must be identical to the current direct call.
+
+### FR-3: Register DI binding in CatalogModule
+The DI binding for `IPurchasePriceRecalculationService → CatalogPurchasePriceRecalculationAdapter` MUST be registered inside `CatalogModule.AddCatalogModule(...)`, alongside the existing `IMaterialCatalogService` registration.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`
+
+**Acceptance criteria:**
+- A new line `services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceRecalculationAdapter>();` is added near line 46 (next to the `PurchaseMaterialCatalogAdapter` registration).
+- The Purchase module's `PurchaseModule.cs` is NOT modified — the provider (Catalog) owns the binding.
+- Lifetime is `Scoped` to match `IMaterialCatalogService` and the surrounding pattern.
+- No code in any module under `Application/Features/Purchase/` references `IProductPriceErpClient` after the change.
+
+### FR-4: Replace dependency in RecalculatePurchasePriceHandler
+`RecalculatePurchasePriceHandler` MUST be modified to depend on `IPurchasePriceRecalculationService` instead of `IProductPriceErpClient`.
+
+**Location:** `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs`
+
+**Changes:**
+- Remove `using Anela.Heblo.Domain.Features.Catalog.Price;` (line 3).
+- Replace field `IProductPriceErpClient _productPriceClient` with `IPurchasePriceRecalculationService _priceRecalculationService` (lines 12, 21).
+- Replace constructor parameter type and assignment (lines 17, 21).
+- Replace call at line 83 from `_productPriceClient.RecalculatePurchasePrice(bom.BoMId, cancellationToken)` to `_priceRecalculationService.RecalculatePurchasePriceAsync(bom.BoMId, cancellationToken)`.
+
+**Acceptance criteria:**
+- The handler has zero `using` directives or symbol references pointing at any `Anela.Heblo.Domain.Features.Catalog.*` or `Anela.Heblo.Application.Features.Catalog.*` namespace.
+- Public behavior of the handler is unchanged: identical request/response shapes, identical error codes (`ErrorCodes.InvalidValue`, `ErrorCodes.CatalogItemNotFound`, `ErrorCodes.Exception`), identical iteration semantics over BoM references, identical logging messages.
+- The handler still runs successfully through the existing MediatR pipeline.
+
+### FR-5: Update existing unit tests
+`RecalculatePurchasePriceHandlerTests` currently mocks `IProductPriceErpClient` directly. The tests MUST be updated to mock the new contract.
+
+**Location:** `backend/test/Anela.Heblo.Tests/Application/Purchase/RecalculatePurchasePriceHandlerTests.cs`
+
+**Changes:**
+- Remove `using Anela.Heblo.Domain.Features.Catalog.Price;` (line 4).
+- Replace `Mock<IProductPriceErpClient> _productPriceClientMock` with `Mock<IPurchasePriceRecalculationService> _priceRecalculationServiceMock`.
+- Replace all `.Setup(x => x.RecalculatePurchasePrice(...))` and `.Verify(...)` calls with the new method name `RecalculatePurchasePriceAsync`.
+- Existing `[Fact]` test cases (single product, recalculate-all, not-found, no-BoM, ERP failure, mixed success/failure, empty BoM, invalid request, cancellation token) MUST all pass unchanged in intent.
+
+**Acceptance criteria:**
+- The test file has no references to `IProductPriceErpClient` after the change.
+- All nine existing tests pass: `Handle_WithValidSingleProduct_ShouldRecalculateSuccessfully`, `Handle_WithRecalculateAll_ShouldProcessOnlyProductsWithBoM`, `Handle_WithSingleProductNotFound_ShouldReturnError`, `Handle_WithSingleProductWithoutBoM_ShouldFail`, `Handle_WithErpClientFailure_ShouldRecordError`, `Handle_WithMixedSuccessAndFailure_ShouldRecordBoth`, `Handle_WithNoProductsWithBoM_ShouldReturnEmptyResult`, `Handle_WithInvalidRequest_ShouldReturnError`, `Handle_WithCancellationToken_ShouldPassTokenToClients`.
+
+### FR-6: Add adapter unit test
+A new test class MUST be added for `CatalogPurchasePriceRecalculationAdapter` to verify the delegation contract.
+
+**Location:** `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapterTests.cs` (or follow the existing test folder convention for Catalog infrastructure adapters).
+
+**Required coverage:**
+- Test that `RecalculatePurchasePriceAsync(bomId, ct)` invokes `IProductPriceErpClient.RecalculatePurchasePrice(bomId, ct)` exactly once with the same arguments.
+- Test that the cancellation token is forwarded verbatim.
+- Test that exceptions thrown by `IProductPriceErpClient` propagate unchanged.
+
+**Acceptance criteria:**
+- Tests use xUnit + FluentAssertions + Moq, matching the project test conventions.
+- Tests follow the Arrange-Act-Assert structure.
+
+### FR-7: Remove allowlist entry and validate architecture test
+The `PurchaseAllowlist` in `ModuleBoundariesTests` MUST be reduced (or removed entirely if this was its only entry) to assert that the violation is fixed.
+
+**Location:** `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs:84-93`
+
+**Changes:**
+- Remove the single allowlist entry: `"Anela.Heblo.Application.Features.Purchase.UseCases.RecalculatePurchasePrice.RecalculatePurchasePriceHandler -> Anela.Heblo.Domain.Features.Catalog.Price.IProductPriceErpClient"`.
+- The `PurchaseAllowlist` becomes an empty `HashSet<string>` (keep the field for future entries — matches the pattern used for `PackingMaterials` / `ExpeditionListArchive` / `Analytics` rules).
+- The associated comment block describing the violation MUST be removed; if the set is empty, the descriptive comment about the allowlist's purpose can be reduced to one line.
+
+**Acceptance criteria:**
+- `Consumer_types_should_not_reference_provider_owned_namespaces` MUST pass for the `Purchase -> Catalog` rule after the changes.
+- No other allowlist entry is added or expanded as part of this work.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+The adapter is a pure delegation layer. Acceptable overhead is one additional virtual dispatch per call. There MUST be no measurable change to recalculation throughput or latency.
+
+### NFR-2: Security
+No new public attack surface is introduced. The adapter is internal-sealed, registered via DI only. Authentication and authorization behaviors of the existing `RecalculatePurchasePrice` endpoint are unchanged because the handler entry point is untouched.
+
+### NFR-3: Backward compatibility
+- The MediatR contract (`RecalculatePurchasePriceRequest` / `RecalculatePurchasePriceResponse`) is NOT modified.
+- The HTTP API surface (controller endpoint, route, request/response shape, status codes) is NOT modified.
+- No database schema or persistence changes.
+- No frontend changes — the OpenAPI client output MUST remain bit-identical.
+
+### NFR-4: Architecture conformance
+After this change, the `ModuleBoundariesTests` reflection-based test enforces — and MUST continue to enforce — that no type in `Anela.Heblo.Application.Features.Purchase.*` references any type in `Anela.Heblo.Domain.Features.Catalog.*`, `Anela.Heblo.Application.Features.Catalog.*`, or `Anela.Heblo.Persistence.Catalog.*` without an explicit allowlist entry. The Purchase allowlist MUST be empty after this work.
+
+### NFR-5: Testability and conventions
+- All code follows `dotnet format` and nullable reference type rules.
+- C# style: classes (not records) for service implementations; `sealed` and explicit access modifiers; expression-bodied members only where they remain readable.
+- Test naming preserves the existing `MethodUnderTest_Scenario_ExpectedBehavior` pattern.
+
+## Data Model
+No data model changes. The single value carried across the new contract boundary is `int bomId`, which is already a primitive integer in the existing code path.
+
+## API / Interface Design
+
+### Internal interface (new)
+```csharp
+namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+public interface IPurchasePriceRecalculationService
+{
+    Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken);
+}
+```
+
+### Internal adapter (new)
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogPurchasePriceRecalculationAdapter : IPurchasePriceRecalculationService
+{
+    private readonly IProductPriceErpClient _productPriceErpClient;
+
+    public CatalogPurchasePriceRecalculationAdapter(IProductPriceErpClient productPriceErpClient)
+    {
+        _productPriceErpClient = productPriceErpClient;
+    }
+
+    public Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken) =>
+        _productPriceErpClient.RecalculatePurchasePrice(bomId, cancellationToken);
+}
+```
+
+### DI registration (added to `CatalogModule.AddCatalogModule`)
+```csharp
+services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceRecalculationAdapter>();
+```
+
+### External API surface
+No changes. The existing controller route and MediatR request/response remain in place.
+
+## Dependencies
+- No new NuGet packages.
+- No changes to existing references between projects (`Anela.Heblo.Application` already references the namespaces involved).
+- The existing implementation of `IProductPriceErpClient` (e.g. `FlexiProductPriceErpClient` in `backend/src/Adapters/Anela.Heblo.Adapters.Flexi/Price/FlexiProductPriceErpClient.cs`) is untouched.
+
+## Out of Scope
+The following are explicitly **not** part of this work:
+
+- Decoupling `FinancialOverview` from `IProductPriceErpClient`. `StockValueService` and `FinancialOverviewModule` reference the same Catalog-owned interface; this is a separate boundary violation tracked outside this task.
+- Relocating `IProductPriceErpClient` itself out of the Catalog domain. The interface is an ERP integration boundary and may legitimately live in Catalog or be moved to a shared integrations namespace; that decision is outside this task.
+- Renaming `IProductPriceErpClient.RecalculatePurchasePrice` to use the `Async` suffix.
+- Adding integration tests or end-to-end tests for the recalculation flow beyond what already exists.
+- Changing any behavior of the recalculation logic (validation rules, error codes, logging, iteration semantics).
+- Updating documentation files other than what is strictly required by the change (no edits to `development_guidelines.md` are needed — this change conforms to the existing rules).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-purchase-recalculatepurchase/task-plan.r1.md
+++ b/artifacts/feat-arch-review-purchase-recalculatepurchase/task-plan.r1.md
@@ -1,0 +1,407 @@
+# Relocate BackgroundJobs Request Body DTOs to Application Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody` from `RecurringJobsController.cs` into the `BackgroundJobs` application module's `Contracts/` folder, with zero behavioural or wire-format change.
+
+**Architecture:** Mechanical relocation. Two new files are created in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/`, the two in-controller class definitions are deleted, and the now-orphan `using System.ComponentModel.DataAnnotations;` directive at the top of the controller is removed. The controller already imports the target `Contracts` namespace, so post-move type resolution is automatic.
+
+**Tech Stack:** .NET 8, C#, ASP.NET Core MVC, xUnit + FluentAssertions + Moq, NSwag (TypeScript client regeneration on build).
+
+---
+
+## Background & Why TDD-Lite Here
+
+The two DTOs are pure data shapes with no behaviour. The behaviour they participate in (HTTP request binding, controller dispatch, MediatR mapping, validation) is already covered by `RecurringJobsControllerTests.cs`. Those existing tests are the regression net for this move — they must continue to pass **without any edit**. There is no new code path to drive via a new RED→GREEN test; the discipline here is to make small, verifiable changes and run the existing test suite + build + OpenAPI diff at each gate.
+
+---
+
+## File Structure
+
+**Files to create (2):**
+
+| Path | Responsibility |
+|------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` | Request body DTO for `PUT /api/RecurringJobs/{jobName}/status` |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` | Request body DTO for `PUT /api/RecurringJobs/{jobName}/cron` |
+
+**Files to modify (1):**
+
+| Path | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` | Delete lines 125–146 (both DTO definitions + their XML doc comments). Delete line 1 (`using System.ComponentModel.DataAnnotations;`) — it is orphan after the move. |
+
+**Files explicitly NOT touched:**
+
+| Path | Reason |
+|------|--------|
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTests.cs` | Already imports `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` at line 2. The four unqualified references (`UpdateJobStatusRequestBody` on lines 115, 153, 183, 221) resolve through that using directive post-move. |
+| `frontend/src/api/hooks/useRecurringJobs.ts` | Consumes generated client types by name. NSwag schema names are namespace-independent. |
+| `frontend/src/api/generated/api-client.ts` | Auto-regenerated on `npm run build`. We **verify** it does not change (it's a checkpoint, not an edit target). |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs` | Sibling DTO; out of scope. |
+| Any file under `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/` | MediatR Request/Response/Handler triples are unchanged. |
+
+---
+
+## Task 1: Create `UpdateJobStatusRequestBody.cs` in Contracts folder
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs`
+
+- [ ] **Step 1: Verify the target folder exists and has the sibling DTO**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/
+```
+Expected output includes: `RecurringJobDto.cs`. If the folder doesn't exist, stop — the spec assumes it does.
+
+- [ ] **Step 2: Create the new DTO file**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs` with this exact content (XML doc comments preserved verbatim from the source on lines 125–134 of `RecurringJobsController.cs`):
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+**Critical invariants:**
+- Type name: `UpdateJobStatusRequestBody` — exact.
+- Property name: `IsEnabled` — exact.
+- `public class` — not `record`, not `sealed`, no `init`/`required` keywords. (Project rule: DTOs are classes, never records, because NSwag mishandles record parameter order.)
+- No constructor declared.
+- File ends with newline.
+
+- [ ] **Step 3: Verify build still succeeds (duplicate type expected)**
+
+At this point both the new file AND the in-controller definition exist, so we will see a CS0101 duplicate-type compile error. That is the expected fail state — confirm it.
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: BUILD FAILED with error `CS0101: The namespace ... already contains a definition for 'UpdateJobStatusRequestBody'` **OR** `CS0436` (type conflicts between namespaces).
+
+If the build succeeds, the new file content is wrong — re-read Step 2. If it fails with any other error, stop and investigate before continuing.
+
+Note: We do not commit yet — the duplicate is resolved in Task 3.
+
+---
+
+## Task 2: Create `UpdateJobCronRequestBody.cs` in Contracts folder
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs`
+
+- [ ] **Step 1: Create the new DTO file**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs` with this exact content (XML doc comments preserved verbatim from lines 136–146 of `RecurringJobsController.cs`):
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+**Critical invariants:**
+- Type name: `UpdateJobCronRequestBody` — exact.
+- Property name: `CronExpression` — exact.
+- `[Required]` attribute — preserved (uses `System.ComponentModel.DataAnnotations`).
+- Default value `= string.Empty` — preserved.
+- `public class` — not `record`, not `sealed`, no `init`/`required` keywords.
+- The `using System.ComponentModel.DataAnnotations;` directive must be at the top of the new file (not in the controller anymore — the controller's copy is removed in Task 3).
+- File ends with newline.
+
+- [ ] **Step 2: Verify build still fails with duplicate-type errors for both DTOs**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: BUILD FAILED with `CS0101`/`CS0436` errors mentioning **both** `UpdateJobStatusRequestBody` and `UpdateJobCronRequestBody`. The Application project itself should compile cleanly; the error originates from the API project, which references Application and now sees the new types alongside the in-controller copies.
+
+If only one duplicate error appears, the second file is missing a type or in the wrong namespace — re-read Step 1.
+
+No commit yet — Task 3 removes the duplicates.
+
+---
+
+## Task 3: Delete in-controller DTOs and orphan `using` directive
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs`
+
+- [ ] **Step 1: Confirm `System.ComponentModel.DataAnnotations` has no other consumer in the file**
+
+Run:
+```bash
+grep -nE '\[Required\]|\[Range\]|\[StringLength\]|\[MaxLength\]|\[MinLength\]|\[RegularExpression\]|\[EmailAddress\]|\[Phone\]|\[Url\]|\[Compare\]|\[CreditCard\]|\[DataType\]|\[EnumDataType\]|\[FileExtensions\]|\[MaxLength\]|\[MinLength\]|\[ValidationAttribute\]' backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: only the line `[Required]` inside the `UpdateJobCronRequestBody` class (line 144). After we delete that class, no usage of `System.ComponentModel.DataAnnotations` remains.
+
+If the grep shows additional attribute usage outside the DTO classes, STOP — do not remove the `using` in Step 2. Update the plan to keep the using and document why.
+
+- [ ] **Step 2: Delete the two in-controller DTO definitions (lines 125–146 of the original file)**
+
+Open `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` and delete exactly these blocks:
+
+The first block to delete (the original lines 125–134):
+```csharp
+/// <summary>
+/// Request body for updating recurring job status
+/// </summary>
+public class UpdateJobStatusRequestBody
+{
+    /// <summary>
+    /// Whether the job should be enabled
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}
+```
+
+The second block to delete (the original lines 136–146):
+```csharp
+/// <summary>
+/// Request body for updating recurring job CRON expression
+/// </summary>
+public class UpdateJobCronRequestBody
+{
+    /// <summary>
+    /// The new CRON expression (e.g. "0 3 * * *")
+    /// </summary>
+    [Required]
+    public string CronExpression { get; set; } = string.Empty;
+}
+```
+
+Also remove the blank line between them and the trailing newline that separates them from the closing brace of the `RecurringJobsController` class. The file must end at line 123 (the closing `}` of the controller class) followed by a single trailing newline.
+
+- [ ] **Step 3: Delete the orphan `using System.ComponentModel.DataAnnotations;` directive (line 1)**
+
+Remove the first line of the file:
+```csharp
+using System.ComponentModel.DataAnnotations;
+```
+
+The remaining `using` directives must keep their existing order:
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.GetRecurringJobsList;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobStatus;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.UpdateRecurringJobCron;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.TriggerRecurringJob;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Anela.Heblo.API.Controllers;
+```
+
+Do not reorder them. Do not add or remove other usings. The `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` line MUST remain — it is now the resolution path for both relocated DTOs.
+
+- [ ] **Step 4: Verify the controller file shape matches expectation**
+
+Run:
+```bash
+wc -l backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: 122 lines (original 146 minus the 22 deleted DTO lines minus the 1 deleted using minus 1 blank-line gap that separated the DTOs).
+
+Run:
+```bash
+grep -nE 'UpdateJobStatusRequestBody|UpdateJobCronRequestBody|System\.ComponentModel\.DataAnnotations' backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+```
+Expected: exactly two matches, both inside `[FromBody]` parameter declarations — no class definitions, no `using` directive. Specifically:
+- One occurrence of `[FromBody] UpdateJobStatusRequestBody request` (inside `UpdateJobStatus` method).
+- One occurrence of `[FromBody] UpdateJobCronRequestBody request` (inside `UpdateJobCron` method).
+- Zero occurrences of `System.ComponentModel.DataAnnotations`.
+
+If the grep shows class definitions or the using directive, Step 2 or Step 3 was incomplete.
+
+- [ ] **Step 5: Build the solution — must now compile cleanly**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`.
+
+If errors persist:
+- `CS0101` on either DTO type → an in-controller definition was not fully deleted (re-do Step 2).
+- `CS0246` "could not be found" on either DTO type → the `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` was accidentally removed (restore it).
+- `CS0246` on `Required` → the `[Required]` attribute is still in some file that no longer imports `System.ComponentModel.DataAnnotations` (verify Task 2's new file kept its `using`).
+
+---
+
+## Task 4: Verify behaviour parity (tests + format + OpenAPI diff)
+
+**Files:** No source changes. This task is verification-only and produces the artifacts we commit in Task 5.
+
+- [ ] **Step 1: Run the BackgroundJobs controller tests (existing, unmodified)**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTests" --no-build
+```
+Expected: All tests pass (zero failures, zero skipped). These tests reference `UpdateJobStatusRequestBody` unqualified on lines 115, 153, 183, 221 and resolve them via `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` (line 2 of the test file).
+
+If any test fails with a type-resolution error, the `Contracts` using in the test file is missing or the new DTO is in the wrong namespace. Investigate before continuing.
+
+- [ ] **Step 2: Run the full backend test suite to confirm no other test is affected**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+Expected: Same pass count as before the change. Any new failure means an unintended consumer (e.g. another test that referenced `Anela.Heblo.API.Controllers.UpdateJobStatusRequestBody` by FQN) — investigate and resolve before continuing. Per the architecture review, the only consumer is `RecurringJobsControllerTests.cs` and it uses unqualified names, so zero new failures is the expected outcome.
+
+- [ ] **Step 3: Run `dotnet format` scoped to the touched files only**
+
+Per NFR-3 (surgical change scope), do not let `dotnet format` rewrite unrelated files. Run:
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs \
+  --verify-no-changes
+```
+Expected: `Format complete` with exit code 0 and no files modified.
+
+If exit code is non-zero, run the same command without `--verify-no-changes` to apply the fixes, then re-run with `--verify-no-changes` to confirm clean. Inspect the resulting diff with `git diff` to make sure formatter did not change anything beyond whitespace/newlines on the three target files.
+
+- [ ] **Step 4: Regenerate the OpenAPI TypeScript client and diff it**
+
+The TypeScript client regenerates on frontend build. Run:
+```bash
+cd frontend && npm run build && cd ..
+```
+Expected: Build succeeds.
+
+Then check that the generated client did NOT change shape:
+```bash
+git diff frontend/src/api/generated/api-client.ts
+```
+Expected: **zero changes**, OR changes that are purely cosmetic (whitespace, comment ordering). Specifically verify these tokens still appear with identical signatures:
+- `class UpdateJobStatusRequestBody` and its `isEnabled` property of type `boolean`.
+- `class UpdateJobCronRequestBody` and its `cronExpression` property of type `string`.
+- `interface IUpdateJobStatusRequestBody` / `interface IUpdateJobCronRequestBody` (NSwag emits both).
+- Methods `recurringJobs_UpdateJobStatus` and `recurringJobs_UpdateJobCron` with identical request body type references.
+
+```bash
+grep -nE 'class UpdateJobStatusRequestBody|class UpdateJobCronRequestBody|recurringJobs_UpdateJobStatus|recurringJobs_UpdateJobCron' frontend/src/api/generated/api-client.ts
+```
+Expected: exactly 4 matches (one per token).
+
+If the type names changed (e.g. NSwag prepended a namespace prefix like `BackgroundJobsContractsUpdateJobStatusRequestBody`), this is a **CRITICAL** blocker per the architecture review. Revert and consult the architecture review's Risks table before proceeding — do not attempt to patch the frontend.
+
+- [ ] **Step 5: Run the frontend lint to confirm the unchanged client still compiles in TypeScript**
+
+Run:
+```bash
+cd frontend && npm run lint && cd ..
+```
+Expected: zero lint errors. If errors appear in `useRecurringJobs.ts` or files that consume it, the NSwag output changed shape and Step 4 should have caught it — go back and re-verify.
+
+---
+
+## Task 5: Commit the change
+
+**Files:** All three touched files staged together.
+
+- [ ] **Step 1: Stage exactly the three touched files**
+
+Run:
+```bash
+git add \
+  backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobStatusRequestBody.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/UpdateJobCronRequestBody.cs
+```
+
+- [ ] **Step 2: Verify the staged diff is surgical (only these three files)**
+
+Run:
+```bash
+git status
+git diff --cached --stat
+```
+Expected:
+- `git status` shows only the three target files as staged, and no other modified files (the generated `api-client.ts` should not be in the diff — Task 4 Step 4 confirmed zero changes).
+- `git diff --cached --stat` shows two new files (the DTOs) and one modified file (the controller) with roughly `-24` lines and `+0` lines on the controller (22 DTO lines + 1 using line + 1 blank gap).
+
+If `api-client.ts` shows changes in `git status` despite Task 4 Step 4 reporting none, re-diff and revert it before continuing — committing a regenerated client with no controller-side changes is fine only when the regeneration is truly identical.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: move BackgroundJobs request body DTOs to Application layer
+
+Relocates UpdateJobStatusRequestBody and UpdateJobCronRequestBody from
+RecurringJobsController.cs into the BackgroundJobs module's Contracts/
+folder. Enforces the rule that the API project does not own DTOs.
+
+Wire format, OpenAPI schema names, and frontend generated client are
+unchanged. Existing RecurringJobsControllerTests pass without edits.
+EOF
+)"
+```
+Expected: Commit succeeds. Any pre-commit hook (build, format, test) should pass — Task 4 already verified each.
+
+If a hook fails, fix the underlying issue and create a NEW commit (do not amend per the global git policy).
+
+- [ ] **Step 4: Final post-commit sanity check**
+
+Run:
+```bash
+git log -1 --stat
+git status
+```
+Expected:
+- `git log -1 --stat` shows the commit with exactly 3 files changed: one modification, two additions.
+- `git status` shows a clean working tree.
+
+---
+
+## Self-Review Checklist
+
+This was checked against the spec before finalising:
+
+**Spec coverage:**
+- FR-1 (relocate `UpdateJobStatusRequestBody`) → Task 1 + Task 3 Step 2.
+- FR-2 (relocate `UpdateJobCronRequestBody` preserving `[Required]`) → Task 2 + Task 3 Step 2.
+- FR-3 (controller cleanup, remove orphan using) → Task 3 Steps 1, 3, 4.
+- FR-4 (consumer compatibility — test file unchanged) → Task 4 Step 1 verifies, file is explicitly in the "do not touch" list.
+- FR-5 (validation: build, format, test, OpenAPI client identical) → Task 4 Steps 2, 3, 4, 5.
+- NFR-1 (behavioural parity) → Task 4 Step 4 OpenAPI diff is the strongest check; Task 4 Step 1 covers controller behaviour.
+- NFR-2 (architectural conformance — DTOs are `public class`, live in `Contracts/`, no record conversion) → Task 1 + Task 2 invariants explicitly enforce this.
+- NFR-3 (surgical change scope — only three files touched) → Task 4 Step 3 uses `--include` scoping, Task 5 Step 2 verifies the staged diff.
+
+**Placeholder scan:** no TBDs, no "implement later", no "similar to Task N", no abstract handwaving — all code blocks are complete and copy-pasteable.
+
+**Type consistency:** type names (`UpdateJobStatusRequestBody`, `UpdateJobCronRequestBody`), property names (`IsEnabled`, `CronExpression`), namespace (`Anela.Heblo.Application.Features.BackgroundJobs.Contracts`), and the `[Required]` attribute are spelt identically across every task that mentions them. The architecture review's grep tokens for the OpenAPI diff match the names used in the new DTOs.
+
+No gaps. No fixes needed.

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -44,6 +44,7 @@ public static class CatalogModule
         services.AddTransient<IManufactureDifficultyRepository, ManufactureDifficultyRepository>();
         // Register adapter to expose catalog services to Purchase module
         services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
+        services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceRecalculationAdapter>();
         services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
 
         // Register cost repositories

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapter.cs
@@ -1,0 +1,17 @@
+using Anela.Heblo.Application.Features.Purchase.Contracts;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogPurchasePriceRecalculationAdapter : IPurchasePriceRecalculationService
+{
+    private readonly IProductPriceErpClient _productPriceErpClient;
+
+    public CatalogPurchasePriceRecalculationAdapter(IProductPriceErpClient productPriceErpClient)
+    {
+        _productPriceErpClient = productPriceErpClient;
+    }
+
+    public Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken) =>
+        _productPriceErpClient.RecalculatePurchasePrice(bomId, cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IPurchasePriceRecalculationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IPurchasePriceRecalculationService.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Application.Features.Purchase.Contracts;
+
+public interface IPurchasePriceRecalculationService
+{
+    Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs
@@ -1,6 +1,5 @@
 using Anela.Heblo.Application.Features.Purchase.Contracts;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog.Price;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -9,16 +8,16 @@ namespace Anela.Heblo.Application.Features.Purchase.UseCases.RecalculatePurchase
 public class RecalculatePurchasePriceHandler : IRequestHandler<RecalculatePurchasePriceRequest, RecalculatePurchasePriceResponse>
 {
     private readonly IMaterialCatalogService _materialCatalog;
-    private readonly IProductPriceErpClient _productPriceClient;
+    private readonly IPurchasePriceRecalculationService _priceRecalculationService;
     private readonly ILogger<RecalculatePurchasePriceHandler> _logger;
 
     public RecalculatePurchasePriceHandler(
         IMaterialCatalogService materialCatalog,
-        IProductPriceErpClient productPriceClient,
+        IPurchasePriceRecalculationService priceRecalculationService,
         ILogger<RecalculatePurchasePriceHandler> logger)
     {
         _materialCatalog = materialCatalog;
-        _productPriceClient = productPriceClient;
+        _priceRecalculationService = priceRecalculationService;
         _logger = logger;
     }
 
@@ -80,7 +79,7 @@ public class RecalculatePurchasePriceHandler : IRequestHandler<RecalculatePurcha
                 _logger.LogDebug("Recalculating price for product {ProductCode} with BoMId {BoMId}",
                     bom.ProductCode, bom.BoMId);
 
-                await _productPriceClient.RecalculatePurchasePrice(bom.BoMId, cancellationToken);
+                await _priceRecalculationService.RecalculatePurchasePriceAsync(bom.BoMId, cancellationToken);
 
                 response.ProcessedProducts.Add(new ProductRecalculationResult
                 {

--- a/backend/test/Anela.Heblo.Tests/Application/Purchase/RecalculatePurchasePriceHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Purchase/RecalculatePurchasePriceHandlerTests.cs
@@ -1,7 +1,6 @@
 using Anela.Heblo.Application.Features.Purchase.Contracts;
 using Anela.Heblo.Application.Features.Purchase.UseCases.RecalculatePurchasePrice;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog.Price;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -11,19 +10,19 @@ namespace Anela.Heblo.Tests.Application.Purchase;
 public class RecalculatePurchasePriceHandlerTests
 {
     private readonly Mock<IMaterialCatalogService> _materialCatalogMock;
-    private readonly Mock<IProductPriceErpClient> _productPriceClientMock;
+    private readonly Mock<IPurchasePriceRecalculationService> _priceRecalculationServiceMock;
     private readonly Mock<ILogger<RecalculatePurchasePriceHandler>> _loggerMock;
     private readonly RecalculatePurchasePriceHandler _handler;
 
     public RecalculatePurchasePriceHandlerTests()
     {
         _materialCatalogMock = new Mock<IMaterialCatalogService>();
-        _productPriceClientMock = new Mock<IProductPriceErpClient>();
+        _priceRecalculationServiceMock = new Mock<IPurchasePriceRecalculationService>();
         _loggerMock = new Mock<ILogger<RecalculatePurchasePriceHandler>>();
 
         _handler = new RecalculatePurchasePriceHandler(
             _materialCatalogMock.Object,
-            _productPriceClientMock.Object,
+            _priceRecalculationServiceMock.Object,
             _loggerMock.Object);
     }
 
@@ -37,7 +36,7 @@ public class RecalculatePurchasePriceHandlerTests
         _materialCatalogMock.Setup(x => x.GetByIdAsync(productCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(product);
 
-        _productPriceClientMock.Setup(x => x.RecalculatePurchasePrice(123, It.IsAny<CancellationToken>()))
+        _priceRecalculationServiceMock.Setup(x => x.RecalculatePurchasePriceAsync(123, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var request = new RecalculatePurchasePriceRequest
@@ -62,7 +61,7 @@ public class RecalculatePurchasePriceHandlerTests
         processedProduct.Success.Should().BeTrue();
         processedProduct.ErrorCode.Should().BeNull();
 
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(123, It.IsAny<CancellationToken>()), Times.Once);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(123, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -78,7 +77,7 @@ public class RecalculatePurchasePriceHandlerTests
         _materialCatalogMock.Setup(x => x.GetMaterialsWithBomAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(bomReferences);
 
-        _productPriceClientMock.Setup(x => x.RecalculatePurchasePrice(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        _priceRecalculationServiceMock.Setup(x => x.RecalculatePurchasePriceAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var request = new RecalculatePurchasePriceRequest
@@ -100,8 +99,8 @@ public class RecalculatePurchasePriceHandlerTests
         result.ProcessedProducts.Should().OnlyContain(p => p.Success);
         result.ProcessedProducts.Select(p => p.ProductCode).Should().BeEquivalentTo(new[] { "PROD001", "PROD002" });
 
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(123, It.IsAny<CancellationToken>()), Times.Once);
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(456, It.IsAny<CancellationToken>()), Times.Once);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(123, It.IsAny<CancellationToken>()), Times.Once);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(456, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public class RecalculatePurchasePriceHandlerTests
         result.Params.Should().ContainKey("ProductCode");
         result.Params["ProductCode"].Should().Be("NONEXISTENT");
 
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -156,7 +155,7 @@ public class RecalculatePurchasePriceHandlerTests
         result.Params.Should().ContainKey("Message");
         result.Params["Message"].Should().Contain("does not have BoM");
 
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -170,7 +169,7 @@ public class RecalculatePurchasePriceHandlerTests
             .ReturnsAsync(product);
 
         var expectedError = "ERP system unavailable";
-        _productPriceClientMock.Setup(x => x.RecalculatePurchasePrice(123, It.IsAny<CancellationToken>()))
+        _priceRecalculationServiceMock.Setup(x => x.RecalculatePurchasePriceAsync(123, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException(expectedError));
 
         var request = new RecalculatePurchasePriceRequest
@@ -211,10 +210,10 @@ public class RecalculatePurchasePriceHandlerTests
         _materialCatalogMock.Setup(x => x.GetMaterialsWithBomAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(bomReferences);
 
-        _productPriceClientMock.Setup(x => x.RecalculatePurchasePrice(123, It.IsAny<CancellationToken>()))
+        _priceRecalculationServiceMock.Setup(x => x.RecalculatePurchasePriceAsync(123, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        _productPriceClientMock.Setup(x => x.RecalculatePurchasePrice(456, It.IsAny<CancellationToken>()))
+        _priceRecalculationServiceMock.Setup(x => x.RecalculatePurchasePriceAsync(456, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Network timeout"));
 
         var request = new RecalculatePurchasePriceRequest
@@ -270,7 +269,7 @@ public class RecalculatePurchasePriceHandlerTests
         result.ProcessedProducts.Should().BeEmpty();
         result.Message.Should().Be("No products found to recalculate");
 
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -305,7 +304,7 @@ public class RecalculatePurchasePriceHandlerTests
         _materialCatalogMock.Setup(x => x.GetByIdAsync(productCode, cancellationToken))
             .ReturnsAsync(product);
 
-        _productPriceClientMock.Setup(x => x.RecalculatePurchasePrice(123, cancellationToken))
+        _priceRecalculationServiceMock.Setup(x => x.RecalculatePurchasePriceAsync(123, cancellationToken))
             .Returns(Task.CompletedTask);
 
         var request = new RecalculatePurchasePriceRequest
@@ -318,7 +317,7 @@ public class RecalculatePurchasePriceHandlerTests
 
         // Assert
         _materialCatalogMock.Verify(x => x.GetByIdAsync(productCode, cancellationToken), Times.Once);
-        _productPriceClientMock.Verify(x => x.RecalculatePurchasePrice(123, cancellationToken), Times.Once);
+        _priceRecalculationServiceMock.Verify(x => x.RecalculatePurchasePriceAsync(123, cancellationToken), Times.Once);
     }
 
     private static MaterialInfo CreateMaterialWithBoM(string productCode, int bomId)

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -79,18 +79,8 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Services.GiftPackageManufactureService -> Anela.Heblo.Domain.Features.Manufacture.ProductPart",
     };
 
-    // Allowlist for Purchase → Catalog. Each entry needs a comment with the justification.
-    // Entries should be removed as the underlying violations are fixed.
-    private static readonly HashSet<string> PurchaseAllowlist = new(StringComparer.Ordinal)
-    {
-        // Pre-existing dependency: RecalculatePurchasePriceHandler consumes IProductPriceErpClient,
-        // which currently lives in Anela.Heblo.Domain.Features.Catalog.Price. IProductPriceErpClient
-        // is an ERP integration boundary (not a domain repository); decoupling it requires a
-        // separate Purchase-owned contract (e.g., IPurchasePriceRecalculator) and is out of scope
-        // for the 2026-05-24 Purchase ↔ Catalog decoupling. Track separately and remove this entry
-        // when IProductPriceErpClient is lifted behind a Purchase-owned contract.
-        "Anela.Heblo.Application.Features.Purchase.UseCases.RecalculatePurchasePrice.RecalculatePurchasePriceHandler -> Anela.Heblo.Domain.Features.Catalog.Price.IProductPriceErpClient",
-    };
+    // Allowlist for Purchase → Catalog. Empty — no active violations.
+    private static readonly HashSet<string> PurchaseAllowlist = new(StringComparer.Ordinal);
 
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogPurchasePriceRecalculationAdapterTests.cs
@@ -1,0 +1,76 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Purchase.Contracts;
+using Anela.Heblo.Domain.Features.Catalog.Price;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class CatalogPurchasePriceRecalculationAdapterTests
+{
+    private readonly Mock<IProductPriceErpClient> _erpClientMock = new();
+
+    private CatalogPurchasePriceRecalculationAdapter CreateAdapter() =>
+        new(_erpClientMock.Object);
+
+    [Fact]
+    public async Task RecalculatePurchasePriceAsync_WithValidBomId_DelegatesToProductPriceErpClient()
+    {
+        // Arrange
+        var bomId = 123;
+        var ct = CancellationToken.None;
+        _erpClientMock
+            .Setup(x => x.RecalculatePurchasePrice(bomId, ct))
+            .Returns(Task.CompletedTask);
+
+        var adapter = CreateAdapter();
+
+        // Act
+        await adapter.RecalculatePurchasePriceAsync(bomId, ct);
+
+        // Assert
+        _erpClientMock.Verify(x => x.RecalculatePurchasePrice(bomId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecalculatePurchasePriceAsync_WithCancellationToken_ForwardsTokenToErpClient()
+    {
+        // Arrange
+        var bomId = 456;
+        var cancellationToken = new CancellationToken(canceled: false);
+        _erpClientMock
+            .Setup(x => x.RecalculatePurchasePrice(bomId, cancellationToken))
+            .Returns(Task.CompletedTask);
+
+        var adapter = CreateAdapter();
+
+        // Act
+        await adapter.RecalculatePurchasePriceAsync(bomId, cancellationToken);
+
+        // Assert
+        _erpClientMock.Verify(
+            x => x.RecalculatePurchasePrice(It.IsAny<int>(), cancellationToken),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecalculatePurchasePriceAsync_WhenErpClientThrows_PropagatesException()
+    {
+        // Arrange
+        var bomId = 789;
+        var ct = CancellationToken.None;
+        _erpClientMock
+            .Setup(x => x.RecalculatePurchasePrice(bomId, ct))
+            .Throws(new InvalidOperationException("ERP error"));
+
+        var adapter = CreateAdapter();
+
+        // Act & Assert
+        await adapter
+            .Invoking(a => a.RecalculatePurchasePriceAsync(bomId, ct))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("ERP error");
+    }
+}


### PR DESCRIPTION
Purchase

## Finding
`RecalculatePurchasePriceHandler` imports and directly injects `IProductPriceErpClient` from the **Catalog module's domain layer**:

- File: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/RecalculatePurchasePrice/RecalculatePurchasePriceHandler.cs`
- Line 4: `using Anela.Heblo.Domain.Features.Catalog.Price;`
- Lines 13–14: `IProductPriceErpClient` injected as a constructor dependency

`IProductPriceErpClient` is defined at `backend/src/Anela.Heblo.Domain/Features/Catalog/Price/IProductPriceErpClient.cs` — it is owned by the Catalog module's domain.

## Why it matters
This violates the module isolation rule from `development_guidelines.md`: modules must communicate **only through the consuming module's own contracts**, never by reaching into another module's domain or application types. The Purchase module now has a hard compile-time dependency on Catalog's domain layer, which prevents future extraction of either module and defeats the contract-based decoupling architecture.

The established pattern in this codebase (see `ILeafletKnowledgeSource` example in the guidelines) is:
1. **Consumer (Purchase)** defines an interface in `Purchase/Contracts/` (e.g. `IPurchasePriceRecalculationService`)
2. **Provider (Catalog)** implements an adapter in `Catalog/Infrastructure/` that delegates to `IProductPriceErpClient`
3. **Catalog's module** registers the DI binding

## Suggested fix
1. Add `backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/IPurchasePriceRecalculationService.cs`:
   ```csharp
   public interface IPurchasePriceRecalculationService
   {
       Task RecalculatePurchasePriceAsync(int bomId, CancellationToken cancellationToken);
   }
   ```
2. Add an adapter in Catalog (e.g. `Catalog/Infrastructure/CatalogPurchasePriceAdapter.cs`) that implements the new interface by delegating to `IProductPriceErpClient`.
3. Update `CatalogModule.cs` to register `services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceAdapter>()`.
4. Replace the `IProductPriceErpClient` dependency in `RecalculatePurchasePriceHandler` with `IPurchasePriceRecalculationService`.

---
_Filed by daily arch-review routine on 2026-05-27._

---

Closes #1808

### Tokens used
19927049
