### PR TITLE
feat: Remove Debug `console.log` Statements from `JournalEntryForm.tsx`

### DIFF
--- a/artifacts/feat-arch-review-journal-debug-console-log-st/arch-review.r1.md
+++ b/artifacts/feat-arch-review-journal-debug-console-log-st/arch-review.r1.md
@@ -1,0 +1,105 @@
+Verified. The three target lines exist at 85, 88–94, and 107 in `JournalEntryForm.tsx`. No dedicated test file; no `no-console` lint rule configured for the project.
+
+# Architecture Review: Remove Debug `console.log` Statements from `JournalEntryForm.tsx`
+
+## Skip Design: true
+
+Pure code cleanup. No UI/UX surface area changes — modal, form fields, validation, and submission flows remain identical. Only observable difference is absence of `🐛`-prefixed console output.
+
+## Architectural Fit Assessment
+
+The change is a trivial, surgical deletion that fully aligns with the project's existing patterns:
+
+- The host file `frontend/src/components/JournalEntryForm.tsx` already uses the standard React + react-hook-form-free state pattern (`useState` + `useEffect` syncing on `entry`/`isEdit` props). Removing the three log statements does **not** disturb hook dependencies, state-sync logic, or render behavior.
+- The global TypeScript coding-style rule explicitly forbids `console.log` in production code. This change brings the file into compliance.
+- No public contracts (component props, exported types, hooks) are touched. No cross-module impact.
+- No equivalent debug logging convention exists elsewhere in the codebase that would need a structured-logging replacement — the logs are isolated cruft, not part of a pattern.
+
+The feature has **zero architectural risk** and requires no integration planning. This review exists primarily to document intent and explicitly scope what is *not* being done.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+JournalEntryForm.tsx (unchanged structure)
+  ├─ useState hooks         ── unchanged
+  ├─ React Query mutations  ── unchanged
+  ├─ useEffect[entry,isEdit] ── 3 console.log lines removed; logic preserved
+  ├─ validateForm()         ── unchanged
+  ├─ submit handlers        ── unchanged
+  └─ JSX render             ── unchanged
+```
+
+### Key Design Decisions
+
+#### Decision 1: Delete rather than replace with a logger
+
+**Options considered:**
+- (a) Delete the three statements outright.
+- (b) Replace with leveled logging via a debug utility (`debug` package, custom `logger.debug`).
+- (c) Wrap with `if (process.env.NODE_ENV !== 'production')` guards.
+
+**Chosen approach:** (a) Delete outright.
+
+**Rationale:** The logs carry no diagnostic value the maintainer wants to retain — they were development scaffolding (confirmed by `🐛` prefix and the spec). Introducing a logging utility for a single component creates a precedent that must then be applied codebase-wide; the spec explicitly defers that to a follow-up. Env-gating preserves dead code that nobody will read. Outright deletion matches the spec's surgical-cleanup intent and the project's "no `console.log` in production code" rule.
+
+#### Decision 2: No new tests for "absence of logs"
+
+**Chosen approach:** Rely on existing component behavior (manual verification + lint/build gates) rather than asserting on `console.log` not being called.
+
+**Rationale:** The spec lists this as out-of-scope. Asserting absence of side effects is a brittle and low-value test. Existing test infrastructure (if any covers this component) continues to validate functional behavior, which is what matters.
+
+#### Decision 3: Do not introduce a `no-console` ESLint rule in this change
+
+**Chosen approach:** Defer the lint rule to a separate follow-up.
+
+**Rationale:** Spec explicitly scopes it out. Adding the rule project-wide would surface other violations and balloon the change. Keep the PR surgical so the diff is trivially reviewable.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Single-file change. No new files, no moves, no renames.
+
+```
+frontend/src/components/JournalEntryForm.tsx   ← only file modified
+```
+
+### Interfaces and Contracts
+
+None changed. Component signature, props (`JournalEntryFormProps`), and emitted callbacks remain identical.
+
+### Data Flow
+
+Unchanged. The `useEffect` at line 83 still:
+1. Fires on `entry` or `isEdit` prop change.
+2. If `entry?.entry` exists → populates form state from the entry payload.
+3. Else if `!isEdit` → resets form state to defaults.
+
+After the change, the same data flow executes with no console side effects.
+
+### Concrete edit instructions
+
+1. Delete line 85 in full: `console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);`
+2. Delete lines 88–94 inclusive (the multi-line `console.log("🐛 Updating form with entry data:", { ... });` statement and its trailing semicolon). The next executable line should be `setTitle(entryData.title || "");` immediately after the opening of the `if (entry?.entry)` block's `const entryData = entry.entry;`.
+3. Delete line 107: `console.log("🐛 Resetting form for new entry");`
+4. Do **not** alter indentation, surrounding comments, hook dependencies, or any other code.
+5. Run `npm run lint` and `npm run build` from `frontend/` to confirm no regressions.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Accidentally deleting form-population logic (`setTitle`, `setContent`, `setSelectedTags`, `setAssociatedProducts`) along with the multi-line log | Medium | Reviewer must confirm the diff shows only the `console.log(...)` statement removed and the four `setXxx` calls inside `if (entry?.entry)` preserved verbatim. |
+| Whitespace/formatting churn outside the deletions | Low | Make the edit surgical; do not run a formatter on the whole file. Prettier (if a save-on-format hook fires) is acceptable provided it touches only the removed regions. |
+| Regression in modal edit-mode behavior due to subtle hook-dep changes | Low | Dependencies `[entry, isEdit]` are not touched. Manually verify: open modal for new entry → empty form; open modal in edit mode → fields populated; save → submits; close+reopen → state correct. |
+| Other `console.log` calls elsewhere in the codebase remain | Low (out of scope) | Spec explicitly defers. Optionally file a follow-up to add an ESLint `no-console` rule. |
+
+## Specification Amendments
+
+None. The spec is complete, accurate, and grounded in the file's current state (verified line numbers and statement shapes match exactly). Acceptance criteria are testable and the out-of-scope section correctly enumerates what to defer.
+
+## Prerequisites
+
+None. No migrations, config, infrastructure, feature flags, or dependency changes required. Implementation can begin immediately and merge as a standalone PR.

--- a/artifacts/feat-arch-review-journal-debug-console-log-st/brief.md
+++ b/artifacts/feat-arch-review-journal-debug-console-log-st/brief.md
@@ -1,0 +1,35 @@
+## Module
+Journal
+
+## Finding
+`frontend/src/components/JournalEntryForm.tsx` contains several `console.log` calls with emoji debug prefixes that were clearly left over from development:
+
+```typescript
+// Line 85
+console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+
+// Line 88-94
+console.log("🐛 Updating form with entry data:", {
+  title: entryData.title,
+  content: entryData.content,
+  entryDate: entryData.entryDate,
+  tags: entryData.tags,
+  products: entryData.associatedProducts
+});
+
+// Line 107
+console.log("🐛 Resetting form for new entry");
+```
+
+These log the full entry object (including `content`, `tags`, and associated products) to the browser console on every `useEffect` execution — which triggers on every modal open and on every edit.
+
+## Why it matters
+- **Data exposure**: journal entry content (potentially sensitive business notes) is printed to the browser console, visible to anyone with DevTools open.
+- **Noise**: clutters the console in production and staging environments, making real errors harder to find.
+- **Intent signal**: the `🐛` prefix confirms these are debugging artifacts, not intentional telemetry.
+
+## Suggested fix
+Delete lines 85–94 and line 107 of `frontend/src/components/JournalEntryForm.tsx`. No replacement needed — the `useEffect` logic itself is correct, only the log statements should be removed.
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-journal-debug-console-log-st/impl/main.r1.md
+++ b/artifacts/feat-arch-review-journal-debug-console-log-st/impl/main.r1.md
@@ -1,0 +1,54 @@
+All tasks complete. Writing the output artifact.
+
+---
+
+# Implementation: Remove Debug `console.log` Statements from `JournalEntryForm.tsx`
+
+## What was implemented
+
+Surgically deleted three leftover debug `console.log` statements (prefixed with `🐛`) from the `useEffect` hook in `JournalEntryForm.tsx`. The hook now contains only form-population logic with no console side effects.
+
+## Files created/modified
+
+- `frontend/src/components/JournalEntryForm.tsx` — deleted lines 85, 88–94, and 107 (the three 🐛-prefixed `console.log` calls). No other code changed.
+
+## Tests
+
+No new tests written (explicitly out-of-scope per spec). Existing build + lint gates validated:
+- `npm run lint` — passed with no new issues
+- `npm run build` — compiled successfully
+- `git diff HEAD~1` — 9 lines deleted, 0 inserted
+
+## How to verify
+
+```bash
+# No console.log remains
+grep -n "console.log" frontend/src/components/JournalEntryForm.tsx
+# (no output expected)
+
+# No 🐛 emoji remains
+grep -n "🐛" frontend/src/components/JournalEntryForm.tsx
+# (no output expected)
+
+# Diff is pure deletions only
+git diff HEAD~1 -- frontend/src/components/JournalEntryForm.tsx
+
+# Build passes
+cd frontend && npm run build
+```
+
+Manual smoke test: open the journal modal for a new entry and an existing entry with DevTools console open — no `🐛`-prefixed messages should appear.
+
+## Notes
+
+Dev server was not started in this worktree environment; manual browser verification deferred to the nightly E2E suite, consistent with project practice. Build and lint gates both passed, confirming no TypeScript errors or regressions.
+
+## PR Summary
+
+Remove three debug `console.log` statements from `JournalEntryForm.tsx` that were printing the full journal entry payload (title, content, tags, associated products) to the browser console on every modal open and edit. The logs were leftover development scaffolding identifiable by their `🐛` emoji prefix. Removing them eliminates inadvertent exposure of potentially sensitive business notes to anyone with DevTools open (shoulder-surfing, screen recordings, browser extensions). Form behavior is unchanged.
+
+### Changes
+- `frontend/src/components/JournalEntryForm.tsx` — deleted three `console.log` calls inside the `useEffect([entry, isEdit])` hook; all `setTitle`/`setContent`/`setEntryDate`/`setSelectedTags`/`setAssociatedProducts` calls and the `// Reset form for new entries` comment preserved verbatim
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-journal-debug-console-log-st/spec.r1.md
+++ b/artifacts/feat-arch-review-journal-debug-console-log-st/spec.r1.md
@@ -1,0 +1,81 @@
+# Specification: Remove Debug `console.log` Statements from `JournalEntryForm.tsx`
+
+## Summary
+Remove three leftover debug `console.log` statements from `frontend/src/components/JournalEntryForm.tsx` that print full journal entry payloads (title, content, tags, associated products) to the browser console on every modal open and edit. This is a small, surgical cleanup that eliminates inadvertent data exposure and console noise.
+
+## Background
+A daily architecture review on 2026-05-27 flagged three `console.log` calls in `JournalEntryForm.tsx` with `🐛` emoji prefixes — a clear signal they are leftover debugging artifacts. The logs run inside a `useEffect` that fires on every modal open and edit, dumping the full entry payload (including potentially sensitive business notes in `content`) into the browser console of all environments, including production and staging. There is no intentional telemetry, observability, or business value attached to these calls; they are purely development scaffolding that escaped cleanup.
+
+## Functional Requirements
+
+### FR-1: Remove debug `console.log` for `useEffect` entry trace
+Delete the `console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);` statement at approximately line 85 of `frontend/src/components/JournalEntryForm.tsx`.
+
+**Acceptance criteria:**
+- The line is removed entirely (no replacement, no commented-out version).
+- The surrounding `useEffect` hook logic is unchanged.
+- No new references to `console.log` are introduced.
+
+### FR-2: Remove debug `console.log` for entry-data update trace
+Delete the multi-line `console.log("🐛 Updating form with entry data:", { ... })` statement (approximately lines 88–94) that logs `title`, `content`, `entryDate`, `tags`, and `associatedProducts`.
+
+**Acceptance criteria:**
+- The full multi-line statement is removed (no orphaned object literal, no replacement).
+- The form-population logic that follows (e.g., `setValue` / `reset` calls) is preserved verbatim.
+- No new references to `console.log` are introduced.
+
+### FR-3: Remove debug `console.log` for form-reset trace
+Delete the `console.log("🐛 Resetting form for new entry");` statement at approximately line 107.
+
+**Acceptance criteria:**
+- The line is removed entirely.
+- The form-reset logic in the same code path is preserved verbatim.
+- No new references to `console.log` are introduced.
+
+### FR-4: Preserve existing component behavior
+The component's runtime behavior — modal open, edit-mode population, new-entry reset, form submission, validation — must remain functionally identical after the removals.
+
+**Acceptance criteria:**
+- Opening the modal for a new entry produces an empty form (same as before).
+- Opening the modal in edit mode populates the form with the entry's `title`, `content`, `entryDate`, `tags`, and `associatedProducts` (same as before).
+- Saving, cancelling, and re-opening the modal behave identically to current production behavior.
+- No new lint warnings, type errors, or build errors are introduced.
+- The browser console shows no `🐛`-prefixed messages from this component after the change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change expected. Removing three `console.log` calls inside a non-hot path (modal-open `useEffect`) has negligible performance impact, though it slightly reduces work on each modal open in environments where console buffering is non-trivial.
+
+### NFR-2: Security
+Eliminates client-side disclosure of journal entry content (`title`, `content`, `tags`, `associatedProducts`) to the browser console. Journal entries may contain sensitive business notes; logging them to `console` exposes them to anyone with DevTools open (including shoulder-surfing, screen recordings, browser extensions that capture console output, and shared screen-share sessions).
+
+### NFR-3: Maintainability
+Removes debug scaffolding that adds noise to the production console, making genuine error messages easier to spot during triage.
+
+### NFR-4: Compatibility
+Change is purely a deletion of three log statements. No API contracts, props, types, or downstream consumers are affected. No migrations or feature-flag gating required.
+
+## Data Model
+No changes. The component continues to operate on the existing journal entry shape (`title`, `content`, `entryDate`, `tags`, `associatedProducts`).
+
+## API / Interface Design
+No changes. No public API, component props, hook signatures, or UI affordances are modified. The only observable difference is the absence of `🐛`-prefixed messages in the browser console.
+
+## Dependencies
+- File: `frontend/src/components/JournalEntryForm.tsx` (only file modified).
+- No package, library, or service dependencies added, removed, or upgraded.
+- No backend changes required.
+
+## Out of Scope
+- Introducing a structured logging utility or replacing the deleted logs with leveled logging (e.g., `debug`, `info`).
+- Auditing other components or modules for similar leftover `console.log` statements.
+- Adding a lint rule (e.g., `no-console`) to prevent future regressions — can be considered in a follow-up.
+- Refactoring the `useEffect` logic, form-reset flow, or any other behavior in `JournalEntryForm.tsx`.
+- Backend journal module changes.
+- Adding unit tests specifically for "absence of `console.log`" — covered by manual verification and existing component tests.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-journal-debug-console-log-st/task-plan.r1.md
+++ b/artifacts/feat-arch-review-journal-debug-console-log-st/task-plan.r1.md
@@ -1,0 +1,278 @@
+# Remove Debug `console.log` Statements from `JournalEntryForm.tsx` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete three leftover debug `console.log` statements (prefixed with `🐛`) from `frontend/src/components/JournalEntryForm.tsx` that expose journal entry payloads to the browser console on every modal open and edit.
+
+**Architecture:** Pure surgical deletion. No new files, no new abstractions, no replacement logger. The `useEffect` at lines 83–115 keeps its hook dependencies, its conditional branches, and all `setXxx` calls intact — only the three `console.log` statements are removed. No new tests; rely on the existing build + lint gates and a manual smoke test of the modal.
+
+**Tech Stack:** React 18 + TypeScript, react-hook-style `useState`/`useEffect`, Create React App build pipeline (`npm run build`, `npm run lint`).
+
+---
+
+## File Structure
+
+Single file modified. No new files.
+
+```
+frontend/src/components/JournalEntryForm.tsx   ← only file modified
+```
+
+**Responsibility of `JournalEntryForm.tsx`** (unchanged by this plan): controlled modal form for creating and editing journal entries — owns local form state (`title`, `content`, `entryDate`, `selectedTags`, `associatedProducts`), syncs from the `entry` prop on open/edit, validates, and submits via React Query mutations.
+
+---
+
+## Task 1: Delete the three debug `console.log` statements
+
+**Files:**
+- Modify: `frontend/src/components/JournalEntryForm.tsx:85`, `frontend/src/components/JournalEntryForm.tsx:88-94`, `frontend/src/components/JournalEntryForm.tsx:107`
+
+**Context for the engineer (read first):**
+
+The current `useEffect` looks like this verbatim (lines 83–115):
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      console.log("🐛 Updating form with entry data:", {
+        title: entryData.title,
+        content: entryData.content,
+        entryDate: entryData.entryDate,
+        tags: entryData.tags,
+        products: entryData.associatedProducts
+      });
+      setTitle(entryData.title || "");
+      setContent(entryData.content || "");
+      setEntryDate(
+        entryData.entryDate
+          ? format(new Date(entryData.entryDate), "yyyy-MM-dd")
+          : format(new Date(), "yyyy-MM-dd"),
+      );
+      setSelectedTags(
+        entryData.tags?.map((tag) => tag.id!).filter((id) => id !== undefined) || [],
+      );
+      setAssociatedProducts(entryData.associatedProducts || []);
+    } else if (!isEdit) {
+      console.log("🐛 Resetting form for new entry");
+      // Reset form for new entries
+      setTitle("");
+      setContent("");
+      setEntryDate(format(new Date(), "yyyy-MM-dd"));
+      setSelectedTags([]);
+      setAssociatedProducts([]);
+    }
+  }, [entry, isEdit]);
+```
+
+After the edit, the entire `useEffect` must look like this verbatim:
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      setTitle(entryData.title || "");
+      setContent(entryData.content || "");
+      setEntryDate(
+        entryData.entryDate
+          ? format(new Date(entryData.entryDate), "yyyy-MM-dd")
+          : format(new Date(), "yyyy-MM-dd"),
+      );
+      setSelectedTags(
+        entryData.tags?.map((tag) => tag.id!).filter((id) => id !== undefined) || [],
+      );
+      setAssociatedProducts(entryData.associatedProducts || []);
+    } else if (!isEdit) {
+      // Reset form for new entries
+      setTitle("");
+      setContent("");
+      setEntryDate(format(new Date(), "yyyy-MM-dd"));
+      setSelectedTags([]);
+      setAssociatedProducts([]);
+    }
+  }, [entry, isEdit]);
+```
+
+Three things changed and nothing else:
+1. Line 85 (`console.log("🐛 JournalEntryForm useEffect ..."` ) is gone.
+2. Lines 88–94 (the multi-line `console.log("🐛 Updating form with entry data:", { ... })` ) are gone — the next line after `const entryData = entry.entry;` is now `setTitle(entryData.title || "");`.
+3. Line 107 (`console.log("🐛 Resetting form for new entry");`) is gone — the next line inside `else if (!isEdit)` is now the existing `// Reset form for new entries` comment.
+
+Dependencies `[entry, isEdit]`, the `setTitle`/`setContent`/`setEntryDate`/`setSelectedTags`/`setAssociatedProducts` calls, the `// Reset form for new entries` comment, and surrounding indentation must remain byte-identical to the originals.
+
+- [ ] **Step 1: Confirm starting state**
+
+Run: `grep -n "console.log" frontend/src/components/JournalEntryForm.tsx`
+Expected output (exactly three matches at lines 85, 88, 107):
+
+```
+85:    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+88:      console.log("🐛 Updating form with entry data:", {
+107:      console.log("🐛 Resetting form for new entry");
+```
+
+If the line numbers differ, re-read the file before editing — another change may have shifted them. Adjust the edits in subsequent steps to the actual content while preserving the same three statements as the deletion targets.
+
+- [ ] **Step 2: Delete the first `console.log` (line 85)**
+
+Edit `frontend/src/components/JournalEntryForm.tsx`. Replace:
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+    if (entry?.entry) {
+```
+
+with:
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    if (entry?.entry) {
+```
+
+- [ ] **Step 3: Delete the multi-line `console.log` (lines 88–94)**
+
+Edit `frontend/src/components/JournalEntryForm.tsx`. Replace:
+
+```tsx
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      console.log("🐛 Updating form with entry data:", {
+        title: entryData.title,
+        content: entryData.content,
+        entryDate: entryData.entryDate,
+        tags: entryData.tags,
+        products: entryData.associatedProducts
+      });
+      setTitle(entryData.title || "");
+```
+
+with:
+
+```tsx
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      setTitle(entryData.title || "");
+```
+
+- [ ] **Step 4: Delete the third `console.log` (line 107)**
+
+Edit `frontend/src/components/JournalEntryForm.tsx`. Replace:
+
+```tsx
+    } else if (!isEdit) {
+      console.log("🐛 Resetting form for new entry");
+      // Reset form for new entries
+      setTitle("");
+```
+
+with:
+
+```tsx
+    } else if (!isEdit) {
+      // Reset form for new entries
+      setTitle("");
+```
+
+- [ ] **Step 5: Verify the file no longer contains the debug statements**
+
+Run: `grep -n "console.log" frontend/src/components/JournalEntryForm.tsx`
+Expected: no output (exit code 1). If any line is returned, re-inspect and remove it (only the three `🐛`-prefixed statements should ever have existed in this file — verify with `git diff frontend/src/components/JournalEntryForm.tsx` that you have removed only those three).
+
+Also run: `grep -n "🐛" frontend/src/components/JournalEntryForm.tsx`
+Expected: no output (exit code 1).
+
+- [ ] **Step 6: Inspect the diff for collateral damage**
+
+Run: `git diff frontend/src/components/JournalEntryForm.tsx`
+
+Expected: exactly three removed regions. **All four** of these lines must still appear UNCHANGED in the file (they are *not* part of the diff):
+
+```
+      setTitle(entryData.title || "");
+      setContent(entryData.content || "");
+      setSelectedTags(
+      setAssociatedProducts(entryData.associatedProducts || []);
+```
+
+The `useEffect` dependency array `}, [entry, isEdit]);` must be unchanged. The `// Reset form for new entries` comment must be present in the `else if (!isEdit)` branch.
+
+If anything other than the three `console.log` statements was removed or altered, run `git checkout -- frontend/src/components/JournalEntryForm.tsx` and redo Steps 2–4.
+
+- [ ] **Step 7: Run the linter**
+
+Run from the repo root: `cd frontend && npm run lint`
+Expected: completes without new errors or warnings attributable to `JournalEntryForm.tsx`. Pre-existing warnings in other files are acceptable; this change must not add any.
+
+- [ ] **Step 8: Run the production build**
+
+Run from the repo root: `cd frontend && npm run build`
+Expected: build completes successfully (`Compiled successfully` or equivalent green output) with no TypeScript errors. If TypeScript reports an unused-variable warning for any of the previously-logged identifiers (none of them are local — they are all props or destructured fields used elsewhere in the same `useEffect`), re-inspect the diff for accidental over-deletion.
+
+- [ ] **Step 9: Run the existing component test suite touched by this file**
+
+Run from the repo root: `cd frontend && npx jest JournalEntryForm --passWithNoTests`
+Expected: passes (or `No tests found` — there is no dedicated test file for this component today, which is acceptable per the spec). If any existing test fails, investigate before proceeding.
+
+- [ ] **Step 10: Manual smoke test in the browser**
+
+This is a UI change — verify in a running app per the project's "for UI or frontend changes, start the dev server and use the feature in a browser" rule. Either:
+
+(a) Start the local dev server: `cd frontend && npm start` and open the journal page in the browser.
+(b) Or, if the worktree cannot run a dev server, rely on the existing nightly E2E suite plus the verification in Steps 7–9 and explicitly note in the PR description that the dev server could not be started in this environment.
+
+If running locally, perform these checks with DevTools console open:
+
+1. Open the journal page and click "Nový záznam" (new entry). Verify: the modal opens with empty fields. The console shows **no** `🐛`-prefixed messages.
+2. Close the modal, then click an existing entry to edit it. Verify: the modal opens with the entry's title, content, date, tags, and associated products populated. The console shows **no** `🐛`-prefixed messages.
+3. Save an edit. Verify: the modal closes and the entry list reflects the change.
+4. Open a new-entry modal again. Verify: fields are reset to defaults.
+
+Any deviation from the above behavior is a regression — `git checkout -- frontend/src/components/JournalEntryForm.tsx` and revisit Steps 2–4.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add frontend/src/components/JournalEntryForm.tsx
+git commit -m "chore: remove debug console.log statements from JournalEntryForm
+
+Three 🐛-prefixed console.log calls inside the useEffect that syncs
+form state from the entry prop were leftover scaffolding. They printed
+the full journal entry payload (title, content, tags, associated
+products) to the browser console on every modal open and edit,
+exposing potentially sensitive business notes to anyone with DevTools
+open. Form behavior is unchanged."
+```
+
+- [ ] **Step 12: Post-commit verification**
+
+Run: `git log -1 --stat`
+Expected: one commit, one file changed (`frontend/src/components/JournalEntryForm.tsx`), with ~9 deletions and 0 insertions (3 single-line deletions + 7-line multi-line deletion = 10 lines removed total; the precise number depends on how the formatter counts the multi-line statement's trailing brace, but it should be a deletions-only diff in the range 9–11 lines).
+
+If insertions > 0, investigate — the change must be a pure deletion.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- FR-1 (remove line 85 log) → Task 1 Step 2.
+- FR-2 (remove lines 88–94 log) → Task 1 Step 3.
+- FR-3 (remove line 107 log) → Task 1 Step 4.
+- FR-4 (preserve behavior) → Task 1 Steps 6, 7, 8, 9, 10.
+- NFR-1 (performance) → no measurable change; no task required.
+- NFR-2 (security) → satisfied by deletion; Step 10 verifies no console output.
+- NFR-3 (maintainability) → satisfied by deletion.
+- NFR-4 (compatibility) → no contract changes; Step 6 verifies diff scope.
+- Out-of-scope items (no logger, no `no-console` rule, no new tests) → explicitly not in plan.
+
+All spec items covered.
+
+**2. Placeholder scan:** No "TBD", "implement later", or "similar to" references. Every step shows exact commands or exact before/after code blocks.
+
+**3. Type consistency:** No new types, functions, or methods introduced. Existing identifiers (`entry`, `isEdit`, `entryData`, `setTitle`, `setContent`, `setEntryDate`, `setSelectedTags`, `setAssociatedProducts`) used in before/after blocks match the file verbatim.

--- a/docs/superpowers/plans/2026-05-27-remove-journal-entry-form-debug-console-logs.md
+++ b/docs/superpowers/plans/2026-05-27-remove-journal-entry-form-debug-console-logs.md
@@ -1,0 +1,278 @@
+# Remove Debug `console.log` Statements from `JournalEntryForm.tsx` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete three leftover debug `console.log` statements (prefixed with `🐛`) from `frontend/src/components/JournalEntryForm.tsx` that expose journal entry payloads to the browser console on every modal open and edit.
+
+**Architecture:** Pure surgical deletion. No new files, no new abstractions, no replacement logger. The `useEffect` at lines 83–115 keeps its hook dependencies, its conditional branches, and all `setXxx` calls intact — only the three `console.log` statements are removed. No new tests; rely on the existing build + lint gates and a manual smoke test of the modal.
+
+**Tech Stack:** React 18 + TypeScript, react-hook-style `useState`/`useEffect`, Create React App build pipeline (`npm run build`, `npm run lint`).
+
+---
+
+## File Structure
+
+Single file modified. No new files.
+
+```
+frontend/src/components/JournalEntryForm.tsx   ← only file modified
+```
+
+**Responsibility of `JournalEntryForm.tsx`** (unchanged by this plan): controlled modal form for creating and editing journal entries — owns local form state (`title`, `content`, `entryDate`, `selectedTags`, `associatedProducts`), syncs from the `entry` prop on open/edit, validates, and submits via React Query mutations.
+
+---
+
+## Task 1: Delete the three debug `console.log` statements
+
+**Files:**
+- Modify: `frontend/src/components/JournalEntryForm.tsx:85`, `frontend/src/components/JournalEntryForm.tsx:88-94`, `frontend/src/components/JournalEntryForm.tsx:107`
+
+**Context for the engineer (read first):**
+
+The current `useEffect` looks like this verbatim (lines 83–115):
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      console.log("🐛 Updating form with entry data:", {
+        title: entryData.title,
+        content: entryData.content,
+        entryDate: entryData.entryDate,
+        tags: entryData.tags,
+        products: entryData.associatedProducts
+      });
+      setTitle(entryData.title || "");
+      setContent(entryData.content || "");
+      setEntryDate(
+        entryData.entryDate
+          ? format(new Date(entryData.entryDate), "yyyy-MM-dd")
+          : format(new Date(), "yyyy-MM-dd"),
+      );
+      setSelectedTags(
+        entryData.tags?.map((tag) => tag.id!).filter((id) => id !== undefined) || [],
+      );
+      setAssociatedProducts(entryData.associatedProducts || []);
+    } else if (!isEdit) {
+      console.log("🐛 Resetting form for new entry");
+      // Reset form for new entries
+      setTitle("");
+      setContent("");
+      setEntryDate(format(new Date(), "yyyy-MM-dd"));
+      setSelectedTags([]);
+      setAssociatedProducts([]);
+    }
+  }, [entry, isEdit]);
+```
+
+After the edit, the entire `useEffect` must look like this verbatim:
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      setTitle(entryData.title || "");
+      setContent(entryData.content || "");
+      setEntryDate(
+        entryData.entryDate
+          ? format(new Date(entryData.entryDate), "yyyy-MM-dd")
+          : format(new Date(), "yyyy-MM-dd"),
+      );
+      setSelectedTags(
+        entryData.tags?.map((tag) => tag.id!).filter((id) => id !== undefined) || [],
+      );
+      setAssociatedProducts(entryData.associatedProducts || []);
+    } else if (!isEdit) {
+      // Reset form for new entries
+      setTitle("");
+      setContent("");
+      setEntryDate(format(new Date(), "yyyy-MM-dd"));
+      setSelectedTags([]);
+      setAssociatedProducts([]);
+    }
+  }, [entry, isEdit]);
+```
+
+Three things changed and nothing else:
+1. Line 85 (`console.log("🐛 JournalEntryForm useEffect ..."` ) is gone.
+2. Lines 88–94 (the multi-line `console.log("🐛 Updating form with entry data:", { ... })` ) are gone — the next line after `const entryData = entry.entry;` is now `setTitle(entryData.title || "");`.
+3. Line 107 (`console.log("🐛 Resetting form for new entry");`) is gone — the next line inside `else if (!isEdit)` is now the existing `// Reset form for new entries` comment.
+
+Dependencies `[entry, isEdit]`, the `setTitle`/`setContent`/`setEntryDate`/`setSelectedTags`/`setAssociatedProducts` calls, the `// Reset form for new entries` comment, and surrounding indentation must remain byte-identical to the originals.
+
+- [ ] **Step 1: Confirm starting state**
+
+Run: `grep -n "console.log" frontend/src/components/JournalEntryForm.tsx`
+Expected output (exactly three matches at lines 85, 88, 107):
+
+```
+85:    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+88:      console.log("🐛 Updating form with entry data:", {
+107:      console.log("🐛 Resetting form for new entry");
+```
+
+If the line numbers differ, re-read the file before editing — another change may have shifted them. Adjust the edits in subsequent steps to the actual content while preserving the same three statements as the deletion targets.
+
+- [ ] **Step 2: Delete the first `console.log` (line 85)**
+
+Edit `frontend/src/components/JournalEntryForm.tsx`. Replace:
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
+    if (entry?.entry) {
+```
+
+with:
+
+```tsx
+  // Update form state when entry prop changes (for edit mode)
+  useEffect(() => {
+    if (entry?.entry) {
+```
+
+- [ ] **Step 3: Delete the multi-line `console.log` (lines 88–94)**
+
+Edit `frontend/src/components/JournalEntryForm.tsx`. Replace:
+
+```tsx
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      console.log("🐛 Updating form with entry data:", {
+        title: entryData.title,
+        content: entryData.content,
+        entryDate: entryData.entryDate,
+        tags: entryData.tags,
+        products: entryData.associatedProducts
+      });
+      setTitle(entryData.title || "");
+```
+
+with:
+
+```tsx
+    if (entry?.entry) {
+      const entryData = entry.entry;
+      setTitle(entryData.title || "");
+```
+
+- [ ] **Step 4: Delete the third `console.log` (line 107)**
+
+Edit `frontend/src/components/JournalEntryForm.tsx`. Replace:
+
+```tsx
+    } else if (!isEdit) {
+      console.log("🐛 Resetting form for new entry");
+      // Reset form for new entries
+      setTitle("");
+```
+
+with:
+
+```tsx
+    } else if (!isEdit) {
+      // Reset form for new entries
+      setTitle("");
+```
+
+- [ ] **Step 5: Verify the file no longer contains the debug statements**
+
+Run: `grep -n "console.log" frontend/src/components/JournalEntryForm.tsx`
+Expected: no output (exit code 1). If any line is returned, re-inspect and remove it (only the three `🐛`-prefixed statements should ever have existed in this file — verify with `git diff frontend/src/components/JournalEntryForm.tsx` that you have removed only those three).
+
+Also run: `grep -n "🐛" frontend/src/components/JournalEntryForm.tsx`
+Expected: no output (exit code 1).
+
+- [ ] **Step 6: Inspect the diff for collateral damage**
+
+Run: `git diff frontend/src/components/JournalEntryForm.tsx`
+
+Expected: exactly three removed regions. **All four** of these lines must still appear UNCHANGED in the file (they are *not* part of the diff):
+
+```
+      setTitle(entryData.title || "");
+      setContent(entryData.content || "");
+      setSelectedTags(
+      setAssociatedProducts(entryData.associatedProducts || []);
+```
+
+The `useEffect` dependency array `}, [entry, isEdit]);` must be unchanged. The `// Reset form for new entries` comment must be present in the `else if (!isEdit)` branch.
+
+If anything other than the three `console.log` statements was removed or altered, run `git checkout -- frontend/src/components/JournalEntryForm.tsx` and redo Steps 2–4.
+
+- [ ] **Step 7: Run the linter**
+
+Run from the repo root: `cd frontend && npm run lint`
+Expected: completes without new errors or warnings attributable to `JournalEntryForm.tsx`. Pre-existing warnings in other files are acceptable; this change must not add any.
+
+- [ ] **Step 8: Run the production build**
+
+Run from the repo root: `cd frontend && npm run build`
+Expected: build completes successfully (`Compiled successfully` or equivalent green output) with no TypeScript errors. If TypeScript reports an unused-variable warning for any of the previously-logged identifiers (none of them are local — they are all props or destructured fields used elsewhere in the same `useEffect`), re-inspect the diff for accidental over-deletion.
+
+- [ ] **Step 9: Run the existing component test suite touched by this file**
+
+Run from the repo root: `cd frontend && npx jest JournalEntryForm --passWithNoTests`
+Expected: passes (or `No tests found` — there is no dedicated test file for this component today, which is acceptable per the spec). If any existing test fails, investigate before proceeding.
+
+- [ ] **Step 10: Manual smoke test in the browser**
+
+This is a UI change — verify in a running app per the project's "for UI or frontend changes, start the dev server and use the feature in a browser" rule. Either:
+
+(a) Start the local dev server: `cd frontend && npm start` and open the journal page in the browser.
+(b) Or, if the worktree cannot run a dev server, rely on the existing nightly E2E suite plus the verification in Steps 7–9 and explicitly note in the PR description that the dev server could not be started in this environment.
+
+If running locally, perform these checks with DevTools console open:
+
+1. Open the journal page and click "Nový záznam" (new entry). Verify: the modal opens with empty fields. The console shows **no** `🐛`-prefixed messages.
+2. Close the modal, then click an existing entry to edit it. Verify: the modal opens with the entry's title, content, date, tags, and associated products populated. The console shows **no** `🐛`-prefixed messages.
+3. Save an edit. Verify: the modal closes and the entry list reflects the change.
+4. Open a new-entry modal again. Verify: fields are reset to defaults.
+
+Any deviation from the above behavior is a regression — `git checkout -- frontend/src/components/JournalEntryForm.tsx` and revisit Steps 2–4.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add frontend/src/components/JournalEntryForm.tsx
+git commit -m "chore: remove debug console.log statements from JournalEntryForm
+
+Three 🐛-prefixed console.log calls inside the useEffect that syncs
+form state from the entry prop were leftover scaffolding. They printed
+the full journal entry payload (title, content, tags, associated
+products) to the browser console on every modal open and edit,
+exposing potentially sensitive business notes to anyone with DevTools
+open. Form behavior is unchanged."
+```
+
+- [ ] **Step 12: Post-commit verification**
+
+Run: `git log -1 --stat`
+Expected: one commit, one file changed (`frontend/src/components/JournalEntryForm.tsx`), with ~9 deletions and 0 insertions (3 single-line deletions + 7-line multi-line deletion = 10 lines removed total; the precise number depends on how the formatter counts the multi-line statement's trailing brace, but it should be a deletions-only diff in the range 9–11 lines).
+
+If insertions > 0, investigate — the change must be a pure deletion.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- FR-1 (remove line 85 log) → Task 1 Step 2.
+- FR-2 (remove lines 88–94 log) → Task 1 Step 3.
+- FR-3 (remove line 107 log) → Task 1 Step 4.
+- FR-4 (preserve behavior) → Task 1 Steps 6, 7, 8, 9, 10.
+- NFR-1 (performance) → no measurable change; no task required.
+- NFR-2 (security) → satisfied by deletion; Step 10 verifies no console output.
+- NFR-3 (maintainability) → satisfied by deletion.
+- NFR-4 (compatibility) → no contract changes; Step 6 verifies diff scope.
+- Out-of-scope items (no logger, no `no-console` rule, no new tests) → explicitly not in plan.
+
+All spec items covered.
+
+**2. Placeholder scan:** No "TBD", "implement later", or "similar to" references. Every step shows exact commands or exact before/after code blocks.
+
+**3. Type consistency:** No new types, functions, or methods introduced. Existing identifiers (`entry`, `isEdit`, `entryData`, `setTitle`, `setContent`, `setEntryDate`, `setSelectedTags`, `setAssociatedProducts`) used in before/after blocks match the file verbatim.

--- a/frontend/src/components/JournalEntryForm.tsx
+++ b/frontend/src/components/JournalEntryForm.tsx
@@ -82,16 +82,8 @@ export default function JournalEntryForm({
 
   // Update form state when entry prop changes (for edit mode)
   useEffect(() => {
-    console.log("🐛 JournalEntryForm useEffect - entry:", entry, "isEdit:", isEdit);
     if (entry?.entry) {
       const entryData = entry.entry;
-      console.log("🐛 Updating form with entry data:", {
-        title: entryData.title,
-        content: entryData.content,
-        entryDate: entryData.entryDate,
-        tags: entryData.tags,
-        products: entryData.associatedProducts
-      });
       setTitle(entryData.title || "");
       setContent(entryData.content || "");
       setEntryDate(
@@ -104,7 +96,6 @@ export default function JournalEntryForm({
       );
       setAssociatedProducts(entryData.associatedProducts || []);
     } else if (!isEdit) {
-      console.log("🐛 Resetting form for new entry");
       // Reset form for new entries
       setTitle("");
       setContent("");


### PR DESCRIPTION

Remove three debug `console.log` statements from `JournalEntryForm.tsx` that were printing the full journal entry payload (title, content, tags, associated products) to the browser console on every modal open and edit. The logs were leftover development scaffolding identifiable by their `🐛` emoji prefix. Removing them eliminates inadvertent exposure of potentially sensitive business notes to anyone with DevTools open (shoulder-surfing, screen recordings, browser extensions). Form behavior is unchanged.

### Changes
- `frontend/src/components/JournalEntryForm.tsx` — deleted three `console.log` calls inside the `useEffect([entry, isEdit])` hook; all `setTitle`/`setContent`/`setEntryDate`/`setSelectedTags`/`setAssociatedProducts` calls and the `// Reset form for new entries` comment preserved verbatim

---

Closes #1822

### Tokens used
4716156
