### PR TITLE
fix: refresh ConversationDetail status immediately after closing

### DIFF
--- a/frontend/src/components/customer-support/smartsupp/ConversationDetail.tsx
+++ b/frontend/src/components/customer-support/smartsupp/ConversationDetail.tsx
@@ -59,6 +59,7 @@ const ConversationDetail: React.FC<ConversationDetailProps> = ({
 }) => {
   const { data, isLoading } = useSmartsuppConversation(conversationId);
   const { mutate: closeConversation, isPending: isClosing } = useCloseConversation();
+  const liveStatus = data?.conversation?.status ?? conversation.status;
 
   const handleClose = () => {
     closeConversation(conversationId, {
@@ -95,7 +96,7 @@ const ConversationDetail: React.FC<ConversationDetailProps> = ({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h3 className="font-semibold text-gray-900 truncate">{displayName}</h3>
-            <StatusPill status={conversation.status} />
+            <StatusPill status={liveStatus} />
           </div>
           {conversation.contactEmail && (
             <p className="text-xs text-gray-500 truncate">{conversation.contactEmail}</p>
@@ -105,7 +106,7 @@ const ConversationDetail: React.FC<ConversationDetailProps> = ({
           {conversation.assignedAgentIds.map((id) => (
             <AgentBadge key={id} agentId={id} name={agentNames[id] ?? id} />
           ))}
-          {conversation.status.toLowerCase() === 'open' && (
+          {liveStatus.toLowerCase() === 'open' && (
             <button
               type="button"
               data-testid="close-conversation-btn"

--- a/frontend/src/components/customer-support/smartsupp/__tests__/ConversationDetail.test.tsx
+++ b/frontend/src/components/customer-support/smartsupp/__tests__/ConversationDetail.test.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ConversationDetail from "../ConversationDetail";
-import { ConversationDto } from "../../../../api/hooks/useSmartsupp";
-
-const mockMutate = jest.fn();
+import {
+  ConversationDto,
+  useSmartsuppConversation,
+  useCloseConversation,
+} from "../../../../api/hooks/useSmartsupp";
 
 jest.mock("react-hot-toast", () => ({
   toast: {
@@ -17,27 +19,8 @@ jest.mock("../../../../api/hooks/useSmartsupp", () => {
   const actual = jest.requireActual("../../../../api/hooks/useSmartsupp");
   return {
     ...actual,
-    useSmartsuppConversation: () => ({
-      data: {
-        success: true,
-        conversation: null,
-        messages: [
-          {
-            id: "m1",
-            authorType: "visitor",
-            authorName: "Jana",
-            content: "Dotaz",
-            createdAt: new Date().toISOString(),
-            isFirstReply: false,
-          },
-        ],
-      },
-      isLoading: false,
-    }),
-    useCloseConversation: () => ({
-      mutate: mockMutate,
-      isPending: false,
-    }),
+    useSmartsuppConversation: jest.fn(),
+    useCloseConversation: jest.fn(),
   };
 });
 
@@ -58,6 +41,17 @@ const conv: ConversationDto = {
   tags: [],
 };
 
+const defaultMessages = [
+  {
+    id: "m1",
+    authorType: "visitor",
+    authorName: "Jana",
+    content: "Dotaz",
+    createdAt: new Date().toISOString(),
+    isFirstReply: false,
+  },
+];
+
 const wrap = (ui: React.ReactNode) => {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
@@ -65,6 +59,18 @@ const wrap = (ui: React.ReactNode) => {
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
+});
+
+beforeEach(() => {
+  jest.mocked(useSmartsuppConversation).mockReturnValue({
+    data: { success: true, conversation: null, messages: defaultMessages, agentNames: {} },
+    isLoading: false,
+  } as ReturnType<typeof useSmartsuppConversation>);
+
+  jest.mocked(useCloseConversation).mockReturnValue({
+    mutate: jest.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCloseConversation>);
 });
 
 describe("ConversationDetail", () => {
@@ -170,11 +176,44 @@ describe("ConversationDetail", () => {
   });
 
   it("calls mutate with conversationId when the close button is clicked", () => {
+    const mockMutate = jest.fn();
+    jest.mocked(useCloseConversation).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCloseConversation>);
     render(wrap(<ConversationDetail conversationId="c1" conversation={conv} />));
     fireEvent.click(screen.getByTestId("close-conversation-btn"));
     expect(mockMutate).toHaveBeenCalledWith(
       "c1",
       expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
     );
+  });
+
+  it("hides the close button when detail query returns resolved status even if prop status is open", () => {
+    jest.mocked(useSmartsuppConversation).mockReturnValue({
+      data: {
+        success: true,
+        conversation: { ...conv, status: "resolved" },
+        messages: [],
+        agentNames: {},
+      },
+      isLoading: false,
+    } as ReturnType<typeof useSmartsuppConversation>);
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} />));
+    expect(screen.queryByTestId("close-conversation-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows resolved status pill when detail query returns resolved status", () => {
+    jest.mocked(useSmartsuppConversation).mockReturnValue({
+      data: {
+        success: true,
+        conversation: { ...conv, status: "resolved" },
+        messages: [],
+        agentNames: {},
+      },
+      isLoading: false,
+    } as ReturnType<typeof useSmartsuppConversation>);
+    render(wrap(<ConversationDetail conversationId="c1" conversation={conv} />));
+    expect(screen.getByTestId("status-pill")).not.toHaveTextContent("Aktivní");
   });
 });


### PR DESCRIPTION
After closing a Smartupp conversation, the status pill and close button in `ConversationDetail` stayed stale because both rendered `conversation.status` from the list-query prop, ignoring the fresher `data.conversation` returned by the detail query. The fix introduces `liveStatus = data?.conversation?.status ?? conversation.status` so the header updates as soon as the detail query refetches on mutation success, without waiting for the slower list query to complete.

Two new tests cover the case where the detail query returns `"resolved"` while the prop still carries `"open"`. The test file was also refactored to use `jest.fn()` in the mock factory (instead of module-scope variables) to avoid a jest-hoist/Babel parse incompatibility with TypeScript type annotations.