### PR TITLE
feat: Distinct Error Codes for `TriggerRecurringJob` Failure Modes

### DIFF
--- a/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/arch-review.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/arch-review.r1.md
@@ -1,0 +1,185 @@
+I have enough context. Two critical findings drive the review: (1) the spec's proposed `1903` collides with the existing `InvalidCronExpression = 1903`, and (2) `BaseApiController.HandleResponse()` already performs error-code → HTTP-status mapping via the `[HttpStatusCode]` attribute on the enum — the bug is that `TriggerJob` is the one endpoint in this controller that doesn't use it.
+
+# Architecture Review: Distinct Error Codes for `TriggerRecurringJob` Failure Modes
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The fix sits inside a well-established convention. Two pillars of that convention are already in place and must be reused, not reinvented:
+
+1. **`ErrorCodes` enum is the single source of truth for both error identity and HTTP status.** Each value is decorated with `[HttpStatusCode(HttpStatusCode.X)]` (see `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`). The pairing of "error code + HTTP status" is declared at the enum, not in the controller.
+2. **`BaseApiController.HandleResponse<T>()` is the single dispatch point** (`backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs:28-59`). It reflects the `[HttpStatusCode]` attribute and returns the matching `ActionResult`. Every other endpoint in `RecurringJobsController` already uses it (`GetRecurringJobs`, `UpdateJobStatus`, `UpdateJobCron`).
+
+The root cause of the reported defect is therefore narrower than the spec describes:
+- `TriggerRecurringJobHandler` collapses three failures onto one code (handler bug — spec is right).
+- `RecurringJobsController.TriggerJob` is the **only** action in the controller that bypasses `HandleResponse()` and instead does `if (!response.Success) return NotFound(response)` (controller bug — spec proposes the wrong fix).
+
+The spec proposes a `switch (response.ErrorCode)` block inside the controller. That diverges from the existing convention and creates a parallel mapping mechanism for one endpoint only. We must instead align `TriggerJob` with the rest of the codebase.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP POST /api/RecurringJobs/{jobName}/trigger
+        │
+        ▼
+RecurringJobsController.TriggerJob
+        │  (delegates failure mapping to BaseApiController.HandleResponse)
+        ▼
+MediatR ── TriggerRecurringJobRequest ──► TriggerRecurringJobHandler
+                                                │
+                ┌───────────────────────────────┼──────────────────────────────────┐
+                ▼                               ▼                                  ▼
+        job not registered             job found, disabled                  enqueue returned null
+        ErrorCodes.RecurringJobNotFound  ErrorCodes.RecurringJobDisabled    ErrorCodes.RecurringJobEnqueueFailed
+        (1901, NotFound)                 (1904, Conflict)                   (1905, InternalServerError)
+                │                               │                                  │
+                └───────────────┐               │               ┌──────────────────┘
+                                ▼               ▼               ▼
+                          BaseApiController.HandleResponse (existing)
+                                          │
+                                          ▼
+                          HttpStatusCodeAttribute reflection ──► 404 / 409 / 500
+```
+
+### Key Design Decisions
+
+#### Decision 1: Reuse `HandleResponse()` instead of adding a per-endpoint `switch`
+**Options considered:**
+- (a) Switch-on-`ErrorCode` inside `TriggerJob` (what the spec proposes).
+- (b) Decorate the new enum values with `[HttpStatusCode]` and delegate failure mapping to the existing `HandleResponse()`.
+
+**Chosen approach:** (b). Keep failure mapping in the enum + base controller. Only the success branch stays bespoke.
+
+**Rationale:** The codebase already has one mapping mechanism. A second one in a single endpoint would (i) drift from the convention used by the three sibling actions in the same controller, (ii) duplicate logic that the reflection-based mapper already provides for free, and (iii) make adding a fourth error code a code change in the controller rather than a one-line enum addition.
+
+#### Decision 2: Preserve `202 Accepted` on success — do not collapse to `200 OK`
+**Options considered:**
+- (a) Replace the body of `TriggerJob` with `return HandleResponse(response);` (would change success to `200 OK`).
+- (b) Keep `Accepted(response)` for success; delegate **only** the failure branch to `HandleResponse`.
+
+**Chosen approach:** (b).
+
+```csharp
+if (!response.Success)
+{
+    return HandleResponse(response);  // failure mapping via [HttpStatusCode] attribute
+}
+return Accepted(response);            // success unchanged
+```
+
+**Rationale:** `202 Accepted` accurately describes a "queued for asynchronous execution" outcome and is already documented (`[ProducesResponseType(typeof(...), StatusCodes.Status202Accepted)]`) and asserted (`RecurringJobsControllerTriggerTests.cs:78`). The spec text says "Success path is unchanged (HTTP 200…)" — that is factually wrong; the actual success status today is `202`. Calling this out as a spec amendment.
+
+`HandleResponse` returns `Ok` on success, but in this code path we only ever reach it when `!response.Success`, so its success branch is never taken — no behavioral regression.
+
+#### Decision 3: Error-code numbering — `1904` and `1905`
+**Options considered:**
+- (a) `1903` and `1904` (spec proposal).
+- (b) `1904` and `1905`.
+
+**Chosen approach:** (b).
+
+**Rationale:** The spec is **factually incorrect** about the `19XX` range. `1903` is already `InvalidCronExpression` (a `BadRequest`-mapped code used by `UpdateRecurringJobCronHandler`). Adopting `1903` for `RecurringJobDisabled` would collide. Current `19XX` allocation:
+
+| Code | Existing | 
+|------|---------|
+| 1901 | `RecurringJobNotFound` (NotFound) |
+| 1902 | `RecurringJobUpdateFailed` (InternalServerError) |
+| 1903 | `InvalidCronExpression` (BadRequest) — **already taken** |
+
+Use the next free slots:
+
+| Code | New | HTTP |
+|------|-----|------|
+| 1904 | `RecurringJobDisabled` | `Conflict` |
+| 1905 | `RecurringJobEnqueueFailed` | `InternalServerError` |
+
+#### Decision 4: HTTP status for "disabled" is `409 Conflict`
+**Rationale:** Matches the spec's intent and the existing convention in this codebase, where "state precondition violated" maps to `Conflict` (e.g., `ManufactureDifficultyConflict = 1303`, `TransportBoxDuplicateActiveBoxFound = 1405`, `OrderNotInPackingState = 3001`). `422 Unprocessable Entity` is reserved for entity-level state-machine errors (`TransportBoxStateChangeError`, `ShipmentLabelsNotGenerated`) — wrong scale here.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edits in three existing locations only:
+
+| File | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` | Add `RecurringJobDisabled = 1904` (`Conflict`) and `RecurringJobEnqueueFailed = 1905` (`InternalServerError`) in the BackgroundJobs (19XX) section. |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs` | Change line 57 → `RecurringJobDisabled`. Change line 74 → `RecurringJobEnqueueFailed`. Line 40 stays as `RecurringJobNotFound`. |
+| `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` | Replace lines 115-118 (`if (!response.Success) return NotFound(response);`) with `if (!response.Success) return HandleResponse(response);`. |
+
+Also update the `[ProducesResponseType]` decorations on `TriggerJob` to reflect the new failure statuses:
+```csharp
+[ProducesResponseType(typeof(TriggerRecurringJobResponse), StatusCodes.Status202Accepted)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]            // RecurringJobNotFound
+[ProducesResponseType(StatusCodes.Status409Conflict)]            // RecurringJobDisabled  (new)
+[ProducesResponseType(StatusCodes.Status500InternalServerError)] // RecurringJobEnqueueFailed (new)
+```
+
+Tests (existing files in `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/`):
+- `RecurringJobsControllerTriggerTests.cs` — update the test currently named `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` (which actually asserts `NotFoundObjectResult`; the test name is already inconsistent). After the fix, `RecurringJobUpdateFailed` will map to `500`, not `404`. Add new tests for `RecurringJobDisabled → 409` and `RecurringJobEnqueueFailed → 500`.
+- `TriggerRecurringJobHandlerIntegrationTests.cs` — add handler-level tests asserting each error branch returns the right `ErrorCode` (the file currently has only happy-path coverage).
+
+### Interfaces and Contracts
+
+No contract changes. `TriggerRecurringJobResponse` shape is unchanged. The only externally visible diff is:
+- `ErrorCode` field can now also carry `1904` or `1905`.
+- HTTP status for the "disabled" and "enqueue-failed" paths changes from `404` to `409` / `500`.
+
+The OpenAPI-generated TypeScript client will pick up `1904` / `1905` automatically if `ErrorCodes` is exported via the spec; if not, frontend gets the integer in the body and the existing decoder still works.
+
+### Data Flow
+
+```
+1. POST /api/RecurringJobs/{jobName}/trigger
+2. Controller builds TriggerRecurringJobRequest { JobName = jobName }
+3. MediatR dispatches to TriggerRecurringJobHandler
+4. Handler picks the failure branch (or success):
+     - not registered      → response.ErrorCode = 1901
+     - registered+disabled → response.ErrorCode = 1904
+     - enqueue returned null → response.ErrorCode = 1905
+     - success             → response.Success = true, JobId set
+5. Controller:
+     - if !Success → BaseApiController.HandleResponse(response)
+                       → reflects [HttpStatusCode] on the enum value
+                       → returns NotFound / Conflict / StatusCode(500)
+     - else → Accepted(response)  // HTTP 202
+6. Each handler failure branch logs at its current severity (Warning/Warning/Error)
+   with the new ErrorCode included in structured-log scope.
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing test `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` asserts `NotFoundObjectResult` for `RecurringJobUpdateFailed`; after the fix it will be `500`. | Medium | Update the test as part of the change, rename for accuracy. Test was previously masking the bug. |
+| Consumer of the endpoint that relied on `404` for any failure will see new `409` / `500` for disabled / enqueue-failed cases. | Medium (intentional). | Call out in PR description and release notes. Frontend currently doesn't differentiate — no UX regression. |
+| Controller never binds `ForceDisabled` from the request — the "disabled" failure branch is unreachable through the API today. | High (latent). | Out of scope per the spec, but **must be flagged** in the PR as a follow-up. Without binding `ForceDisabled`, the new `RecurringJobDisabled` code is only reachable via direct `IMediator.Send` from server code or tests. The new error code is still correct to introduce, but a follow-up should add `[FromQuery] bool forceDisabled = false` to the controller signature. |
+| Adding a `switch` in the controller (spec's proposal) would silently bypass the convention used by sibling endpoints, increasing maintenance risk. | High (design). | Rejected — see Decision 1. Use `HandleResponse()`. |
+| `1903` collision with `InvalidCronExpression`. | Critical (build break / runtime mis-mapping). | Use `1904` and `1905` — see Decision 3. |
+
+## Specification Amendments
+
+The spec must be updated before implementation:
+
+1. **FR-1 (`RecurringJobDisabled`): change value from `1903` to `1904`.** The proposed `1903` collides with the existing `InvalidCronExpression = 1903`. The spec's Data Model note ("`1902` is intentionally skipped to leave room…") is factually wrong: `1902` is `RecurringJobUpdateFailed` and `1903` is `InvalidCronExpression`. There is no gap to fill in the 1900 range; the next free codes are 1904 and 1905.
+
+2. **FR-2 (`RecurringJobEnqueueFailed`): change value from `1904` to `1905`.**
+
+3. **FR-4 (HTTP status mapping):** Drop the per-endpoint `switch (response.ErrorCode)` design. Instead:
+   - Annotate the two new enum values with `[HttpStatusCode(HttpStatusCode.Conflict)]` and `[HttpStatusCode(HttpStatusCode.InternalServerError)]` respectively.
+   - In `TriggerJob`, replace the failure mapping with `return HandleResponse(response);`. The existing reflection-based mapper handles all three statuses (`404` / `409` / `500`) and the default fallback. This matches `GetRecurringJobs`, `UpdateJobStatus`, and `UpdateJobCron` in the same controller.
+
+4. **Response — success:** correct the spec from "HTTP `200 OK`" to **`202 Accepted`**, matching the current behavior and the controller's `[ProducesResponseType(..., Status202Accepted)]` decoration. Update the success-path text in the "API / Interface Design" section accordingly.
+
+5. **Out of Scope / Follow-up note:** Add a follow-up reminder that `RecurringJobsController.TriggerJob` does not currently bind `ForceDisabled` from the HTTP request. The new `RecurringJobDisabled` code will only be reachable via in-process callers until that binding is added. (Spec already lists "Changes to the recurring-job registration, scheduling, or disabling flow" as out of scope, but the missing binding should be explicitly flagged for a separate ticket.)
+
+6. **FR-5 (Logging continuity):** clarify "include the new error code in structured logging properties" — the existing handler already logs warnings/errors; the practical addition is including `ErrorCode = <int>` in the structured payload (e.g., via `using (_logger.BeginScope(...))` or a templated property). No new log-message text required.
+
+## Prerequisites
+
+None. No migrations, no infrastructure, no config, no new NuGet references. All changes are local to three source files and two test files in the BackgroundJobs vertical slice.

--- a/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/brief.md
+++ b/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/brief.md
@@ -1,0 +1,45 @@
+## Module
+BackgroundJobs
+
+## Finding
+`TriggerRecurringJobHandler` uses `ErrorCodes.RecurringJobNotFound` (1901) for three semantically distinct failure conditions:
+
+| Line | Actual condition | Error code used |
+|------|-----------------|-----------------|
+| 39 | Job not registered in DI (genuinely not found) | `RecurringJobNotFound` ✅ |
+| 57 | Job is found but disabled, `ForceDisabled=false` | `RecurringJobNotFound` ❌ |
+| 74 | Job found and enabled, but `IHangfireJobEnqueuer.EnqueueJob` returned `null` | `RecurringJobNotFound` ❌ |
+
+File: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs`
+
+The controller maps `!response.Success` → HTTP 404 (`NotFound`):
+
+```csharp
+// RecurringJobsController.cs lines 116-119
+if (!response.Success)
+{
+    return NotFound(response);
+}
+```
+
+So a disabled job or a failed enqueue both surface to the API consumer as `404 Not Found` with error code 1901, which is factually incorrect.
+
+## Why it matters
+API consumers (frontend, monitoring tools) cannot distinguish "job doesn't exist" from "job is disabled" or "Hangfire failed to enqueue". Correct HTTP semantics would be:
+- Job disabled → `409 Conflict` or `422 Unprocessable Entity`
+- Enqueue failure → `500 Internal Server Error`
+
+Misusing a single error code also makes error monitoring ambiguous.
+
+## Suggested fix
+Add two new error codes to `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`:
+
+```csharp
+RecurringJobDisabled = 1903,
+RecurringJobEnqueueFailed = 1904,
+```
+
+Return `RecurringJobDisabled` when the job is found-but-disabled, and `RecurringJobEnqueueFailed` when `EnqueueJob` returns `null`. Update the controller to check `response.ErrorCode` and return the appropriate HTTP status for each case.
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/impl/main.r1.md
@@ -1,0 +1,25 @@
+All tasks complete. Here's the summary:
+
+---
+
+## Implementation Complete ✅
+
+### What was done
+
+Fixed the `TriggerRecurringJob` feature to return three distinct error codes instead of collapsing all failures to `RecurringJobNotFound`:
+
+| Failure condition | Before | After | HTTP |
+|---|---|---|---|
+| Job not registered | `RecurringJobNotFound` (1901) | `RecurringJobNotFound` (1901) | 404 |
+| Job registered but disabled | `RecurringJobNotFound` (1901) ❌ | `RecurringJobDisabled` (1904) ✅ | 409 |
+| Enqueue returned null | `RecurringJobNotFound` (1901) ❌ | `RecurringJobEnqueueFailed` (1905) ✅ | 500 |
+
+### Key architectural alignment
+The controller now uses `HandleResponse(response)` — consistent with `GetRecurringJobs`, `UpdateJobStatus`, and `UpdateJobCron` in the same controller. No per-endpoint `switch` was introduced.
+
+### Test results
+- **4068 passed, 0 failed** across the full suite
+- 6 new/updated handler + controller tests covering all three failure branches and all three HTTP status mappings
+
+### Follow-up required (out of scope per spec)
+`TriggerJob` does not bind `ForceDisabled` from the HTTP request — the new 409 code is only reachable via in-process callers until `[FromQuery] bool forceDisabled = false` is added to the action.

--- a/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/impl/triggerrecurringjob-distinct-error-codes.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/impl/triggerrecurringjob-distinct-error-codes.r1.md
@@ -1,0 +1,96 @@
+# Implementation: Distinct Error Codes for `TriggerRecurringJob` Failure Modes
+
+## What was implemented
+
+Replaced the single `RecurringJobNotFound` error code that `TriggerRecurringJobHandler` returned for all three failure conditions with three distinct codes, and fixed the controller's `TriggerJob` action to route failures through the existing attribute-based HTTP-status mapper (`BaseApiController.HandleResponse`) instead of short-circuiting to `NotFound`.
+
+Two new `ErrorCodes` enum members were introduced:
+- `RecurringJobDisabled = 1904` — `[HttpStatusCode(HttpStatusCode.Conflict)]` → HTTP 409
+- `RecurringJobEnqueueFailed = 1905` — `[HttpStatusCode(HttpStatusCode.InternalServerError)]` → HTTP 500
+
+`RecurringJobNotFound = 1901` is now restricted to its literal meaning (job not registered).
+
+An incidental requirement surfaced during verification: the existing `LocalizationCoverageTests.FrontendI18n_ShouldHaveTranslationsForAllErrorCodes` test enforces Czech translations for every `ErrorCodes` value. Czech translations for the two new codes were added to `frontend/src/i18n.ts` to satisfy that test.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — added `RecurringJobDisabled = 1904` and `RecurringJobEnqueueFailed = 1905` with `[HttpStatusCode]` attributes in the BackgroundJobs section
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs` — changed the "disabled" and "enqueue null" branches to return the correct new codes; augmented all three failure-branch logs with `ErrorCode` as a structured property
+- `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` — replaced `return NotFound(response)` with `return HandleResponse(response)` in `TriggerJob`; added `[ProducesResponseType(409)]` and `[ProducesResponseType(500)]` decorations
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` — **new**: pure unit tests covering all three handler failure branches
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs` — renamed the inaccurate `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` test; added `TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict` and `TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError`
+- `frontend/src/i18n.ts` — added Czech translations for `RecurringJobDisabled` and `RecurringJobEnqueueFailed` (required by `LocalizationCoverageTests`)
+
+## Tests
+
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` — 3 unit tests:
+  - `Handle_WhenJobIsNotRegistered_ReturnsRecurringJobNotFound`
+  - `Handle_WhenJobIsDisabledAndForceDisabledIsFalse_ReturnsRecurringJobDisabled`
+  - `Handle_WhenEnqueuerReturnsNull_ReturnsRecurringJobEnqueueFailed`
+
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs` — 6 tests (3 existing + 3 new/updated):
+  - `TriggerJob_WithValidJobName_ShouldReturnAcceptedWithSuccessResponse` (unchanged)
+  - `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` (unchanged — 404 regression)
+  - `TriggerJob_WhenUpdateFailedErrorReturned_ShouldReturn500` (renamed from inaccurate test)
+  - `TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict` (new)
+  - `TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError` (new)
+  - `TriggerJob_ShouldPassCancellationTokenToMediator` (unchanged)
+
+Full suite result: **4068 passed, 0 failed, 3 skipped** (skips are pre-existing integration tests requiring live external services).
+
+## How to verify
+
+```bash
+# From the worktree root
+dotnet build Anela.Heblo.sln
+
+# BackgroundJobs tests only (fast)
+dotnet test Anela.Heblo.sln --no-build \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs" 
+
+# Full suite
+dotnet test Anela.Heblo.sln --no-build
+
+# Audit: RecurringJobNotFound should only appear in TriggerRecurringJobHandler's not-registered branch
+grep -n "ErrorCodes.RecurringJobNotFound" \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs
+# Expected: lines 41 (log param) and 43 (return) — both in the job == null block
+```
+
+## Notes
+
+**Spec amendments applied (per arch-review.r1.md):**
+- Error codes are `1904` and `1905`, not `1903` and `1904` as the original spec proposed — `1903` was already `InvalidCronExpression`.
+- Controller uses `HandleResponse(response)` (attribute-based mapping) instead of a `switch (response.ErrorCode)` block — consistent with `GetRecurringJobs`, `UpdateJobStatus`, and `UpdateJobCron` in the same controller.
+- Success path preserved as `Accepted(response)` → HTTP 202, not `200 OK` (spec had an error in the success description).
+
+**Follow-up items (out of scope per spec, flagged in PR):**
+1. `RecurringJobsController.TriggerJob` does not bind `ForceDisabled` from the HTTP request. The new `RecurringJobDisabled` (1904) code is only reachable via in-process callers (unit tests, direct `IMediator.Send`) until a `?forceDisabled=true` query parameter is added to the action.
+2. `TriggerRecurringJobRequest.ForceDisabled` is semantically inverted — the name implies "make it disabled" but it actually means "force trigger even when disabled". Consider renaming to `ForceRun` or `IgnoreDisabledState` in a follow-up.
+
+**Frontend i18n:** The `LocalizationCoverageTests` test enforces Czech translations for every `ErrorCodes` value. Adding new enum members without translations causes a test failure. This means frontend i18n updates for new error codes are implicitly required by the test suite for any future error code additions.
+
+## PR Summary
+
+Replaces the single `RecurringJobNotFound` (1901) error code that `TriggerRecurringJobHandler` returned for all three failure conditions with three semantically correct codes:
+
+- **Not registered** → `RecurringJobNotFound` (1901) → HTTP 404 (unchanged)
+- **Registered but disabled** → `RecurringJobDisabled` (1904) → HTTP 409 Conflict (new)
+- **Enqueue returned null** → `RecurringJobEnqueueFailed` (1905) → HTTP 500 (new)
+
+The controller's `TriggerJob` action was the only endpoint in `RecurringJobsController` bypassing `BaseApiController.HandleResponse`. It now uses `HandleResponse` for the failure path, consistent with the three sibling actions.
+
+**Breaking behavior change:** Clients relying on `404` for any `TriggerJob` failure will now receive `409` for disabled jobs and `500` for enqueue failures. The `404` is preserved only for genuinely unknown job IDs.
+
+**Follow-up ticket required:** `TriggerJob` does not bind `ForceDisabled` from the HTTP request, so `RecurringJobDisabled` (1904) is not reachable via HTTP until `[FromQuery] bool forceDisabled = false` is added to the action signature.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — new `RecurringJobDisabled = 1904` and `RecurringJobEnqueueFailed = 1905` with `[HttpStatusCode]` attributes
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs` — corrected two failure branches; all three branches now log `ErrorCode` as structured property
+- `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` — `return NotFound(response)` → `return HandleResponse(response)`; added `[ProducesResponseType(409)]` and `[ProducesResponseType(500)]`
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` — new: 3 handler unit tests (all three failure branches)
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs` — renamed inaccurate test; added 2 new controller-level tests (409 and 500 mapping)
+- `frontend/src/i18n.ts` — Czech translations for the two new error codes (required by `LocalizationCoverageTests`)
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/spec.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/spec.r1.md
@@ -1,0 +1,184 @@
+# Specification: Distinct Error Codes for `TriggerRecurringJob` Failure Modes
+
+## Summary
+The `TriggerRecurringJobHandler` currently collapses three semantically distinct failure conditions ("job not registered", "job disabled", "enqueue failed") into a single error code (`RecurringJobNotFound = 1901`) and a single HTTP status (`404 Not Found`). This specification introduces two new error codes and aligns the HTTP response status with the actual failure semantics so API consumers can correctly distinguish missing, disabled, and enqueue-failure conditions.
+
+## Background
+`TriggerRecurringJobHandler` (at `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs`) is the MediatR handler used to manually trigger a registered Hangfire recurring job. The handler returns a non-success response in three distinct cases:
+
+| Line | Actual condition | Current error code |
+|------|------------------|--------------------|
+| 39   | Job is not registered in the DI container (genuinely unknown) | `RecurringJobNotFound` (correct) |
+| 57   | Job is registered but disabled and `ForceDisabled = false` | `RecurringJobNotFound` (incorrect) |
+| 74   | Job is registered and enabled, but `IHangfireJobEnqueuer.EnqueueJob` returned `null` | `RecurringJobNotFound` (incorrect) |
+
+The matching MVC controller (`RecurringJobsController.cs`, lines 116–119) translates any non-success response into HTTP `404 Not Found`. As a result, "disabled" and "enqueue failure" outcomes are indistinguishable from a true "not found" outcome both in error code and HTTP status. This breaks observability (error monitoring cannot bucket the failures), frontend UX (cannot show appropriate messaging), and HTTP semantics.
+
+The arch review routine flagged the issue on 2026-05-27.
+
+## Functional Requirements
+
+### FR-1: Introduce `RecurringJobDisabled` error code
+Add a new error code `RecurringJobDisabled = 1903` to `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`. Use it to indicate that the requested recurring job exists in the registry but is currently disabled (the caller did not request `ForceDisabled = true`).
+
+**Acceptance criteria:**
+- `ErrorCodes.RecurringJobDisabled` is defined with the integer value `1903`.
+- Value `1903` does not collide with any other entry in `ErrorCodes`.
+- The handler's "found but disabled" branch (current line ~57) returns `Success = false` with `ErrorCode = ErrorCodes.RecurringJobDisabled`.
+- The error response includes the job identifier so the consumer can correlate the result.
+
+### FR-2: Introduce `RecurringJobEnqueueFailed` error code
+Add a new error code `RecurringJobEnqueueFailed = 1904` to `ErrorCodes.cs`. Use it to indicate that the job is registered and enabled, but the underlying Hangfire enqueue call returned `null` (Hangfire-side failure).
+
+**Acceptance criteria:**
+- `ErrorCodes.RecurringJobEnqueueFailed` is defined with the integer value `1904`.
+- Value `1904` does not collide with any other entry in `ErrorCodes`.
+- The handler's "enqueue returned null" branch (current line ~74) returns `Success = false` with `ErrorCode = ErrorCodes.RecurringJobEnqueueFailed`.
+- The error response includes the job identifier.
+
+### FR-3: Preserve `RecurringJobNotFound` semantics
+Restrict `RecurringJobNotFound` (1901) to its literal meaning: the requested job identifier is not registered in the DI container / job registry.
+
+**Acceptance criteria:**
+- The handler's "job not registered" branch (current line ~39) is the only path returning `ErrorCode = ErrorCodes.RecurringJobNotFound`.
+- A grep for `ErrorCodes.RecurringJobNotFound` in the BackgroundJobs use case folder yields exactly one usage (the not-registered branch).
+
+### FR-4: HTTP status mapping in `RecurringJobsController`
+Update `RecurringJobsController.TriggerRecurringJob` (currently mapping any failure to `NotFound`) to switch on `response.ErrorCode` and return the appropriate HTTP status code:
+
+| Error code | HTTP status |
+|------------|-------------|
+| `RecurringJobNotFound` (1901) | `404 Not Found` |
+| `RecurringJobDisabled` (1903) | `409 Conflict` |
+| `RecurringJobEnqueueFailed` (1904) | `500 Internal Server Error` |
+| Any other / fallback | `500 Internal Server Error` |
+
+**Acceptance criteria:**
+- Triggering an unknown job id returns HTTP 404 with `errorCode = 1901`.
+- Triggering a disabled job with `forceDisabled = false` returns HTTP 409 with `errorCode = 1903`.
+- Triggering a job for which `IHangfireJobEnqueuer.EnqueueJob` returns `null` returns HTTP 500 with `errorCode = 1904`.
+- The success path is unchanged (HTTP 200 with the existing response body).
+- The response body for failures continues to be the existing `TriggerRecurringJobResponse` shape (no breaking field changes).
+
+### FR-5: Logging continuity
+Each failure branch must continue to log at its current severity, but include the new error code in structured logging properties so log queries can group on it.
+
+**Acceptance criteria:**
+- "Not found" branch logs at `Warning` and includes `ErrorCode = 1901`.
+- "Disabled" branch logs at `Warning` and includes `ErrorCode = 1903`.
+- "Enqueue failed" branch logs at `Error` and includes `ErrorCode = 1904`.
+- Existing log message templates are preserved; only structured properties are augmented.
+
+### FR-6: Unit test coverage
+Add or update unit tests for `TriggerRecurringJobHandler` to cover the three failure branches and assert the correct error code is returned. Add or update controller-level tests (or integration tests, whichever pattern is already in use for `RecurringJobsController`) to assert the HTTP status mapping defined in FR-4.
+
+**Acceptance criteria:**
+- Test "returns RecurringJobNotFound when job id is not registered" passes.
+- Test "returns RecurringJobDisabled when job is disabled and forceDisabled is false" passes.
+- Test "returns RecurringJobEnqueueFailed when EnqueueJob returns null" passes.
+- Test "controller maps RecurringJobDisabled to 409" passes.
+- Test "controller maps RecurringJobEnqueueFailed to 500" passes.
+- Test "controller maps RecurringJobNotFound to 404" passes (regression).
+- Overall changed-file test coverage remains ≥ 80%.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. The change is limited to constant lookups, a switch statement in the controller, and structured-log property additions. Response time for the trigger endpoint must remain within existing baseline (target: < 200 ms p95 for the in-process portion, excluding Hangfire latency).
+
+### NFR-2: Security
+No security surface change. The endpoint's existing authentication and authorization requirements are preserved verbatim. Error responses must not leak internal exception details, stack traces, or job-handler internals — they should expose only the job identifier and the error code/message already produced by the handler.
+
+### NFR-3: Backward compatibility
+- The existing client of error code `1901` may observe a behavioral change: HTTP `404` will no longer be returned for disabled jobs or enqueue failures. This is an intentional correction, but must be called out in the PR description and release notes.
+- The response DTO shape (`TriggerRecurringJobResponse`) is unchanged. No regeneration of OpenAPI client breaking-changes is expected; the TypeScript client will pick up the new error code constants once `ErrorCodes` is exposed (if it is exposed at all — see Open Questions).
+
+### NFR-4: Observability
+Error-monitoring dashboards filtering on `ErrorCode` will now see three distinct buckets (1901 / 1903 / 1904) instead of one. No dashboard migration is required; existing 1901 queries continue to work and will simply receive fewer hits.
+
+## Data Model
+No database schema changes. The only "data" being added is two integer constants in the `ErrorCodes` static class:
+
+```
+ErrorCodes.RecurringJobNotFound        = 1901   // (existing)
+ErrorCodes.RecurringJobDisabled        = 1903   // (new)
+ErrorCodes.RecurringJobEnqueueFailed   = 1904   // (new)
+```
+
+Note: `1902` is intentionally skipped to leave room for an in-flight error code, if any exists in the `1900` range. The architect should verify the gap is intentional and not collide with any pending change.
+
+## API / Interface Design
+
+### Endpoint
+`POST /api/recurring-jobs/{jobId}/trigger` (path and verb unchanged — confirm exact route in `RecurringJobsController` during implementation).
+
+### Request
+Unchanged. Existing `TriggerRecurringJobRequest` (or equivalent query/body parameters, including `forceDisabled`) is preserved.
+
+### Response — success
+Unchanged. HTTP `200 OK` with the existing `TriggerRecurringJobResponse` body, `Success = true`, and the Hangfire enqueue identifier.
+
+### Response — failures
+
+**Job not registered**
+```
+HTTP/1.1 404 Not Found
+{
+  "success": false,
+  "errorCode": 1901,
+  "message": "Recurring job '{jobId}' is not registered.",
+  ...
+}
+```
+
+**Job disabled (and `forceDisabled = false`)**
+```
+HTTP/1.1 409 Conflict
+{
+  "success": false,
+  "errorCode": 1903,
+  "message": "Recurring job '{jobId}' is disabled. Pass forceDisabled=true to override.",
+  ...
+}
+```
+
+**Enqueue failed**
+```
+HTTP/1.1 500 Internal Server Error
+{
+  "success": false,
+  "errorCode": 1904,
+  "message": "Failed to enqueue recurring job '{jobId}'.",
+  ...
+}
+```
+
+### Error mapping (controller)
+The controller's existing `if (!response.Success) return NotFound(response);` is replaced with a switch on `response.ErrorCode`:
+
+- `1901` → `NotFound(response)`
+- `1903` → `Conflict(response)`
+- `1904` → `StatusCode(StatusCodes.Status500InternalServerError, response)`
+- default → `StatusCode(StatusCodes.Status500InternalServerError, response)`
+
+## Dependencies
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` — new constants.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs` — branch-specific error codes.
+- `RecurringJobsController.cs` (BackgroundJobs feature folder under the API project) — HTTP status mapping.
+- Existing test project for BackgroundJobs use cases (xUnit / NUnit, whichever the repo already uses) — new tests.
+- No new NuGet packages.
+- No frontend changes required for this specification, but the frontend should be informed so it can optionally surface differentiated UX in a follow-up.
+
+## Out of Scope
+- Reworking the response DTO (`TriggerRecurringJobResponse`) shape or field names.
+- Adding retry logic for the enqueue-failure case.
+- Auditing other handlers in BackgroundJobs (or elsewhere) for similar error-code conflation — that is a candidate follow-up task but is not part of this change.
+- Changes to the recurring-job registration, scheduling, or disabling flow.
+- Localization of error messages.
+- Frontend UX changes that distinguish 409 vs 500 vs 404 in the UI.
+- Updating any external documentation portal beyond what is already auto-generated from OpenAPI.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/task-plan.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-triggerrecurr/task-plan.r1.md
@@ -1,0 +1,704 @@
+# Distinct Error Codes for `TriggerRecurringJob` Failure Modes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single `RecurringJobNotFound` code that `TriggerRecurringJobHandler` returns for three distinct failure conditions with three distinct codes, and route the controller's failure path through the existing attribute-based HTTP-status mapper so `404` / `409` / `500` are returned correctly.
+
+**Architecture:** Two new `ErrorCodes` enum members (`RecurringJobDisabled = 1904`, `RecurringJobEnqueueFailed = 1905`), each annotated with the appropriate `[HttpStatusCode]` attribute. The handler picks the correct code per failure branch. The controller stops short-circuiting failures to `NotFound(...)` and instead delegates to the existing `BaseApiController.HandleResponse(...)` (which reflects the enum attribute) — matching the convention used by every sibling endpoint in the controller. The `Accepted(...)` (202) success path is preserved.
+
+**Tech Stack:** .NET 8, C#, ASP.NET Core MVC, MediatR, xUnit, FluentAssertions, Moq.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` | Single source of truth for error code + HTTP status pairing | Add two enum values with `[HttpStatusCode]` attributes |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs` | Maps handler failure conditions to error codes | Change two return branches; augment logs with `ErrorCode` structured property |
+| `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` | Translates handler response to HTTP | Replace bespoke `NotFound(...)` short-circuit with `HandleResponse(response)` for the failure branch; update `[ProducesResponseType]` decorations |
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` (new) | Pure unit tests for handler failure branches (mocked deps) | New file with three tests covering the three failure codes |
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs` | Tests controller's HTTP mapping for trigger endpoint | Rename the inaccurate existing failure test, add two new tests for `409` and `500` mappings |
+
+No new files in `src/`. No new NuGet packages. No DB migrations. No frontend changes.
+
+---
+
+## Task 1: Add `RecurringJobDisabled` (1904) and `RecurringJobEnqueueFailed` (1905) to `ErrorCodes`
+
+**Why first:** Subsequent tasks reference these enum members; the project must compile.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:201-207`
+
+This is an additive, enabling change — no behavior changes yet, so no dedicated test is required. The new values are exercised transitively by the handler tests (Task 3) and controller tests (Task 5). The integer-value uniqueness and attribute presence are protected by the C# compiler (duplicate enum values are a compile error) and by the test assertions in Tasks 3/5.
+
+- [ ] **Step 1: Verify the current state of the BackgroundJobs section**
+
+Open `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` and locate the BackgroundJobs (19XX) section (lines 201–207). It currently ends with:
+
+```csharp
+// BackgroundJobs module errors (19XX)
+[HttpStatusCode(HttpStatusCode.NotFound)]
+RecurringJobNotFound = 1901,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobUpdateFailed = 1902,
+[HttpStatusCode(HttpStatusCode.BadRequest)]
+InvalidCronExpression = 1903,
+```
+
+Confirm nothing currently uses `1904` or `1905` (a quick scan of the enum body around lines 201–230 is enough; `1904` would belong to KnowledgeBase 20XX or to BackgroundJobs — it is unused).
+
+- [ ] **Step 2: Add the two new enum values**
+
+Insert the following two entries immediately after `InvalidCronExpression = 1903,` and before the blank line that precedes the `// KnowledgeBase module errors (20XX)` comment:
+
+```csharp
+[HttpStatusCode(HttpStatusCode.Conflict)]
+RecurringJobDisabled = 1904,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobEnqueueFailed = 1905,
+```
+
+The complete BackgroundJobs section after the edit must read:
+
+```csharp
+// BackgroundJobs module errors (19XX)
+[HttpStatusCode(HttpStatusCode.NotFound)]
+RecurringJobNotFound = 1901,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobUpdateFailed = 1902,
+[HttpStatusCode(HttpStatusCode.BadRequest)]
+InvalidCronExpression = 1903,
+[HttpStatusCode(HttpStatusCode.Conflict)]
+RecurringJobDisabled = 1904,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobEnqueueFailed = 1905,
+```
+
+- [ ] **Step 3: Confirm the project builds**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Errors`.
+
+If the build fails with a duplicate-value error, search the file for the conflicting integer — the spec/arch-review have already verified `1904`/`1905` are free in the 19XX section, but the compiler will catch any collision elsewhere.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat(backgroundjobs): add RecurringJobDisabled and RecurringJobEnqueueFailed error codes
+
+Introduces ErrorCodes.RecurringJobDisabled (1904, Conflict) and
+ErrorCodes.RecurringJobEnqueueFailed (1905, InternalServerError) so the
+TriggerRecurringJob handler can distinguish disabled and enqueue-failure
+conditions from a true \"not found\" outcome."
+```
+
+---
+
+## Task 2: Add `TriggerRecurringJobHandler` unit tests for the three failure branches (RED)
+
+**Why now:** TDD — write the failing tests before changing the handler. These three tests will fail because the handler currently returns `RecurringJobNotFound` for all three branches.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs`
+
+This file uses Moq for `IRecurringJobStatusChecker` and `IHangfireJobEnqueuer` — fully isolated unit tests, no Hangfire infrastructure. The existing `TriggerRecurringJobHandlerIntegrationTests.cs` covers happy paths against real Hangfire and is not touched here.
+
+- [ ] **Step 1: Create the new test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` with the following content:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.TriggerRecurringJob;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+/// <summary>
+/// Pure unit tests for TriggerRecurringJobHandler failure branches.
+/// Happy-path coverage lives in TriggerRecurringJobHandlerIntegrationTests.
+/// </summary>
+public class TriggerRecurringJobHandlerTests
+{
+    private static TriggerRecurringJobHandler CreateHandler(
+        IEnumerable<IRecurringJob>? jobs = null,
+        Mock<IRecurringJobStatusChecker>? statusChecker = null,
+        Mock<IHangfireJobEnqueuer>? enqueuer = null)
+    {
+        return new TriggerRecurringJobHandler(
+            jobs ?? Array.Empty<IRecurringJob>(),
+            (statusChecker ?? new Mock<IRecurringJobStatusChecker>()).Object,
+            (enqueuer ?? new Mock<IHangfireJobEnqueuer>()).Object,
+            new Mock<ILogger<TriggerRecurringJobHandler>>().Object);
+    }
+
+    private static IRecurringJob CreateJob(string jobName)
+    {
+        var job = new Mock<IRecurringJob>();
+        job.SetupGet(j => j.Metadata).Returns(new RecurringJobMetadata
+        {
+            JobName = jobName,
+            DisplayName = jobName,
+            Description = "test",
+            CronExpression = "0 0 * * *"
+        });
+        return job.Object;
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsNotRegistered_ReturnsRecurringJobNotFound()
+    {
+        // Arrange
+        var handler = CreateHandler(jobs: Array.Empty<IRecurringJob>());
+        var request = new TriggerRecurringJobRequest { JobName = "missing-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobNotFound);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("missing-job");
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsDisabledAndForceDisabledIsFalse_ReturnsRecurringJobDisabled()
+    {
+        // Arrange
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(
+            jobs: new[] { CreateJob("disabled-job") },
+            statusChecker: statusChecker);
+
+        var request = new TriggerRecurringJobRequest { JobName = "disabled-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobDisabled);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("disabled-job");
+    }
+
+    [Fact]
+    public async Task Handle_WhenEnqueuerReturnsNull_ReturnsRecurringJobEnqueueFailed()
+    {
+        // Arrange
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(x => x.IsJobEnabledAsync("enabled-job", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var enqueuer = new Mock<IHangfireJobEnqueuer>();
+        enqueuer
+            .Setup(x => x.EnqueueJob(It.IsAny<IRecurringJob>(), It.IsAny<CancellationToken>()))
+            .Returns((string?)null);
+
+        var handler = CreateHandler(
+            jobs: new[] { CreateJob("enabled-job") },
+            statusChecker: statusChecker,
+            enqueuer: enqueuer);
+
+        var request = new TriggerRecurringJobRequest { JobName = "enabled-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobEnqueueFailed);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("enabled-job");
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail with the expected reasons**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.TriggerRecurringJobHandlerTests" \
+  --no-restore
+```
+
+Expected output:
+- `Handle_WhenJobIsNotRegistered_ReturnsRecurringJobNotFound` → **PASS** (handler already returns `RecurringJobNotFound` for this branch — it is the only correct branch today).
+- `Handle_WhenJobIsDisabledAndForceDisabledIsFalse_ReturnsRecurringJobDisabled` → **FAIL** (handler returns `RecurringJobNotFound` instead of `RecurringJobDisabled`).
+- `Handle_WhenEnqueuerReturnsNull_ReturnsRecurringJobEnqueueFailed` → **FAIL** (handler returns `RecurringJobNotFound` instead of `RecurringJobEnqueueFailed`).
+
+Two failing tests is the RED state we want. Do not commit yet — the next task fixes them.
+
+---
+
+## Task 3: Update `TriggerRecurringJobHandler` failure branches and logging (GREEN)
+
+**Why now:** Make the failing tests pass and augment logs per FR-5.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs`
+
+- [ ] **Step 1: Update the "disabled" branch (current lines 53–64) to return `RecurringJobDisabled` and include `ErrorCode` in the log**
+
+Locate lines 53–64 in `TriggerRecurringJobHandler.cs`:
+
+```csharp
+if (!isEnabled)
+{
+    _logger.LogWarning("Job {JobName} is disabled. Use forceDisabled=true to trigger anyway.", request.JobName);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+Replace with:
+
+```csharp
+if (!isEnabled)
+{
+    _logger.LogWarning(
+        "Job {JobName} is disabled. Use forceDisabled=true to trigger anyway. ErrorCode={ErrorCode}",
+        request.JobName,
+        (int)ErrorCodes.RecurringJobDisabled);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobDisabled,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Update the "enqueue returned null" branch (current lines 70–81) to return `RecurringJobEnqueueFailed` and include `ErrorCode` in the log**
+
+Locate lines 70–81:
+
+```csharp
+if (jobId == null)
+{
+    _logger.LogError("Failed to enqueue job {JobName}", request.JobName);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+Replace with:
+
+```csharp
+if (jobId == null)
+{
+    _logger.LogError(
+        "Failed to enqueue job {JobName}. ErrorCode={ErrorCode}",
+        request.JobName,
+        (int)ErrorCodes.RecurringJobEnqueueFailed);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobEnqueueFailed,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+- [ ] **Step 3: Augment the "not registered" branch (current lines 36–47) log with `ErrorCode` for consistency**
+
+Locate lines 36–47:
+
+```csharp
+if (job == null)
+{
+    _logger.LogWarning("Job {JobName} not found in registered jobs", request.JobName);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+Replace with:
+
+```csharp
+if (job == null)
+{
+    _logger.LogWarning(
+        "Job {JobName} not found in registered jobs. ErrorCode={ErrorCode}",
+        request.JobName,
+        (int)ErrorCodes.RecurringJobNotFound);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+The return value of this branch is unchanged. The error code stays `RecurringJobNotFound` — this is the only branch that should ever produce it.
+
+- [ ] **Step 4: Re-run the handler tests and verify all three pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.TriggerRecurringJobHandlerTests" \
+  --no-restore
+```
+
+Expected: all 3 tests **PASS**.
+
+- [ ] **Step 5: Re-run the existing integration tests to verify the happy path is intact**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.TriggerRecurringJobHandlerIntegrationTests" \
+  --no-restore
+```
+
+Expected: all 3 integration tests **PASS** (no behavior changes on the success path; the handler still calls `_jobEnqueuer.EnqueueJob` exactly the same way).
+
+- [ ] **Step 6: Verify `RecurringJobNotFound` is now only referenced from the not-registered branch in the handler**
+
+```bash
+grep -n "RecurringJobNotFound" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/
+```
+
+Expected: exactly one match, in `TriggerRecurringJobHandler.cs` at the "not registered" branch (currently around line 41–44 after the edits above).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
+git commit -m "feat(backgroundjobs): distinguish disabled and enqueue-failure outcomes in TriggerRecurringJob handler
+
+- Disabled branch now returns RecurringJobDisabled (1904) instead of RecurringJobNotFound
+- Enqueue-null branch now returns RecurringJobEnqueueFailed (1905) instead of RecurringJobNotFound
+- Not-registered branch is the sole producer of RecurringJobNotFound (1901)
+- Failure logs now include the ErrorCode structured property
+- New unit tests cover all three failure branches"
+```
+
+---
+
+## Task 4: Update `RecurringJobsController.TriggerJob` to delegate failure mapping to `HandleResponse` (controller TDD — RED first)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs:100-121`
+
+The existing controller test file already covers `RecurringJobNotFound → 404` (which keeps working — `BaseApiController.HandleResponse` returns `NotFoundObjectResult` for the `NotFound` status). It also has a misleadingly named test `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` that actually asserts `NotFoundObjectResult` for `RecurringJobUpdateFailed` — that test was masking the bug and must be updated.
+
+- [ ] **Step 1: Rewrite the existing misleading test and add two new failure-mapping tests**
+
+Open `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs`.
+
+Replace the entire body of `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` (lines 115–140) with a renamed, accurate test, and append two new tests for `RecurringJobDisabled` and `RecurringJobEnqueueFailed`. The replacement code (drop into the class, after the existing `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` test and before `TriggerJob_ShouldPassCancellationTokenToMediator`):
+
+```csharp
+[Fact]
+public async Task TriggerJob_WhenUpdateFailedErrorReturned_ShouldReturn500()
+{
+    // Arrange
+    // RecurringJobUpdateFailed (1902) is annotated [HttpStatusCode(InternalServerError)].
+    // After delegating failure mapping to BaseApiController.HandleResponse, this must
+    // produce an ObjectResult with StatusCode 500 — not a 404 (which the old test
+    // asserted, masking the controller bug).
+    var jobName = "test-job";
+    var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobUpdateFailed);
+
+    _mediatorMock
+        .Setup(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(errorResponse);
+
+    // Act
+    var result = await _controller.TriggerJob(jobName);
+
+    // Assert
+    var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+    returnedResponse.Success.Should().BeFalse();
+    returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobUpdateFailed);
+}
+
+[Fact]
+public async Task TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict()
+{
+    // Arrange
+    var jobName = "disabled-job";
+    var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobDisabled);
+
+    _mediatorMock
+        .Setup(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(errorResponse);
+
+    // Act
+    var result = await _controller.TriggerJob(jobName);
+
+    // Assert
+    var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+    returnedResponse.Success.Should().BeFalse();
+    returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobDisabled);
+}
+
+[Fact]
+public async Task TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError()
+{
+    // Arrange
+    var jobName = "test-job";
+    var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobEnqueueFailed);
+
+    _mediatorMock
+        .Setup(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(errorResponse);
+
+    // Act
+    var result = await _controller.TriggerJob(jobName);
+
+    // Assert
+    var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+    returnedResponse.Success.Should().BeFalse();
+    returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobEnqueueFailed);
+}
+```
+
+Notes on assertions:
+- `BaseApiController.HandleResponse` returns `NotFoundObjectResult` for `NotFound`, but falls through to the generic `ObjectResult` (via `StatusCode((int)statusCode, response)`) for `Conflict` and `InternalServerError`. The tests therefore assert `ObjectResult` + `StatusCode == 409 / 500`, not `ConflictObjectResult` or any specialized type.
+- The existing test `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` continues to assert `NotFoundObjectResult` and remains unchanged — that is the correct return type for the `NotFound` branch in `HandleResponse`.
+
+- [ ] **Step 2: Run the controller tests and verify the three new/updated tests fail**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTriggerTests" \
+  --no-restore
+```
+
+Expected:
+- `TriggerJob_WithValidJobName_ShouldReturnAcceptedWithSuccessResponse` → **PASS** (success branch unchanged).
+- `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` → **PASS** (controller currently returns `NotFound(response)` for all failures — happens to be correct for this code).
+- `TriggerJob_WhenUpdateFailedErrorReturned_ShouldReturn500` → **FAIL** (controller returns `NotFoundObjectResult`, test expects `ObjectResult` with 500).
+- `TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict` → **FAIL** (same reason; 404 vs 409).
+- `TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError` → **FAIL** (same reason; 404 vs 500).
+- `TriggerJob_ShouldPassCancellationTokenToMediator` → **PASS** (unchanged).
+
+Three failing tests is the RED state we want.
+
+- [ ] **Step 3: Update `RecurringJobsController.TriggerJob` to delegate failure mapping**
+
+Open `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` and locate the `TriggerJob` action (lines 100–121).
+
+Replace lines 100–121 with:
+
+```csharp
+/// <summary>
+/// Manually trigger a recurring job to run immediately
+/// </summary>
+/// <param name="jobName">The name of the job to trigger</param>
+/// <param name="cancellationToken">Cancellation token</param>
+/// <returns>Background job ID if triggered successfully</returns>
+[HttpPost("{jobName}/trigger")]
+[ProducesResponseType(typeof(TriggerRecurringJobResponse), StatusCodes.Status202Accepted)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+[ProducesResponseType(StatusCodes.Status409Conflict)]
+[ProducesResponseType(StatusCodes.Status500InternalServerError)]
+public async Task<ActionResult<TriggerRecurringJobResponse>> TriggerJob(
+    string jobName,
+    CancellationToken cancellationToken = default)
+{
+    var request = new TriggerRecurringJobRequest
+    {
+        JobName = jobName
+    };
+
+    var response = await _mediator.Send(request, cancellationToken);
+
+    if (!response.Success)
+    {
+        return HandleResponse(response);
+    }
+
+    return Accepted(response);
+}
+```
+
+Changes vs. the old version:
+- Added `[ProducesResponseType(StatusCodes.Status409Conflict)]` and `[ProducesResponseType(StatusCodes.Status500InternalServerError)]` decorations.
+- The failure branch now calls `HandleResponse(response)` (from `BaseApiController`) — reflection-based status mapping via the `[HttpStatusCode]` attribute on each `ErrorCodes` value.
+- The success branch still returns `Accepted(response)` → HTTP `202` (preserving existing behavior and matching the `Status202Accepted` `[ProducesResponseType]` decoration).
+- `HandleResponse<T>` returns `ActionResult<T>`; assigning it directly inside an `ActionResult<TriggerRecurringJobResponse>`-returning method works because `ActionResult<T>` has implicit conversion from itself. The C# compiler will accept `return HandleResponse(response);` — no cast needed.
+
+- [ ] **Step 4: Re-run the controller tests and verify all six pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTriggerTests" \
+  --no-restore
+```
+
+Expected: all 6 controller-trigger tests **PASS**.
+
+- [ ] **Step 5: Run the broader BackgroundJobs test set to confirm nothing else regressed**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs" \
+  --no-restore
+```
+
+Expected: all BackgroundJobs tests **PASS**. Pay particular attention to `RecurringJobsControllerTests.cs` (the other controller test file) — it covers the unchanged endpoints (`GetRecurringJobs`, `UpdateJobStatus`, `UpdateJobCron`) and must continue to pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs
+git commit -m "feat(backgroundjobs): map TriggerJob failures via BaseApiController.HandleResponse
+
+The TriggerJob endpoint previously short-circuited every handler failure to
+HTTP 404 NotFound, masking 'disabled' and 'enqueue failed' outcomes. It now
+delegates failure mapping to BaseApiController.HandleResponse, which reads
+the [HttpStatusCode] attribute on each ErrorCodes value — matching the
+convention already used by GetRecurringJobs, UpdateJobStatus, and UpdateJobCron
+in the same controller.
+
+- 404 NotFound for RecurringJobNotFound (1901)
+- 409 Conflict for RecurringJobDisabled (1904)
+- 500 InternalServerError for RecurringJobEnqueueFailed (1905) and any other failure
+
+The 202 Accepted success path is preserved. ProducesResponseType decorations
+updated to advertise the new statuses."
+```
+
+---
+
+## Task 5: Full backend verification
+
+**Files:** none modified.
+
+This is the project-wide gate from `CLAUDE.md` ("Validation before completion"). No further code changes — only verification.
+
+- [ ] **Step 1: Format**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Expected: no formatting violations remain. If any files are reformatted, stage them and amend the most recent commit OR add a follow-up `chore: dotnet format` commit — do not skip formatting.
+
+- [ ] **Step 2: Full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded. 0 Errors`. Warnings present before the change should not increase.
+
+- [ ] **Step 3: Full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all tests **PASS**. The change touches a single use case and one controller action; broader test impact is not expected, but the full run confirms no transitive coupling was missed.
+
+- [ ] **Step 4: Final `grep` audit — exactly one production usage of `ErrorCodes.RecurringJobNotFound`**
+
+```bash
+grep -rn "ErrorCodes.RecurringJobNotFound" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/
+```
+
+Expected: exactly one match, in `TriggerRecurringJobHandler.cs` (the "not registered" branch). Any additional production-code matches indicate the refactor is incomplete.
+
+- [ ] **Step 5: If anything was reformatted in Step 1, commit it**
+
+```bash
+git status
+# If files were changed by dotnet format:
+git add -A
+git commit -m "chore: apply dotnet format after error-code refactor"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Self-Review
+
+**Spec coverage check (against `spec.r1.md` + `arch-review.r1.md` amendments):**
+
+| Requirement | Implemented in |
+|-------------|----------------|
+| FR-1 `RecurringJobDisabled = 1904` (amended from 1903) | Task 1 |
+| FR-2 `RecurringJobEnqueueFailed = 1905` (amended from 1904) | Task 1 |
+| FR-3 `RecurringJobNotFound` restricted to not-registered branch | Task 3 Step 6; Task 5 Step 4 (audit) |
+| FR-4 HTTP status mapping (amended: via `[HttpStatusCode]` + `HandleResponse`, not switch) | Task 1 (attributes) + Task 4 (`HandleResponse` delegation) |
+| FR-5 Logging continuity (severity preserved; `ErrorCode` added as structured property) | Task 3 Steps 1–3 |
+| FR-6 Unit test coverage for three handler branches and three controller mappings | Task 2 (handler) + Task 4 (controller) |
+| NFR-1 Performance: constant lookups, switch, log property — no measurable impact | No work item (architectural property of the chosen design) |
+| NFR-2 Security: unchanged auth, no internal leaks beyond job id and code | No work item (no new error-message fields introduced) |
+| NFR-3 Backward compatibility: response DTO shape unchanged; behavioral change in HTTP status called out in commit messages | Task 4 Step 6 commit body |
+| NFR-4 Observability: three distinct buckets visible in dashboards | Task 1 + Task 3 |
+| Arch-review amendment: success path is `202 Accepted` (not `200 OK`) | Task 4 Step 3 — `return Accepted(response);` preserved |
+| Arch-review amendment: `[HttpStatusCode]` attribute approach replaces controller `switch` | Task 1 (attributes) + Task 4 Step 3 (controller delegation) |
+
+**Placeholder scan:** All steps contain concrete code/commands and explicit expected outputs. No TBD, no "implement later", no "similar to Task N". Code blocks are full and self-contained.
+
+**Type / signature consistency:**
+- `ErrorCodes.RecurringJobDisabled` and `ErrorCodes.RecurringJobEnqueueFailed` — same names used across Tasks 1, 2, 3, 4.
+- `TriggerRecurringJobResponse(ErrorCodes)` constructor — used identically in handler edits (Task 3) and controller tests (Task 4).
+- `HandleResponse(response)` (lowercase `r`, single argument) — matches the actual signature on `BaseApiController` (`backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs:28`).
+- `BaseApiController.HandleResponse` does not have a dedicated `ConflictObjectResult` branch in its `switch`; for `Conflict` and `InternalServerError` it returns `StatusCode((int)statusCode, response)` which produces an `ObjectResult`. Tests assert on `ObjectResult` + `StatusCode == 409 / 500` accordingly (Task 4 Step 1) — confirmed against `BaseApiController.cs:45-54`.
+- `IRecurringJob.Metadata` returns `RecurringJobMetadata` with `JobName`, `DisplayName`, `Description`, `CronExpression` — matches the test helper in Task 2 Step 1 and the existing usage in `TriggerRecurringJobHandlerIntegrationTests.cs:188-194`.
+
+**Out-of-scope reminders (per arch-review):**
+- The controller does not currently bind `ForceDisabled` from the request. The new `RecurringJobDisabled` code is therefore unreachable via HTTP today — only via in-process callers (e.g., the new unit tests) — until a follow-up adds `[FromQuery] bool forceDisabled = false` to `TriggerJob`. This is intentionally out of scope for this plan. Flag it in the PR description.
+- The spec's NFR-3 / arch-review "Risks" call out the behavior change for any HTTP client that relied on `404` for any failure. This is intentional and must be highlighted in the PR description and release notes (see Task 4 Step 6 commit body).

--- a/backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs
@@ -101,6 +101,8 @@ public class RecurringJobsController : BaseApiController
     [ProducesResponseType(typeof(TriggerRecurringJobResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<TriggerRecurringJobResponse>> TriggerJob(
         string jobName,
         CancellationToken cancellationToken = default)
@@ -114,7 +116,7 @@ public class RecurringJobsController : BaseApiController
 
         if (!response.Success)
         {
-            return NotFound(response);
+            return HandleResponse(response);
         }
 
         return Accepted(response);

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs
@@ -35,7 +35,10 @@ public class TriggerRecurringJobHandler : IRequestHandler<TriggerRecurringJobReq
 
         if (job == null)
         {
-            _logger.LogWarning("Job {JobName} not found in registered jobs", request.JobName);
+            _logger.LogWarning(
+                "Job {JobName} not found in registered jobs. ErrorCode={ErrorCode}",
+                request.JobName,
+                (int)ErrorCodes.RecurringJobNotFound);
             return new TriggerRecurringJobResponse(
                 ErrorCodes.RecurringJobNotFound,
                 new Dictionary<string, string>
@@ -52,9 +55,12 @@ public class TriggerRecurringJobHandler : IRequestHandler<TriggerRecurringJobReq
             var isEnabled = await _statusChecker.IsJobEnabledAsync(request.JobName, cancellationToken);
             if (!isEnabled)
             {
-                _logger.LogWarning("Job {JobName} is disabled. Use forceDisabled=true to trigger anyway.", request.JobName);
+                _logger.LogWarning(
+                    "Job {JobName} is disabled. Use forceDisabled=true to trigger anyway. ErrorCode={ErrorCode}",
+                    request.JobName,
+                    (int)ErrorCodes.RecurringJobDisabled);
                 return new TriggerRecurringJobResponse(
-                    ErrorCodes.RecurringJobNotFound,
+                    ErrorCodes.RecurringJobDisabled,
                     new Dictionary<string, string>
                     {
                         { "jobName", request.JobName },
@@ -69,9 +75,12 @@ public class TriggerRecurringJobHandler : IRequestHandler<TriggerRecurringJobReq
 
         if (jobId == null)
         {
-            _logger.LogError("Failed to enqueue job {JobName}", request.JobName);
+            _logger.LogError(
+                "Failed to enqueue job {JobName}. ErrorCode={ErrorCode}",
+                request.JobName,
+                (int)ErrorCodes.RecurringJobEnqueueFailed);
             return new TriggerRecurringJobResponse(
-                ErrorCodes.RecurringJobNotFound,
+                ErrorCodes.RecurringJobEnqueueFailed,
                 new Dictionary<string, string>
                 {
                     { "jobName", request.JobName },

--- a/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+++ b/backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
@@ -205,6 +205,10 @@ public enum ErrorCodes
     RecurringJobUpdateFailed = 1902,
     [HttpStatusCode(HttpStatusCode.BadRequest)]
     InvalidCronExpression = 1903,
+    [HttpStatusCode(HttpStatusCode.Conflict)]
+    RecurringJobDisabled = 1904,
+    [HttpStatusCode(HttpStatusCode.InternalServerError)]
+    RecurringJobEnqueueFailed = 1905,
 
     // KnowledgeBase module errors (20XX)
     [HttpStatusCode(HttpStatusCode.NotFound)]

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs
@@ -113,7 +113,7 @@ public class RecurringJobsControllerTriggerTests
     }
 
     [Fact]
-    public async Task TriggerJob_WhenTriggerFails_ShouldReturnBadRequest()
+    public async Task TriggerJob_WhenUpdateFailedErrorReturned_ShouldReturn500()
     {
         // Arrange
         var jobName = "test-job";
@@ -129,10 +129,67 @@ public class RecurringJobsControllerTriggerTests
         var result = await _controller.TriggerJob(jobName);
 
         // Assert
-        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
-        var returnedResponse = notFoundResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+        var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
         returnedResponse.Success.Should().BeFalse();
         returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobUpdateFailed);
+
+        _mediatorMock.Verify(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict()
+    {
+        // Arrange
+        var jobName = "disabled-job";
+        var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobDisabled);
+
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(errorResponse);
+
+        // Act
+        var result = await _controller.TriggerJob(jobName);
+
+        // Assert
+        var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+        returnedResponse.Success.Should().BeFalse();
+        returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobDisabled);
+
+        _mediatorMock.Verify(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError()
+    {
+        // Arrange
+        var jobName = "test-job";
+        var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobEnqueueFailed);
+
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(errorResponse);
+
+        // Act
+        var result = await _controller.TriggerJob(jobName);
+
+        // Assert
+        var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+        returnedResponse.Success.Should().BeFalse();
+        returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobEnqueueFailed);
 
         _mediatorMock.Verify(x => x.Send(
             It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
@@ -1,0 +1,112 @@
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.TriggerRecurringJob;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+/// <summary>
+/// Pure unit tests for TriggerRecurringJobHandler failure branches.
+/// Happy-path coverage lives in TriggerRecurringJobHandlerIntegrationTests.
+/// </summary>
+public class TriggerRecurringJobHandlerTests
+{
+    private static TriggerRecurringJobHandler CreateHandler(
+        IEnumerable<IRecurringJob>? jobs = null,
+        Mock<IRecurringJobStatusChecker>? statusChecker = null,
+        Mock<IHangfireJobEnqueuer>? enqueuer = null)
+    {
+        return new TriggerRecurringJobHandler(
+            jobs ?? Array.Empty<IRecurringJob>(),
+            (statusChecker ?? new Mock<IRecurringJobStatusChecker>()).Object,
+            (enqueuer ?? new Mock<IHangfireJobEnqueuer>()).Object,
+            new Mock<ILogger<TriggerRecurringJobHandler>>().Object);
+    }
+
+    private static IRecurringJob CreateJob(string jobName)
+    {
+        var job = new Mock<IRecurringJob>();
+        job.SetupGet(j => j.Metadata).Returns(new RecurringJobMetadata
+        {
+            JobName = jobName,
+            DisplayName = jobName,
+            Description = "test",
+            CronExpression = "0 0 * * *"
+        });
+        return job.Object;
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsNotRegistered_ReturnsRecurringJobNotFound()
+    {
+        // Arrange
+        var handler = CreateHandler(jobs: Array.Empty<IRecurringJob>());
+        var request = new TriggerRecurringJobRequest { JobName = "missing-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobNotFound);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("missing-job");
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsDisabledAndForceDisabledIsFalse_ReturnsRecurringJobDisabled()
+    {
+        // Arrange
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(
+            jobs: new[] { CreateJob("disabled-job") },
+            statusChecker: statusChecker);
+
+        var request = new TriggerRecurringJobRequest { JobName = "disabled-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobDisabled);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("disabled-job");
+    }
+
+    [Fact]
+    public async Task Handle_WhenEnqueuerReturnsNull_ReturnsRecurringJobEnqueueFailed()
+    {
+        // Arrange
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(x => x.IsJobEnabledAsync("enabled-job", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var enqueuer = new Mock<IHangfireJobEnqueuer>();
+        enqueuer
+            .Setup(x => x.EnqueueJob(It.IsAny<IRecurringJob>(), It.IsAny<CancellationToken>()))
+            .Returns((string?)null);
+
+        var handler = CreateHandler(
+            jobs: new[] { CreateJob("enabled-job") },
+            statusChecker: statusChecker,
+            enqueuer: enqueuer);
+
+        var request = new TriggerRecurringJobRequest { JobName = "enabled-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobEnqueueFailed);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("enabled-job");
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
@@ -15,6 +15,8 @@ namespace Anela.Heblo.Tests.Features.BackgroundJobs;
 /// </summary>
 public class TriggerRecurringJobHandlerTests
 {
+    private const string DefaultCronExpression = "0 0 * * *";
+
     private static TriggerRecurringJobHandler CreateHandler(
         IEnumerable<IRecurringJob>? jobs = null,
         Mock<IRecurringJobStatusChecker>? statusChecker = null,
@@ -35,7 +37,7 @@ public class TriggerRecurringJobHandlerTests
             JobName = jobName,
             DisplayName = jobName,
             Description = "test",
-            CronExpression = "0 0 * * *"
+            CronExpression = DefaultCronExpression
         });
         return job.Object;
     }

--- a/docs/superpowers/plans/2026-05-27-trigger-recurring-job-distinct-error-codes.md
+++ b/docs/superpowers/plans/2026-05-27-trigger-recurring-job-distinct-error-codes.md
@@ -1,0 +1,704 @@
+# Distinct Error Codes for `TriggerRecurringJob` Failure Modes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single `RecurringJobNotFound` code that `TriggerRecurringJobHandler` returns for three distinct failure conditions with three distinct codes, and route the controller's failure path through the existing attribute-based HTTP-status mapper so `404` / `409` / `500` are returned correctly.
+
+**Architecture:** Two new `ErrorCodes` enum members (`RecurringJobDisabled = 1904`, `RecurringJobEnqueueFailed = 1905`), each annotated with the appropriate `[HttpStatusCode]` attribute. The handler picks the correct code per failure branch. The controller stops short-circuiting failures to `NotFound(...)` and instead delegates to the existing `BaseApiController.HandleResponse(...)` (which reflects the enum attribute) — matching the convention used by every sibling endpoint in the controller. The `Accepted(...)` (202) success path is preserved.
+
+**Tech Stack:** .NET 8, C#, ASP.NET Core MVC, MediatR, xUnit, FluentAssertions, Moq.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` | Single source of truth for error code + HTTP status pairing | Add two enum values with `[HttpStatusCode]` attributes |
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs` | Maps handler failure conditions to error codes | Change two return branches; augment logs with `ErrorCode` structured property |
+| `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` | Translates handler response to HTTP | Replace bespoke `NotFound(...)` short-circuit with `HandleResponse(response)` for the failure branch; update `[ProducesResponseType]` decorations |
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` (new) | Pure unit tests for handler failure branches (mocked deps) | New file with three tests covering the three failure codes |
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs` | Tests controller's HTTP mapping for trigger endpoint | Rename the inaccurate existing failure test, add two new tests for `409` and `500` mappings |
+
+No new files in `src/`. No new NuGet packages. No DB migrations. No frontend changes.
+
+---
+
+## Task 1: Add `RecurringJobDisabled` (1904) and `RecurringJobEnqueueFailed` (1905) to `ErrorCodes`
+
+**Why first:** Subsequent tasks reference these enum members; the project must compile.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:201-207`
+
+This is an additive, enabling change — no behavior changes yet, so no dedicated test is required. The new values are exercised transitively by the handler tests (Task 3) and controller tests (Task 5). The integer-value uniqueness and attribute presence are protected by the C# compiler (duplicate enum values are a compile error) and by the test assertions in Tasks 3/5.
+
+- [ ] **Step 1: Verify the current state of the BackgroundJobs section**
+
+Open `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs` and locate the BackgroundJobs (19XX) section (lines 201–207). It currently ends with:
+
+```csharp
+// BackgroundJobs module errors (19XX)
+[HttpStatusCode(HttpStatusCode.NotFound)]
+RecurringJobNotFound = 1901,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobUpdateFailed = 1902,
+[HttpStatusCode(HttpStatusCode.BadRequest)]
+InvalidCronExpression = 1903,
+```
+
+Confirm nothing currently uses `1904` or `1905` (a quick scan of the enum body around lines 201–230 is enough; `1904` would belong to KnowledgeBase 20XX or to BackgroundJobs — it is unused).
+
+- [ ] **Step 2: Add the two new enum values**
+
+Insert the following two entries immediately after `InvalidCronExpression = 1903,` and before the blank line that precedes the `// KnowledgeBase module errors (20XX)` comment:
+
+```csharp
+[HttpStatusCode(HttpStatusCode.Conflict)]
+RecurringJobDisabled = 1904,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobEnqueueFailed = 1905,
+```
+
+The complete BackgroundJobs section after the edit must read:
+
+```csharp
+// BackgroundJobs module errors (19XX)
+[HttpStatusCode(HttpStatusCode.NotFound)]
+RecurringJobNotFound = 1901,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobUpdateFailed = 1902,
+[HttpStatusCode(HttpStatusCode.BadRequest)]
+InvalidCronExpression = 1903,
+[HttpStatusCode(HttpStatusCode.Conflict)]
+RecurringJobDisabled = 1904,
+[HttpStatusCode(HttpStatusCode.InternalServerError)]
+RecurringJobEnqueueFailed = 1905,
+```
+
+- [ ] **Step 3: Confirm the project builds**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: `Build succeeded. 0 Errors`.
+
+If the build fails with a duplicate-value error, search the file for the conflicting integer — the spec/arch-review have already verified `1904`/`1905` are free in the 19XX section, but the compiler will catch any collision elsewhere.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs
+git commit -m "feat(backgroundjobs): add RecurringJobDisabled and RecurringJobEnqueueFailed error codes
+
+Introduces ErrorCodes.RecurringJobDisabled (1904, Conflict) and
+ErrorCodes.RecurringJobEnqueueFailed (1905, InternalServerError) so the
+TriggerRecurringJob handler can distinguish disabled and enqueue-failure
+conditions from a true \"not found\" outcome."
+```
+
+---
+
+## Task 2: Add `TriggerRecurringJobHandler` unit tests for the three failure branches (RED)
+
+**Why now:** TDD — write the failing tests before changing the handler. These three tests will fail because the handler currently returns `RecurringJobNotFound` for all three branches.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs`
+
+This file uses Moq for `IRecurringJobStatusChecker` and `IHangfireJobEnqueuer` — fully isolated unit tests, no Hangfire infrastructure. The existing `TriggerRecurringJobHandlerIntegrationTests.cs` covers happy paths against real Hangfire and is not touched here.
+
+- [ ] **Step 1: Create the new test file**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs` with the following content:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Application.Features.BackgroundJobs.UseCases.TriggerRecurringJob;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+/// <summary>
+/// Pure unit tests for TriggerRecurringJobHandler failure branches.
+/// Happy-path coverage lives in TriggerRecurringJobHandlerIntegrationTests.
+/// </summary>
+public class TriggerRecurringJobHandlerTests
+{
+    private static TriggerRecurringJobHandler CreateHandler(
+        IEnumerable<IRecurringJob>? jobs = null,
+        Mock<IRecurringJobStatusChecker>? statusChecker = null,
+        Mock<IHangfireJobEnqueuer>? enqueuer = null)
+    {
+        return new TriggerRecurringJobHandler(
+            jobs ?? Array.Empty<IRecurringJob>(),
+            (statusChecker ?? new Mock<IRecurringJobStatusChecker>()).Object,
+            (enqueuer ?? new Mock<IHangfireJobEnqueuer>()).Object,
+            new Mock<ILogger<TriggerRecurringJobHandler>>().Object);
+    }
+
+    private static IRecurringJob CreateJob(string jobName)
+    {
+        var job = new Mock<IRecurringJob>();
+        job.SetupGet(j => j.Metadata).Returns(new RecurringJobMetadata
+        {
+            JobName = jobName,
+            DisplayName = jobName,
+            Description = "test",
+            CronExpression = "0 0 * * *"
+        });
+        return job.Object;
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsNotRegistered_ReturnsRecurringJobNotFound()
+    {
+        // Arrange
+        var handler = CreateHandler(jobs: Array.Empty<IRecurringJob>());
+        var request = new TriggerRecurringJobRequest { JobName = "missing-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobNotFound);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("missing-job");
+    }
+
+    [Fact]
+    public async Task Handle_WhenJobIsDisabledAndForceDisabledIsFalse_ReturnsRecurringJobDisabled()
+    {
+        // Arrange
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(x => x.IsJobEnabledAsync("disabled-job", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = CreateHandler(
+            jobs: new[] { CreateJob("disabled-job") },
+            statusChecker: statusChecker);
+
+        var request = new TriggerRecurringJobRequest { JobName = "disabled-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobDisabled);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("disabled-job");
+    }
+
+    [Fact]
+    public async Task Handle_WhenEnqueuerReturnsNull_ReturnsRecurringJobEnqueueFailed()
+    {
+        // Arrange
+        var statusChecker = new Mock<IRecurringJobStatusChecker>();
+        statusChecker
+            .Setup(x => x.IsJobEnabledAsync("enabled-job", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var enqueuer = new Mock<IHangfireJobEnqueuer>();
+        enqueuer
+            .Setup(x => x.EnqueueJob(It.IsAny<IRecurringJob>(), It.IsAny<CancellationToken>()))
+            .Returns((string?)null);
+
+        var handler = CreateHandler(
+            jobs: new[] { CreateJob("enabled-job") },
+            statusChecker: statusChecker,
+            enqueuer: enqueuer);
+
+        var request = new TriggerRecurringJobRequest { JobName = "enabled-job", ForceDisabled = false };
+
+        // Act
+        var response = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.RecurringJobEnqueueFailed);
+        response.Params.Should().ContainKey("jobName").WhoseValue.Should().Be("enabled-job");
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail with the expected reasons**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.TriggerRecurringJobHandlerTests" \
+  --no-restore
+```
+
+Expected output:
+- `Handle_WhenJobIsNotRegistered_ReturnsRecurringJobNotFound` → **PASS** (handler already returns `RecurringJobNotFound` for this branch — it is the only correct branch today).
+- `Handle_WhenJobIsDisabledAndForceDisabledIsFalse_ReturnsRecurringJobDisabled` → **FAIL** (handler returns `RecurringJobNotFound` instead of `RecurringJobDisabled`).
+- `Handle_WhenEnqueuerReturnsNull_ReturnsRecurringJobEnqueueFailed` → **FAIL** (handler returns `RecurringJobNotFound` instead of `RecurringJobEnqueueFailed`).
+
+Two failing tests is the RED state we want. Do not commit yet — the next task fixes them.
+
+---
+
+## Task 3: Update `TriggerRecurringJobHandler` failure branches and logging (GREEN)
+
+**Why now:** Make the failing tests pass and augment logs per FR-5.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs`
+
+- [ ] **Step 1: Update the "disabled" branch (current lines 53–64) to return `RecurringJobDisabled` and include `ErrorCode` in the log**
+
+Locate lines 53–64 in `TriggerRecurringJobHandler.cs`:
+
+```csharp
+if (!isEnabled)
+{
+    _logger.LogWarning("Job {JobName} is disabled. Use forceDisabled=true to trigger anyway.", request.JobName);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+Replace with:
+
+```csharp
+if (!isEnabled)
+{
+    _logger.LogWarning(
+        "Job {JobName} is disabled. Use forceDisabled=true to trigger anyway. ErrorCode={ErrorCode}",
+        request.JobName,
+        (int)ErrorCodes.RecurringJobDisabled);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobDisabled,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Update the "enqueue returned null" branch (current lines 70–81) to return `RecurringJobEnqueueFailed` and include `ErrorCode` in the log**
+
+Locate lines 70–81:
+
+```csharp
+if (jobId == null)
+{
+    _logger.LogError("Failed to enqueue job {JobName}", request.JobName);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+Replace with:
+
+```csharp
+if (jobId == null)
+{
+    _logger.LogError(
+        "Failed to enqueue job {JobName}. ErrorCode={ErrorCode}",
+        request.JobName,
+        (int)ErrorCodes.RecurringJobEnqueueFailed);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobEnqueueFailed,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+- [ ] **Step 3: Augment the "not registered" branch (current lines 36–47) log with `ErrorCode` for consistency**
+
+Locate lines 36–47:
+
+```csharp
+if (job == null)
+{
+    _logger.LogWarning("Job {JobName} not found in registered jobs", request.JobName);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+Replace with:
+
+```csharp
+if (job == null)
+{
+    _logger.LogWarning(
+        "Job {JobName} not found in registered jobs. ErrorCode={ErrorCode}",
+        request.JobName,
+        (int)ErrorCodes.RecurringJobNotFound);
+    return new TriggerRecurringJobResponse(
+        ErrorCodes.RecurringJobNotFound,
+        new Dictionary<string, string>
+        {
+            { "jobName", request.JobName },
+            { "forceDisabled", request.ForceDisabled.ToString() }
+        }
+    );
+}
+```
+
+The return value of this branch is unchanged. The error code stays `RecurringJobNotFound` — this is the only branch that should ever produce it.
+
+- [ ] **Step 4: Re-run the handler tests and verify all three pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.TriggerRecurringJobHandlerTests" \
+  --no-restore
+```
+
+Expected: all 3 tests **PASS**.
+
+- [ ] **Step 5: Re-run the existing integration tests to verify the happy path is intact**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.TriggerRecurringJobHandlerIntegrationTests" \
+  --no-restore
+```
+
+Expected: all 3 integration tests **PASS** (no behavior changes on the success path; the handler still calls `_jobEnqueuer.EnqueueJob` exactly the same way).
+
+- [ ] **Step 6: Verify `RecurringJobNotFound` is now only referenced from the not-registered branch in the handler**
+
+```bash
+grep -n "RecurringJobNotFound" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/
+```
+
+Expected: exactly one match, in `TriggerRecurringJobHandler.cs` at the "not registered" branch (currently around line 41–44 after the edits above).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/TriggerRecurringJobHandlerTests.cs
+git commit -m "feat(backgroundjobs): distinguish disabled and enqueue-failure outcomes in TriggerRecurringJob handler
+
+- Disabled branch now returns RecurringJobDisabled (1904) instead of RecurringJobNotFound
+- Enqueue-null branch now returns RecurringJobEnqueueFailed (1905) instead of RecurringJobNotFound
+- Not-registered branch is the sole producer of RecurringJobNotFound (1901)
+- Failure logs now include the ErrorCode structured property
+- New unit tests cover all three failure branches"
+```
+
+---
+
+## Task 4: Update `RecurringJobsController.TriggerJob` to delegate failure mapping to `HandleResponse` (controller TDD — RED first)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs`
+- Modify: `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs:100-121`
+
+The existing controller test file already covers `RecurringJobNotFound → 404` (which keeps working — `BaseApiController.HandleResponse` returns `NotFoundObjectResult` for the `NotFound` status). It also has a misleadingly named test `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` that actually asserts `NotFoundObjectResult` for `RecurringJobUpdateFailed` — that test was masking the bug and must be updated.
+
+- [ ] **Step 1: Rewrite the existing misleading test and add two new failure-mapping tests**
+
+Open `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs`.
+
+Replace the entire body of `TriggerJob_WhenTriggerFails_ShouldReturnBadRequest` (lines 115–140) with a renamed, accurate test, and append two new tests for `RecurringJobDisabled` and `RecurringJobEnqueueFailed`. The replacement code (drop into the class, after the existing `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` test and before `TriggerJob_ShouldPassCancellationTokenToMediator`):
+
+```csharp
+[Fact]
+public async Task TriggerJob_WhenUpdateFailedErrorReturned_ShouldReturn500()
+{
+    // Arrange
+    // RecurringJobUpdateFailed (1902) is annotated [HttpStatusCode(InternalServerError)].
+    // After delegating failure mapping to BaseApiController.HandleResponse, this must
+    // produce an ObjectResult with StatusCode 500 — not a 404 (which the old test
+    // asserted, masking the controller bug).
+    var jobName = "test-job";
+    var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobUpdateFailed);
+
+    _mediatorMock
+        .Setup(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(errorResponse);
+
+    // Act
+    var result = await _controller.TriggerJob(jobName);
+
+    // Assert
+    var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+    returnedResponse.Success.Should().BeFalse();
+    returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobUpdateFailed);
+}
+
+[Fact]
+public async Task TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict()
+{
+    // Arrange
+    var jobName = "disabled-job";
+    var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobDisabled);
+
+    _mediatorMock
+        .Setup(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(errorResponse);
+
+    // Act
+    var result = await _controller.TriggerJob(jobName);
+
+    // Assert
+    var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+    returnedResponse.Success.Should().BeFalse();
+    returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobDisabled);
+}
+
+[Fact]
+public async Task TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError()
+{
+    // Arrange
+    var jobName = "test-job";
+    var errorResponse = new TriggerRecurringJobResponse(ErrorCodes.RecurringJobEnqueueFailed);
+
+    _mediatorMock
+        .Setup(x => x.Send(
+            It.Is<TriggerRecurringJobRequest>(r => r.JobName == jobName),
+            It.IsAny<CancellationToken>()))
+        .ReturnsAsync(errorResponse);
+
+    // Act
+    var result = await _controller.TriggerJob(jobName);
+
+    // Assert
+    var objectResult = result.Result.Should().BeAssignableTo<ObjectResult>().Subject;
+    objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    var returnedResponse = objectResult.Value.Should().BeAssignableTo<TriggerRecurringJobResponse>().Subject;
+    returnedResponse.Success.Should().BeFalse();
+    returnedResponse.ErrorCode.Should().Be(ErrorCodes.RecurringJobEnqueueFailed);
+}
+```
+
+Notes on assertions:
+- `BaseApiController.HandleResponse` returns `NotFoundObjectResult` for `NotFound`, but falls through to the generic `ObjectResult` (via `StatusCode((int)statusCode, response)`) for `Conflict` and `InternalServerError`. The tests therefore assert `ObjectResult` + `StatusCode == 409 / 500`, not `ConflictObjectResult` or any specialized type.
+- The existing test `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` continues to assert `NotFoundObjectResult` and remains unchanged — that is the correct return type for the `NotFound` branch in `HandleResponse`.
+
+- [ ] **Step 2: Run the controller tests and verify the three new/updated tests fail**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTriggerTests" \
+  --no-restore
+```
+
+Expected:
+- `TriggerJob_WithValidJobName_ShouldReturnAcceptedWithSuccessResponse` → **PASS** (success branch unchanged).
+- `TriggerJob_WithNonExistentJobName_ShouldReturnNotFound` → **PASS** (controller currently returns `NotFound(response)` for all failures — happens to be correct for this code).
+- `TriggerJob_WhenUpdateFailedErrorReturned_ShouldReturn500` → **FAIL** (controller returns `NotFoundObjectResult`, test expects `ObjectResult` with 500).
+- `TriggerJob_WhenJobIsDisabled_ShouldReturn409Conflict` → **FAIL** (same reason; 404 vs 409).
+- `TriggerJob_WhenEnqueueFails_ShouldReturn500InternalServerError` → **FAIL** (same reason; 404 vs 500).
+- `TriggerJob_ShouldPassCancellationTokenToMediator` → **PASS** (unchanged).
+
+Three failing tests is the RED state we want.
+
+- [ ] **Step 3: Update `RecurringJobsController.TriggerJob` to delegate failure mapping**
+
+Open `backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs` and locate the `TriggerJob` action (lines 100–121).
+
+Replace lines 100–121 with:
+
+```csharp
+/// <summary>
+/// Manually trigger a recurring job to run immediately
+/// </summary>
+/// <param name="jobName">The name of the job to trigger</param>
+/// <param name="cancellationToken">Cancellation token</param>
+/// <returns>Background job ID if triggered successfully</returns>
+[HttpPost("{jobName}/trigger")]
+[ProducesResponseType(typeof(TriggerRecurringJobResponse), StatusCodes.Status202Accepted)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status404NotFound)]
+[ProducesResponseType(StatusCodes.Status409Conflict)]
+[ProducesResponseType(StatusCodes.Status500InternalServerError)]
+public async Task<ActionResult<TriggerRecurringJobResponse>> TriggerJob(
+    string jobName,
+    CancellationToken cancellationToken = default)
+{
+    var request = new TriggerRecurringJobRequest
+    {
+        JobName = jobName
+    };
+
+    var response = await _mediator.Send(request, cancellationToken);
+
+    if (!response.Success)
+    {
+        return HandleResponse(response);
+    }
+
+    return Accepted(response);
+}
+```
+
+Changes vs. the old version:
+- Added `[ProducesResponseType(StatusCodes.Status409Conflict)]` and `[ProducesResponseType(StatusCodes.Status500InternalServerError)]` decorations.
+- The failure branch now calls `HandleResponse(response)` (from `BaseApiController`) — reflection-based status mapping via the `[HttpStatusCode]` attribute on each `ErrorCodes` value.
+- The success branch still returns `Accepted(response)` → HTTP `202` (preserving existing behavior and matching the `Status202Accepted` `[ProducesResponseType]` decoration).
+- `HandleResponse<T>` returns `ActionResult<T>`; assigning it directly inside an `ActionResult<TriggerRecurringJobResponse>`-returning method works because `ActionResult<T>` has implicit conversion from itself. The C# compiler will accept `return HandleResponse(response);` — no cast needed.
+
+- [ ] **Step 4: Re-run the controller tests and verify all six pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs.RecurringJobsControllerTriggerTests" \
+  --no-restore
+```
+
+Expected: all 6 controller-trigger tests **PASS**.
+
+- [ ] **Step 5: Run the broader BackgroundJobs test set to confirm nothing else regressed**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs" \
+  --no-restore
+```
+
+Expected: all BackgroundJobs tests **PASS**. Pay particular attention to `RecurringJobsControllerTests.cs` (the other controller test file) — it covers the unchanged endpoints (`GetRecurringJobs`, `UpdateJobStatus`, `UpdateJobCron`) and must continue to pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/RecurringJobsController.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobsControllerTriggerTests.cs
+git commit -m "feat(backgroundjobs): map TriggerJob failures via BaseApiController.HandleResponse
+
+The TriggerJob endpoint previously short-circuited every handler failure to
+HTTP 404 NotFound, masking 'disabled' and 'enqueue failed' outcomes. It now
+delegates failure mapping to BaseApiController.HandleResponse, which reads
+the [HttpStatusCode] attribute on each ErrorCodes value — matching the
+convention already used by GetRecurringJobs, UpdateJobStatus, and UpdateJobCron
+in the same controller.
+
+- 404 NotFound for RecurringJobNotFound (1901)
+- 409 Conflict for RecurringJobDisabled (1904)
+- 500 InternalServerError for RecurringJobEnqueueFailed (1905) and any other failure
+
+The 202 Accepted success path is preserved. ProducesResponseType decorations
+updated to advertise the new statuses."
+```
+
+---
+
+## Task 5: Full backend verification
+
+**Files:** none modified.
+
+This is the project-wide gate from `CLAUDE.md` ("Validation before completion"). No further code changes — only verification.
+
+- [ ] **Step 1: Format**
+
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+Expected: no formatting violations remain. If any files are reformatted, stage them and amend the most recent commit OR add a follow-up `chore: dotnet format` commit — do not skip formatting.
+
+- [ ] **Step 2: Full backend build**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded. 0 Errors`. Warnings present before the change should not increase.
+
+- [ ] **Step 3: Full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build
+```
+
+Expected: all tests **PASS**. The change touches a single use case and one controller action; broader test impact is not expected, but the full run confirms no transitive coupling was missed.
+
+- [ ] **Step 4: Final `grep` audit — exactly one production usage of `ErrorCodes.RecurringJobNotFound`**
+
+```bash
+grep -rn "ErrorCodes.RecurringJobNotFound" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/
+```
+
+Expected: exactly one match, in `TriggerRecurringJobHandler.cs` (the "not registered" branch). Any additional production-code matches indicate the refactor is incomplete.
+
+- [ ] **Step 5: If anything was reformatted in Step 1, commit it**
+
+```bash
+git status
+# If files were changed by dotnet format:
+git add -A
+git commit -m "chore: apply dotnet format after error-code refactor"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Self-Review
+
+**Spec coverage check (against `spec.r1.md` + `arch-review.r1.md` amendments):**
+
+| Requirement | Implemented in |
+|-------------|----------------|
+| FR-1 `RecurringJobDisabled = 1904` (amended from 1903) | Task 1 |
+| FR-2 `RecurringJobEnqueueFailed = 1905` (amended from 1904) | Task 1 |
+| FR-3 `RecurringJobNotFound` restricted to not-registered branch | Task 3 Step 6; Task 5 Step 4 (audit) |
+| FR-4 HTTP status mapping (amended: via `[HttpStatusCode]` + `HandleResponse`, not switch) | Task 1 (attributes) + Task 4 (`HandleResponse` delegation) |
+| FR-5 Logging continuity (severity preserved; `ErrorCode` added as structured property) | Task 3 Steps 1–3 |
+| FR-6 Unit test coverage for three handler branches and three controller mappings | Task 2 (handler) + Task 4 (controller) |
+| NFR-1 Performance: constant lookups, switch, log property — no measurable impact | No work item (architectural property of the chosen design) |
+| NFR-2 Security: unchanged auth, no internal leaks beyond job id and code | No work item (no new error-message fields introduced) |
+| NFR-3 Backward compatibility: response DTO shape unchanged; behavioral change in HTTP status called out in commit messages | Task 4 Step 6 commit body |
+| NFR-4 Observability: three distinct buckets visible in dashboards | Task 1 + Task 3 |
+| Arch-review amendment: success path is `202 Accepted` (not `200 OK`) | Task 4 Step 3 — `return Accepted(response);` preserved |
+| Arch-review amendment: `[HttpStatusCode]` attribute approach replaces controller `switch` | Task 1 (attributes) + Task 4 Step 3 (controller delegation) |
+
+**Placeholder scan:** All steps contain concrete code/commands and explicit expected outputs. No TBD, no "implement later", no "similar to Task N". Code blocks are full and self-contained.
+
+**Type / signature consistency:**
+- `ErrorCodes.RecurringJobDisabled` and `ErrorCodes.RecurringJobEnqueueFailed` — same names used across Tasks 1, 2, 3, 4.
+- `TriggerRecurringJobResponse(ErrorCodes)` constructor — used identically in handler edits (Task 3) and controller tests (Task 4).
+- `HandleResponse(response)` (lowercase `r`, single argument) — matches the actual signature on `BaseApiController` (`backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs:28`).
+- `BaseApiController.HandleResponse` does not have a dedicated `ConflictObjectResult` branch in its `switch`; for `Conflict` and `InternalServerError` it returns `StatusCode((int)statusCode, response)` which produces an `ObjectResult`. Tests assert on `ObjectResult` + `StatusCode == 409 / 500` accordingly (Task 4 Step 1) — confirmed against `BaseApiController.cs:45-54`.
+- `IRecurringJob.Metadata` returns `RecurringJobMetadata` with `JobName`, `DisplayName`, `Description`, `CronExpression` — matches the test helper in Task 2 Step 1 and the existing usage in `TriggerRecurringJobHandlerIntegrationTests.cs:188-194`.
+
+**Out-of-scope reminders (per arch-review):**
+- The controller does not currently bind `ForceDisabled` from the request. The new `RecurringJobDisabled` code is therefore unreachable via HTTP today — only via in-process callers (e.g., the new unit tests) — until a follow-up adds `[FromQuery] bool forceDisabled = false` to `TriggerJob`. This is intentionally out of scope for this plan. Flag it in the PR description.
+- The spec's NFR-3 / arch-review "Risks" call out the behavior change for any HTTP client that relied on `404` for any failure. This is intentional and must be highlighted in the PR description and release notes (see Task 4 Step 6 commit body).

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -190,8 +190,6 @@ const resources = {
         RecurringJobNotFound: "Opakovaná úloha nenalezena",
         RecurringJobUpdateFailed: "Aktualizace opakované úlohy selhala",
         InvalidCronExpression: "Neplatný výraz CRON",
-        RecurringJobDisabled: "Opakovaná úloha je vypnutá",
-        RecurringJobEnqueueFailed: "Zařazení opakované úlohy do fronty se nezdařilo",
 
         // KnowledgeBase module errors
         KnowledgeBaseFeedbackLogNotFound: "Záznam zpětné vazby nenalezen",

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -190,6 +190,8 @@ const resources = {
         RecurringJobNotFound: "Opakovaná úloha nenalezena",
         RecurringJobUpdateFailed: "Aktualizace opakované úlohy selhala",
         InvalidCronExpression: "Neplatný výraz CRON",
+        RecurringJobDisabled: "Opakovaná úloha je vypnutá",
+        RecurringJobEnqueueFailed: "Zařazení opakované úlohy do fronty se nezdařilo",
 
         // KnowledgeBase module errors
         KnowledgeBaseFeedbackLogNotFound: "Záznam zpětné vazby nenalezen",


### PR DESCRIPTION
BackgroundJobs

## Finding
`TriggerRecurringJobHandler` uses `ErrorCodes.RecurringJobNotFound` (1901) for three semantically distinct failure conditions:

| Line | Actual condition | Error code used |
|------|-----------------|-----------------|
| 39 | Job not registered in DI (genuinely not found) | `RecurringJobNotFound` ✅ |
| 57 | Job is found but disabled, `ForceDisabled=false` | `RecurringJobNotFound` ❌ |
| 74 | Job found and enabled, but `IHangfireJobEnqueuer.EnqueueJob` returned `null` | `RecurringJobNotFound` ❌ |

File: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/UseCases/TriggerRecurringJob/TriggerRecurringJobHandler.cs`

The controller maps `!response.Success` → HTTP 404 (`NotFound`):

```csharp
// RecurringJobsController.cs lines 116-119
if (!response.Success)
{
    return NotFound(response);
}
```

So a disabled job or a failed enqueue both surface to the API consumer as `404 Not Found` with error code 1901, which is factually incorrect.

## Why it matters
API consumers (frontend, monitoring tools) cannot distinguish "job doesn't exist" from "job is disabled" or "Hangfire failed to enqueue". Correct HTTP semantics would be:
- Job disabled → `409 Conflict` or `422 Unprocessable Entity`
- Enqueue failure → `500 Internal Server Error`

Misusing a single error code also makes error monitoring ambiguous.

## Suggested fix
Add two new error codes to `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs`:

```csharp
RecurringJobDisabled = 1903,
RecurringJobEnqueueFailed = 1904,
```

Return `RecurringJobDisabled` when the job is found-but-disabled, and `RecurringJobEnqueueFailed` when `EnqueueJob` returns `null`. Update the controller to check `response.ErrorCode` and return the appropriate HTTP status for each case.

---
_Filed by daily arch-review routine on 2026-05-27._

---

Closes #1818

### Tokens used
19573101
