### PR TITLE
feat: Decouple Article Module from UserManagement's IGraphService

### DIFF
--- a/artifacts/feat-arch-review-article-backfillarticlereque/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-backfillarticlereque/arch-review.r1.md
@@ -1,0 +1,292 @@
+I have enough context to write the review. The proposed approach mirrors the established `IArticleStyleGuideSource` / `KnowledgeBaseArticleStyleGuideSource` precedent in this very codebase, so my role is mainly to confirm fit and flag a few concrete corrections.
+
+# Architecture Review: Decouple Article Module from UserManagement's IGraphService
+
+## Skip Design: true
+
+Backend-only refactor — no UI components, screens, or visual changes. The admin endpoint shape is unchanged.
+
+## Architectural Fit Assessment
+
+The proposed design **fully aligns** with established codebase precedent. The Article module already owns one cross-module contract using exactly this pattern:
+
+- **Precedent A** — `IArticleStyleGuideSource` (Article module, `Features/Article/Contracts/`) is implemented by `KnowledgeBaseArticleStyleGuideSource` in `Features/KnowledgeBase/Infrastructure/`, registered in `KnowledgeBaseModule`.
+- **Precedent B** — `ILeafletKnowledgeSource` (Leaflet module) is implemented by `KnowledgeBaseLeafletSourceAdapter` (`internal sealed`) in KnowledgeBase, registered in `KnowledgeBaseModule`.
+
+The new `IArticleUserResolver` ↔ `GraphArticleUserResolver` pair is structurally identical to those, so there is no architectural friction. The only integration surfaces are:
+
+1. **DI bootstrap** — one line added next to the existing `IGraphService` registration in `UserManagementModule.AddUserManagement()`.
+2. **Compile-time graph** — Article's `Features/Article/Admin/` namespace loses its `using Anela.Heblo.Application.Features.UserManagement.Services;` import.
+3. **Architecture test** — new entry in `ModuleBoundariesTests.Rules()`.
+
+No new namespaces, no infrastructure, no migrations, no client regeneration.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────┐         ┌──────────────────────────────────────────────────┐
+│  Article module                             │         │  UserManagement module                           │
+│                                             │         │                                                  │
+│  Features/Article/Admin/                    │         │  Features/UserManagement/Infrastructure/         │
+│    BackfillArticleRequestedByHandler  ────┐ │  uses   │    GraphArticleUserResolver  ────┐               │
+│      (depends on IArticleUserResolver)    │ ├────────►│      (impl IArticleUserResolver) │               │
+│                                           │ │         │                                  │ delegates to  │
+│  Features/Article/Contracts/              │ │         │                                  ▼               │
+│    IArticleUserResolver       ◄───────────┘ │ impl    │  Features/UserManagement/Services/               │
+│    ArticleUserMatch (record)        ◄───────┼─────────│    IGraphService / GraphService / MockGraphSvc   │
+│                                             │         │                                                  │
+└─────────────────────────────────────────────┘         └──────────────────────────────────────────────────┘
+        (consumer)                                                    (provider + adapter)
+
+Compile-time direction:  UserManagement.Infrastructure → Article.Contracts   (provider depends on consumer)
+DI wiring:               UserManagementModule registers IArticleUserResolver → GraphArticleUserResolver
+```
+
+### Key Design Decisions
+
+#### Decision 1: Adapter visibility — `internal sealed`, not `public sealed`
+
+**Options considered:** `public sealed` (as written in spec) vs `internal sealed` (matches `KnowledgeBaseLeafletSourceAdapter`).
+
+**Chosen approach:** `internal sealed`.
+
+**Rationale:** The adapter is a DI-registered implementation detail of the UserManagement module. Only the DI container needs to instantiate it; no external code should reference the concrete type. `KnowledgeBaseLeafletSourceAdapter` uses `internal sealed` for exactly this reason. DI works fine with internal classes within the same assembly (`Anela.Heblo.Application`). Use `internal sealed` to match precedent and prevent accidental coupling to the concrete class.
+
+#### Decision 2: Adapter location — `Features/UserManagement/Infrastructure/`
+
+**Options considered:** `Features/UserManagement/Infrastructure/`, `Features/UserManagement/Services/`, or a new `Features/UserManagement/Adapters/`.
+
+**Chosen approach:** `Features/UserManagement/Infrastructure/`.
+
+**Rationale:** This is a new folder for UserManagement (the module currently has `Contracts/`, `Services/`, `UseCases/`), but it matches the existing convention in `Features/KnowledgeBase/Infrastructure/` and `Features/Leaflet/Infrastructure/` for adapters and integration code. `Services/` is reserved for primary in-module services like `IGraphService`. Do not create `Adapters/` — that would be a new convention without precedent.
+
+#### Decision 3: Contract return type — `IReadOnlyList<ArticleUserMatch>`
+
+**Options considered:** `List<T>` (brief), `IReadOnlyList<T>` (spec), `IEnumerable<T>`.
+
+**Chosen approach:** `IReadOnlyList<ArticleUserMatch>` (spec is correct, brief was loose).
+
+**Rationale:** The handler enumerates and groups the result; it does not mutate the list. Returning `IReadOnlyList<T>` signals immutability to consumers, matches modern .NET style, and aligns with the `ILeafletKnowledgeSource.SearchSimilarAsync` return type. The adapter still materializes a `List<T>` internally and exposes it as `IReadOnlyList<T>`.
+
+#### Decision 4: Record vs class for `ArticleUserMatch`
+
+**Options considered:** `record` (spec) vs `class` (project rule: "DTOs are classes, never C# records").
+
+**Chosen approach:** `record`.
+
+**Rationale:** The DTOs-are-classes rule applies **only to OpenAPI-exposed contracts** because the TypeScript generator mishandles record parameter order. `ArticleUserMatch` is purely internal to the application layer — it never crosses the HTTP boundary, never appears in `Anela.Heblo.Application.Shared` or controller signatures. Per `docs/architecture/development_guidelines.md`, records are allowed for internal domain/application types. Spec correctly identifies this.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create:**
+```
+backend/src/Anela.Heblo.Application/Features/Article/Contracts/
+    IArticleUserResolver.cs             # contract + ArticleUserMatch record (single file, follows IArticleStyleGuideSource shape)
+
+backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/
+    GraphArticleUserResolver.cs         # internal sealed adapter
+```
+
+**Modify:**
+```
+backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs
+    - drop UserManagement using
+    - swap IGraphService → IArticleUserResolver, field _graph → _userResolver
+    - swap GetGroupMembersAsync → ResolveByGroupAsync
+    - downstream consumers of UserDto.Id/DisplayName work unchanged against ArticleUserMatch.Id/DisplayName
+
+backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
+    - in both branches of the if/else (mock vs real), add adjacent to IGraphService registration:
+        services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+      The adapter delegates to IGraphService, so it works the same way whether IGraphService is Mock or real.
+      A single registration outside the if/else is preferred — see spec amendment below.
+
+backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs
+    - drop `using Anela.Heblo.Application.Features.UserManagement.*`
+    - replace Mock<IGraphService> with Mock<IArticleUserResolver>
+    - replace `Member(...)` helper to construct ArticleUserMatch instead of UserDto
+    - all existing assertions remain valid
+
+backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+    - add new ModuleBoundaryRule for Article → UserManagement (see Interfaces section below)
+```
+
+### Interfaces and Contracts
+
+```csharp
+// Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Article-owned read-only abstraction for resolving the set of users associated
+/// with a directory group (used by the RequestedBy backfill admin command).
+/// Implemented by the UserManagement module via an adapter.
+/// </summary>
+public interface IArticleUserResolver
+{
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+```csharp
+// Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph) => _graph = graph;
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+        return members
+            .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+            .ToList();
+    }
+}
+```
+
+```csharp
+// Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs — new rule (no allowlist entries needed)
+new ModuleBoundaryRule(
+    Name: "Article -> UserManagement",
+    InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+    ForbiddenNamespacePrefixes: new[]
+    {
+        "Anela.Heblo.Application.Features.UserManagement",
+        // Domain/Persistence subnamespaces for UserManagement currently don't exist,
+        // but include the prefixes defensively to catch future additions.
+        "Anela.Heblo.Domain.Features.UserManagement",
+        "Anela.Heblo.Persistence.UserManagement",
+    },
+    Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+```
+
+### Data Flow
+
+```
+Backfill admin command (HTTP)
+        │
+        ▼
+BackfillArticleRequestedByHandler.Handle(GroupId, DryRun)
+        │
+        │  _userResolver.ResolveByGroupAsync(GroupId, ct)
+        ▼
+[DI resolves IArticleUserResolver → GraphArticleUserResolver]
+        │
+        │  _graph.GetGroupMembersAsync(GroupId, ct)
+        ▼
+GraphService / MockGraphService → List<UserDto>
+        │
+        │  .Select(m => new ArticleUserMatch(m.Id, m.DisplayName)).ToList()
+        ▼
+IReadOnlyList<ArticleUserMatch>
+        │
+        ▼
+Handler groups by DisplayName (OrdinalIgnoreCase), iterates rows from IArticleAdminRepository,
+applies LooksLikeIdentifier / unique-match / ambiguous / unresolved logic,
+saves repository changes when DryRun is false and any row resolved.
+```
+
+The handler's existing logic (`LooksLikeIdentifier`, the GroupBy on `DisplayName`, the resolution counters, the dry-run guard, the SaveChanges decision) is **completely unaffected**. The only change is the type of `members` and the field name.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Spec uses wrong DI extension method name (`AddUserManagementModule`); actual is `AddUserManagement`. | Low | Implementer locates by file (`UserManagementModule.cs`) and finds existing `IGraphService` registration; this review records the correction. |
+| `UserManagementModule.AddUserManagement` registers `IGraphService` inside an if/else (mock vs real). Naively adding the adapter line into only one branch would break the other auth mode. | Medium | Register `IArticleUserResolver → GraphArticleUserResolver` **once, outside the if/else** (the adapter depends on `IGraphService`, whichever implementation DI resolves at runtime). See Spec Amendment 1. |
+| `BackfillArticleRequestedByHandlerTests.cs` is not listed in spec FR-2 file changes, but it depends on `IGraphService` and `UserDto` and will fail to compile after the refactor. | Medium | Add explicit test update to the implementation checklist. Spec NFR-5 mentions this conceptually; the file path needs to be called out. See Spec Amendment 2. |
+| Future developer reintroduces `using ...UserManagement` in another Article file (e.g., `UseCases/...`). | Medium | New `ModuleBoundariesTests` rule (FR-5) catches this at CI time. Mitigation is the feature itself. |
+| Adapter exposed as `public sealed` (per spec) invites external callers to reference the concrete type and bypass the interface. | Low | Make adapter `internal sealed` to match `KnowledgeBaseLeafletSourceAdapter`. See Spec Amendment 3. |
+| The new architecture rule's forbidden-namespace list omits `Anela.Heblo.Domain.Features.UserManagement` / `Anela.Heblo.Persistence.UserManagement`. Those subnamespaces don't exist today but could be added later, silently allowing a new violation channel. | Low | Include all three prefixes in the forbidden list for defensive symmetry with the other rules (Logistics → Manufacture, etc.). See Spec Amendment 4. |
+| Architectural test scans only the `Anela.Heblo.Application` assembly. If UserManagement domain types are later added under `Anela.Heblo.Domain.Features.UserManagement` and the Article handler picks them up, the rule must already cover Domain. | Low | Same mitigation as above. The forbidden-prefix list covers Domain even before the namespace exists. |
+
+## Specification Amendments
+
+The spec is largely correct; the following targeted corrections must be applied during implementation:
+
+### Amendment 1 — Correct method name and registration placement in `UserManagementModule`
+
+FR-4 refers to `AddUserManagementModule`. The actual extension method is `AddUserManagement` in `UserManagementModule.cs`. Moreover, the method registers `IGraphService` inside an `if (useMockAuth || bypassJwtValidation)` / `else` block — both branches need `IArticleUserResolver` available, so the new registration must be placed **outside the if/else** (it works identically whether `IGraphService` resolves to `MockGraphService` or `GraphService`):
+
+```csharp
+public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+{
+    var useMockAuth = configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, defaultValue: false);
+    var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, defaultValue: false);
+
+    if (useMockAuth || bypassJwtValidation)
+    {
+        services.AddScoped<IGraphService, MockGraphService>();
+    }
+    else
+    {
+        services.AddHttpClient("MicrosoftGraph");
+        services.AddScoped<IGraphService, GraphService>();
+    }
+
+    // Cross-module contract: UserManagement implements Article's IArticleUserResolver via adapter.
+    services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+
+    return services;
+}
+```
+
+### Amendment 2 — Add explicit FR for test-file refactor
+
+NFR-5 mentions this in passing but does not enumerate the file. Promote it to an FR (call it FR-7 or fold into FR-2's "Files to modify"):
+
+> **FR-7: Update `BackfillArticleRequestedByHandlerTests.cs`**
+> - Path: `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs`
+> - Remove `using Anela.Heblo.Application.Features.UserManagement.Contracts;` and `using Anela.Heblo.Application.Features.UserManagement.Services;`
+> - Replace `Mock<IGraphService> _graph` with `Mock<IArticleUserResolver> _userResolver`
+> - Replace the `Member(id, displayName)` helper to return `ArticleUserMatch` instead of `UserDto`
+> - Replace all `_graph.Setup(g => g.GetGroupMembersAsync(...))` calls with `_userResolver.Setup(r => r.ResolveByGroupAsync(...))`
+> - Acceptance: all existing test cases pass without behavioral changes (test bodies remain otherwise unmodified).
+
+### Amendment 3 — Adapter is `internal sealed`, not `public sealed`
+
+FR-3 specifies `public sealed class GraphArticleUserResolver`. Change to `internal sealed class` to match the precedent `KnowledgeBaseLeafletSourceAdapter`. DI works identically; the adapter has no callers outside the DI container.
+
+### Amendment 4 — Architectural test forbidden-prefix list
+
+FR-5 should explicitly list all three sibling namespace prefixes (Application, Domain, Persistence) for UserManagement, matching the shape of existing rules in `ModuleBoundariesTests.cs` (e.g., Logistics → Manufacture). Domain and Persistence variants do not exist today but the rule must be forward-defensive:
+
+```csharp
+ForbiddenNamespacePrefixes: new[]
+{
+    "Anela.Heblo.Application.Features.UserManagement",
+    "Anela.Heblo.Domain.Features.UserManagement",
+    "Anela.Heblo.Persistence.UserManagement",
+},
+```
+
+### Amendment 5 — XML doc on the contract
+
+Add an XML `<summary>` to `IArticleUserResolver` matching the precedent shape used by `IArticleStyleGuideSource` and `ILeafletKnowledgeSource`. This is not behavioral but it documents the consumer-owned-contract intent at the type level.
+
+## Prerequisites
+
+None. All required infrastructure already exists:
+
+- `Anela.Heblo.Application` assembly already contains the `Features/Article/Contracts/` folder (with `IArticleStyleGuideSource.cs`).
+- `Anela.Heblo.Application` assembly does not yet contain `Features/UserManagement/Infrastructure/`, but creating a new folder is a no-op (no MSBuild changes; the project SDK auto-includes `.cs` files).
+- `ModuleBoundariesTests` already supports an extensible rules table — the new rule is one entry in `Rules()`.
+- `IGraphService` continues to be registered by `AddUserManagement`; the new adapter depends on it directly.
+- xUnit + Moq + FluentAssertions are already in `Anela.Heblo.Tests`; no new test dependencies.
+- No database migrations, no Azure Key Vault secrets, no config changes, no OpenAPI client regeneration.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-article-backfillarticlereque/brief.md
+++ b/artifacts/feat-arch-review-article-backfillarticlereque/brief.md
@@ -1,0 +1,53 @@
+## Module
+Article
+
+## Finding
+`BackfillArticleRequestedByHandler` in the Article module has a direct compile-time dependency on `IGraphService`, which is owned by the UserManagement module:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs:1
+using Anela.Heblo.Application.Features.UserManagement.Services;
+```
+
+The handler injects `IGraphService` (line 16) and calls `_graph.GetGroupMembersAsync(request.GroupId, ct)` (line 37). `IGraphService` is declared in `Anela.Heblo.Application.Features.UserManagement.Services.IGraphService` — a type owned and registered by the UserManagement module.
+
+This violation is **not covered** by the existing `ModuleBoundariesTests.cs`. The architecture test file (`backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`) has an `Article → KnowledgeBase` rule but no `Article → UserManagement` rule, so this cross-module reference would pass CI undetected.
+
+## Why it matters
+The development guidelines and the cross-module communication pattern (`ILeafletKnowledgeSource`) are explicit: the consuming module must define its own contract interface and have the providing module implement an adapter. Directly importing `IGraphService` creates a hard coupling between Article and UserManagement:
+- A rename or refactor of `IGraphService` in UserManagement breaks the Article module at compile time.
+- The Article module gains an implicit dependency on UserManagement's DI registration (`AddUserManagementModule` must register `IGraphService` before the Article backfill command works).
+- The boundary is invisible to `ModuleBoundariesTests`, so future regressions in this direction won't fail CI.
+
+## Suggested fix
+
+1. **Define a consumer-owned contract in Article's `Contracts/` folder:**
+   ```csharp
+   // backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs
+   public interface IArticleUserResolver
+   {
+       Task<List<ArticleUserMatch>> ResolveByGroupAsync(string groupId, CancellationToken ct);
+   }
+   public record ArticleUserMatch(string Id, string DisplayName);
+   ```
+
+2. **Have UserManagement provide an adapter** (in `UserManagement/Infrastructure/`):
+   ```csharp
+   public sealed class GraphArticleUserResolver : IArticleUserResolver
+   {
+       private readonly IGraphService _graph;
+       public GraphArticleUserResolver(IGraphService graph) => _graph = graph;
+       public async Task<List<ArticleUserMatch>> ResolveByGroupAsync(string groupId, CancellationToken ct)
+       {
+           var members = await _graph.GetGroupMembersAsync(groupId, ct);
+           return members.Select(m => new ArticleUserMatch(m.Id, m.DisplayName)).ToList();
+       }
+   }
+   ```
+
+3. **Register the binding in `UserManagementModule.cs`:** `services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();`
+
+4. **Add an `Article → UserManagement` rule to `ModuleBoundariesTests.cs`** (no allowlist entries needed after the fix).
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-article-backfillarticlereque/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-backfillarticlereque/impl/main.r1.md
@@ -1,0 +1,60 @@
+All 7 tasks complete. Writing the output artifact.
+
+---
+
+# Implementation: Decouple Article Module from UserManagement's IGraphService
+
+## What was implemented
+
+Introduced a consumer-owned contract pattern to remove the Article module's direct compile-time dependency on UserManagement's `IGraphService`. The Article module now defines its own `IArticleUserResolver` interface; UserManagement provides an `internal sealed GraphArticleUserResolver` adapter that implements it. A new architecture boundary test prevents future regressions.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` — New Article-owned interface + `ArticleUserMatch` sealed record
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — New `internal sealed` adapter; delegates to `IGraphService`, maps `UserDto → ArticleUserMatch`
+- `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — Swapped `IGraphService _graph` for `IArticleUserResolver _userResolver`; no behavioral changes
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — Added `services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>()` outside the mock/real `IGraphService` if/else
+- `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — Replaced `Mock<IGraphService>` with `Mock<IArticleUserResolver>`; all 8 test cases preserved
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — Added `Article -> UserManagement` rule with Domain/Application/Persistence forbidden prefixes; empty allowlist
+
+## Tests
+
+- `BackfillArticleRequestedByHandlerTests.cs` — 8 tests, all passing; covers validation error, GUID/email skip, unique match, ambiguous match, unknown, dry-run, mixed set
+- `ModuleBoundariesTests.cs` — New `Article -> UserManagement` theory case passes; load-bearing verification confirmed (sentinel field injection caused failure)
+- Full test suite: 4064 passed, 0 failed
+
+## How to verify
+
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~BackfillArticleRequestedByHandlerTests|FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Also confirm zero Article → UserManagement imports:
+```bash
+grep -rn "using Anela.Heblo.Application.Features.UserManagement" \
+  src/Anela.Heblo.Application/Features/Article/
+```
+
+## Notes
+
+- Adapter is `internal sealed` (not `public`) per `KnowledgeBaseLeafletSourceAdapter` precedent — only DI needs it
+- DI registration placed outside the mock/real `IGraphService` if/else so it works in both auth modes
+- `ArticleUserMatch` is a `sealed record` (not class) — it is internal to the application layer and never crosses the OpenAPI boundary, so the DTO-must-be-class rule does not apply
+- Commit: `80c3fb82`
+
+## PR Summary
+
+Decouples `BackfillArticleRequestedByHandler` from `UserManagement.IGraphService` by introducing the consumer-owned contract pattern already used for `IArticleStyleGuideSource` and `ILeafletKnowledgeSource`. The Article module now defines `IArticleUserResolver` in its own `Contracts/` folder; UserManagement provides `GraphArticleUserResolver` as an `internal sealed` adapter registered once in `AddUserManagement` outside the mock/real branch. A new `ModuleBoundariesTests` rule (Article → UserManagement) enforces the boundary at CI time.
+
+### Changes
+- `Features/Article/Contracts/IArticleUserResolver.cs` — new consumer-owned contract + `ArticleUserMatch` record
+- `Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — new `internal sealed` adapter
+- `Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — swap `IGraphService` → `IArticleUserResolver`
+- `Features/UserManagement/UserManagementModule.cs` — register adapter outside mock/real if/else
+- `Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — swap mock to `IArticleUserResolver`
+- `Tests/Architecture/ModuleBoundariesTests.cs` — add `Article -> UserManagement` boundary rule
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-article-backfillarticlereque/spec.r1.md
+++ b/artifacts/feat-arch-review-article-backfillarticlereque/spec.r1.md
@@ -1,0 +1,209 @@
+# Specification: Decouple Article Module from UserManagement's IGraphService
+
+## Summary
+The `BackfillArticleRequestedByHandler` in the Article module directly depends on `IGraphService`, a contract owned by the UserManagement module, violating cross-module communication rules. This feature introduces a consumer-owned contract (`IArticleUserResolver`) in the Article module and an adapter implementation in UserManagement, restoring the inverted-dependency pattern used elsewhere (e.g. `ILeafletKnowledgeSource`) and adding architectural test coverage to prevent regressions.
+
+## Background
+The codebase follows a Clean Architecture / Vertical Slice organization where modules communicate through **consumer-owned contracts**: the consuming module defines an interface in its own `Contracts/` folder, and the providing module implements an adapter. This keeps inter-module boundaries explicit and enforced.
+
+The Article module's backfill admin command currently breaks this rule:
+
+- File: `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+- Line 1: `using Anela.Heblo.Application.Features.UserManagement.Services;`
+- Line 16: Constructor injects `IGraphService _graph`
+- Line 37: Calls `_graph.GetGroupMembersAsync(request.GroupId, ct)`
+
+`IGraphService` is owned and registered by the UserManagement module. This creates three problems:
+
+1. **Compile-time coupling** — A rename or signature change to `IGraphService` in UserManagement breaks the Article module's build.
+2. **Hidden DI dependency** — The Article handler silently relies on `AddUserManagementModule()` running before the Article backfill command can resolve.
+3. **Undetected boundary violation** — `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` already enforces `Article → KnowledgeBase` but has no `Article → UserManagement` rule, so this regression slipped past CI and any future regressions in the same direction would as well.
+
+The remediation aligns with existing precedent: `ILeafletKnowledgeSource` is the contract used by KnowledgeBase consumers — Article defines its needs, and the providing module supplies the implementation.
+
+## Functional Requirements
+
+### FR-1: Define consumer-owned contract in Article module
+Create a new contract interface in the Article module's `Contracts/` folder describing the user-resolution capability the backfill handler actually needs — group-id-to-user-list resolution, expressed in Article's own vocabulary, with no Graph or Azure AD terminology.
+
+**Files to create:**
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs`
+
+**Interface shape:**
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+public interface IArticleUserResolver
+{
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(string groupId, CancellationToken ct);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+**Acceptance criteria:**
+- New file exists at the specified path.
+- Interface and record are declared in the `Anela.Heblo.Application.Features.Article.Contracts` namespace.
+- Interface depends only on BCL types and types in the Article module.
+- No `using` directive references `UserManagement`.
+- `ArticleUserMatch` is an internal-domain record (records are allowed for internal types per `development_guidelines.md`; it is not a DTO exposed via OpenAPI).
+
+### FR-2: Refactor BackfillArticleRequestedByHandler to consume the new contract
+Replace the direct `IGraphService` dependency with `IArticleUserResolver`. The handler logic must remain functionally identical: same backfill behavior, same outputs, same error handling.
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+
+**Changes:**
+- Remove `using Anela.Heblo.Application.Features.UserManagement.Services;`
+- Add `using Anela.Heblo.Application.Features.Article.Contracts;`
+- Change the injected field type from `IGraphService` to `IArticleUserResolver` (and rename the field accordingly, e.g. `_userResolver`).
+- Replace `_graph.GetGroupMembersAsync(request.GroupId, ct)` with `_userResolver.ResolveByGroupAsync(request.GroupId, ct)`.
+- Adapt downstream code that consumed the previous result type (Graph group-member objects) to consume `ArticleUserMatch` (`Id`, `DisplayName`).
+
+**Acceptance criteria:**
+- The handler file contains no reference to `UserManagement`, `IGraphService`, or any Graph types.
+- All behavior covered by existing tests for the backfill command continues to pass.
+- `dotnet build` succeeds.
+- `dotnet format` reports no changes needed.
+
+### FR-3: Provide adapter implementation in UserManagement module
+Create an adapter in the UserManagement module that implements `IArticleUserResolver` by delegating to `IGraphService`. The adapter is responsible for mapping Graph-shaped results to `ArticleUserMatch` instances.
+
+**Files to create:**
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`
+
+**Implementation shape:**
+```csharp
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+public sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph) => _graph = graph;
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(string groupId, CancellationToken ct)
+    {
+        var members = await _graph.GetGroupMembersAsync(groupId, ct);
+        return members
+            .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+            .ToList();
+    }
+}
+```
+
+**Acceptance criteria:**
+- File exists at the specified path inside the UserManagement module.
+- Class is `sealed` and depends on `IGraphService` via constructor injection.
+- Null/empty-member edge cases produce an empty list rather than throwing.
+- Mapping preserves `Id` and `DisplayName` from each Graph member with no transformation.
+
+### FR-4: Register the adapter in the UserManagement module bootstrap
+Wire `IArticleUserResolver → GraphArticleUserResolver` in UserManagement's DI registration so consumers (Article) can resolve it transparently.
+
+**Files to modify:**
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` (or whichever file contains the module's `AddUserManagementModule` extension; locate the existing registration of `IGraphService` and add the new line adjacent to it)
+
+**Change:**
+```csharp
+services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+```
+
+**Acceptance criteria:**
+- The registration is added to the existing `AddUserManagementModule` (or equivalent) method.
+- DI lifetime matches `IGraphService`'s lifetime (assume `Scoped`; verify against actual registration).
+- The application boots successfully; `IArticleUserResolver` can be resolved at runtime.
+- No registration of `IArticleUserResolver` exists in the Article module's DI bootstrap.
+
+### FR-5: Add architectural test enforcing Article → UserManagement boundary
+Extend `ModuleBoundariesTests.cs` to assert that the Article module's source code has no dependency on `UserManagement` types. This must fail loudly if a future change reintroduces the violation.
+
+**Files to modify:**
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+**Test shape:**
+Add a new test (following the existing `Article → KnowledgeBase` rule as a template) that asserts no type under `Anela.Heblo.Application.Features.Article` depends on any type under `Anela.Heblo.Application.Features.UserManagement`. No allowlist exceptions should be necessary after the refactor.
+
+**Acceptance criteria:**
+- The new test is named to match the pattern of existing rules (e.g. `Article_ShouldNotDependOn_UserManagement`).
+- Running the test against the refactored code passes with no allowlist entries.
+- Manually re-introducing a `UserManagement` `using` in the Article module causes the test to fail.
+
+### FR-6: Verify nothing else in Article references UserManagement
+Confirm `BackfillArticleRequestedByHandler` is the only offender. If other files in `Features/Article/` import from `Features/UserManagement/`, either remediate them with the same pattern or document them as out-of-scope follow-ups.
+
+**Acceptance criteria:**
+- Grep results for `using Anela.Heblo.Application.Features.UserManagement` under `backend/src/Anela.Heblo.Application/Features/Article/` return zero matches after the refactor.
+- If additional references are found, they are either fixed in this change or filed as a follow-up issue (noted in Open Questions).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable runtime overhead. The adapter adds a single in-process method indirection and a `Select(...).ToList()` projection over a small, bounded collection (group members). Backfill is an admin-triggered command, not a hot path; performance is not a constraint.
+
+### NFR-2: Security
+No change to the security posture. The adapter does not log, persist, or transmit member data beyond what the current handler already does. Authorization on the backfill command (whatever guards the existing endpoint) is preserved.
+
+### NFR-3: Architectural conformance
+After this change, the Article module's compile-time dependency graph must not include the UserManagement module. This is enforced by FR-5.
+
+### NFR-4: Backwards compatibility
+Public API behavior of the backfill admin endpoint is unchanged — same request shape, same response shape, same status codes, same error semantics. No database schema changes, no migrations, no client regeneration required.
+
+### NFR-5: Testability
+The Article module's handler tests can now mock `IArticleUserResolver` directly without dragging in any Graph types or UserManagement dependencies. Existing handler tests (if they mocked `IGraphService`) must be updated to mock `IArticleUserResolver` instead.
+
+## Data Model
+
+No persistent data model changes. One in-memory type is introduced:
+
+| Type | Module | Kind | Purpose |
+|------|--------|------|---------|
+| `IArticleUserResolver` | Article | Interface | Consumer-owned contract; abstracts group-to-user resolution from Article's perspective |
+| `ArticleUserMatch` | Article | Record | DTO-internal projection of a user (Id + DisplayName) for the backfill use case |
+| `GraphArticleUserResolver` | UserManagement | Class | Adapter; implements `IArticleUserResolver` by delegating to `IGraphService` |
+
+`ArticleUserMatch` is internal to the application layer and not serialized over the wire, so a `record` is appropriate (the DTO-must-be-class rule applies only to OpenAPI-exposed contracts).
+
+## API / Interface Design
+
+No HTTP, MediatR, or external API surface changes.
+
+**Internal interface added:**
+```csharp
+public interface IArticleUserResolver
+{
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(string groupId, CancellationToken ct);
+}
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+**DI binding added (UserManagement):**
+```csharp
+services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+```
+
+The MediatR command (`BackfillArticleRequestedByCommand` or equivalent) and its HTTP entry point keep their existing signatures and behavior.
+
+## Dependencies
+
+- **UserManagement module** must continue to register `IGraphService` (no change). The adapter depends on this existing registration.
+- **Architecture test framework** already present in `backend/test/Anela.Heblo.Tests/Architecture/` (NetArchTest or similar — follow the pattern already used for the `Article → KnowledgeBase` rule).
+- **Module load order** — `AddUserManagementModule` must continue to run as part of the application bootstrap so the `IArticleUserResolver` binding is registered. This is the existing behavior; no change required.
+
+## Out of Scope
+
+- Other architecture violations not flagged in the brief (Article-internal or cross-module dependencies beyond the specific `IGraphService` import in `BackfillArticleRequestedByHandler`).
+- Refactoring `IGraphService` itself or its callers within the UserManagement module.
+- Introducing a generic user-resolution abstraction shared across modules. Each consumer should own its own contract; cross-module reuse of `IArticleUserResolver` is explicitly rejected — if another module needs similar functionality, it defines its own contract and its own adapter.
+- Performance tuning, caching, or batching of group-member queries.
+- Adding new architecture test rules beyond `Article → UserManagement` (other module pairs are out of scope for this change).
+- Renaming or restructuring the `BackfillArticleRequestedByHandler` itself or the associated MediatR command.
+- Changes to the admin UI or any frontend code (this is a backend-only refactor).
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-backfillarticlereque/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-backfillarticlereque/task-plan.r1.md
@@ -1,0 +1,711 @@
+# Decouple Article Module from UserManagement's IGraphService — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the Article module's direct dependency on UserManagement's `IGraphService` by introducing a consumer-owned contract (`IArticleUserResolver`) in the Article module, an adapter (`GraphArticleUserResolver`) in UserManagement that implements it via `IGraphService`, and an architecture test that prevents future Article → UserManagement boundary violations.
+
+**Architecture:** Standard consumer-owned contract pattern already used in this codebase (mirrors `IArticleStyleGuideSource` ↔ `KnowledgeBaseArticleStyleGuideSource` and `ILeafletKnowledgeSource` ↔ `KnowledgeBaseLeafletSourceAdapter`). The Article module declares an interface in its `Contracts/` folder; UserManagement provides an `internal sealed` adapter under its `Infrastructure/` folder and registers it in `UserManagementModule.AddUserManagement`. DI binding is added **once outside the existing mock/real `IGraphService` if/else** so the adapter resolves regardless of auth mode.
+
+**Tech Stack:** .NET 8, C# nullable reference types, MediatR, xUnit + Moq + FluentAssertions, NetArchTest-style reflection-based boundary tests (custom helper in `ModuleBoundariesTests.cs`).
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` — interface + `ArticleUserMatch` record. Single file matching the shape of `IArticleStyleGuideSource.cs`. Article-owned vocabulary; depends only on BCL.
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — `internal sealed` adapter delegating to `IGraphService` and mapping `UserDto` → `ArticleUserMatch`.
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — drop UserManagement `using`; swap `IGraphService _graph` for `IArticleUserResolver _userResolver`; swap `GetGroupMembersAsync` for `ResolveByGroupAsync`. Logic unchanged.
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — add one DI registration outside the mock-vs-real `if/else`.
+- `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — swap `Mock<IGraphService>` → `Mock<IArticleUserResolver>`; rewrite `Member` helper to construct `ArticleUserMatch`; rewrite mock setups accordingly. All test bodies otherwise unchanged.
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — add `Article -> UserManagement` rule to the `Rules()` `TheoryData`. No allowlist entries.
+
+**No changes to:** controllers, routing, OpenAPI specs, database schema, frontend code, Azure config, deployment.
+
+---
+
+## Task 1: Add the failing architecture-boundary test (RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (add new `ModuleBoundaryRule` entry in `Rules()`)
+
+- [ ] **Step 1: Add the new rule to `Rules()`**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Locate the `public static TheoryData<ModuleBoundaryRule> Rules() => new()` block (around line 85). Insert the following `new ModuleBoundaryRule(...)` entry immediately after the existing `Article -> KnowledgeBase` rule (it ends around line 107) — keep `Article` rules grouped together. The forbidden-prefix list defensively covers Domain and Persistence subnamespaces even though they don't exist for UserManagement today.
+
+```csharp
+        new ModuleBoundaryRule(
+            Name: "Article -> UserManagement",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.UserManagement",
+                "Anela.Heblo.Application.Features.UserManagement",
+                "Anela.Heblo.Persistence.UserManagement",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+```
+
+- [ ] **Step 2: Run the new rule to verify it fails (RED)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces"
+```
+
+Expected: the theory case for `Article -> UserManagement` **FAILS** with a violation message naming `Anela.Heblo.Application.Features.Article.Admin.BackfillArticleRequestedByHandler -> Anela.Heblo.Application.Features.UserManagement.Services.IGraphService` (and possibly other UserManagement types referenced by the handler — that's fine).
+
+Do **not** commit yet — the codebase is intentionally in a RED state. The next tasks implement the refactor to turn it GREEN.
+
+---
+
+## Task 2: Create the consumer-owned contract `IArticleUserResolver`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs`
+
+- [ ] **Step 1: Create the contract file**
+
+Create `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` with the following content. XML doc matches the style used by `IArticleStyleGuideSource`. `ArticleUserMatch` is an internal projection (records are permitted because it never crosses the OpenAPI boundary).
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Article-owned read-only abstraction for resolving the set of users associated
+/// with a directory group (used by the RequestedBy backfill admin command).
+/// Implemented by the UserManagement module via an adapter.
+/// </summary>
+public interface IArticleUserResolver
+{
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+- [ ] **Step 2: Verify the contract compiles in isolation**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build **succeeds**. The new file has no consumers yet, so adding it is a non-breaking change.
+
+---
+
+## Task 3: Create the adapter `GraphArticleUserResolver` in UserManagement
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`
+
+- [ ] **Step 1: Create the adapter file**
+
+Create `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`. The class is `internal sealed` (matches `KnowledgeBaseLeafletSourceAdapter` precedent — only DI needs to instantiate it; nothing outside this assembly should reference the concrete type). The folder `Features/UserManagement/Infrastructure/` does not yet exist; creating a `.cs` file under it auto-includes the folder via the .NET SDK — no project-file edits required.
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph)
+    {
+        _graph = graph;
+    }
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+        return members
+            .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+            .ToList();
+    }
+}
+```
+
+- [ ] **Step 2: Verify the adapter compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build **succeeds**. The adapter has no callers yet other than the DI container (registration comes in Task 4), so adding it is non-breaking.
+
+---
+
+## Task 4: Register the adapter in `UserManagementModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`
+
+- [ ] **Step 1: Add the using directive and DI registration**
+
+Open `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`. The current file structure has a single `AddUserManagement` extension method with an `if (useMockAuth || bypassJwtValidation) { ... } else { ... }` that registers `IGraphService` differently per branch. The adapter depends on `IGraphService` — whichever implementation DI resolves at runtime — so the registration must sit **outside the if/else**.
+
+Add the using directive at the top (alphabetical order with existing usings):
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+```
+
+(The first line — `Anela.Heblo.Application.Features.Article.Contracts` — is required for the `IArticleUserResolver` symbol. The second — `Anela.Heblo.Application.Features.UserManagement.Infrastructure` — is required for the `GraphArticleUserResolver` symbol.)
+
+Then update the body of `AddUserManagement` to add the new registration after the `if/else`, immediately before `return services;`. The full method body should look like this after the change:
+
+```csharp
+    public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Check if mock authentication is enabled
+        var useMockAuth = configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, defaultValue: false);
+        var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, defaultValue: false);
+
+        if (useMockAuth || bypassJwtValidation)
+        {
+            // Register mock GraphService for mock authentication
+            services.AddScoped<IGraphService, MockGraphService>();
+        }
+        else
+        {
+            // Register the named "MicrosoftGraph" HttpClient for IHttpClientFactory.
+            // Matches the shared "MicrosoftGraph" named client used by Marketing/MeetingTasks/CatalogDocuments/KnowledgeBase/Photobank modules.
+            services.AddHttpClient("MicrosoftGraph");
+
+            // Register real GraphService for production authentication
+            services.AddScoped<IGraphService, GraphService>();
+
+            // Note: GraphServiceClient must be registered in the API layer with proper authentication
+            // through Microsoft.Identity.Web's AddMicrosoftGraph() method
+        }
+
+        // Cross-module contract: UserManagement implements Article's IArticleUserResolver via adapter.
+        // Works regardless of which IGraphService implementation (Mock vs real) is registered above.
+        services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+
+        // Note: HttpContextAccessor must be registered in the API layer
+
+        return services;
+    }
+```
+
+- [ ] **Step 2: Verify the application still builds**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build **succeeds**. `IArticleUserResolver` is now registered but still unused by any handler, so behavior is unchanged.
+
+---
+
+## Task 5: Refactor the handler and its tests in lockstep
+
+The handler and its tests must change together because the test file currently mocks `IGraphService` to inject into the handler's constructor. Refactoring just one side breaks the build.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs`
+
+- [ ] **Step 1: Refactor `BackfillArticleRequestedByHandler.cs`**
+
+Replace the **entire file contents** with the version below. The behavioral logic (`LooksLikeIdentifier`, `GroupBy` on display name, dry-run guard, save-changes condition, all logging) is identical — only the dependency type, field name, and one method call change.
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Article;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Article.Admin;
+
+public sealed class BackfillArticleRequestedByHandler
+    : IRequestHandler<BackfillArticleRequestedByCommand, BackfillArticleRequestedByResponse>
+{
+    private readonly IArticleAdminRepository _repository;
+    private readonly IArticleUserResolver _userResolver;
+    private readonly ILogger<BackfillArticleRequestedByHandler> _logger;
+
+    public BackfillArticleRequestedByHandler(
+        IArticleAdminRepository repository,
+        IArticleUserResolver userResolver,
+        ILogger<BackfillArticleRequestedByHandler> logger)
+    {
+        _repository = repository;
+        _userResolver = userResolver;
+        _logger = logger;
+    }
+
+    public async Task<BackfillArticleRequestedByResponse> Handle(
+        BackfillArticleRequestedByCommand request,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.GroupId))
+        {
+            return new BackfillArticleRequestedByResponse(
+                ErrorCodes.ValidationError,
+                new Dictionary<string, string> { { "field", "GroupId" } });
+        }
+
+        var members = await _userResolver.ResolveByGroupAsync(request.GroupId, ct);
+        var byDisplayName = members
+            .GroupBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var rows = await _repository.ListWithRequestedByAsync(ct);
+        var response = new BackfillArticleRequestedByResponse
+        {
+            Total = rows.Count,
+            WasDryRun = request.DryRun,
+        };
+
+        var anyResolved = false;
+
+        foreach (var row in rows)
+        {
+            var original = row.RequestedBy!;
+
+            if (LooksLikeIdentifier(original))
+            {
+                response.AlreadyMigrated++;
+                _logger.LogInformation(
+                    "Article {ArticleId} RequestedBy={Value} already looks like an identifier; skipping.",
+                    row.Id, original);
+                continue;
+            }
+
+            if (!byDisplayName.TryGetValue(original, out var matches))
+            {
+                response.Unresolved++;
+                response.UnresolvedRows.Add(new UnresolvedArticleRow
+                {
+                    ArticleId = row.Id,
+                    OriginalValue = original,
+                    Reason = "no match in Graph group members",
+                });
+                _logger.LogWarning(
+                    "Article {ArticleId} RequestedBy={Value} has no match in group {GroupId}.",
+                    row.Id, original, request.GroupId);
+                continue;
+            }
+
+            if (matches.Count > 1)
+            {
+                response.Ambiguous++;
+                response.UnresolvedRows.Add(new UnresolvedArticleRow
+                {
+                    ArticleId = row.Id,
+                    OriginalValue = original,
+                    Reason = $"ambiguous: {matches.Count} group members share this display name",
+                });
+                _logger.LogWarning(
+                    "Article {ArticleId} RequestedBy={Value} is ambiguous ({Count} matches).",
+                    row.Id, original, matches.Count);
+                continue;
+            }
+
+            var match = matches[0];
+            if (!request.DryRun)
+            {
+                row.RequestedBy = match.Id;
+            }
+            anyResolved = true;
+            response.Resolved++;
+            _logger.LogInformation(
+                "Article {ArticleId} resolved: {DisplayName} -> {Id}.",
+                row.Id, original, match.Id);
+        }
+
+        if (anyResolved && !request.DryRun)
+        {
+            await _repository.SaveChangesAsync(ct);
+        }
+
+        return response;
+    }
+
+    private static bool LooksLikeIdentifier(string value)
+    {
+        if (Guid.TryParse(value, out _))
+        {
+            return true;
+        }
+
+        return value.Contains('@', StringComparison.Ordinal);
+    }
+}
+```
+
+Confirm the file:
+- Contains **no** `using Anela.Heblo.Application.Features.UserManagement...` directive.
+- Field is `_userResolver` of type `IArticleUserResolver`.
+- The only behavioral change is `_graph.GetGroupMembersAsync(...)` → `_userResolver.ResolveByGroupAsync(...)`.
+- Log messages and the `"no match in Graph group members"` reason string are unchanged (the existing test asserts `Reason.Contains("no match")` so this is safe; we deliberately keep the string identical to avoid spec drift and to keep existing test assertions valid).
+
+- [ ] **Step 2: Refactor `BackfillArticleRequestedByHandlerTests.cs`**
+
+Replace the **entire file contents** with the version below. The changes:
+- Drop `using Anela.Heblo.Application.Features.UserManagement.Contracts;` and `using Anela.Heblo.Application.Features.UserManagement.Services;`.
+- Add `using Anela.Heblo.Application.Features.Article.Contracts;`.
+- Field `Mock<IGraphService> _graph` → `Mock<IArticleUserResolver> _userResolver`.
+- `CreateHandler()` passes `_userResolver.Object` in place of `_graph.Object`.
+- `Member` helper returns `ArticleUserMatch` (positional ctor) instead of `UserDto`.
+- All `_graph.Setup(g => g.GetGroupMembersAsync(...))` calls become `_userResolver.Setup(r => r.ResolveByGroupAsync(...))`.
+- Mock return-type lists become `List<ArticleUserMatch>` (still satisfies `IReadOnlyList<ArticleUserMatch>` since `List<T>` implements `IReadOnlyList<T>`).
+- All assertions and test names remain identical.
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Admin;
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Article;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
+
+namespace Anela.Heblo.Tests.Article.Admin;
+
+public class BackfillArticleRequestedByHandlerTests
+{
+    private const string GroupId = "marketing-group-id";
+
+    private readonly Mock<IArticleAdminRepository> _repository = new();
+    private readonly Mock<IArticleUserResolver> _userResolver = new();
+
+    private BackfillArticleRequestedByHandler CreateHandler() =>
+        new(_repository.Object, _userResolver.Object, NullLogger<BackfillArticleRequestedByHandler>.Instance);
+
+    private static DomainArticle Row(string requestedBy)
+        => new() { Id = Guid.NewGuid(), Topic = "Topic", RequestedBy = requestedBy };
+
+    private static ArticleUserMatch Member(string id, string displayName)
+        => new(id, displayName);
+
+    [Fact]
+    public async Task Handle_MissingGroupId_ReturnsValidationError()
+    {
+        var request = new BackfillArticleRequestedByCommand { GroupId = "", DryRun = true };
+
+        var response = await CreateHandler().Handle(request, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public async Task Handle_SkipsGuidShapedRowsAsAlreadyMigrated()
+    {
+        var alreadyMigrated = Row(Guid.NewGuid().ToString());
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { alreadyMigrated });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>());
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
+
+        response.AlreadyMigrated.Should().Be(1);
+        response.Resolved.Should().Be(0);
+        response.UnresolvedRows.Should().BeEmpty();
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SkipsEmailShapedRowsAsAlreadyMigrated()
+    {
+        var alreadyMigrated = Row("john@example.com");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { alreadyMigrated });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>());
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
+
+        response.AlreadyMigrated.Should().Be(1);
+        response.Resolved.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_UniqueDisplayNameMatch_ResolvesRow()
+    {
+        var row = Row("Jan Novák");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("jan-oid", "Jan Novák") });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Resolved.Should().Be(1);
+        response.WasDryRun.Should().BeFalse();
+        row.RequestedBy.Should().Be("jan-oid");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AmbiguousDisplayName_LeavesRowAndReports()
+    {
+        var row = Row("Jan Novák");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>
+            {
+                Member("jan-oid-a", "Jan Novák"),
+                Member("jan-oid-b", "Jan Novák"),
+            });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Ambiguous.Should().Be(1);
+        response.Resolved.Should().Be(0);
+        response.UnresolvedRows.Should().ContainSingle(u =>
+            u.ArticleId == row.Id && u.OriginalValue == "Jan Novák" && u.Reason.Contains("ambiguous"));
+        row.RequestedBy.Should().Be("Jan Novák");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownDisplayName_LeavesRowAndReports()
+    {
+        var row = Row("Ghost User");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("someone-oid", "Someone Else") });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Unresolved.Should().Be(1);
+        response.UnresolvedRows.Should().ContainSingle(u =>
+            u.OriginalValue == "Ghost User" && u.Reason.Contains("no match"));
+        row.RequestedBy.Should().Be("Ghost User");
+    }
+
+    [Fact]
+    public async Task Handle_DryRun_DoesNotSaveResolvedRows()
+    {
+        var row = Row("Jan Novák");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("jan-oid", "Jan Novák") });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
+
+        response.Resolved.Should().Be(1);
+        response.WasDryRun.Should().BeTrue();
+        // Dry-run must not mutate entities — entity state unchanged
+        row.RequestedBy.Should().Be("Jan Novák");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MixedSet_CountsCorrectly()
+    {
+        var rows = new List<DomainArticle>
+        {
+            Row(Guid.NewGuid().ToString()),    // already migrated (GUID)
+            Row("ondra@example.com"),           // already migrated (email)
+            Row("Jan Novák"),                  // resolved
+            Row("Petra Dvořáková"),            // ambiguous
+            Row("Ghost User"),                  // unresolved
+        };
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rows);
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>
+            {
+                Member("jan-oid", "Jan Novák"),
+                Member("petra-oid-1", "Petra Dvořáková"),
+                Member("petra-oid-2", "Petra Dvořáková"),
+            });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Total.Should().Be(5);
+        response.AlreadyMigrated.Should().Be(2);
+        response.Resolved.Should().Be(1);
+        response.Ambiguous.Should().Be(1);
+        response.Unresolved.Should().Be(1);
+        response.UnresolvedRows.Should().HaveCount(2);
+    }
+}
+```
+
+- [ ] **Step 3: Run the handler test suite to confirm behavior is preserved (GREEN for behavioral tests)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~BackfillArticleRequestedByHandlerTests"
+```
+
+Expected: all 8 tests in `BackfillArticleRequestedByHandlerTests` **PASS**.
+
+- [ ] **Step 4: Re-run the architecture-boundary test (GREEN for boundary)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces"
+```
+
+Expected: the `Article -> UserManagement` theory case now **PASSES**. All other rules (Leaflet → KB, Article → KB, Logistics → Manufacture, etc.) continue to pass with their existing allowlists.
+
+---
+
+## Task 6: Verify the new boundary rule is load-bearing
+
+The architecture test is regression-prevention; we must prove it actually catches a UserManagement → Article violation by injecting one and confirming the test fails. This is a manual verification — do **not** commit the violation.
+
+**Files:**
+- Temporarily modify: `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+
+- [ ] **Step 1: Inject a sentinel violation**
+
+At the top of `BackfillArticleRequestedByHandler.cs`, temporarily add the line below as the **first** using directive. This re-introduces the exact violation we just removed.
+
+```csharp
+using Anela.Heblo.Application.Features.UserManagement.Services;
+```
+
+Save the file. (The new `using` will be unused; that's fine — the architecture test inspects type references, not just whether the type is used in code. To be safe and avoid `CS8019 Unused using directive` from breaking the build under TreatWarningsAsErrors, also temporarily add a trivial reference inside `Handle`, e.g., declare `IGraphService? _unused = null;` as a local — but only if a sentinel using alone doesn't cause the rule to fire. Try the using-only approach first.)
+
+- [ ] **Step 2: Run the architecture rule — confirm it fails**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces"
+```
+
+Expected: the `Article -> UserManagement` theory case **FAILS** with a violation message naming the handler and an `IGraphService` (or similar UserManagement) type. This confirms the rule catches the violation.
+
+If the test still passes (e.g., because the reflection-based scanner only inspects member signatures and not unused usings), instead inject a more reliable sentinel by adding a private field — e.g., `private readonly IGraphService? _sentinel = null;` — and re-run.
+
+- [ ] **Step 3: Revert the sentinel**
+
+Remove the temporary `using` line (and any temporary field/local you added) so the handler returns to its clean post-Task-5 state. Save the file.
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: all `ModuleBoundariesTests` theory cases and facts **PASS** again.
+
+---
+
+## Task 7: Final validation and commit
+
+**Files:** none modified in this task; only verification commands.
+
+- [ ] **Step 1: Confirm no Article file imports UserManagement**
+
+Run the grep from FR-6 of the spec:
+
+```bash
+grep -rn "using Anela.Heblo.Application.Features.UserManagement" \
+  backend/src/Anela.Heblo.Application/Features/Article/
+```
+
+Expected: **zero matches**. If matches appear, repeat Task 5 on the offending file (same pattern) or file a follow-up issue as noted in spec FR-6.
+
+- [ ] **Step 2: Full backend build**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build **succeeds** with no warnings introduced by this change.
+
+- [ ] **Step 3: Format check**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code 0 with no files reported as needing formatting. If it reports changes needed, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply formatting, then verify-no-changes again.
+
+- [ ] **Step 4: Full test suite for affected projects**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all tests **PASS**, including:
+- All 8 `BackfillArticleRequestedByHandlerTests` cases.
+- All `ModuleBoundariesTests` theory cases (now including `Article -> UserManagement`) and facts.
+
+- [ ] **Step 5: Commit**
+
+All six files modified together form a single atomic refactor. Stage and commit:
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs \
+  backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs \
+  backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: decouple Article from UserManagement via IArticleUserResolver
+
+BackfillArticleRequestedByHandler now consumes an Article-owned
+IArticleUserResolver contract instead of UserManagement's IGraphService.
+UserManagement provides an internal sealed GraphArticleUserResolver
+adapter, registered once in AddUserManagement outside the mock/real
+IGraphService branch so the binding works for both auth modes.
+
+A new ModuleBoundariesTests rule (Article -> UserManagement) prevents
+regressions.
+EOF
+)"
+```
+
+Expected: commit created successfully, repo working tree clean.
+
+---
+
+## Spec Coverage Check
+
+- **FR-1** (define `IArticleUserResolver` contract) — Task 2.
+- **FR-2** (refactor `BackfillArticleRequestedByHandler`) — Task 5 Step 1.
+- **FR-3** (provide `GraphArticleUserResolver` adapter) — Task 3; arch-review Amendment 3 (`internal sealed`) applied.
+- **FR-4** (register adapter in `UserManagementModule`) — Task 4; arch-review Amendment 1 (correct method name `AddUserManagement` + placement outside if/else) applied.
+- **FR-5** (architecture test) — Task 1 (RED) + Task 6 (load-bearing verification); arch-review Amendment 4 (Domain + Persistence prefixes) applied.
+- **FR-6** (verify nothing else in Article references UserManagement) — Task 7 Step 1.
+- **FR-7 / NFR-5** (handler tests updated) — Task 5 Step 2; arch-review Amendment 2 (test file refactor enumerated explicitly) applied.
+- **Arch-review Amendment 5** (XML `<summary>` on contract) — Task 2 Step 1.
+- **NFR-1, NFR-2** — preserved by construction (no behavioral changes).
+- **NFR-3** (compile-time graph excludes UserManagement) — enforced by Task 1 / Task 6.
+- **NFR-4** (no public API or schema changes) — preserved by construction.

--- a/backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.UserManagement.Services;
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Article;
 using MediatR;
@@ -10,16 +10,16 @@ public sealed class BackfillArticleRequestedByHandler
     : IRequestHandler<BackfillArticleRequestedByCommand, BackfillArticleRequestedByResponse>
 {
     private readonly IArticleAdminRepository _repository;
-    private readonly IGraphService _graph;
+    private readonly IArticleUserResolver _userResolver;
     private readonly ILogger<BackfillArticleRequestedByHandler> _logger;
 
     public BackfillArticleRequestedByHandler(
         IArticleAdminRepository repository,
-        IGraphService graph,
+        IArticleUserResolver userResolver,
         ILogger<BackfillArticleRequestedByHandler> logger)
     {
         _repository = repository;
-        _graph = graph;
+        _userResolver = userResolver;
         _logger = logger;
     }
 
@@ -34,7 +34,7 @@ public sealed class BackfillArticleRequestedByHandler
                 new Dictionary<string, string> { { "field", "GroupId" } });
         }
 
-        var members = await _graph.GetGroupMembersAsync(request.GroupId, ct);
+        var members = await _userResolver.ResolveByGroupAsync(request.GroupId, ct);
         var byDisplayName = members
             .GroupBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);

--- a/backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs
@@ -1,0 +1,15 @@
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Article-owned read-only abstraction for resolving the set of users associated
+/// with a directory group (used by the RequestedBy backfill admin command).
+/// Implemented by the UserManagement module via an adapter.
+/// </summary>
+public interface IArticleUserResolver
+{
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);

--- a/backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs
+++ b/backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs
@@ -1,0 +1,24 @@
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph)
+    {
+        _graph = graph;
+    }
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+        return members
+            .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+            .ToList();
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs
@@ -1,7 +1,9 @@
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
 using Anela.Heblo.Application.Features.UserManagement.Services;
+using Anela.Heblo.Domain.Features.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Anela.Heblo.Domain.Features.Configuration;
 using Microsoft.Graph;
 
 namespace Anela.Heblo.Application.Features.UserManagement;
@@ -31,6 +33,10 @@ public static class UserManagementModule
             // Note: GraphServiceClient must be registered in the API layer with proper authentication
             // through Microsoft.Identity.Web's AddMicrosoftGraph() method
         }
+
+        // Cross-module contract: UserManagement implements Article's IArticleUserResolver via adapter.
+        // Works regardless of which IGraphService implementation (Mock vs real) is registered above.
+        services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
 
         // Note: HttpContextAccessor must be registered in the API layer
 

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -107,6 +107,17 @@ public class ModuleBoundariesTests
             Allowlist: ArticleAllowlist),
 
         new ModuleBoundaryRule(
+            Name: "Article -> UserManagement",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.UserManagement",
+                "Anela.Heblo.Application.Features.UserManagement",
+                "Anela.Heblo.Persistence.UserManagement",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+
+        new ModuleBoundaryRule(
             Name: "Logistics -> Manufacture",
             InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Logistics",
             ForbiddenNamespacePrefixes: new[]

--- a/backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs
@@ -1,6 +1,5 @@
 using Anela.Heblo.Application.Features.Article.Admin;
-using Anela.Heblo.Application.Features.UserManagement.Contracts;
-using Anela.Heblo.Application.Features.UserManagement.Services;
+using Anela.Heblo.Application.Features.Article.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
@@ -15,16 +14,16 @@ public class BackfillArticleRequestedByHandlerTests
     private const string GroupId = "marketing-group-id";
 
     private readonly Mock<IArticleAdminRepository> _repository = new();
-    private readonly Mock<IGraphService> _graph = new();
+    private readonly Mock<IArticleUserResolver> _userResolver = new();
 
     private BackfillArticleRequestedByHandler CreateHandler() =>
-        new(_repository.Object, _graph.Object, NullLogger<BackfillArticleRequestedByHandler>.Instance);
+        new(_repository.Object, _userResolver.Object, NullLogger<BackfillArticleRequestedByHandler>.Instance);
 
     private static DomainArticle Row(string requestedBy)
         => new() { Id = Guid.NewGuid(), Topic = "Topic", RequestedBy = requestedBy };
 
-    private static UserDto Member(string id, string displayName)
-        => new() { Id = id, DisplayName = displayName, Email = $"{displayName}@example.com" };
+    private static ArticleUserMatch Member(string id, string displayName)
+        => new(id, displayName);
 
     [Fact]
     public async Task Handle_MissingGroupId_ReturnsValidationError()
@@ -43,8 +42,8 @@ public class BackfillArticleRequestedByHandlerTests
         var alreadyMigrated = Row(Guid.NewGuid().ToString());
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DomainArticle> { alreadyMigrated });
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto>());
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>());
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
@@ -61,8 +60,8 @@ public class BackfillArticleRequestedByHandlerTests
         var alreadyMigrated = Row("john@example.com");
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DomainArticle> { alreadyMigrated });
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto>());
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>());
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
@@ -77,8 +76,8 @@ public class BackfillArticleRequestedByHandlerTests
         var row = Row("Jan Novák");
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DomainArticle> { row });
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto> { Member("jan-oid", "Jan Novák") });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("jan-oid", "Jan Novák") });
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
@@ -95,8 +94,8 @@ public class BackfillArticleRequestedByHandlerTests
         var row = Row("Jan Novák");
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DomainArticle> { row });
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto>
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>
             {
                 Member("jan-oid-a", "Jan Novák"),
                 Member("jan-oid-b", "Jan Novák"),
@@ -119,8 +118,8 @@ public class BackfillArticleRequestedByHandlerTests
         var row = Row("Ghost User");
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DomainArticle> { row });
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto> { Member("someone-oid", "Someone Else") });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("someone-oid", "Someone Else") });
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
@@ -137,8 +136,8 @@ public class BackfillArticleRequestedByHandlerTests
         var row = Row("Jan Novák");
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<DomainArticle> { row });
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto> { Member("jan-oid", "Jan Novák") });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("jan-oid", "Jan Novák") });
 
         var response = await CreateHandler().Handle(
             new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
@@ -163,8 +162,8 @@ public class BackfillArticleRequestedByHandlerTests
         };
         _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(rows);
-        _graph.Setup(g => g.GetGroupMembersAsync(GroupId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<UserDto>
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>
             {
                 Member("jan-oid", "Jan Novák"),
                 Member("petra-oid-1", "Petra Dvořáková"),

--- a/docs/superpowers/plans/2026-05-27-decouple-article-from-usermanagement.md
+++ b/docs/superpowers/plans/2026-05-27-decouple-article-from-usermanagement.md
@@ -1,0 +1,711 @@
+# Decouple Article Module from UserManagement's IGraphService — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the Article module's direct dependency on UserManagement's `IGraphService` by introducing a consumer-owned contract (`IArticleUserResolver`) in the Article module, an adapter (`GraphArticleUserResolver`) in UserManagement that implements it via `IGraphService`, and an architecture test that prevents future Article → UserManagement boundary violations.
+
+**Architecture:** Standard consumer-owned contract pattern already used in this codebase (mirrors `IArticleStyleGuideSource` ↔ `KnowledgeBaseArticleStyleGuideSource` and `ILeafletKnowledgeSource` ↔ `KnowledgeBaseLeafletSourceAdapter`). The Article module declares an interface in its `Contracts/` folder; UserManagement provides an `internal sealed` adapter under its `Infrastructure/` folder and registers it in `UserManagementModule.AddUserManagement`. DI binding is added **once outside the existing mock/real `IGraphService` if/else** so the adapter resolves regardless of auth mode.
+
+**Tech Stack:** .NET 8, C# nullable reference types, MediatR, xUnit + Moq + FluentAssertions, NetArchTest-style reflection-based boundary tests (custom helper in `ModuleBoundariesTests.cs`).
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` — interface + `ArticleUserMatch` record. Single file matching the shape of `IArticleStyleGuideSource.cs`. Article-owned vocabulary; depends only on BCL.
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — `internal sealed` adapter delegating to `IGraphService` and mapping `UserDto` → `ArticleUserMatch`.
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — drop UserManagement `using`; swap `IGraphService _graph` for `IArticleUserResolver _userResolver`; swap `GetGroupMembersAsync` for `ResolveByGroupAsync`. Logic unchanged.
+- `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs` — add one DI registration outside the mock-vs-real `if/else`.
+- `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — swap `Mock<IGraphService>` → `Mock<IArticleUserResolver>`; rewrite `Member` helper to construct `ArticleUserMatch`; rewrite mock setups accordingly. All test bodies otherwise unchanged.
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — add `Article -> UserManagement` rule to the `Rules()` `TheoryData`. No allowlist entries.
+
+**No changes to:** controllers, routing, OpenAPI specs, database schema, frontend code, Azure config, deployment.
+
+---
+
+## Task 1: Add the failing architecture-boundary test (RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (add new `ModuleBoundaryRule` entry in `Rules()`)
+
+- [ ] **Step 1: Add the new rule to `Rules()`**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Locate the `public static TheoryData<ModuleBoundaryRule> Rules() => new()` block (around line 85). Insert the following `new ModuleBoundaryRule(...)` entry immediately after the existing `Article -> KnowledgeBase` rule (it ends around line 107) — keep `Article` rules grouped together. The forbidden-prefix list defensively covers Domain and Persistence subnamespaces even though they don't exist for UserManagement today.
+
+```csharp
+        new ModuleBoundaryRule(
+            Name: "Article -> UserManagement",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Article",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.UserManagement",
+                "Anela.Heblo.Application.Features.UserManagement",
+                "Anela.Heblo.Persistence.UserManagement",
+            },
+            Allowlist: new HashSet<string>(StringComparer.Ordinal)),
+```
+
+- [ ] **Step 2: Run the new rule to verify it fails (RED)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces"
+```
+
+Expected: the theory case for `Article -> UserManagement` **FAILS** with a violation message naming `Anela.Heblo.Application.Features.Article.Admin.BackfillArticleRequestedByHandler -> Anela.Heblo.Application.Features.UserManagement.Services.IGraphService` (and possibly other UserManagement types referenced by the handler — that's fine).
+
+Do **not** commit yet — the codebase is intentionally in a RED state. The next tasks implement the refactor to turn it GREEN.
+
+---
+
+## Task 2: Create the consumer-owned contract `IArticleUserResolver`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs`
+
+- [ ] **Step 1: Create the contract file**
+
+Create `backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs` with the following content. XML doc matches the style used by `IArticleStyleGuideSource`. `ArticleUserMatch` is an internal projection (records are permitted because it never crosses the OpenAPI boundary).
+
+```csharp
+namespace Anela.Heblo.Application.Features.Article.Contracts;
+
+/// <summary>
+/// Article-owned read-only abstraction for resolving the set of users associated
+/// with a directory group (used by the RequestedBy backfill admin command).
+/// Implemented by the UserManagement module via an adapter.
+/// </summary>
+public interface IArticleUserResolver
+{
+    Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ArticleUserMatch(string Id, string DisplayName);
+```
+
+- [ ] **Step 2: Verify the contract compiles in isolation**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build **succeeds**. The new file has no consumers yet, so adding it is a non-breaking change.
+
+---
+
+## Task 3: Create the adapter `GraphArticleUserResolver` in UserManagement
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`
+
+- [ ] **Step 1: Create the adapter file**
+
+Create `backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs`. The class is `internal sealed` (matches `KnowledgeBaseLeafletSourceAdapter` precedent — only DI needs to instantiate it; nothing outside this assembly should reference the concrete type). The folder `Features/UserManagement/Infrastructure/` does not yet exist; creating a `.cs` file under it auto-includes the folder via the .NET SDK — no project-file edits required.
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Services;
+
+namespace Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+
+internal sealed class GraphArticleUserResolver : IArticleUserResolver
+{
+    private readonly IGraphService _graph;
+
+    public GraphArticleUserResolver(IGraphService graph)
+    {
+        _graph = graph;
+    }
+
+    public async Task<IReadOnlyList<ArticleUserMatch>> ResolveByGroupAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        var members = await _graph.GetGroupMembersAsync(groupId, cancellationToken);
+        return members
+            .Select(m => new ArticleUserMatch(m.Id, m.DisplayName))
+            .ToList();
+    }
+}
+```
+
+- [ ] **Step 2: Verify the adapter compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build **succeeds**. The adapter has no callers yet other than the DI container (registration comes in Task 4), so adding it is non-breaking.
+
+---
+
+## Task 4: Register the adapter in `UserManagementModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`
+
+- [ ] **Step 1: Add the using directive and DI registration**
+
+Open `backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs`. The current file structure has a single `AddUserManagement` extension method with an `if (useMockAuth || bypassJwtValidation) { ... } else { ... }` that registers `IGraphService` differently per branch. The adapter depends on `IGraphService` — whichever implementation DI resolves at runtime — so the registration must sit **outside the if/else**.
+
+Add the using directive at the top (alphabetical order with existing usings):
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Features.UserManagement.Infrastructure;
+```
+
+(The first line — `Anela.Heblo.Application.Features.Article.Contracts` — is required for the `IArticleUserResolver` symbol. The second — `Anela.Heblo.Application.Features.UserManagement.Infrastructure` — is required for the `GraphArticleUserResolver` symbol.)
+
+Then update the body of `AddUserManagement` to add the new registration after the `if/else`, immediately before `return services;`. The full method body should look like this after the change:
+
+```csharp
+    public static IServiceCollection AddUserManagement(this IServiceCollection services, IConfiguration configuration)
+    {
+        // Check if mock authentication is enabled
+        var useMockAuth = configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, defaultValue: false);
+        var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, defaultValue: false);
+
+        if (useMockAuth || bypassJwtValidation)
+        {
+            // Register mock GraphService for mock authentication
+            services.AddScoped<IGraphService, MockGraphService>();
+        }
+        else
+        {
+            // Register the named "MicrosoftGraph" HttpClient for IHttpClientFactory.
+            // Matches the shared "MicrosoftGraph" named client used by Marketing/MeetingTasks/CatalogDocuments/KnowledgeBase/Photobank modules.
+            services.AddHttpClient("MicrosoftGraph");
+
+            // Register real GraphService for production authentication
+            services.AddScoped<IGraphService, GraphService>();
+
+            // Note: GraphServiceClient must be registered in the API layer with proper authentication
+            // through Microsoft.Identity.Web's AddMicrosoftGraph() method
+        }
+
+        // Cross-module contract: UserManagement implements Article's IArticleUserResolver via adapter.
+        // Works regardless of which IGraphService implementation (Mock vs real) is registered above.
+        services.AddScoped<IArticleUserResolver, GraphArticleUserResolver>();
+
+        // Note: HttpContextAccessor must be registered in the API layer
+
+        return services;
+    }
+```
+
+- [ ] **Step 2: Verify the application still builds**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build **succeeds**. `IArticleUserResolver` is now registered but still unused by any handler, so behavior is unchanged.
+
+---
+
+## Task 5: Refactor the handler and its tests in lockstep
+
+The handler and its tests must change together because the test file currently mocks `IGraphService` to inject into the handler's constructor. Refactoring just one side breaks the build.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+- Modify: `backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs`
+
+- [ ] **Step 1: Refactor `BackfillArticleRequestedByHandler.cs`**
+
+Replace the **entire file contents** with the version below. The behavioral logic (`LooksLikeIdentifier`, `GroupBy` on display name, dry-run guard, save-changes condition, all logging) is identical — only the dependency type, field name, and one method call change.
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Article;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Article.Admin;
+
+public sealed class BackfillArticleRequestedByHandler
+    : IRequestHandler<BackfillArticleRequestedByCommand, BackfillArticleRequestedByResponse>
+{
+    private readonly IArticleAdminRepository _repository;
+    private readonly IArticleUserResolver _userResolver;
+    private readonly ILogger<BackfillArticleRequestedByHandler> _logger;
+
+    public BackfillArticleRequestedByHandler(
+        IArticleAdminRepository repository,
+        IArticleUserResolver userResolver,
+        ILogger<BackfillArticleRequestedByHandler> logger)
+    {
+        _repository = repository;
+        _userResolver = userResolver;
+        _logger = logger;
+    }
+
+    public async Task<BackfillArticleRequestedByResponse> Handle(
+        BackfillArticleRequestedByCommand request,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.GroupId))
+        {
+            return new BackfillArticleRequestedByResponse(
+                ErrorCodes.ValidationError,
+                new Dictionary<string, string> { { "field", "GroupId" } });
+        }
+
+        var members = await _userResolver.ResolveByGroupAsync(request.GroupId, ct);
+        var byDisplayName = members
+            .GroupBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var rows = await _repository.ListWithRequestedByAsync(ct);
+        var response = new BackfillArticleRequestedByResponse
+        {
+            Total = rows.Count,
+            WasDryRun = request.DryRun,
+        };
+
+        var anyResolved = false;
+
+        foreach (var row in rows)
+        {
+            var original = row.RequestedBy!;
+
+            if (LooksLikeIdentifier(original))
+            {
+                response.AlreadyMigrated++;
+                _logger.LogInformation(
+                    "Article {ArticleId} RequestedBy={Value} already looks like an identifier; skipping.",
+                    row.Id, original);
+                continue;
+            }
+
+            if (!byDisplayName.TryGetValue(original, out var matches))
+            {
+                response.Unresolved++;
+                response.UnresolvedRows.Add(new UnresolvedArticleRow
+                {
+                    ArticleId = row.Id,
+                    OriginalValue = original,
+                    Reason = "no match in Graph group members",
+                });
+                _logger.LogWarning(
+                    "Article {ArticleId} RequestedBy={Value} has no match in group {GroupId}.",
+                    row.Id, original, request.GroupId);
+                continue;
+            }
+
+            if (matches.Count > 1)
+            {
+                response.Ambiguous++;
+                response.UnresolvedRows.Add(new UnresolvedArticleRow
+                {
+                    ArticleId = row.Id,
+                    OriginalValue = original,
+                    Reason = $"ambiguous: {matches.Count} group members share this display name",
+                });
+                _logger.LogWarning(
+                    "Article {ArticleId} RequestedBy={Value} is ambiguous ({Count} matches).",
+                    row.Id, original, matches.Count);
+                continue;
+            }
+
+            var match = matches[0];
+            if (!request.DryRun)
+            {
+                row.RequestedBy = match.Id;
+            }
+            anyResolved = true;
+            response.Resolved++;
+            _logger.LogInformation(
+                "Article {ArticleId} resolved: {DisplayName} -> {Id}.",
+                row.Id, original, match.Id);
+        }
+
+        if (anyResolved && !request.DryRun)
+        {
+            await _repository.SaveChangesAsync(ct);
+        }
+
+        return response;
+    }
+
+    private static bool LooksLikeIdentifier(string value)
+    {
+        if (Guid.TryParse(value, out _))
+        {
+            return true;
+        }
+
+        return value.Contains('@', StringComparison.Ordinal);
+    }
+}
+```
+
+Confirm the file:
+- Contains **no** `using Anela.Heblo.Application.Features.UserManagement...` directive.
+- Field is `_userResolver` of type `IArticleUserResolver`.
+- The only behavioral change is `_graph.GetGroupMembersAsync(...)` → `_userResolver.ResolveByGroupAsync(...)`.
+- Log messages and the `"no match in Graph group members"` reason string are unchanged (the existing test asserts `Reason.Contains("no match")` so this is safe; we deliberately keep the string identical to avoid spec drift and to keep existing test assertions valid).
+
+- [ ] **Step 2: Refactor `BackfillArticleRequestedByHandlerTests.cs`**
+
+Replace the **entire file contents** with the version below. The changes:
+- Drop `using Anela.Heblo.Application.Features.UserManagement.Contracts;` and `using Anela.Heblo.Application.Features.UserManagement.Services;`.
+- Add `using Anela.Heblo.Application.Features.Article.Contracts;`.
+- Field `Mock<IGraphService> _graph` → `Mock<IArticleUserResolver> _userResolver`.
+- `CreateHandler()` passes `_userResolver.Object` in place of `_graph.Object`.
+- `Member` helper returns `ArticleUserMatch` (positional ctor) instead of `UserDto`.
+- All `_graph.Setup(g => g.GetGroupMembersAsync(...))` calls become `_userResolver.Setup(r => r.ResolveByGroupAsync(...))`.
+- Mock return-type lists become `List<ArticleUserMatch>` (still satisfies `IReadOnlyList<ArticleUserMatch>` since `List<T>` implements `IReadOnlyList<T>`).
+- All assertions and test names remain identical.
+
+```csharp
+using Anela.Heblo.Application.Features.Article.Admin;
+using Anela.Heblo.Application.Features.Article.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.Article;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
+
+namespace Anela.Heblo.Tests.Article.Admin;
+
+public class BackfillArticleRequestedByHandlerTests
+{
+    private const string GroupId = "marketing-group-id";
+
+    private readonly Mock<IArticleAdminRepository> _repository = new();
+    private readonly Mock<IArticleUserResolver> _userResolver = new();
+
+    private BackfillArticleRequestedByHandler CreateHandler() =>
+        new(_repository.Object, _userResolver.Object, NullLogger<BackfillArticleRequestedByHandler>.Instance);
+
+    private static DomainArticle Row(string requestedBy)
+        => new() { Id = Guid.NewGuid(), Topic = "Topic", RequestedBy = requestedBy };
+
+    private static ArticleUserMatch Member(string id, string displayName)
+        => new(id, displayName);
+
+    [Fact]
+    public async Task Handle_MissingGroupId_ReturnsValidationError()
+    {
+        var request = new BackfillArticleRequestedByCommand { GroupId = "", DryRun = true };
+
+        var response = await CreateHandler().Handle(request, default);
+
+        response.Success.Should().BeFalse();
+        response.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public async Task Handle_SkipsGuidShapedRowsAsAlreadyMigrated()
+    {
+        var alreadyMigrated = Row(Guid.NewGuid().ToString());
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { alreadyMigrated });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>());
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
+
+        response.AlreadyMigrated.Should().Be(1);
+        response.Resolved.Should().Be(0);
+        response.UnresolvedRows.Should().BeEmpty();
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SkipsEmailShapedRowsAsAlreadyMigrated()
+    {
+        var alreadyMigrated = Row("john@example.com");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { alreadyMigrated });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>());
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
+
+        response.AlreadyMigrated.Should().Be(1);
+        response.Resolved.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_UniqueDisplayNameMatch_ResolvesRow()
+    {
+        var row = Row("Jan Novák");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("jan-oid", "Jan Novák") });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Resolved.Should().Be(1);
+        response.WasDryRun.Should().BeFalse();
+        row.RequestedBy.Should().Be("jan-oid");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AmbiguousDisplayName_LeavesRowAndReports()
+    {
+        var row = Row("Jan Novák");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>
+            {
+                Member("jan-oid-a", "Jan Novák"),
+                Member("jan-oid-b", "Jan Novák"),
+            });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Ambiguous.Should().Be(1);
+        response.Resolved.Should().Be(0);
+        response.UnresolvedRows.Should().ContainSingle(u =>
+            u.ArticleId == row.Id && u.OriginalValue == "Jan Novák" && u.Reason.Contains("ambiguous"));
+        row.RequestedBy.Should().Be("Jan Novák");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownDisplayName_LeavesRowAndReports()
+    {
+        var row = Row("Ghost User");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("someone-oid", "Someone Else") });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Unresolved.Should().Be(1);
+        response.UnresolvedRows.Should().ContainSingle(u =>
+            u.OriginalValue == "Ghost User" && u.Reason.Contains("no match"));
+        row.RequestedBy.Should().Be("Ghost User");
+    }
+
+    [Fact]
+    public async Task Handle_DryRun_DoesNotSaveResolvedRows()
+    {
+        var row = Row("Jan Novák");
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DomainArticle> { row });
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch> { Member("jan-oid", "Jan Novák") });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = true }, default);
+
+        response.Resolved.Should().Be(1);
+        response.WasDryRun.Should().BeTrue();
+        // Dry-run must not mutate entities — entity state unchanged
+        row.RequestedBy.Should().Be("Jan Novák");
+        _repository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MixedSet_CountsCorrectly()
+    {
+        var rows = new List<DomainArticle>
+        {
+            Row(Guid.NewGuid().ToString()),    // already migrated (GUID)
+            Row("ondra@example.com"),           // already migrated (email)
+            Row("Jan Novák"),                  // resolved
+            Row("Petra Dvořáková"),            // ambiguous
+            Row("Ghost User"),                  // unresolved
+        };
+        _repository.Setup(r => r.ListWithRequestedByAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rows);
+        _userResolver.Setup(r => r.ResolveByGroupAsync(GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ArticleUserMatch>
+            {
+                Member("jan-oid", "Jan Novák"),
+                Member("petra-oid-1", "Petra Dvořáková"),
+                Member("petra-oid-2", "Petra Dvořáková"),
+            });
+
+        var response = await CreateHandler().Handle(
+            new BackfillArticleRequestedByCommand { GroupId = GroupId, DryRun = false }, default);
+
+        response.Total.Should().Be(5);
+        response.AlreadyMigrated.Should().Be(2);
+        response.Resolved.Should().Be(1);
+        response.Ambiguous.Should().Be(1);
+        response.Unresolved.Should().Be(1);
+        response.UnresolvedRows.Should().HaveCount(2);
+    }
+}
+```
+
+- [ ] **Step 3: Run the handler test suite to confirm behavior is preserved (GREEN for behavioral tests)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~BackfillArticleRequestedByHandlerTests"
+```
+
+Expected: all 8 tests in `BackfillArticleRequestedByHandlerTests` **PASS**.
+
+- [ ] **Step 4: Re-run the architecture-boundary test (GREEN for boundary)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces"
+```
+
+Expected: the `Article -> UserManagement` theory case now **PASSES**. All other rules (Leaflet → KB, Article → KB, Logistics → Manufacture, etc.) continue to pass with their existing allowlists.
+
+---
+
+## Task 6: Verify the new boundary rule is load-bearing
+
+The architecture test is regression-prevention; we must prove it actually catches a UserManagement → Article violation by injecting one and confirming the test fails. This is a manual verification — do **not** commit the violation.
+
+**Files:**
+- Temporarily modify: `backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs`
+
+- [ ] **Step 1: Inject a sentinel violation**
+
+At the top of `BackfillArticleRequestedByHandler.cs`, temporarily add the line below as the **first** using directive. This re-introduces the exact violation we just removed.
+
+```csharp
+using Anela.Heblo.Application.Features.UserManagement.Services;
+```
+
+Save the file. (The new `using` will be unused; that's fine — the architecture test inspects type references, not just whether the type is used in code. To be safe and avoid `CS8019 Unused using directive` from breaking the build under TreatWarningsAsErrors, also temporarily add a trivial reference inside `Handle`, e.g., declare `IGraphService? _unused = null;` as a local — but only if a sentinel using alone doesn't cause the rule to fire. Try the using-only approach first.)
+
+- [ ] **Step 2: Run the architecture rule — confirm it fails**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces"
+```
+
+Expected: the `Article -> UserManagement` theory case **FAILS** with a violation message naming the handler and an `IGraphService` (or similar UserManagement) type. This confirms the rule catches the violation.
+
+If the test still passes (e.g., because the reflection-based scanner only inspects member signatures and not unused usings), instead inject a more reliable sentinel by adding a private field — e.g., `private readonly IGraphService? _sentinel = null;` — and re-run.
+
+- [ ] **Step 3: Revert the sentinel**
+
+Remove the temporary `using` line (and any temporary field/local you added) so the handler returns to its clean post-Task-5 state. Save the file.
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: all `ModuleBoundariesTests` theory cases and facts **PASS** again.
+
+---
+
+## Task 7: Final validation and commit
+
+**Files:** none modified in this task; only verification commands.
+
+- [ ] **Step 1: Confirm no Article file imports UserManagement**
+
+Run the grep from FR-6 of the spec:
+
+```bash
+grep -rn "using Anela.Heblo.Application.Features.UserManagement" \
+  backend/src/Anela.Heblo.Application/Features/Article/
+```
+
+Expected: **zero matches**. If matches appear, repeat Task 5 on the offending file (same pattern) or file a follow-up issue as noted in spec FR-6.
+
+- [ ] **Step 2: Full backend build**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build **succeeds** with no warnings introduced by this change.
+
+- [ ] **Step 3: Format check**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code 0 with no files reported as needing formatting. If it reports changes needed, run `dotnet format backend/Anela.Heblo.sln` (without `--verify-no-changes`) to apply formatting, then verify-no-changes again.
+
+- [ ] **Step 4: Full test suite for affected projects**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: all tests **PASS**, including:
+- All 8 `BackfillArticleRequestedByHandlerTests` cases.
+- All `ModuleBoundariesTests` theory cases (now including `Article -> UserManagement`) and facts.
+
+- [ ] **Step 5: Commit**
+
+All six files modified together form a single atomic refactor. Stage and commit:
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/Article/Contracts/IArticleUserResolver.cs \
+  backend/src/Anela.Heblo.Application/Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs \
+  backend/src/Anela.Heblo.Application/Features/Article/Admin/BackfillArticleRequestedByHandler.cs \
+  backend/src/Anela.Heblo.Application/Features/UserManagement/UserManagementModule.cs \
+  backend/test/Anela.Heblo.Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs \
+  backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: decouple Article from UserManagement via IArticleUserResolver
+
+BackfillArticleRequestedByHandler now consumes an Article-owned
+IArticleUserResolver contract instead of UserManagement's IGraphService.
+UserManagement provides an internal sealed GraphArticleUserResolver
+adapter, registered once in AddUserManagement outside the mock/real
+IGraphService branch so the binding works for both auth modes.
+
+A new ModuleBoundariesTests rule (Article -> UserManagement) prevents
+regressions.
+EOF
+)"
+```
+
+Expected: commit created successfully, repo working tree clean.
+
+---
+
+## Spec Coverage Check
+
+- **FR-1** (define `IArticleUserResolver` contract) — Task 2.
+- **FR-2** (refactor `BackfillArticleRequestedByHandler`) — Task 5 Step 1.
+- **FR-3** (provide `GraphArticleUserResolver` adapter) — Task 3; arch-review Amendment 3 (`internal sealed`) applied.
+- **FR-4** (register adapter in `UserManagementModule`) — Task 4; arch-review Amendment 1 (correct method name `AddUserManagement` + placement outside if/else) applied.
+- **FR-5** (architecture test) — Task 1 (RED) + Task 6 (load-bearing verification); arch-review Amendment 4 (Domain + Persistence prefixes) applied.
+- **FR-6** (verify nothing else in Article references UserManagement) — Task 7 Step 1.
+- **FR-7 / NFR-5** (handler tests updated) — Task 5 Step 2; arch-review Amendment 2 (test file refactor enumerated explicitly) applied.
+- **Arch-review Amendment 5** (XML `<summary>` on contract) — Task 2 Step 1.
+- **NFR-1, NFR-2** — preserved by construction (no behavioral changes).
+- **NFR-3** (compile-time graph excludes UserManagement) — enforced by Task 1 / Task 6.
+- **NFR-4** (no public API or schema changes) — preserved by construction.


### PR DESCRIPTION

Decouples `BackfillArticleRequestedByHandler` from `UserManagement.IGraphService` by introducing the consumer-owned contract pattern already used for `IArticleStyleGuideSource` and `ILeafletKnowledgeSource`. The Article module now defines `IArticleUserResolver` in its own `Contracts/` folder; UserManagement provides `GraphArticleUserResolver` as an `internal sealed` adapter registered once in `AddUserManagement` outside the mock/real branch. A new `ModuleBoundariesTests` rule (Article → UserManagement) enforces the boundary at CI time.

### Changes
- `Features/Article/Contracts/IArticleUserResolver.cs` — new consumer-owned contract + `ArticleUserMatch` record
- `Features/UserManagement/Infrastructure/GraphArticleUserResolver.cs` — new `internal sealed` adapter
- `Features/Article/Admin/BackfillArticleRequestedByHandler.cs` — swap `IGraphService` → `IArticleUserResolver`
- `Features/UserManagement/UserManagementModule.cs` — register adapter outside mock/real if/else
- `Tests/Article/Admin/BackfillArticleRequestedByHandlerTests.cs` — swap mock to `IArticleUserResolver`
- `Tests/Architecture/ModuleBoundariesTests.cs` — add `Article -> UserManagement` boundary rule

---

Closes #1824

### Tokens used
13636614
