### PR TITLE
feat: Consolidate Hangfire RecurringJob Registration

### DIFF
--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/arch-review.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/arch-review.r1.md
@@ -1,0 +1,270 @@
+I have enough context. Key finding: the spec's FR-6 proposes placing the helper in `Anela.Heblo.API/Infrastructure/Hangfire/`, but this would create a circular dependency — the `Application` project does not (and per Clean Architecture cannot) reference `API`. The helper must live where both call sites can reach it: in the `Application` project (which already references `Hangfire.Core`).
+
+```markdown
+# Architecture Review: Consolidate Hangfire RecurringJob Registration
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The feature is a pure backend refactor inside the BackgroundJobs vertical slice. It does not introduce a new pattern — it removes duplication of an existing one. The cross-cutting concern (binding a runtime `Type` to `RecurringJob.AddOrUpdate<TJob>`) is currently implemented twice, once in `Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs:79–142` and once in `Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs:41–81`, with divergent Hangfire overloads. Both call sites already depend on `IRecurringJob` (domain) and Hangfire's static `RecurringJob` API.
+
+Main integration points:
+- **`IRecurringJob`** (`Anela.Heblo.Domain.Features.BackgroundJobs.IRecurringJob`) — the generic constraint and the source of `Metadata.JobName`, `Metadata.CronExpression`, `Metadata.TimeZoneId`, and the `ExecuteAsync(CancellationToken)` entry point.
+- **`RecurringJobDiscoveryService`** (`IHostedService` in API) — startup registration.
+- **`HangfireRecurringJobScheduler`** (singleton service in Application, behind `IHangfireRecurringJobScheduler`) — runtime CRON updates, consumed by `UpdateRecurringJobCronHandler`.
+- **Existing test fixture** (`backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/RecurringJobDiscoveryServiceTests.cs`) — already exercises the registration path via Hangfire's in-memory storage in a `[Collection("Hangfire")]` collection fixture.
+
+### Critical correction to FR-6 (helper placement)
+
+**The spec's proposed location (`Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`) is not viable.** Project references confirm:
+
+- `Anela.Heblo.API.csproj:58` references `Anela.Heblo.Application`.
+- `Anela.Heblo.Application.csproj` does **not** reference `Anela.Heblo.API` (and must not — that would be a circular project reference).
+- `Anela.Heblo.Application.csproj:13` already pulls in `Hangfire.Core` 1.8.21, so the Application layer can legally call `RecurringJob.AddOrUpdate<TJob>` and construct `RecurringJobOptions` directly.
+
+The helper **must live in `Anela.Heblo.Application`** so `HangfireRecurringJobScheduler` can call it without inverting the layer dependency. `RecurringJobDiscoveryService` (in API) reaches it via the existing API → Application reference, which is the correct direction.
+
+The spec's rationale (helper sits "next to the only layer that references Hangfire") is factually wrong: both layers already reference Hangfire, and only Application is reachable from both call sites.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+                 ┌─────────────────────────────────────────────────────────┐
+                 │  Anela.Heblo.Domain.Features.BackgroundJobs             │
+                 │    IRecurringJob                                        │
+                 │    RecurringJobMetadata (JobName/Cron/TimeZoneId)       │
+                 └─────────────────────────────────────────────────────────┘
+                                          ▲
+                                          │
+   ┌──────────────────────────────────────┴──────────────────────────────┐
+   │  Anela.Heblo.Application.Features.BackgroundJobs                    │
+   │                                                                     │
+   │   Services/                                                         │
+   │     HangfireJobRegistrationHelper  ◄────── single call site to      │
+   │       └─ RegisterOrUpdate(jobType, name, cron, tzId)                │
+   │           └─ reflection → RegisterOrUpdateGeneric<TJob>             │
+   │               └─ RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)
+   │                                                                     │
+   │     HangfireRecurringJobScheduler  ─── calls helper ───┐            │
+   │     (IHangfireRecurringJobScheduler)                   │            │
+   │                                                        ▼            │
+   └────────────────────────────────────────────────────────┼────────────┘
+                                          ▲                 │
+                                          │  uses           │
+   ┌──────────────────────────────────────┴─────────────────┴────────────┐
+   │  Anela.Heblo.API.Infrastructure.Hangfire                            │
+   │     RecurringJobDiscoveryService (IHostedService)                   │
+   │       └─ for each IRecurringJob: calls helper                       │
+   └─────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Helper location — Application, not API
+
+**Options considered:**
+- (A) Place helper in `Anela.Heblo.API/Infrastructure/Hangfire/` (spec's FR-6).
+- (B) Place helper in `Anela.Heblo.Application/Features/BackgroundJobs/Services/`.
+- (C) Place helper in a shared cross-cutting project (e.g., `Anela.Heblo.Xcc`).
+
+**Chosen approach:** (B) — `Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`.
+
+**Rationale:** (A) is impossible (Application cannot reference API). (C) leaks Hangfire knowledge into a layer that today has no business with the BackgroundJobs slice. (B) co-locates the helper with `HangfireRecurringJobScheduler` (already in this folder), keeps the vertical slice cohesive, respects the existing Clean Architecture dependency direction (`API → Application → Domain`), and only requires Application to use `Hangfire.Core` — which it already does.
+
+#### Decision 2: Helper API shape
+
+**Options considered:**
+- (A) Spec's signature: `static void RegisterOrUpdate(Type jobType, string jobName, string cronExpression, string timeZoneId)`.
+- (B) Accept `IRecurringJob` instance and read metadata internally: `static void RegisterOrUpdate(IRecurringJob job, string cronExpression)`.
+
+**Chosen approach:** (A). The CRON expression is **not** always `job.Metadata.CronExpression` — `RecurringJobDiscoveryService` prefers the DB-stored value over metadata (`RecurringJobDiscoveryService.cs:69–77`), and `HangfireRecurringJobScheduler.UpdateCronSchedule` is invoked precisely because a new CRON arrived from the API. The helper's contract therefore must accept CRON as an explicit parameter; making it derive from metadata would force callers to mutate metadata first or violate the immutability of `RecurringJobMetadata` (its members are `init`-only). The `jobType` + (name, cron, tz) tuple is the minimum stable surface.
+
+#### Decision 3: Standardise on the `RecurringJobOptions` overload
+
+**Options considered:**
+- (A) Standardise on the legacy `TimeZoneInfo` overload.
+- (B) Standardise on the `RecurringJobOptions` overload (spec's FR-2).
+
+**Chosen approach:** (B). The `RecurringJobOptions` overload is the supported newer API (Hangfire 1.8+). The legacy overload is retained only for backward compatibility and risks divergent defaults (misfire policy, queue assignment) as Hangfire evolves. The startup path already uses (B); standardising the scheduler path closes the gap.
+
+#### Decision 4: Generic dispatch via reflection (no change)
+
+**Options considered:**
+- (A) Keep the reflection plumbing (resolve a private generic method by name, close it with `MakeGenericMethod`, invoke).
+- (B) Replace reflection with a non-generic Hangfire API path (e.g., `IRecurringJobManager.AddOrUpdate` with a serialised job descriptor).
+- (C) Code-generate a dispatcher per `IRecurringJob` implementation.
+
+**Chosen approach:** (A). (B) is explicitly out of scope per the spec, and Hangfire's non-generic surface requires more invasive changes (serialised job descriptor, manual storage interaction) that would break feature parity. (C) is gold-plating for an N≤10 set of recurring jobs invoked once at startup and per-CRON-edit. Reflection cost is negligible at this call rate.
+
+#### Decision 5: Internal vs. public helper visibility
+
+**Options considered:**
+- (A) `internal static` (spec's sketch).
+- (B) `public static`.
+
+**Chosen approach:** (B) — `public static`. The helper sits in `Anela.Heblo.Application` and is consumed by `Anela.Heblo.API`. Because these are separate assemblies, `internal` would block the API call site. Existing service classes in this folder (`HangfireRecurringJobScheduler`) are also `public`. Keep the private generic dispatcher method (`RegisterOrUpdateGeneric<TJob>`) `private static` since reflection ignores visibility — this preserves the spec's intent of "no public generic surface".
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New file (the only file added):
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`
+
+Modified files:
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs`
+  - Remove the `RegisterRecurringJobInternal<TJob>` method (lines 129–142) and the reflection dispatch (lines 79–96).
+  - Replace with a single call: `HangfireJobRegistrationHelper.RegisterOrUpdate(jobType, metadata.JobName, cronExpression, metadata.TimeZoneId);`.
+  - Add `using Anela.Heblo.Application.Features.BackgroundJobs.Services;`.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs`
+  - Remove the `UpdateJobInternal<TJob>` method (lines 71–81) and the reflection dispatch (lines 42–55).
+  - Replace with a single call: `HangfireJobRegistrationHelper.RegisterOrUpdate(jobType, jobName, cronExpression, job.Metadata.TimeZoneId);`.
+  - Remove the now-unused `using System.Reflection;`.
+
+No DI changes. No `BackgroundJobsModule` changes. No `csproj` changes.
+
+### Interfaces and Contracts
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+public static class HangfireJobRegistrationHelper
+{
+    /// <summary>
+    /// Registers or updates a Hangfire recurring job for the given runtime job type.
+    /// Always uses the RecurringJobOptions overload to keep startup and live-update
+    /// paths identical.
+    /// </summary>
+    /// <exception cref="ArgumentException">Any string argument is null/empty/whitespace.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="jobType"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="jobType"/> does not implement <see cref="IRecurringJob"/>.</exception>
+    /// <exception cref="TimeZoneNotFoundException">The time zone id is not resolvable on this host.</exception>
+    public static void RegisterOrUpdate(
+        Type jobType,
+        string jobName,
+        string cronExpression,
+        string timeZoneId);
+}
+```
+
+Internal contract (private, reflection target):
+
+```csharp
+private static void RegisterOrUpdateGeneric<TJob>(
+    string jobName,
+    string cronExpression,
+    string timeZoneId)
+    where TJob : IRecurringJob
+{
+    RecurringJob.AddOrUpdate<TJob>(
+        jobName,
+        job => job.ExecuteAsync(default),
+        cronExpression,
+        new RecurringJobOptions
+        {
+            TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+        });
+}
+```
+
+Input validation order (fail fast, in this order, to keep error messages deterministic):
+1. `ArgumentNullException.ThrowIfNull(jobType)`.
+2. `ArgumentException.ThrowIfNullOrWhiteSpace(jobName)`.
+3. `ArgumentException.ThrowIfNullOrWhiteSpace(cronExpression)`.
+4. `ArgumentException.ThrowIfNullOrWhiteSpace(timeZoneId)`.
+5. `if (!typeof(IRecurringJob).IsAssignableFrom(jobType)) throw new ArgumentException($"{jobType.FullName} does not implement {nameof(IRecurringJob)}.", nameof(jobType));`.
+6. Reflection: `typeof(HangfireJobRegistrationHelper).GetMethod(nameof(RegisterOrUpdateGeneric), BindingFlags.NonPublic | BindingFlags.Static)` → close → `Invoke`.
+
+**Exception propagation:** Wrap the `Invoke` call so that `TargetInvocationException` is unwrapped (`ex.InnerException ?? ex`) and rethrown. Today `HangfireRecurringJobScheduler.UpdateCronSchedule` catches `Exception` and logs at line 57–64 — that catch must stay in the scheduler. Do **not** swallow exceptions inside the helper; let callers decide logging policy. (`RecurringJobDiscoveryService` already wraps each registration in a per-job try/catch at lines 67–107.)
+
+### Data Flow
+
+**Startup registration:**
+```
+RecurringJobDiscoveryService.StartAsync
+  → resolve IEnumerable<IRecurringJob> from DI
+  → load RecurringJobConfiguration list from repository
+  → for each job:
+      compute cronExpression (DB override or metadata default)
+      → HangfireJobRegistrationHelper.RegisterOrUpdate(
+            job.GetType(), metadata.JobName, cronExpression, metadata.TimeZoneId)
+        → RegisterOrUpdateGeneric<TJob>(...)
+          → RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions { TimeZone = ... })
+```
+
+**Runtime CRON update:**
+```
+UpdateRecurringJobCronHandler.Handle
+  → repository.UpdateAsync (persist new CRON)
+  → IHangfireRecurringJobScheduler.UpdateCronSchedule(jobName, cron)
+      → resolve IRecurringJob instance by JobName
+      → HangfireJobRegistrationHelper.RegisterOrUpdate(
+            job.GetType(), jobName, cronExpression, job.Metadata.TimeZoneId)
+        → same code path as startup
+```
+
+Both paths now produce identical Hangfire `RecurringJob` records: same overload, same `RecurringJobOptions.TimeZone`, same defaults for the unspecified options.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Hangfire metadata drift between old and new code paths after deploy (existing recurring jobs in storage were last written with the legacy overload) | LOW | First scheduler call (or first startup after deploy) overwrites the entry with the `RecurringJobOptions` overload. The `RecurringJob.AddOrUpdate` upsert semantics handle this. No data migration required. |
+| `TargetInvocationException` swallowed at the helper boundary, hiding root cause | MEDIUM | Helper unwraps `TargetInvocationException` and rethrows the inner exception. Existing per-job try/catch blocks in both callers log structured context. |
+| `TimeZoneInfo.FindSystemTimeZoneById` fails on non-IANA hosts (Windows containers, exotic Linux images) | LOW | Behaviour is unchanged from today — both call sites already invoke this. Helper preserves the existing failure mode; scheduler keeps its catch + warning log. |
+| Reflection target method renamed without test coverage breaking | MEDIUM | Helper passes `nameof(RegisterOrUpdateGeneric)` to `GetMethod`, so renames in modern IDEs follow. Add a unit test that asserts the helper can resolve and invoke the private dispatcher for an `IRecurringJob` test double (see Testing below). |
+| Application now contains Hangfire registration logic that previously lived only in API infrastructure — perceived as a layering smell | LOW | Application already references `Hangfire.Core` and already contains `HangfireRecurringJobScheduler` and `HangfireJobEnqueuer` services. The helper is a peer to those existing services, not a new layering exception. |
+| `RecurringJobOptions`-based registration may use different default queue/misfire policy than the legacy overload, causing a subtle behaviour change in production | LOW | Hangfire's `RecurringJobOptions` defaults match the legacy overload's defaults for everything except explicitly-set properties (only `TimeZone` is set). Verified by Hangfire docs. Behaviour parity test (see below) confirms. |
+
+## Specification Amendments
+
+### Amendment 1: Correct FR-6 helper location
+
+Replace FR-6 acceptance criteria with:
+
+> - The helper lives under `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`.
+> - The helper is `public static` so the API project can consume it across assembly boundaries.
+> - Both consumers (`RecurringJobDiscoveryService` in `Anela.Heblo.API` and `HangfireRecurringJobScheduler` in `Anela.Heblo.Application`) compile without introducing new project references — the existing `Anela.Heblo.API → Anela.Heblo.Application` reference is sufficient.
+
+**Rationale:** `Anela.Heblo.Application` cannot reference `Anela.Heblo.API`; placing the helper in API as the spec proposes would create a circular project reference. Application already references `Hangfire.Core`, so all required types are available.
+
+### Amendment 2: Make helper visibility `public`
+
+Replace the spec's `internal static class HangfireJobRegistrationHelper` with `public static class HangfireJobRegistrationHelper`. Cross-assembly consumption from the API project is required; `internal` would break the build. The private generic dispatcher remains `private static` — reflection resolves it via `BindingFlags.NonPublic`.
+
+### Amendment 3: Explicit exception unwrapping
+
+Add to FR-1 acceptance criteria:
+
+> - The helper unwraps `TargetInvocationException` thrown by `MethodInfo.Invoke` and rethrows the inner exception so callers see the underlying Hangfire/TimeZone failure directly.
+
+### Amendment 4: Add a behaviour-parity test
+
+Add to FR-5 acceptance criteria (under existing test coverage):
+
+> - A new test in `RecurringJobDiscoveryServiceTests.cs` (or a sibling `HangfireRecurringJobSchedulerTests.cs`) registers a recurring job via `RecurringJobDiscoveryService.StartAsync`, then updates its CRON via `HangfireRecurringJobScheduler.UpdateCronSchedule`, and asserts that the resulting Hangfire `RecurringJob` entry has the expected `Cron`, `TimeZoneId`, and method signature. This protects against future overload drift.
+
+### Amendment 5: Helper unit tests
+
+Add to FR-1 acceptance criteria:
+
+> - A new `HangfireJobRegistrationHelperTests` class (mirroring `RecurringJobDiscoveryServiceTests`'s use of `[Collection("Hangfire")]` and in-memory storage) covers:
+>   - Successful registration of a test `IRecurringJob` implementation.
+>   - `ArgumentException`/`ArgumentNullException` on each invalid input.
+>   - `ArgumentException` when `jobType` does not implement `IRecurringJob`.
+>   - Exception unwrapping behaviour (e.g., invalid time-zone id surfaces as `TimeZoneNotFoundException`, not `TargetInvocationException`).
+
+## Prerequisites
+
+None. The refactor is self-contained:
+
+- No database migration (Hangfire storage schema unchanged; `RecurringJobConfiguration` table unchanged).
+- No DI / module registration changes (`BackgroundJobsModule` and `ServiceCollectionExtensions` are untouched).
+- No new NuGet packages (`Hangfire.Core` is already a dependency of `Anela.Heblo.Application`).
+- No configuration changes (`HangfireOptions`, `appsettings`, etc.).
+- No public API surface change (HTTP, MediatR, DTOs, frontend, OpenAPI client all unaffected).
+- Existing test infrastructure (`HangfireTestFixture`, `[Collection("Hangfire")]`) is reusable as-is for the new helper tests.
+```

--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/brief.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/brief.md
@@ -1,0 +1,39 @@
+## Module
+BackgroundJobs
+
+## Finding
+Two separate classes build a generic `RecurringJob.AddOrUpdate<TJob>` call via reflection, but use different `Hangfire` API overloads:
+
+**`RecurringJobDiscoveryService.RegisterRecurringJobInternal<TJob>`**  
+`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` lines 129–142:
+```csharp
+RecurringJob.AddOrUpdate<TJob>(
+    jobName,
+    job => job.ExecuteAsync(default),
+    cronExpression,
+    new RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId) });
+```
+
+**`HangfireRecurringJobScheduler.UpdateJobInternal<TJob>`**  
+`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` lines 71–80:
+```csharp
+RecurringJob.AddOrUpdate<TJob>(
+    jobName,
+    j => j.ExecuteAsync(default),
+    cronExpression,
+    TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+```
+
+The two overloads of `RecurringJob.AddOrUpdate` have different behaviour: the `RecurringJobOptions` overload is the newer API and supports additional options; the bare `TimeZoneInfo` overload is a legacy signature. This means startup registration (via `RecurringJobDiscoveryService`) and live CRON update (via `HangfireRecurringJobScheduler`) silently use different code paths, which could produce subtle inconsistencies when Hangfire updates its defaults for the legacy overload.
+
+Both methods also duplicate the same reflection plumbing to resolve the generic method by name (`GetMethod(nameof(...), NonPublic | Static)` → `MakeGenericMethod(jobType)` → `Invoke`).
+
+## Why it matters
+- Real code duplication: the same reflection pattern appears in two places; future changes (e.g., adding a queue name or priority) must be applied twice
+- Divergent overloads: a change to timezone handling or job options will only be applied to whichever site is edited first
+
+## Suggested fix
+Extract a single shared static helper (e.g., `HangfireJobRegistrationHelper.RegisterOrUpdate<TJob>`) in the API infrastructure layer, called by both `RecurringJobDiscoveryService` and `HangfireRecurringJobScheduler`. Standardise on the `RecurringJobOptions` overload. This removes the duplication and ensures startup registration and live updates follow identical paths.
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/impl.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/impl.r1.md
@@ -1,0 +1,68 @@
+# Implementation: Consolidate Hangfire RecurringJob Registration
+
+## What was implemented
+
+Extracted shared `HangfireJobRegistrationHelper` that centralises the reflection-based generic dispatch and the call to `RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)`. Both startup registration (`RecurringJobDiscoveryService`) and runtime CRON updates (`HangfireRecurringJobScheduler`) now delegate to this single helper, eliminating duplicated reflection plumbing and standardising on the newer `RecurringJobOptions` overload across both code paths.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — new public static helper; validates inputs, resolves private `RegisterOrUpdateGeneric<TJob>` via reflection, invokes `RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)`, unwraps `TargetInvocationException`
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — replaced reflection block (lines 79–96) + deleted `RegisterRecurringJobInternal<TJob>` private method; now calls helper; updated usings
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` — replaced reflection block (lines 41–64) + deleted `UpdateJobInternal<TJob>` private method; now calls helper; updated XML doc and usings
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — new unit tests (TDD red→green): 8 test methods covering successful registration, idempotent updates, all argument validation cases, type-contract enforcement, and `TargetInvocationException` unwrapping
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs` — new behaviour-parity tests: 3 tests covering unknown-job no-op, CRON update after discovery registration, and structural parity between discovery and scheduler registration paths
+
+## Tests
+
+| File | Coverage |
+|------|----------|
+| `HangfireJobRegistrationHelperTests.cs` | Valid registration; idempotent update; null `jobType`; null/empty/whitespace `jobName`, `cronExpression`, `timeZoneId`; non-`IRecurringJob` type; `TimeZoneNotFoundException` unwrapping |
+| `HangfireRecurringJobSchedulerTests.cs` | Unknown job name (no-op); CRON update after startup registration; structural parity (return type, timezone, job type, method name identical after both paths) |
+| `RecurringJobDiscoveryServiceTests.cs` (existing) | All 3 pre-existing tests continue to pass |
+
+Total BackgroundJobs test count: **88 passed, 0 failed**.
+
+## How to verify
+
+```bash
+# Run all BackgroundJobs tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Features.BackgroundJobs" --nologo
+
+# Confirm exactly one RecurringJob.AddOrUpdate call site
+grep -rn "RecurringJob.AddOrUpdate" backend/src
+# Expected: 1 match in HangfireJobRegistrationHelper.cs
+
+# Confirm no orphaned old methods
+grep -rn "RegisterRecurringJobInternal\|UpdateJobInternal" backend/src backend/test
+# Expected: no matches
+
+# Full build
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+## Notes
+
+- **Helper location corrected from spec FR-6**: Spec proposed `Anela.Heblo.API/Infrastructure/Hangfire/`; architecture review (Amendment 1) corrected to `Anela.Heblo.Application/Features/BackgroundJobs/Services/` because `Application` cannot reference `API` (circular). Application already references `Hangfire.Core`.
+- **`public static` visibility** (Amendment 2): `internal` would block API-project consumption across assembly boundaries.
+- **`TargetInvocationException` unwrapping** (Amendment 3): Helper rethrows `ex.InnerException` so callers see `TimeZoneNotFoundException` directly; both caller try/catch blocks log structured context as before.
+- **Legacy `TimeZoneInfo` overload** is fully removed from the codebase; the single call site in `RegisterOrUpdateGeneric<TJob>` uses `RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId) }` only.
+- No `csproj` changes, no DI changes, no database migrations, no public API surface changes.
+
+## PR Summary
+
+Consolidated duplicated Hangfire recurring-job registration into a single `HangfireJobRegistrationHelper`, eliminating two independent copies of the reflection plumbing (`GetMethod → MakeGenericMethod → Invoke`) and standardising both startup and runtime-update paths on the `RecurringJobOptions` overload.
+
+Before this change, `RecurringJobDiscoveryService` (startup) used the `RecurringJobOptions` overload while `HangfireRecurringJobScheduler` (runtime updates) used the legacy `TimeZoneInfo` overload, meaning the two code paths could produce subtly different Hangfire recurring-job records and any future option (queue name, misfire policy, retry count) would require editing both files.
+
+After this change there is exactly one `RecurringJob.AddOrUpdate<TJob>` call site in the entire solution; all future changes to recurring-job registration are made in one place.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — new shared helper: input validation, reflection dispatch, `RecurringJobOptions` overload, `TargetInvocationException` unwrapping
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — delegates to helper; reflection block + private generic method removed
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` — delegates to helper; reflection block + private generic method removed
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — unit tests for the new helper (8 cases)
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs` — behaviour-parity tests (3 cases)
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/impl/main.r1.md
@@ -1,0 +1,33 @@
+---
+
+# Implementation: Consolidate Hangfire RecurringJob Registration
+
+## Status: DONE ✅
+
+All 6 tasks completed, both spec and code quality reviews passed for each.
+
+### What was built
+
+Extracted `HangfireJobRegistrationHelper` — a single shared helper that replaces two independent copies of reflection-based `RecurringJob.AddOrUpdate<TJob>` plumbing. Both startup registration (`RecurringJobDiscoveryService`) and runtime CRON updates (`HangfireRecurringJobScheduler`) now delegate to it, and both produce identical Hangfire records via the `RecurringJobOptions` overload.
+
+### Key architectural correction applied
+
+Spec FR-6 proposed placing the helper in the API project — the architecture review correctly flagged this as a circular dependency. Helper lives in `Anela.Heblo.Application/Features/BackgroundJobs/Services/` (public static) where both consumers can reach it via the existing `API → Application` reference.
+
+### Commits
+
+| SHA | Description |
+|-----|-------------|
+| `525245a6` | `test: add HangfireJobRegistrationHelper unit tests (red)` |
+| `7ce1ac77` | `feat(background-jobs): add HangfireJobRegistrationHelper` |
+| `607b23e0` | `refactor(background-jobs): route RecurringJobDiscoveryService through HangfireJobRegistrationHelper` |
+| `be6add90` | `refactor(background-jobs): route HangfireRecurringJobScheduler through HangfireJobRegistrationHelper` |
+| `eb63d094` | `test: add HangfireRecurringJobScheduler parity tests` |
+
+### Validation results
+
+- **88 BackgroundJobs tests** — 0 failures
+- **Build** — 0 errors
+- **Single `RecurringJob.AddOrUpdate` call site** confirmed in `HangfireJobRegistrationHelper.cs` only
+- **No orphaned** `RegisterRecurringJobInternal` or `UpdateJobInternal` references
+- **Legacy `TimeZoneInfo` overload** fully eliminated

--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/impl/main.r1.md
@@ -1,33 +1,64 @@
+Now writing the final implementation artifact:
+
 ---
 
 # Implementation: Consolidate Hangfire RecurringJob Registration
 
-## Status: DONE ✅
+## What was implemented
 
-All 6 tasks completed, both spec and code quality reviews passed for each.
+Extracted a single shared `HangfireJobRegistrationHelper` to replace two duplicated reflection-based Hangfire registration paths. Both `RecurringJobDiscoveryService` (startup) and `HangfireRecurringJobScheduler` (runtime CRON updates) now delegate to the helper, ensuring both paths use the same `RecurringJobOptions` overload and produce identical Hangfire `RecurringJob` records.
 
-### What was built
+## Files created/modified
 
-Extracted `HangfireJobRegistrationHelper` — a single shared helper that replaces two independent copies of reflection-based `RecurringJob.AddOrUpdate<TJob>` plumbing. Both startup registration (`RecurringJobDiscoveryService`) and runtime CRON updates (`HangfireRecurringJobScheduler`) now delegate to it, and both produce identical Hangfire records via the `RecurringJobOptions` overload.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — Public static helper: validates inputs, resolves private generic dispatcher via reflection, invokes `RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)`, unwraps `TargetInvocationException`
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — Removed `RegisterRecurringJobInternal<TJob>` + reflection dispatch; now calls `HangfireJobRegistrationHelper.RegisterOrUpdate(...)` 
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` — Removed `UpdateJobInternal<TJob>` (legacy `TimeZoneInfo` overload) + reflection dispatch; now calls helper; removed `using System.Reflection` and `using Hangfire`
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — 11 test cases covering: successful registration, update-on-second-call, ArgumentNullException, ArgumentException for all 3 string args (Theory ×3 each), ArgumentException for non-IRecurringJob type (verifies paramName), TimeZoneNotFoundException unwrapping
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs` — 3 parity tests: unknown-job-name returns cleanly, update-after-discovery changes CRON, structural parity (job type/method/timezone match between discovery and scheduler paths)
 
-### Key architectural correction applied
+## Tests
 
-Spec FR-6 proposed placing the helper in the API project — the architecture review correctly flagged this as a circular dependency. Helper lives in `Anela.Heblo.Application/Features/BackgroundJobs/Services/` (public static) where both consumers can reach it via the existing `API → Application` reference.
+- `HangfireJobRegistrationHelperTests` — 11 cases; all pass
+- `HangfireRecurringJobSchedulerTests` — 3 cases; all pass
+- Existing `RecurringJobDiscoveryServiceTests` — 3 cases; continue to pass
+- Full BackgroundJobs suite: **88 tests pass, 0 failures**
+- Full solution build: **0 errors, 12 pre-existing warnings**
 
-### Commits
+## How to verify
 
-| SHA | Description |
-|-----|-------------|
-| `525245a6` | `test: add HangfireJobRegistrationHelper unit tests (red)` |
-| `7ce1ac77` | `feat(background-jobs): add HangfireJobRegistrationHelper` |
-| `607b23e0` | `refactor(background-jobs): route RecurringJobDiscoveryService through HangfireJobRegistrationHelper` |
-| `be6add90` | `refactor(background-jobs): route HangfireRecurringJobScheduler through HangfireJobRegistrationHelper` |
-| `eb63d094` | `test: add HangfireRecurringJobScheduler parity tests` |
+```bash
+cd backend
+dotnet test Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Features.BackgroundJobs" --nologo
+# Expected: 88 passed, 0 failed
 
-### Validation results
+grep -rn "RecurringJob.AddOrUpdate" src/
+# Expected: 1 match in HangfireJobRegistrationHelper.cs:77
 
-- **88 BackgroundJobs tests** — 0 failures
-- **Build** — 0 errors
-- **Single `RecurringJob.AddOrUpdate` call site** confirmed in `HangfireJobRegistrationHelper.cs` only
-- **No orphaned** `RegisterRecurringJobInternal` or `UpdateJobInternal` references
-- **Legacy `TimeZoneInfo` overload** fully eliminated
+grep -rn "RegisterRecurringJobInternal\|UpdateJobInternal" src/ test/
+# Expected: no matches
+```
+
+## Notes
+
+- **Architecture correction (Amendment 1):** The spec proposed the helper in `Anela.Heblo.API/Infrastructure/Hangfire/` — this would create a circular project reference since `Application` cannot reference `API`. The helper lives in `Application` instead, reachable via the existing `API → Application` reference direction.
+- **Visibility (Amendment 2):** Helper is `public static` (not `internal`) because it's consumed cross-assembly from the `API` project.
+- One post-review fix applied: added `_ =` discard on `closed.Invoke(...)` return value for defensive clarity.
+- Minor issues noted by reviewer (redundant DI registration in test setup, shared `TestWebHostEnvironment` utility) are non-blocking and left as-is per YAGNI.
+
+## PR Summary
+
+Extracted `HangfireJobRegistrationHelper` — a single public static helper — to consolidate two independently-drifted Hangfire recurring-job registration paths. Before this change, `RecurringJobDiscoveryService` used the `RecurringJobOptions` overload while `HangfireRecurringJobScheduler` used the legacy `TimeZoneInfo` overload, meaning startup and runtime CRON updates could produce subtly different Hangfire storage records and any future option (queue name, misfire policy, etc.) would require editing both files.
+
+Both consumers now call `HangfireJobRegistrationHelper.RegisterOrUpdate(jobType, jobName, cron, tzId)`, which validates inputs, dispatches to a private generic method via reflection, unwraps `TargetInvocationException`, and calls `RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)`. New parity tests assert that a job registered via discovery and then updated via the scheduler ends up with the same method signature, time zone, and job type in Hangfire storage.
+
+### Changes
+- `HangfireJobRegistrationHelper.cs` — new; single reflection-based registration entry point
+- `RecurringJobDiscoveryService.cs` — removed `RegisterRecurringJobInternal<TJob>` + reflection dispatch (~14 lines)
+- `HangfireRecurringJobScheduler.cs` — removed `UpdateJobInternal<TJob>` + reflection dispatch (~22 lines); class doc updated
+- `HangfireJobRegistrationHelperTests.cs` — new; 11 unit tests (validation, happy path, exception unwrapping)
+- `HangfireRecurringJobSchedulerTests.cs` — new; 3 parity/integration tests
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/spec.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/spec.r1.md
@@ -1,0 +1,132 @@
+# Specification: Consolidate Hangfire RecurringJob Registration
+
+## Summary
+Two classes in the BackgroundJobs module duplicate the reflection-based plumbing that invokes the generic `RecurringJob.AddOrUpdate<TJob>` Hangfire API, and they call different overloads (legacy `TimeZoneInfo` vs. newer `RecurringJobOptions`). This refactor extracts a single shared helper that standardises on the `RecurringJobOptions` overload, eliminating duplication and ensuring startup registration and live CRON updates follow identical code paths.
+
+## Background
+`RecurringJobDiscoveryService` registers recurring jobs at application startup by discovering `IRecurringBackgroundJob` implementations and binding them to Hangfire. `HangfireRecurringJobScheduler` is the runtime-facing scheduler that updates the CRON expression of an existing recurring job when configuration changes (e.g., via admin UI or API).
+
+Both classes use reflection to resolve a generic private method by name (`GetMethod(..., NonPublic | Static)` → `MakeGenericMethod(jobType)` → `Invoke`) so that they can call `RecurringJob.AddOrUpdate<TJob>` with a `TJob` only known at runtime. The reflection plumbing is identical, but the inner method bodies bind to different Hangfire overloads:
+
+- `RecurringJobDiscoveryService.RegisterRecurringJobInternal<TJob>` — uses the `RecurringJobOptions` overload (newer API, extensible with queue name, priority, misfire handling, etc.).
+- `HangfireRecurringJobScheduler.UpdateJobInternal<TJob>` — uses the bare `TimeZoneInfo` overload (legacy signature).
+
+Risks of the status quo:
+- **Divergent behaviour**: Hangfire may apply different defaults to the legacy overload (e.g., misfire policy, queue assignment) than to the `RecurringJobOptions` overload. Startup and runtime updates can therefore produce subtly different `RecurringJob` records in storage.
+- **Double-edit burden**: Adding a queue name, priority, or any other Hangfire option requires editing both files. A miss leaves the system half-configured.
+- **Reflection drift**: Two copies of the reflection plumbing must stay in sync (method name, binding flags, generic dispatch).
+
+## Functional Requirements
+
+### FR-1: Single Hangfire registration helper
+Introduce a single static helper that encapsulates both the reflection-based generic dispatch and the call to `RecurringJob.AddOrUpdate<TJob>`. The helper accepts the runtime `Type` of the job, the job name, the CRON expression, and the time zone identifier.
+
+**Acceptance criteria:**
+- A new static class (e.g., `HangfireJobRegistrationHelper`) exposes a method such as `RegisterOrUpdate(Type jobType, string jobName, string cronExpression, string timeZoneId)` (or equivalent signature) that performs the registration.
+- The helper internally calls the generic `RecurringJob.AddOrUpdate<TJob>` overload that accepts `RecurringJobOptions` (the newer API).
+- The reflection plumbing (`GetMethod(...) → MakeGenericMethod → Invoke`) lives in this helper only — no other class duplicates it.
+- The helper validates inputs (non-null/non-empty job name, CRON expression, time zone id) and fails fast with a clear exception if the supplied `Type` does not implement the expected job interface.
+
+### FR-2: Standardise on `RecurringJobOptions` overload
+Both startup registration and runtime CRON updates must go through the helper and therefore use the same `RecurringJobOptions`-based overload.
+
+**Acceptance criteria:**
+- After refactor, the codebase contains exactly one call site for `RecurringJob.AddOrUpdate<TJob>` (inside the helper).
+- That call site passes a `RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId) }`.
+- The bare `TimeZoneInfo` overload (`RecurringJob.AddOrUpdate<TJob>(name, expr, cron, TimeZoneInfo)`) is no longer referenced anywhere in the solution.
+
+### FR-3: Refactor `RecurringJobDiscoveryService`
+`RecurringJobDiscoveryService.RegisterRecurringJobInternal<TJob>` (and any associated reflection helpers) is removed; the service now delegates to the shared helper.
+
+**Acceptance criteria:**
+- `RecurringJobDiscoveryService` no longer contains a private generic `RegisterRecurringJobInternal<TJob>` method nor its reflection-based dispatcher.
+- The service calls `HangfireJobRegistrationHelper.RegisterOrUpdate(...)` (or equivalent) once per discovered job.
+- Discovered jobs continue to be registered at startup with the same job name, CRON expression, and time zone as before the refactor.
+
+### FR-4: Refactor `HangfireRecurringJobScheduler`
+`HangfireRecurringJobScheduler.UpdateJobInternal<TJob>` (and its reflection dispatcher) is removed; runtime updates go through the shared helper.
+
+**Acceptance criteria:**
+- `HangfireRecurringJobScheduler` no longer contains a private generic `UpdateJobInternal<TJob>` method nor its reflection-based dispatcher.
+- The scheduler calls `HangfireJobRegistrationHelper.RegisterOrUpdate(...)` (or equivalent) when applying a CRON update.
+- An existing recurring job updated through the scheduler ends up with identical Hangfire metadata as one freshly registered at startup with the same CRON and time zone.
+
+### FR-5: Behaviour parity
+The refactor must not change observable behaviour: the same set of recurring jobs is registered with the same names, CRON expressions, and time zones; runtime CRON updates take effect as before.
+
+**Acceptance criteria:**
+- After the refactor, the set of recurring jobs visible in the Hangfire dashboard (`/hangfire/recurring`) for a given configuration is identical to the pre-refactor set (same names, CRON expressions, time zones).
+- A CRON update through `HangfireRecurringJobScheduler` updates the `Cron` field of the corresponding Hangfire recurring job entry in the same way as before.
+- Backend tests covering startup registration and CRON-update flows continue to pass.
+
+### FR-6: Helper placement
+The helper lives in the API infrastructure layer (next to `RecurringJobDiscoveryService`), since that is the only layer that already references the Hangfire API directly. `HangfireRecurringJobScheduler` (in `Application.Features.BackgroundJobs.Services`) already references Hangfire types, so a dependency on the API infrastructure helper is acceptable.
+
+**Acceptance criteria:**
+- The helper lives under `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/` (e.g., `HangfireJobRegistrationHelper.cs`).
+- Both consumers (`RecurringJobDiscoveryService` and `HangfireRecurringJobScheduler`) compile and resolve the helper without introducing new project-level circular dependencies.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance regression. Registration is invoked once per job at startup and per ad-hoc update; reflection cost is unchanged (still one `GetMethod` + `MakeGenericMethod` + `Invoke` per call). No need to cache the reflected `MethodInfo` in this refactor; if a future profile shows it matters, that's a follow-up.
+
+### NFR-2: Security
+No new security surface. The helper is internal to the application and only invoked from trusted server-side code paths that already have authority to register Hangfire jobs.
+
+### NFR-3: Maintainability
+After the refactor, future changes to recurring-job registration (e.g., adding a queue name, priority, misfire handling, or attempts) must be made in exactly one place. The reflection plumbing exists in exactly one location.
+
+### NFR-4: Testability
+The helper should be unit-testable in isolation where practical. Where Hangfire's static API makes direct unit testing impractical, existing integration coverage of the two consumers is sufficient.
+
+## Data Model
+No data model changes. Hangfire's existing `RecurringJob` storage records are unaffected in structure; only the code that writes them is consolidated.
+
+## API / Interface Design
+
+### New helper (sketch)
+```csharp
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+
+internal static class HangfireJobRegistrationHelper
+{
+    public static void RegisterOrUpdate(
+        Type jobType,
+        string jobName,
+        string cronExpression,
+        string timeZoneId);
+}
+```
+
+Internally:
+1. Validates inputs.
+2. Resolves a private generic method `RegisterOrUpdateGeneric<TJob>` via reflection.
+3. Constructs the closed generic via `MakeGenericMethod(jobType)`.
+4. Invokes it; the generic body calls:
+   ```csharp
+   RecurringJob.AddOrUpdate<TJob>(
+       jobName,
+       job => job.ExecuteAsync(default),
+       cronExpression,
+       new RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId) });
+   ```
+
+No public API surface (HTTP endpoints, MediatR requests, DTOs, frontend) changes.
+
+## Dependencies
+- **Hangfire** — existing dependency; standardising on `RecurringJobOptions` requires no version bump (the overload is already in use at the startup-registration site).
+- **`IRecurringBackgroundJob`** (or equivalent interface defining `ExecuteAsync(CancellationToken)`) — assumed to be the contract that both call sites rely on; the helper closes the generic over types that implement this interface.
+
+## Out of Scope
+- Adding new Hangfire options (queue name, priority, misfire handling, retry attempts) — the refactor only consolidates current behaviour; new options are a follow-up.
+- Caching the reflected `MethodInfo` for micro-optimisation.
+- Rewriting recurring-job discovery (assembly scanning, interface conventions) — `RecurringJobDiscoveryService`'s discovery logic stays as-is; only its registration call is rerouted.
+- Migrating away from reflection by introducing a non-generic Hangfire API path or a code-generated dispatcher.
+- Changes to the admin UI or API endpoints that drive runtime CRON updates.
+- Any database migration — Hangfire's storage schema is untouched.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-backgroundjobs-duplicated-an/task-plan.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-duplicated-an/task-plan.r1.md
@@ -1,0 +1,824 @@
+# Consolidate Hangfire RecurringJob Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace two duplicated reflection-based Hangfire registration paths with a single shared helper that standardises on the `RecurringJobOptions` overload.
+
+**Architecture:** Add `HangfireJobRegistrationHelper` (public static) in `Anela.Heblo.Application/Features/BackgroundJobs/Services/`. Both `RecurringJobDiscoveryService` (startup) and `HangfireRecurringJobScheduler` (runtime updates) delegate to it. Helper validates inputs, resolves a private generic dispatcher via reflection, unwraps `TargetInvocationException`, and invokes `RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)` so both call sites produce identical Hangfire records.
+
+**Tech Stack:** .NET 8, C#, Hangfire.Core 1.8.21, xUnit, Hangfire.MemoryStorage (tests).
+
+> **Layer placement note:** The original spec FR-6 proposed placing the helper in `Anela.Heblo.API/Infrastructure/Hangfire/`, but the architecture review (Amendment 1) corrected this — `Anela.Heblo.Application` cannot reference `Anela.Heblo.API` (would be circular). Application already references `Hangfire.Core`, so the helper lives in Application and is consumed by API via the existing `API → Application` reference.
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — shared helper (public static)
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — helper unit tests
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs` — scheduler + parity tests
+
+**Modified files:**
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — remove reflection dispatch + private generic method, call helper instead
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` — remove reflection dispatch + private generic method, call helper instead
+
+**Unchanged (verified, no edits required):**
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJob.cs`
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs`
+- `BackgroundJobsModule.cs`, `ServiceCollectionExtensions.cs` — no DI changes
+- All `csproj` files — no new references
+
+---
+
+## Task 1: Add helper unit tests (TDD red)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Hangfire;
+using Hangfire.Storage;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+[Collection("Hangfire")]
+public class HangfireJobRegistrationHelperTests : IDisposable
+{
+    public HangfireJobRegistrationHelperTests(HangfireTestFixture fixture)
+    {
+        // Hangfire is initialized by the shared collection fixture.
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithValidInputs_RegistersJobInHangfireStorage()
+    {
+        // Arrange
+        const string jobName = "helper-test-job";
+        const string cron = "0 5 * * *";
+        const string tz = "Europe/Prague";
+
+        // Act
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob),
+            jobName,
+            cron,
+            tz);
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = connection.GetRecurringJobs().SingleOrDefault(j => j.Id == jobName);
+        Assert.NotNull(job);
+        Assert.Equal(cron, job.Cron);
+        Assert.Equal(tz, job.TimeZoneId);
+        // The helper must register the async overload (returns Task)
+        Assert.Equal(typeof(Task), job.Job.Method.ReturnType);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_CalledTwice_UpdatesCronOnSecondCall()
+    {
+        // Arrange
+        const string jobName = "helper-test-update-job";
+        const string firstCron = "0 1 * * *";
+        const string secondCron = "0 2 * * *";
+
+        // Act — register, then re-register with new CRON
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob), jobName, firstCron, "Europe/Prague");
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob), jobName, secondCron, "Europe/Prague");
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = Assert.Single(connection.GetRecurringJobs(), j => j.Id == jobName);
+        Assert.Equal(secondCron, job.Cron);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithNullJobType_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                null!, "name", "0 0 * * *", "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingJobName_ThrowsArgumentException(string? jobName)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), jobName!, "0 0 * * *", "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingCron_ThrowsArgumentException(string? cron)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), "name", cron!, "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingTimeZoneId_ThrowsArgumentException(string? tz)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), "name", "0 0 * * *", tz!));
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithTypeNotImplementingIRecurringJob_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(NotARecurringJob), "name", "0 0 * * *", "Europe/Prague"));
+        Assert.Equal("jobType", ex.ParamName);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithInvalidTimeZoneId_ThrowsUnwrappedTimeZoneNotFoundException()
+    {
+        // The helper must unwrap TargetInvocationException so callers see the
+        // real cause (TimeZoneNotFoundException), not the reflection wrapper.
+        Assert.Throws<TimeZoneNotFoundException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob),
+                "helper-test-tz-job",
+                "0 0 * * *",
+                "Not/A/Real/TimeZone"));
+    }
+
+    public void Dispose()
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        foreach (var job in connection.GetRecurringJobs())
+        {
+            RecurringJob.RemoveIfExists(job.Id);
+        }
+    }
+
+    private class HelperTestRecurringJob : IRecurringJob
+    {
+        public RecurringJobMetadata Metadata { get; } = new()
+        {
+            JobName = "helper-test-job",
+            DisplayName = "Helper Test Job",
+            Description = "Used by HangfireJobRegistrationHelperTests",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "Europe/Prague",
+        };
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private class NotARecurringJob
+    {
+        // Used to assert the helper rejects types that do not implement IRecurringJob.
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (helper does not exist yet)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" \
+    --no-restore --nologo
+```
+
+Expected: Build error — `The type or namespace name 'HangfireJobRegistrationHelper' could not be found`. This is the RED state; the tests cannot even compile yet.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs
+git commit -m "test: add HangfireJobRegistrationHelper unit tests (red)"
+```
+
+---
+
+## Task 2: Create the helper (TDD green)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`
+
+- [ ] **Step 1: Write the helper**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`:
+
+```csharp
+using System.Reflection;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Hangfire;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+/// <summary>
+/// Single entry point for binding a runtime <see cref="Type"/> to
+/// <see cref="RecurringJob.AddOrUpdate{TJob}(string, System.Linq.Expressions.Expression{Action{TJob}}, string, RecurringJobOptions)"/>.
+/// Used by both startup discovery and runtime CRON updates so that both code paths
+/// produce identical Hangfire <c>RecurringJob</c> records.
+/// </summary>
+public static class HangfireJobRegistrationHelper
+{
+    /// <summary>
+    /// Registers or updates a Hangfire recurring job for the given runtime job type.
+    /// Always uses the <see cref="RecurringJobOptions"/> overload.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="jobType"/> is null.</exception>
+    /// <exception cref="ArgumentException">A string argument is null/empty/whitespace, or <paramref name="jobType"/> does not implement <see cref="IRecurringJob"/>.</exception>
+    /// <exception cref="TimeZoneNotFoundException">The time zone id is not resolvable on this host.</exception>
+    public static void RegisterOrUpdate(
+        Type jobType,
+        string jobName,
+        string cronExpression,
+        string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(jobType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cronExpression);
+        ArgumentException.ThrowIfNullOrWhiteSpace(timeZoneId);
+
+        if (!typeof(IRecurringJob).IsAssignableFrom(jobType))
+        {
+            throw new ArgumentException(
+                $"{jobType.FullName} does not implement {nameof(IRecurringJob)}.",
+                nameof(jobType));
+        }
+
+        var dispatcher = typeof(HangfireJobRegistrationHelper)
+            .GetMethod(nameof(RegisterOrUpdateGeneric), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"Could not resolve {nameof(RegisterOrUpdateGeneric)} via reflection.");
+
+        var closed = dispatcher.MakeGenericMethod(jobType);
+
+        try
+        {
+            closed.Invoke(null, new object[] { jobName, cronExpression, timeZoneId });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            // Surface the real cause (e.g. TimeZoneNotFoundException) instead of the
+            // reflection wrapper, so callers can log structured context.
+            throw ex.InnerException;
+        }
+    }
+
+    private static void RegisterOrUpdateGeneric<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId)
+        where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            job => job.ExecuteAsync(default),
+            cronExpression,
+            new RecurringJobOptions
+            {
+                TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+            });
+    }
+}
+```
+
+- [ ] **Step 2: Run the helper tests to verify they pass**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" \
+    --no-restore --nologo
+```
+
+Expected: All 11 tests (`Theory` rows count separately) pass.
+
+- [ ] **Step 3: Commit the helper**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
+git commit -m "feat(background-jobs): add HangfireJobRegistrationHelper"
+```
+
+---
+
+## Task 3: Refactor `RecurringJobDiscoveryService` to use the helper
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs`
+
+- [ ] **Step 1: Replace reflection dispatch with helper call**
+
+In `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs`:
+
+Replace the entire block from line 79 to line 96 (the `var registerMethod = ...` block, the null-check, the `MakeGenericMethod` call, and the `Invoke`) with a single helper call:
+
+```csharp
+                    HangfireJobRegistrationHelper.RegisterOrUpdate(
+                        jobType,
+                        metadata.JobName,
+                        cronExpression,
+                        metadata.TimeZoneId);
+```
+
+The surrounding `try/catch` (lines 67 outer and 102–107) **stays as-is** — the catch already logs structured context for `metadata.JobName` and `jobType.Name`.
+
+- [ ] **Step 2: Delete the now-unused private generic method**
+
+Delete the entire `RegisterRecurringJobInternal<TJob>` method (lines 129–142):
+
+```csharp
+    private static void RegisterRecurringJobInternal<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId) where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            job => job.ExecuteAsync(default),
+            cronExpression,
+            new RecurringJobOptions
+            {
+                TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+            });
+    }
+```
+
+- [ ] **Step 3: Add the helper using and remove unused usings**
+
+At the top of the file, add:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+```
+
+Verify these `using` statements remain (they are still used elsewhere in the file):
+- `using Anela.Heblo.Domain.Features.BackgroundJobs;` — for `IRecurringJob`, `IRecurringJobConfigurationRepository`
+- `using Anela.Heblo.Xcc;` — for `HangfireOptions`
+- `using Hangfire;` — *no longer used* once `RegisterRecurringJobInternal` is gone. Remove it.
+- `using Microsoft.Extensions.Options;` — for `IOptions<HangfireOptions>`
+
+The final top-of-file usings should be:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Xcc;
+using Microsoft.Extensions.Options;
+```
+
+- [ ] **Step 4: Build to verify the API project compiles**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: Build succeeds with zero errors. Warnings should not increase versus baseline.
+
+- [ ] **Step 5: Run the existing `RecurringJobDiscoveryServiceTests` to verify behaviour parity**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~RecurringJobDiscoveryServiceTests" \
+    --no-restore --nologo
+```
+
+Expected: All three existing tests pass (`StartAsync_WithSchedulerEnabled_RegistersRecurringJobs`, `StartAsync_WhenDbConfigExists_UsesDbCronInsteadOfMetadataDefault`, `StartAsync_WithSchedulerDisabled_DoesNotRegisterJobs`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
+git commit -m "refactor(background-jobs): route RecurringJobDiscoveryService through HangfireJobRegistrationHelper"
+```
+
+---
+
+## Task 4: Refactor `HangfireRecurringJobScheduler` to use the helper
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs`
+
+- [ ] **Step 1: Replace reflection dispatch with helper call**
+
+Open `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs`.
+
+Replace the block from line 41 to line 64 (everything from `var jobType = job.GetType();` through the `try { genericMethod.Invoke(...) } catch (...) { ... return; }` block) with this simpler implementation:
+
+```csharp
+        try
+        {
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                job.GetType(),
+                jobName,
+                cronExpression,
+                job.Metadata.TimeZoneId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to update live Hangfire schedule for {JobName}. " +
+                "TimeZone '{TimeZoneId}' may be invalid or unsupported on this host.",
+                jobName, job.Metadata.TimeZoneId);
+            return;
+        }
+```
+
+The trailing success log (lines 66–68) stays as-is.
+
+- [ ] **Step 2: Delete the now-unused private generic method**
+
+Delete the entire `UpdateJobInternal<TJob>` method (lines 71–81):
+
+```csharp
+    private static void UpdateJobInternal<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId) where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            j => j.ExecuteAsync(default),
+            cronExpression,
+            TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+    }
+```
+
+- [ ] **Step 3: Remove unused usings**
+
+At the top of the file, remove these `using` lines — they were used only by the deleted reflection block and the deleted private method:
+
+```csharp
+using System.Reflection;
+using Hangfire;
+```
+
+Verify these `using` statements remain (still used):
+- `using Anela.Heblo.Domain.Features.BackgroundJobs;` — for `IRecurringJob`
+- `using Microsoft.Extensions.DependencyInjection;` — for `CreateScope`, `GetServices`
+- `using Microsoft.Extensions.Logging;` — for `ILogger<>`
+
+The final top-of-file usings should be:
+
+```csharp
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+```
+
+(No `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` is needed — the helper is in the same namespace.)
+
+- [ ] **Step 4: Update the class-level docstring**
+
+Update the XML doc comment on the `HangfireRecurringJobScheduler` class (lines 9–12) from:
+
+```csharp
+/// <summary>
+/// Updates a Hangfire recurring job's CRON schedule live using the same
+/// reflection pattern as RecurringJobDiscoveryService.
+/// </summary>
+```
+
+to:
+
+```csharp
+/// <summary>
+/// Updates a Hangfire recurring job's CRON schedule live by delegating to
+/// <see cref="HangfireJobRegistrationHelper"/> so the runtime-update path uses
+/// the same registration code as startup discovery.
+/// </summary>
+```
+
+- [ ] **Step 5: Build the solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: Build succeeds with zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs
+git commit -m "refactor(background-jobs): route HangfireRecurringJobScheduler through HangfireJobRegistrationHelper"
+```
+
+---
+
+## Task 5: Add behaviour-parity test for the scheduler
+
+This task creates a new test file that exercises `HangfireRecurringJobScheduler` against in-memory Hangfire storage and asserts that:
+1. The scheduler successfully updates the CRON of a previously-registered job.
+2. The resulting Hangfire record after a scheduler update is structurally identical (CRON, time zone, async return type) to a record produced by `RecurringJobDiscoveryService` — the behaviour-parity check from arch-review Amendment 4.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs`:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Anela.Heblo.Xcc;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+[Collection("Hangfire")]
+public class HangfireRecurringJobSchedulerTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    public HangfireRecurringJobSchedulerTests(HangfireTestFixture fixture)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment { EnvironmentName = "Test" });
+        services.AddScoped<IRecurringJob, ParityTestRecurringJob>();
+        services.AddScoped<ParityTestRecurringJob>();
+        services.AddSingleton<IRecurringJobConfigurationRepository, EmptyStubRepository>();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void UpdateCronSchedule_WithUnknownJobName_LogsWarningAndReturns()
+    {
+        // Arrange
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+
+        // Act
+        scheduler.UpdateCronSchedule("does-not-exist", "0 0 * * *");
+
+        // Assert — no job was created
+        using var connection = JobStorage.Current.GetConnection();
+        Assert.Empty(connection.GetRecurringJobs().Where(j => j.Id == "does-not-exist"));
+    }
+
+    [Fact]
+    public async Task UpdateCronSchedule_AfterDiscoveryRegistration_UpdatesCronInStorage()
+    {
+        // Arrange — first register via discovery service (startup path)
+        const string newCron = "0 4 * * 2"; // differs from metadata default
+        var hangfireOptions = Options.Create(new HangfireOptions { SchedulerEnabled = true });
+        var discovery = new RecurringJobDiscoveryService(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<RecurringJobDiscoveryService>>(),
+            _serviceProvider.GetRequiredService<IWebHostEnvironment>(),
+            hangfireOptions);
+        await discovery.StartAsync(CancellationToken.None);
+
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+
+        // Act — update via the runtime scheduler path
+        scheduler.UpdateCronSchedule("parity-test-job", newCron);
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = Assert.Single(connection.GetRecurringJobs(), j => j.Id == "parity-test-job");
+        Assert.Equal(newCron, job.Cron);
+        Assert.Equal("Europe/Prague", job.TimeZoneId);
+    }
+
+    [Fact]
+    public async Task UpdateCronSchedule_ProducesIdenticalRecordStructureToDiscoveryRegistration()
+    {
+        // Arrange — register two jobs: one via the discovery path, one re-registered
+        // via the scheduler path. Both should end up with the same async method signature
+        // and same time-zone metadata. This is the behaviour-parity check (arch-review Amendment 4).
+        var hangfireOptions = Options.Create(new HangfireOptions { SchedulerEnabled = true });
+        var discovery = new RecurringJobDiscoveryService(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<RecurringJobDiscoveryService>>(),
+            _serviceProvider.GetRequiredService<IWebHostEnvironment>(),
+            hangfireOptions);
+        await discovery.StartAsync(CancellationToken.None);
+
+        using (var connection = JobStorage.Current.GetConnection())
+        {
+            var discovered = Assert.Single(connection.GetRecurringJobs(), j => j.Id == "parity-test-job");
+
+            // Act — re-register through the scheduler with a new CRON
+            var scheduler = new HangfireRecurringJobScheduler(
+                _serviceProvider,
+                _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+            scheduler.UpdateCronSchedule("parity-test-job", "0 7 * * *");
+
+            // Assert — re-fetch and compare structural metadata
+            var afterUpdate = Assert.Single(
+                JobStorage.Current.GetConnection().GetRecurringJobs(),
+                j => j.Id == "parity-test-job");
+
+            Assert.Equal(discovered.Job.Method.ReturnType, afterUpdate.Job.Method.ReturnType);
+            Assert.Equal(typeof(Task), afterUpdate.Job.Method.ReturnType);
+            Assert.Equal(discovered.TimeZoneId, afterUpdate.TimeZoneId);
+            Assert.Equal(discovered.Job.Type, afterUpdate.Job.Type);
+            Assert.Equal(discovered.Job.Method.Name, afterUpdate.Job.Method.Name);
+        }
+    }
+
+    public void Dispose()
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        foreach (var job in connection.GetRecurringJobs())
+        {
+            RecurringJob.RemoveIfExists(job.Id);
+        }
+        _serviceProvider?.Dispose();
+    }
+
+    private class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "TestApp";
+        public string ContentRootPath { get; set; } = "/test";
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+        public string WebRootPath { get; set; } = "/test/wwwroot";
+        public IFileProvider WebRootFileProvider { get; set; } = null!;
+    }
+
+    private class ParityTestRecurringJob : IRecurringJob
+    {
+        public RecurringJobMetadata Metadata { get; } = new()
+        {
+            JobName = "parity-test-job",
+            DisplayName = "Parity Test Job",
+            Description = "Used by HangfireRecurringJobSchedulerTests",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "Europe/Prague",
+        };
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private class EmptyStubRepository : IRecurringJobConfigurationRepository
+    {
+        public Task<List<RecurringJobConfiguration>> GetAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<RecurringJobConfiguration>());
+
+        public Task<RecurringJobConfiguration?> GetByJobNameAsync(string jobName, CancellationToken cancellationToken = default)
+            => Task.FromResult<RecurringJobConfiguration?>(null);
+
+        public Task UpdateAsync(RecurringJobConfiguration configuration, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 2: Run the new scheduler tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~HangfireRecurringJobSchedulerTests" \
+    --no-restore --nologo
+```
+
+Expected: All 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs
+git commit -m "test: add HangfireRecurringJobScheduler parity tests"
+```
+
+---
+
+## Task 6: Full validation and final commit
+
+This task is the final sanity check: run the full BackgroundJobs test suite, the full backend build, and `dotnet format` to satisfy `CLAUDE.md`'s validation gate.
+
+- [ ] **Step 1: Run the entire BackgroundJobs test folder**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Features.BackgroundJobs" \
+    --no-restore --nologo
+```
+
+Expected: All BackgroundJobs tests pass — no regression in the existing `RecurringJobDiscoveryServiceTests`, `UpdateRecurringJobCronHandlerTests`, `TriggerRecurringJobHandlerIntegrationTests`, `HangfireJobEnqueuerTests`, etc.
+
+- [ ] **Step 2: Build the full backend solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: Build succeeds with zero errors. Warning count should not increase versus the baseline before this branch.
+
+- [ ] **Step 3: Run `dotnet format` (CLAUDE.md gate)**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+If any files are reformatted, stage and commit them:
+
+```bash
+git add -u
+git diff --cached --quiet || git commit -m "chore: dotnet format"
+```
+
+- [ ] **Step 4: Confirm no leftover references to the old internal methods**
+
+Search for any orphaned references:
+
+```bash
+grep -rn "RegisterRecurringJobInternal\|UpdateJobInternal" backend/src backend/test
+```
+
+Expected output: empty (no matches). If anything appears, it is dead code from a missed deletion — remove it and amend the relevant prior commit or add a fix commit.
+
+- [ ] **Step 5: Confirm exactly one `RecurringJob.AddOrUpdate` call site remains (FR-2 acceptance)**
+
+Run:
+```bash
+grep -rn "RecurringJob.AddOrUpdate" backend/src
+```
+
+Expected output: a single match inside `HangfireJobRegistrationHelper.cs` (the `RegisterOrUpdateGeneric<TJob>` body).
+
+Also confirm the legacy `TimeZoneInfo`-only overload is gone:
+
+```bash
+grep -rn "AddOrUpdate<.*>(.*TimeZoneInfo\." backend/src
+```
+
+Expected output: empty.
+
+- [ ] **Step 6: Final commit if anything was tweaked in Step 5**
+
+If any additional changes were required, commit them:
+
+```bash
+git add -u
+git diff --cached --quiet || git commit -m "chore(background-jobs): tidy post-consolidation"
+```
+
+If no changes were needed, this step is a no-op.
+
+---
+
+## Acceptance Criteria Mapping
+
+| Spec/Arch Requirement | Implemented in |
+|---|---|
+| FR-1: Single helper with reflection plumbing + input validation | Task 1 (tests), Task 2 (impl) |
+| FR-2: Only one `RecurringJob.AddOrUpdate<TJob>` call site, `RecurringJobOptions` overload | Task 2 (helper), Task 6 Step 5 (verification) |
+| FR-3: `RecurringJobDiscoveryService` delegates to helper, no more reflection there | Task 3 |
+| FR-4: `HangfireRecurringJobScheduler` delegates to helper, no more reflection there | Task 4 |
+| FR-5: Behaviour parity (same names/CRON/TZ; runtime updates work) | Task 3 Step 5 (existing tests), Task 5 (parity test) |
+| FR-6 (corrected by Amendment 1): Helper in `Application/Features/BackgroundJobs/Services/`, `public static`, no new project references | Task 2 |
+| Amendment 2: `public static` visibility | Task 2 |
+| Amendment 3: Unwrap `TargetInvocationException` | Task 1 (test), Task 2 (impl) |
+| Amendment 4: Behaviour-parity test | Task 5 |
+| Amendment 5: Helper unit tests | Task 1 |
+| NFR-3: Single place for future Hangfire options changes | Task 2 |
+| NFR-4: Helper unit-testable in isolation | Task 1 |

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
@@ -1,6 +1,6 @@
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Xcc;
-using Hangfire;
 using Microsoft.Extensions.Options;
 
 namespace Anela.Heblo.API.Infrastructure.Hangfire;
@@ -76,24 +76,11 @@ public class RecurringJobDiscoveryService : IHostedService
                         cronSource = "DB";
                     }
 
-                    var registerMethod = typeof(RecurringJobDiscoveryService)
-                        .GetMethod(
-                            nameof(RegisterRecurringJobInternal),
-                            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
-                    if (registerMethod == null)
-                    {
-                        _logger.LogError("Could not find RegisterRecurringJobInternal method");
-                        continue;
-                    }
-
-                    var genericRegisterMethod = registerMethod.MakeGenericMethod(jobType);
-                    genericRegisterMethod.Invoke(null, new object[]
-                    {
+                    HangfireJobRegistrationHelper.RegisterOrUpdate(
+                        jobType,
                         metadata.JobName,
                         cronExpression,
-                        metadata.TimeZoneId
-                    });
+                        metadata.TimeZoneId);
 
                     _logger.LogInformation(
                         "Registered recurring job: {JobName} ({JobType}) with schedule {Cron} (from {CronSource})",
@@ -124,20 +111,5 @@ public class RecurringJobDiscoveryService : IHostedService
     {
         _logger.LogInformation("Stopping recurring job discovery service");
         return Task.CompletedTask;
-    }
-
-    private static void RegisterRecurringJobInternal<TJob>(
-        string jobName,
-        string cronExpression,
-        string timeZoneId) where TJob : IRecurringJob
-    {
-        RecurringJob.AddOrUpdate<TJob>(
-            jobName,
-            job => job.ExecuteAsync(default),
-            cronExpression,
-            new RecurringJobOptions
-            {
-                TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
-            });
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
@@ -58,7 +58,7 @@ public static class HangfireJobRegistrationHelper
 
         try
         {
-            closed.Invoke(null, new object[] { jobName, cronExpression, timeZoneId });
+            _ = closed.Invoke(null, new object[] { jobName, cronExpression, timeZoneId });
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Hangfire;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+/// <summary>
+/// Single entry point for binding a runtime <see cref="Type"/> to
+/// <see cref="RecurringJob.AddOrUpdate{TJob}(string, System.Linq.Expressions.Expression{Action{TJob}}, string, RecurringJobOptions)"/>.
+/// Used by both startup discovery and runtime CRON updates so that both code paths
+/// produce identical Hangfire <c>RecurringJob</c> records.
+/// </summary>
+public static class HangfireJobRegistrationHelper
+{
+    /// <summary>
+    /// Registers or updates a Hangfire recurring job for the given runtime job type.
+    /// Always uses the <see cref="RecurringJobOptions"/> overload.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="jobType"/> is null.</exception>
+    /// <exception cref="ArgumentException">A string argument is null/empty/whitespace, or <paramref name="jobType"/> does not implement <see cref="IRecurringJob"/>.</exception>
+    /// <exception cref="TimeZoneNotFoundException">The time zone id is not resolvable on this host.</exception>
+    public static void RegisterOrUpdate(
+        Type jobType,
+        string jobName,
+        string cronExpression,
+        string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(jobType);
+
+        if (string.IsNullOrWhiteSpace(jobName))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(jobName));
+        }
+
+        if (string.IsNullOrWhiteSpace(cronExpression))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(cronExpression));
+        }
+
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(timeZoneId));
+        }
+
+        if (!typeof(IRecurringJob).IsAssignableFrom(jobType))
+        {
+            throw new ArgumentException(
+                $"{jobType.FullName} does not implement {nameof(IRecurringJob)}.",
+                nameof(jobType));
+        }
+
+        var dispatcher = typeof(HangfireJobRegistrationHelper)
+            .GetMethod(nameof(RegisterOrUpdateGeneric), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"Could not resolve {nameof(RegisterOrUpdateGeneric)} via reflection.");
+
+        var closed = dispatcher.MakeGenericMethod(jobType);
+
+        try
+        {
+            closed.Invoke(null, new object[] { jobName, cronExpression, timeZoneId });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            // Surface the real cause (e.g. TimeZoneNotFoundException) instead of the
+            // reflection wrapper, so callers can log structured context.
+            throw ex.InnerException;
+        }
+    }
+
+    private static void RegisterOrUpdateGeneric<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId)
+        where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            job => job.ExecuteAsync(default),
+            cronExpression,
+            new RecurringJobOptions
+            {
+                TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+            });
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs
@@ -1,14 +1,13 @@
-using System.Reflection;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
 
 /// <summary>
-/// Updates a Hangfire recurring job's CRON schedule live using the same
-/// reflection pattern as RecurringJobDiscoveryService.
+/// Updates a Hangfire recurring job's CRON schedule live by delegating to
+/// <see cref="HangfireJobRegistrationHelper"/> so the runtime-update path uses
+/// the same registration code as startup discovery.
 /// </summary>
 public class HangfireRecurringJobScheduler : IHangfireRecurringJobScheduler
 {
@@ -38,21 +37,13 @@ public class HangfireRecurringJobScheduler : IHangfireRecurringJobScheduler
             return;
         }
 
-        var jobType = job.GetType();
-        var registerMethod = typeof(HangfireRecurringJobScheduler)
-            .GetMethod(nameof(UpdateJobInternal), BindingFlags.NonPublic | BindingFlags.Static);
-
-        if (registerMethod == null)
-        {
-            _logger.LogError("Could not find UpdateJobInternal method via reflection");
-            return;
-        }
-
-        var genericMethod = registerMethod.MakeGenericMethod(jobType);
-
         try
         {
-            genericMethod.Invoke(null, new object[] { jobName, cronExpression, job.Metadata.TimeZoneId });
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                job.GetType(),
+                jobName,
+                cronExpression,
+                job.Metadata.TimeZoneId);
         }
         catch (Exception ex)
         {
@@ -66,17 +57,5 @@ public class HangfireRecurringJobScheduler : IHangfireRecurringJobScheduler
         _logger.LogInformation(
             "Live Hangfire schedule updated for {JobName} → {CronExpression}",
             jobName, cronExpression);
-    }
-
-    private static void UpdateJobInternal<TJob>(
-        string jobName,
-        string cronExpression,
-        string timeZoneId) where TJob : IRecurringJob
-    {
-        RecurringJob.AddOrUpdate<TJob>(
-            jobName,
-            j => j.ExecuteAsync(default),
-            cronExpression,
-            TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs
@@ -1,0 +1,154 @@
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Hangfire;
+using Hangfire.Storage;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+[Collection("Hangfire")]
+public class HangfireJobRegistrationHelperTests : IDisposable
+{
+    public HangfireJobRegistrationHelperTests(HangfireTestFixture fixture)
+    {
+        // Hangfire is initialized by the shared collection fixture.
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithValidInputs_RegistersJobInHangfireStorage()
+    {
+        // Arrange
+        const string jobName = "helper-test-job";
+        const string cron = "0 5 * * *";
+        const string tz = "Europe/Prague";
+
+        // Act
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob),
+            jobName,
+            cron,
+            tz);
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = connection.GetRecurringJobs().SingleOrDefault(j => j.Id == jobName);
+        Assert.NotNull(job);
+        Assert.Equal(cron, job.Cron);
+        Assert.Equal(tz, job.TimeZoneId);
+        // The helper must register the async overload (returns Task)
+        Assert.Equal(typeof(Task), job.Job.Method.ReturnType);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_CalledTwice_UpdatesCronOnSecondCall()
+    {
+        // Arrange
+        const string jobName = "helper-test-update-job";
+        const string firstCron = "0 1 * * *";
+        const string secondCron = "0 2 * * *";
+
+        // Act — register, then re-register with new CRON
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob), jobName, firstCron, "Europe/Prague");
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob), jobName, secondCron, "Europe/Prague");
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = Assert.Single(connection.GetRecurringJobs(), j => j.Id == jobName);
+        Assert.Equal(secondCron, job.Cron);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithNullJobType_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                null!, "name", "0 0 * * *", "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingJobName_ThrowsArgumentException(string? jobName)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), jobName!, "0 0 * * *", "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingCron_ThrowsArgumentException(string? cron)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), "name", cron!, "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingTimeZoneId_ThrowsArgumentException(string? tz)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), "name", "0 0 * * *", tz!));
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithTypeNotImplementingIRecurringJob_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(NotARecurringJob), "name", "0 0 * * *", "Europe/Prague"));
+        Assert.Equal("jobType", ex.ParamName);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithInvalidTimeZoneId_ThrowsUnwrappedTimeZoneNotFoundException()
+    {
+        // The helper must unwrap TargetInvocationException so callers see the
+        // real cause (TimeZoneNotFoundException), not the reflection wrapper.
+        Assert.Throws<TimeZoneNotFoundException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob),
+                "helper-test-tz-job",
+                "0 0 * * *",
+                "Not/A/Real/TimeZone"));
+    }
+
+    public void Dispose()
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        foreach (var job in connection.GetRecurringJobs())
+        {
+            RecurringJob.RemoveIfExists(job.Id);
+        }
+    }
+
+    private class HelperTestRecurringJob : IRecurringJob
+    {
+        public RecurringJobMetadata Metadata { get; } = new()
+        {
+            JobName = "helper-test-job",
+            DisplayName = "Helper Test Job",
+            Description = "Used by HangfireJobRegistrationHelperTests",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "Europe/Prague",
+        };
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private class NotARecurringJob
+    {
+        // Used to assert the helper rejects types that do not implement IRecurringJob.
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs
@@ -1,0 +1,171 @@
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Anela.Heblo.Xcc;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+[Collection("Hangfire")]
+public class HangfireRecurringJobSchedulerTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    public HangfireRecurringJobSchedulerTests(HangfireTestFixture fixture)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment { EnvironmentName = "Test" });
+        services.AddScoped<IRecurringJob, ParityTestRecurringJob>();
+        services.AddScoped<ParityTestRecurringJob>();
+        services.AddSingleton<IRecurringJobConfigurationRepository, EmptyStubRepository>();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void UpdateCronSchedule_WithUnknownJobName_LogsWarningAndReturns()
+    {
+        // Arrange
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+
+        // Act
+        scheduler.UpdateCronSchedule("does-not-exist", "0 0 * * *");
+
+        // Assert — no job was created
+        using var connection = JobStorage.Current.GetConnection();
+        Assert.DoesNotContain(connection.GetRecurringJobs(), j => j.Id == "does-not-exist");
+    }
+
+    [Fact]
+    public async Task UpdateCronSchedule_AfterDiscoveryRegistration_UpdatesCronInStorage()
+    {
+        // Arrange — first register via discovery service (startup path)
+        const string newCron = "0 4 * * 2"; // differs from metadata default
+        var hangfireOptions = Options.Create(new HangfireOptions { SchedulerEnabled = true });
+        var discovery = new RecurringJobDiscoveryService(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<RecurringJobDiscoveryService>>(),
+            _serviceProvider.GetRequiredService<IWebHostEnvironment>(),
+            hangfireOptions);
+        await discovery.StartAsync(CancellationToken.None);
+
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+
+        // Act — update via the runtime scheduler path
+        scheduler.UpdateCronSchedule("parity-test-job", newCron);
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = Assert.Single(connection.GetRecurringJobs(), j => j.Id == "parity-test-job");
+        Assert.Equal(newCron, job.Cron);
+        Assert.Equal("Europe/Prague", job.TimeZoneId);
+    }
+
+    [Fact]
+    public async Task UpdateCronSchedule_ProducesIdenticalRecordStructureToDiscoveryRegistration()
+    {
+        // Arrange — register via the discovery path
+        var hangfireOptions = Options.Create(new HangfireOptions { SchedulerEnabled = true });
+        var discovery = new RecurringJobDiscoveryService(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<RecurringJobDiscoveryService>>(),
+            _serviceProvider.GetRequiredService<IWebHostEnvironment>(),
+            hangfireOptions);
+        await discovery.StartAsync(CancellationToken.None);
+
+        // Capture the discovery-registered record before updating
+        string discoveredTimeZoneId;
+        Type discoveredJobType;
+        string discoveredMethodName;
+        Type discoveredReturnType;
+
+        using (var conn1 = JobStorage.Current.GetConnection())
+        {
+            var discovered = Assert.Single(conn1.GetRecurringJobs(), j => j.Id == "parity-test-job");
+            discoveredTimeZoneId = discovered.TimeZoneId;
+            discoveredJobType = discovered.Job.Type;
+            discoveredMethodName = discovered.Job.Method.Name;
+            discoveredReturnType = discovered.Job.Method.ReturnType;
+        }
+
+        // Act — re-register through the scheduler with a new CRON
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+        scheduler.UpdateCronSchedule("parity-test-job", "0 7 * * *");
+
+        // Assert — re-fetch and compare structural metadata
+        using (var conn2 = JobStorage.Current.GetConnection())
+        {
+            var afterUpdate = Assert.Single(conn2.GetRecurringJobs(), j => j.Id == "parity-test-job");
+
+            Assert.Equal(discoveredReturnType, afterUpdate.Job.Method.ReturnType);
+            Assert.Equal(typeof(Task), afterUpdate.Job.Method.ReturnType);
+            Assert.Equal(discoveredTimeZoneId, afterUpdate.TimeZoneId);
+            Assert.Equal(discoveredJobType, afterUpdate.Job.Type);
+            Assert.Equal(discoveredMethodName, afterUpdate.Job.Method.Name);
+        }
+    }
+
+    public void Dispose()
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        foreach (var job in connection.GetRecurringJobs())
+        {
+            RecurringJob.RemoveIfExists(job.Id);
+        }
+        _serviceProvider?.Dispose();
+    }
+
+    private class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "TestApp";
+        public string ContentRootPath { get; set; } = "/test";
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+        public string WebRootPath { get; set; } = "/test/wwwroot";
+        public IFileProvider WebRootFileProvider { get; set; } = null!;
+    }
+
+    private class ParityTestRecurringJob : IRecurringJob
+    {
+        public RecurringJobMetadata Metadata { get; } = new()
+        {
+            JobName = "parity-test-job",
+            DisplayName = "Parity Test Job",
+            Description = "Used by HangfireRecurringJobSchedulerTests",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "Europe/Prague",
+        };
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private class EmptyStubRepository : IRecurringJobConfigurationRepository
+    {
+        public Task<List<RecurringJobConfiguration>> GetAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<RecurringJobConfiguration>());
+
+        public Task<RecurringJobConfiguration?> GetByJobNameAsync(string jobName, CancellationToken cancellationToken = default)
+            => Task.FromResult<RecurringJobConfiguration?>(null);
+
+        public Task UpdateAsync(RecurringJobConfiguration configuration, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/docs/superpowers/plans/2026-05-27-consolidate-hangfire-recurringjob-registration.md
+++ b/docs/superpowers/plans/2026-05-27-consolidate-hangfire-recurringjob-registration.md
@@ -1,0 +1,824 @@
+# Consolidate Hangfire RecurringJob Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace two duplicated reflection-based Hangfire registration paths with a single shared helper that standardises on the `RecurringJobOptions` overload.
+
+**Architecture:** Add `HangfireJobRegistrationHelper` (public static) in `Anela.Heblo.Application/Features/BackgroundJobs/Services/`. Both `RecurringJobDiscoveryService` (startup) and `HangfireRecurringJobScheduler` (runtime updates) delegate to it. Helper validates inputs, resolves a private generic dispatcher via reflection, unwraps `TargetInvocationException`, and invokes `RecurringJob.AddOrUpdate<TJob>(..., RecurringJobOptions)` so both call sites produce identical Hangfire records.
+
+**Tech Stack:** .NET 8, C#, Hangfire.Core 1.8.21, xUnit, Hangfire.MemoryStorage (tests).
+
+> **Layer placement note:** The original spec FR-6 proposed placing the helper in `Anela.Heblo.API/Infrastructure/Hangfire/`, but the architecture review (Amendment 1) corrected this — `Anela.Heblo.Application` cannot reference `Anela.Heblo.API` (would be circular). Application already references `Hangfire.Core`, so the helper lives in Application and is consumed by API via the existing `API → Application` reference.
+
+---
+
+## File Structure
+
+**New files:**
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — shared helper (public static)
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — helper unit tests
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs` — scheduler + parity tests
+
+**Modified files:**
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — remove reflection dispatch + private generic method, call helper instead
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` — remove reflection dispatch + private generic method, call helper instead
+
+**Unchanged (verified, no edits required):**
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/IRecurringJob.cs`
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs`
+- `BackgroundJobsModule.cs`, `ServiceCollectionExtensions.cs` — no DI changes
+- All `csproj` files — no new references
+
+---
+
+## Task 1: Add helper unit tests (TDD red)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Hangfire;
+using Hangfire.Storage;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+[Collection("Hangfire")]
+public class HangfireJobRegistrationHelperTests : IDisposable
+{
+    public HangfireJobRegistrationHelperTests(HangfireTestFixture fixture)
+    {
+        // Hangfire is initialized by the shared collection fixture.
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithValidInputs_RegistersJobInHangfireStorage()
+    {
+        // Arrange
+        const string jobName = "helper-test-job";
+        const string cron = "0 5 * * *";
+        const string tz = "Europe/Prague";
+
+        // Act
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob),
+            jobName,
+            cron,
+            tz);
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = connection.GetRecurringJobs().SingleOrDefault(j => j.Id == jobName);
+        Assert.NotNull(job);
+        Assert.Equal(cron, job.Cron);
+        Assert.Equal(tz, job.TimeZoneId);
+        // The helper must register the async overload (returns Task)
+        Assert.Equal(typeof(Task), job.Job.Method.ReturnType);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_CalledTwice_UpdatesCronOnSecondCall()
+    {
+        // Arrange
+        const string jobName = "helper-test-update-job";
+        const string firstCron = "0 1 * * *";
+        const string secondCron = "0 2 * * *";
+
+        // Act — register, then re-register with new CRON
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob), jobName, firstCron, "Europe/Prague");
+        HangfireJobRegistrationHelper.RegisterOrUpdate(
+            typeof(HelperTestRecurringJob), jobName, secondCron, "Europe/Prague");
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = Assert.Single(connection.GetRecurringJobs(), j => j.Id == jobName);
+        Assert.Equal(secondCron, job.Cron);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithNullJobType_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                null!, "name", "0 0 * * *", "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingJobName_ThrowsArgumentException(string? jobName)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), jobName!, "0 0 * * *", "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingCron_ThrowsArgumentException(string? cron)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), "name", cron!, "Europe/Prague"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterOrUpdate_WithMissingTimeZoneId_ThrowsArgumentException(string? tz)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob), "name", "0 0 * * *", tz!));
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithTypeNotImplementingIRecurringJob_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(NotARecurringJob), "name", "0 0 * * *", "Europe/Prague"));
+        Assert.Equal("jobType", ex.ParamName);
+    }
+
+    [Fact]
+    public void RegisterOrUpdate_WithInvalidTimeZoneId_ThrowsUnwrappedTimeZoneNotFoundException()
+    {
+        // The helper must unwrap TargetInvocationException so callers see the
+        // real cause (TimeZoneNotFoundException), not the reflection wrapper.
+        Assert.Throws<TimeZoneNotFoundException>(() =>
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                typeof(HelperTestRecurringJob),
+                "helper-test-tz-job",
+                "0 0 * * *",
+                "Not/A/Real/TimeZone"));
+    }
+
+    public void Dispose()
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        foreach (var job in connection.GetRecurringJobs())
+        {
+            RecurringJob.RemoveIfExists(job.Id);
+        }
+    }
+
+    private class HelperTestRecurringJob : IRecurringJob
+    {
+        public RecurringJobMetadata Metadata { get; } = new()
+        {
+            JobName = "helper-test-job",
+            DisplayName = "Helper Test Job",
+            Description = "Used by HangfireJobRegistrationHelperTests",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "Europe/Prague",
+        };
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private class NotARecurringJob
+    {
+        // Used to assert the helper rejects types that do not implement IRecurringJob.
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (helper does not exist yet)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" \
+    --no-restore --nologo
+```
+
+Expected: Build error — `The type or namespace name 'HangfireJobRegistrationHelper' could not be found`. This is the RED state; the tests cannot even compile yet.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs
+git commit -m "test: add HangfireJobRegistrationHelper unit tests (red)"
+```
+
+---
+
+## Task 2: Create the helper (TDD green)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`
+
+- [ ] **Step 1: Write the helper**
+
+Create `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`:
+
+```csharp
+using System.Reflection;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Hangfire;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+/// <summary>
+/// Single entry point for binding a runtime <see cref="Type"/> to
+/// <see cref="RecurringJob.AddOrUpdate{TJob}(string, System.Linq.Expressions.Expression{Action{TJob}}, string, RecurringJobOptions)"/>.
+/// Used by both startup discovery and runtime CRON updates so that both code paths
+/// produce identical Hangfire <c>RecurringJob</c> records.
+/// </summary>
+public static class HangfireJobRegistrationHelper
+{
+    /// <summary>
+    /// Registers or updates a Hangfire recurring job for the given runtime job type.
+    /// Always uses the <see cref="RecurringJobOptions"/> overload.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="jobType"/> is null.</exception>
+    /// <exception cref="ArgumentException">A string argument is null/empty/whitespace, or <paramref name="jobType"/> does not implement <see cref="IRecurringJob"/>.</exception>
+    /// <exception cref="TimeZoneNotFoundException">The time zone id is not resolvable on this host.</exception>
+    public static void RegisterOrUpdate(
+        Type jobType,
+        string jobName,
+        string cronExpression,
+        string timeZoneId)
+    {
+        ArgumentNullException.ThrowIfNull(jobType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(jobName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cronExpression);
+        ArgumentException.ThrowIfNullOrWhiteSpace(timeZoneId);
+
+        if (!typeof(IRecurringJob).IsAssignableFrom(jobType))
+        {
+            throw new ArgumentException(
+                $"{jobType.FullName} does not implement {nameof(IRecurringJob)}.",
+                nameof(jobType));
+        }
+
+        var dispatcher = typeof(HangfireJobRegistrationHelper)
+            .GetMethod(nameof(RegisterOrUpdateGeneric), BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"Could not resolve {nameof(RegisterOrUpdateGeneric)} via reflection.");
+
+        var closed = dispatcher.MakeGenericMethod(jobType);
+
+        try
+        {
+            closed.Invoke(null, new object[] { jobName, cronExpression, timeZoneId });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            // Surface the real cause (e.g. TimeZoneNotFoundException) instead of the
+            // reflection wrapper, so callers can log structured context.
+            throw ex.InnerException;
+        }
+    }
+
+    private static void RegisterOrUpdateGeneric<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId)
+        where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            job => job.ExecuteAsync(default),
+            cronExpression,
+            new RecurringJobOptions
+            {
+                TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+            });
+    }
+}
+```
+
+- [ ] **Step 2: Run the helper tests to verify they pass**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" \
+    --no-restore --nologo
+```
+
+Expected: All 11 tests (`Theory` rows count separately) pass.
+
+- [ ] **Step 3: Commit the helper**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
+git commit -m "feat(background-jobs): add HangfireJobRegistrationHelper"
+```
+
+---
+
+## Task 3: Refactor `RecurringJobDiscoveryService` to use the helper
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs`
+
+- [ ] **Step 1: Replace reflection dispatch with helper call**
+
+In `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs`:
+
+Replace the entire block from line 79 to line 96 (the `var registerMethod = ...` block, the null-check, the `MakeGenericMethod` call, and the `Invoke`) with a single helper call:
+
+```csharp
+                    HangfireJobRegistrationHelper.RegisterOrUpdate(
+                        jobType,
+                        metadata.JobName,
+                        cronExpression,
+                        metadata.TimeZoneId);
+```
+
+The surrounding `try/catch` (lines 67 outer and 102–107) **stays as-is** — the catch already logs structured context for `metadata.JobName` and `jobType.Name`.
+
+- [ ] **Step 2: Delete the now-unused private generic method**
+
+Delete the entire `RegisterRecurringJobInternal<TJob>` method (lines 129–142):
+
+```csharp
+    private static void RegisterRecurringJobInternal<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId) where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            job => job.ExecuteAsync(default),
+            cronExpression,
+            new RecurringJobOptions
+            {
+                TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)
+            });
+    }
+```
+
+- [ ] **Step 3: Add the helper using and remove unused usings**
+
+At the top of the file, add:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+```
+
+Verify these `using` statements remain (they are still used elsewhere in the file):
+- `using Anela.Heblo.Domain.Features.BackgroundJobs;` — for `IRecurringJob`, `IRecurringJobConfigurationRepository`
+- `using Anela.Heblo.Xcc;` — for `HangfireOptions`
+- `using Hangfire;` — *no longer used* once `RegisterRecurringJobInternal` is gone. Remove it.
+- `using Microsoft.Extensions.Options;` — for `IOptions<HangfireOptions>`
+
+The final top-of-file usings should be:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Xcc;
+using Microsoft.Extensions.Options;
+```
+
+- [ ] **Step 4: Build to verify the API project compiles**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: Build succeeds with zero errors. Warnings should not increase versus baseline.
+
+- [ ] **Step 5: Run the existing `RecurringJobDiscoveryServiceTests` to verify behaviour parity**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~RecurringJobDiscoveryServiceTests" \
+    --no-restore --nologo
+```
+
+Expected: All three existing tests pass (`StartAsync_WithSchedulerEnabled_RegistersRecurringJobs`, `StartAsync_WhenDbConfigExists_UsesDbCronInsteadOfMetadataDefault`, `StartAsync_WithSchedulerDisabled_DoesNotRegisterJobs`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
+git commit -m "refactor(background-jobs): route RecurringJobDiscoveryService through HangfireJobRegistrationHelper"
+```
+
+---
+
+## Task 4: Refactor `HangfireRecurringJobScheduler` to use the helper
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs`
+
+- [ ] **Step 1: Replace reflection dispatch with helper call**
+
+Open `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs`.
+
+Replace the block from line 41 to line 64 (everything from `var jobType = job.GetType();` through the `try { genericMethod.Invoke(...) } catch (...) { ... return; }` block) with this simpler implementation:
+
+```csharp
+        try
+        {
+            HangfireJobRegistrationHelper.RegisterOrUpdate(
+                job.GetType(),
+                jobName,
+                cronExpression,
+                job.Metadata.TimeZoneId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to update live Hangfire schedule for {JobName}. " +
+                "TimeZone '{TimeZoneId}' may be invalid or unsupported on this host.",
+                jobName, job.Metadata.TimeZoneId);
+            return;
+        }
+```
+
+The trailing success log (lines 66–68) stays as-is.
+
+- [ ] **Step 2: Delete the now-unused private generic method**
+
+Delete the entire `UpdateJobInternal<TJob>` method (lines 71–81):
+
+```csharp
+    private static void UpdateJobInternal<TJob>(
+        string jobName,
+        string cronExpression,
+        string timeZoneId) where TJob : IRecurringJob
+    {
+        RecurringJob.AddOrUpdate<TJob>(
+            jobName,
+            j => j.ExecuteAsync(default),
+            cronExpression,
+            TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+    }
+```
+
+- [ ] **Step 3: Remove unused usings**
+
+At the top of the file, remove these `using` lines — they were used only by the deleted reflection block and the deleted private method:
+
+```csharp
+using System.Reflection;
+using Hangfire;
+```
+
+Verify these `using` statements remain (still used):
+- `using Anela.Heblo.Domain.Features.BackgroundJobs;` — for `IRecurringJob`
+- `using Microsoft.Extensions.DependencyInjection;` — for `CreateScope`, `GetServices`
+- `using Microsoft.Extensions.Logging;` — for `ILogger<>`
+
+The final top-of-file usings should be:
+
+```csharp
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+```
+
+(No `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` is needed — the helper is in the same namespace.)
+
+- [ ] **Step 4: Update the class-level docstring**
+
+Update the XML doc comment on the `HangfireRecurringJobScheduler` class (lines 9–12) from:
+
+```csharp
+/// <summary>
+/// Updates a Hangfire recurring job's CRON schedule live using the same
+/// reflection pattern as RecurringJobDiscoveryService.
+/// </summary>
+```
+
+to:
+
+```csharp
+/// <summary>
+/// Updates a Hangfire recurring job's CRON schedule live by delegating to
+/// <see cref="HangfireJobRegistrationHelper"/> so the runtime-update path uses
+/// the same registration code as startup discovery.
+/// </summary>
+```
+
+- [ ] **Step 5: Build the solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: Build succeeds with zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs
+git commit -m "refactor(background-jobs): route HangfireRecurringJobScheduler through HangfireJobRegistrationHelper"
+```
+
+---
+
+## Task 5: Add behaviour-parity test for the scheduler
+
+This task creates a new test file that exercises `HangfireRecurringJobScheduler` against in-memory Hangfire storage and asserts that:
+1. The scheduler successfully updates the CRON of a previously-registered job.
+2. The resulting Hangfire record after a scheduler update is structurally identical (CRON, time zone, async return type) to a record produced by `RecurringJobDiscoveryService` — the behaviour-parity check from arch-review Amendment 4.
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs`:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Anela.Heblo.Xcc;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+[Collection("Hangfire")]
+public class HangfireRecurringJobSchedulerTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    public HangfireRecurringJobSchedulerTests(HangfireTestFixture fixture)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment { EnvironmentName = "Test" });
+        services.AddScoped<IRecurringJob, ParityTestRecurringJob>();
+        services.AddScoped<ParityTestRecurringJob>();
+        services.AddSingleton<IRecurringJobConfigurationRepository, EmptyStubRepository>();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void UpdateCronSchedule_WithUnknownJobName_LogsWarningAndReturns()
+    {
+        // Arrange
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+
+        // Act
+        scheduler.UpdateCronSchedule("does-not-exist", "0 0 * * *");
+
+        // Assert — no job was created
+        using var connection = JobStorage.Current.GetConnection();
+        Assert.Empty(connection.GetRecurringJobs().Where(j => j.Id == "does-not-exist"));
+    }
+
+    [Fact]
+    public async Task UpdateCronSchedule_AfterDiscoveryRegistration_UpdatesCronInStorage()
+    {
+        // Arrange — first register via discovery service (startup path)
+        const string newCron = "0 4 * * 2"; // differs from metadata default
+        var hangfireOptions = Options.Create(new HangfireOptions { SchedulerEnabled = true });
+        var discovery = new RecurringJobDiscoveryService(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<RecurringJobDiscoveryService>>(),
+            _serviceProvider.GetRequiredService<IWebHostEnvironment>(),
+            hangfireOptions);
+        await discovery.StartAsync(CancellationToken.None);
+
+        var scheduler = new HangfireRecurringJobScheduler(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+
+        // Act — update via the runtime scheduler path
+        scheduler.UpdateCronSchedule("parity-test-job", newCron);
+
+        // Assert
+        using var connection = JobStorage.Current.GetConnection();
+        var job = Assert.Single(connection.GetRecurringJobs(), j => j.Id == "parity-test-job");
+        Assert.Equal(newCron, job.Cron);
+        Assert.Equal("Europe/Prague", job.TimeZoneId);
+    }
+
+    [Fact]
+    public async Task UpdateCronSchedule_ProducesIdenticalRecordStructureToDiscoveryRegistration()
+    {
+        // Arrange — register two jobs: one via the discovery path, one re-registered
+        // via the scheduler path. Both should end up with the same async method signature
+        // and same time-zone metadata. This is the behaviour-parity check (arch-review Amendment 4).
+        var hangfireOptions = Options.Create(new HangfireOptions { SchedulerEnabled = true });
+        var discovery = new RecurringJobDiscoveryService(
+            _serviceProvider,
+            _serviceProvider.GetRequiredService<ILogger<RecurringJobDiscoveryService>>(),
+            _serviceProvider.GetRequiredService<IWebHostEnvironment>(),
+            hangfireOptions);
+        await discovery.StartAsync(CancellationToken.None);
+
+        using (var connection = JobStorage.Current.GetConnection())
+        {
+            var discovered = Assert.Single(connection.GetRecurringJobs(), j => j.Id == "parity-test-job");
+
+            // Act — re-register through the scheduler with a new CRON
+            var scheduler = new HangfireRecurringJobScheduler(
+                _serviceProvider,
+                _serviceProvider.GetRequiredService<ILogger<HangfireRecurringJobScheduler>>());
+            scheduler.UpdateCronSchedule("parity-test-job", "0 7 * * *");
+
+            // Assert — re-fetch and compare structural metadata
+            var afterUpdate = Assert.Single(
+                JobStorage.Current.GetConnection().GetRecurringJobs(),
+                j => j.Id == "parity-test-job");
+
+            Assert.Equal(discovered.Job.Method.ReturnType, afterUpdate.Job.Method.ReturnType);
+            Assert.Equal(typeof(Task), afterUpdate.Job.Method.ReturnType);
+            Assert.Equal(discovered.TimeZoneId, afterUpdate.TimeZoneId);
+            Assert.Equal(discovered.Job.Type, afterUpdate.Job.Type);
+            Assert.Equal(discovered.Job.Method.Name, afterUpdate.Job.Method.Name);
+        }
+    }
+
+    public void Dispose()
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        foreach (var job in connection.GetRecurringJobs())
+        {
+            RecurringJob.RemoveIfExists(job.Id);
+        }
+        _serviceProvider?.Dispose();
+    }
+
+    private class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "TestApp";
+        public string ContentRootPath { get; set; } = "/test";
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+        public string WebRootPath { get; set; } = "/test/wwwroot";
+        public IFileProvider WebRootFileProvider { get; set; } = null!;
+    }
+
+    private class ParityTestRecurringJob : IRecurringJob
+    {
+        public RecurringJobMetadata Metadata { get; } = new()
+        {
+            JobName = "parity-test-job",
+            DisplayName = "Parity Test Job",
+            Description = "Used by HangfireRecurringJobSchedulerTests",
+            CronExpression = "0 0 * * *",
+            TimeZoneId = "Europe/Prague",
+        };
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private class EmptyStubRepository : IRecurringJobConfigurationRepository
+    {
+        public Task<List<RecurringJobConfiguration>> GetAllAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new List<RecurringJobConfiguration>());
+
+        public Task<RecurringJobConfiguration?> GetByJobNameAsync(string jobName, CancellationToken cancellationToken = default)
+            => Task.FromResult<RecurringJobConfiguration?>(null);
+
+        public Task UpdateAsync(RecurringJobConfiguration configuration, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task SeedDefaultConfigurationsAsync(IEnumerable<IRecurringJob> jobs, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 2: Run the new scheduler tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~HangfireRecurringJobSchedulerTests" \
+    --no-restore --nologo
+```
+
+Expected: All 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireRecurringJobSchedulerTests.cs
+git commit -m "test: add HangfireRecurringJobScheduler parity tests"
+```
+
+---
+
+## Task 6: Full validation and final commit
+
+This task is the final sanity check: run the full BackgroundJobs test suite, the full backend build, and `dotnet format` to satisfy `CLAUDE.md`'s validation gate.
+
+- [ ] **Step 1: Run the entire BackgroundJobs test folder**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+    --filter "FullyQualifiedName~Features.BackgroundJobs" \
+    --no-restore --nologo
+```
+
+Expected: All BackgroundJobs tests pass — no regression in the existing `RecurringJobDiscoveryServiceTests`, `UpdateRecurringJobCronHandlerTests`, `TriggerRecurringJobHandlerIntegrationTests`, `HangfireJobEnqueuerTests`, etc.
+
+- [ ] **Step 2: Build the full backend solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: Build succeeds with zero errors. Warning count should not increase versus the baseline before this branch.
+
+- [ ] **Step 3: Run `dotnet format` (CLAUDE.md gate)**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln
+```
+
+If any files are reformatted, stage and commit them:
+
+```bash
+git add -u
+git diff --cached --quiet || git commit -m "chore: dotnet format"
+```
+
+- [ ] **Step 4: Confirm no leftover references to the old internal methods**
+
+Search for any orphaned references:
+
+```bash
+grep -rn "RegisterRecurringJobInternal\|UpdateJobInternal" backend/src backend/test
+```
+
+Expected output: empty (no matches). If anything appears, it is dead code from a missed deletion — remove it and amend the relevant prior commit or add a fix commit.
+
+- [ ] **Step 5: Confirm exactly one `RecurringJob.AddOrUpdate` call site remains (FR-2 acceptance)**
+
+Run:
+```bash
+grep -rn "RecurringJob.AddOrUpdate" backend/src
+```
+
+Expected output: a single match inside `HangfireJobRegistrationHelper.cs` (the `RegisterOrUpdateGeneric<TJob>` body).
+
+Also confirm the legacy `TimeZoneInfo`-only overload is gone:
+
+```bash
+grep -rn "AddOrUpdate<.*>(.*TimeZoneInfo\." backend/src
+```
+
+Expected output: empty.
+
+- [ ] **Step 6: Final commit if anything was tweaked in Step 5**
+
+If any additional changes were required, commit them:
+
+```bash
+git add -u
+git diff --cached --quiet || git commit -m "chore(background-jobs): tidy post-consolidation"
+```
+
+If no changes were needed, this step is a no-op.
+
+---
+
+## Acceptance Criteria Mapping
+
+| Spec/Arch Requirement | Implemented in |
+|---|---|
+| FR-1: Single helper with reflection plumbing + input validation | Task 1 (tests), Task 2 (impl) |
+| FR-2: Only one `RecurringJob.AddOrUpdate<TJob>` call site, `RecurringJobOptions` overload | Task 2 (helper), Task 6 Step 5 (verification) |
+| FR-3: `RecurringJobDiscoveryService` delegates to helper, no more reflection there | Task 3 |
+| FR-4: `HangfireRecurringJobScheduler` delegates to helper, no more reflection there | Task 4 |
+| FR-5: Behaviour parity (same names/CRON/TZ; runtime updates work) | Task 3 Step 5 (existing tests), Task 5 (parity test) |
+| FR-6 (corrected by Amendment 1): Helper in `Application/Features/BackgroundJobs/Services/`, `public static`, no new project references | Task 2 |
+| Amendment 2: `public static` visibility | Task 2 |
+| Amendment 3: Unwrap `TargetInvocationException` | Task 1 (test), Task 2 (impl) |
+| Amendment 4: Behaviour-parity test | Task 5 |
+| Amendment 5: Helper unit tests | Task 1 |
+| NFR-3: Single place for future Hangfire options changes | Task 2 |
+| NFR-4: Helper unit-testable in isolation | Task 1 |


### PR DESCRIPTION
BackgroundJobs

## Finding
Two separate classes build a generic `RecurringJob.AddOrUpdate<TJob>` call via reflection, but use different `Hangfire` API overloads:

**`RecurringJobDiscoveryService.RegisterRecurringJobInternal<TJob>`**  
`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` lines 129–142:
```csharp
RecurringJob.AddOrUpdate<TJob>(
    jobName,
    job => job.ExecuteAsync(default),
    cronExpression,
    new RecurringJobOptions { TimeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId) });
```

**`HangfireRecurringJobScheduler.UpdateJobInternal<TJob>`**  
`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireRecurringJobScheduler.cs` lines 71–80:
```csharp
RecurringJob.AddOrUpdate<TJob>(
    jobName,
    j => j.ExecuteAsync(default),
    cronExpression,
    TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
```

The two overloads of `RecurringJob.AddOrUpdate` have different behaviour: the `RecurringJobOptions` overload is the newer API and supports additional options; the bare `TimeZoneInfo` overload is a legacy signature. This means startup registration (via `RecurringJobDiscoveryService`) and live CRON update (via `HangfireRecurringJobScheduler`) silently use different code paths, which could produce subtle inconsistencies when Hangfire updates its defaults for the legacy overload.

Both methods also duplicate the same reflection plumbing to resolve the generic method by name (`GetMethod(nameof(...), NonPublic | Static)` → `MakeGenericMethod(jobType)` → `Invoke`).

## Why it matters
- Real code duplication: the same reflection pattern appears in two places; future changes (e.g., adding a queue name or priority) must be applied twice
- Divergent overloads: a change to timezone handling or job options will only be applied to whichever site is edited first

## Suggested fix
Extract a single shared static helper (e.g., `HangfireJobRegistrationHelper.RegisterOrUpdate<TJob>`) in the API infrastructure layer, called by both `RecurringJobDiscoveryService` and `HangfireRecurringJobScheduler`. Standardise on the `RecurringJobOptions` overload. This removes the duplication and ensures startup registration and live updates follow identical paths.

---
_Filed by daily arch-review routine on 2026-05-27._

---

Closes #1819

### Tokens used
21831626
