### PR TITLE
ci: drop hardcoded REACT_APP_API_URL so same image runs in stg and prod

### DIFF
--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -220,7 +220,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            REACT_APP_API_URL=https://heblo.stg.anela.cz
             REACT_APP_USE_MOCK_AUTH=false
             REACT_APP_AZURE_CLIENT_ID=${{ secrets.REACT_APP_AZURE_CLIENT_ID }}
             REACT_APP_AZURE_AUTHORITY=${{ secrets.REACT_APP_AZURE_AUTHORITY }}

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -184,8 +184,11 @@ jobs:
       - name: 🏷️ Generate version tag
         id: version
         run: |
-          # Use PR-specific versioning for feature branches
-          VERSION="staging-PR${{ github.event.pull_request.number }}-${{ steps.gitversion.outputs.shortSha }}"
+          # Tag with the PR's branch HEAD SHA (not the merge commit SHA from GitVersion)
+          # so deploy-staging-manual.yml — which resolves via `gh pr view --json headRefOid` —
+          # asks for the same tag this job pushes.
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          VERSION="staging-PR${{ github.event.pull_request.number }}-${HEAD_SHA:0:7}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "📌 Version: $VERSION"
           echo "🔢 GitVersion SemVer: ${{ steps.gitversion.outputs.fullSemVer }}"

--- a/.github/workflows/ci-main-branch.yml
+++ b/.github/workflows/ci-main-branch.yml
@@ -385,7 +385,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            REACT_APP_API_URL=https://heblo.anela.cz
             REACT_APP_USE_MOCK_AUTH=false
             REACT_APP_AZURE_CLIENT_ID=${{ secrets.REACT_APP_AZURE_CLIENT_ID }}
             REACT_APP_AZURE_AUTHORITY=${{ secrets.REACT_APP_AZURE_AUTHORITY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ These encode **project-specific** gotchas not covered by the global rules in `~/
 - **E2E tests use fixtures from `frontend/test/e2e/fixtures/test-data.ts`.** Throw (don't skip) when expected data is missing. (See `docs/testing/test-data-fixtures.md`.)
 - **E2E tests live in their module folder** under `frontend/test/e2e/<module>/`. (See `docs/testing/e2e-module-guide.md`.)
 - **Shoptet API findings must be documented before use.** No sandbox — every call hits a live store. Write new endpoints, status values, and quirks to `docs/integrations/shoptet-api.md` before relying on them.
+- **All secrets go to Azure Key Vault, never to Web App environment variables.** Staging: `kv-heblo-stg`. KV secrets use `--` as separator (e.g. `ConnectionStrings--Staging`, `HomeAssistant--BaseUrl`). The app reads `KeyVault:Uri` from App Settings and loads all secrets from KV at startup. Do not add or update secrets in Azure Portal App Settings — use `az keyvault secret set --vault-name kv-heblo-stg --name "..." --value "..."` instead.
 
 ## Validation before completion
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@
 FROM node:20-alpine AS frontend-build
 WORKDIR /app/frontend
 
-# Accept build arguments for React environment variables
-ARG REACT_APP_API_URL=http://localhost:8080
+# Accept build arguments for React environment variables.
+# REACT_APP_API_URL is intentionally empty: runtimeConfig.ts falls back to
+# window.location.origin when empty, so the same image serves frontend + API from one
+# host in stg/prod. A truthy default (e.g. http://localhost:8080) gets baked into the
+# bundle and ships to users, causing ERR_CONNECTION_REFUSED in their browsers.
+ARG REACT_APP_API_URL=
 ARG REACT_APP_USE_MOCK_AUTH=true
 ARG REACT_APP_AZURE_CLIENT_ID=
 ARG REACT_APP_AZURE_AUTHORITY=


### PR DESCRIPTION
## Summary

- Remove `REACT_APP_API_URL` build-arg from both `ci-main-branch.yml` and `ci-feature-branch.yml`. The FE's `runtimeConfig.ts` already falls back to `window.location.origin`, so a single image now works in both staging and production (FE+BE are co-located in the same container).
- Fixes the staging CORS error where the staging FE was calling the production backend because the URL was baked into the image at build time.
- Documents the KV-only secrets policy in `CLAUDE.md` — all secrets must live in Azure Key Vault (`kv-heblo-stg` for staging), never in Web App env settings.

## Test plan

- [ ] Merge → CI builds a fresh image without the baked URL
- [ ] Trigger `deploy-staging-manual.yml` for `main` and verify the staging FE calls `https://heblo.stg.anela.cz/api/*` (same origin), not `heblo.anela.cz`
- [ ] Sanity-check production after the next main deploy still hits its own origin