### PR TITLE
feat(manufacture): replace quick-range buttons with period dropdown in Batch Planning

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Common.TimePeriods;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -11,44 +12,41 @@ public class BatchPlanningService : IBatchPlanningService
     private readonly ICatalogRepository _catalogRepository;
     private readonly IManufactureClient _manufactureClient;
     private readonly IBatchDistributionCalculator _batchDistributionCalculator;
+    private readonly IConsumptionRateCalculator _consumptionRateCalculator;
     private readonly ILogger<BatchPlanningService> _logger;
 
     public BatchPlanningService(
         ICatalogRepository catalogRepository,
         IManufactureClient manufactureClient,
         IBatchDistributionCalculator batchDistributionCalculator,
+        IConsumptionRateCalculator consumptionRateCalculator,
         ILogger<BatchPlanningService> logger)
     {
         _catalogRepository = catalogRepository;
         _manufactureClient = manufactureClient;
         _batchDistributionCalculator = batchDistributionCalculator;
+        _consumptionRateCalculator = consumptionRateCalculator;
         _logger = logger;
     }
 
-    public async Task<CalculateBatchPlanResponse> CalculateBatchPlan(CalculateBatchPlanRequest request, CancellationToken cancellationToken)
+    public async Task<CalculateBatchPlanResponse> CalculateBatchPlan(
+        CalculateBatchPlanRequest request,
+        IReadOnlyList<DateRange> salesRanges,
+        CancellationToken cancellationToken = default)
     {
         if (request.ManufactureType == ManufactureType.SinglePhase)
         {
-            return await CalculateSinglePhaseBatchPlanInternal(request, cancellationToken);
+            return await CalculateSinglePhaseBatchPlanInternal(request, salesRanges, cancellationToken);
         }
         else
         {
-            return await CalculateMultiPhaseBatchPlanInternal(request, cancellationToken);
+            return await CalculateMultiPhaseBatchPlanInternal(request, salesRanges, cancellationToken);
         }
     }
 
-    private double CalculateDailySalesRate(CatalogAggregate product, DateTime? fromDate, DateTime? toDate, double salesMultiplier = 1.0)
+    private double CalculateDailySalesRate(CatalogAggregate product, IReadOnlyList<DateRange> salesRanges, double salesMultiplier = 1.0)
     {
-        // Set default time period if not provided
-        var endDate = toDate ?? DateTime.Now;
-        var startDate = fromDate ?? endDate.AddDays(-30); // Default 30 days
-
-        var totalSales = product.GetTotalSold(startDate, endDate);
-        var days = (endDate - startDate).TotalDays;
-
-        var baseDailySalesRate = days > 0 ? totalSales / days : 0;
-
-        // Apply sales multiplier to affect future production planning
+        var baseDailySalesRate = _consumptionRateCalculator.CalculateDailySalesRate(product.SalesHistory, salesRanges);
         return Math.Round(baseDailySalesRate * salesMultiplier, 2);
     }
 
@@ -225,9 +223,10 @@ public class BatchPlanningService : IBatchPlanningService
     private BatchPlanItemDto CreateBatchPlanItem(
         CatalogAggregate product,
         CalculateBatchPlanRequest request,
+        IReadOnlyList<DateRange> salesRanges,
         string? productName = null)
     {
-        var dailySalesRate = CalculateDailySalesRate(product, request.FromDate, request.ToDate, request.SalesMultiplier ?? 1.0);
+        var dailySalesRate = CalculateDailySalesRate(product, salesRanges, request.SalesMultiplier ?? 1.0);
         var currentDaysCoverage = dailySalesRate > 0 ? (double)product.Stock.Total / dailySalesRate : 0;
         var constraint = request.ProductConstraints.FirstOrDefault(c => c.ProductCode == product.ProductCode);
 
@@ -306,7 +305,10 @@ public class BatchPlanningService : IBatchPlanningService
 
 
 
-    private async Task<CalculateBatchPlanResponse> CalculateSinglePhaseBatchPlanInternal(CalculateBatchPlanRequest request, CancellationToken cancellationToken)
+    private async Task<CalculateBatchPlanResponse> CalculateSinglePhaseBatchPlanInternal(
+        CalculateBatchPlanRequest request,
+        IReadOnlyList<DateRange> salesRanges,
+        CancellationToken cancellationToken)
     {
         // For single-phase manufacturing, the request.ProductCode is actually the product code
         var product = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
@@ -316,7 +318,7 @@ public class BatchPlanningService : IBatchPlanningService
         }
 
         // Create batch plan item using common helper
-        var batchPlanItem = CreateBatchPlanItem(product, request);
+        var batchPlanItem = CreateBatchPlanItem(product, request, salesRanges);
 
         // Calculate target production in units (not weight) for single-phase
         var (targetProductionUnits, totalWeight) = CalculateSinglePhaseTargetProduction(product, request, batchPlanItem.DailySalesRate);
@@ -350,7 +352,10 @@ public class BatchPlanningService : IBatchPlanningService
         };
     }
 
-    private async Task<CalculateBatchPlanResponse> CalculateMultiPhaseBatchPlanInternal(CalculateBatchPlanRequest request, CancellationToken cancellationToken)
+    private async Task<CalculateBatchPlanResponse> CalculateMultiPhaseBatchPlanInternal(
+        CalculateBatchPlanRequest request,
+        IReadOnlyList<DateRange> salesRanges,
+        CancellationToken cancellationToken)
     {
         // 1. Get semiproduct info
         var semiproduct = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
@@ -383,7 +388,7 @@ public class BatchPlanningService : IBatchPlanningService
                 continue;
             }
 
-            var item = CreateBatchPlanItem(product, request, template.ProductName);
+            var item = CreateBatchPlanItem(product, request, salesRanges, template.ProductName);
             batchPlanItems.Add(item);
         }
 

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/IBatchPlanningService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/IBatchPlanningService.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Common.TimePeriods;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Domain.Features.Manufacture;
 
@@ -5,7 +6,10 @@ namespace Anela.Heblo.Application.Features.Manufacture.Services;
 
 public interface IBatchPlanningService
 {
-    Task<CalculateBatchPlanResponse> CalculateBatchPlan(CalculateBatchPlanRequest request, CancellationToken cancellationToken = default);
+    Task<CalculateBatchPlanResponse> CalculateBatchPlan(
+        CalculateBatchPlanRequest request,
+        IReadOnlyList<DateRange> salesRanges,
+        CancellationToken cancellationToken = default);
 }
 
 public class SinglePhaseBatchResult

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs
@@ -1,23 +1,30 @@
+using Anela.Heblo.Application.Common.TimePeriods;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
-using Anela.Heblo.Xcc;
 using MediatR;
 
 namespace Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 
 public class CalculateBatchPlanHandler : IRequestHandler<CalculateBatchPlanRequest, CalculateBatchPlanResponse>
 {
+    private const int DefaultFallbackDays = 30;
+
     private readonly IBatchPlanningService _batchPlanningService;
     private readonly ICatalogRepository _catalogRepository;
-    private readonly IManufactureClient _manufactureClient
-        ;
+    private readonly IManufactureClient _manufactureClient;
+    private readonly ITimePeriodResolver _timePeriodResolver;
 
-    public CalculateBatchPlanHandler(IBatchPlanningService batchPlanningService, ICatalogRepository catalogRepository, IManufactureClient manufactureClient)
+    public CalculateBatchPlanHandler(
+        IBatchPlanningService batchPlanningService,
+        ICatalogRepository catalogRepository,
+        IManufactureClient manufactureClient,
+        ITimePeriodResolver timePeriodResolver)
     {
         _batchPlanningService = batchPlanningService;
         _catalogRepository = catalogRepository;
         _manufactureClient = manufactureClient;
+        _timePeriodResolver = timePeriodResolver;
     }
 
     public async Task<CalculateBatchPlanResponse> Handle(CalculateBatchPlanRequest request, CancellationToken cancellationToken)
@@ -36,6 +43,19 @@ public class CalculateBatchPlanHandler : IRequestHandler<CalculateBatchPlanReque
             }
         }
 
-        return await _batchPlanningService.CalculateBatchPlan(request, cancellationToken);
+        var salesRanges = ResolveSalesRanges(request);
+        return await _batchPlanningService.CalculateBatchPlan(request, salesRanges, cancellationToken);
+    }
+
+    private IReadOnlyList<DateRange> ResolveSalesRanges(CalculateBatchPlanRequest request)
+    {
+        if (request.TimePeriod.HasValue)
+        {
+            return _timePeriodResolver.Resolve(request.TimePeriod.Value, request.FromDate, request.ToDate);
+        }
+
+        var endDate = request.ToDate ?? DateTime.Now;
+        var startDate = request.FromDate ?? endDate.AddDays(-DefaultFallbackDays);
+        return new[] { new DateRange(startDate, endDate) };
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Anela.Heblo.Application.Common.TimePeriods;
 using Anela.Heblo.Domain.Features.Manufacture;
 using MediatR;
 
@@ -12,6 +13,11 @@ public class CalculateBatchPlanRequest : IRequest<CalculateBatchPlanResponse>
     // Time period selection (same as Purchase Analysis)
     public DateTime? FromDate { get; set; }
     public DateTime? ToDate { get; set; }
+
+    // When set, the handler resolves this into one or more DateRanges via ITimePeriodResolver
+    // and uses them for sales-rate computation. FromDate/ToDate then act as CustomPeriod fallback.
+    // When null, the handler wraps [FromDate, ToDate] into a single-element range list.
+    public TimePeriod? TimePeriod { get; set; }
 
     // Sales calculation settings
     public double? SalesMultiplier { get; set; } = 1.0;

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/BatchPlanningServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/BatchPlanningServiceTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Common.TimePeriods;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Application.Shared;
@@ -5,6 +6,7 @@ using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -16,7 +18,11 @@ public class BatchPlanningServiceTests
     private readonly Mock<IManufactureClient> _manufactureClientMock;
     private readonly Mock<IBatchDistributionCalculator> _batchDistributionCalculatorMock;
     private readonly Mock<ILogger<BatchPlanningService>> _loggerMock;
+    private readonly IConsumptionRateCalculator _consumptionRateCalculator;
     private readonly BatchPlanningService _service;
+
+    private static readonly IReadOnlyList<DateRange> DefaultRanges =
+        new[] { new DateRange(DateTime.Now.AddDays(-30), DateTime.Now) };
 
     public BatchPlanningServiceTests()
     {
@@ -24,7 +30,13 @@ public class BatchPlanningServiceTests
         _manufactureClientMock = new Mock<IManufactureClient>();
         _batchDistributionCalculatorMock = new Mock<IBatchDistributionCalculator>();
         _loggerMock = new Mock<ILogger<BatchPlanningService>>();
-        _service = new BatchPlanningService(_catalogRepositoryMock.Object, _manufactureClientMock.Object, _batchDistributionCalculatorMock.Object, _loggerMock.Object);
+        _consumptionRateCalculator = new ConsumptionRateCalculator(NullLogger<ConsumptionRateCalculator>.Instance);
+        _service = new BatchPlanningService(
+            _catalogRepositoryMock.Object,
+            _manufactureClientMock.Object,
+            _batchDistributionCalculatorMock.Object,
+            _consumptionRateCalculator,
+            _loggerMock.Object);
     }
 
     [Fact]
@@ -43,7 +55,7 @@ public class BatchPlanningServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.CalculateBatchPlan(request, CancellationToken.None));
+            _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None));
         Assert.Contains("not found", exception.Message);
     }
 
@@ -68,7 +80,7 @@ public class BatchPlanningServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _service.CalculateBatchPlan(request, CancellationToken.None));
+            _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None));
         Assert.Contains("No products found", exception.Message);
     }
 
@@ -92,7 +104,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);
@@ -127,7 +139,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);
@@ -156,7 +168,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);
@@ -186,7 +198,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);
@@ -223,7 +235,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.False(result.Success); // Should indicate error
@@ -282,7 +294,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success); // Should succeed
@@ -324,7 +336,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);
@@ -333,6 +345,89 @@ public class BatchPlanningServiceTests
         Assert.Equal(200, result.DirectSemiproductAmount);
         // Total volume used by variants must not exceed the reduced available volume
         Assert.True(result.TotalVolumeUsed <= 1300);
+    }
+
+    [Fact]
+    public async Task CalculateBatchPlan_MultipleRanges_UsesSumOfSalesAcrossAllRanges()
+    {
+        // Arrange: simulate Q9M-style two ranges. Product sells 2 units/day in range A (30 days)
+        // and 1 unit/day in range B (30 days). Combined daily rate must equal
+        // (2*30 + 1*30) / (30 + 30) = 1.5 units/day — confirming sales sum across both ranges
+        // rather than only the primary range (which would give 2.0 or 1.0).
+        var rangeAFrom = DateTime.Now.AddDays(-365);
+        var rangeATo = rangeAFrom.AddDays(30);
+        var rangeBFrom = DateTime.Now.AddDays(-30);
+        var rangeBTo = DateTime.Now;
+        var ranges = new[]
+        {
+            new DateRange(rangeAFrom, rangeATo),
+            new DateRange(rangeBFrom, rangeBTo)
+        };
+
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.TargetDaysCoverage,
+            TargetDaysCoverage = 30
+        };
+
+        var semiproduct = CreateSemiproduct("SEMI001", 1000);
+        var templates = CreateManufactureTemplates();
+        var prod1 = new CatalogAggregate
+        {
+            ProductCode = "PROD001",
+            ProductName = "Product 1",
+            Stock = new StockData { Erp = 50 },
+            NetWeight = 10.0,
+            MinimalManufactureQuantity = 10,
+            SalesHistory = CreateSalesAcrossRanges(rangeAFrom, 30, 2.0, rangeBFrom, 30, 1.0)
+        };
+        var prod2 = new CatalogAggregate
+        {
+            ProductCode = "PROD002",
+            ProductName = "Product 2",
+            Stock = new StockData { Erp = 25 },
+            NetWeight = 5.0,
+            MinimalManufactureQuantity = 20,
+            SalesHistory = CreateSalesHistory(1)
+        };
+
+        SetupRepositoryMocks(semiproduct, templates, new List<CatalogAggregate> { prod1, prod2 });
+
+        // Act
+        var result = await _service.CalculateBatchPlan(request, ranges, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.Success);
+        var item = result.ProductSizes.First(p => p.ProductCode == "PROD001");
+        // Expected daily rate: (2*30 + 1*30) / (30 + 30) = 1.5 (Math.Round to 2 decimals)
+        Assert.Equal(1.5, item.DailySalesRate, 2);
+    }
+
+    private static List<Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord> CreateSalesAcrossRanges(
+        DateTime range1From, int range1Days, double range1Daily,
+        DateTime range2From, int range2Days, double range2Daily)
+    {
+        var sales = new List<Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord>();
+        for (int i = 0; i < range1Days; i++)
+        {
+            sales.Add(new Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord
+            {
+                Date = range1From.AddDays(i),
+                AmountB2B = range1Daily / 2,
+                AmountB2C = range1Daily / 2
+            });
+        }
+        for (int i = 0; i < range2Days; i++)
+        {
+            sales.Add(new Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord
+            {
+                Date = range2From.AddDays(i),
+                AmountB2B = range2Daily / 2,
+                AmountB2C = range2Daily / 2
+            });
+        }
+        return sales;
     }
 
     [Fact]
@@ -356,7 +451,7 @@ public class BatchPlanningServiceTests
         SetupRepositoryMocks(semiproduct, templates, products);
 
         // Act
-        var result = await _service.CalculateBatchPlan(request, CancellationToken.None);
+        var result = await _service.CalculateBatchPlan(request, DefaultRanges, CancellationToken.None);
 
         // Assert
         Assert.True(result.Success);

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Common.TimePeriods;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -10,16 +11,22 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class CalculateBatchPlanHandlerTests
 {
     private readonly Mock<IBatchPlanningService> _batchPlanningServiceMock;
-    private readonly CalculateBatchPlanHandler _handler;
     private readonly Mock<IManufactureClient> _manufactureClientMock;
     private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<ITimePeriodResolver> _timePeriodResolverMock;
+    private readonly CalculateBatchPlanHandler _handler;
 
     public CalculateBatchPlanHandlerTests()
     {
         _batchPlanningServiceMock = new Mock<IBatchPlanningService>();
         _catalogRepositoryMock = new Mock<ICatalogRepository>();
         _manufactureClientMock = new Mock<IManufactureClient>();
-        _handler = new CalculateBatchPlanHandler(_batchPlanningServiceMock.Object, _catalogRepositoryMock.Object, _manufactureClientMock.Object);
+        _timePeriodResolverMock = new Mock<ITimePeriodResolver>();
+        _handler = new CalculateBatchPlanHandler(
+            _batchPlanningServiceMock.Object,
+            _catalogRepositoryMock.Object,
+            _manufactureClientMock.Object,
+            _timePeriodResolverMock.Object);
     }
 
     [Fact]
@@ -54,7 +61,7 @@ public class CalculateBatchPlanHandlerTests
         };
 
         _batchPlanningServiceMock
-            .Setup(x => x.CalculateBatchPlan(request, It.IsAny<CancellationToken>()))
+            .Setup(x => x.CalculateBatchPlan(request, It.IsAny<IReadOnlyList<DateRange>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResponse);
 
         // Act
@@ -66,7 +73,7 @@ public class CalculateBatchPlanHandlerTests
         Assert.Equal("SEMI001", result.Semiproduct.ProductCode);
 
         _batchPlanningServiceMock.Verify(
-            x => x.CalculateBatchPlan(request, It.IsAny<CancellationToken>()),
+            x => x.CalculateBatchPlan(request, It.IsAny<IReadOnlyList<DateRange>>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -82,12 +89,85 @@ public class CalculateBatchPlanHandlerTests
         };
 
         _batchPlanningServiceMock
-            .Setup(x => x.CalculateBatchPlan(It.IsAny<CalculateBatchPlanRequest>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.CalculateBatchPlan(It.IsAny<CalculateBatchPlanRequest>(), It.IsAny<IReadOnlyList<DateRange>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ArgumentException("Semiproduct not found"));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
             _handler.Handle(request, CancellationToken.None));
         Assert.Contains("Semiproduct not found", exception.Message);
+    }
+
+    [Fact]
+    public async Task Handle_TimePeriodSet_ResolvesViaTimePeriodResolver()
+    {
+        // Arrange
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.0,
+            TimePeriod = TimePeriod.Q9M
+        };
+
+        var resolvedRanges = new[]
+        {
+            new DateRange(DateTime.Now.AddMonths(-6), DateTime.Now),
+            new DateRange(DateTime.Now.AddYears(-1), DateTime.Now.AddYears(-1).AddMonths(3))
+        };
+
+        _timePeriodResolverMock
+            .Setup(x => x.Resolve(TimePeriod.Q9M, It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+            .Returns(resolvedRanges);
+
+        _batchPlanningServiceMock
+            .Setup(x => x.CalculateBatchPlan(request, It.IsAny<IReadOnlyList<DateRange>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CalculateBatchPlanResponse { Success = true });
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        _timePeriodResolverMock.Verify(
+            x => x.Resolve(TimePeriod.Q9M, It.IsAny<DateTime?>(), It.IsAny<DateTime?>()),
+            Times.Once);
+        _batchPlanningServiceMock.Verify(
+            x => x.CalculateBatchPlan(request, resolvedRanges, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TimePeriodNull_UsesSingleRangeFromFromDateToDate()
+    {
+        // Arrange
+        var from = new DateTime(2026, 1, 1);
+        var to = new DateTime(2026, 3, 31);
+        var request = new CalculateBatchPlanRequest
+        {
+            ProductCode = "SEMI001",
+            ControlMode = BatchPlanControlMode.MmqMultiplier,
+            MmqMultiplier = 1.0,
+            FromDate = from,
+            ToDate = to,
+            TimePeriod = null
+        };
+
+        IReadOnlyList<DateRange>? capturedRanges = null;
+        _batchPlanningServiceMock
+            .Setup(x => x.CalculateBatchPlan(request, It.IsAny<IReadOnlyList<DateRange>>(), It.IsAny<CancellationToken>()))
+            .Callback<CalculateBatchPlanRequest, IReadOnlyList<DateRange>, CancellationToken>((_, ranges, _) => capturedRanges = ranges)
+            .ReturnsAsync(new CalculateBatchPlanResponse { Success = true });
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedRanges);
+        Assert.Single(capturedRanges!);
+        Assert.Equal(from, capturedRanges![0].From);
+        Assert.Equal(to, capturedRanges[0].To);
+        _timePeriodResolverMock.Verify(
+            x => x.Resolve(It.IsAny<TimePeriod>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>()),
+            Times.Never);
     }
 }

--- a/frontend/src/api/generated/api-client.ts
+++ b/frontend/src/api/generated/api-client.ts
@@ -24369,6 +24369,7 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
     productCode!: string;
     fromDate?: Date | undefined;
     toDate?: Date | undefined;
+    timePeriod?: TimePeriod | undefined;
     salesMultiplier?: number | undefined;
     controlMode?: BatchPlanControlMode;
     mmqMultiplier?: number | undefined;
@@ -24392,6 +24393,7 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
             this.productCode = _data["productCode"];
             this.fromDate = _data["fromDate"] ? new Date(_data["fromDate"].toString()) : <any>undefined;
             this.toDate = _data["toDate"] ? new Date(_data["toDate"].toString()) : <any>undefined;
+            this.timePeriod = _data["timePeriod"];
             this.salesMultiplier = _data["salesMultiplier"];
             this.controlMode = _data["controlMode"];
             this.mmqMultiplier = _data["mmqMultiplier"];
@@ -24419,6 +24421,7 @@ export class CalculateBatchPlanRequest implements ICalculateBatchPlanRequest {
         data["productCode"] = this.productCode;
         data["fromDate"] = this.fromDate ? this.fromDate.toISOString() : <any>undefined;
         data["toDate"] = this.toDate ? this.toDate.toISOString() : <any>undefined;
+        data["timePeriod"] = this.timePeriod;
         data["salesMultiplier"] = this.salesMultiplier;
         data["controlMode"] = this.controlMode;
         data["mmqMultiplier"] = this.mmqMultiplier;
@@ -24439,6 +24442,7 @@ export interface ICalculateBatchPlanRequest {
     productCode: string;
     fromDate?: Date | undefined;
     toDate?: Date | undefined;
+    timePeriod?: TimePeriod | undefined;
     salesMultiplier?: number | undefined;
     controlMode?: BatchPlanControlMode;
     mmqMultiplier?: number | undefined;
@@ -24447,6 +24451,15 @@ export interface ICalculateBatchPlanRequest {
     productConstraints?: ProductSizeConstraint[];
     directSemiproductAmount?: number | undefined;
     manufactureType?: ManufactureType | undefined;
+}
+
+export enum TimePeriod {
+    PreviousQuarter = "PreviousQuarter",
+    FutureQuarter = "FutureQuarter",
+    Y2Y = "Y2Y",
+    PreviousSeason = "PreviousSeason",
+    Q9M = "Q9M",
+    CustomPeriod = "CustomPeriod",
 }
 
 export class ProductSizeConstraint implements IProductSizeConstraint {
@@ -27751,15 +27764,6 @@ export interface IManufacturingStockSummaryDto {
     analysisPeriodStart?: Date;
     analysisPeriodEnd?: Date;
     productFamilies?: string[];
-}
-
-export enum TimePeriod {
-    PreviousQuarter = "PreviousQuarter",
-    FutureQuarter = "FutureQuarter",
-    Y2Y = "Y2Y",
-    PreviousSeason = "PreviousSeason",
-    Q9M = "Q9M",
-    CustomPeriod = "CustomPeriod",
 }
 
 export enum ManufacturingStockSortBy {
@@ -32858,7 +32862,6 @@ export interface IGetPurchaseOrdersResponse extends IBaseResponse {
 export class PurchaseOrderSummaryDto implements IPurchaseOrderSummaryDto {
     id?: number;
     orderNumber?: string;
-    supplierId?: number;
     supplierName?: string;
     orderDate?: Date;
     expectedDeliveryDate?: Date | undefined;
@@ -32884,7 +32887,6 @@ export class PurchaseOrderSummaryDto implements IPurchaseOrderSummaryDto {
         if (_data) {
             this.id = _data["id"];
             this.orderNumber = _data["orderNumber"];
-            this.supplierId = _data["supplierId"];
             this.supplierName = _data["supplierName"];
             this.orderDate = _data["orderDate"] ? new Date(_data["orderDate"].toString()) : <any>undefined;
             this.expectedDeliveryDate = _data["expectedDeliveryDate"] ? new Date(_data["expectedDeliveryDate"].toString()) : <any>undefined;
@@ -32910,7 +32912,6 @@ export class PurchaseOrderSummaryDto implements IPurchaseOrderSummaryDto {
         data = typeof data === 'object' ? data : {};
         data["id"] = this.id;
         data["orderNumber"] = this.orderNumber;
-        data["supplierId"] = this.supplierId;
         data["supplierName"] = this.supplierName;
         data["orderDate"] = this.orderDate ? this.orderDate.toISOString() : <any>undefined;
         data["expectedDeliveryDate"] = this.expectedDeliveryDate ? this.expectedDeliveryDate.toISOString() : <any>undefined;
@@ -32929,7 +32930,6 @@ export class PurchaseOrderSummaryDto implements IPurchaseOrderSummaryDto {
 export interface IPurchaseOrderSummaryDto {
     id?: number;
     orderNumber?: string;
-    supplierId?: number;
     supplierName?: string;
     orderDate?: Date;
     expectedDeliveryDate?: Date | undefined;

--- a/frontend/src/components/pages/ManufactureBatchPlanning.tsx
+++ b/frontend/src/components/pages/ManufactureBatchPlanning.tsx
@@ -22,7 +22,8 @@ import { QUERY_KEYS } from "../../api/client";
 import ManufactureOrderDetail from "../manufacture/pages/ManufactureOrderDetail";
 import { usePlanningList } from "../../contexts/PlanningListContext";
 import { useCatalogAutocomplete } from "../../api/hooks/useCatalogAutocomplete";
-import { TimePeriod, resolveTimePeriod } from '../../utils/timePeriod';
+import { TimePeriod, resolveTimePeriod, getTimePeriodDisplayText } from '../../utils/timePeriod';
+import { calculateTimePeriodRange } from '../../api/hooks/useManufacturingStockAnalysis';
 import { useScreenView } from '../../telemetry/useScreenView';
 
 const BatchPlanningCalculator: React.FC = () => {
@@ -50,10 +51,15 @@ const BatchPlanningCalculator: React.FC = () => {
   
   // Sales settings state
   const [salesMultiplier, setSalesMultiplier] = useState<number>(1.3);
-  const [fromDate, setFromDate] = useState<Date>(resolveTimePeriod(TimePeriod.Y2Y).primary?.from ?? new Date());
-  const [toDate, setToDate] = useState<Date>(new Date());
-  // Tracks the active multi-range preset (e.g. Q9M). When null, payload uses single [fromDate, toDate] range.
-  const [selectedTimePeriod, setSelectedTimePeriod] = useState<TimePeriod | null>(null);
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState<TimePeriod>(TimePeriod.Q9M);
+  // Only used when selectedTimePeriod === TimePeriod.CustomPeriod.
+  // Seeded from Q9M's primary range so the Custom pickers open with a sensible default.
+  const [fromDate, setFromDate] = useState<Date>(
+    resolveTimePeriod(TimePeriod.Q9M).primary?.from ?? new Date()
+  );
+  const [toDate, setToDate] = useState<Date>(
+    resolveTimePeriod(TimePeriod.Q9M).primary?.to ?? new Date()
+  );
   
   // Product constraints state (for fixed quantities)
   const [productConstraints, setProductConstraints] = useState<Map<string, { isFixed: boolean; quantity: number }>>(new Map());
@@ -237,43 +243,46 @@ const BatchPlanningCalculator: React.FC = () => {
     : productGridData;
 
 
-  // Quick date range selectors
-  type QuickRangeType = "lastq" | "y2y" | "nextq" | "9m";
-  const quickRangePeriodMap: Record<QuickRangeType, TimePeriod> = {
-    lastq: TimePeriod.PreviousQuarter,
-    y2y: TimePeriod.Y2Y,
-    nextq: TimePeriod.FutureQuarter,
-    "9m": TimePeriod.Q9M,
-  };
-
-  const handleQuickDateRange = (type: QuickRangeType) => {
-    const period = quickRangePeriodMap[type];
-    const resolved = resolveTimePeriod(period);
-    if (!resolved.primary) return;
-    setFromDate(resolved.primary.from);
-    setToDate(resolved.primary.to);
-    // Multi-range presets (currently only Q9M) must be carried as TimePeriod so backend
-    // aggregates sales across all ranges. Single-range presets clear the override.
-    setSelectedTimePeriod(resolved.ranges.length > 1 ? period : null);
+  const handleTimePeriodChange = (period: TimePeriod) => {
+    if (period === TimePeriod.CustomPeriod) {
+      // Seed Custom pickers from Q9M primary range so user has a sensible starting point.
+      const range = calculateTimePeriodRange(TimePeriod.Q9M);
+      if (range) {
+        setFromDate(range.fromDate);
+        setToDate(range.toDate);
+      }
+    }
+    setSelectedTimePeriod(period);
     setNeedsRecalculation(true);
   };
 
-  // Get tooltip text for date range buttons. For multi-range presets, lists all ranges.
-  const getDateRangeTooltip = (type: QuickRangeType) => {
-    const resolved = resolveTimePeriod(quickRangePeriodMap[type]);
-    if (resolved.ranges.length === 0) return "";
-    return resolved.ranges
-      .map((r) => `${r.from.toLocaleDateString("cs-CZ")} - ${r.to.toLocaleDateString("cs-CZ")}`)
-      .join(" | ");
+  const getTimePeriodTooltip = (period: TimePeriod): string => {
+    if (period === TimePeriod.CustomPeriod) {
+      return `${fromDate.toLocaleDateString("cs-CZ")} - ${toDate.toLocaleDateString("cs-CZ")}`;
+    }
+    const range = calculateTimePeriodRange(period);
+    if (!range) return getTimePeriodDisplayText(period);
+    if (range.ranges && range.ranges.length > 1) {
+      return range.ranges
+        .map((r, i) => `Období ${String.fromCharCode('A'.charCodeAt(0) + i)}: ${r.from.toLocaleDateString("cs-CZ")} – ${r.to.toLocaleDateString("cs-CZ")}`)
+        .join("\n");
+    }
+    return `${range.fromDate.toLocaleDateString("cs-CZ")} - ${range.toDate.toLocaleDateString("cs-CZ")}`;
   };
 
-  const calculateBatchPlan = (semiproductCode: string, fromDateParam?: Date, toDateParam?: Date) => {
+  // Builds the period portion of any CalculateBatchPlanRequest.
+  // Named periods send only timePeriod (backend resolves ranges).
+  // CustomPeriod sends fromDate/toDate and no timePeriod.
+  const buildPeriodPayload = () =>
+    selectedTimePeriod === TimePeriod.CustomPeriod
+      ? { fromDate, toDate, timePeriod: undefined }
+      : { fromDate: undefined, toDate: undefined, timePeriod: selectedTimePeriod };
+
+  const calculateBatchPlan = (semiproductCode: string) => {
     const requestData: any = {
       productCode: semiproductCode,
       controlMode: controlMode,
-      fromDate: fromDateParam || fromDate,
-      toDate: toDateParam || toDate,
-      timePeriod: selectedTimePeriod ?? undefined,
+      ...buildPeriodPayload(),
       salesMultiplier: salesMultiplier,
       directSemiproductAmount: directSemiproductAmount > 0 ? directSemiproductAmount : undefined,
     };
@@ -296,9 +305,9 @@ const BatchPlanningCalculator: React.FC = () => {
     setNeedsRecalculation(false); // Clear the flag after calculation
   };
 
-  const calculateBatchPlanWithConstraints = (semiproductCode: string, fromDateParam?: Date, toDateParam?: Date) => {
+  const calculateBatchPlanWithConstraints = (semiproductCode: string) => {
     // Convert constraints Map to ProductSizeConstraint array
-    const constraints = Array.from(productConstraints.entries()).map(([productCode, constraint]) => 
+    const constraints = Array.from(productConstraints.entries()).map(([productCode, constraint]) =>
       new ProductSizeConstraint({
         productCode,
         isFixed: constraint.isFixed,
@@ -309,9 +318,7 @@ const BatchPlanningCalculator: React.FC = () => {
     const requestData: any = {
       productCode: semiproductCode,
       controlMode: controlMode,
-      fromDate: fromDateParam || fromDate,
-      toDate: toDateParam || toDate,
-      timePeriod: selectedTimePeriod ?? undefined,
+      ...buildPeriodPayload(),
       salesMultiplier: salesMultiplier,
       productConstraints: constraints,
       directSemiproductAmount: directSemiproductAmount > 0 ? directSemiproductAmount : undefined,
@@ -353,9 +360,7 @@ const BatchPlanningCalculator: React.FC = () => {
       const requestData: any = {
         productCode: product.productCode,
         controlMode: BatchPlanControlMode.MmqMultiplier,
-        fromDate: fromDate,
-        toDate: toDate,
-        timePeriod: selectedTimePeriod ?? undefined,
+        ...buildPeriodPayload(),
         salesMultiplier: salesMultiplier,
         mmqMultiplier: 1.0, // Use reset value
       };
@@ -395,9 +400,9 @@ const BatchPlanningCalculator: React.FC = () => {
   const handleManualCalculate = () => {
     if (selectedSemiproduct?.productCode) {
       if (productConstraints.size > 0) {
-        calculateBatchPlanWithConstraints(selectedSemiproduct.productCode, fromDate, toDate);
+        calculateBatchPlanWithConstraints(selectedSemiproduct.productCode);
       } else {
-        calculateBatchPlan(selectedSemiproduct.productCode, fromDate, toDate);
+        calculateBatchPlan(selectedSemiproduct.productCode);
       }
     }
   };
@@ -544,95 +549,82 @@ const BatchPlanningCalculator: React.FC = () => {
                       <Settings className="w-3 h-3 text-gray-500 mr-1" />
                       Nastavení prodejů
                     </h4>
-                    
-                    {/* First row: Sales Multiplier + Quick Date Range Buttons */}
-                    <div className="flex items-center gap-3">
-                      {/* Sales Multiplier */}
-                      <div className="flex items-center gap-2">
-                        <label className="text-xs text-gray-600 whitespace-nowrap">Multiplikátor:</label>
+
+                    {/* Multiplier row */}
+                    <div className="flex items-center gap-2">
+                      <label className="text-xs text-gray-600 whitespace-nowrap">Multiplikátor:</label>
+                      <input
+                        type="number"
+                        step="0.1"
+                        min="0.1"
+                        max="9.9"
+                        value={salesMultiplier.toFixed(1)}
+                        onChange={(e) => {
+                          setSalesMultiplier(Number(e.target.value));
+                          setNeedsRecalculation(true);
+                        }}
+                        className="w-20 px-2 py-1 text-sm border border-gray-300 rounded text-center focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                        title="Sales Multiplier (1.0-9.9)"
+                      />
+                    </div>
+
+                    {/* Period dropdown row */}
+                    <div className="flex items-center gap-2">
+                      <label
+                        htmlFor="sales-period-select"
+                        className="text-xs text-gray-600 whitespace-nowrap"
+                      >
+                        Časové období:
+                      </label>
+                      <select
+                        id="sales-period-select"
+                        value={selectedTimePeriod}
+                        onChange={(e) => handleTimePeriodChange(e.target.value as TimePeriod)}
+                        className="px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500 bg-white"
+                        title={getTimePeriodTooltip(selectedTimePeriod)}
+                      >
+                        {[
+                          TimePeriod.PreviousQuarter,
+                          TimePeriod.FutureQuarter,
+                          TimePeriod.Y2Y,
+                          TimePeriod.PreviousSeason,
+                          TimePeriod.Q9M,
+                          TimePeriod.CustomPeriod,
+                        ].map((period) => (
+                          <option key={period} value={period}>
+                            {getTimePeriodDisplayText(period)}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    {/* Custom date pickers — only visible when CustomPeriod is selected */}
+                    {selectedTimePeriod === TimePeriod.CustomPeriod && (
+                      <div className="flex gap-3 items-center">
+                        <label htmlFor="sales-from-date" className="text-xs text-gray-600 whitespace-nowrap">Datum od:</label>
                         <input
-                          type="number"
-                          step="0.1"
-                          min="0.1"
-                          max="9.9"
-                          value={salesMultiplier.toFixed(1)}
+                          id="sales-from-date"
+                          type="date"
+                          value={fromDate.toLocaleDateString('sv')}
                           onChange={(e) => {
-                            setSalesMultiplier(Number(e.target.value));
+                            setFromDate(new Date(e.target.value));
                             setNeedsRecalculation(true);
                           }}
-                          className="w-20 px-2 py-1 text-sm border border-gray-300 rounded text-center focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                          title="Sales Multiplier (1.0-9.9)"
+                          className="w-44 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                        />
+                        <label htmlFor="sales-to-date" className="text-xs text-gray-600 whitespace-nowrap">do:</label>
+                        <input
+                          id="sales-to-date"
+                          type="date"
+                          value={toDate.toLocaleDateString('sv')}
+                          onChange={(e) => {
+                            setToDate(new Date(e.target.value));
+                            setNeedsRecalculation(true);
+                          }}
+                          className="w-44 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"
                         />
                       </div>
-
-                      {/* Spacer to push buttons to align with date pickers */}
-                      <div className="flex-1"></div>
-
-                      {/* Quick date range buttons - aligned with date pickers */}
-                      <div className="flex gap-2">
-                        <button
-                          onClick={() => handleQuickDateRange("lastq")}
-                          className="px-3 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded border border-gray-300 transition-colors"
-                          title={getDateRangeTooltip("lastq")}
-                        >
-                          LastQ
-                        </button>
-                        <button
-                          onClick={() => handleQuickDateRange("y2y")}
-                          className="px-3 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded border border-gray-300 transition-colors"
-                          title={getDateRangeTooltip("y2y")}
-                        >
-                          Y2Y
-                        </button>
-                        <button
-                          onClick={() => handleQuickDateRange("nextq")}
-                          className="px-3 py-1 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded border border-gray-300 transition-colors"
-                          title={getDateRangeTooltip("nextq")}
-                        >
-                          NextQ
-                        </button>
-                        <button
-                          onClick={() => handleQuickDateRange("9m")}
-                          className={`px-3 py-1 text-xs rounded border transition-colors ${
-                            selectedTimePeriod === TimePeriod.Q9M
-                              ? "bg-indigo-100 hover:bg-indigo-200 text-indigo-700 border-indigo-300"
-                              : "bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-300"
-                          }`}
-                          title={getDateRangeTooltip("9m")}
-                        >
-                          9M
-                        </button>
-                      </div>
-                    </div>
-
-                    {/* Second row: Date Pickers */}
-                    <div className="flex gap-3 items-center">
-                      <label className="text-xs text-gray-600 whitespace-nowrap">Datum od:</label>
-                      <input
-                        type="date"
-                        value={fromDate.toISOString().split('T')[0]}
-                        onChange={(e) => {
-                          const newFromDate = new Date(e.target.value);
-                          setFromDate(newFromDate);
-                          setSelectedTimePeriod(null);
-                          setNeedsRecalculation(true);
-                        }}
-                        className="w-44 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                      />
-
-                      <label className="text-xs text-gray-600 whitespace-nowrap">do:</label>
-                      <input
-                        type="date"
-                        value={toDate.toISOString().split('T')[0]}
-                        onChange={(e) => {
-                          const newToDate = new Date(e.target.value);
-                          setToDate(newToDate);
-                          setSelectedTimePeriod(null);
-                          setNeedsRecalculation(true);
-                        }}
-                        className="w-44 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                      />
-                    </div>
+                    )}
                   </div>
                 </div>
 

--- a/frontend/src/components/pages/ManufactureBatchPlanning.tsx
+++ b/frontend/src/components/pages/ManufactureBatchPlanning.tsx
@@ -550,26 +550,25 @@ const BatchPlanningCalculator: React.FC = () => {
                       Nastavení prodejů
                     </h4>
 
-                    {/* Multiplier row */}
-                    <div className="flex items-center gap-2">
-                      <label className="text-xs text-gray-600 whitespace-nowrap">Multiplikátor:</label>
-                      <input
-                        type="number"
-                        step="0.1"
-                        min="0.1"
-                        max="9.9"
-                        value={salesMultiplier.toFixed(1)}
-                        onChange={(e) => {
-                          setSalesMultiplier(Number(e.target.value));
-                          setNeedsRecalculation(true);
-                        }}
-                        className="w-20 px-2 py-1 text-sm border border-gray-300 rounded text-center focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                        title="Sales Multiplier (1.0-9.9)"
-                      />
-                    </div>
-
-                    {/* Period dropdown row */}
-                    <div className="flex items-center gap-2">
+                    {/* Multiplier + Period in one row */}
+                    <div className="flex items-center gap-4">
+                      <div className="flex items-center gap-2">
+                        <label className="text-xs text-gray-600 whitespace-nowrap">Multiplikátor:</label>
+                        <input
+                          type="number"
+                          step="0.1"
+                          min="0.1"
+                          max="9.9"
+                          value={salesMultiplier.toFixed(1)}
+                          onChange={(e) => {
+                            setSalesMultiplier(Number(e.target.value));
+                            setNeedsRecalculation(true);
+                          }}
+                          className="w-20 px-2 py-1 text-sm border border-gray-300 rounded text-center focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                          title="Sales Multiplier (1.0-9.9)"
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
                       <label
                         htmlFor="sales-period-select"
                         className="text-xs text-gray-600 whitespace-nowrap"
@@ -596,6 +595,7 @@ const BatchPlanningCalculator: React.FC = () => {
                           </option>
                         ))}
                       </select>
+                      </div>
                     </div>
 
                     {/* Custom date pickers — only visible when CustomPeriod is selected */}

--- a/frontend/src/components/pages/ManufactureBatchPlanning.tsx
+++ b/frontend/src/components/pages/ManufactureBatchPlanning.tsx
@@ -52,6 +52,8 @@ const BatchPlanningCalculator: React.FC = () => {
   const [salesMultiplier, setSalesMultiplier] = useState<number>(1.3);
   const [fromDate, setFromDate] = useState<Date>(resolveTimePeriod(TimePeriod.Y2Y).primary?.from ?? new Date());
   const [toDate, setToDate] = useState<Date>(new Date());
+  // Tracks the active multi-range preset (e.g. Q9M). When null, payload uses single [fromDate, toDate] range.
+  const [selectedTimePeriod, setSelectedTimePeriod] = useState<TimePeriod | null>(null);
   
   // Product constraints state (for fixed quantities)
   const [productConstraints, setProductConstraints] = useState<Map<string, { isFixed: boolean; quantity: number }>>(new Map());
@@ -236,31 +238,33 @@ const BatchPlanningCalculator: React.FC = () => {
 
 
   // Quick date range selectors
-  const handleQuickDateRange = (
-    type: "lastq" | "y2y" | "nextq",
-  ) => {
-    const periodMap: Record<"lastq" | "y2y" | "nextq", TimePeriod> = {
-      lastq: TimePeriod.PreviousQuarter,
-      y2y: TimePeriod.Y2Y,
-      nextq: TimePeriod.FutureQuarter,
-    };
-    const resolved = resolveTimePeriod(periodMap[type]);
+  type QuickRangeType = "lastq" | "y2y" | "nextq" | "9m";
+  const quickRangePeriodMap: Record<QuickRangeType, TimePeriod> = {
+    lastq: TimePeriod.PreviousQuarter,
+    y2y: TimePeriod.Y2Y,
+    nextq: TimePeriod.FutureQuarter,
+    "9m": TimePeriod.Q9M,
+  };
+
+  const handleQuickDateRange = (type: QuickRangeType) => {
+    const period = quickRangePeriodMap[type];
+    const resolved = resolveTimePeriod(period);
     if (!resolved.primary) return;
     setFromDate(resolved.primary.from);
     setToDate(resolved.primary.to);
+    // Multi-range presets (currently only Q9M) must be carried as TimePeriod so backend
+    // aggregates sales across all ranges. Single-range presets clear the override.
+    setSelectedTimePeriod(resolved.ranges.length > 1 ? period : null);
     setNeedsRecalculation(true);
   };
 
-  // Get tooltip text for date range buttons
-  const getDateRangeTooltip = (type: "lastq" | "y2y" | "nextq") => {
-    const periodMap: Record<"lastq" | "y2y" | "nextq", TimePeriod> = {
-      lastq: TimePeriod.PreviousQuarter,
-      y2y: TimePeriod.Y2Y,
-      nextq: TimePeriod.FutureQuarter,
-    };
-    const resolved = resolveTimePeriod(periodMap[type]);
-    if (!resolved.primary) return "";
-    return `${resolved.primary.from.toLocaleDateString("cs-CZ")} - ${resolved.primary.to.toLocaleDateString("cs-CZ")}`;
+  // Get tooltip text for date range buttons. For multi-range presets, lists all ranges.
+  const getDateRangeTooltip = (type: QuickRangeType) => {
+    const resolved = resolveTimePeriod(quickRangePeriodMap[type]);
+    if (resolved.ranges.length === 0) return "";
+    return resolved.ranges
+      .map((r) => `${r.from.toLocaleDateString("cs-CZ")} - ${r.to.toLocaleDateString("cs-CZ")}`)
+      .join(" | ");
   };
 
   const calculateBatchPlan = (semiproductCode: string, fromDateParam?: Date, toDateParam?: Date) => {
@@ -269,6 +273,7 @@ const BatchPlanningCalculator: React.FC = () => {
       controlMode: controlMode,
       fromDate: fromDateParam || fromDate,
       toDate: toDateParam || toDate,
+      timePeriod: selectedTimePeriod ?? undefined,
       salesMultiplier: salesMultiplier,
       directSemiproductAmount: directSemiproductAmount > 0 ? directSemiproductAmount : undefined,
     };
@@ -306,6 +311,7 @@ const BatchPlanningCalculator: React.FC = () => {
       controlMode: controlMode,
       fromDate: fromDateParam || fromDate,
       toDate: toDateParam || toDate,
+      timePeriod: selectedTimePeriod ?? undefined,
       salesMultiplier: salesMultiplier,
       productConstraints: constraints,
       directSemiproductAmount: directSemiproductAmount > 0 ? directSemiproductAmount : undefined,
@@ -349,6 +355,7 @@ const BatchPlanningCalculator: React.FC = () => {
         controlMode: BatchPlanControlMode.MmqMultiplier,
         fromDate: fromDate,
         toDate: toDate,
+        timePeriod: selectedTimePeriod ?? undefined,
         salesMultiplier: salesMultiplier,
         mmqMultiplier: 1.0, // Use reset value
       };
@@ -584,6 +591,17 @@ const BatchPlanningCalculator: React.FC = () => {
                         >
                           NextQ
                         </button>
+                        <button
+                          onClick={() => handleQuickDateRange("9m")}
+                          className={`px-3 py-1 text-xs rounded border transition-colors ${
+                            selectedTimePeriod === TimePeriod.Q9M
+                              ? "bg-indigo-100 hover:bg-indigo-200 text-indigo-700 border-indigo-300"
+                              : "bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-300"
+                          }`}
+                          title={getDateRangeTooltip("9m")}
+                        >
+                          9M
+                        </button>
                       </div>
                     </div>
 
@@ -596,11 +614,12 @@ const BatchPlanningCalculator: React.FC = () => {
                         onChange={(e) => {
                           const newFromDate = new Date(e.target.value);
                           setFromDate(newFromDate);
+                          setSelectedTimePeriod(null);
                           setNeedsRecalculation(true);
                         }}
                         className="w-44 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"
                       />
-                      
+
                       <label className="text-xs text-gray-600 whitespace-nowrap">do:</label>
                       <input
                         type="date"
@@ -608,6 +627,7 @@ const BatchPlanningCalculator: React.FC = () => {
                         onChange={(e) => {
                           const newToDate = new Date(e.target.value);
                           setToDate(newToDate);
+                          setSelectedTimePeriod(null);
                           setNeedsRecalculation(true);
                         }}
                         className="w-44 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-indigo-500"

--- a/frontend/src/components/pages/__tests__/BatchPlanningCalculator.test.tsx
+++ b/frontend/src/components/pages/__tests__/BatchPlanningCalculator.test.tsx
@@ -205,7 +205,7 @@ describe("BatchPlanningCalculator", () => {
       expect(screen.getByTestId("semiproduct-input")).toBeInTheDocument();
     });
 
-    it("should expose all quick date range presets including 9M", () => {
+    it("should render period dropdown with Q9M selected by default", () => {
       const Wrapper = createWrapper();
       render(
         <Wrapper>
@@ -213,12 +213,20 @@ describe("BatchPlanningCalculator", () => {
         </Wrapper>
       );
 
-      // All four sales-bin presets must be present so users can pick Q9M
-      // alongside the single-range presets.
-      expect(screen.getByRole("button", { name: "LastQ" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Y2Y" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "NextQ" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "9M" })).toBeInTheDocument();
+      // Period dropdown replaces the four quick-range buttons
+      const periodSelect = screen.getByLabelText(/Časové období/i);
+      expect(periodSelect).toBeInTheDocument();
+
+      // All six options are present
+      expect(screen.getByRole("option", { name: "Minulý kvartal" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Budoucí kvartal" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Y2Y (12 měsíců)" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Předchozí sezona" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "9M (6 měsíců + prognóza 3 měsíce)" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Vlastní období" })).toBeInTheDocument();
+
+      // Q9M is selected by default
+      expect(periodSelect).toHaveValue("Q9M");
     });
   });
 

--- a/frontend/src/components/pages/__tests__/BatchPlanningCalculator.test.tsx
+++ b/frontend/src/components/pages/__tests__/BatchPlanningCalculator.test.tsx
@@ -222,7 +222,7 @@ describe("BatchPlanningCalculator", () => {
       expect(screen.getByRole("option", { name: "Budoucí kvartal" })).toBeInTheDocument();
       expect(screen.getByRole("option", { name: "Y2Y (12 měsíců)" })).toBeInTheDocument();
       expect(screen.getByRole("option", { name: "Předchozí sezona" })).toBeInTheDocument();
-      expect(screen.getByRole("option", { name: "9M (6 měsíců + prognóza 3 měsíce)" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "9M" })).toBeInTheDocument();
       expect(screen.getByRole("option", { name: "Vlastní období" })).toBeInTheDocument();
 
       // Q9M is selected by default

--- a/frontend/src/components/pages/__tests__/BatchPlanningCalculator.test.tsx
+++ b/frontend/src/components/pages/__tests__/BatchPlanningCalculator.test.tsx
@@ -204,6 +204,22 @@ describe("BatchPlanningCalculator", () => {
       expect(screen.getByTestId("catalog-autocomplete")).toBeInTheDocument();
       expect(screen.getByTestId("semiproduct-input")).toBeInTheDocument();
     });
+
+    it("should expose all quick date range presets including 9M", () => {
+      const Wrapper = createWrapper();
+      render(
+        <Wrapper>
+          <BatchPlanningCalculator />
+        </Wrapper>
+      );
+
+      // All four sales-bin presets must be present so users can pick Q9M
+      // alongside the single-range presets.
+      expect(screen.getByRole("button", { name: "LastQ" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Y2Y" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "NextQ" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "9M" })).toBeInTheDocument();
+    });
   });
 
   describe("Successful Response Handling", () => {

--- a/frontend/src/utils/timePeriod/displayText.ts
+++ b/frontend/src/utils/timePeriod/displayText.ts
@@ -11,7 +11,7 @@ export function getTimePeriodDisplayText(period: TimePeriod): string {
     case TimePeriod.PreviousSeason:
       return "Předchozí sezona";
     case TimePeriod.Q9M:
-      return "9M (6 měsíců + prognóza 3 měsíce)";
+      return "9M";
     case TimePeriod.CustomPeriod:
       return "Vlastní období";
     default:


### PR DESCRIPTION
## Summary

- Replaces the 4 quick-range buttons (LastQ / Y2Y / NextQ / 9M) and always-visible date pickers in the \"Nastavení prodejů\" panel with a single `<select>` dropdown, mirroring the pattern already used in Stock Analysis
- Six preset periods available: Minulý kvartal, Budoucí kvartal, Y2Y, Předchozí sezona, **9M (default)**, Vlastní období — date pickers only appear when Vlastní období is selected
- Request payload now cleanly routes: named periods send `timePeriod` (backend resolves multi-range logic), Custom period sends `fromDate`/`toDate`

## Test Plan

- [ ] Page opens at `/manufacturing/batch-planning` with dropdown defaulted to `9M (6 měsíců + prognóza 3 měsíce)`, no date pickers visible
- [ ] Pick a semiproduct → calc fires; Network tab shows `timePeriod: "Q9M"`, no `fromDate`/`toDate`
- [ ] Change dropdown to `Minulý kvartal` → recalc badge appears; after recalc, request has `timePeriod: "PreviousQuarter"`
- [ ] Change dropdown to `Vlastní období` → two date pickers appear seeded with Q9M's primary range; edit a date → recalc fires with `fromDate`/`toDate` set, no `timePeriod`
- [ ] Hover the dropdown → tooltip shows resolved date range (multi-line Období A / Období B for Q9M)
- [ ] Unit tests: `npm test -- --testPathPattern="BatchPlanningCalculator"` → 6/6 pass