### PR TITLE
feat: Project ArticleRepository.GetFeedbackPagedAsync to DTO at the Database Level

### DIFF
--- a/artifacts/feat-arch-review-article-getfeedbackpagedasyn/arch-review.r1.md
+++ b/artifacts/feat-arch-review-article-getfeedbackpagedasyn/arch-review.r1.md
@@ -1,0 +1,235 @@
+I have everything I need to write the architecture review. The key finding from exploration: `IArticleRepository` lives in the Domain layer (`Anela.Heblo.Domain`), and the established pattern (e.g., `ArticleFeedbackStats`) puts auxiliary repository return types — including `record`s — in the Domain layer next to the interface. The spec's proposed Application-layer location for `ArticleFeedbackProjection` would create a layering inversion (Domain referencing Application).
+
+```markdown
+# Architecture Review: Project ArticleRepository.GetFeedbackPagedAsync to DTO at the Database Level
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with the repository's existing shape. `IArticleRepository` already exposes a non-entity return type for an aggregate-style query (`ArticleFeedbackStats`, a `record` in the Domain layer). Introducing a second narrow return type for `GetFeedbackPagedAsync` is a natural continuation of the same pattern, not a new architectural concept.
+
+The two integration points are:
+1. **Domain ⇄ Persistence contract**: `IArticleRepository.GetFeedbackPagedAsync` signature changes; only the EF Core implementation is affected.
+2. **Persistence ⇄ Application boundary**: `GetArticleFeedbackListHandler` consumes the new projection type and maps it to the OpenAPI-exposed `ArticleFeedbackSummary`. The public DTO is unchanged, so the OpenAPI/TypeScript client is unaffected.
+
+The change is internal-only, surgical, and respects module isolation. `IArticleRepository` has no external consumers beyond this single handler (verified by grep — only the interface, implementation, handler, and one test file reference `GetFeedbackPagedAsync`).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+[Application]
+  GetArticleFeedbackListHandler
+        │ depends on
+        ▼
+[Domain]  ◄──── IArticleRepository
+                  │ returns
+                  ▼
+                ArticleFeedbackProjection  ◄── NEW (Domain layer)
+                ArticleFeedbackStats           (existing pattern)
+                  ▲
+                  │ implements
+[Persistence]   ArticleRepository
+                  │ uses EF Core .Select()
+                  ▼
+                [ApplicationDbContext.Articles]
+```
+
+The projection type is a Domain-layer construct that crosses the Persistence-Application boundary unchanged, the same way `ArticleFeedbackStats` already does. Persistence projects EF entities into it; Application consumes it and maps to the public DTO.
+
+### Key Design Decisions
+
+#### Decision 1: Projection type lives in Domain, not Application
+
+**Options considered:**
+- (A) `Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/ArticleFeedbackProjection.cs` (spec proposal).
+- (B) `Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs` (next to `IArticleRepository`).
+- (C) `Anela.Heblo.Persistence/Features/Article/ArticleFeedbackProjection.cs` (internal to Persistence; handler reshapes via a wrapper).
+
+**Chosen approach:** (B) — Domain layer, next to `IArticleRepository`.
+
+**Rationale:** Option (A) is **architecturally invalid**. `IArticleRepository` is declared in `Anela.Heblo.Domain`, which only references `Anela.Heblo.Xcc`. If the projection lives in Application, the Domain `csproj` would need a reference to Application — a layering inversion that breaks Clean Architecture and would not compile without restructuring project references. Option (C) duplicates the type or forces the handler to re-project, defeating the purpose. Option (B) matches the established convention (`ArticleFeedbackStats` is a `record` in the same Domain folder), preserves layering, and lets both Persistence and Application consume the type without any new project references.
+
+#### Decision 2: `record` over `class` for the projection
+
+**Options considered:** `record` with positional constructor vs. mutable `class`.
+
+**Chosen approach:** `sealed record` with a positional primary constructor (`ArticleFeedbackProjection(Guid Id, string? Title, ...)`).
+
+**Rationale:** The projection never crosses the OpenAPI boundary (verified — `ArticleFeedbackSummary` remains the API contract). The project rule "DTOs are classes, never C# records" exists to protect the OpenAPI generator from positional-parameter mishandling; it does not apply to internal Domain types. The existing `ArticleFeedbackStats` is itself a `sealed record` in the same folder, set the precedent. EF Core 8 translates `.Select(a => new ArticleFeedbackProjection(...))` into a column-restricted `SELECT` provided the constructor parameters bind unambiguously to entity properties.
+
+#### Decision 3: Sort and filter operate on `IQueryable<Article>`; projection happens last
+
+**Options considered:** Project early (after filters, before sort) vs. project late (immediately before `ToListAsync`).
+
+**Chosen approach:** Project late — apply `.Select(...)` after `Skip/Take` and immediately before `ToListAsync`. The `CountAsync` runs against the pre-`Skip/Take` `IQueryable<Article>`.
+
+**Rationale:** Filters reference columns (`PrecisionScore`, `StyleScore`, `RequestedBy`) that are all in the projection, but the sort switch could theoretically be extended to columns not in the projection (e.g., a future `Status` sort). Projecting late keeps the filter/sort logic identical to today's code, reducing the diff and the regression surface. EF Core will still emit a column-restricted `SELECT` because the final `Select` determines the materialised columns — `CountAsync` translates to `SELECT COUNT(*)` and never materialises rows.
+
+#### Decision 4: SQL-shape regression test via `ToQueryString()`
+
+**Options considered:** (a) `IQueryable.ToQueryString()` assertion in an in-memory test; (b) EF Core `DbCommandInterceptor` against a real provider; (c) Snapshot-test the generated SQL.
+
+**Chosen approach:** (a) — a unit-level test against the existing in-memory or SQLite test infrastructure that calls the same `_context.Articles` query path used by `ArticleRepository.GetFeedbackPagedAsync`, captures `query.ToQueryString()`, and asserts the resulting SQL does not contain `HtmlContent` (case-insensitive substring check).
+
+**Rationale:** Simplest, no test-infrastructure changes, no provider-specific behaviour. Refactor the repository so the query-building portion is reachable from a test (either by extracting the `IQueryable` composition into a static/internal helper, or by exposing the configured `IQueryable` through an `internal` test-only seam guarded by `InternalsVisibleTo`). Option (b) is overkill for a single-method guard.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New file:
+```
+backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs
+```
+
+Modified files:
+```
+backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs
+backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs
+backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
+```
+
+New test (or new fact in an existing repository test file):
+```
+backend/test/Anela.Heblo.Tests/Article/.../ArticleRepositoryFeedbackProjectionSqlTests.cs
+```
+
+No new projects, no `csproj` changes, no DI registration changes.
+
+### Interfaces and Contracts
+
+**`ArticleFeedbackProjection.cs` (Domain layer, new):**
+```csharp
+namespace Anela.Heblo.Domain.Features.Article;
+
+public sealed record ArticleFeedbackProjection(
+    Guid Id,
+    string? Title,
+    string Topic,
+    string? RequestedBy,
+    DateTimeOffset CreatedAt,
+    int? PrecisionScore,
+    int? StyleScore,
+    string? FeedbackComment);
+```
+
+Field types are taken directly from `Article.cs`:
+- `Id` → `Guid` (non-null)
+- `Title` → `string?`
+- `Topic` → `string` (non-null, defaults to `""`)
+- `RequestedBy` → `string?`
+- `CreatedAt` → `DateTimeOffset` (note: spec said `DateTime`; the entity uses `DateTimeOffset`)
+- `PrecisionScore` → `int?`
+- `StyleScore` → `int?`
+- `FeedbackComment` → `string?`
+
+**Updated `IArticleRepository.GetFeedbackPagedAsync`:**
+```csharp
+Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
+    bool? hasFeedback,
+    string? requestedBy,
+    string sortBy,
+    bool descending,
+    int page,
+    int pageSize,
+    CancellationToken ct = default);
+```
+
+All other methods on `IArticleRepository` remain untouched — `GetByIdAsync`, `GetForUpdateAsync`, `GetPagedAsync`, `GetWithStepsAsync` legitimately need the full `Article` aggregate (sources, steps) and are out of scope.
+
+**Updated `ArticleRepository.GetFeedbackPagedAsync` body (preserving existing filter/sort logic):**
+```csharp
+var query = _context.Articles.AsNoTracking();
+
+if (hasFeedback == true)
+    query = query.Where(a => a.PrecisionScore != null || a.StyleScore != null);
+else if (hasFeedback == false)
+    query = query.Where(a => a.PrecisionScore == null && a.StyleScore == null);
+
+if (!string.IsNullOrWhiteSpace(requestedBy))
+    query = query.Where(a => a.RequestedBy == requestedBy);
+
+query = sortBy switch
+{
+    "PrecisionScore" => descending ? query.OrderByDescending(a => a.PrecisionScore) : query.OrderBy(a => a.PrecisionScore),
+    "StyleScore"     => descending ? query.OrderByDescending(a => a.StyleScore)     : query.OrderBy(a => a.StyleScore),
+    _                => descending ? query.OrderByDescending(a => a.CreatedAt)      : query.OrderBy(a => a.CreatedAt),
+};
+
+var total = await query.CountAsync(ct);
+var items = await query
+    .Skip((page - 1) * pageSize)
+    .Take(pageSize)
+    .Select(a => new ArticleFeedbackProjection(
+        a.Id, a.Title, a.Topic, a.RequestedBy,
+        a.CreatedAt, a.PrecisionScore, a.StyleScore, a.FeedbackComment))
+    .ToListAsync(ct);
+
+return (items, total);
+```
+
+**Updated `GetArticleFeedbackListHandler` mapping** (only the projection lambda changes; logic is byte-identical):
+```csharp
+Items = items.Select(a => new ArticleFeedbackSummary
+{
+    Id = a.Id,
+    Title = a.Title,
+    Topic = a.Topic,
+    RequestedBy = a.RequestedBy,
+    CreatedAt = a.CreatedAt,
+    PrecisionScore = a.PrecisionScore,
+    StyleScore = a.StyleScore,
+    HasComment = !string.IsNullOrWhiteSpace(a.FeedbackComment),
+}).ToList(),
+```
+
+### Data Flow
+
+For a feedback-list page request:
+1. Controller → MediatR `Send` → `GetArticleFeedbackListHandler.Handle`.
+2. Handler issues two parallel repository calls: `GetFeedbackPagedAsync` (now returns `IReadOnlyList<ArticleFeedbackProjection>`) and `GetFeedbackStatsAsync` (unchanged).
+3. `ArticleRepository.GetFeedbackPagedAsync` builds the `IQueryable<Article>` exactly as today (filters, sort, count), then projects to `ArticleFeedbackProjection` via `.Select(...)` before `ToListAsync`. SQL `SELECT` lists only the eight projected columns.
+4. Handler maps the projection rows to the OpenAPI-exposed `ArticleFeedbackSummary` (computing `HasComment` from `FeedbackComment`) and returns the response.
+
+OpenAPI contract, controller, frontend hook, TypeScript client: all unchanged.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Projection placed in Application layer per spec text → Domain→Application reference cycle, build fails. | High | Place `ArticleFeedbackProjection.cs` in `Anela.Heblo.Domain/Features/Article/` (this review's Decision 1). Verify with `dotnet build` after adding the file. |
+| EF Core translation surprise: `.Select(new Record(...))` falls back to client-side evaluation, defeating the optimisation. | Medium | Add the SQL-shape regression test (Decision 4) that asserts `HtmlContent` is absent from `query.ToQueryString()`. CI fails if EF Core ever changes behaviour. |
+| Existing handler unit tests (`GetArticleFeedbackListHandlerTests`) break because mocks return `IReadOnlyList<Article>`. | Low | Spec FR-4 already calls this out — update mock setups to return `IReadOnlyList<ArticleFeedbackProjection>`. The three existing tests need only their `ReturnsAsync(...)` lines adjusted. |
+| Future caller of `GetFeedbackPagedAsync` needs a field not in the projection (e.g., `Status`, `GeneratedAt`). | Low | Document in `ArticleFeedbackProjection` that it serves the feedback-list use case; future callers needing more should add a separate repository method (e.g., `GetFeedbackPagedWithStatusAsync`) rather than widening this projection. |
+| Sort by a column omitted from the projection — currently impossible (`AllowedSortColumns` enumerates `CreatedAt`, `PrecisionScore`, `StyleScore`, all in the projection), but adding `Status` sort later would require including the column. | Low | No action now. If `AllowedSortColumns` grows, the implementer must add the new column to `ArticleFeedbackProjection` in the same change. Note this in a one-line comment above the `Select(...)`. |
+| `record` constructor parameter order drift later renames or reorders fields → silent positional mis-binding in EF projection. | Low | Constructor parameters bind by name in EF Core 8 record-projection translation, but positional callers in the repository will fail at compile time on any signature change — this is a feature, not a risk. |
+
+## Specification Amendments
+
+1. **FR-2 location amendment (mandatory).** The spec proposes `backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/ArticleFeedbackProjection.cs`. This is incorrect because `IArticleRepository` lives in `Anela.Heblo.Domain`, which does not (and must not) reference `Anela.Heblo.Application`. Correct location: `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs`, next to `IArticleRepository.cs` and `ArticleFeedbackStats.cs`.
+
+2. **FR-2 / OQ-1 confirmation.** The spec's Open Question OQ-1 (project-wide "DTOs are classes, never records" rule) is resolved: the rule does not apply to internal projection types. Precedent: `ArticleFeedbackStats` (Domain, `sealed record`). Use `sealed record` for `ArticleFeedbackProjection`. (The spec already states OQ-1 is "None" in its final form; this is a confirmation, not a change.)
+
+3. **Data Model `CreatedAt` type clarification.** The spec writes `CreatedAt : DateTime (or DateTimeOffset, matching entity)`. The entity is `DateTimeOffset` (`Article.CreatedAt`). The projection MUST use `DateTimeOffset` to avoid a redundant value-conversion in EF Core and to keep the mapping to `ArticleFeedbackSummary.CreatedAt` (also `DateTimeOffset`) trivially type-compatible.
+
+4. **NFR-4 / FR-1 test approach narrowed.** The spec lists three acceptable mechanisms. To keep test infrastructure simple and avoid adding an EF interceptor fixture, **prefer mechanism (a)**: capture `query.ToQueryString()` on the pre-`ToListAsync` `IQueryable<ArticleFeedbackProjection>` and assert `HtmlContent` is absent from the SQL string. This requires exposing the query-composition path to a test — either via `InternalsVisibleTo` on a small internal helper, or by adding an integration test that uses SQLite/InMemory and calls the public repository method against an instrumented `DbContext`. Choose whichever path requires fewer changes to existing test infrastructure.
+
+5. **Acceptance criterion clarification for FR-1.** Add: the SQL-shape test MUST also assert that the projected columns (`Id`, `Title`, `Topic`, `RequestedBy`, `CreatedAt`, `PrecisionScore`, `StyleScore`, `FeedbackComment`) appear in the `SELECT`. A pure "doesn't contain HtmlContent" assertion would pass on a query that selects nothing at all.
+
+## Prerequisites
+
+None. The change requires:
+- No database migrations (schema unchanged).
+- No new NuGet packages.
+- No new project references.
+- No DI registration changes.
+- No infrastructure changes.
+- No feature flag.
+- No OpenAPI/TypeScript client regeneration.
+
+Implementation may begin immediately. Validate with `dotnet build` after adding `ArticleFeedbackProjection.cs` and updating the interface, and with `dotnet test` after updating the handler-test mocks.
+```

--- a/artifacts/feat-arch-review-article-getfeedbackpagedasyn/brief.md
+++ b/artifacts/feat-arch-review-article-getfeedbackpagedasyn/brief.md
@@ -1,0 +1,68 @@
+## Module
+Article
+
+## Finding
+`ArticleRepository.GetFeedbackPagedAsync` materialises full `Article` entities — including the `HtmlContent` text column — but the only caller (`GetArticleFeedbackListHandler`) projects to a seven-field DTO:
+
+```csharp
+// backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs:59-97
+public async Task<(IReadOnlyList<DomainArticle> Items, int TotalCount)> GetFeedbackPagedAsync(...)
+{
+    var query = _context.Articles.AsNoTracking();
+    // ... filters and sorting ...
+    var items = await query
+        .Skip((page - 1) * pageSize)
+        .Take(pageSize)
+        .ToListAsync(ct);   // loads ALL columns, including HtmlContent
+    return (items, total);
+}
+```
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs:44-54
+Items = items.Select(a => new ArticleFeedbackSummary
+{
+    Id = a.Id,
+    Title = a.Title,
+    Topic = a.Topic,
+    RequestedBy = a.RequestedBy,
+    CreatedAt = a.CreatedAt,
+    PrecisionScore = a.PrecisionScore,
+    StyleScore = a.StyleScore,
+    HasComment = !string.IsNullOrWhiteSpace(a.FeedbackComment),
+}).ToList(),
+```
+
+`HtmlContent` is a `text` column (no `HasMaxLength` in `ArticleConfiguration`) containing the full generated article — typically 5–20 KB of HTML per article. This column is fetched from the database, transferred over the wire, and held in memory for every page load of the feedback list, then silently discarded.
+
+The repository method also returns the full entity for integration/admin queries that genuinely need all fields, so the current signature forces an all-or-nothing choice.
+
+## Why it matters
+- **Unnecessary I/O and memory**: `HtmlContent` is the largest column on the table. Loading it for every feedback-list page multiplies network bytes and allocations by ~10× vs. projecting to needed fields.
+- **Scales poorly**: As the article backlog grows the cost per page load grows linearly. A feedback list showing 50 items at 10 KB per article body = 500 KB of dead transfer per request.
+- **KISS principle**: the repository returns more than it contracts with its callers — every future consumer of this method is implicitly burdened with the same overhead.
+
+## Suggested fix
+Add a lightweight DB projection directly in the repository, returning only the columns the handler needs. The minimal change is an inline `.Select()` inside `GetFeedbackPagedAsync`:
+
+```csharp
+// backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs
+public async Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(...)
+{
+    var query = _context.Articles.AsNoTracking();
+    // ... same filter/sort logic ...
+    var items = await query
+        .Skip((page - 1) * pageSize)
+        .Take(pageSize)
+        .Select(a => new ArticleFeedbackProjection(
+            a.Id, a.Title, a.Topic, a.RequestedBy,
+            a.CreatedAt, a.PrecisionScore, a.StyleScore, a.FeedbackComment))
+        .ToListAsync(ct);
+    return (items, total);
+}
+```
+
+`ArticleFeedbackProjection` would be a simple record/class in the Application layer (or Persistence if kept internal). The `IArticleRepository` interface signature would change to `(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)`. The handler mapping becomes trivial.
+
+---
+_Filed by daily arch-review routine on 2026-05-27._

--- a/artifacts/feat-arch-review-article-getfeedbackpagedasyn/impl/main.r1.md
+++ b/artifacts/feat-arch-review-article-getfeedbackpagedasyn/impl/main.r1.md
@@ -1,0 +1,8 @@
+Tests pass. Implementation complete. What would you like to do?
+
+1. **Merge back to `main` locally**
+2. **Push and create a Pull Request**
+3. **Keep the branch as-is** (I'll handle it later)
+4. **Discard this work**
+
+Which option?

--- a/artifacts/feat-arch-review-article-getfeedbackpagedasyn/spec.r1.md
+++ b/artifacts/feat-arch-review-article-getfeedbackpagedasyn/spec.r1.md
@@ -1,0 +1,161 @@
+# Specification: Project ArticleRepository.GetFeedbackPagedAsync to DTO at the Database Level
+
+## Summary
+Replace the entity-materialising query in `ArticleRepository.GetFeedbackPagedAsync` with a database-level projection that returns only the eight columns the feedback list handler needs. This eliminates fetching the large `HtmlContent` text column on every feedback-list page load, reducing wire bytes and memory allocations by roughly an order of magnitude per request.
+
+## Background
+The Article module exposes a feedback list page that lets reviewers browse articles awaiting feedback. The handler powering this page (`GetArticleFeedbackListHandler`) consumes a paged result from `ArticleRepository.GetFeedbackPagedAsync` and projects each entity into an `ArticleFeedbackSummary` DTO with only seven scalar fields plus a `HasComment` boolean derived from `FeedbackComment`.
+
+The repository currently materialises full `Article` entities (`ToListAsync` over `IQueryable<Article>` with no `.Select`). The `Article.HtmlContent` column is declared as `text` in `ArticleConfiguration` with no length cap and stores the full generated article body — typically 5–20 KB of HTML per row. For a 50-item page, this is ~500 KB of dead transfer per request, allocated, copied across the network, deserialised by EF Core, then discarded when the handler projects to its DTO.
+
+The arch-review routine flagged this on 2026-05-27 as a KISS violation: the repository returns more than its only caller needs, and any future caller of `GetFeedbackPagedAsync` inherits the same overhead. The fix is straightforward: project at the database in the repository, change the method's return type to a purpose-built projection record, and update the handler's mapping accordingly.
+
+## Functional Requirements
+
+### FR-1: Database-level projection in GetFeedbackPagedAsync
+`ArticleRepository.GetFeedbackPagedAsync` MUST issue a SQL query that selects only the columns required by `GetArticleFeedbackListHandler`. The `HtmlContent` column MUST NOT appear in the generated SQL `SELECT` list.
+
+The projected columns are:
+- `Id`
+- `Title`
+- `Topic`
+- `RequestedBy`
+- `CreatedAt`
+- `PrecisionScore`
+- `StyleScore`
+- `FeedbackComment` (used to compute `HasComment` in the handler; not exposed downstream)
+
+**Acceptance criteria:**
+- An integration test (or in-memory DB test) capturing the EF Core-generated SQL for `GetFeedbackPagedAsync` confirms the `SELECT` clause contains only the eight listed columns and excludes `HtmlContent`.
+- The method's behavioural contract (paging, filtering, sorting, total count semantics) is unchanged — existing handler tests continue to pass without modification beyond the type change.
+
+### FR-2: Introduce ArticleFeedbackProjection type
+A new type `ArticleFeedbackProjection` MUST be introduced to carry the projected row shape between the repository and the handler.
+
+- Location: `backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/ArticleFeedbackProjection.cs` (Application layer, alongside the handler that consumes it).
+- Shape: an immutable C# `record` (this is an **internal projection type**, not a DTO crossing the OpenAPI boundary, so the project-wide "DTOs are classes, never records" rule does not apply — see Open Questions OQ-1 for confirmation request).
+- Fields, in declaration order: `Id`, `Title`, `Topic`, `RequestedBy`, `CreatedAt`, `PrecisionScore`, `StyleScore`, `FeedbackComment`. Types match the corresponding `Article` entity properties (including nullability).
+- Visibility: `public` (it is referenced from both the Persistence and Application projects via `IArticleRepository`).
+
+**Acceptance criteria:**
+- The type compiles and is referenced by both `IArticleRepository.GetFeedbackPagedAsync` and `GetArticleFeedbackListHandler`.
+- No other type in the solution duplicates this shape; there is exactly one projection record for the feedback list path.
+
+### FR-3: Update IArticleRepository contract
+The `IArticleRepository.GetFeedbackPagedAsync` signature MUST change to return `Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)>` instead of `Task<(IReadOnlyList<Article> Items, int TotalCount)>`. All other parameters (filters, paging, sort, cancellation token) remain identical.
+
+**Acceptance criteria:**
+- `IArticleRepository` interface reflects the new return type.
+- `ArticleRepository` implementation matches the interface.
+- No call site of `GetFeedbackPagedAsync` exists outside `GetArticleFeedbackListHandler` (verified by repository-wide grep before merge); if any other caller surfaces, FR-5 applies.
+
+### FR-4: Simplify handler mapping
+`GetArticleFeedbackListHandler` MUST be updated so its mapping from repository result to `ArticleFeedbackSummary` consumes `ArticleFeedbackProjection` instances directly. The mapping logic for `HasComment` (computed from `FeedbackComment`) is preserved.
+
+**Acceptance criteria:**
+- The handler compiles against the new repository signature.
+- All existing unit/integration tests for `GetArticleFeedbackListHandler` pass without changes to their assertions (only any test-side mocks/fakes of `IArticleRepository` need their return type adjusted).
+- The shape and contents of `ArticleFeedbackSummary` (the OpenAPI-exposed DTO) are unchanged. The OpenAPI client does **not** regenerate as a result of this change.
+
+### FR-5: Preserve other repository methods returning full Article
+This change is scoped strictly to `GetFeedbackPagedAsync`. Other `ArticleRepository` methods that legitimately return full `Article` entities (e.g. detail/admin queries) MUST remain untouched. The all-or-nothing concern raised in the brief is resolved by giving the feedback list path its own narrow projection, not by changing the repository's other contracts.
+
+**Acceptance criteria:**
+- `git diff` for the change touches only: `ArticleRepository.cs`, `IArticleRepository.cs`, the new `ArticleFeedbackProjection.cs`, `GetArticleFeedbackListHandler.cs`, and the corresponding test files. No other repository methods are modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- The SQL generated for `GetFeedbackPagedAsync` MUST exclude the `HtmlContent` column. Verified at the EF Core query-translation level (FR-1 acceptance criterion).
+- Expected wire-byte reduction per feedback-list page: ~90% (from ~500 KB to ~50 KB for a 50-item page with typical content sizes).
+- Existing pagination performance (filtering, sorting, count query) MUST NOT regress. The same indexes and predicates apply.
+
+### NFR-2: Security
+No security-relevant change. The set of fields exposed to the API consumer via `ArticleFeedbackSummary` is unchanged. Removing `HtmlContent` from the transport path is a defence-in-depth bonus (less sensitive content traverses unnecessary layers) but is not the goal.
+
+### NFR-3: Maintainability
+- The repository contract narrows to match its caller's needs (KISS). Any future caller that genuinely needs full `Article` entities must use (or add) a different method.
+- The projection record lives next to its consumer handler, keeping cohesion high.
+
+### NFR-4: Test coverage
+- Existing test coverage for `GetArticleFeedbackListHandler` MUST be preserved.
+- At least one integration test MUST assert that the SQL generated for `GetFeedbackPagedAsync` does not reference `HtmlContent`. Acceptable implementations: (a) inspecting `IQueryable.ToQueryString()` on the pre-`ToListAsync` query, (b) using an EF Core interceptor in a test fixture to capture the executed SQL, or (c) any equivalent mechanism that fails if `HtmlContent` is re-introduced into the projection.
+
+## Data Model
+
+No schema changes. The `Article` entity, `ArticleConfiguration`, and database table are untouched.
+
+New in-memory type:
+
+```
+ArticleFeedbackProjection (record, Application layer)
+├── Id              : <Article.Id type>
+├── Title           : string
+├── Topic           : string
+├── RequestedBy     : string
+├── CreatedAt       : DateTime (or DateTimeOffset, matching entity)
+├── PrecisionScore  : <score type, likely int? or decimal?>
+├── StyleScore      : <score type>
+└── FeedbackComment : string?
+```
+
+Exact field types mirror the `Article` entity properties as declared in `ArticleConfiguration` / the domain model. The implementer reads them from the existing entity rather than re-deriving.
+
+## API / Interface Design
+
+**No public API changes.** The `ArticleFeedbackSummary` DTO returned by the feedback list endpoint is unchanged, so the OpenAPI contract and the generated TypeScript client are unaffected.
+
+**Internal interface change:**
+
+```csharp
+// IArticleRepository.cs — before
+Task<(IReadOnlyList<Article> Items, int TotalCount)> GetFeedbackPagedAsync(
+    /* existing parameters */,
+    CancellationToken ct);
+
+// IArticleRepository.cs — after
+Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
+    /* existing parameters, unchanged */,
+    CancellationToken ct);
+```
+
+**Repository implementation shape:**
+
+```csharp
+var query = _context.Articles.AsNoTracking();
+// existing filter / sort logic, applied to query (still typed as IQueryable<Article>)
+var total = await query.CountAsync(ct);
+var items = await query
+    .Skip((page - 1) * pageSize)
+    .Take(pageSize)
+    .Select(a => new ArticleFeedbackProjection(
+        a.Id, a.Title, a.Topic, a.RequestedBy,
+        a.CreatedAt, a.PrecisionScore, a.StyleScore, a.FeedbackComment))
+    .ToListAsync(ct);
+return (items, total);
+```
+
+Filtering and sorting continue to operate on `IQueryable<Article>` so that existing predicates (which may reference any column) remain valid. The projection happens immediately before `ToListAsync`.
+
+## Dependencies
+
+- **EF Core**: relies on existing translation of `.Select(a => new ArticleFeedbackProjection(...))` into a column-restricted `SELECT`. EF Core 8 supports projecting into records via constructor.
+- **No new NuGet packages.**
+- **No new external services.**
+- **Migration**: none — schema unchanged.
+- **Feature flag**: none — this is a pure internal refactor with identical observable behaviour at the API boundary.
+
+## Out of Scope
+
+- Projecting other `IArticleRepository` methods that return full `Article` entities. Each such method has its own callers and call patterns; revisit them as separate findings if they show the same anti-pattern.
+- Adding `HasMaxLength` or any other column-level constraints to `HtmlContent` in `ArticleConfiguration`.
+- Changing pagination defaults, max page size, or sort options.
+- Changing the `ArticleFeedbackSummary` DTO shape or the feedback list UI.
+- Adding caching for the feedback list endpoint.
+- Compressing `HtmlContent` at rest.
+
+## Open Questions
+
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-article-getfeedbackpagedasyn/task-plan.r1.md
+++ b/artifacts/feat-arch-review-article-getfeedbackpagedasyn/task-plan.r1.md
@@ -1,0 +1,588 @@
+# Article Feedback Repository Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the entity-materialising query in `ArticleRepository.GetFeedbackPagedAsync` with a column-restricted projection so EF Core no longer pulls the multi-kilobyte `HtmlContent` column on every feedback list request.
+
+**Architecture:** Add `ArticleFeedbackProjection` (a `sealed record`) to the Domain layer next to `IArticleRepository` and `ArticleFeedbackStats` (the established pattern for non-entity repository return types). Update `IArticleRepository.GetFeedbackPagedAsync` to return `IReadOnlyList<ArticleFeedbackProjection>`. The Persistence implementation continues to build its filter/sort logic on `IQueryable<Article>` but appends a `.Select(...)` immediately before `ToListAsync`. The Application handler's mapping body is byte-identical because the projection's positional record properties (`Id`, `Title`, `Topic`, ...) match the existing entity property accesses. A SQL-shape regression test using `Testcontainers.PostgreSql` + `DbCommandInterceptor` (mirroring `PhotobankRepositoryGetTagsSqlShapeTests`) guards against future regression.
+
+**Tech Stack:** .NET 8, EF Core 8, PostgreSQL, xUnit, FluentAssertions, Moq, Testcontainers.PostgreSql.
+
+---
+
+## File Structure
+
+### Created
+
+| File | Responsibility |
+|------|---------------|
+| `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs` | Immutable Domain-layer record carrying the eight columns the feedback list path consumes. |
+| `backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs` | Integration test that captures the SQL emitted by `GetFeedbackPagedAsync` against real Postgres and asserts `HtmlContent` is absent and the projected columns are present. |
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs` | Return type of `GetFeedbackPagedAsync` changes from `IReadOnlyList<Article>` to `IReadOnlyList<ArticleFeedbackProjection>`. Other methods untouched. |
+| `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs` | `GetFeedbackPagedAsync` body adds `.Select(a => new ArticleFeedbackProjection(...))` immediately before `ToListAsync`. Filter and sort logic unchanged. |
+| `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs` | Three Moq setups updated to return `IReadOnlyList<ArticleFeedbackProjection>` instead of `IReadOnlyList<Article>`. Assertions unchanged. |
+
+### Unmodified (verified)
+
+`backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs` requires no code edits. The handler accesses `a.Id`, `a.Title`, `a.Topic`, `a.RequestedBy`, `a.CreatedAt`, `a.PrecisionScore`, `a.StyleScore`, `a.FeedbackComment` — all of which are positional record properties on `ArticleFeedbackProjection` with identical names and matching types. The file is only verified to compile after the interface change, not edited.
+
+---
+
+## Task 1: Add `ArticleFeedbackProjection` Domain record
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs`
+
+**Rationale:** Adding the type first lets the rest of the refactor proceed with a stable name to bind against. The Domain layer is the only legal home — `IArticleRepository` lives in `Anela.Heblo.Domain` and the Domain `csproj` does not (and must not) reference `Anela.Heblo.Application`. The existing `ArticleFeedbackStats` (`sealed record` in the same folder) is the precedent.
+
+- [ ] **Step 1: Create `ArticleFeedbackProjection.cs`**
+
+Write the file at `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Article;
+
+public sealed record ArticleFeedbackProjection(
+    Guid Id,
+    string? Title,
+    string Topic,
+    string? RequestedBy,
+    DateTimeOffset CreatedAt,
+    int? PrecisionScore,
+    int? StyleScore,
+    string? FeedbackComment);
+```
+
+Field types and nullability are taken directly from `Article.cs`:
+- `Id` → `Guid` (non-null)
+- `Title` → `string?`
+- `Topic` → `string` (non-null; entity defaults it to `""`)
+- `RequestedBy` → `string?`
+- `CreatedAt` → `DateTimeOffset` (note: the spec text said `DateTime`; entity is `DateTimeOffset` — use `DateTimeOffset`)
+- `PrecisionScore` → `int?`
+- `StyleScore` → `int?`
+- `FeedbackComment` → `string?`
+
+- [ ] **Step 2: Build the Domain project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs
+git commit -m "feat: add ArticleFeedbackProjection domain record"
+```
+
+---
+
+## Task 2: Write SQL-shape regression test (RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs`
+
+**Rationale:** Write the test before the implementation change. The test calls `ArticleRepository.GetFeedbackPagedAsync` against a real Postgres container, captures the SQL via `DbCommandInterceptor`, and asserts the projected columns appear in the SELECT while `HtmlContent` does not. Before Task 4 it MUST fail (current impl SELECTs `HtmlContent`). After Task 4 it MUST pass.
+
+The test mirrors `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetTagsSqlShapeTests.cs` — the established pattern for SQL-shape verification in this codebase. No `InternalsVisibleTo` or test seam is required.
+
+- [ ] **Step 1: Create the test directory and file**
+
+Write the file at `backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs` with this exact content:
+
+```csharp
+using System.Data.Common;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Article;
+using DotNet.Testcontainers.Configurations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Anela.Heblo.Tests.Article.Persistence;
+
+[Trait("Category", "Integration")]
+public class ArticleRepositoryFeedbackProjectionSqlTests : IAsyncLifetime
+{
+    static ArticleRepositoryFeedbackProjectionSqlTests()
+    {
+        // Required on macOS with Podman: the Ryuk ResourceReaper container
+        // cannot bind to the Docker socket and throws a NullReferenceException.
+        TestcontainersSettings.ResourceReaperEnabled = false;
+    }
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:16")
+        .Build();
+
+    private readonly CapturingCommandInterceptor _interceptor = new();
+    private ApplicationDbContext _context = null!;
+    private ArticleRepository _repository = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        // Minimal schema — only the columns the projection query touches plus the
+        // required NOT NULL columns from ArticleConfiguration. HtmlContent is
+        // included so the test would actually fail if the production query still
+        // pulled it.
+        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE public."Articles" (
+                    "Id"              uuid                     NOT NULL PRIMARY KEY,
+                    "Topic"           varchar(2000)            NOT NULL,
+                    "Scope"           varchar(50)              NOT NULL,
+                    "Audience"        varchar(500),
+                    "Angle"           varchar(500),
+                    "Length"          varchar(50)              NOT NULL,
+                    "LanguageNote"    varchar(500),
+                    "UsedKnowledgeBase" boolean                NOT NULL DEFAULT false,
+                    "UsedWebSearch"   boolean                  NOT NULL DEFAULT false,
+                    "StyleGuideDriveId" varchar(500),
+                    "StyleGuideItemPath" varchar(500),
+                    "Title"           text,
+                    "HtmlContent"     text,
+                    "Status"          integer                  NOT NULL,
+                    "ErrorMessage"    varchar(2000),
+                    "RequestedBy"     varchar(200),
+                    "PrecisionScore"  integer,
+                    "StyleScore"      integer,
+                    "FeedbackComment" text,
+                    "CreatedAt"       timestamptz              NOT NULL,
+                    "GeneratedAt"     timestamptz
+                );
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .AddInterceptors(_interceptor)
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new ArticleRepository(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        await _container.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetFeedbackPagedAsync_DoesNotSelectHtmlContent()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetFeedbackPagedAsync(
+            hasFeedback: null,
+            requestedBy: null,
+            sortBy: "CreatedAt",
+            descending: true,
+            page: 1,
+            pageSize: 20,
+            ct: CancellationToken.None);
+
+        // The COUNT(*) and the SELECT-with-Skip/Take both fire; inspect the row-returning
+        // SELECT (the one that contains a column list, not just COUNT).
+        var rowSelect = _interceptor.Commands
+            .FirstOrDefault(c => c.Contains("FROM \"Articles\"", StringComparison.OrdinalIgnoreCase)
+                && !c.Contains("COUNT(*)", StringComparison.OrdinalIgnoreCase));
+
+        rowSelect.Should().NotBeNull("the repository must issue a row-returning SELECT against Articles");
+        rowSelect!.Should().NotContain("\"HtmlContent\"",
+            "HtmlContent is multi-KB per row and is never read by the feedback list handler");
+    }
+
+    [Fact]
+    public async Task GetFeedbackPagedAsync_SelectsExactlyTheProjectedColumns()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetFeedbackPagedAsync(
+            hasFeedback: null,
+            requestedBy: null,
+            sortBy: "CreatedAt",
+            descending: true,
+            page: 1,
+            pageSize: 20,
+            ct: CancellationToken.None);
+
+        var rowSelect = _interceptor.Commands
+            .First(c => c.Contains("FROM \"Articles\"", StringComparison.OrdinalIgnoreCase)
+                && !c.Contains("COUNT(*)", StringComparison.OrdinalIgnoreCase));
+
+        // Every projected column appears in the SELECT.
+        foreach (var column in new[]
+                 {
+                     "\"Id\"", "\"Title\"", "\"Topic\"", "\"RequestedBy\"",
+                     "\"CreatedAt\"", "\"PrecisionScore\"", "\"StyleScore\"", "\"FeedbackComment\""
+                 })
+        {
+            rowSelect.Should().Contain(column,
+                $"projected column {column} must appear in the SELECT");
+        }
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = new();
+
+        public void Reset() => Commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the new test — confirm it fails (RED)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ArticleRepositoryFeedbackProjectionSqlTests"`
+
+Expected: `GetFeedbackPagedAsync_DoesNotSelectHtmlContent` FAILS with an assertion that the SELECT contains `"HtmlContent"`. This proves the test correctly detects the current bad behaviour. **Do not commit yet** — failing tests do not land in main.
+
+If Docker/Podman is unavailable in the environment, document that the test will be validated in Task 6 after the production change lands; proceed to Task 3.
+
+---
+
+## Task 3: Update `IArticleRepository.GetFeedbackPagedAsync` signature
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs`
+
+- [ ] **Step 1: Change the return type**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs`. Replace the lines:
+
+```csharp
+    Task<(IReadOnlyList<Article> Items, int TotalCount)> GetFeedbackPagedAsync(
+        bool? hasFeedback,
+        string? requestedBy,
+        string sortBy,
+        bool descending,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+```
+
+with:
+
+```csharp
+    Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
+        bool? hasFeedback,
+        string? requestedBy,
+        string sortBy,
+        bool descending,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+```
+
+No other methods on the interface change. Other methods (`GetByIdAsync`, `GetForUpdateAsync`, `GetPagedAsync`, `GetWithStepsAsync`) legitimately return the full `Article` aggregate and are out of scope.
+
+- [ ] **Step 2: Build the Domain project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: build succeeds (interface change in isolation compiles fine).
+
+- [ ] **Step 3: Build the whole solution to observe expected break**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: Build FAILS. Errors will appear in:
+- `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs` — implementation no longer satisfies the interface.
+- `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs` — Moq setups return the wrong tuple type.
+
+`GetArticleFeedbackListHandler.cs` should still compile because it accesses members that exist on both `Article` and `ArticleFeedbackProjection`.
+
+**Do not commit yet** — broken build does not land in main.
+
+---
+
+## Task 4: Update `ArticleRepository.GetFeedbackPagedAsync` to project at the database
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs`
+
+- [ ] **Step 1: Replace the method body**
+
+Edit `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs`. Replace the entire `GetFeedbackPagedAsync` method (currently lines 59–98) with:
+
+```csharp
+    public async Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
+        bool? hasFeedback,
+        string? requestedBy,
+        string sortBy,
+        bool descending,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _context.Articles.AsNoTracking();
+
+        if (hasFeedback == true)
+            query = query.Where(a => a.PrecisionScore != null || a.StyleScore != null);
+        else if (hasFeedback == false)
+            query = query.Where(a => a.PrecisionScore == null && a.StyleScore == null);
+
+        if (!string.IsNullOrWhiteSpace(requestedBy))
+            query = query.Where(a => a.RequestedBy == requestedBy);
+
+        query = sortBy switch
+        {
+            "PrecisionScore" => descending
+                ? query.OrderByDescending(a => a.PrecisionScore)
+                : query.OrderBy(a => a.PrecisionScore),
+            "StyleScore" => descending
+                ? query.OrderByDescending(a => a.StyleScore)
+                : query.OrderBy(a => a.StyleScore),
+            _ => descending
+                ? query.OrderByDescending(a => a.CreatedAt)
+                : query.OrderBy(a => a.CreatedAt)
+        };
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(a => new ArticleFeedbackProjection(
+                a.Id,
+                a.Title,
+                a.Topic,
+                a.RequestedBy,
+                a.CreatedAt,
+                a.PrecisionScore,
+                a.StyleScore,
+                a.FeedbackComment))
+            .ToListAsync(ct);
+
+        return (items, total);
+    }
+```
+
+Note: filters and sort continue to operate on `IQueryable<Article>`; the projection is applied immediately before `ToListAsync` so any future sort column added to `AllowedSortColumns` continues to work without further change (provided it's already present on the entity). The `CountAsync` runs before `Skip/Take/Select` and EF Core translates it to `SELECT COUNT(*)`, so no rows are materialised by the count call.
+
+The `Anela.Heblo.Domain.Features.Article` using directive at the top of the file is already present (line 1), so `ArticleFeedbackProjection` is in scope. No new `using` is needed.
+
+- [ ] **Step 2: Build the Persistence project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Build the whole solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: only `GetArticleFeedbackListHandlerTests.cs` still fails (Moq setups return the wrong tuple). `GetArticleFeedbackListHandler.cs` compiles unchanged because positional record properties (`a.Id`, `a.Title`, ...) match the existing field accesses.
+
+---
+
+## Task 5: Update handler unit-test mock setups
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs`
+
+**Rationale:** The handler under test now consumes `IReadOnlyList<ArticleFeedbackProjection>`. The three test methods each set up `_repository.Setup(r => r.GetFeedbackPagedAsync(...)).ReturnsAsync(((IReadOnlyList<DomainArticle>)..., ...))`. Each setup must change to return `IReadOnlyList<ArticleFeedbackProjection>`. Assertions remain unchanged.
+
+- [ ] **Step 1: Replace `Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults`**
+
+In `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs`, replace:
+
+```csharp
+    [Fact]
+    public async Task Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults()
+    {
+        var article = new DomainArticle
+        {
+            Id = Guid.NewGuid(),
+            Topic = "Sun care",
+            Title = "Sun care title",
+            RequestedBy = "alice",
+            CreatedAt = DateTimeOffset.UtcNow,
+            PrecisionScore = 4,
+            StyleScore = 5,
+            FeedbackComment = "ok",
+        };
+
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                null, null, "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<DomainArticle>)new[] { article }, 1));
+```
+
+with:
+
+```csharp
+    [Fact]
+    public async Task Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults()
+    {
+        var article = new ArticleFeedbackProjection(
+            Id: Guid.NewGuid(),
+            Title: "Sun care title",
+            Topic: "Sun care",
+            RequestedBy: "alice",
+            CreatedAt: DateTimeOffset.UtcNow,
+            PrecisionScore: 4,
+            StyleScore: 5,
+            FeedbackComment: "ok");
+
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                null, null, "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)new[] { article }, 1));
+```
+
+The downstream assertions (`response.Items[0].Id.Should().Be(article.Id)`, etc.) work unchanged because positional record properties expose the named values via `init` properties.
+
+- [ ] **Step 2: Replace `Handle_UnknownSortBy_FallsBackToCreatedAt`**
+
+In the same file, replace:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<DomainArticle>)Array.Empty<DomainArticle>(), 0));
+```
+
+with:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)Array.Empty<ArticleFeedbackProjection>(), 0));
+```
+
+- [ ] **Step 3: Replace `Handle_PageSizeOutsideAllowlist_FallsBackTo20`**
+
+In the same file, replace:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<DomainArticle>)Array.Empty<DomainArticle>(), 0));
+```
+
+with:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)Array.Empty<ArticleFeedbackProjection>(), 0));
+```
+
+- [ ] **Step 4: Remove the `DomainArticle` alias if it is no longer referenced**
+
+After the three edits, the line `using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;` at the top of the file is unused. Grep the file for `DomainArticle` — if there are no remaining references, delete that `using` line. If any reference remains (e.g. an unrelated test added later), leave the alias.
+
+Run a grep within the file:
+
+```bash
+grep -n "DomainArticle" backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
+```
+
+If output is empty, delete `using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;`.
+
+- [ ] **Step 5: Run the handler tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetArticleFeedbackListHandlerTests"`
+Expected: all three handler tests PASS.
+
+---
+
+## Task 6: Run the SQL-shape regression test — confirm GREEN
+
+**Files:**
+- (No edits — verification only.)
+
+- [ ] **Step 1: Run the SQL-shape test against the production change**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ArticleRepositoryFeedbackProjectionSqlTests"`
+
+Expected: both facts PASS.
+- `GetFeedbackPagedAsync_DoesNotSelectHtmlContent` — passes because the `.Select(...)` restricts the SQL to projected columns.
+- `GetFeedbackPagedAsync_SelectsExactlyTheProjectedColumns` — passes because EF Core emits each projected column name in the SELECT.
+
+If the Postgres container cannot start in the environment (Docker/Podman unavailable), document the failure as environmental and ensure the test runs in CI before merge.
+
+- [ ] **Step 2: Build the whole solution and run the entire test suite**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds, no warnings introduced.
+
+Run: `dotnet test backend/Anela.Heblo.sln --filter "Category!=Integration"`
+Expected: all non-integration tests pass.
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: all tests pass (subject to Docker availability for the integration tier).
+
+- [ ] **Step 3: Apply formatting**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: no changes (or only whitespace adjustments to files touched in this plan).
+
+- [ ] **Step 4: Commit the refactor**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs \
+        backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs
+git commit -m "refactor(article): project feedback list at database level
+
+Restrict ArticleRepository.GetFeedbackPagedAsync to the eight columns the
+feedback list handler reads, eliminating the multi-KB HtmlContent transfer
+on every page request. Return type narrows to IReadOnlyList<ArticleFeedbackProjection>.
+Adds a SQL-shape regression test guarding against HtmlContent re-entering
+the SELECT."
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- FR-1 (DB-level projection, no `HtmlContent` in SELECT) → Task 4 (impl) + Task 2/6 (SQL-shape test enforces it).
+- FR-2 (introduce `ArticleFeedbackProjection`) → Task 1. Location amended per arch review §1 to Domain layer.
+- FR-3 (update `IArticleRepository` contract) → Task 3.
+- FR-4 (simplify handler mapping) → Verified no edits needed; positional record properties match. Documented in "Unmodified" file table.
+- FR-5 (preserve other repository methods) → Task 3 Step 1 explicitly states "No other methods on the interface change."
+- NFR-1 (performance, no `HtmlContent`) → Task 4 + Task 6.
+- NFR-2 (security — unchanged surface) → No additional task; covered by FR-4 verification.
+- NFR-3 (maintainability) → Achieved by Task 1 type design and arch review's Decision 4 documentation pattern.
+- NFR-4 (SQL-shape test coverage) → Task 2 + Task 6.
+
+**Type consistency check:**
+- `ArticleFeedbackProjection` field types match `Article` entity property types exactly, including nullability and `DateTimeOffset` (not `DateTime`).
+- Handler accesses (`a.Id`, `a.Title`, `a.Topic`, `a.RequestedBy`, `a.CreatedAt`, `a.PrecisionScore`, `a.StyleScore`, `a.FeedbackComment`) match the positional record's auto-generated properties.
+- Test mocks use the same `IReadOnlyList<ArticleFeedbackProjection>` shape that the interface declares.
+
+**Placeholder scan:** No TBDs, no "implement later" markers, no "similar to Task N" cross-references — every code block in every step contains the literal content the engineer needs to type.

--- a/backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs
@@ -1,0 +1,11 @@
+namespace Anela.Heblo.Domain.Features.Article;
+
+public sealed record ArticleFeedbackProjection(
+    Guid Id,
+    string? Title,
+    string Topic,
+    string? RequestedBy,
+    DateTimeOffset CreatedAt,
+    int? PrecisionScore,
+    int? StyleScore,
+    string? FeedbackComment);

--- a/backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs
@@ -6,7 +6,7 @@ public interface IArticleRepository
     Task<Article?> GetByIdAsync(Guid id, CancellationToken ct = default);
     Task<Article?> GetForUpdateAsync(Guid id, CancellationToken ct = default);
     Task<(List<Article> Items, int TotalCount)> GetPagedAsync(ArticleStatus? status, int page, int pageSize, CancellationToken ct = default);
-    Task<(IReadOnlyList<Article> Items, int TotalCount)> GetFeedbackPagedAsync(
+    Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
         bool? hasFeedback,
         string? requestedBy,
         string sortBy,

--- a/backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs
@@ -56,7 +56,7 @@ public class ArticleRepository : IArticleRepository
             .FirstOrDefaultAsync(a => a.Id == id, ct);
     }
 
-    public async Task<(IReadOnlyList<DomainArticle> Items, int TotalCount)> GetFeedbackPagedAsync(
+    public async Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
         bool? hasFeedback,
         string? requestedBy,
         string sortBy,
@@ -92,6 +92,15 @@ public class ArticleRepository : IArticleRepository
         var items = await query
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
+            .Select(a => new ArticleFeedbackProjection(
+                a.Id,
+                a.Title,
+                a.Topic,
+                a.RequestedBy,
+                a.CreatedAt,
+                a.PrecisionScore,
+                a.StyleScore,
+                a.FeedbackComment))
             .ToListAsync(ct);
 
         return (items, total);

--- a/backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs
@@ -109,7 +109,7 @@ public class ArticleRepositoryFeedbackProjectionSqlTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetFeedbackPagedAsync_SelectsExactlyTheProjectedColumns()
+    public async Task GetFeedbackPagedAsync_SelectsAllProjectedColumns()
     {
         _interceptor.Reset();
 

--- a/backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs
@@ -1,0 +1,166 @@
+using System.Data.Common;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Article;
+using DotNet.Testcontainers.Configurations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Anela.Heblo.Tests.Article.Persistence;
+
+[Trait("Category", "Integration")]
+public class ArticleRepositoryFeedbackProjectionSqlTests : IAsyncLifetime
+{
+    static ArticleRepositoryFeedbackProjectionSqlTests()
+    {
+        // Required on macOS with Podman: the Ryuk ResourceReaper container
+        // cannot bind to the Docker socket and throws a NullReferenceException.
+        TestcontainersSettings.ResourceReaperEnabled = false;
+    }
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:16")
+        .Build();
+
+    private readonly CapturingCommandInterceptor _interceptor = new();
+    private ApplicationDbContext _context = null!;
+    private ArticleRepository _repository = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        // Minimal schema — only the columns the projection query touches plus the
+        // required NOT NULL columns from ArticleConfiguration. HtmlContent is
+        // included so the test would actually fail if the production query still
+        // pulled it.
+        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE public."Articles" (
+                    "Id"              uuid                     NOT NULL PRIMARY KEY,
+                    "Topic"           varchar(2000)            NOT NULL,
+                    "Scope"           varchar(50)              NOT NULL,
+                    "Audience"        varchar(500),
+                    "Angle"           varchar(500),
+                    "Length"          varchar(50)              NOT NULL,
+                    "LanguageNote"    varchar(500),
+                    "UsedKnowledgeBase" boolean                NOT NULL DEFAULT false,
+                    "UsedWebSearch"   boolean                  NOT NULL DEFAULT false,
+                    "StyleGuideDriveId" varchar(500),
+                    "StyleGuideItemPath" varchar(500),
+                    "Title"           text,
+                    "HtmlContent"     text,
+                    "Status"          integer                  NOT NULL,
+                    "ErrorMessage"    varchar(2000),
+                    "RequestedBy"     varchar(200),
+                    "PrecisionScore"  integer,
+                    "StyleScore"      integer,
+                    "FeedbackComment" text,
+                    "CreatedAt"       timestamptz              NOT NULL,
+                    "GeneratedAt"     timestamptz
+                );
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .AddInterceptors(_interceptor)
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new ArticleRepository(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        await _container.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetFeedbackPagedAsync_DoesNotSelectHtmlContent()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetFeedbackPagedAsync(
+            hasFeedback: null,
+            requestedBy: null,
+            sortBy: "CreatedAt",
+            descending: true,
+            page: 1,
+            pageSize: 20,
+            ct: CancellationToken.None);
+
+        // The COUNT(*) and the SELECT-with-Skip/Take both fire; inspect the row-returning
+        // SELECT (the one that contains a column list, not just COUNT).
+        var rowSelect = _interceptor.Commands
+            .FirstOrDefault(c => c.Contains("FROM \"Articles\"", StringComparison.OrdinalIgnoreCase)
+                && !c.Contains("COUNT(*)", StringComparison.OrdinalIgnoreCase));
+
+        rowSelect.Should().NotBeNull("the repository must issue a row-returning SELECT against Articles");
+        rowSelect!.Should().NotContain("\"HtmlContent\"",
+            "HtmlContent is multi-KB per row and is never read by the feedback list handler");
+    }
+
+    [Fact]
+    public async Task GetFeedbackPagedAsync_SelectsExactlyTheProjectedColumns()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetFeedbackPagedAsync(
+            hasFeedback: null,
+            requestedBy: null,
+            sortBy: "CreatedAt",
+            descending: true,
+            page: 1,
+            pageSize: 20,
+            ct: CancellationToken.None);
+
+        var rowSelect = _interceptor.Commands
+            .First(c => c.Contains("FROM \"Articles\"", StringComparison.OrdinalIgnoreCase)
+                && !c.Contains("COUNT(*)", StringComparison.OrdinalIgnoreCase));
+
+        // Every projected column appears in the SELECT.
+        foreach (var column in new[]
+                 {
+                     "\"Id\"", "\"Title\"", "\"Topic\"", "\"RequestedBy\"",
+                     "\"CreatedAt\"", "\"PrecisionScore\"", "\"StyleScore\"", "\"FeedbackComment\""
+                 })
+        {
+            rowSelect.Should().Contain(column,
+                $"projected column {column} must appear in the SELECT");
+        }
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = new();
+
+        public void Reset() => Commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
@@ -2,7 +2,6 @@ using Anela.Heblo.Application.Features.Article.UseCases.GetFeedbackList;
 using Anela.Heblo.Domain.Features.Article;
 using FluentAssertions;
 using Moq;
-using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;
 
 namespace Anela.Heblo.Tests.Article.UseCases;
 
@@ -15,21 +14,19 @@ public class GetArticleFeedbackListHandlerTests
     [Fact]
     public async Task Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults()
     {
-        var article = new DomainArticle
-        {
-            Id = Guid.NewGuid(),
-            Topic = "Sun care",
-            Title = "Sun care title",
-            RequestedBy = "alice",
-            CreatedAt = DateTimeOffset.UtcNow,
-            PrecisionScore = 4,
-            StyleScore = 5,
-            FeedbackComment = "ok",
-        };
+        var article = new ArticleFeedbackProjection(
+            Id: Guid.NewGuid(),
+            Title: "Sun care title",
+            Topic: "Sun care",
+            RequestedBy: "alice",
+            CreatedAt: DateTimeOffset.UtcNow,
+            PrecisionScore: 4,
+            StyleScore: 5,
+            FeedbackComment: "ok");
 
         _repository.Setup(r => r.GetFeedbackPagedAsync(
                 null, null, "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(((IReadOnlyList<DomainArticle>)new[] { article }, 1));
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)new[] { article }, 1));
 
         _repository.Setup(r => r.GetFeedbackStatsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ArticleFeedbackStats(10, 4, 4.5, 4.0));
@@ -58,7 +55,7 @@ public class GetArticleFeedbackListHandlerTests
     {
         _repository.Setup(r => r.GetFeedbackPagedAsync(
                 It.IsAny<bool?>(), It.IsAny<string?>(), "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(((IReadOnlyList<DomainArticle>)Array.Empty<DomainArticle>(), 0));
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)Array.Empty<ArticleFeedbackProjection>(), 0));
         _repository.Setup(r => r.GetFeedbackStatsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ArticleFeedbackStats(0, 0, null, null));
 
@@ -77,7 +74,7 @@ public class GetArticleFeedbackListHandlerTests
         _repository.Setup(r => r.GetFeedbackPagedAsync(
                 It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
                 It.IsAny<int>(), 20, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(((IReadOnlyList<DomainArticle>)Array.Empty<DomainArticle>(), 0));
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)Array.Empty<ArticleFeedbackProjection>(), 0));
         _repository.Setup(r => r.GetFeedbackStatsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ArticleFeedbackStats(0, 0, null, null));
 

--- a/docs/superpowers/plans/2026-05-27-article-feedback-projection.md
+++ b/docs/superpowers/plans/2026-05-27-article-feedback-projection.md
@@ -1,0 +1,588 @@
+# Article Feedback Repository Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the entity-materialising query in `ArticleRepository.GetFeedbackPagedAsync` with a column-restricted projection so EF Core no longer pulls the multi-kilobyte `HtmlContent` column on every feedback list request.
+
+**Architecture:** Add `ArticleFeedbackProjection` (a `sealed record`) to the Domain layer next to `IArticleRepository` and `ArticleFeedbackStats` (the established pattern for non-entity repository return types). Update `IArticleRepository.GetFeedbackPagedAsync` to return `IReadOnlyList<ArticleFeedbackProjection>`. The Persistence implementation continues to build its filter/sort logic on `IQueryable<Article>` but appends a `.Select(...)` immediately before `ToListAsync`. The Application handler's mapping body is byte-identical because the projection's positional record properties (`Id`, `Title`, `Topic`, ...) match the existing entity property accesses. A SQL-shape regression test using `Testcontainers.PostgreSql` + `DbCommandInterceptor` (mirroring `PhotobankRepositoryGetTagsSqlShapeTests`) guards against future regression.
+
+**Tech Stack:** .NET 8, EF Core 8, PostgreSQL, xUnit, FluentAssertions, Moq, Testcontainers.PostgreSql.
+
+---
+
+## File Structure
+
+### Created
+
+| File | Responsibility |
+|------|---------------|
+| `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs` | Immutable Domain-layer record carrying the eight columns the feedback list path consumes. |
+| `backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs` | Integration test that captures the SQL emitted by `GetFeedbackPagedAsync` against real Postgres and asserts `HtmlContent` is absent and the projected columns are present. |
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs` | Return type of `GetFeedbackPagedAsync` changes from `IReadOnlyList<Article>` to `IReadOnlyList<ArticleFeedbackProjection>`. Other methods untouched. |
+| `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs` | `GetFeedbackPagedAsync` body adds `.Select(a => new ArticleFeedbackProjection(...))` immediately before `ToListAsync`. Filter and sort logic unchanged. |
+| `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs` | Three Moq setups updated to return `IReadOnlyList<ArticleFeedbackProjection>` instead of `IReadOnlyList<Article>`. Assertions unchanged. |
+
+### Unmodified (verified)
+
+`backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs` requires no code edits. The handler accesses `a.Id`, `a.Title`, `a.Topic`, `a.RequestedBy`, `a.CreatedAt`, `a.PrecisionScore`, `a.StyleScore`, `a.FeedbackComment` — all of which are positional record properties on `ArticleFeedbackProjection` with identical names and matching types. The file is only verified to compile after the interface change, not edited.
+
+---
+
+## Task 1: Add `ArticleFeedbackProjection` Domain record
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs`
+
+**Rationale:** Adding the type first lets the rest of the refactor proceed with a stable name to bind against. The Domain layer is the only legal home — `IArticleRepository` lives in `Anela.Heblo.Domain` and the Domain `csproj` does not (and must not) reference `Anela.Heblo.Application`. The existing `ArticleFeedbackStats` (`sealed record` in the same folder) is the precedent.
+
+- [ ] **Step 1: Create `ArticleFeedbackProjection.cs`**
+
+Write the file at `backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs` with this exact content:
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Article;
+
+public sealed record ArticleFeedbackProjection(
+    Guid Id,
+    string? Title,
+    string Topic,
+    string? RequestedBy,
+    DateTimeOffset CreatedAt,
+    int? PrecisionScore,
+    int? StyleScore,
+    string? FeedbackComment);
+```
+
+Field types and nullability are taken directly from `Article.cs`:
+- `Id` → `Guid` (non-null)
+- `Title` → `string?`
+- `Topic` → `string` (non-null; entity defaults it to `""`)
+- `RequestedBy` → `string?`
+- `CreatedAt` → `DateTimeOffset` (note: the spec text said `DateTime`; entity is `DateTimeOffset` — use `DateTimeOffset`)
+- `PrecisionScore` → `int?`
+- `StyleScore` → `int?`
+- `FeedbackComment` → `string?`
+
+- [ ] **Step 2: Build the Domain project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Article/ArticleFeedbackProjection.cs
+git commit -m "feat: add ArticleFeedbackProjection domain record"
+```
+
+---
+
+## Task 2: Write SQL-shape regression test (RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs`
+
+**Rationale:** Write the test before the implementation change. The test calls `ArticleRepository.GetFeedbackPagedAsync` against a real Postgres container, captures the SQL via `DbCommandInterceptor`, and asserts the projected columns appear in the SELECT while `HtmlContent` does not. Before Task 4 it MUST fail (current impl SELECTs `HtmlContent`). After Task 4 it MUST pass.
+
+The test mirrors `backend/test/Anela.Heblo.Tests/Features/Photobank/PhotobankRepositoryGetTagsSqlShapeTests.cs` — the established pattern for SQL-shape verification in this codebase. No `InternalsVisibleTo` or test seam is required.
+
+- [ ] **Step 1: Create the test directory and file**
+
+Write the file at `backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs` with this exact content:
+
+```csharp
+using System.Data.Common;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.Features.Article;
+using DotNet.Testcontainers.Configurations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Anela.Heblo.Tests.Article.Persistence;
+
+[Trait("Category", "Integration")]
+public class ArticleRepositoryFeedbackProjectionSqlTests : IAsyncLifetime
+{
+    static ArticleRepositoryFeedbackProjectionSqlTests()
+    {
+        // Required on macOS with Podman: the Ryuk ResourceReaper container
+        // cannot bind to the Docker socket and throws a NullReferenceException.
+        TestcontainersSettings.ResourceReaperEnabled = false;
+    }
+
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:16")
+        .Build();
+
+    private readonly CapturingCommandInterceptor _interceptor = new();
+    private ApplicationDbContext _context = null!;
+    private ArticleRepository _repository = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        // Minimal schema — only the columns the projection query touches plus the
+        // required NOT NULL columns from ArticleConfiguration. HtmlContent is
+        // included so the test would actually fail if the production query still
+        // pulled it.
+        await using (var conn = new NpgsqlConnection(_container.GetConnectionString()))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = """
+                CREATE TABLE public."Articles" (
+                    "Id"              uuid                     NOT NULL PRIMARY KEY,
+                    "Topic"           varchar(2000)            NOT NULL,
+                    "Scope"           varchar(50)              NOT NULL,
+                    "Audience"        varchar(500),
+                    "Angle"           varchar(500),
+                    "Length"          varchar(50)              NOT NULL,
+                    "LanguageNote"    varchar(500),
+                    "UsedKnowledgeBase" boolean                NOT NULL DEFAULT false,
+                    "UsedWebSearch"   boolean                  NOT NULL DEFAULT false,
+                    "StyleGuideDriveId" varchar(500),
+                    "StyleGuideItemPath" varchar(500),
+                    "Title"           text,
+                    "HtmlContent"     text,
+                    "Status"          integer                  NOT NULL,
+                    "ErrorMessage"    varchar(2000),
+                    "RequestedBy"     varchar(200),
+                    "PrecisionScore"  integer,
+                    "StyleScore"      integer,
+                    "FeedbackComment" text,
+                    "CreatedAt"       timestamptz              NOT NULL,
+                    "GeneratedAt"     timestamptz
+                );
+                """;
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .AddInterceptors(_interceptor)
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new ArticleRepository(_context);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        await _container.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetFeedbackPagedAsync_DoesNotSelectHtmlContent()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetFeedbackPagedAsync(
+            hasFeedback: null,
+            requestedBy: null,
+            sortBy: "CreatedAt",
+            descending: true,
+            page: 1,
+            pageSize: 20,
+            ct: CancellationToken.None);
+
+        // The COUNT(*) and the SELECT-with-Skip/Take both fire; inspect the row-returning
+        // SELECT (the one that contains a column list, not just COUNT).
+        var rowSelect = _interceptor.Commands
+            .FirstOrDefault(c => c.Contains("FROM \"Articles\"", StringComparison.OrdinalIgnoreCase)
+                && !c.Contains("COUNT(*)", StringComparison.OrdinalIgnoreCase));
+
+        rowSelect.Should().NotBeNull("the repository must issue a row-returning SELECT against Articles");
+        rowSelect!.Should().NotContain("\"HtmlContent\"",
+            "HtmlContent is multi-KB per row and is never read by the feedback list handler");
+    }
+
+    [Fact]
+    public async Task GetFeedbackPagedAsync_SelectsExactlyTheProjectedColumns()
+    {
+        _interceptor.Reset();
+
+        await _repository.GetFeedbackPagedAsync(
+            hasFeedback: null,
+            requestedBy: null,
+            sortBy: "CreatedAt",
+            descending: true,
+            page: 1,
+            pageSize: 20,
+            ct: CancellationToken.None);
+
+        var rowSelect = _interceptor.Commands
+            .First(c => c.Contains("FROM \"Articles\"", StringComparison.OrdinalIgnoreCase)
+                && !c.Contains("COUNT(*)", StringComparison.OrdinalIgnoreCase));
+
+        // Every projected column appears in the SELECT.
+        foreach (var column in new[]
+                 {
+                     "\"Id\"", "\"Title\"", "\"Topic\"", "\"RequestedBy\"",
+                     "\"CreatedAt\"", "\"PrecisionScore\"", "\"StyleScore\"", "\"FeedbackComment\""
+                 })
+        {
+            rowSelect.Should().Contain(column,
+                $"projected column {column} must appear in the SELECT");
+        }
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = new();
+
+        public void Reset() => Commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the new test — confirm it fails (RED)**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ArticleRepositoryFeedbackProjectionSqlTests"`
+
+Expected: `GetFeedbackPagedAsync_DoesNotSelectHtmlContent` FAILS with an assertion that the SELECT contains `"HtmlContent"`. This proves the test correctly detects the current bad behaviour. **Do not commit yet** — failing tests do not land in main.
+
+If Docker/Podman is unavailable in the environment, document that the test will be validated in Task 6 after the production change lands; proceed to Task 3.
+
+---
+
+## Task 3: Update `IArticleRepository.GetFeedbackPagedAsync` signature
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs`
+
+- [ ] **Step 1: Change the return type**
+
+Edit `backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs`. Replace the lines:
+
+```csharp
+    Task<(IReadOnlyList<Article> Items, int TotalCount)> GetFeedbackPagedAsync(
+        bool? hasFeedback,
+        string? requestedBy,
+        string sortBy,
+        bool descending,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+```
+
+with:
+
+```csharp
+    Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
+        bool? hasFeedback,
+        string? requestedBy,
+        string sortBy,
+        bool descending,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+```
+
+No other methods on the interface change. Other methods (`GetByIdAsync`, `GetForUpdateAsync`, `GetPagedAsync`, `GetWithStepsAsync`) legitimately return the full `Article` aggregate and are out of scope.
+
+- [ ] **Step 2: Build the Domain project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj`
+Expected: build succeeds (interface change in isolation compiles fine).
+
+- [ ] **Step 3: Build the whole solution to observe expected break**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: Build FAILS. Errors will appear in:
+- `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs` — implementation no longer satisfies the interface.
+- `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs` — Moq setups return the wrong tuple type.
+
+`GetArticleFeedbackListHandler.cs` should still compile because it accesses members that exist on both `Article` and `ArticleFeedbackProjection`.
+
+**Do not commit yet** — broken build does not land in main.
+
+---
+
+## Task 4: Update `ArticleRepository.GetFeedbackPagedAsync` to project at the database
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs`
+
+- [ ] **Step 1: Replace the method body**
+
+Edit `backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs`. Replace the entire `GetFeedbackPagedAsync` method (currently lines 59–98) with:
+
+```csharp
+    public async Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(
+        bool? hasFeedback,
+        string? requestedBy,
+        string sortBy,
+        bool descending,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _context.Articles.AsNoTracking();
+
+        if (hasFeedback == true)
+            query = query.Where(a => a.PrecisionScore != null || a.StyleScore != null);
+        else if (hasFeedback == false)
+            query = query.Where(a => a.PrecisionScore == null && a.StyleScore == null);
+
+        if (!string.IsNullOrWhiteSpace(requestedBy))
+            query = query.Where(a => a.RequestedBy == requestedBy);
+
+        query = sortBy switch
+        {
+            "PrecisionScore" => descending
+                ? query.OrderByDescending(a => a.PrecisionScore)
+                : query.OrderBy(a => a.PrecisionScore),
+            "StyleScore" => descending
+                ? query.OrderByDescending(a => a.StyleScore)
+                : query.OrderBy(a => a.StyleScore),
+            _ => descending
+                ? query.OrderByDescending(a => a.CreatedAt)
+                : query.OrderBy(a => a.CreatedAt)
+        };
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(a => new ArticleFeedbackProjection(
+                a.Id,
+                a.Title,
+                a.Topic,
+                a.RequestedBy,
+                a.CreatedAt,
+                a.PrecisionScore,
+                a.StyleScore,
+                a.FeedbackComment))
+            .ToListAsync(ct);
+
+        return (items, total);
+    }
+```
+
+Note: filters and sort continue to operate on `IQueryable<Article>`; the projection is applied immediately before `ToListAsync` so any future sort column added to `AllowedSortColumns` continues to work without further change (provided it's already present on the entity). The `CountAsync` runs before `Skip/Take/Select` and EF Core translates it to `SELECT COUNT(*)`, so no rows are materialised by the count call.
+
+The `Anela.Heblo.Domain.Features.Article` using directive at the top of the file is already present (line 1), so `ArticleFeedbackProjection` is in scope. No new `using` is needed.
+
+- [ ] **Step 2: Build the Persistence project**
+
+Run: `dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Build the whole solution**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+
+Expected: only `GetArticleFeedbackListHandlerTests.cs` still fails (Moq setups return the wrong tuple). `GetArticleFeedbackListHandler.cs` compiles unchanged because positional record properties (`a.Id`, `a.Title`, ...) match the existing field accesses.
+
+---
+
+## Task 5: Update handler unit-test mock setups
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs`
+
+**Rationale:** The handler under test now consumes `IReadOnlyList<ArticleFeedbackProjection>`. The three test methods each set up `_repository.Setup(r => r.GetFeedbackPagedAsync(...)).ReturnsAsync(((IReadOnlyList<DomainArticle>)..., ...))`. Each setup must change to return `IReadOnlyList<ArticleFeedbackProjection>`. Assertions remain unchanged.
+
+- [ ] **Step 1: Replace `Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults`**
+
+In `backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs`, replace:
+
+```csharp
+    [Fact]
+    public async Task Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults()
+    {
+        var article = new DomainArticle
+        {
+            Id = Guid.NewGuid(),
+            Topic = "Sun care",
+            Title = "Sun care title",
+            RequestedBy = "alice",
+            CreatedAt = DateTimeOffset.UtcNow,
+            PrecisionScore = 4,
+            StyleScore = 5,
+            FeedbackComment = "ok",
+        };
+
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                null, null, "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<DomainArticle>)new[] { article }, 1));
+```
+
+with:
+
+```csharp
+    [Fact]
+    public async Task Handle_DefaultParams_RunsPagedAndStatsInParallelAndProjectsResults()
+    {
+        var article = new ArticleFeedbackProjection(
+            Id: Guid.NewGuid(),
+            Title: "Sun care title",
+            Topic: "Sun care",
+            RequestedBy: "alice",
+            CreatedAt: DateTimeOffset.UtcNow,
+            PrecisionScore: 4,
+            StyleScore: 5,
+            FeedbackComment: "ok");
+
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                null, null, "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)new[] { article }, 1));
+```
+
+The downstream assertions (`response.Items[0].Id.Should().Be(article.Id)`, etc.) work unchanged because positional record properties expose the named values via `init` properties.
+
+- [ ] **Step 2: Replace `Handle_UnknownSortBy_FallsBackToCreatedAt`**
+
+In the same file, replace:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<DomainArticle>)Array.Empty<DomainArticle>(), 0));
+```
+
+with:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), "CreatedAt", true, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)Array.Empty<ArticleFeedbackProjection>(), 0));
+```
+
+- [ ] **Step 3: Replace `Handle_PageSizeOutsideAllowlist_FallsBackTo20`**
+
+In the same file, replace:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<DomainArticle>)Array.Empty<DomainArticle>(), 0));
+```
+
+with:
+
+```csharp
+        _repository.Setup(r => r.GetFeedbackPagedAsync(
+                It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<int>(), 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((IReadOnlyList<ArticleFeedbackProjection>)Array.Empty<ArticleFeedbackProjection>(), 0));
+```
+
+- [ ] **Step 4: Remove the `DomainArticle` alias if it is no longer referenced**
+
+After the three edits, the line `using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;` at the top of the file is unused. Grep the file for `DomainArticle` — if there are no remaining references, delete that `using` line. If any reference remains (e.g. an unrelated test added later), leave the alias.
+
+Run a grep within the file:
+
+```bash
+grep -n "DomainArticle" backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs
+```
+
+If output is empty, delete `using DomainArticle = Anela.Heblo.Domain.Features.Article.Article;`.
+
+- [ ] **Step 5: Run the handler tests**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetArticleFeedbackListHandlerTests"`
+Expected: all three handler tests PASS.
+
+---
+
+## Task 6: Run the SQL-shape regression test — confirm GREEN
+
+**Files:**
+- (No edits — verification only.)
+
+- [ ] **Step 1: Run the SQL-shape test against the production change**
+
+Run: `dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ArticleRepositoryFeedbackProjectionSqlTests"`
+
+Expected: both facts PASS.
+- `GetFeedbackPagedAsync_DoesNotSelectHtmlContent` — passes because the `.Select(...)` restricts the SQL to projected columns.
+- `GetFeedbackPagedAsync_SelectsExactlyTheProjectedColumns` — passes because EF Core emits each projected column name in the SELECT.
+
+If the Postgres container cannot start in the environment (Docker/Podman unavailable), document the failure as environmental and ensure the test runs in CI before merge.
+
+- [ ] **Step 2: Build the whole solution and run the entire test suite**
+
+Run: `dotnet build backend/Anela.Heblo.sln`
+Expected: build succeeds, no warnings introduced.
+
+Run: `dotnet test backend/Anela.Heblo.sln --filter "Category!=Integration"`
+Expected: all non-integration tests pass.
+
+Run: `dotnet test backend/Anela.Heblo.sln`
+Expected: all tests pass (subject to Docker availability for the integration tier).
+
+- [ ] **Step 3: Apply formatting**
+
+Run: `dotnet format backend/Anela.Heblo.sln`
+Expected: no changes (or only whitespace adjustments to files touched in this plan).
+
+- [ ] **Step 4: Commit the refactor**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/Article/IArticleRepository.cs \
+        backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs \
+        backend/test/Anela.Heblo.Tests/Article/UseCases/GetArticleFeedbackListHandlerTests.cs \
+        backend/test/Anela.Heblo.Tests/Article/Persistence/ArticleRepositoryFeedbackProjectionSqlTests.cs
+git commit -m "refactor(article): project feedback list at database level
+
+Restrict ArticleRepository.GetFeedbackPagedAsync to the eight columns the
+feedback list handler reads, eliminating the multi-KB HtmlContent transfer
+on every page request. Return type narrows to IReadOnlyList<ArticleFeedbackProjection>.
+Adds a SQL-shape regression test guarding against HtmlContent re-entering
+the SELECT."
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:**
+- FR-1 (DB-level projection, no `HtmlContent` in SELECT) → Task 4 (impl) + Task 2/6 (SQL-shape test enforces it).
+- FR-2 (introduce `ArticleFeedbackProjection`) → Task 1. Location amended per arch review §1 to Domain layer.
+- FR-3 (update `IArticleRepository` contract) → Task 3.
+- FR-4 (simplify handler mapping) → Verified no edits needed; positional record properties match. Documented in "Unmodified" file table.
+- FR-5 (preserve other repository methods) → Task 3 Step 1 explicitly states "No other methods on the interface change."
+- NFR-1 (performance, no `HtmlContent`) → Task 4 + Task 6.
+- NFR-2 (security — unchanged surface) → No additional task; covered by FR-4 verification.
+- NFR-3 (maintainability) → Achieved by Task 1 type design and arch review's Decision 4 documentation pattern.
+- NFR-4 (SQL-shape test coverage) → Task 2 + Task 6.
+
+**Type consistency check:**
+- `ArticleFeedbackProjection` field types match `Article` entity property types exactly, including nullability and `DateTimeOffset` (not `DateTime`).
+- Handler accesses (`a.Id`, `a.Title`, `a.Topic`, `a.RequestedBy`, `a.CreatedAt`, `a.PrecisionScore`, `a.StyleScore`, `a.FeedbackComment`) match the positional record's auto-generated properties.
+- Test mocks use the same `IReadOnlyList<ArticleFeedbackProjection>` shape that the interface declares.
+
+**Placeholder scan:** No TBDs, no "implement later" markers, no "similar to Task N" cross-references — every code block in every step contains the literal content the engineer needs to type.


### PR DESCRIPTION
Article

## Finding
`ArticleRepository.GetFeedbackPagedAsync` materialises full `Article` entities — including the `HtmlContent` text column — but the only caller (`GetArticleFeedbackListHandler`) projects to a seven-field DTO:

```csharp
// backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs:59-97
public async Task<(IReadOnlyList<DomainArticle> Items, int TotalCount)> GetFeedbackPagedAsync(...)
{
    var query = _context.Articles.AsNoTracking();
    // ... filters and sorting ...
    var items = await query
        .Skip((page - 1) * pageSize)
        .Take(pageSize)
        .ToListAsync(ct);   // loads ALL columns, including HtmlContent
    return (items, total);
}
```

```csharp
// backend/src/Anela.Heblo.Application/Features/Article/UseCases/GetFeedbackList/GetArticleFeedbackListHandler.cs:44-54
Items = items.Select(a => new ArticleFeedbackSummary
{
    Id = a.Id,
    Title = a.Title,
    Topic = a.Topic,
    RequestedBy = a.RequestedBy,
    CreatedAt = a.CreatedAt,
    PrecisionScore = a.PrecisionScore,
    StyleScore = a.StyleScore,
    HasComment = !string.IsNullOrWhiteSpace(a.FeedbackComment),
}).ToList(),
```

`HtmlContent` is a `text` column (no `HasMaxLength` in `ArticleConfiguration`) containing the full generated article — typically 5–20 KB of HTML per article. This column is fetched from the database, transferred over the wire, and held in memory for every page load of the feedback list, then silently discarded.

The repository method also returns the full entity for integration/admin queries that genuinely need all fields, so the current signature forces an all-or-nothing choice.

## Why it matters
- **Unnecessary I/O and memory**: `HtmlContent` is the largest column on the table. Loading it for every feedback-list page multiplies network bytes and allocations by ~10× vs. projecting to needed fields.
- **Scales poorly**: As the article backlog grows the cost per page load grows linearly. A feedback list showing 50 items at 10 KB per article body = 500 KB of dead transfer per request.
- **KISS principle**: the repository returns more than it contracts with its callers — every future consumer of this method is implicitly burdened with the same overhead.

## Suggested fix
Add a lightweight DB projection directly in the repository, returning only the columns the handler needs. The minimal change is an inline `.Select()` inside `GetFeedbackPagedAsync`:

```csharp
// backend/src/Anela.Heblo.Persistence/Features/Article/ArticleRepository.cs
public async Task<(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)> GetFeedbackPagedAsync(...)
{
    var query = _context.Articles.AsNoTracking();
    // ... same filter/sort logic ...
    var items = await query
        .Skip((page - 1) * pageSize)
        .Take(pageSize)
        .Select(a => new ArticleFeedbackProjection(
            a.Id, a.Title, a.Topic, a.RequestedBy,
            a.CreatedAt, a.PrecisionScore, a.StyleScore, a.FeedbackComment))
        .ToListAsync(ct);
    return (items, total);
}
```

`ArticleFeedbackProjection` would be a simple record/class in the Application layer (or Persistence if kept internal). The `IArticleRepository` interface signature would change to `(IReadOnlyList<ArticleFeedbackProjection> Items, int TotalCount)`. The handler mapping becomes trivial.

---
_Filed by daily arch-review routine on 2026-05-27._

---

Closes #1825

### Tokens used
20686562
