### PR TITLE
feat: Relocate UpdatePurchaseOrderRequestValidator to Correct Use Case Folder

### DIFF
--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/arch-review.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/arch-review.r1.md
@@ -1,148 +1,131 @@
-```markdown
-# Architecture Review: Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler
+# Architecture Review: Relocate UpdatePurchaseOrderRequestValidator to Correct Use Case Folder
 
 ## Skip Design: true
 
+Backend-only file move + namespace correction with no UI surface and no behavioral change.
+
 ## Architectural Fit Assessment
 
-This change is a **pure dead-code removal in a single MediatR handler**. It does not introduce architectural deviations — it *restores* alignment with the codebase's stated direction:
+The change fully aligns with the established Vertical Slice Architecture used across `backend/src/Anela.Heblo.Application/Features/`. Every other use case folder co-locates its validator next to its handler/request/response (`UseCases/UpdateLot/UpdateLotRequestValidator.cs`, `UseCases/UpdateProductCompositionOrder/UpdateProductCompositionOrderRequestValidator.cs`, `UseCases/CreatePurchaseOrder/CreatePurchaseOrderRequestValidator.cs`). The current placement under `CreatePurchaseOrder/` is the lone outlier — restoring it is a pure consistency fix.
 
-- The Catalog domain already exposes `ICatalogRepository.GetByIdsAsync` (`backend/src/Anela.Heblo.Domain/Features/Catalog/ICatalogRepository.cs:54`), explicitly added to avoid N+1 patterns. The removed loop directly contradicted that design.
-- The Purchase feature follows the Application's Vertical Slice convention: each use case is one folder under `Features/Purchase/UseCases/*` with `Handler` + `Request` + `Response`. The edit stays inside `UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs` — no slice boundaries are crossed.
-- The `PurchaseOrderLineDto.MaterialName` is sourced from the denormalized `PurchaseOrderLine.MaterialName` entity field. This is the established convention in both `CreatePurchaseOrderHandler.MapToResponseAsync` (no catalog lookup) and `GetPurchaseOrderByIdHandler` (catalog lookup only because `CatalogNote` lives solely in the catalog). The Update handler is the outlier.
+Integration points are minimal and all internal to the Purchase module:
+1. **DI registration** in `backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` (line 23)
+2. **Validator → DTO coupling** with `UpdatePurchaseOrderRequest` (already in the target namespace)
+3. **MediatR validation pipeline** (resolves `IValidator<UpdatePurchaseOrderRequest>` from DI — unchanged)
 
-**Integration points** are limited to: the single handler file, its DI registration (unchanged), and any tests that referenced catalog calls inside `MapToResponseAsync` (none exist — only `UpdatePurchaseOrderStatusHandlerTests.cs` lives under the Purchase test folder).
+No callers reference the validator by its incorrect namespace — verified with grep across solution.
 
 ## Proposed Architecture
 
 ### Component Overview
 
 ```
-PUT /api/purchase-orders/{id}
-        │
-        ▼
-PurchaseOrdersController ── MediatR ──► UpdatePurchaseOrderHandler
-                                              │
-                                              ├─ ISupplierRepository.GetByIdAsync  (validates supplier)
-                                              ├─ ICatalogRepository.GetByIdAsync   (USED — to set MaterialName on AddLine/UpdateLine in Handle())
-                                              ├─ IPurchaseOrderRepository           (load, persist)
-                                              │
-                                              └─ MapToResponseAsync(purchaseOrder)  ◄── NO catalog calls after this change
-                                                       │
-                                                       └─► UpdatePurchaseOrderResponse  (MaterialName comes from entity)
+Features/Purchase/
+├── PurchaseModule.cs                          (DI registration — unchanged)
+└── UseCases/
+    ├── CreatePurchaseOrder/
+    │   ├── CreatePurchaseOrderHandler.cs
+    │   ├── CreatePurchaseOrderRequest.cs
+    │   ├── CreatePurchaseOrderRequestValidator.cs
+    │   ├── CreatePurchaseOrderResponse.cs
+    │   └── UpdatePurchaseOrderRequestValidator.cs   ← REMOVE
+    └── UpdatePurchaseOrder/
+        ├── UpdatePurchaseOrderHandler.cs
+        ├── UpdatePurchaseOrderRequest.cs
+        ├── UpdatePurchaseOrderRequestValidator.cs   ← ADD (same content, corrected namespace)
+        └── UpdatePurchaseOrderResponse.cs
 ```
-
-The architecture **does not change**. Only the `MapToResponseAsync` method is simplified: the loop body becomes a pure entity-to-DTO projection with no awaits.
 
 ### Key Design Decisions
 
-#### Decision 1: Drop the lookup outright vs. switch to `GetByIdsAsync`
+#### Decision 1: Pure file move vs. split-and-rewrite
+
 **Options considered:**
-- (a) Delete the two unused lines (spec FR-1).
-- (b) Replace the per-line `GetByIdAsync` with a single `GetByIdsAsync` outside the loop.
+- (A) Move the file as-is and adjust namespace + redundant `using`.
+- (B) Split `UpdatePurchaseOrderLineRequestValidator` into its own file during the move.
 
-**Chosen approach:** (a) — delete.
+**Chosen approach:** (A) — single-file move, namespace fix only.
 
-**Rationale:** The fetched value is never read. Replacing a dead call with a "more efficient" dead call still produces zero observable output and adds a dictionary allocation. `GetByIdsAsync` becomes warranted only when a catalog-only field (e.g. `CatalogNote`) is added to `UpdatePurchaseOrderResponse`; that is explicitly out of scope.
+**Rationale:** YAGNI + surgical change. The sibling `CreatePurchaseOrderRequestValidator.cs` co-locates its line validator in the same file (lines 69–91). Matching that convention keeps the diff minimal and avoids drift. The spec explicitly forbids non-structural changes.
 
-#### Decision 2: Keep `ICatalogRepository` as a constructor dependency
+#### Decision 2: Trust explicit DI registration over assembly scanning
+
 **Options considered:**
-- (a) Remove `_catalogRepository`, the constructor parameter, and the `using Anela.Heblo.Domain.Features.Catalog;` directive (FR-2's conditional path).
-- (b) Keep the dependency.
+- (A) Rely on existing explicit DI registration in `PurchaseModule.cs`.
+- (B) Switch to `AddValidatorsFromAssembly` while in the neighborhood.
 
-**Chosen approach:** (b) — keep.
+**Chosen approach:** (A) — leave DI registration untouched.
 
-**Rationale:** Verification of the file shows `ICatalogRepository` is still consumed inside the main `Handle` method at `UpdatePurchaseOrderHandler.cs:80` and `:93`, where it computes `materialName` for `UpdateLine`/`AddLine`. Those calls are legitimate (the result is passed to the domain method). The conditional in spec FR-2 ("If `MapToResponseAsync` was the only consumer…") therefore evaluates to false. Field, constructor parameter, and `using` directive must **stay**.
-
-> This is an amendment to the spec — see "Specification Amendments" below.
-
-#### Decision 3: Scope of the "sibling handler" check (FR-4)
-**Options considered:**
-- (a) Grep narrowly for unused `material` lookups inside response-mapping methods.
-- (b) Grep for any `_catalogRepository.GetByIdAsync(...)` inside a line loop.
-
-**Chosen approach:** (a) — match the spec's definition of "dead" (result unused).
-
-**Rationale:** A grep across `Features/Purchase/UseCases` shows four call sites:
-- `UpdatePurchaseOrderHandler.cs:80, :93` — result **used** in `UpdateLine`/`AddLine`. Not dead. Not an N+1 to fix in this change.
-- `UpdatePurchaseOrderHandler.cs:128` — result **unused**. This is the target of FR-1.
-- `CreatePurchaseOrderHandler.cs:79` — result **used** in `AddLine`. Not dead. `CreatePurchaseOrderHandler.MapToResponseAsync` already does the right thing (no catalog calls). 
-- `GetPurchaseOrderByIdHandler.cs:54` — result **used** for `CatalogNote`. Legitimate per the brief.
-
-Conclusion: only the one site qualifies. The other in-loop `GetByIdAsync` calls in the same handler (`:80`, `:93`) are an N+1 *performance* concern but not "dead." They are out of scope for this brief and should be filed separately if desired.
+**Rationale:** Spec FR-3 references `AddValidatorsFromAssembly`, but the actual code path is explicit registration:
+```csharp
+services.AddScoped<IValidator<UpdatePurchaseOrderRequest>, UpdatePurchaseOrderRequestValidator>();
+```
+This is namespace-agnostic — the type reference will continue to resolve because `PurchaseModule.cs` already imports both namespaces (lines 3–4). Switching to assembly scanning is out of scope and would be a separate architectural decision affecting all features.
 
 ## Implementation Guidance
 
 ### Directory / Module Structure
 
-No new files. Single-file edit:
+**Create:** `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
 
-```
-backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/
-    └── UpdatePurchaseOrderHandler.cs   ← edit MapToResponseAsync only
-```
+**Delete:** `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+
+Prefer `git mv` so file history is preserved.
 
 ### Interfaces and Contracts
 
-No interface or contract changes:
-- `UpdatePurchaseOrderRequest` / `UpdatePurchaseOrderResponse` / `PurchaseOrderLineDto` shapes are unchanged.
-- `ICatalogRepository`, `IPurchaseOrderRepository`, `ISupplierRepository` are unchanged.
-- The handler's constructor signature is **unchanged** (Decision 2).
-- DI registration is **unchanged**.
+No interface or contract changes. The moved file must:
+
+1. Declare: `namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`
+2. **Remove** the now-redundant import: `using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`
+3. **Retain** `using FluentValidation;` (still needed for `AbstractValidator<T>`).
+4. **Add** `using System;` only if `dotnet format` flags `DateTime` as ambiguous — likely not needed; `System` is implicit.
+5. **Retain** both classes (`UpdatePurchaseOrderRequestValidator` and `UpdatePurchaseOrderLineRequestValidator`) in the same file.
+
+Final file shape (illustrative skeleton, content unchanged from current):
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+
+public class UpdatePurchaseOrderRequestValidator : AbstractValidator<UpdatePurchaseOrderRequest> { /* …unchanged… */ }
+public class UpdatePurchaseOrderLineRequestValidator : AbstractValidator<UpdatePurchaseOrderLineRequest> { /* …unchanged… */ }
+```
 
 ### Data Flow
 
-For `PUT /api/purchase-orders/{id}` after the change, the response-mapping phase has the following shape:
-
-```
-purchaseOrder (entity, already loaded with .Lines tracked)
-        │
-        ▼
-foreach line in purchaseOrder.Lines:        ── synchronous, no awaits ──►
-    project to PurchaseOrderLineDto using only entity fields
-        │
-        ▼
-return UpdatePurchaseOrderResponse { ..., Lines = lines }
-```
-
-The handler-level data flow (load → validate supplier → mutate aggregate → save) is untouched.
-
-The concrete edit:
-
-- Remove `UpdatePurchaseOrderHandler.cs:127–129` (the comment and the two `var material` / `var materialName` lines).
-- The enclosing `foreach (var line in purchaseOrder.Lines)` loop body becomes the single `lines.Add(new PurchaseOrderLineDto { … })` block already present at `:131–141`.
-- `MapToResponseAsync` no longer needs to be `async` in principle, **but** keep it `async Task<UpdatePurchaseOrderResponse>` and keep the `CancellationToken cancellationToken` parameter to avoid a ripple change at the single call site (`:110`) and to preserve any future extension point. The compiler will emit a CS1998 ("async method lacks await") — suppress this by either:
-    - (preferred) changing the signature to `private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)` and updating the call site `return MapToResponse(purchaseOrder, request.SupplierId);` — this is the cleaner option and aligns with NFR-2 ("no new warnings").
-    - or adding `await Task.CompletedTask;` — **not recommended**; it just papers over the warning.
-
-> **Recommended:** drop `async`, the `Task<…>` wrapper, and the `CancellationToken` parameter from `MapToResponseAsync`, and rename to `MapToResponse`. Update the call site at `:110` accordingly. This keeps the method honest and satisfies NFR-2 without any warning suppression.
+Unchanged. MediatR pipeline → resolves `IValidator<UpdatePurchaseOrderRequest>` from DI → fluent rules evaluate → `UpdatePurchaseOrderHandler.Handle` runs on validation success.
 
 ## Risks and Mitigations
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| Removing the await turns the method synchronous → CS1998 warning ("no new warnings" NFR-2 violated). | Medium | Apply Decision 3's recommended sub-step: change signature to a sync `MapToResponse` and update the single caller. |
-| A test asserts on a mocked `_catalogRepository.GetByIdAsync` call count for the update flow. | Low | Search `backend/test/**/UpdatePurchaseOrder*` — only `UpdatePurchaseOrderStatusHandlerTests.cs` exists, and it targets a different handler. No update needed. If a test is later found, relax the call-count assertion. |
-| Behavior divergence if `line.MaterialName` were ever stale relative to the catalog. | Low | The behavior is **already** this way — the response always returned `line.MaterialName`. Removing the unused lookup cannot change observable output. The denormalized `MaterialName` is refreshed on every `AddLine`/`UpdateLine` in `Handle` (which still uses the catalog), so staleness is bounded to lines that the user does not touch — same as today. |
-| Accidental removal of `_catalogRepository` field breaks `Handle` at `:80` / `:93`. | High | Decision 2 explicitly keeps the field. Reviewer checklist item: confirm `_catalogRepository` references still resolve after the edit. |
-| `using Anela.Heblo.Domain.Features.Catalog;` removed prematurely. | Low | The `using` is still needed for `ICatalogRepository` type binding in the field declaration. Do not remove. |
+| Stale build artifacts cache the old namespace | LOW | Run `dotnet clean` before `dotnet build` if anything looks odd. |
+| `dotnet format` reorders or strips additional `using` directives | LOW | Run `dotnet format` after the move and visually diff to confirm only the redundant `UpdatePurchaseOrder` using is removed. |
+| Future maintainer rediscovers the same misplacement elsewhere | LOW | Out of scope here (per spec). Owner should consider a follow-up arch-review pass across all `Features/*/UseCases/*` folders. |
+| DI resolution breaks because `PurchaseModule.cs` loses ability to locate the type | NONE | `PurchaseModule.cs` already imports `UseCases.UpdatePurchaseOrder` (line 4) and references the validator by type, not by fully-qualified name. No change required. |
 
 ## Specification Amendments
 
-1. **FR-2 is a no-op.** Verification confirms `_catalogRepository` is still consumed in `Handle` (lines 80 and 93, used by `UpdateLine`/`AddLine`). The field, constructor parameter, and `using Anela.Heblo.Domain.Features.Catalog;` directive **must remain**. The spec's conditional ("If `MapToResponseAsync` was the only consumer…") evaluates to false. Update the spec to state this explicitly so the implementer does not delete the dependency.
+1. **Correct FR-3 mechanism.** The spec states that "FluentValidation auto-registration (via `AddValidatorsFromAssembly` or equivalent)" handles discovery. In this codebase, validators are registered **explicitly** in `PurchaseModule.cs` (lines 22–23), not via assembly scanning. The acceptance criterion still holds — the existing explicit registration will continue to work because it binds by type — but the spec should reflect the actual mechanism. Suggested replacement wording:
 
-2. **Add sub-step to FR-1: convert `MapToResponseAsync` to a sync `MapToResponse`.** After the two dead lines are removed, the method has no remaining awaits. To honor NFR-2 (no new warnings, no `await Task.CompletedTask` filler), change the signature to `private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)`, drop the unused `CancellationToken`, and update the single call site at `UpdatePurchaseOrderHandler.cs:110`.
+   > FR-3 acceptance: The explicit DI registration in `PurchaseModule.cs` (`services.AddScoped<IValidator<UpdatePurchaseOrderRequest>, UpdatePurchaseOrderRequestValidator>()`) continues to resolve the moved type without modification, because `PurchaseModule.cs` already imports the `UpdatePurchaseOrder` namespace.
 
-3. **FR-4 outcome clarified.** The grep `_catalogRepository.GetByIdAsync` under `Features/Purchase/UseCases` returns four hits; only `UpdatePurchaseOrderHandler.cs:128` matches the "dead" criterion (result unused). The other three in-loop calls (`UpdatePurchaseOrderHandler.cs:80`, `:93`, `CreatePurchaseOrderHandler.cs:79`) use the result and are out of scope. PR description should list this verification explicitly.
+2. **Clarify FR-2 import handling.** Only one `using` directive becomes redundant (`using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`). Keep `using FluentValidation;`. `System` types (`DateTime`) are covered by implicit usings in this project (verify via `Directory.Build.props` or the `.csproj` if any analyzer complains; not expected).
 
-4. **Note on adjacent N+1.** `UpdatePurchaseOrderHandler.Handle` itself runs `GetByIdAsync` per line in the request (`:80`, `:93`). This is a genuine N+1 with a *used* result. It is **not** dead code and is therefore out of scope per the brief's framing, but it is the natural next ticket: refactor to a single `GetByIdsAsync(request.Lines.Select(l => l.MaterialId).Distinct())` call outside the loop. Recommend filing as a follow-up brief; do not bundle it here.
+3. **Add explicit "preserve git history" guidance.** Use `git mv` rather than delete + create so blame/history follow the file.
 
 ## Prerequisites
 
-None. No migrations, configuration, infrastructure, or interface changes are required.
+None. This is a self-contained refactor:
 
-- The `ICatalogRepository.GetByIdsAsync` bulk method already exists and is registered, but is **not used** by this change (Decision 1).
-- No frontend regeneration needed: the OpenAPI schema for `UpdatePurchaseOrderResponse` is byte-identical (NFR-3).
-- No test fixtures or seed data changes.
-- Validation gates per `CLAUDE.md`: `dotnet build` + `dotnet format` + run the Purchase test project. No E2E run required for a behavior-preserving dead-code removal.
-```
+- No migrations
+- No config changes
+- No infrastructure changes
+- No new dependencies
+- No coordination with other workstreams
+
+Validation gate before merge (per project CLAUDE.md):
+- `dotnet build` — zero errors, zero new warnings
+- `dotnet format` — clean on the moved file
+- `dotnet test` — all existing tests pass unchanged (no validator-specific tests exist today; integration of validation through the MediatR pipeline is exercised by handler-level tests if present)

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/brief.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/brief.md
@@ -2,44 +2,23 @@
 Purchase
 
 ## Finding
-`UpdatePurchaseOrderHandler.MapToResponseAsync` fetches a catalog item for every order line, but the fetched object is never used — the DTO maps `line.MaterialName` (already stored on the entity):
+The validator for `UpdatePurchaseOrderRequest` is physically located inside the `CreatePurchaseOrder` use case folder and carries the wrong namespace:
 
-```csharp
-// backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-157
-private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
-{
-    var lines = new List<PurchaseOrderLineDto>();
-    foreach (var line in purchaseOrder.Lines)
-    {
-        // Try to get material name from catalog
-        var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);  // ← fetched
-        var materialName = material?.ProductName ?? "Unknown Material";                              // ← computed
+- **File (wrong location):** `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+- **Line 4 (wrong namespace):** `namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;`
+- **Line 1 (validated type from another use case):** `using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`
 
-        lines.Add(new PurchaseOrderLineDto
-        {
-            ...
-            MaterialName = line.MaterialName,   // ← entity value used, not 'materialName'
-            ...
-        });
-    }
-```
-
-`materialName` is computed but then discarded — the DTO always reads `line.MaterialName`. For an order with N lines this makes N catalog lookups (each of which queries a large in-memory cache or external system) and throws the results away.
-
-Compare with `GetPurchaseOrderByIdHandler`, which performs the same lookup legitimately: it maps `CatalogNote = catalogItem.Note` — a field that only lives in the catalog and cannot come from the entity.
+The file validates `UpdatePurchaseOrderRequest` and `UpdatePurchaseOrderLineRequest` — both of which belong to the `UpdatePurchaseOrder` use case — but is filed under the `CreatePurchaseOrder` folder.
 
 ## Why it matters
-- Every `PUT /api/purchase-orders/{id}` request fires N catalog reads that produce no visible output. This is wasted compute on every update.
-- `ICatalogRepository.GetByIdsAsync` was added specifically to eliminate N+1 patterns (its code comment says so). Using `GetByIdAsync` in a loop already goes against that design; computing and discarding the result compounds the waste.
+This breaks the co-location principle of Vertical Slice Architecture (one use case folder contains everything for that use case). A developer searching for the `UpdatePurchaseOrder` validator will not find it in the expected `UseCases/UpdatePurchaseOrder/` directory. The namespace mismatch also signals incorrect ownership — any IDE navigation from `UpdatePurchaseOrderHandler` to its validator will be misleading.
 
 ## Suggested fix
-Delete the two dead lines from `MapToResponseAsync`:
+Move the file to `UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs` and update the namespace to:
 ```csharp
-// Remove:
-var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
-var materialName = material?.ProductName ?? "Unknown Material";
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
 ```
-The DTO already reads `line.MaterialName`; no replacement is needed. If `CatalogNote` ever needs to appear on the update response too, use `GetByIdsAsync` once (bulk) outside the loop, as `GetPurchaseOrderByIdHandler` does.
+No logic changes needed — just a rename/move.
 
 ---
-_Filed by daily arch-review routine on 2026-05-22._
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/impl/main.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/impl/main.r1.md
@@ -1,4 +1,4 @@
-This is a standalone worktree clone (not linked to the main repo's worktree list). GIT_DIR == GIT_COMMON → standard 4-option menu.
+`GIT_DIR == GIT_COMMON` → Normal repo (standalone checkout, no linked worktree). Named branch `feat-arch-review-purchase-updatepurchaseorder`, base branch `main`.
 
 ---
 

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/spec.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/spec.r1.md
@@ -1,96 +1,82 @@
-# Specification: Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler
+# Specification: Relocate UpdatePurchaseOrderRequestValidator to Correct Use Case Folder
 
 ## Summary
-Remove a dead catalog lookup in `UpdatePurchaseOrderHandler.MapToResponseAsync` that performs N catalog reads per order update without using the result. The DTO already sources `MaterialName` from the entity, so the lookup is wasted compute on every `PUT /api/purchase-orders/{id}` request.
+The `UpdatePurchaseOrderRequestValidator` is currently misplaced inside the `CreatePurchaseOrder` use case folder with an incorrect namespace. This spec covers moving the file to its proper `UpdatePurchaseOrder` use case folder and updating its namespace to align with Vertical Slice Architecture co-location principles. No behavior changes are introduced.
 
 ## Background
-During the daily architecture review on 2026-05-22, an N+1 anti-pattern was found in the Purchase module's update flow.
+The codebase follows Vertical Slice Architecture, where each use case folder under `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/` contains all artifacts for that use case (handler, request/response DTOs, validators, mappings).
 
-`UpdatePurchaseOrderHandler.MapToResponseAsync` (backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-157) iterates over each order line and calls `_catalogRepository.GetByIdAsync(line.MaterialId, ...)`. The fetched `material` is used only to compute a local `materialName` variable that is then discarded — the DTO assigns `MaterialName = line.MaterialName` (the value already persisted on the entity), not the computed variable.
+The file `UpdatePurchaseOrderRequestValidator.cs` validates `UpdatePurchaseOrderRequest` and `UpdatePurchaseOrderLineRequest`, both owned by the `UpdatePurchaseOrder` use case. However, it is physically located under `UseCases/CreatePurchaseOrder/` with namespace `Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder`. This causes:
+- IDE navigation from `UpdatePurchaseOrderHandler` to its validator to fail or mislead.
+- Developers expecting to find the validator in `UseCases/UpdatePurchaseOrder/` will not find it there.
+- Namespace ownership incorrectly attributes the validator to the `CreatePurchaseOrder` slice.
 
-For an order with N lines this triggers N catalog lookups that contribute nothing to the response. The repository's bulk method `GetByIdsAsync` was added explicitly to eliminate this kind of N+1 pattern (per its in-code comment). The sibling handler `GetPurchaseOrderByIdHandler` performs the same lookup *legitimately* because it maps `CatalogNote = catalogItem.Note`, a field that lives only in the catalog. The update handler has no such need.
+This was filed by the daily arch-review routine on 2026-05-27.
 
 ## Functional Requirements
 
-### FR-1: Remove the unused catalog lookup
-Delete the two unused lines from `MapToResponseAsync` in `UpdatePurchaseOrderHandler`:
-
-```csharp
-var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
-var materialName = material?.ProductName ?? "Unknown Material";
-```
-
-No replacement is required. The DTO continues to read `MaterialName = line.MaterialName` from the entity.
+### FR-1: Relocate validator file
+Move `UpdatePurchaseOrderRequestValidator.cs` from the `CreatePurchaseOrder` use case folder to the `UpdatePurchaseOrder` use case folder.
 
 **Acceptance criteria:**
-- Lines 125-126 (approx.) of `UpdatePurchaseOrderHandler.cs` are removed.
-- The `foreach (var line in purchaseOrder.Lines)` loop no longer awaits any catalog repository call.
-- The returned `UpdatePurchaseOrderResponse` is byte-identical to the previous implementation for any valid input (i.e., `MaterialName` values in the response are unchanged because they came from `line.MaterialName` all along).
-- `_catalogRepository` is still injected only if used elsewhere in the handler; otherwise the field, constructor parameter, and `using` for `Anela.Heblo.Domain.Features.Catalog` are removed.
+- File no longer exists at `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`.
+- File exists at `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`.
+- File content (validation logic) is otherwise unchanged.
 
-### FR-2: Remove now-dead dependencies on `ICatalogRepository`
-If `MapToResponseAsync` was the only consumer of `ICatalogRepository` in `UpdatePurchaseOrderHandler`, remove:
-- The private readonly `_catalogRepository` field.
-- The constructor parameter and its assignment.
-- Any unused `using` directive for the catalog namespace.
+### FR-2: Update namespace declaration
+Update the namespace inside the moved file to reflect its new location.
 
 **Acceptance criteria:**
-- `UpdatePurchaseOrderHandler` does not reference `ICatalogRepository` after the change unless another method genuinely uses it.
-- The project compiles (`dotnet build`) with no new warnings.
-- DI registration for the handler still resolves correctly (the handler's constructor takes only the dependencies it actually uses).
+- Namespace line reads: `namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`
+- The `using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;` line is removed (no longer needed once namespaces align).
+- No other `using` directives are removed unless they become genuinely unused.
 
-### FR-3: Preserve existing handler behavior
-The handler must continue to:
-- Update the purchase order as before.
-- Recompute supplier, totals, and line aggregates exactly as it does today.
-- Return the same shape of `UpdatePurchaseOrderResponse` with the same field values for the same inputs.
+### FR-3: Preserve validator registration and behavior
+The validator must continue to be discovered and applied to `UpdatePurchaseOrderRequest` exactly as before.
 
 **Acceptance criteria:**
-- No change to the public method signatures of `UpdatePurchaseOrderHandler`, the request, or the response DTO.
-- No change to validation, persistence, or transaction semantics.
-- Existing unit/integration tests for `UpdatePurchaseOrderHandler` pass without modification (other than any test that asserted on the catalog call count, if such a test exists).
+- FluentValidation auto-registration (via `AddValidatorsFromAssembly` or equivalent in DI setup) continues to register the validator after the move.
+- `UpdatePurchaseOrder` handler/pipeline invokes the validator with no code changes elsewhere.
+- All existing tests pass without modification.
 
-### FR-4: Verify no other handlers have the same dead lookup
-Briefly check sibling handlers in `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/**` for the same pattern (catalog `GetByIdAsync` inside a line loop whose result is unused). Apply the same removal where confirmed.
+### FR-4: No regressions in build or callers
+The move must not break compilation or any consumers.
 
 **Acceptance criteria:**
-- A grep for `GetByIdAsync(line.MaterialId` (or equivalent) under the Purchase use-cases folder reveals no remaining dead lookups.
-- Any additional removals are listed in the PR description.
-- If `GetPurchaseOrderByIdHandler` is the only other handler with such a call, it is left untouched (its use of `catalogItem.Note` is legitimate).
+- `dotnet build` succeeds with zero errors and no new warnings.
+- `dotnet format` reports no violations on the moved file.
+- No other source file requires changes (apart from imports/usings only if a consumer explicitly referenced the old namespace — none expected).
 
 ## Non-Functional Requirements
 
 ### NFR-1: Performance
-- After the change, `PUT /api/purchase-orders/{id}` issues zero catalog repository calls during response mapping (down from N per order line).
-- No regression in response time; expected modest improvement proportional to line count and catalog backing-store latency.
+No runtime performance impact expected. This is a purely structural change.
 
-### NFR-2: Code quality
-- `dotnet build` produces no new warnings.
-- `dotnet format` leaves the file unchanged after the edit.
-- No dead `using` directives remain.
+### NFR-2: Security
+No security impact. No auth, validation rules, or data handling logic is modified.
 
-### NFR-3: Backwards compatibility
-- The HTTP contract for `PUT /api/purchase-orders/{id}` is unchanged.
-- The generated OpenAPI schema for `UpdatePurchaseOrderResponse` is identical.
-- No frontend changes are required.
+### NFR-3: Maintainability
+The change improves codebase maintainability by restoring Vertical Slice co-location, enabling correct IDE navigation, and aligning physical structure with logical ownership.
+
+### NFR-4: Backwards Compatibility
+No public API, contract, or behavior changes. No DB or migration impact. No frontend impact.
 
 ## Data Model
-No changes. `PurchaseOrderLine` continues to store `MaterialName` as a denormalized field; `UpdatePurchaseOrderResponse.PurchaseOrderLineDto.MaterialName` continues to be sourced from that field.
+No data model changes.
 
 ## API / Interface Design
-No changes. The affected endpoint is `PUT /api/purchase-orders/{id}`; its request and response shapes are unchanged.
+No API or interface changes. The validator is internal to the application layer.
 
 ## Dependencies
-- `Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder.UpdatePurchaseOrderHandler` (the file being edited).
-- `Anela.Heblo.Domain.Features.Catalog.ICatalogRepository` (dependency may be removed from this handler).
-- Existing test project for the Purchase feature (no new tests required unless coverage gaps are uncovered).
+- FluentValidation (existing dependency) — assembly scanning must pick up validators in the `UpdatePurchaseOrder` folder; this is already the case for other validators in sibling use case folders.
+- No new packages or external services.
 
 ## Out of Scope
-- Refactoring `GetPurchaseOrderByIdHandler` (its catalog lookup is legitimate). If a bulk `GetByIdsAsync` refactor for that handler is desired, it should be filed as a separate brief.
-- Adding `CatalogNote` (or other catalog-only fields) to `UpdatePurchaseOrderResponse`. If product later wants this, the implementation must use `GetByIdsAsync` once outside the loop.
-- Broader audit of N+1 patterns outside the Purchase module.
-- Any frontend changes.
-- Changes to caching policy in `ICatalogRepository`.
+- Refactoring or improving the validation rules themselves.
+- Auditing other use case folders for similar misplacements (a separate arch-review task).
+- Renaming the validator class or related DTOs.
+- Changes to `CreatePurchaseOrder` use case logic or its own validators.
+- Test additions beyond verifying that existing tests still pass.
 
 ## Open Questions
 None.

--- a/artifacts/feat-arch-review-purchase-updatepurchaseorder/task-plan.r1.md
+++ b/artifacts/feat-arch-review-purchase-updatepurchaseorder/task-plan.r1.md
@@ -1,424 +1,342 @@
-# Remove Dead Catalog Lookup in UpdatePurchaseOrderHandler — Implementation Plan
+# Relocate UpdatePurchaseOrderRequestValidator Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Remove the dead, per-line `_catalogRepository.GetByIdAsync` call inside `UpdatePurchaseOrderHandler.MapToResponseAsync` whose result is never used, and convert the now-await-free method to a synchronous helper without changing any observable behavior of `PUT /api/purchase-orders/{id}`.
+**Goal:** Move `UpdatePurchaseOrderRequestValidator.cs` from the `CreatePurchaseOrder` use case folder to the `UpdatePurchaseOrder` use case folder and correct its namespace, restoring Vertical Slice co-location with zero behavior change.
 
-**Architecture:** Single-file edit in a MediatR handler under Vertical Slice `Features/Purchase/UseCases/UpdatePurchaseOrder/`. The fix is pure dead-code removal — no new interfaces, no DI changes, no contract changes. `ICatalogRepository` stays as a dependency because it is still legitimately consumed in `Handle` (lines 80 and 93) to compute `materialName` for `UpdateLine`/`AddLine`. The response DTO already sourced `MaterialName` from the entity (`line.MaterialName`), so deleting the unused lookup leaves the response byte-identical.
+**Architecture:** Pure structural refactor inside `Anela.Heblo.Application.Features.Purchase`. Use `git mv` to preserve file history. Update the namespace declaration and drop the now-redundant `using` directive. DI registration in `PurchaseModule.cs` already imports both namespaces and binds by type, so no DI changes are required.
 
-**Tech Stack:** .NET 8, C#, MediatR, xUnit + Moq + FluentAssertions for tests, EF Core (via `IPurchaseOrderRepository`).
+**Tech Stack:** .NET 8, C#, FluentValidation, MediatR. Build with `dotnet build`, format with `dotnet format`, tests with `dotnet test`.
 
 ---
 
 ## File Structure
 
-**Modified files:**
-- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs` — remove dead lines inside `MapToResponseAsync`, convert it to a synchronous `MapToResponse`, update the single call site.
+**Move (via `git mv`):**
+- From: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+- To: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
 
-**Created files:**
-- `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs` — new test file with a focused regression test that proves `MapToResponse` does **not** invoke `ICatalogRepository.GetByIdAsync` on the response-mapping path. Mirrors the structure of the sibling `CreatePurchaseOrderHandlerTests.cs` for consistency.
+**Modify (in place after move):**
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs` — namespace + remove redundant `using`.
 
-**Out-of-scope (verified by grep, do not touch):**
-- `CreatePurchaseOrderHandler.cs:79` — catalog lookup result is used in `AddLine`. Not dead.
-- `GetPurchaseOrderByIdHandler.cs:54` — catalog lookup feeds `CatalogNote` (catalog-only field). Legitimate.
-- `UpdatePurchaseOrderHandler.cs:80` and `:93` — catalog lookup result is used by `UpdateLine`/`AddLine`. These are an adjacent N+1 with a *used* result; they are a separate ticket per the arch review and **must not** be changed here.
+**Unchanged (verify only):**
+- `backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` — already imports both `CreatePurchaseOrder` and `UpdatePurchaseOrder` namespaces (lines 3–4) and registers the validator by type (line 23). No edit required.
 
----
-
-## Task 1: Add regression test that proves `MapToResponse` never calls the catalog
-
-We add the test **first** (TDD red step) so that we have a guarantee that the post-edit behavior really removes the unused call.
-
-**Files:**
-- Create: `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs`
-
-### Step 1.1: Write the failing test
-
-- [ ] **Step 1.1:** Create the test file with a single test that exercises the update flow with one existing line and one new line, then asserts that the catalog repository is invoked **at most twice** (once for the `UpdateLine` branch at handler line 80, once for the `AddLine` branch at handler line 93) — i.e. **never** invoked a third time during response mapping.
-
-Create `backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs` with:
-
-```csharp
-using Anela.Heblo.Application.Features.Purchase.Contracts;
-using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
-using Anela.Heblo.Domain.Features.Catalog;
-using Anela.Heblo.Domain.Features.Purchase;
-using Anela.Heblo.Domain.Features.Users;
-using FluentAssertions;
-using Microsoft.Extensions.Logging;
-using Moq;
-using Xunit;
-
-namespace Anela.Heblo.Tests.Features.Purchase;
-
-public class UpdatePurchaseOrderHandlerTests
-{
-    private readonly Mock<ILogger<UpdatePurchaseOrderHandler>> _loggerMock = new();
-    private readonly Mock<IPurchaseOrderRepository> _repositoryMock = new();
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock = new();
-    private readonly Mock<ICurrentUserService> _currentUserServiceMock = new();
-    private readonly Mock<ISupplierRepository> _supplierRepositoryMock = new();
-    private readonly UpdatePurchaseOrderHandler _handler;
-
-    private const long ValidSupplierId = 1;
-    private const string ValidSupplierName = "Test Supplier";
-    private const string ExistingMaterialId = "MAT-EXISTING";
-    private const string NewMaterialId = "MAT-NEW";
-
-    public UpdatePurchaseOrderHandlerTests()
-    {
-        _currentUserServiceMock
-            .Setup(x => x.GetCurrentUser())
-            .Returns(new CurrentUser("test-user-id", "Test User", "test@example.com", true));
-
-        _supplierRepositoryMock
-            .Setup(x => x.GetByIdAsync(ValidSupplierId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Supplier { Id = ValidSupplierId, Name = ValidSupplierName, Code = "SUP001" });
-
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string id, CancellationToken _) => new CatalogAggregate { ProductCode = id, ProductName = $"Material {id}" });
-
-        _handler = new UpdatePurchaseOrderHandler(
-            _loggerMock.Object,
-            _repositoryMock.Object,
-            _catalogRepositoryMock.Object,
-            _currentUserServiceMock.Object,
-            _supplierRepositoryMock.Object);
-    }
-
-    [Fact]
-    public async Task Handle_WithUpdateAndAddLines_DoesNotCallCatalogDuringResponseMapping()
-    {
-        // Arrange — seed an order that has one existing line.
-        var order = new PurchaseOrder(
-            orderNumber: "PO-2024-001",
-            supplierId: ValidSupplierId,
-            supplierName: ValidSupplierName,
-            orderDate: new DateTime(2024, 8, 2),
-            expectedDeliveryDate: new DateTime(2024, 8, 16),
-            contactVia: null,
-            notes: null,
-            createdBy: "seed");
-        order.AddLine(ExistingMaterialId, "Existing Material", quantity: 1m, unitPrice: 10m, notes: null);
-        var existingLineId = order.Lines.Single().Id;
-
-        _repositoryMock
-            .Setup(x => x.GetByIdWithDetailsAsync(order.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(order);
-
-        var request = new UpdatePurchaseOrderRequest
-        {
-            Id = order.Id,
-            SupplierId = ValidSupplierId,
-            OrderNumber = order.OrderNumber,
-            ExpectedDeliveryDate = order.ExpectedDeliveryDate,
-            ContactVia = null,
-            Notes = null,
-            Lines = new List<UpdatePurchaseOrderLineRequestDto>
-            {
-                new()
-                {
-                    Id = existingLineId,
-                    MaterialId = ExistingMaterialId,
-                    Name = "Existing Material",
-                    Quantity = 2m,
-                    UnitPrice = 10m,
-                    Notes = null,
-                },
-                new()
-                {
-                    Id = null,
-                    MaterialId = NewMaterialId,
-                    Name = "New Material",
-                    Quantity = 3m,
-                    UnitPrice = 20m,
-                    Notes = null,
-                },
-            },
-        };
-
-        // Act
-        var response = await _handler.Handle(request, CancellationToken.None);
-
-        // Assert — response is well-formed and MaterialName comes from the entity.
-        response.Success.Should().BeTrue();
-        response.Lines.Should().HaveCount(2);
-        response.Lines.Should().OnlyContain(line => !string.IsNullOrEmpty(line.MaterialName));
-
-        // Assert — catalog is hit exactly twice (once per request line, inside Handle),
-        // and never again inside MapToResponse. This is the regression guard.
-        _catalogRepositoryMock.Verify(
-            x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Exactly(2));
-    }
-}
-```
-
-> **Note for the implementer:** Property names on `UpdatePurchaseOrderRequest`, `UpdatePurchaseOrderLineRequestDto`, `PurchaseOrder`, and `CatalogAggregate` shown above must match the codebase exactly. If a property does not exist with the spelling shown (e.g. `Name` on the line request, or `ProductName`/`ProductCode` on `CatalogAggregate`), open the type and use the actual property name — do not invent fields. The intent of the test is to: (1) drive the handler through both the update-existing-line and add-new-line branches, and (2) verify `_catalogRepositoryMock.GetByIdAsync` is called exactly twice (i.e. zero times during response mapping). Adjust property spellings to match the real types; do not change the assertion semantics.
-
-### Step 1.2: Run the test to confirm it fails
-
-- [ ] **Step 1.2:** Run only the new test. It must fail with a Moq `Times.Exactly(2)` assertion failure showing **3** invocations of `_catalogRepository.GetByIdAsync` (two from `Handle` lines 80/93, plus one from `MapToResponseAsync` line 128).
-
-Run:
-
-```bash
-cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~UpdatePurchaseOrderHandlerTests"
-```
-
-Expected: **FAIL** with FluentAssertions/Moq output indicating the mock was invoked 3 times when 2 were expected.
-
-If the test instead fails at the Arrange stage (e.g. with `ArgumentException` or `NullReferenceException`) because property names on the seed types do not match the codebase, **fix the property names in the test only** (do not change the handler), re-run, and confirm the failure mode is the catalog call-count mismatch before proceeding.
-
-### Step 1.3: Commit the failing test
-
-- [ ] **Step 1.3:** Commit the failing test as a guardrail before the source edit.
-
-```bash
-git add backend/test/Anela.Heblo.Tests/Features/Purchase/UpdatePurchaseOrderHandlerTests.cs
-git commit -m "test(purchase): add regression for unused catalog lookup in UpdatePurchaseOrder mapping"
-```
+No tests reference the validator class by name (verified via grep), and FluentValidation registration is explicit (type-based), so no test or DI updates are needed.
 
 ---
 
-## Task 2: Remove the dead lookup and convert `MapToResponseAsync` to a synchronous helper
+## Task 1: Move the file via git mv
 
 **Files:**
-- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:110` (single call site)
-- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:121-142` (method signature and body)
+- Move: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs` → `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
 
-### Step 2.1: Delete the dead `material` / `materialName` lines inside `MapToResponseAsync`
-
-- [ ] **Step 2.1:** Remove the comment and two unused variable declarations inside the `foreach (var line in purchaseOrder.Lines)` loop. The `lines.Add(new PurchaseOrderLineDto { … })` block stays exactly as-is and still reads `MaterialName = line.MaterialName` from the entity.
-
-In `UpdatePurchaseOrderHandler.cs`, replace:
-
-```csharp
-        foreach (var line in purchaseOrder.Lines)
-        {
-            // Try to get material name from catalog
-            var material = await _catalogRepository.GetByIdAsync(line.MaterialId, cancellationToken);
-            var materialName = material?.ProductName ?? "Unknown Material";
-
-            lines.Add(new PurchaseOrderLineDto
-            {
-                Id = line.Id,
-                MaterialId = line.MaterialId,
-                Code = line.MaterialId, // Code is same as MaterialId
-                MaterialName = line.MaterialName,
-                Quantity = line.Quantity,
-                UnitPrice = line.UnitPrice,
-                LineTotal = line.LineTotal,
-                Notes = line.Notes
-            });
-        }
-```
-
-with:
-
-```csharp
-        foreach (var line in purchaseOrder.Lines)
-        {
-            lines.Add(new PurchaseOrderLineDto
-            {
-                Id = line.Id,
-                MaterialId = line.MaterialId,
-                Code = line.MaterialId, // Code is same as MaterialId
-                MaterialName = line.MaterialName,
-                Quantity = line.Quantity,
-                UnitPrice = line.UnitPrice,
-                LineTotal = line.LineTotal,
-                Notes = line.Notes
-            });
-        }
-```
-
-### Step 2.2: Convert `MapToResponseAsync` to synchronous `MapToResponse`
-
-- [ ] **Step 2.2:** The method body now contains no `await`. To avoid the CS1998 "async method lacks await" warning (NFR-2: no new warnings) without papering over it with `await Task.CompletedTask`, drop `async`, drop the `Task<…>` wrapper, drop the unused `CancellationToken cancellationToken` parameter, and rename `MapToResponseAsync` → `MapToResponse`.
-
-Change the method signature from:
-
-```csharp
-    private async Task<UpdatePurchaseOrderResponse> MapToResponseAsync(PurchaseOrder purchaseOrder, long supplierId, CancellationToken cancellationToken)
-    {
-```
-
-to:
-
-```csharp
-    private UpdatePurchaseOrderResponse MapToResponse(PurchaseOrder purchaseOrder, long supplierId)
-    {
-```
-
-The body (the `var lines = new List<PurchaseOrderLineDto>(); foreach …; return new UpdatePurchaseOrderResponse { … };`) stays exactly as edited in Step 2.1.
-
-### Step 2.3: Update the single call site
-
-- [ ] **Step 2.3:** Update the caller at `UpdatePurchaseOrderHandler.cs:110` to drop the `await` and the trailing `cancellationToken` argument, and to use the new method name.
-
-Change:
-
-```csharp
-            return await MapToResponseAsync(purchaseOrder, request.SupplierId, cancellationToken);
-```
-
-to:
-
-```csharp
-            return MapToResponse(purchaseOrder, request.SupplierId);
-```
-
-### Step 2.4: Verify `_catalogRepository`, the constructor parameter, and the `using` directive are unchanged
-
-- [ ] **Step 2.4:** Open `UpdatePurchaseOrderHandler.cs` and confirm — **without making any edits** — that the following are still present:
-  - `using Anela.Heblo.Domain.Features.Catalog;` at the top
-  - `private readonly ICatalogRepository _catalogRepository;` field
-  - `ICatalogRepository catalogRepository` constructor parameter and the `_catalogRepository = catalogRepository;` assignment
-  - The two `_catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken)` calls inside `Handle` at the original lines 80 and 93 (their result is consumed by `UpdateLine`/`AddLine`).
-
-This is a checkpoint, not an edit. If any of the above is missing after Step 2.1–2.3, the edit was too aggressive — revert and redo Step 2.1.
-
-### Step 2.5: Run the new regression test — must now pass
-
-- [ ] **Step 2.5:** Re-run only the new test.
+- [ ] **Step 1: Confirm source file exists and target slot is free**
 
 Run:
 
 ```bash
-cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~UpdatePurchaseOrderHandlerTests"
-```
-
-Expected: **PASS**. The mock now records exactly 2 calls to `GetByIdAsync` (the two inside `Handle`), confirming `MapToResponse` no longer hits the catalog.
-
-### Step 2.6: Run the full Purchase test class to confirm no regression
-
-- [ ] **Step 2.6:** Run all Purchase feature tests to confirm sibling handlers (`CreatePurchaseOrderHandlerTests`, `UpdatePurchaseOrderStatusHandlerTests`, etc.) still pass — they should be unaffected.
-
-Run:
-
-```bash
-cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
-  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Purchase"
-```
-
-Expected: **PASS** for all tests in the namespace. If any test fails, stop and investigate — the edit must be behavior-preserving for everything except the catalog call count.
-
-### Step 2.7: Build and format
-
-- [ ] **Step 2.7:** Run the project validation gates required by `CLAUDE.md`.
-
-Run:
-
-```bash
-cd backend && dotnet build && dotnet format --verify-no-changes
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/
 ```
 
 Expected:
-- `dotnet build`: **succeeds with zero new warnings**. In particular, no `CS1998` warning on `MapToResponseAsync`/`MapToResponse` (the method is now correctly synchronous).
-- `dotnet format --verify-no-changes`: **exit 0**. If it reports formatting differences, run `dotnet format` (without `--verify-no-changes`) and re-run the check.
+- First command lists the file (exit 0).
+- Second command lists `UpdatePurchaseOrderHandler.cs`, `UpdatePurchaseOrderRequest.cs`, `UpdatePurchaseOrderResponse.cs` — and does NOT list `UpdatePurchaseOrderRequestValidator.cs`.
 
-### Step 2.8: Commit the fix
+If the target already has the file, stop — the move has already happened, jump to Task 2 verification.
 
-- [ ] **Step 2.8:** Commit the source edit.
-
-```bash
-git add backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs
-git commit -m "refactor(purchase): remove dead per-line catalog lookup in UpdatePurchaseOrder response mapping"
-```
-
----
-
-## Task 3: Verify no other Purchase handler has the same dead pattern (FR-4)
-
-This is verification work, not editing. It produces the audit line that goes into the PR description.
-
-### Step 3.1: Re-grep all `_catalogRepository.GetByIdAsync` sites under `Features/Purchase/UseCases`
-
-- [ ] **Step 3.1:** Confirm the only remaining call sites are ones with a *used* result.
+- [ ] **Step 2: Move the file using git mv (preserves history)**
 
 Run:
 
 ```bash
-cd backend/src/Anela.Heblo.Application/Features/Purchase/UseCases && \
-  grep -rn "_catalogRepository.GetByIdAsync" .
+git mv backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
 ```
 
-Expected output (line numbers shifted after the edit; line 128 in `UpdatePurchaseOrderHandler.cs` must be gone):
+Expected: no output. `git status` should now show a single rename:
 
-```
-./GetPurchaseOrderById/GetPurchaseOrderByIdHandler.cs:54:            var catalogItem = await _catalogRepository.GetByIdAsync(materialId, cancellationToken);
-./UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:80:                    var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
-./UpdatePurchaseOrder/UpdatePurchaseOrderHandler.cs:93:                    var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
-./CreatePurchaseOrder/CreatePurchaseOrderHandler.cs:79:                var material = await _catalogRepository.GetByIdAsync(lineRequest.MaterialId, cancellationToken);
+```bash
+git status
 ```
 
-Exactly 4 remaining hits. Each one:
+Expected output (relevant lines):
 
-- `GetPurchaseOrderByIdHandler.cs:54` — `catalogItem` is consumed to populate `CatalogNote`. **Legitimate, leave it.**
-- `UpdatePurchaseOrderHandler.cs:80` — `material` feeds `UpdateLine`. **Used, out of scope.**
-- `UpdatePurchaseOrderHandler.cs:93` — `material` feeds `AddLine`. **Used, out of scope.**
-- `CreatePurchaseOrderHandler.cs:79` — `material` feeds `AddLine`. **Used, out of scope.**
+```
+renamed:    backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs -> backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
 
-If the grep shows any **new** call site whose result is not consumed on the next line or two, that is a finding for this brief — repeat Task 2 against that file. Otherwise, the audit is clean.
+If `git status` shows a delete + add instead of a rename, that is acceptable too — git rename detection is heuristic and the next task's small edit may push it over the similarity threshold either way.
 
-### Step 3.2: Capture the audit line for the PR description
+- [ ] **Step 3: Verify the build still compiles at this moment (sanity check)**
 
-- [ ] **Step 3.2:** Note the grep result verbatim for inclusion in the PR description under a "Verification" section, e.g.:
-
-> Grep of `_catalogRepository.GetByIdAsync` under `Features/Purchase/UseCases` returns 4 hits: `GetPurchaseOrderByIdHandler.cs:54` (used: `CatalogNote`), `UpdatePurchaseOrderHandler.cs:80`/`:93` (used: `UpdateLine`/`AddLine`), `CreatePurchaseOrderHandler.cs:79` (used: `AddLine`). The dead site at `UpdatePurchaseOrderHandler.cs:128` is gone. The adjacent N+1 in `UpdatePurchaseOrderHandler.Handle` is a separate, follow-up ticket.
-
-No commit in this task — the output goes into the PR description, not the repo.
-
----
-
-## Task 4: Final validation gates
-
-### Step 4.1: Run the entire backend test suite
-
-- [ ] **Step 4.1:** Confirm nothing outside the Purchase folder breaks.
+The build will fail at this point because the namespace inside the file is still `CreatePurchaseOrder` but the file now lives under `UpdatePurchaseOrder`. The C# compiler does not care about file location vs. namespace; however, the redundant `using` self-import (`using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;` inside a file that itself declares `namespace ... CreatePurchaseOrder`) still resolves. We expect this to BUILD because namespaces are decoupled from filesystem layout in C#.
 
 Run:
 
 ```bash
-cd backend && dotnet test
+dotnet build backend/Anela.Heblo.sln
 ```
 
-Expected: **PASS** across the whole solution. If unrelated tests fail, they are pre-existing failures and not the concern of this change — note them and proceed. If a test that mentions `UpdatePurchaseOrder` fails, stop and investigate.
+Expected: build succeeds (zero errors). Warnings count should be unchanged from baseline.
 
-### Step 4.2: Confirm the OpenAPI schema is byte-identical (NFR-3)
-
-- [ ] **Step 4.2:** The `UpdatePurchaseOrderResponse` DTO shape is unchanged (no fields added, removed, or renamed) and the handler still returns the same field values. No frontend regeneration is required. To double-check, confirm no DTO file under `Features/Purchase/Contracts/` was modified:
-
-```bash
-git diff --name-only main...HEAD -- backend/src/Anela.Heblo.Application/Features/Purchase/Contracts/
-```
-
-Expected: **empty output**. If anything appears, the edit drifted out of scope — revert the DTO change.
-
-### Step 4.3: Self-review against the spec and arch review
-
-- [ ] **Step 4.3:** Walk the spec's acceptance criteria once and confirm each is satisfied by the change set:
-  - **FR-1:** The two dead lines (and their comment) are gone from `MapToResponse`. The loop has no awaits. The response's `MaterialName` still comes from `line.MaterialName`. ✅
-  - **FR-2 (per arch-review amendment):** `_catalogRepository`, the constructor parameter, and the `using Anela.Heblo.Domain.Features.Catalog;` directive are **retained** because `Handle` still uses them. ✅
-  - **FR-3:** Public method signatures of the handler/request/response are unchanged. Validation, persistence, and transaction semantics are untouched. ✅
-  - **FR-4:** Grep verified — only one site qualified as dead. ✅
-  - **NFR-1:** `PUT /api/purchase-orders/{id}` now issues zero catalog calls during response mapping (proven by Task 1's test). ✅
-  - **NFR-2:** `dotnet build` clean, `dotnet format` clean, no `CS1998`. ✅
-  - **NFR-3:** HTTP contract and OpenAPI schema unchanged. ✅
-
-If any criterion is unsatisfied, return to the corresponding task. Otherwise, the change is ready to ship.
+Rationale for this checkpoint: if build fails here, something unexpected is wrong (e.g., partial classes, source generators) — diagnose before changing the namespace.
 
 ---
 
-## Notes for the implementer
+## Task 2: Fix namespace declaration and redundant using
 
-- **Do not touch `Handle` lines 80 and 93.** They look like the same anti-pattern but their result is consumed. Refactoring them to `GetByIdsAsync` is a separate, explicitly-out-of-scope follow-up.
-- **Do not remove `ICatalogRepository` from the constructor.** It is still needed by `Handle`. The spec's conditional FR-2 ("If `MapToResponseAsync` was the only consumer…") is false here — the arch review amended the spec on this point.
-- **Do not add `await Task.CompletedTask`** to silence CS1998. The correct fix is converting the method to synchronous (Task 2.2/2.3).
-- **Do not change the DTO.** Adding `CatalogNote` (or any other catalog-only field) to `UpdatePurchaseOrderResponse` is explicitly out of scope.
-- **Frontend is untouched.** No `npm run build`/lint runs needed for this change.
-- **E2E is not required.** Per `CLAUDE.md`, E2E runs nightly; a behavior-preserving dead-code removal does not warrant an on-demand E2E run.
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+
+- [ ] **Step 1: Inspect the current file contents**
+
+Read the moved file. Expected current top of file:
+
+```csharp
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
+
+public class UpdatePurchaseOrderRequestValidator : AbstractValidator<UpdatePurchaseOrderRequest>
+{
+    // …unchanged…
+}
+
+public class UpdatePurchaseOrderLineRequestValidator : AbstractValidator<UpdatePurchaseOrderLineRequest>
+{
+    // …unchanged…
+}
+```
+
+- [ ] **Step 2: Replace the using + namespace header**
+
+Using the Edit tool, perform these two changes in `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`:
+
+**Edit A — remove the redundant self-import and correct the namespace.**
+
+Replace this block (exact match of the first 4 lines):
+
+```csharp
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
+```
+
+With:
+
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+```
+
+No other line in the file changes. All validation rules, the `BeAReasonableDate` helper, and the `UpdatePurchaseOrderLineRequestValidator` class remain byte-for-byte identical.
+
+- [ ] **Step 3: Verify the file shape after edit**
+
+Run:
+
+```bash
+head -n 6 backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+Expected output:
+
+```
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+
+public class UpdatePurchaseOrderRequestValidator : AbstractValidator<UpdatePurchaseOrderRequest>
+{
+```
+
+Also confirm `DateTime` is still resolvable. The project uses implicit usings (no explicit `using System;` was present before the move and it still isn't). If `dotnet build` later complains about `DateTime`, add `using System;` as the first using directive — but expect this NOT to be needed.
+
+---
+
+## Task 3: Verify build, format, and tests
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run dotnet build**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with `0 Error(s)` and warning count unchanged from baseline.
+
+If errors appear:
+- `CS0246` / `The type or namespace name 'UpdatePurchaseOrderRequest' could not be found` → the moved file is missing access to the request DTO. Check that `UpdatePurchaseOrderRequest.cs` actually declares `namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`. If yes, the moved validator is already in that namespace and should see it directly with no `using`. If no, the request DTO is in a different namespace — add the appropriate `using` to the validator.
+- `CS0234` / `does not exist in the namespace` referencing `CreatePurchaseOrder.UpdatePurchaseOrderRequestValidator` → some caller (not expected, but possible) referenced the old fully-qualified name. Grep for it: `git grep "CreatePurchaseOrder.UpdatePurchaseOrderRequestValidator"`. If found, replace the namespace prefix. Should not happen per arch-review.
+
+- [ ] **Step 2: Run dotnet format on the touched file**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs --verify-no-changes
+```
+
+Expected: exit code 0, no output, no diff to apply.
+
+If `--verify-no-changes` fails:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+git diff backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+Inspect the diff. Only whitespace/using-ordering changes are acceptable. If `dotnet format` strips additional `using` directives, that means they were already unused — accept the change.
+
+- [ ] **Step 3: Run the affected test projects**
+
+The Purchase feature's tests live under `backend/test/`. Run them to confirm no regression:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build --filter "FullyQualifiedName~Purchase"
+```
+
+Expected: all tests pass. Exit code 0.
+
+If the filter matches zero tests, fall back to the full suite to be safe:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all tests pass (same pass count as baseline before this change).
+
+- [ ] **Step 4: Confirm no stray references to the old location**
+
+Run:
+
+```bash
+git grep -n "CreatePurchaseOrder.UpdatePurchaseOrderRequestValidator" -- backend/
+git grep -n "UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator" -- backend/
+```
+
+Expected: both commands return no matches (exit code 1, no output).
+
+- [ ] **Step 5: Confirm DI registration still resolves (smoke check via grep)**
+
+Run:
+
+```bash
+git grep -n "IValidator<UpdatePurchaseOrderRequest>" -- backend/src/
+```
+
+Expected output (relevant line):
+
+```
+backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs:23:        services.AddScoped<IValidator<UpdatePurchaseOrderRequest>, UpdatePurchaseOrderRequestValidator>();
+```
+
+This confirms `PurchaseModule.cs` still references the validator by type, and because the file imports the `UpdatePurchaseOrder` namespace at line 4, type resolution continues to work without code changes.
+
+---
+
+## Task 4: Commit the change
+
+**Files:** None (git operations only)
+
+- [ ] **Step 1: Stage the rename**
+
+Run:
+
+```bash
+git status
+```
+
+Expected output (relevant lines):
+
+```
+Changes to be committed:
+  renamed:    backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs -> backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+If the rename appears as a separate delete + add (git's rename detection didn't pick it up), still acceptable — the next commit will record both changes atomically.
+
+If unstaged changes remain (e.g., the namespace edit wasn't staged with `git mv`), stage them:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+- [ ] **Step 2: Inspect the rename diff one more time**
+
+Run:
+
+```bash
+git diff --cached -M backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/
+```
+
+Expected diff (with rename detection):
+
+```diff
+diff --git a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+similarity index 9X%
+rename from backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+rename to backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+@@ -1,4 +1,3 @@
+-using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+ using FluentValidation;
+
+-namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
++namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+```
+
+If you see other changes, abort and investigate — this change must remain surgical.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: relocate UpdatePurchaseOrderRequestValidator to UpdatePurchaseOrder use case
+
+Move UpdatePurchaseOrderRequestValidator.cs from CreatePurchaseOrder/ to
+UpdatePurchaseOrder/ and correct its namespace. Restores Vertical Slice
+co-location with the rest of the UpdatePurchaseOrder use case. No behavior
+change — DI registration in PurchaseModule.cs already imports both namespaces
+and binds by type, so no other edits are needed.
+EOF
+)"
+```
+
+Expected: commit succeeds. Hook output (if any) should remain green.
+
+- [ ] **Step 4: Final verification**
+
+Run:
+
+```bash
+git log -1 --stat
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/
+```
+
+Expected:
+- `git log -1 --stat` shows the rename.
+- `CreatePurchaseOrder/` lists only its own files (no `UpdatePurchaseOrderRequestValidator.cs`).
+- `UpdatePurchaseOrder/` includes `UpdatePurchaseOrderRequestValidator.cs` alongside its handler/request/response.
+
+---
+
+## Spec Coverage Check
+
+- **FR-1 (Relocate file):** Task 1 step 2 (`git mv`), verified in Task 4 step 4.
+- **FR-2 (Update namespace):** Task 2 step 2 (Edit A). Redundant `using` removed in the same edit.
+- **FR-3 (Preserve registration and behavior):** No code change required; verified in Task 3 step 5 (DI registration grep) and Task 3 step 3 (tests).
+- **FR-4 (No regressions):** Task 3 steps 1–4 (`dotnet build`, `dotnet format`, `dotnet test`, stray-reference grep).
+- **NFR-1/2/3/4 (Performance / Security / Maintainability / Backwards compatibility):** No code paths altered. The structural change satisfies the maintainability NFR by definition (correct Vertical Slice placement).
+- **Arch amendment 1 (explicit DI, not assembly scanning):** Honored — we leave `PurchaseModule.cs` untouched and verify the explicit registration line continues to compile and resolve.
+- **Arch amendment 2 (keep `using FluentValidation;`, drop only the self-namespace `using`):** Honored exactly in Task 2 step 2.
+- **Arch amendment 3 (preserve git history via `git mv`):** Honored in Task 1 step 2.

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
@@ -1,7 +1,6 @@
-using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
 using FluentValidation;
 
-namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
 
 public class UpdatePurchaseOrderRequestValidator : AbstractValidator<UpdatePurchaseOrderRequest>
 {

--- a/docs/superpowers/plans/2026-05-27-relocate-updatepurchaseorder-validator.md
+++ b/docs/superpowers/plans/2026-05-27-relocate-updatepurchaseorder-validator.md
@@ -1,0 +1,342 @@
+# Relocate UpdatePurchaseOrderRequestValidator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `UpdatePurchaseOrderRequestValidator.cs` from the `CreatePurchaseOrder` use case folder to the `UpdatePurchaseOrder` use case folder and correct its namespace, restoring Vertical Slice co-location with zero behavior change.
+
+**Architecture:** Pure structural refactor inside `Anela.Heblo.Application.Features.Purchase`. Use `git mv` to preserve file history. Update the namespace declaration and drop the now-redundant `using` directive. DI registration in `PurchaseModule.cs` already imports both namespaces and binds by type, so no DI changes are required.
+
+**Tech Stack:** .NET 8, C#, FluentValidation, MediatR. Build with `dotnet build`, format with `dotnet format`, tests with `dotnet test`.
+
+---
+
+## File Structure
+
+**Move (via `git mv`):**
+- From: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+- To: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+
+**Modify (in place after move):**
+- `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs` — namespace + remove redundant `using`.
+
+**Unchanged (verify only):**
+- `backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs` — already imports both `CreatePurchaseOrder` and `UpdatePurchaseOrder` namespaces (lines 3–4) and registers the validator by type (line 23). No edit required.
+
+No tests reference the validator class by name (verified via grep), and FluentValidation registration is explicit (type-based), so no test or DI updates are needed.
+
+---
+
+## Task 1: Move the file via git mv
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs` → `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+
+- [ ] **Step 1: Confirm source file exists and target slot is free**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/
+```
+
+Expected:
+- First command lists the file (exit 0).
+- Second command lists `UpdatePurchaseOrderHandler.cs`, `UpdatePurchaseOrderRequest.cs`, `UpdatePurchaseOrderResponse.cs` — and does NOT list `UpdatePurchaseOrderRequestValidator.cs`.
+
+If the target already has the file, stop — the move has already happened, jump to Task 2 verification.
+
+- [ ] **Step 2: Move the file using git mv (preserves history)**
+
+Run:
+
+```bash
+git mv backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+Expected: no output. `git status` should now show a single rename:
+
+```bash
+git status
+```
+
+Expected output (relevant lines):
+
+```
+renamed:    backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs -> backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+If `git status` shows a delete + add instead of a rename, that is acceptable too — git rename detection is heuristic and the next task's small edit may push it over the similarity threshold either way.
+
+- [ ] **Step 3: Verify the build still compiles at this moment (sanity check)**
+
+The build will fail at this point because the namespace inside the file is still `CreatePurchaseOrder` but the file now lives under `UpdatePurchaseOrder`. The C# compiler does not care about file location vs. namespace; however, the redundant `using` self-import (`using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;` inside a file that itself declares `namespace ... CreatePurchaseOrder`) still resolves. We expect this to BUILD because namespaces are decoupled from filesystem layout in C#.
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds (zero errors). Warnings count should be unchanged from baseline.
+
+Rationale for this checkpoint: if build fails here, something unexpected is wrong (e.g., partial classes, source generators) — diagnose before changing the namespace.
+
+---
+
+## Task 2: Fix namespace declaration and redundant using
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
+
+- [ ] **Step 1: Inspect the current file contents**
+
+Read the moved file. Expected current top of file:
+
+```csharp
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
+
+public class UpdatePurchaseOrderRequestValidator : AbstractValidator<UpdatePurchaseOrderRequest>
+{
+    // …unchanged…
+}
+
+public class UpdatePurchaseOrderLineRequestValidator : AbstractValidator<UpdatePurchaseOrderLineRequest>
+{
+    // …unchanged…
+}
+```
+
+- [ ] **Step 2: Replace the using + namespace header**
+
+Using the Edit tool, perform these two changes in `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`:
+
+**Edit A — remove the redundant self-import and correct the namespace.**
+
+Replace this block (exact match of the first 4 lines):
+
+```csharp
+using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
+```
+
+With:
+
+```csharp
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+```
+
+No other line in the file changes. All validation rules, the `BeAReasonableDate` helper, and the `UpdatePurchaseOrderLineRequestValidator` class remain byte-for-byte identical.
+
+- [ ] **Step 3: Verify the file shape after edit**
+
+Run:
+
+```bash
+head -n 6 backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+Expected output:
+
+```
+using FluentValidation;
+
+namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+
+public class UpdatePurchaseOrderRequestValidator : AbstractValidator<UpdatePurchaseOrderRequest>
+{
+```
+
+Also confirm `DateTime` is still resolvable. The project uses implicit usings (no explicit `using System;` was present before the move and it still isn't). If `dotnet build` later complains about `DateTime`, add `using System;` as the first using directive — but expect this NOT to be needed.
+
+---
+
+## Task 3: Verify build, format, and tests
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run dotnet build**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded` with `0 Error(s)` and warning count unchanged from baseline.
+
+If errors appear:
+- `CS0246` / `The type or namespace name 'UpdatePurchaseOrderRequest' could not be found` → the moved file is missing access to the request DTO. Check that `UpdatePurchaseOrderRequest.cs` actually declares `namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`. If yes, the moved validator is already in that namespace and should see it directly with no `using`. If no, the request DTO is in a different namespace — add the appropriate `using` to the validator.
+- `CS0234` / `does not exist in the namespace` referencing `CreatePurchaseOrder.UpdatePurchaseOrderRequestValidator` → some caller (not expected, but possible) referenced the old fully-qualified name. Grep for it: `git grep "CreatePurchaseOrder.UpdatePurchaseOrderRequestValidator"`. If found, replace the namespace prefix. Should not happen per arch-review.
+
+- [ ] **Step 2: Run dotnet format on the touched file**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs --verify-no-changes
+```
+
+Expected: exit code 0, no output, no diff to apply.
+
+If `--verify-no-changes` fails:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+git diff backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+Inspect the diff. Only whitespace/using-ordering changes are acceptable. If `dotnet format` strips additional `using` directives, that means they were already unused — accept the change.
+
+- [ ] **Step 3: Run the affected test projects**
+
+The Purchase feature's tests live under `backend/test/`. Run them to confirm no regression:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build --filter "FullyQualifiedName~Purchase"
+```
+
+Expected: all tests pass. Exit code 0.
+
+If the filter matches zero tests, fall back to the full suite to be safe:
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all tests pass (same pass count as baseline before this change).
+
+- [ ] **Step 4: Confirm no stray references to the old location**
+
+Run:
+
+```bash
+git grep -n "CreatePurchaseOrder.UpdatePurchaseOrderRequestValidator" -- backend/
+git grep -n "UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator" -- backend/
+```
+
+Expected: both commands return no matches (exit code 1, no output).
+
+- [ ] **Step 5: Confirm DI registration still resolves (smoke check via grep)**
+
+Run:
+
+```bash
+git grep -n "IValidator<UpdatePurchaseOrderRequest>" -- backend/src/
+```
+
+Expected output (relevant line):
+
+```
+backend/src/Anela.Heblo.Application/Features/Purchase/PurchaseModule.cs:23:        services.AddScoped<IValidator<UpdatePurchaseOrderRequest>, UpdatePurchaseOrderRequestValidator>();
+```
+
+This confirms `PurchaseModule.cs` still references the validator by type, and because the file imports the `UpdatePurchaseOrder` namespace at line 4, type resolution continues to work without code changes.
+
+---
+
+## Task 4: Commit the change
+
+**Files:** None (git operations only)
+
+- [ ] **Step 1: Stage the rename**
+
+Run:
+
+```bash
+git status
+```
+
+Expected output (relevant lines):
+
+```
+Changes to be committed:
+  renamed:    backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs -> backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+If the rename appears as a separate delete + add (git's rename detection didn't pick it up), still acceptable — the next commit will record both changes atomically.
+
+If unstaged changes remain (e.g., the namespace edit wasn't staged with `git mv`), stage them:
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+```
+
+- [ ] **Step 2: Inspect the rename diff one more time**
+
+Run:
+
+```bash
+git diff --cached -M backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/
+```
+
+Expected diff (with rename detection):
+
+```diff
+diff --git a/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs b/backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+similarity index 9X%
+rename from backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+rename to backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs
+@@ -1,4 +1,3 @@
+-using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+ using FluentValidation;
+
+-namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;
++namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
+```
+
+If you see other changes, abort and investigate — this change must remain surgical.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: relocate UpdatePurchaseOrderRequestValidator to UpdatePurchaseOrder use case
+
+Move UpdatePurchaseOrderRequestValidator.cs from CreatePurchaseOrder/ to
+UpdatePurchaseOrder/ and correct its namespace. Restores Vertical Slice
+co-location with the rest of the UpdatePurchaseOrder use case. No behavior
+change — DI registration in PurchaseModule.cs already imports both namespaces
+and binds by type, so no other edits are needed.
+EOF
+)"
+```
+
+Expected: commit succeeds. Hook output (if any) should remain green.
+
+- [ ] **Step 4: Final verification**
+
+Run:
+
+```bash
+git log -1 --stat
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/
+ls backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/UpdatePurchaseOrder/
+```
+
+Expected:
+- `git log -1 --stat` shows the rename.
+- `CreatePurchaseOrder/` lists only its own files (no `UpdatePurchaseOrderRequestValidator.cs`).
+- `UpdatePurchaseOrder/` includes `UpdatePurchaseOrderRequestValidator.cs` alongside its handler/request/response.
+
+---
+
+## Spec Coverage Check
+
+- **FR-1 (Relocate file):** Task 1 step 2 (`git mv`), verified in Task 4 step 4.
+- **FR-2 (Update namespace):** Task 2 step 2 (Edit A). Redundant `using` removed in the same edit.
+- **FR-3 (Preserve registration and behavior):** No code change required; verified in Task 3 step 5 (DI registration grep) and Task 3 step 3 (tests).
+- **FR-4 (No regressions):** Task 3 steps 1–4 (`dotnet build`, `dotnet format`, `dotnet test`, stray-reference grep).
+- **NFR-1/2/3/4 (Performance / Security / Maintainability / Backwards compatibility):** No code paths altered. The structural change satisfies the maintainability NFR by definition (correct Vertical Slice placement).
+- **Arch amendment 1 (explicit DI, not assembly scanning):** Honored — we leave `PurchaseModule.cs` untouched and verify the explicit registration line continues to compile and resolve.
+- **Arch amendment 2 (keep `using FluentValidation;`, drop only the self-namespace `using`):** Honored exactly in Task 2 step 2.
+- **Arch amendment 3 (preserve git history via `git mv`):** Honored in Task 1 step 2.


### PR DESCRIPTION
Purchase

## Finding
The validator for `UpdatePurchaseOrderRequest` is physically located inside the `CreatePurchaseOrder` use case folder and carries the wrong namespace:

- **File (wrong location):** `backend/src/Anela.Heblo.Application/Features/Purchase/UseCases/CreatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs`
- **Line 4 (wrong namespace):** `namespace Anela.Heblo.Application.Features.Purchase.UseCases.CreatePurchaseOrder;`
- **Line 1 (validated type from another use case):** `using Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;`

The file validates `UpdatePurchaseOrderRequest` and `UpdatePurchaseOrderLineRequest` — both of which belong to the `UpdatePurchaseOrder` use case — but is filed under the `CreatePurchaseOrder` folder.

## Why it matters
This breaks the co-location principle of Vertical Slice Architecture (one use case folder contains everything for that use case). A developer searching for the `UpdatePurchaseOrder` validator will not find it in the expected `UseCases/UpdatePurchaseOrder/` directory. The namespace mismatch also signals incorrect ownership — any IDE navigation from `UpdatePurchaseOrderHandler` to its validator will be misleading.

## Suggested fix
Move the file to `UseCases/UpdatePurchaseOrder/UpdatePurchaseOrderRequestValidator.cs` and update the namespace to:
```csharp
namespace Anela.Heblo.Application.Features.Purchase.UseCases.UpdatePurchaseOrder;
```
No logic changes needed — just a rename/move.

---
_Filed by daily arch-review routine on 2026-05-27._

---

Closes #1809

### Tokens used
9326630
