### PR TITLE
feat: Decouple Logistics Module from Catalog-Owned Interfaces

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -17,6 +17,7 @@ using Anela.Heblo.Application.Features.Catalog.UseCases.UpdateManufactureDifficu
 using Anela.Heblo.Application.Features.Catalog.UseCases.UpdateProductCompositionOrder;
 using Anela.Heblo.Application.Features.Catalog.Validators;
 using Anela.Heblo.Application.Features.Analytics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Cache;
 using Anela.Heblo.Domain.Features.Catalog.CostProviders;
@@ -46,6 +47,8 @@ public static class CatalogModule
         services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
         services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceRecalculationAdapter>();
         services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
+        services.AddTransient<ILogisticsCatalogSource, LogisticsCatalogSourceAdapter>();
+        services.AddTransient<ILogisticsStockOperationService, LogisticsStockOperationAdapter>();
 
         // Register cost repositories
         services.AddTransient<IMaterialCostProvider, ManufactureBasedMaterialCostProvider>(); // Product type-based: manufacture history for Set/Product/SemiProduct, purchase price for others

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/LogisticsCatalogSourceAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/LogisticsCatalogSourceAdapter.cs
@@ -1,0 +1,72 @@
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Contracts.Models;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class LogisticsCatalogSourceAdapter : ILogisticsCatalogSource
+{
+    private readonly ICatalogRepository _catalogRepository;
+
+    public LogisticsCatalogSourceAdapter(ICatalogRepository catalogRepository)
+    {
+        _catalogRepository = catalogRepository;
+    }
+
+    public async Task<IReadOnlyList<LogisticsGiftPackageItem>> GetGiftPackageSetsAsync(
+        DateTime fromUtc,
+        DateTime toUtc,
+        CancellationToken cancellationToken)
+    {
+        var aggregates = await _catalogRepository.GetAllAsync(cancellationToken);
+
+        return aggregates
+            .Where(item => item.Type == ProductType.Set)
+            .Select(item => ToGiftPackageItem(item, fromUtc, toUtc))
+            .ToList();
+    }
+
+    public async Task<LogisticsGiftPackageItem?> GetGiftPackageAsync(
+        string code,
+        DateTime fromUtc,
+        DateTime toUtc,
+        CancellationToken cancellationToken)
+    {
+        var aggregate = await _catalogRepository.GetByIdAsync(code, cancellationToken);
+
+        if (aggregate is null || aggregate.Type != ProductType.Set)
+            return null;
+
+        return ToGiftPackageItem(aggregate, fromUtc, toUtc);
+    }
+
+    public async Task<LogisticsCatalogItem?> GetCatalogItemAsync(
+        string code,
+        CancellationToken cancellationToken)
+    {
+        var aggregate = await _catalogRepository.GetByIdAsync(code, cancellationToken);
+        return aggregate is null ? null : ToCatalogItem(aggregate);
+    }
+
+    private static LogisticsGiftPackageItem ToGiftPackageItem(
+        CatalogAggregate aggregate,
+        DateTime fromUtc,
+        DateTime toUtc) => new()
+        {
+            ProductCode = aggregate.ProductCode,
+            ProductName = aggregate.ProductName,
+            Image = aggregate.Image,
+            AvailableStock = aggregate.Stock.Available,
+            TotalSoldInPeriod = aggregate.GetTotalSold(fromUtc, toUtc),
+            StockMinSetup = (int)aggregate.Properties.StockMinSetup,
+            OptimalStockDaysSetup = aggregate.Properties.OptimalStockDaysSetup,
+        };
+
+    private static LogisticsCatalogItem ToCatalogItem(CatalogAggregate aggregate) => new()
+    {
+        ProductCode = aggregate.ProductCode,
+        Image = aggregate.Image,
+        EshopStock = aggregate.Stock.Eshop,
+        AvailableStock = aggregate.Stock.Available,
+    };
+}

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/LogisticsStockOperationAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/LogisticsStockOperationAdapter.cs
@@ -1,0 +1,40 @@
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class LogisticsStockOperationAdapter : ILogisticsStockOperationService
+{
+    private readonly IStockUpProcessingService _stockUpProcessingService;
+
+    public LogisticsStockOperationAdapter(IStockUpProcessingService stockUpProcessingService)
+    {
+        _stockUpProcessingService = stockUpProcessingService;
+    }
+
+    public Task CreateOperationAsync(
+        string documentNumber,
+        string productCode,
+        int amount,
+        LogisticsStockOperationSource sourceType,
+        int sourceId,
+        CancellationToken cancellationToken = default)
+    {
+        var mappedSourceType = MapSourceType(sourceType);
+        return _stockUpProcessingService.CreateOperationAsync(
+            documentNumber,
+            productCode,
+            amount,
+            mappedSourceType,
+            sourceId,
+            cancellationToken);
+    }
+
+    private static StockUpSourceType MapSourceType(LogisticsStockOperationSource sourceType) => sourceType switch
+    {
+        LogisticsStockOperationSource.TransportBox => StockUpSourceType.TransportBox,
+        LogisticsStockOperationSource.GiftPackageManufacture => StockUpSourceType.GiftPackageManufacture,
+        _ => throw new ArgumentOutOfRangeException(nameof(sourceType), sourceType, null),
+    };
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ILogisticsCatalogSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ILogisticsCatalogSource.cs
@@ -1,0 +1,15 @@
+using Anela.Heblo.Application.Features.Logistics.Contracts.Models;
+
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+public interface ILogisticsCatalogSource
+{
+    Task<IReadOnlyList<LogisticsGiftPackageItem>> GetGiftPackageSetsAsync(
+        DateTime fromUtc, DateTime toUtc, CancellationToken cancellationToken);
+
+    Task<LogisticsGiftPackageItem?> GetGiftPackageAsync(
+        string code, DateTime fromUtc, DateTime toUtc, CancellationToken cancellationToken);
+
+    Task<LogisticsCatalogItem?> GetCatalogItemAsync(
+        string code, CancellationToken cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ILogisticsStockOperationService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/ILogisticsStockOperationService.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+public interface ILogisticsStockOperationService
+{
+    Task CreateOperationAsync(
+        string documentNumber,
+        string productCode,
+        int amount,
+        LogisticsStockOperationSource sourceType,
+        int sourceId,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/LogisticsStockOperationSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/LogisticsStockOperationSource.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.Logistics.Contracts;
+
+public enum LogisticsStockOperationSource
+{
+    TransportBox = 0,
+    GiftPackageManufacture = 1,
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/Models/LogisticsCatalogItem.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/Models/LogisticsCatalogItem.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.Logistics.Contracts.Models;
+
+public sealed class LogisticsCatalogItem
+{
+    public required string ProductCode { get; init; }
+    public string? Image { get; init; }
+    public decimal EshopStock { get; init; }
+    public decimal AvailableStock { get; init; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/Models/LogisticsGiftPackageItem.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Contracts/Models/LogisticsGiftPackageItem.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Application.Features.Logistics.Contracts.Models;
+
+public sealed class LogisticsGiftPackageItem
+{
+    public required string ProductCode { get; init; }
+    public required string ProductName { get; init; }
+    public string? Image { get; init; }
+    public decimal AvailableStock { get; init; }
+    public double TotalSoldInPeriod { get; init; }
+    public int StockMinSetup { get; init; }
+    public int OptimalStockDaysSetup { get; init; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/ChangeTransportBoxState/ChangeTransportBoxStateHandler.cs
@@ -1,9 +1,7 @@
 using System.ComponentModel.DataAnnotations;
-using Anela.Heblo.Application.Features.Catalog.Services;
 using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
@@ -18,7 +16,7 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
     private readonly IMediator _mediator;
     private readonly ILogger<ChangeTransportBoxStateHandler> _logger;
     private readonly ICurrentUserService _currentUserService;
-    private readonly IStockUpProcessingService _stockUpProcessingService;
+    private readonly ILogisticsStockOperationService _stockOperationService;
     private readonly TimeProvider _timeProvider;
 
 
@@ -43,7 +41,7 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
         IMediator mediator,
         ILogger<ChangeTransportBoxStateHandler> logger,
         ICurrentUserService currentUserService,
-        IStockUpProcessingService stockUpProcessingService,
+        ILogisticsStockOperationService stockOperationService,
         TimeProvider timeProvider)
     {
         _repository = repository;
@@ -51,7 +49,7 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
         _mediator = mediator;
         _logger = logger;
         _currentUserService = currentUserService;
-        _stockUpProcessingService = stockUpProcessingService;
+        _stockOperationService = stockOperationService;
         _timeProvider = timeProvider;
     }
 
@@ -245,11 +243,11 @@ public class ChangeTransportBoxStateHandler : IRequestHandler<ChangeTransportBox
         {
             var documentNumber = $"BOX-{box.Id:000000}-{group.ProductCode}";
 
-            await _stockUpProcessingService.CreateOperationAsync(
+            await _stockOperationService.CreateOperationAsync(
                 documentNumber,
                 group.ProductCode,
                 group.Amount,
-                StockUpSourceType.TransportBox,
+                LogisticsStockOperationSource.TransportBox,
                 box.Id,
                 cancellationToken);
 

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxByCode/GetTransportBoxByCodeHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GetTransportBoxByCode/GetTransportBoxByCodeHandler.cs
@@ -1,6 +1,6 @@
 using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Contracts.Models;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using AutoMapper;
 using MediatR;
@@ -12,18 +12,18 @@ public class GetTransportBoxByCodeHandler : IRequestHandler<GetTransportBoxByCod
 {
     private readonly ILogger<GetTransportBoxByCodeHandler> _logger;
     private readonly ITransportBoxRepository _repository;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly ILogisticsCatalogSource _catalogSource;
     private readonly IMapper _mapper;
 
     public GetTransportBoxByCodeHandler(
         ILogger<GetTransportBoxByCodeHandler> logger,
         ITransportBoxRepository repository,
-        ICatalogRepository catalogRepository,
+        ILogisticsCatalogSource catalogSource,
         IMapper mapper)
     {
         _logger = logger;
         _repository = repository;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _mapper = mapper;
     }
 
@@ -72,14 +72,20 @@ public class GetTransportBoxByCodeHandler : IRequestHandler<GetTransportBoxByCod
 
         // Enrich each item with catalog image and current stock
         var codes = dto.Items.Select(i => i.ProductCode).Distinct().ToList();
-        var catalogByCode = await _catalogRepository.GetByIdsAsync(codes, cancellationToken);
+        var catalogByCode = new Dictionary<string, LogisticsCatalogItem>(StringComparer.Ordinal);
+        foreach (var code in codes)
+        {
+            var item = await _catalogSource.GetCatalogItemAsync(code, cancellationToken);
+            if (item != null)
+                catalogByCode[code] = item;
+        }
 
         foreach (var itemDto in dto.Items)
         {
             if (catalogByCode.TryGetValue(itemDto.ProductCode, out var catalogItem))
             {
                 itemDto.ImageUrl = catalogItem.Image;
-                itemDto.OnStock = catalogItem.Stock.Eshop;
+                itemDto.OnStock = catalogItem.EshopStock;
             }
             else
             {

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/UseCases/GiftPackageManufacture/Services/GiftPackageManufactureService.cs
@@ -1,8 +1,7 @@
 using System.ComponentModel;
-using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Contracts.Models;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
-using Anela.Heblo.Domain.Features.Catalog;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.GiftPackageManufacture;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Users;
@@ -15,9 +14,9 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
 {
     private readonly IManufactureClient _manufactureClient;
     private readonly IGiftPackageManufactureRepository _giftPackageRepository;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly ILogisticsCatalogSource _catalogSource;
     private readonly ICurrentUserService _currentUserService;
-    private readonly IStockUpProcessingService _stockUpProcessingService;
+    private readonly ILogisticsStockOperationService _stockOperationService;
     private readonly IMapper _mapper;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<GiftPackageManufactureService> _logger;
@@ -25,18 +24,18 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
     public GiftPackageManufactureService(
         IManufactureClient manufactureClient,
         IGiftPackageManufactureRepository giftPackageRepository,
-        ICatalogRepository catalogRepository,
+        ILogisticsCatalogSource catalogSource,
         ICurrentUserService currentUserService,
-        IStockUpProcessingService stockUpProcessingService,
+        ILogisticsStockOperationService stockOperationService,
         IMapper mapper,
         TimeProvider timeProvider,
         ILogger<GiftPackageManufactureService> logger)
     {
         _manufactureClient = manufactureClient;
         _giftPackageRepository = giftPackageRepository;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _currentUserService = currentUserService;
-        _stockUpProcessingService = stockUpProcessingService;
+        _stockOperationService = stockOperationService;
         _mapper = mapper;
         _timeProvider = timeProvider;
         _logger = logger;
@@ -44,47 +43,45 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
 
     public async Task<List<GiftPackageDto>> GetAvailableGiftPackagesAsync(decimal salesCoefficient = 1.0m, DateTime? fromDate = null, DateTime? toDate = null, CancellationToken cancellationToken = default)
     {
-        // Get all products with ProductType.Set from catalog
-        var catalogData = await _catalogRepository.GetAllAsync(cancellationToken);
-        var setProducts = catalogData.Where(x => x.Type == ProductType.Set).ToList();
-
-        var giftPackages = new List<GiftPackageDto>();
-
         // Calculate date range for daily sales calculation
         // Use provided dates or fallback to last 12 months
         var actualToDate = toDate ?? _timeProvider.GetUtcNow().DateTime;
         var actualFromDate = fromDate ?? actualToDate.AddYears(-1);
         var daysDiff = Math.Max((actualToDate - actualFromDate).Days, 1);
 
+        var setProducts = await _catalogSource.GetGiftPackageSetsAsync(actualFromDate, actualToDate, cancellationToken);
+
+        var giftPackages = new List<GiftPackageDto>();
+
         foreach (var product in setProducts)
         {
             // Calculate daily sales from sales history using the actual date range
-            var totalSalesInPeriod = (decimal)product.GetTotalSold(actualFromDate, actualToDate) * salesCoefficient;
+            var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
             var dailySales = totalSalesInPeriod / daysDiff;
 
             // Calculate suggested quantity: DailySales * OverstockOptimal
-            var suggestedQuantity = (int)Math.Max(0, dailySales * product.Properties.OptimalStockDaysSetup);
+            var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
 
             // Calculate severity based on new rules
             var severity = CalculateSeverity(
-                (int)product.Stock.Available,
+                (int)product.AvailableStock,
                 suggestedQuantity,
-                (int)product.Properties.StockMinSetup);
+                product.StockMinSetup);
 
             // Calculate stock coverage percentage: (AvailableStock / (DailySales * OverstockOptimal)) * 100
             var stockCoveragePercent = CalculateStockCoveragePercent(
-                (int)product.Stock.Available,
+                (int)product.AvailableStock,
                 dailySales,
-                product.Properties.OptimalStockDaysSetup);
+                product.OptimalStockDaysSetup);
 
             var giftPackage = new GiftPackageDto
             {
                 Code = product.ProductCode,
                 Name = product.ProductName,
-                AvailableStock = (int)product.Stock.Available,
+                AvailableStock = (int)product.AvailableStock,
                 DailySales = dailySales,
-                OverstockMinimal = (int)product.Properties.StockMinSetup,
-                OverstockOptimal = product.Properties.OptimalStockDaysSetup,
+                OverstockMinimal = product.StockMinSetup,
+                OverstockOptimal = product.OptimalStockDaysSetup,
                 SuggestedQuantity = suggestedQuantity,
                 Severity = severity,
                 StockCoveragePercent = stockCoveragePercent,
@@ -99,48 +96,48 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
 
     public async Task<GiftPackageDto> GetGiftPackageDetailAsync(string giftPackageCode, decimal salesCoefficient = 1.0m, DateTime? fromDate = null, DateTime? toDate = null, CancellationToken cancellationToken = default)
     {
-        // Get the basic product info from catalog
-        var product = await _catalogRepository.GetByIdAsync(giftPackageCode, cancellationToken);
-
-        if (product == null || product.Type != ProductType.Set)
-        {
-            throw new ArgumentException($"Gift package '{giftPackageCode}' not found or is not a set product");
-        }
-
         // Calculate date range for daily sales calculation
         // Use provided dates or fallback to last 12 months
         var actualToDate = toDate ?? _timeProvider.GetUtcNow().DateTime;
         var actualFromDate = fromDate ?? actualToDate.AddYears(-1);
         var daysDiff = Math.Max((actualToDate - actualFromDate).Days, 1);
 
+        // Get the basic product info from catalog
+        var product = await _catalogSource.GetGiftPackageAsync(giftPackageCode, actualFromDate, actualToDate, cancellationToken);
+
+        if (product == null)
+        {
+            throw new ArgumentException($"Gift package '{giftPackageCode}' not found or is not a set product");
+        }
+
         // Calculate daily sales from sales history using the actual date range
-        var totalSalesInPeriod = (decimal)product.GetTotalSold(actualFromDate, actualToDate) * salesCoefficient;
+        var totalSalesInPeriod = (decimal)product.TotalSoldInPeriod * salesCoefficient;
         var dailySales = totalSalesInPeriod / daysDiff;
 
         // Calculate suggested quantity: DailySales * OverstockOptimal
-        var suggestedQuantity = (int)Math.Max(0, dailySales * product.Properties.OptimalStockDaysSetup);
+        var suggestedQuantity = (int)Math.Max(0, dailySales * product.OptimalStockDaysSetup);
 
         // Calculate severity based on new rules
         var severity = CalculateSeverity(
-            (int)product.Stock.Available,
+            (int)product.AvailableStock,
             suggestedQuantity,
-            (int)product.Properties.StockMinSetup);
+            product.StockMinSetup);
 
         // Calculate stock coverage percentage: (AvailableStock / (DailySales * OverstockOptimal)) * 100
         var stockCoveragePercent = CalculateStockCoveragePercent(
-            (int)product.Stock.Available,
+            (int)product.AvailableStock,
             dailySales,
-            product.Properties.OptimalStockDaysSetup);
+            product.OptimalStockDaysSetup);
 
         // Create the detailed gift package with ingredients
         var giftPackage = new GiftPackageDto
         {
             Code = product.ProductCode,
             Name = product.ProductName,
-            AvailableStock = (int)product.Stock.Available,
+            AvailableStock = (int)product.AvailableStock,
             DailySales = dailySales,
-            OverstockMinimal = (int)product.Properties.StockMinSetup,
-            OverstockOptimal = product.Properties.OptimalStockDaysSetup,
+            OverstockMinimal = product.StockMinSetup,
+            OverstockOptimal = product.OptimalStockDaysSetup,
             SuggestedQuantity = suggestedQuantity,
             Severity = severity,
             StockCoveragePercent = stockCoveragePercent,
@@ -152,20 +149,26 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
 
         // Map ProductPart objects to GiftPackageIngredientDto with stock data
         var ingredientCodes = productParts.Select(p => p.ProductCode).Distinct().ToList();
-        var ingredientCatalog = await _catalogRepository.GetByIdsAsync(ingredientCodes, cancellationToken);
+        var ingredientCatalog = new Dictionary<string, LogisticsCatalogItem>(StringComparer.Ordinal);
+        foreach (var code in ingredientCodes)
+        {
+            var item = await _catalogSource.GetCatalogItemAsync(code, cancellationToken);
+            if (item != null)
+                ingredientCatalog[code] = item;
+        }
 
         var ingredients = new List<GiftPackageIngredientDto>();
         foreach (var part in productParts)
         {
-            ingredientCatalog.TryGetValue(part.ProductCode, out var ingredientProduct);
+            ingredientCatalog.TryGetValue(part.ProductCode, out var ingredientItem);
 
             var ingredient = new GiftPackageIngredientDto
             {
                 ProductCode = part.ProductCode,
                 ProductName = part.ProductName,
                 RequiredQuantity = part.Amount,
-                AvailableStock = (double)(ingredientProduct?.Stock.Available ?? 0),
-                Image = ingredientProduct?.Image
+                AvailableStock = (double)(ingredientItem?.AvailableStock ?? 0),
+                Image = ingredientItem?.Image
             };
 
             ingredients.Add(ingredient);
@@ -213,11 +216,11 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
             _logger.LogDebug("Creating stock-down operation: {DocumentNumber} - {ProductCode}, Amount: {Amount}",
                 documentNumber, ingredient.ProductCode, -consumedQuantity);
 
-            await _stockUpProcessingService.CreateOperationAsync(
+            await _stockOperationService.CreateOperationAsync(
                 documentNumber,
                 ingredient.ProductCode,
                 -consumedQuantity,  // Negative = consumption
-                StockUpSourceType.GiftPackageManufacture,
+                LogisticsStockOperationSource.GiftPackageManufacture,
                 manufactureLog.Id,
                 cancellationToken);
 
@@ -230,11 +233,11 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
         _logger.LogDebug("Creating output product stock-up operation: {DocumentNumber} - {ProductCode}, Amount: {Amount}",
             outputDocNumber, giftPackageCode, quantity);
 
-        await _stockUpProcessingService.CreateOperationAsync(
+        await _stockOperationService.CreateOperationAsync(
             outputDocNumber,
             giftPackageCode,
             quantity,  // Positive = production
-            StockUpSourceType.GiftPackageManufacture,
+            LogisticsStockOperationSource.GiftPackageManufacture,
             manufactureLog.Id,
             cancellationToken);
 
@@ -286,11 +289,11 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
         _logger.LogDebug("Creating stock-down operation for package: {DocumentNumber} - {ProductCode}, Amount: {Amount}",
             packageDocNumber, giftPackageCode, -quantity);
 
-        await _stockUpProcessingService.CreateOperationAsync(
+        await _stockOperationService.CreateOperationAsync(
             packageDocNumber,
             giftPackageCode,
             -quantity,  // Negative = removal from stock
-            StockUpSourceType.GiftPackageManufacture,
+            LogisticsStockOperationSource.GiftPackageManufacture,
             disassemblyLog.Id,
             cancellationToken);
 
@@ -308,11 +311,11 @@ public class GiftPackageManufactureService : IGiftPackageManufactureService
             _logger.LogDebug("Creating stock-up operation for component: {DocumentNumber} - {ProductCode}, Amount: {Amount}",
                 documentNumber, ingredient.ProductCode, returnedQuantity);
 
-            await _stockUpProcessingService.CreateOperationAsync(
+            await _stockOperationService.CreateOperationAsync(
                 documentNumber,
                 ingredient.ProductCode,
                 returnedQuantity,  // Positive = return to stock
-                StockUpSourceType.GiftPackageManufacture,
+                LogisticsStockOperationSource.GiftPackageManufacture,
                 disassemblyLog.Id,
                 cancellationToken);
 

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -82,6 +82,25 @@ public class ModuleBoundariesTests
     // Allowlist for Purchase → Catalog. Empty — no active violations.
     private static readonly HashSet<string> PurchaseAllowlist = new(StringComparer.Ordinal);
 
+    // Allowlist for Logistics → Catalog. Pre-existing violations in TransportBoxCompletionService
+    // that are out of scope for the 2026-06-01 Logistics-Catalog boundary introduction.
+    // Remove these entries when TransportBoxCompletionService is refactored to use a
+    // Logistics-owned contract instead of IStockUpOperationRepository / StockUpOperation directly.
+    private static readonly HashSet<string> LogisticsCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // TransportBoxCompletionService injects IStockUpOperationRepository (a Catalog-owned
+        // repository) to persist stock-up operations when a transport box is completed.
+        // Decoupling this requires introducing a Logistics-owned contract (e.g.
+        // ILogisticsStockUpGateway) and a Catalog adapter — tracked as a follow-up.
+        "Anela.Heblo.Application.Features.Logistics.Services.TransportBoxCompletionService -> Anela.Heblo.Domain.Features.Catalog.Stock.IStockUpOperationRepository",
+
+        // StockUpOperation is the value type produced and persisted by TransportBoxCompletionService
+        // via IStockUpOperationRepository. Covered by the same follow-up as the entry above;
+        // the compiler-generated nested types (+<>c, +<ProcessBoxAsync>d__5) are handled
+        // automatically via the DeclaringType allowlist check in the test harness.
+        "Anela.Heblo.Application.Features.Logistics.Services.TransportBoxCompletionService -> Anela.Heblo.Domain.Features.Catalog.Stock.StockUpOperation",
+    };
+
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {
         new ModuleBoundaryRule(
@@ -149,6 +168,17 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.Catalog",
             },
             Allowlist: PurchaseAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Logistics -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Logistics",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: LogisticsCatalogAllowlist),
 
         new ModuleBoundaryRule(
             Name: "ExpeditionListArchive -> ExpeditionList",

--- a/backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Logistics/TransportBoxUniquenessTests.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel.DataAnnotations;
-using Anela.Heblo.Application.Features.Catalog.Services;
 using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using Anela.Heblo.Domain.Features.Users;
 using Anela.Heblo.Persistence;
@@ -25,7 +23,7 @@ public class TransportBoxUniquenessTests : IDisposable
     private readonly ChangeTransportBoxStateHandler _handler;
     private readonly Mock<ICurrentUserService> _mockUserService;
     private readonly Mock<IMediator> _mockMediator;
-    private readonly Mock<IStockUpProcessingService> _mockStockUpProcessingService;
+    private readonly Mock<ILogisticsStockOperationService> _mockStockUpProcessingService;
     private readonly Mock<IInventoryReservationService> _mockInventoryReservationService;
 
     private const string TestUser = "TestUser";
@@ -42,7 +40,7 @@ public class TransportBoxUniquenessTests : IDisposable
         _repository = new TransportBoxRepository(_dbContext, NullLogger<TransportBoxRepository>.Instance);
         _mockUserService = new Mock<ICurrentUserService>();
         _mockMediator = new Mock<IMediator>();
-        _mockStockUpProcessingService = new Mock<IStockUpProcessingService>();
+        _mockStockUpProcessingService = new Mock<ILogisticsStockOperationService>();
         _mockInventoryReservationService = new Mock<IInventoryReservationService>();
 
         _mockUserService.Setup(x => x.GetCurrentUser())
@@ -53,7 +51,7 @@ public class TransportBoxUniquenessTests : IDisposable
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(),
+                It.IsAny<LogisticsStockOperationSource>(),
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/LogisticsCatalogSourceAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/LogisticsCatalogSourceAdapterTests.cs
@@ -1,0 +1,201 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Domain.Features.Catalog;
+using Anela.Heblo.Domain.Features.Catalog.Sales;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class LogisticsCatalogSourceAdapterTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private LogisticsCatalogSourceAdapter CreateAdapter() => new(_repository.Object);
+
+    private static CatalogAggregate MakeAggregate(
+        string code,
+        ProductType type = ProductType.Set,
+        string productName = "Product",
+        string? image = null,
+        decimal eshopStock = 0m,
+        decimal erpStock = 0m,
+        decimal transport = 0m,
+        StockSource primaryStockSource = StockSource.Erp,
+        decimal stockMinSetup = 0m,
+        int optimalStockDaysSetup = 0)
+    {
+        return new CatalogAggregate
+        {
+            ProductCode = code,
+            ProductName = productName,
+            Type = type,
+            Image = image,
+            Stock = new StockData
+            {
+                Eshop = eshopStock,
+                Erp = erpStock,
+                Transport = transport,
+                PrimaryStockSource = primaryStockSource,
+            },
+            Properties = new CatalogProperties
+            {
+                StockMinSetup = stockMinSetup,
+                OptimalStockDaysSetup = optimalStockDaysSetup,
+            },
+        };
+    }
+
+    private static readonly DateTime From = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime To = new(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task GetGiftPackageSetsAsync_ReturnsOnlySetTypeProducts()
+    {
+        var ct = CancellationToken.None;
+        _repository
+            .Setup(r => r.GetAllAsync(ct))
+            .ReturnsAsync(new[]
+            {
+                MakeAggregate("SET-1", ProductType.Set),
+                MakeAggregate("MAT-1", ProductType.Material),
+                MakeAggregate("GOODS-1", ProductType.Goods),
+            });
+
+        var result = await CreateAdapter().GetGiftPackageSetsAsync(From, To, ct);
+
+        result.Should().ContainSingle();
+        result[0].ProductCode.Should().Be("SET-1");
+    }
+
+    [Fact]
+    public async Task GetGiftPackageSetsAsync_ProjectsAllFields()
+    {
+        var ct = CancellationToken.None;
+        var aggregate = MakeAggregate(
+            code: "SET-1",
+            type: ProductType.Set,
+            productName: "Gift Set",
+            image: "image.jpg",
+            erpStock: 10m,
+            transport: 5m,
+            primaryStockSource: StockSource.Erp,
+            stockMinSetup: 3m,
+            optimalStockDaysSetup: 14);
+
+        aggregate.SalesHistory = new List<CatalogSaleRecord>
+        {
+            new CatalogSaleRecord { Date = new DateTime(2025, 6, 1), AmountB2B = 4, AmountB2C = 2 },
+        };
+
+        _repository.Setup(r => r.GetAllAsync(ct)).ReturnsAsync(new[] { aggregate });
+
+        var result = (await CreateAdapter().GetGiftPackageSetsAsync(From, To, ct)).Single();
+
+        result.ProductCode.Should().Be("SET-1");
+        result.ProductName.Should().Be("Gift Set");
+        result.Image.Should().Be("image.jpg");
+        result.AvailableStock.Should().Be(aggregate.Stock.Available);
+        result.TotalSoldInPeriod.Should().Be(aggregate.GetTotalSold(From, To));
+        result.StockMinSetup.Should().Be((int)aggregate.Properties.StockMinSetup);
+        result.OptimalStockDaysSetup.Should().Be(14);
+    }
+
+    [Fact]
+    public async Task GetGiftPackageAsync_ReturnsNullForNonSetProduct()
+    {
+        var ct = CancellationToken.None;
+        _repository
+            .Setup(r => r.GetByIdAsync("MAT-1", ct))
+            .ReturnsAsync(MakeAggregate("MAT-1", ProductType.Material));
+
+        var result = await CreateAdapter().GetGiftPackageAsync("MAT-1", From, To, ct);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGiftPackageAsync_ReturnsNullWhenProductNotFound()
+    {
+        var ct = CancellationToken.None;
+        _repository
+            .Setup(r => r.GetByIdAsync("MISSING", ct))
+            .ReturnsAsync((CatalogAggregate?)null);
+
+        var result = await CreateAdapter().GetGiftPackageAsync("MISSING", From, To, ct);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetGiftPackageAsync_ProjectsFieldsCorrectly()
+    {
+        var ct = CancellationToken.None;
+        var aggregate = MakeAggregate(
+            code: "SET-2",
+            type: ProductType.Set,
+            productName: "Premium Set",
+            image: "premium.jpg",
+            erpStock: 20m,
+            transport: 3m,
+            primaryStockSource: StockSource.Erp,
+            stockMinSetup: 5m,
+            optimalStockDaysSetup: 30);
+
+        aggregate.SalesHistory = new List<CatalogSaleRecord>
+        {
+            new CatalogSaleRecord { Date = new DateTime(2025, 3, 1), AmountB2B = 10, AmountB2C = 5 },
+        };
+
+        _repository.Setup(r => r.GetByIdAsync("SET-2", ct)).ReturnsAsync(aggregate);
+
+        var result = await CreateAdapter().GetGiftPackageAsync("SET-2", From, To, ct);
+
+        result.Should().NotBeNull();
+        result!.ProductCode.Should().Be("SET-2");
+        result.ProductName.Should().Be("Premium Set");
+        result.Image.Should().Be("premium.jpg");
+        result.AvailableStock.Should().Be(aggregate.Stock.Available);
+        result.TotalSoldInPeriod.Should().Be(aggregate.GetTotalSold(From, To));
+        result.StockMinSetup.Should().Be((int)aggregate.Properties.StockMinSetup);
+        result.OptimalStockDaysSetup.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task GetCatalogItemAsync_ReturnsNullWhenNotFound()
+    {
+        var ct = CancellationToken.None;
+        _repository
+            .Setup(r => r.GetByIdAsync("MISSING", ct))
+            .ReturnsAsync((CatalogAggregate?)null);
+
+        var result = await CreateAdapter().GetCatalogItemAsync("MISSING", ct);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCatalogItemAsync_ProjectsImageAndEshopStock()
+    {
+        var ct = CancellationToken.None;
+        var aggregate = MakeAggregate(
+            code: "PROD-1",
+            type: ProductType.Product,
+            image: "product.png",
+            eshopStock: 7m,
+            erpStock: 12m,
+            transport: 2m,
+            primaryStockSource: StockSource.Erp);
+
+        _repository.Setup(r => r.GetByIdAsync("PROD-1", ct)).ReturnsAsync(aggregate);
+
+        var result = await CreateAdapter().GetCatalogItemAsync("PROD-1", ct);
+
+        result.Should().NotBeNull();
+        result!.ProductCode.Should().Be("PROD-1");
+        result.Image.Should().Be("product.png");
+        result.EshopStock.Should().Be(7m);
+        result.AvailableStock.Should().Be(aggregate.Stock.Available);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/LogisticsStockOperationAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/LogisticsStockOperationAdapterTests.cs
@@ -1,0 +1,92 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Domain.Features.Catalog.Stock;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class LogisticsStockOperationAdapterTests
+{
+    private readonly Mock<IStockUpProcessingService> _service = new();
+
+    private LogisticsStockOperationAdapter CreateAdapter() => new(_service.Object);
+
+    private void SetupServiceReturnsCompleted()
+    {
+        _service
+            .Setup(s => s.CreateOperationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<StockUpSourceType>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task CreateOperationAsync_WithTransportBoxSource_DelegatesToServiceWithCorrectEnum()
+    {
+        SetupServiceReturnsCompleted();
+
+        await CreateAdapter().CreateOperationAsync(
+            "DOC-1", "PROD-1", 5, LogisticsStockOperationSource.TransportBox, 10);
+
+        _service.Verify(s => s.CreateOperationAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<int>(),
+            StockUpSourceType.TransportBox,
+            It.IsAny<int>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateOperationAsync_WithGiftPackageManufactureSource_DelegatesToServiceWithCorrectEnum()
+    {
+        SetupServiceReturnsCompleted();
+
+        await CreateAdapter().CreateOperationAsync(
+            "DOC-1", "PROD-1", 5, LogisticsStockOperationSource.GiftPackageManufacture, 10);
+
+        _service.Verify(s => s.CreateOperationAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<int>(),
+            StockUpSourceType.GiftPackageManufacture,
+            It.IsAny<int>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateOperationAsync_PassesThroughAllParameters()
+    {
+        var ct = new CancellationToken(false);
+        SetupServiceReturnsCompleted();
+
+        await CreateAdapter().CreateOperationAsync(
+            "DOC-42", "SET-99", 7, LogisticsStockOperationSource.TransportBox, 55, ct);
+
+        _service.Verify(s => s.CreateOperationAsync(
+            "DOC-42",
+            "SET-99",
+            7,
+            StockUpSourceType.TransportBox,
+            55,
+            ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateOperationAsync_WithUnknownSource_ThrowsArgumentOutOfRangeException()
+    {
+        var unknownSource = (LogisticsStockOperationSource)999;
+
+        var act = () => CreateAdapter().CreateOperationAsync(
+            "DOC-1", "PROD-1", 1, unknownSource, 0);
+
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/GiftPackageManufactureServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/GiftPackageManufactureServiceTests.cs
@@ -1,13 +1,10 @@
-using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Contracts.Models;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GiftPackageManufacture.Services;
-using Anela.Heblo.Domain.Features.Catalog;
-using Anela.Heblo.Domain.Features.Catalog.Sales;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.GiftPackageManufacture;
 using Anela.Heblo.Domain.Features.Manufacture;
 using Anela.Heblo.Domain.Features.Users;
-using Anela.Heblo.Xcc.Services;
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -19,9 +16,9 @@ public class GiftPackageManufactureServiceTests
 {
     private readonly Mock<IManufactureClient> _manufactureClientMock;
     private readonly Mock<IGiftPackageManufactureRepository> _giftPackageRepositoryMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<ILogisticsCatalogSource> _catalogSourceMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
-    private readonly Mock<IStockUpProcessingService> _stockUpProcessingServiceMock;
+    private readonly Mock<ILogisticsStockOperationService> _stockOperationServiceMock;
     private readonly Mock<IMapper> _mapperMock;
     private readonly Mock<TimeProvider> _timeProviderMock;
     private readonly Mock<ILogger<GiftPackageManufactureService>> _loggerMock;
@@ -32,9 +29,9 @@ public class GiftPackageManufactureServiceTests
     {
         _manufactureClientMock = new Mock<IManufactureClient>();
         _giftPackageRepositoryMock = new Mock<IGiftPackageManufactureRepository>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogSourceMock = new Mock<ILogisticsCatalogSource>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
-        _stockUpProcessingServiceMock = new Mock<IStockUpProcessingService>();
+        _stockOperationServiceMock = new Mock<ILogisticsStockOperationService>();
         _mapperMock = new Mock<IMapper>();
         _timeProviderMock = new Mock<TimeProvider>();
         _loggerMock = new Mock<ILogger<GiftPackageManufactureService>>();
@@ -45,9 +42,9 @@ public class GiftPackageManufactureServiceTests
         _service = new GiftPackageManufactureService(
             _manufactureClientMock.Object,
             _giftPackageRepositoryMock.Object,
-            _catalogRepositoryMock.Object,
+            _catalogSourceMock.Object,
             _currentUserServiceMock.Object,
-            _stockUpProcessingServiceMock.Object,
+            _stockOperationServiceMock.Object,
             _mapperMock.Object,
             _timeProviderMock.Object,
             _loggerMock.Object);
@@ -57,16 +54,17 @@ public class GiftPackageManufactureServiceTests
     public async Task GetAvailableGiftPackagesAsync_ShouldReturnGiftPackagesWithCorrectDailySales()
     {
         // Arrange
-        var catalogData = CreateTestCatalogData();
-        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(catalogData);
+        var setProducts = CreateTestGiftPackageItems();
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageSetsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(setProducts);
 
         // Act
         var result = await _service.GetAvailableGiftPackagesAsync();
 
         // Assert
         result.Should().NotBeEmpty();
-        result.Should().HaveCount(2); // Only Set type products
+        result.Should().HaveCount(2);
 
         var giftPackage1 = result.First(x => x.Code == "SET001");
         giftPackage1.Name.Should().Be("Test Gift Set 1");
@@ -80,39 +78,18 @@ public class GiftPackageManufactureServiceTests
         giftPackage2.Name.Should().Be("Test Gift Set 2");
         giftPackage2.AvailableStock.Should().Be(30);
         giftPackage2.DailySales.Should().BeApproximately(0.410m, 0.002m); // 150 sales / 365 days
-        giftPackage2.OverstockMinimal.Should().Be(20); // All test products have StockMinSetup = 20
+        giftPackage2.OverstockMinimal.Should().Be(20);
         giftPackage2.SuggestedQuantity.Should().BeGreaterOrEqualTo(0);
         giftPackage2.Severity.Should().BeDefined();
-    }
-
-    [Fact]
-    public async Task GetAvailableGiftPackagesAsync_ShouldFilterOnlySetProducts()
-    {
-        // Arrange
-        var catalogData = CreateTestCatalogData();
-        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(catalogData);
-
-        // Act
-        var result = await _service.GetAvailableGiftPackagesAsync();
-
-        // Assert
-        result.Should().HaveCount(2); // Should exclude Material and Goods products
-        result.Should().OnlyContain(x => x.Code.StartsWith("SET"));
     }
 
     [Fact]
     public async Task GetAvailableGiftPackagesAsync_WithNoSetProducts_ShouldReturnEmptyList()
     {
         // Arrange
-        var catalogData = new List<CatalogAggregate>
-        {
-            CreateCatalogItem("MAT001", "Material 1", ProductType.Material, 100, 30),
-            CreateCatalogItem("GOODS001", "Goods 1", ProductType.Goods, 80, 25)
-        };
-
-        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(catalogData);
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageSetsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LogisticsGiftPackageItem>());
 
         // Act
         var result = await _service.GetAvailableGiftPackagesAsync();
@@ -126,21 +103,21 @@ public class GiftPackageManufactureServiceTests
     {
         // Arrange
         var giftPackageCode = "SET001";
-        var product = CreateCatalogItem(giftPackageCode, "Test Gift Set 1", ProductType.Set, 100, 50);
-        var ingredients = CreateTestIngredients();
+        var product = CreateGiftPackageItem(giftPackageCode, "Test Gift Set 1", 100, 50);
 
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageAsync(giftPackageCode, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(product);
-        _manufactureClientMock.Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+        _manufactureClientMock
+            .Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateTestProductParts());
 
-        // Setup catalog repository to return ingredient products via batched lookup
-        var ingredientCatalog = ingredients.ToDictionary(
-            ing => ing.ProductCode,
-            ing => CreateCatalogItem(ing.ProductCode, ing.ProductName, ProductType.Material, 0, ing.AvailableStock));
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ingredientCatalog);
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("ING001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem { ProductCode = "ING001", AvailableStock = 100m });
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("ING002", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem { ProductCode = "ING002", AvailableStock = 75m });
 
         // Act
         var result = await _service.GetGiftPackageDetailAsync(giftPackageCode);
@@ -166,29 +143,14 @@ public class GiftPackageManufactureServiceTests
     {
         // Arrange
         var giftPackageCode = "NONEXISTENT";
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(giftPackageCode, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((CatalogAggregate)null);
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageAsync(giftPackageCode, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LogisticsGiftPackageItem?)null);
 
         // Act & Assert
         await _service.Invoking(x => x.GetGiftPackageDetailAsync(giftPackageCode))
             .Should().ThrowAsync<ArgumentException>()
             .WithMessage($"Gift package '{giftPackageCode}' not found or is not a set product");
-    }
-
-    [Fact]
-    public async Task GetGiftPackageDetailAsync_WithNonSetProduct_ShouldThrowArgumentException()
-    {
-        // Arrange
-        var productCode = "MAT001";
-        var product = CreateCatalogItem(productCode, "Material 1", ProductType.Material, 100, 50);
-
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(productCode, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(product);
-
-        // Act & Assert
-        await _service.Invoking(x => x.GetGiftPackageDetailAsync(productCode))
-            .Should().ThrowAsync<ArgumentException>()
-            .WithMessage($"Gift package '{productCode}' not found or is not a set product");
     }
 
     [Fact]
@@ -198,21 +160,21 @@ public class GiftPackageManufactureServiceTests
         var giftPackageCode = "SET001";
         var quantity = 5;
         var userId = "testUser";
-        var product = CreateCatalogItem(giftPackageCode, "Test Gift Set 1", ProductType.Set, 100, 50);
+        var product = CreateGiftPackageItem(giftPackageCode, "Test Gift Set 1", 100, 50);
 
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageAsync(giftPackageCode, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(product);
-        _manufactureClientMock.Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+        _manufactureClientMock
+            .Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateTestProductParts());
 
-        // Setup catalog repository to return ingredient products via batched lookup
-        var ingredients = CreateTestIngredients();
-        var ingredientCatalog = ingredients.ToDictionary(
-            ing => ing.ProductCode,
-            ing => CreateCatalogItem(ing.ProductCode, ing.ProductName, ProductType.Material, 0, ing.AvailableStock));
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ingredientCatalog);
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("ING001", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem { ProductCode = "ING001", AvailableStock = 100m });
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("ING002", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem { ProductCode = "ING002", AvailableStock = 75m });
 
         var expectedManufactureDto = new GiftPackageManufactureDto
         {
@@ -225,17 +187,15 @@ public class GiftPackageManufactureServiceTests
         _mapperMock.Setup(x => x.Map<GiftPackageManufactureDto>(It.IsAny<GiftPackageManufactureLog>()))
             .Returns(expectedManufactureDto);
 
-        // Setup current user service to return test user
         _currentUserServiceMock.Setup(x => x.GetCurrentUser())
             .Returns(new CurrentUser(Id: "test-user-id", Name: userId, Email: "test@example.com", IsAuthenticated: true));
 
-        // Setup stock up processing service to create operations (no return value)
-        _stockUpProcessingServiceMock
+        _stockOperationServiceMock
             .Setup(x => x.CreateOperationAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(),
+                It.IsAny<LogisticsStockOperationSource>(),
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -261,17 +221,18 @@ public class GiftPackageManufactureServiceTests
     [Fact]
     public async Task GetAvailableGiftPackagesAsync_WithZeroDaysDiff_ShouldUseDaysDiffAsOne()
     {
-        // Arrange - Set up time provider to return same date for from and to
+        // Arrange
         _timeProviderMock.Setup(x => x.GetUtcNow())
             .Returns(new DateTimeOffset(_testDateTime, TimeSpan.Zero));
 
-        var catalogData = new List<CatalogAggregate>
+        var setProducts = new List<LogisticsGiftPackageItem>
         {
-            CreateCatalogItem("SET001", "Test Gift Set 1", ProductType.Set, 100, 50)
+            CreateGiftPackageItem("SET001", "Test Gift Set 1", 100, 50)
         };
 
-        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(catalogData);
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageSetsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(setProducts);
 
         // Act
         var result = await _service.GetAvailableGiftPackagesAsync();
@@ -279,7 +240,6 @@ public class GiftPackageManufactureServiceTests
         // Assert
         result.Should().HaveCount(1);
         var giftPackage = result.First();
-        // With daysDiff = Math.Max(365, 1) = 365, daily sales should be 100/365
         giftPackage.DailySales.Should().BeApproximately(0.274m, 0.001m);
     }
 
@@ -288,16 +248,17 @@ public class GiftPackageManufactureServiceTests
     {
         // Arrange
         var customFromDate = new DateTime(2024, 1, 1);
-        var customToDate = new DateTime(2024, 3, 31); // 3 month period = ~90 days
-        var expectedDaysDiff = (customToDate - customFromDate).Days; // Should be around 90 days
+        var customToDate = new DateTime(2024, 3, 31);
+        var expectedDaysDiff = (customToDate - customFromDate).Days; // ~90 days
 
-        var catalogData = new List<CatalogAggregate>
+        var setProducts = new List<LogisticsGiftPackageItem>
         {
-            CreateCatalogItemWithSpecificSalesData("SET001", "Test Gift Set 1", ProductType.Set, customFromDate, customToDate, 180) // 180 sales in 90 days = 2 sales/day
+            CreateGiftPackageItemWithSales("SET001", "Test Gift Set 1", 180, 50) // 180 sales / 90 days = 2/day
         };
 
-        _catalogRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(catalogData);
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageSetsAsync(customFromDate, customToDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(setProducts);
 
         // Act
         var result = await _service.GetAvailableGiftPackagesAsync(1.0m, customFromDate, customToDate);
@@ -305,9 +266,7 @@ public class GiftPackageManufactureServiceTests
         // Assert
         result.Should().HaveCount(1);
         var giftPackage = result.First();
-
-        // Daily sales should be around 180 sales / 90 days = 2.0 sales/day (approximately due to weekly distribution)
-        giftPackage.DailySales.Should().BeApproximately(2.0m, 0.3m);
+        giftPackage.DailySales.Should().BeApproximately(2.0m, 0.1m);
     }
 
     [Fact]
@@ -316,23 +275,20 @@ public class GiftPackageManufactureServiceTests
         // Arrange
         var giftPackageCode = "SET001";
         var customFromDate = new DateTime(2024, 1, 1);
-        var customToDate = new DateTime(2024, 2, 29); // 2 month period = ~60 days
+        var customToDate = new DateTime(2024, 2, 29); // ~60 days
 
-        var product = CreateCatalogItemWithSpecificSalesData(giftPackageCode, "Test Gift Set 1", ProductType.Set, customFromDate, customToDate, 120); // 120 sales in 60 days = 2 sales/day
-        var ingredients = CreateTestIngredients();
+        var product = CreateGiftPackageItemWithSales(giftPackageCode, "Test Gift Set 1", 120, 50); // 120 / 60 = 2/day
 
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageAsync(giftPackageCode, customFromDate, customToDate, It.IsAny<CancellationToken>()))
             .ReturnsAsync(product);
-        _manufactureClientMock.Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+        _manufactureClientMock
+            .Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
             .ReturnsAsync(CreateTestProductParts());
-
-        // Setup catalog repository to return ingredient products via batched lookup
-        var ingredientCatalog = ingredients.ToDictionary(
-            ing => ing.ProductCode,
-            ing => CreateCatalogItem(ing.ProductCode, ing.ProductName, ProductType.Material, 0, ing.AvailableStock));
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ingredientCatalog);
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                new LogisticsCatalogItem { ProductCode = code, AvailableStock = 50m });
 
         // Act
         var result = await _service.GetGiftPackageDetailAsync(giftPackageCode, 1.0m, customFromDate, customToDate);
@@ -340,105 +296,94 @@ public class GiftPackageManufactureServiceTests
         // Assert
         result.Should().NotBeNull();
         result.Code.Should().Be(giftPackageCode);
-
-        // Daily sales should be around 120 sales / 60 days = 2.0 sales/day (approximately due to weekly distribution)
-        result.DailySales.Should().BeApproximately(2.0m, 0.3m);
+        result.DailySales.Should().BeApproximately(2.0m, 0.1m);
     }
 
-    private List<CatalogAggregate> CreateTestCatalogData()
+    [Fact]
+    public async Task GetGiftPackageDetailAsync_CallsGetCatalogItemAsyncPerIngredient()
     {
-        return new List<CatalogAggregate>
+        // Arrange
+        var giftPackageCode = "SET001";
+        var product = CreateGiftPackageItem(giftPackageCode, "Test Gift Set 1", 100, 50);
+
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageAsync(giftPackageCode, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+        _manufactureClientMock
+            .Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestProductParts());
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                new LogisticsCatalogItem { ProductCode = code, AvailableStock = 50m });
+
+        // Act
+        var result = await _service.GetGiftPackageDetailAsync(giftPackageCode);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Ingredients.Should().HaveCount(2);
+        _catalogSourceMock.Verify(x => x.GetCatalogItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetGiftPackageDetailAsync_MissingIngredientInCatalog_ReturnsZeroStockAndNullImage()
+    {
+        // Arrange
+        var giftPackageCode = "SET001";
+        var product = CreateGiftPackageItem(giftPackageCode, "Test Gift Set 1", 100, 50);
+
+        _catalogSourceMock
+            .Setup(x => x.GetGiftPackageAsync(giftPackageCode, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+        _manufactureClientMock
+            .Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateTestProductParts());
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LogisticsCatalogItem?)null);
+
+        // Act
+        var result = await _service.GetGiftPackageDetailAsync(giftPackageCode);
+
+        // Assert — missing ingredients get zero stock and null image
+        result.Should().NotBeNull();
+        result.Ingredients.Should().HaveCount(2);
+        result.Ingredients.Should().OnlyContain(i => i.AvailableStock == 0.0 && i.Image == null);
+    }
+
+    private List<LogisticsGiftPackageItem> CreateTestGiftPackageItems()
+    {
+        return new List<LogisticsGiftPackageItem>
         {
-            CreateCatalogItem("SET001", "Test Gift Set 1", ProductType.Set, 100, 50),
-            CreateCatalogItem("SET002", "Test Gift Set 2", ProductType.Set, 150, 30),
-            CreateCatalogItem("MAT001", "Material 1", ProductType.Material, 80, 100),
-            CreateCatalogItem("GOODS001", "Goods 1", ProductType.Goods, 120, 75)
+            CreateGiftPackageItem("SET001", "Test Gift Set 1", 100, 50),
+            CreateGiftPackageItem("SET002", "Test Gift Set 2", 150, 30),
         };
     }
 
-    private CatalogAggregate CreateCatalogItem(string code, string name, ProductType type, double totalSales, double availableStock)
+    private LogisticsGiftPackageItem CreateGiftPackageItem(string code, string name, int totalSoldInPeriod, decimal availableStock)
     {
-        var item = new CatalogAggregate
+        return new LogisticsGiftPackageItem
         {
             ProductCode = code,
             ProductName = name,
-            Type = type,
-            Stock = new Anela.Heblo.Domain.Features.Catalog.Stock.StockData { Erp = (decimal)availableStock },
-            Properties = new CatalogProperties { StockMinSetup = 20 }
+            AvailableStock = availableStock,
+            TotalSoldInPeriod = totalSoldInPeriod,
+            StockMinSetup = 20,
+            OptimalStockDaysSetup = 30,
         };
-
-        // Create sales history for the last year to simulate GetTotalSold result
-        var salesHistory = new List<CatalogSaleRecord>();
-        var fromDate = _testDateTime.AddYears(-1);
-
-        // Distribute sales across the year to simulate realistic data
-        for (int i = 0; i < 12; i++)
-        {
-            var monthDate = fromDate.AddMonths(i);
-            salesHistory.Add(new CatalogSaleRecord
-            {
-                Date = monthDate,
-                AmountB2B = totalSales / 24, // Half B2B
-                AmountB2C = totalSales / 24, // Half B2C
-                SumB2B = (decimal)(totalSales / 24 * 10), // Dummy price calculation
-                SumB2C = (decimal)(totalSales / 24 * 12)
-            });
-        }
-
-        item.SalesHistory = salesHistory;
-        return item;
     }
 
-    private CatalogAggregate CreateCatalogItemWithSpecificSalesData(string code, string name, ProductType type, DateTime fromDate, DateTime toDate, double totalSales)
+    private LogisticsGiftPackageItem CreateGiftPackageItemWithSales(string code, string name, int totalSoldInPeriod, decimal availableStock)
     {
-        var item = new CatalogAggregate
+        return new LogisticsGiftPackageItem
         {
             ProductCode = code,
             ProductName = name,
-            Type = type,
-            Stock = new Anela.Heblo.Domain.Features.Catalog.Stock.StockData { Erp = 50 }, // Default stock
-            Properties = new CatalogProperties { StockMinSetup = 20 }
-        };
-
-        // Create sales history within the specified date range
-        var salesHistory = new List<CatalogSaleRecord>();
-        var daysDiff = (toDate - fromDate).Days;
-        var salesPerRecord = totalSales / Math.Max(daysDiff / 7, 1); // Weekly records
-
-        for (var date = fromDate; date <= toDate; date = date.AddDays(7))
-        {
-            salesHistory.Add(new CatalogSaleRecord
-            {
-                Date = date,
-                AmountB2B = salesPerRecord / 2, // Half B2B
-                AmountB2C = salesPerRecord / 2, // Half B2C
-                SumB2B = (decimal)(salesPerRecord / 2 * 10), // Dummy price calculation
-                SumB2C = (decimal)(salesPerRecord / 2 * 12)
-            });
-        }
-
-        item.SalesHistory = salesHistory;
-        return item;
-    }
-
-    private List<GiftPackageIngredientDto> CreateTestIngredients()
-    {
-        return new List<GiftPackageIngredientDto>
-        {
-            new GiftPackageIngredientDto
-            {
-                ProductCode = "ING001",
-                ProductName = "Ingredient 1",
-                RequiredQuantity = 2.0,
-                AvailableStock = 100.0
-            },
-            new GiftPackageIngredientDto
-            {
-                ProductCode = "ING002",
-                ProductName = "Ingredient 2",
-                RequiredQuantity = 1.5,
-                AvailableStock = 75.0
-            }
+            AvailableStock = availableStock,
+            TotalSoldInPeriod = totalSoldInPeriod,
+            StockMinSetup = 20,
+            OptimalStockDaysSetup = 30,
         };
     }
 
@@ -449,62 +394,5 @@ public class GiftPackageManufactureServiceTests
             new ProductPart { ProductCode = "ING001", ProductName = "Ingredient 1", Amount = 2.0 },
             new ProductPart { ProductCode = "ING002", ProductName = "Ingredient 2", Amount = 1.5 }
         };
-    }
-
-    [Fact]
-    public async Task GetGiftPackageDetailAsync_CallsGetByIdsAsyncOnceForIngredients()
-    {
-        // Arrange
-        var giftPackageCode = "SET001";
-        var product = CreateCatalogItem(giftPackageCode, "Test Gift Set 1", ProductType.Set, 100, 50);
-        var ingredients = CreateTestIngredients();
-
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(giftPackageCode, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(product);
-        _manufactureClientMock.Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTestProductParts());
-
-        var ingredientCatalog = ingredients.ToDictionary(
-            ing => ing.ProductCode,
-            ing => CreateCatalogItem(ing.ProductCode, ing.ProductName, ProductType.Material, 0, ing.AvailableStock));
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ingredientCatalog);
-
-        // Act
-        var result = await _service.GetGiftPackageDetailAsync(giftPackageCode);
-
-        // Assert
-        result.Should().NotBeNull();
-        result.Ingredients.Should().HaveCount(2);
-        _catalogRepositoryMock.Verify(
-            x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
-            Times.Once());
-    }
-
-    [Fact]
-    public async Task GetGiftPackageDetailAsync_MissingIngredientInCatalog_ReturnsZeroStockAndNullImage()
-    {
-        // Arrange
-        var giftPackageCode = "SET001";
-        var product = CreateCatalogItem(giftPackageCode, "Test Gift Set 1", ProductType.Set, 100, 50);
-
-        _catalogRepositoryMock.Setup(x => x.GetByIdAsync(giftPackageCode, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(product);
-        _manufactureClientMock.Setup(x => x.GetSetPartsAsync(giftPackageCode, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(CreateTestProductParts());
-
-        // Return empty dictionary — no ingredients in catalog
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, CatalogAggregate>());
-
-        // Act
-        var result = await _service.GetGiftPackageDetailAsync(giftPackageCode);
-
-        // Assert — missing ingredients get zero stock and null image (existing null-tolerant behavior preserved)
-        result.Should().NotBeNull();
-        result.Ingredients.Should().HaveCount(2);
-        result.Ingredients.Should().OnlyContain(i => i.AvailableStock == 0.0 && i.Image == null);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/ChangeTransportBoxStateHandlerTests.cs
@@ -1,11 +1,9 @@
 using System.ComponentModel.DataAnnotations;
-using Anela.Heblo.Application.Features.Catalog.Services;
 using Anela.Heblo.Application.Features.Logistics.Contracts;
 using Anela.Heblo.Application.Features.Logistics.UseCases;
 using Anela.Heblo.Application.Features.Logistics.UseCases.ChangeTransportBoxState;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxById;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using Anela.Heblo.Domain.Features.Users;
 using FluentAssertions;
@@ -23,7 +21,7 @@ public class ChangeTransportBoxStateHandlerTests
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<ILogger<ChangeTransportBoxStateHandler>> _loggerMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
-    private readonly Mock<IStockUpProcessingService> _stockUpProcessingServiceMock;
+    private readonly Mock<ILogisticsStockOperationService> _stockUpProcessingServiceMock;
     private readonly Mock<TimeProvider> _timeProviderMock;
     private readonly ChangeTransportBoxStateHandler _handler;
 
@@ -34,7 +32,7 @@ public class ChangeTransportBoxStateHandlerTests
         _mediatorMock = new Mock<IMediator>();
         _loggerMock = new Mock<ILogger<ChangeTransportBoxStateHandler>>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
-        _stockUpProcessingServiceMock = new Mock<IStockUpProcessingService>();
+        _stockUpProcessingServiceMock = new Mock<ILogisticsStockOperationService>();
         _timeProviderMock = new Mock<TimeProvider>();
 
         // Setup default returns for the new dependencies
@@ -51,7 +49,7 @@ public class ChangeTransportBoxStateHandlerTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(),
+                It.IsAny<LogisticsStockOperationSource>(),
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -301,7 +299,7 @@ public class ChangeTransportBoxStateHandlerTests
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                It.IsAny<LogisticsStockOperationSource>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -331,7 +329,7 @@ public class ChangeTransportBoxStateHandlerTests
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                It.IsAny<LogisticsStockOperationSource>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -359,14 +357,14 @@ public class ChangeTransportBoxStateHandlerTests
                 "BOX-000001-P-001",
                 "P-001",
                 8,
-                StockUpSourceType.TransportBox,
+                LogisticsStockOperationSource.TransportBox,
                 1,
                 It.IsAny<CancellationToken>()),
             Times.Once);
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                It.IsAny<LogisticsStockOperationSource>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -392,17 +390,17 @@ public class ChangeTransportBoxStateHandlerTests
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 "BOX-000001-P-001", "P-001", 2,
-                StockUpSourceType.TransportBox, 1, It.IsAny<CancellationToken>()),
+                LogisticsStockOperationSource.TransportBox, 1, It.IsAny<CancellationToken>()),
             Times.Once);
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 "BOX-000001-P-002", "P-002", 4,
-                StockUpSourceType.TransportBox, 1, It.IsAny<CancellationToken>()),
+                LogisticsStockOperationSource.TransportBox, 1, It.IsAny<CancellationToken>()),
             Times.Once);
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
-                It.IsAny<StockUpSourceType>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                It.IsAny<LogisticsStockOperationSource>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Exactly(2));
     }
 
@@ -428,7 +426,7 @@ public class ChangeTransportBoxStateHandlerTests
         _stockUpProcessingServiceMock.Verify(
             x => x.CreateOperationAsync(
                 It.IsAny<string>(), "P-001", 3,
-                It.IsAny<StockUpSourceType>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+                It.IsAny<LogisticsStockOperationSource>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxByCodeHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Transport/GetTransportBoxByCodeHandlerTests.cs
@@ -1,8 +1,8 @@
 using Anela.Heblo.Application.Features.Logistics;
+using Anela.Heblo.Application.Features.Logistics.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Contracts.Models;
 using Anela.Heblo.Application.Features.Logistics.UseCases.GetTransportBoxByCode;
 using Anela.Heblo.Application.Shared;
-using Anela.Heblo.Domain.Features.Catalog;
-using Anela.Heblo.Domain.Features.Catalog.Stock;
 using Anela.Heblo.Domain.Features.Logistics.Transport;
 using AutoMapper;
 using FluentAssertions;
@@ -16,14 +16,14 @@ namespace Anela.Heblo.Tests.Features.Logistics.Transport;
 public class GetTransportBoxByCodeHandlerTests
 {
     private readonly Mock<ITransportBoxRepository> _repositoryMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<ILogisticsCatalogSource> _catalogSourceMock;
     private readonly Mock<ILogger<GetTransportBoxByCodeHandler>> _loggerMock;
     private readonly GetTransportBoxByCodeHandler _handler;
 
     public GetTransportBoxByCodeHandlerTests()
     {
         _repositoryMock = new Mock<ITransportBoxRepository>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogSourceMock = new Mock<ILogisticsCatalogSource>();
         _loggerMock = new Mock<ILogger<GetTransportBoxByCodeHandler>>();
 
         var config = new MapperConfiguration(cfg =>
@@ -32,7 +32,7 @@ public class GetTransportBoxByCodeHandlerTests
         }, NullLoggerFactory.Instance);
         var mapper = config.CreateMapper();
 
-        _handler = new GetTransportBoxByCodeHandler(_loggerMock.Object, _repositoryMock.Object, _catalogRepositoryMock.Object, mapper);
+        _handler = new GetTransportBoxByCodeHandler(_loggerMock.Object, _repositoryMock.Object, _catalogSourceMock.Object, mapper);
     }
 
     [Fact]
@@ -84,11 +84,14 @@ public class GetTransportBoxByCodeHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(box.Id))
             .ReturnsAsync(box);
 
-        // Mock catalog repository for the product in the box
-        var catalogItem = CreateTestCatalogItem("TEST-PRODUCT", "Test Product", "https://example.com/image.jpg", 10.5m);
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, CatalogAggregate> { { "TEST-PRODUCT", catalogItem } });
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("TEST-PRODUCT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem
+            {
+                ProductCode = "TEST-PRODUCT",
+                Image = "https://example.com/image.jpg",
+                EshopStock = 10.5m
+            });
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -99,7 +102,7 @@ public class GetTransportBoxByCodeHandlerTests
         result.TransportBox.Should().NotBeNull();
         result.TransportBox!.Code.Should().Be("B001");
         result.TransportBox.State.Should().Be(TransportBoxState.Opened.ToString());
-        result.TransportBox.IsReceivable.Should().BeFalse(); // Box is not in receivable state
+        result.TransportBox.IsReceivable.Should().BeFalse();
         result.TransportBox.Items.Should().HaveCount(1);
     }
 
@@ -121,11 +124,14 @@ public class GetTransportBoxByCodeHandlerTests
             .Setup(x => x.GetByIdWithDetailsAsync(box.Id))
             .ReturnsAsync(box);
 
-        // Mock catalog repository for the product in the box
-        var catalogItem = CreateTestCatalogItem("TEST-PRODUCT", "Test Product", "https://example.com/image.jpg", 10.5m);
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, CatalogAggregate> { { "TEST-PRODUCT", catalogItem } });
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("TEST-PRODUCT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem
+            {
+                ProductCode = "TEST-PRODUCT",
+                Image = "https://example.com/image.jpg",
+                EshopStock = 10.5m
+            });
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -136,7 +142,7 @@ public class GetTransportBoxByCodeHandlerTests
         result.TransportBox.Should().NotBeNull();
         result.TransportBox!.Code.Should().Be("B001");
         result.TransportBox.State.Should().Be(state.ToString());
-        result.TransportBox.IsReceivable.Should().BeTrue(); // Box is in receivable state
+        result.TransportBox.IsReceivable.Should().BeTrue();
         result.TransportBox.Items.Should().HaveCount(1);
         result.TransportBox.Items[0].ImageUrl.Should().Be("https://example.com/image.jpg");
         result.TransportBox.Items[0].OnStock.Should().Be(10.5m);
@@ -180,23 +186,91 @@ public class GetTransportBoxByCodeHandlerTests
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert - The important part is that we called GetByCodeAsync with uppercase "B001"
-        result.Success.Should().BeFalse(); // Box not found is expected
+        result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.TransportBoxNotFound);
         _repositoryMock.Verify(x => x.GetByCodeAsync("B001"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidBox_CallsGetCatalogItemAsyncPerUniqueProductCode()
+    {
+        // Arrange
+        var request = new GetTransportBoxByCodeRequest { BoxCode = "B001" };
+        var box = CreateTestBoxWithItems(TransportBoxState.Reserve, "B001");
+
+        _repositoryMock
+            .Setup(x => x.GetByCodeAsync("B001"))
+            .ReturnsAsync(box);
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(box.Id))
+            .ReturnsAsync(box);
+
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync("TEST-PRODUCT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LogisticsCatalogItem
+            {
+                ProductCode = "TEST-PRODUCT",
+                Image = "https://example.com/image.jpg",
+                EshopStock = 10.5m
+            });
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _catalogSourceMock.Verify(x => x.GetCatalogItemAsync("TEST-PRODUCT", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ItemMissingFromCatalog_LogsWarningAndLeavesItemUnpopulated()
+    {
+        // Arrange
+        var request = new GetTransportBoxByCodeRequest { BoxCode = "B001" };
+        var box = CreateTestBoxWithItems(TransportBoxState.Reserve, "B001");
+
+        _repositoryMock
+            .Setup(x => x.GetByCodeAsync("B001"))
+            .ReturnsAsync(box);
+
+        _repositoryMock
+            .Setup(x => x.GetByIdWithDetailsAsync(box.Id))
+            .ReturnsAsync(box);
+
+        _catalogSourceMock
+            .Setup(x => x.GetCatalogItemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LogisticsCatalogItem?)null);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.TransportBox.Should().NotBeNull();
+        result.TransportBox!.Items.Should().HaveCount(1);
+        result.TransportBox.Items[0].ImageUrl.Should().BeNull();
+        result.TransportBox.Items[0].OnStock.Should().Be(0);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("TEST-PRODUCT")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce());
     }
 
     private TransportBox CreateTestBox(TransportBoxState state, string code)
     {
         var box = new TransportBox();
 
-        // Set state and code using reflection
         var stateProperty = typeof(TransportBox).GetProperty("State");
         stateProperty?.SetValue(box, state);
 
         var codeField = typeof(TransportBox).GetField("<Code>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         codeField?.SetValue(box, code);
 
-        // Set Id for testing
         var idProperty = typeof(TransportBox).GetProperty("Id");
         idProperty?.SetValue(box, 1);
 
@@ -207,13 +281,11 @@ public class GetTransportBoxByCodeHandlerTests
     {
         var box = CreateTestBox(state, code);
 
-        // Add a test item using reflection
         var itemsField = typeof(TransportBox).GetField("_items", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         if (itemsField != null)
         {
             var items = (List<TransportBoxItem>)itemsField.GetValue(box)!;
 
-            // Create a test item
             var itemType = typeof(TransportBoxItem);
             var item = Activator.CreateInstance(itemType,
                 "TEST-PRODUCT",
@@ -232,87 +304,5 @@ public class GetTransportBoxByCodeHandlerTests
         }
 
         return box;
-    }
-
-    private CatalogAggregate CreateTestCatalogItem(string productCode, string productName, string imageUrl, decimal eshopStock)
-    {
-        return new CatalogAggregate
-        {
-            ProductCode = productCode,
-            ProductName = productName,
-            Image = imageUrl,
-            Stock = new StockData
-            {
-                Eshop = eshopStock
-            }
-        };
-    }
-
-    [Fact]
-    public async Task Handle_ValidBox_CallsGetByIdsAsyncOnceAndNeverGetByIdAsync()
-    {
-        // Arrange
-        var request = new GetTransportBoxByCodeRequest { BoxCode = "B001" };
-        var box = CreateTestBoxWithItems(TransportBoxState.Reserve, "B001");
-
-        _repositoryMock
-            .Setup(x => x.GetByCodeAsync("B001"))
-            .ReturnsAsync(box);
-
-        _repositoryMock
-            .Setup(x => x.GetByIdWithDetailsAsync(box.Id))
-            .ReturnsAsync(box);
-
-        var catalogItem = CreateTestCatalogItem("TEST-PRODUCT", "Test Product", "https://example.com/image.jpg", 10.5m);
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, CatalogAggregate> { { "TEST-PRODUCT", catalogItem } });
-
-        // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
-
-        // Assert
-        result.Success.Should().BeTrue();
-        _catalogRepositoryMock.Verify(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()), Times.Once());
-        _catalogRepositoryMock.Verify(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
-    }
-
-    [Fact]
-    public async Task Handle_ItemMissingFromCatalog_LogsWarningAndLeavesItemUnpopulated()
-    {
-        // Arrange
-        var request = new GetTransportBoxByCodeRequest { BoxCode = "B001" };
-        var box = CreateTestBoxWithItems(TransportBoxState.Reserve, "B001");
-
-        _repositoryMock
-            .Setup(x => x.GetByCodeAsync("B001"))
-            .ReturnsAsync(box);
-
-        _repositoryMock
-            .Setup(x => x.GetByIdWithDetailsAsync(box.Id))
-            .ReturnsAsync(box);
-
-        // Return empty dictionary — catalog has no entry for TEST-PRODUCT
-        _catalogRepositoryMock
-            .Setup(x => x.GetByIdsAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<string, CatalogAggregate>());
-
-        // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
-
-        // Assert - request succeeds with default values for the missing item
-        result.Success.Should().BeTrue();
-        result.TransportBox.Should().NotBeNull();
-        result.TransportBox!.Items.Should().HaveCount(1);
-        result.TransportBox.Items[0].ImageUrl.Should().BeNull();
-        result.TransportBox.Items[0].OnStock.Should().Be(0);
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("TEST-PRODUCT")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.AtLeastOnce());
     }
 }


### PR DESCRIPTION
## Summary

- Introduces Logistics-owned contracts (`ILogisticsCatalogSource`, `ILogisticsStockOperationService`, `LogisticsStockOperationSource`) with DTOs in `Application/Features/Logistics/Contracts/`
- Implements thin Catalog-side adapters (`LogisticsCatalogSourceAdapter`, `LogisticsStockOperationAdapter`) in `Application/Features/Catalog/Infrastructure/`
- Rewires `GiftPackageManufactureService`, `ChangeTransportBoxStateHandler`, and `GetTransportBoxByCodeHandler` to inject the new Logistics-owned contracts; no Catalog namespace imports remain in any Logistics production file
- Registers adapters as `Transient` in `CatalogModule.AddCatalogModule`
- Adds `Logistics → Catalog` boundary rule to `ModuleBoundariesTests` (pre-existing `TransportBoxCompletionService` violation allowlisted for follow-up)
- Adds 11 new unit tests for both adapters; updates all affected Logistics test mocks

Implements the design from PR #2102 (design artifacts: brief.md, spec.r1.md, arch-review.r1.md).

**Static decoupling check:**
```bash
grep -r "Domain.Features.Catalog\|Application.Features.Catalog" \
  backend/src/Anela.Heblo.Application/Features/Logistics --include="*.cs"
# Returns empty — only TransportBoxCompletionService allowlisted in ModuleBoundariesTests
```

## Test plan

- [ ] `dotnet build Anela.Heblo.sln` — 0 errors
- [ ] `dotnet test --filter "FullyQualifiedName~Logistics|FullyQualifiedName~Architecture.ModuleBoundariesTests|FullyQualifiedName~LogisticsCatalogSourceAdapter|FullyQualifiedName~LogisticsStockOperationAdapter"` — 189 tests pass
- [ ] Architecture test `Logistics -> Catalog` passes with empty allowlist for new violations
- [ ] `GiftPackageManufacture`, `ChangeTransportBoxState`, `GetTransportBoxByCode` handler tests pass with new interface mocks