### PR TITLE
feat: Move HangfireJobRegistrationHelper to API Layer

### DIFF
--- a/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/arch-review.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/arch-review.r1.md
@@ -1,0 +1,179 @@
+# Architecture Review: Move HangfireJobRegistrationHelper to API Layer
+
+## Skip Design: true
+
+This is a backend-only structural refactor — no UI, no new visual components, no design system impact.
+
+## Architectural Fit Assessment
+
+The proposal aligns with the codebase's documented Clean Architecture rule, but it does **not fully restore the boundary** as FR-2's strictest acceptance criterion implies. Active exploration of the `Anela.Heblo.Application` project surfaced **six other files** with `using Hangfire;` directives that the spec does not address:
+
+- `Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs` (uses `Hangfire.JobStorage`)
+- `Features/Dashboard/DashboardModule.cs` (registers `JobStorage.Current` in DI)
+- `Features/Article/UseCases/Generate/GenerateArticleJob.cs` (`[AutomaticRetry]` attribute)
+- `Features/Article/UseCases/GenerateArticle/GenerateArticleHandler.cs`
+- `Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs`
+- `Features/MeetingTasks/Infrastructure/Jobs/PlaudPollingJob.cs`
+
+Consequently the `Hangfire.Core` `PackageReference` in `Anela.Heblo.Application.csproj` **must remain** after this refactor. FR-2's hard rule "`grep -r "using Hangfire" backend/src/Anela.Heblo.Application/` returns no results" conflicts with its softer escape clause "unless another legitimate Application-layer use remains". This conflict must be resolved in the spec before implementation begins (see *Specification Amendments*).
+
+Integration points are localised and well-understood: the only callers are `RecurringJobDiscoveryService` (startup) and `HangfireRecurringJobScheduler` (runtime CRON updates), both already in `Anela.Heblo.API/Infrastructure/Hangfire/`. Test infrastructure (`HangfireTestFixture`, `[Collection("Hangfire")]`) is already in `Anela.Heblo.Tests` and needs only namespace/folder updates.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Domain
+  └─ Features/BackgroundJobs/IRecurringJob (abstraction)
+
+Anela.Heblo.Application                       (no Hangfire-static use after refactor)
+  └─ Features/BackgroundJobs/
+        ├─ Services/IHangfireJobEnqueuer            (abstraction)
+        └─ Services/IHangfireRecurringJobScheduler  (abstraction)
+  └─ Application.csproj
+        └─ PackageReference Hangfire.Core           (REMAINS — used by other tiles/jobs)
+
+Anela.Heblo.API
+  └─ Infrastructure/Hangfire/
+        ├─ HangfireJobEnqueuer.cs
+        ├─ HangfireRecurringJobScheduler.cs ─────────► calls ─┐
+        ├─ RecurringJobDiscoveryService.cs ──────────► calls ─┤
+        ├─ HangfireJobRegistrationHelper.cs  (NEW LOCATION) ◄─┘
+        └─ ... (dashboard auth filters, schema init, worker)
+  └─ Extensions/ServiceCollectionExtensions.cs (AddHangfireServices — unchanged)
+
+Anela.Heblo.Tests
+  └─ Features/BackgroundJobs/Infrastructure/HangfireTestFixture.cs (unchanged)
+  └─ Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs (RELOCATED)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Target namespace and folder
+
+**Options considered:**
+- (a) `Anela.Heblo.API.Infrastructure.Hangfire` — matches sibling files (`HangfireRecurringJobScheduler`, `RecurringJobDiscoveryService`, `HangfireJobEnqueuer`).
+- (b) `Anela.Heblo.API.Hangfire` — shorter but inconsistent with current sibling files.
+
+**Chosen approach:** (a) — file at `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`, namespace `Anela.Heblo.API.Infrastructure.Hangfire`.
+
+**Rationale:** Mirrors the existing convention used by every Hangfire adapter file in the API project today. Zero new precedent.
+
+#### Decision 2: Keep `public static`, do not introduce a wrapper interface
+
+**Options considered:**
+- (a) Preserve `public static class HangfireJobRegistrationHelper` exactly.
+- (b) Convert to `internal static` since callers are now in the same assembly.
+- (c) Refactor to an injected `IHangfireJobRegistrar` for testability.
+
+**Chosen approach:** (a). The spec is explicit: "The class type, public surface … must be preserved exactly" and "Renaming the helper or splitting its responsibilities … is a separate change".
+
+**Rationale:** This is a pure structural move. Accessibility change is technically safe (both callers are in the API assembly, no `InternalsVisibleTo` gymnastics needed because `Anela.Heblo.API` already exposes internals to `Anela.Heblo.Tests`) but it is **out of scope** per FR-1's "accessibility … are unchanged" clause and Out of Scope section. A follow-up task can tighten visibility and introduce a wrapper.
+
+#### Decision 3: Test project placement
+
+**Options considered:**
+- (a) Keep tests in the single `Anela.Heblo.Tests` project but relocate folder to mirror the new source path: `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs`.
+- (b) Leave tests at the current path and only update the `using` directive.
+
+**Chosen approach:** (a) — move the test file to a folder that mirrors the production location.
+
+**Rationale:** The repo has a single shared test project (`Anela.Heblo.Tests`) covering both Application and API code. FR-4's "move them to the appropriate API test project" is satisfied at the *folder* level, not the *project* level. Mirroring source paths under `tests/` is the codebase's existing convention (see `Adapters.Flexi.Tests` etc.) and aligns with `csharp-testing` guidance.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Create / move:**
+- Move `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` → `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs` using `git mv` (preserves history per NFR-4).
+- Move `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` → `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs` using `git mv`.
+
+**Edit:**
+- In the moved helper file: change namespace from `Anela.Heblo.Application.Features.BackgroundJobs.Services` to `Anela.Heblo.API.Infrastructure.Hangfire`. Body unchanged.
+- In `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireRecurringJobScheduler.cs` (line 1): remove `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` — no replacement needed (helper is now in the same namespace as the file).
+- In `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` (line 1): same removal.
+- In the moved test file: update `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` → `using Anela.Heblo.API.Infrastructure.Hangfire;`. Also update the test class namespace from `Anela.Heblo.Tests.Features.BackgroundJobs` → `Anela.Heblo.Tests.Infrastructure.Hangfire` and adjust the `using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;` reference (the `HangfireTestFixture` stays put).
+
+**Do NOT edit:**
+- `Anela.Heblo.Application.csproj` — `Hangfire.Core` PackageReference must remain (see Architectural Fit).
+- Any of the other six Application files that use `Hangfire` — explicitly out of scope.
+- `BackgroundJobsModule.cs` — its comment already correctly describes the architecture and references only `IHangfireJobEnqueuer`/`IHangfireRecurringJobScheduler`, which are unaffected.
+
+### Interfaces and Contracts
+
+No interface changes. The helper's public surface is preserved:
+
+```csharp
+public static class HangfireJobRegistrationHelper
+{
+    public static void RegisterOrUpdate(
+        Type jobType,
+        string jobName,
+        string cronExpression,
+        string timeZoneId);
+}
+```
+
+The two `IHangfire*` abstractions in `Anela.Heblo.Application.Features.BackgroundJobs.Services` remain untouched and continue to be the cross-layer contracts.
+
+### Data Flow
+
+Unchanged. Both call paths produce identical Hangfire records:
+
+```
+Startup:   RecurringJobDiscoveryService (API/Hosted)
+           ─► reads DB CRON via IRecurringJobConfigurationRepository
+           ─► HangfireJobRegistrationHelper.RegisterOrUpdate(...)
+           ─► RecurringJob.AddOrUpdate<TJob>(...)
+
+Runtime:   UpdateRecurringJobCronHandler (Application/MediatR)
+           ─► IHangfireRecurringJobScheduler.UpdateCronSchedule (API impl)
+           ─► HangfireJobRegistrationHelper.RegisterOrUpdate(...)
+           ─► RecurringJob.AddOrUpdate<TJob>(...)
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| FR-2's strict `grep` acceptance criterion is unsatisfiable while six other files in Application still use `Hangfire`; blind enforcement would scope-creep this refactor. | High | Apply the *Specification Amendments* below before implementation. Narrow FR-2 to the helper's own dependency. |
+| Reviewers expect `Hangfire.Core` removed from `Application.csproj` and reject the PR. | Medium | Add a one-line note to the PR description: "Application.csproj retains Hangfire.Core because FailedJobsTile, AutomaticRetry attributes, GenerateArticleJob, ProductExportDownloadJob, PlaudPollingJob, and GenerateArticleHandler still depend on it. Out of scope per spec." Link to a follow-up tracking issue. |
+| `git mv` not used → file history orphaned, violating NFR-4. | Medium | Mandate `git mv` in the PR checklist. Verify with `git log --follow backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`. |
+| Test file relocated but `HangfireTestFixture` not — broken `using` reference. | Low | The fixture lives at `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/Infrastructure/HangfireTestFixture.cs` and stays put. The moved test must keep `using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;`. Verify the `[Collection("Hangfire")]` attribute still resolves. |
+| Reflection inside `HangfireJobRegistrationHelper.RegisterOrUpdate` looks up `RegisterOrUpdateGeneric` by name with `BindingFlags.NonPublic | BindingFlags.Static`. Type identity is preserved by the namespace change, but a typo in the move would surface only at runtime. | Medium | Existing tests `RegisterOrUpdate_WithValidInputs_RegistersJobInHangfireStorage` and `RegisterOrUpdate_WithInvalidTimeZoneId_ThrowsUnwrappedTimeZoneNotFoundException` cover the reflection path. Confirm both pass after move (NFR-2). |
+| Hidden assembly-internal consumer (e.g. a Razor/MVC view, reflective scan) referencing the old namespace string. | Low | Run `grep -r "Anela.Heblo.Application.Features.BackgroundJobs.Services.HangfireJobRegistrationHelper"` across the whole repo (including non-`.cs` files) before declaring done. |
+
+## Specification Amendments
+
+The following changes to `spec.r1.md` are **required** before implementation can start cleanly:
+
+**Amendment A — FR-2 acceptance criteria (rewrite):**
+
+Replace the current FR-2 acceptance bullets with:
+
+> - `HangfireJobRegistrationHelper.cs` no longer exists under `Anela.Heblo.Application/`.
+> - No new `using Hangfire;` directive is introduced in `Anela.Heblo.Application/` by this change. (Pre-existing usages in `FailedJobsTile`, `DashboardModule`, `GenerateArticleJob`, `GenerateArticleHandler`, `ProductExportDownloadJob`, `PlaudPollingJob` remain and are explicitly out of scope.)
+> - `Anela.Heblo.Application.csproj`'s `Hangfire.Core` `PackageReference` is **retained**, justified by the six pre-existing consumers listed above. A follow-up issue is filed to evaluate moving those consumers (or their Hangfire-coupled bits) to API/Infrastructure in a future change.
+> - `dotnet build` succeeds for the full solution.
+
+**Amendment B — Out of Scope (add bullet):**
+
+> - Removing the residual `Application` → `Hangfire.Core` package reference. Six other files in `Application` still use Hangfire types (`JobStorage`, `[AutomaticRetry]`, etc.). A separate, broader Clean Architecture cleanup is needed and is explicitly **not** addressed here.
+
+**Amendment C — FR-4 clarification:**
+
+The repo has a single shared `Anela.Heblo.Tests` project — there is no separate "API test project". FR-4's intent is satisfied by:
+- Moving `HangfireJobRegistrationHelperTests.cs` to a folder that mirrors the new source location: `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/`.
+- Updating its namespace to `Anela.Heblo.Tests.Infrastructure.Hangfire`.
+- Updating the `using` directive to `Anela.Heblo.API.Infrastructure.Hangfire`.
+
+## Prerequisites
+
+None.
+
+- No migrations.
+- No infrastructure changes (`AddHangfireServices` registration is unchanged).
+- No new packages — `Hangfire.AspNetCore` and `Hangfire.Core` are already referenced by `Anela.Heblo.API.csproj` (transitively giving the helper access to `Hangfire.RecurringJob` in its new home).
+- No configuration changes.
+- No deployment ordering constraints — single Docker image, single deploy.

--- a/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/brief.md
+++ b/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/brief.md
@@ -1,0 +1,21 @@
+## Module
+BackgroundJobs
+
+## Finding
+`HangfireJobRegistrationHelper` is a public static class in the Application layer that directly calls the Hangfire infrastructure API:
+
+- **File**: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`
+- **Lines 4, 52–68, 71–86**: `using Hangfire;` + `RecurringJob.AddOrUpdate<TJob>(...)` and reflection dispatch to `RegisterOrUpdateGeneric<TJob>` which calls the Hangfire static API.
+
+The module's own `BackgroundJobsModule.cs` comment explicitly acknowledges the correct rule: *"Hangfire adapter implementations (IHangfireJobEnqueuer, IHangfireRecurringJobScheduler) are registered in Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices because their implementations live in the API project (Clean Architecture dependency rule)."*
+
+Despite that, this static helper — which does exactly the same kind of infrastructure work — was placed in the Application project.
+
+## Why it matters
+Clean Architecture forbids the Application layer from depending on Infrastructure. `Hangfire.RecurringJob` is a concrete infrastructure class. Placing it in Application introduces a hard dependency from Application → Hangfire in the compiled assembly, which defeats the architectural boundary the codebase otherwise respects. It also makes it impossible to test registration logic without a real Hangfire storage.
+
+## Suggested fix
+Move `HangfireJobRegistrationHelper` to the API project alongside the other Hangfire infrastructure code, e.g. `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`. The callers (startup discovery and runtime CRON update in the API/Infrastructure layer) already live there and the class has no callers in Application itself.
+
+---
+_Filed by daily arch-review routine on 2026-05-28._

--- a/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/impl/main.r1.md
@@ -1,0 +1,50 @@
+All 6 tasks complete. Here is the output artifact:
+
+---
+
+# Implementation: Move HangfireJobRegistrationHelper to API Layer
+
+## What was implemented
+
+Pure structural refactor relocating `HangfireJobRegistrationHelper` from `Anela.Heblo.Application/Features/BackgroundJobs/Services/` to `Anela.Heblo.API/Infrastructure/Hangfire/`. The Application layer no longer takes a compile-time dependency on the Hangfire static API through this helper. Class body, method signatures, reflection dispatch, and runtime behavior are byte-for-byte unchanged.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs` — helper moved here; namespace updated to `Anela.Heblo.API.Infrastructure.Hangfire`
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — deleted (moved via `git mv`)
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — removed now-unused `using Anela.Heblo.Application.Features.BackgroundJobs.Services;`
+- `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs` — test file moved here; namespace updated to `Anela.Heblo.Tests.Infrastructure.Hangfire`; using directive updated to `Anela.Heblo.API.Infrastructure.Hangfire`
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — deleted (moved via `git mv`)
+
+## Tests
+
+`backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs` — 14 tests covering: valid inputs, double-registration (update), null job type, missing job name (3 variants), missing cron (3 variants), missing time zone (3 variants), non-`IRecurringJob` type, invalid time zone ID. Both reflection-path tests (`RegistersJobInHangfireStorage`, `ThrowsUnwrappedTimeZoneNotFoundException`) pass.
+
+## How to verify
+
+```bash
+dotnet build backend/Anela.Heblo.sln -nologo -v minimal
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" --no-build --nologo
+git log --follow --oneline -3 -- backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+```
+
+## Notes
+
+The plan estimated 7 pre-refactor files with `using Hangfire` in Application; the actual count was 8 (`IHangfireJobEnqueuer.cs` also has one). Post-refactor count is 7 (not 6 as the plan estimated). This does not affect correctness — the amended spec requires only that `HangfireJobRegistrationHelper.cs` be removed from Application, which it is. `Hangfire.Core` PackageReference on `Anela.Heblo.Application.csproj` was intentionally retained (FailedJobsTile, DashboardModule, GenerateArticleJob, GenerateArticleHandler, ProductExportDownloadJob, PlaudPollingJob, and IHangfireJobEnqueuer still depend on it). Removing those references is out of scope per arch-review Amendment B.
+
+## PR Summary
+
+Moves `HangfireJobRegistrationHelper` from the Application layer to `Anela.Heblo.API/Infrastructure/Hangfire/` to restore the Clean Architecture boundary for this helper. The Application project was taking a direct compile-time dependency on the Hangfire static API (`RecurringJob.AddOrUpdate`) through this class, which belongs alongside the other Hangfire adapter code in the API project. Runtime behavior, public surface, and `git --follow` history are fully preserved.
+
+### Changes
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs` — moved here from Application; namespace updated to match sibling files
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — removed (moved via `git mv`)
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — removed now-redundant using directive (helper now in same namespace)
+- `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs` — test file relocated to mirror production path; namespace and using updated
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — removed (moved via `git mv`)
+
+`Hangfire.Core` on `Application.csproj` is intentionally retained — seven other Application files still depend on it. A separate cleanup is needed to evaluate moving those consumers.
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/spec.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/spec.r1.md
@@ -1,0 +1,105 @@
+# Specification: Move HangfireJobRegistrationHelper to API Layer
+
+## Summary
+Relocate `HangfireJobRegistrationHelper` from the Application layer to the API layer to restore the Clean Architecture boundary. The Application project must not reference `Hangfire` (an infrastructure concern); all Hangfire static API calls and registration helpers must live alongside the other Hangfire adapter code in the API project.
+
+## Background
+The `BackgroundJobs` module follows Clean Architecture: Application defines abstractions (`IHangfireJobEnqueuer`, `IHangfireRecurringJobScheduler`) and the API project provides the Hangfire-backed implementations (registered in `Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices`). The module's own `BackgroundJobsModule.cs` documents this rule explicitly.
+
+However, `HangfireJobRegistrationHelper` — a public static class in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — violates this rule:
+- It has `using Hangfire;` at line 4
+- It calls `RecurringJob.AddOrUpdate<TJob>(...)` directly (lines 52–68)
+- It uses reflection to dispatch to `RegisterOrUpdateGeneric<TJob>`, which calls the Hangfire static API (lines 71–86)
+
+This creates a compile-time dependency from `Anela.Heblo.Application` → `Hangfire`, defeating the architectural boundary the rest of the codebase respects. It also blocks meaningful unit testing of registration logic because every call path needs a real Hangfire `JobStorage`.
+
+The brief confirms the helper has **no callers in the Application project itself** — only startup discovery and runtime CRON-update code in the API/Infrastructure layer use it. The move is therefore a pure structural refactor.
+
+## Functional Requirements
+
+### FR-1: Relocate HangfireJobRegistrationHelper to the API project
+Move the file from
+`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs`
+to
+`backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`.
+
+The class type, public surface (method names, generic parameters, signatures, accessibility), and behavior must be preserved exactly. Only the namespace changes (to match the new physical location, e.g. `Anela.Heblo.API.Infrastructure.Hangfire`).
+
+**Acceptance criteria:**
+- The file no longer exists under `Anela.Heblo.Application/Features/BackgroundJobs/Services/`.
+- The file exists at `Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`.
+- The class declaration, method signatures, parameters, return types, and modifiers are unchanged.
+- The namespace reflects the new location and matches the convention used by other types in `Anela.Heblo.API/Infrastructure/Hangfire/`.
+- `git mv` (or equivalent rename in tooling) preserves history where possible.
+
+### FR-2: Remove the Application → Hangfire compile-time dependency
+After the move, the `Anela.Heblo.Application` project must not contain any `using Hangfire;` directives or references to Hangfire types. The Hangfire NuGet package reference (if it exists on the Application `.csproj` solely to support this helper) must be removed from `Anela.Heblo.Application.csproj`.
+
+**Acceptance criteria:**
+- `grep -r "using Hangfire" backend/src/Anela.Heblo.Application/` returns no results.
+- `grep -r "Hangfire\." backend/src/Anela.Heblo.Application/` returns no infrastructure-type references (abstractions named `IHangfire*` defined in Application are not in scope).
+- `Anela.Heblo.Application.csproj` does not declare a `PackageReference` to `Hangfire` or `Hangfire.*` unless another legitimate Application-layer use remains (verify and document).
+- `dotnet build` succeeds for the full solution.
+
+### FR-3: Update all call sites
+Every caller of `HangfireJobRegistrationHelper` must be updated to reference the new namespace. The brief states all callers already live in the API/Infrastructure layer (startup discovery and runtime CRON update), so no cross-layer wiring changes are required.
+
+**Acceptance criteria:**
+- All references to `HangfireJobRegistrationHelper` compile against the new namespace.
+- No `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` (or equivalent legacy namespace) remains anywhere in the solution referring to this helper.
+- Behavior at startup and at runtime CRON updates is unchanged (same jobs registered with the same CRON expressions, queues, and identifiers).
+
+### FR-4: Update or relocate tests
+Any unit/integration tests that target `HangfireJobRegistrationHelper` must be updated to reference the new namespace. If those tests currently live under an Application test project but the helper is now in the API layer, move them to the appropriate API test project. If no tests exist today, none are required by this refactor (testability improvements are out of scope — see Out of Scope).
+
+**Acceptance criteria:**
+- All existing tests for the helper continue to pass.
+- No test references the legacy namespace.
+- Test project layout matches the production project layout (tests for API-layer types live in the API test project).
+
+### FR-5: Preserve runtime behavior
+This is a non-functional refactor. CRON registration, job identifiers, queue assignments, retry attributes, and any reflection-based dispatch behavior must be byte-for-byte equivalent before and after the move.
+
+**Acceptance criteria:**
+- Startup logs list the same set of recurring jobs in the same order with the same CRON expressions.
+- A smoke run against a local Hangfire dashboard shows identical job definitions to the pre-refactor baseline.
+- No new warnings or errors appear in startup logs attributable to this change.
+
+## Non-Functional Requirements
+
+### NFR-1: Architecture
+After the change, `Anela.Heblo.Application` must satisfy the Clean Architecture inward-dependency rule: no references to `Hangfire`, `Microsoft.AspNetCore.*` web infrastructure, or other API/Infrastructure-layer concerns. This refactor closes the specific Application → Hangfire violation; broader audits are out of scope.
+
+### NFR-2: Build & validation
+- `dotnet build` for the full solution must succeed with no new warnings.
+- `dotnet format` must report no formatting changes after the move.
+- All existing backend tests must continue to pass (`dotnet test`).
+
+### NFR-3: Backwards compatibility
+There is no public API exposed by this helper outside the backend solution (it is not used by the frontend, OpenAPI surface, or external consumers). No deprecation period or shim is required. The class is internal-to-codebase and can be moved cleanly.
+
+### NFR-4: Source control
+Use `git mv` (or an editor refactor that preserves history) so that `git log --follow` continues to surface the file's full history at the new path.
+
+## Data Model
+Not applicable. No database tables, entities, or persisted state are affected. No migrations are needed.
+
+## API / Interface Design
+Not applicable. No HTTP endpoints, MediatR contracts, or DTOs are added, removed, or modified. The change is purely structural inside the backend solution.
+
+## Dependencies
+- **Existing**: `Hangfire` NuGet package (already referenced by `Anela.Heblo.API`).
+- **No new packages** are introduced.
+- **Related code** (must remain in sync, but no change required by this spec): `BackgroundJobsModule.cs`, `Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices`, the `IHangfireJobEnqueuer` / `IHangfireRecurringJobScheduler` abstractions in Application and their API-layer implementations.
+
+## Out of Scope
+- **Testability improvements**: Introducing a wrapper around `RecurringJob.AddOrUpdate` to enable unit testing without a real Hangfire `JobStorage`. The brief mentions this as a benefit of moving the class, but the refactor itself does not require it. File a separate task if desired.
+- **Broader Clean Architecture audit**: Other potential layering violations in the `BackgroundJobs` module or elsewhere are not addressed here.
+- **Renaming the helper or splitting its responsibilities**: Generic dispatch via reflection and the `RegisterOrUpdateGeneric<TJob>` pattern remain as-is. Any redesign is a separate change.
+- **Changing job registration semantics**: No CRON expressions, queue names, retry policies, or job IDs change.
+- **Frontend changes**: None — this helper has no UI surface.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/task-plan.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-hangfirejobre/task-plan.r1.md
@@ -1,0 +1,14 @@
+Plan saved to `docs/superpowers/plans/2026-06-01-move-hangfire-job-registration-helper.md`.
+
+## Summary
+
+Six-task, TDD-flavored plan for relocating `HangfireJobRegistrationHelper` from the Application layer to the API layer:
+
+1. **Baseline** — verify clean build, green tests, and snapshot the `using Hangfire` count in Application as evidence (7 → 6).
+2. **Move source** — `git mv` the helper + change namespace to `Anela.Heblo.API.Infrastructure.Hangfire`; intentionally leaves the test project broken to confirm Task 3 is needed.
+3. **Move tests** — `git mv` test file to mirror the production path, update one using directive and the namespace. The `HangfireTestFixture` stays put.
+4. **Cleanup** — remove the now-unused `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` from `RecurringJobDiscoveryService.cs`. Deliberately keep it in `HangfireRecurringJobScheduler.cs` (still needed for `IHangfireRecurringJobScheduler`).
+5. **Validate** — repo-wide stale-reference grep, full build/test/format, `git log --follow` check.
+6. **Commit** — single atomic conventional-commit, explicitly documenting why `Hangfire.Core` stays on `Application.csproj` (six other callers; out of scope per Amendment B).
+
+Every step includes the exact command, expected output, and any code change inline. The self-review table at the end maps each FR/NFR/Decision/Risk from the spec and arch-review to the task that addresses it.

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Hangfire;
 
-namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
 
 /// <summary>
 /// Single entry point for binding a runtime <see cref="Type"/> to

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
@@ -1,4 +1,3 @@
-using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Xcc;
 using Microsoft.Extensions.Options;

--- a/backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs
@@ -1,11 +1,11 @@
-using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.API.Infrastructure.Hangfire;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
 using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
 using Hangfire;
 using Hangfire.Storage;
 using Xunit;
 
-namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+namespace Anela.Heblo.Tests.Infrastructure.Hangfire;
 
 [Collection("Hangfire")]
 public class HangfireJobRegistrationHelperTests : IDisposable

--- a/docs/superpowers/plans/2026-06-01-move-hangfire-job-registration-helper.md
+++ b/docs/superpowers/plans/2026-06-01-move-hangfire-job-registration-helper.md
@@ -1,0 +1,585 @@
+# Move HangfireJobRegistrationHelper to API Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Relocate `HangfireJobRegistrationHelper` from `Anela.Heblo.Application` to `Anela.Heblo.API/Infrastructure/Hangfire/`, restoring the Clean Architecture boundary for the helper itself while preserving exact runtime behavior, public surface, and `git --follow` history.
+
+**Architecture:** Pure structural refactor — single file move (source + test) plus namespace updates. No interface changes, no DI wiring changes, no package additions. Existing tests (8 in `HangfireJobRegistrationHelperTests`) act as the regression safety net. The `Hangfire.Core` `PackageReference` on `Anela.Heblo.Application.csproj` is **retained** because six other Application-layer files still depend on it (out of scope per the architecture review).
+
+**Tech Stack:** .NET 8, C# 12, xUnit, Hangfire 1.8.21, `git mv`.
+
+---
+
+## File Structure
+
+### Files moved (use `git mv`)
+
+| From | To |
+|---|---|
+| `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` | `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs` |
+| `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` | `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs` |
+
+### Files edited in place (using directive cleanup)
+
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — remove now-unused `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` (line 1). All other types used by this file resolve from `Anela.Heblo.Domain.*`, `Microsoft.*`, or the file's own namespace.
+
+### Files explicitly NOT edited
+
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireRecurringJobScheduler.cs` — keeps `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` because that namespace still provides the `IHangfireRecurringJobScheduler` interface it implements. The helper resolves via the file's own `Anela.Heblo.API.Infrastructure.Hangfire` namespace.
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — the `Hangfire.Core` `PackageReference` (line 13) **stays**. Six other Application files (`FailedJobsTile`, `DashboardModule`, `GenerateArticleJob`, `GenerateArticleHandler`, `ProductExportDownloadJob`, `PlaudPollingJob`) still use Hangfire types. Removing the package would break them and is explicitly out of scope per `spec.r1.md` Out of Scope and `arch-review.r1.md` Amendment B.
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/BackgroundJobsModule.cs` — already accurate (refers only to the unchanged `IHangfireJobEnqueuer`/`IHangfireRecurringJobScheduler` abstractions).
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/Infrastructure/HangfireTestFixture.cs` — stays at this path; the moved test references it via `using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;` (unchanged).
+
+### Target final state for the moved helper
+
+```csharp
+using System.Reflection;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Hangfire;
+
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+
+/// <summary>
+/// Single entry point for binding a runtime <see cref="Type"/> to
+/// <see cref="RecurringJob.AddOrUpdate{TJob}(string, System.Linq.Expressions.Expression{Action{TJob}}, string, RecurringJobOptions)"/>.
+/// Used by both startup discovery and runtime CRON updates so that both code paths
+/// produce identical Hangfire <c>RecurringJob</c> records.
+/// </summary>
+public static class HangfireJobRegistrationHelper
+{
+    // ... body unchanged from current Application-layer version ...
+}
+```
+
+### Target final state for the moved test class declaration
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using Anela.Heblo.Domain.Features.BackgroundJobs;
+using Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure;
+using Hangfire;
+using Hangfire.Storage;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Infrastructure.Hangfire;
+
+[Collection("Hangfire")]
+public class HangfireJobRegistrationHelperTests : IDisposable
+{
+    // ... body unchanged ...
+}
+```
+
+---
+
+## Task 1: Establish green baseline
+
+Confirm the solution builds, formats, and the `HangfireJobRegistrationHelperTests` are green **before** any changes. This locks in the regression-safety contract.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Build the solution to confirm a clean starting point**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln -nologo -v minimal
+```
+
+Expected: `Build succeeded` with `0 Warning(s)` and `0 Error(s)` for the affected projects (`Anela.Heblo.Application`, `Anela.Heblo.API`, `Anela.Heblo.Tests`). If warnings exist that pre-date this refactor, note them — the post-refactor build must not show *new* warnings.
+
+- [ ] **Step 2: Run the target tests to confirm baseline green**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" \
+  --no-build --nologo -v normal
+```
+
+Expected: `Passed!` with 8 tests passed (1×`WithValidInputs`, 1×`CalledTwice`, 1×`WithNullJobType`, 3×`WithMissingJobName`, 3×`WithMissingCron`, 3×`WithMissingTimeZoneId`, 1×`TypeNotImplementingIRecurringJob`, 1×`WithInvalidTimeZoneId` — total 8 distinct `[Fact]`/`[Theory]` rows expanding to ~14 test runs).
+
+- [ ] **Step 3: Confirm formatter is clean**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes --severity warn
+```
+
+Expected: exit code 0 with no diff. If pre-existing format drift is reported, document it; the refactor must not introduce *new* drift.
+
+- [ ] **Step 4: Snapshot current `using Hangfire` count in Application (for FR-2 acceptance evidence)**
+
+Run:
+
+```bash
+grep -rln "using Hangfire" backend/src/Anela.Heblo.Application/ | sort
+```
+
+Expected (pre-refactor, 7 files):
+
+```
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/GenerateArticle/GenerateArticleHandler.cs
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs
+backend/src/Anela.Heblo.Application/Features/Dashboard/DashboardModule.cs
+backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
+backend/src/Anela.Heblo.Application/Features/MeetingTasks/Infrastructure/Jobs/PlaudPollingJob.cs
+```
+
+Record this list — after the refactor the same command must return exactly six files (helper removed; others untouched).
+
+---
+
+## Task 2: Move the source file with `git mv` and update its namespace
+
+This task physically relocates the file with history preserved, then changes only its namespace. The class body is byte-for-byte identical.
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` → `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`
+- Modify: the moved file (namespace only).
+
+- [ ] **Step 1: Verify the destination folder exists**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.API/Infrastructure/Hangfire/
+```
+
+Expected: lists sibling files including `HangfireJobEnqueuer.cs`, `HangfireRecurringJobScheduler.cs`, `RecurringJobDiscoveryService.cs`. The folder exists; no `mkdir` is needed.
+
+- [ ] **Step 2: Move the file with `git mv` (preserves history per NFR-4)**
+
+Run:
+
+```bash
+git mv \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs \
+  backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+```
+
+Expected: no output (success). Then verify:
+
+```bash
+git status
+```
+
+Expected output includes:
+
+```
+        renamed:    backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs -> backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+```
+
+A `renamed:` (not `deleted: ... new file: ...`) line is the proof that history is preserved.
+
+- [ ] **Step 3: Update the namespace in the moved file**
+
+Edit `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs`. Change line 5 only:
+
+From:
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+```
+
+To:
+
+```csharp
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+```
+
+No other line in the file changes. The `using` directives (`System.Reflection`, `Anela.Heblo.Domain.Features.BackgroundJobs`, `Hangfire`), class signature, both methods, all attributes, and reflection lookups stay identical.
+
+- [ ] **Step 4: Confirm history follows through the rename**
+
+Run:
+
+```bash
+git log --follow --oneline -3 -- backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+```
+
+Expected: shows at least the original creation commit (`9d8eeb81 feat: Consolidate Hangfire RecurringJob Registration (#1911)`) plus any later edits — proving the rename was tracked.
+
+- [ ] **Step 5: Sanity-build the API project to confirm the helper compiles in its new home**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj -nologo -v minimal
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. The two callers (`RecurringJobDiscoveryService`, `HangfireRecurringJobScheduler`) live in the same `Anela.Heblo.API.Infrastructure.Hangfire` namespace as the moved helper, so they resolve it without any new `using` directive.
+
+**Do not commit yet** — the test project does not yet compile (test file still references the old namespace). Move on to Task 3.
+
+---
+
+## Task 3: Move the test file and update its namespace + using directive
+
+The test class moves to mirror the production folder structure. Its `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` directive must be replaced with `using Anela.Heblo.API.Infrastructure.Hangfire;` so it can resolve the helper at the new location.
+
+**Files:**
+- Move: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` → `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs`
+- Modify: the moved test file (namespace + one using directive).
+
+- [ ] **Step 1: Create the destination test folder if missing**
+
+Run:
+
+```bash
+mkdir -p backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire
+```
+
+Expected: no output (folder created or already exists; idempotent).
+
+- [ ] **Step 2: Verify the test build is currently broken (red proof that Task 2 needs a follow-through)**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj -nologo -v minimal
+```
+
+Expected: `Build FAILED` with error CS0234 or CS0246, e.g.:
+
+```
+HangfireJobRegistrationHelperTests.cs(...): error CS0234: The type or namespace name 'HangfireJobRegistrationHelper' does not exist in the namespace 'Anela.Heblo.Application.Features.BackgroundJobs.Services'
+```
+
+This confirms the test file is the only remaining stale reference. **This is expected mid-refactor — it gets fixed in the next steps.**
+
+- [ ] **Step 3: Move the test file with `git mv`**
+
+Run:
+
+```bash
+git mv \
+  backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs \
+  backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs
+```
+
+Expected: no output. Then `git status` shows another `renamed:` entry.
+
+- [ ] **Step 4: Update the using directive in the moved test file**
+
+Edit `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs`. Change line 1:
+
+From:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+```
+
+To:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Hangfire;
+```
+
+Leave the remaining usings (`Anela.Heblo.Domain.Features.BackgroundJobs`, `Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure`, `Hangfire`, `Hangfire.Storage`, `Xunit`) untouched. The `HangfireTestFixture` and `[Collection("Hangfire")]` resolution still works because the fixture stays at `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/Infrastructure/HangfireTestFixture.cs` with namespace `Anela.Heblo.Tests.Features.BackgroundJobs.Infrastructure`.
+
+- [ ] **Step 5: Update the test class namespace**
+
+In the same file, change line 8 (after the using-block change above the declaration moves to where the namespace lives, around line 8):
+
+From:
+
+```csharp
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+```
+
+To:
+
+```csharp
+namespace Anela.Heblo.Tests.Infrastructure.Hangfire;
+```
+
+The class body — including the two private nested types `HelperTestRecurringJob` and `NotARecurringJob`, the `Dispose()` method, and all `[Fact]`/`[Theory]` methods — is unchanged.
+
+- [ ] **Step 6: Build the test project to confirm it compiles again**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj -nologo -v minimal
+```
+
+Expected: `Build succeeded` with `0 Error(s)`.
+
+- [ ] **Step 7: Run only the moved tests to confirm runtime equivalence**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~HangfireJobRegistrationHelperTests" \
+  --no-build --nologo -v normal
+```
+
+Expected: `Passed!` with the same test count as the baseline in Task 1 Step 2. In particular, these two tests prove the reflection path still works after the namespace change:
+
+- `RegisterOrUpdate_WithValidInputs_RegistersJobInHangfireStorage` — exercises `RegisterOrUpdateGeneric<TJob>` via reflection and asserts the job lands in `JobStorage.Current` with the right cron, time zone, and async `Task` return type.
+- `RegisterOrUpdate_WithInvalidTimeZoneId_ThrowsUnwrappedTimeZoneNotFoundException` — exercises the `TargetInvocationException` unwrapping path.
+
+If either fails, the reflection lookup (`typeof(HangfireJobRegistrationHelper).GetMethod(nameof(RegisterOrUpdateGeneric), ...)`) is broken — re-read the moved helper file and confirm `RegisterOrUpdateGeneric` is still a `private static` method on the same `HangfireJobRegistrationHelper` type.
+
+---
+
+## Task 4: Remove the now-unused using directive in `RecurringJobDiscoveryService`
+
+Of the two API call sites, only `RecurringJobDiscoveryService.cs` imports the legacy `Anela.Heblo.Application.Features.BackgroundJobs.Services` namespace solely for the helper — the file uses no other type from that namespace. Removing the now-unused directive keeps the file tidy and is required by FR-3 ("No `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` … remains anywhere in the solution referring to this helper").
+
+`HangfireRecurringJobScheduler.cs` keeps the directive because it implements `IHangfireRecurringJobScheduler` from the same namespace.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs:1`
+
+- [ ] **Step 1: Confirm the file does not depend on any other type from that namespace**
+
+Run:
+
+```bash
+grep -E "(IHangfireJobEnqueuer|IHangfireRecurringJobScheduler|HangfireJobRegistrationHelper)" \
+  backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs
+```
+
+Expected: matches only `HangfireJobRegistrationHelper.RegisterOrUpdate(...)` at one location (around line 79). The other two interfaces are not used in this file — so removing the using is safe.
+
+- [ ] **Step 2: Delete the legacy using directive**
+
+Edit `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs`. Delete line 1:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+```
+
+The remaining usings (`Anela.Heblo.Domain.Features.BackgroundJobs`, `Anela.Heblo.Xcc`, `Microsoft.Extensions.Options`) stay. The file's namespace `Anela.Heblo.API.Infrastructure.Hangfire` (line 6) already resolves `HangfireJobRegistrationHelper` at its new location.
+
+- [ ] **Step 3: Confirm `HangfireRecurringJobScheduler.cs` is intentionally untouched**
+
+Run:
+
+```bash
+grep -n "using Anela.Heblo.Application.Features.BackgroundJobs.Services" \
+  backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireRecurringJobScheduler.cs
+```
+
+Expected: matches line 1. This is correct — the file implements `IHangfireRecurringJobScheduler` from that namespace and must keep the using.
+
+- [ ] **Step 4: Re-build the API project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj -nologo -v minimal
+```
+
+Expected: `Build succeeded` with `0 Error(s)` and no *new* warnings versus the Task 1 baseline.
+
+---
+
+## Task 5: Repo-wide stale-reference audit and full validation
+
+Catch any hidden consumer of the old namespace (Razor views, configuration files, comments, or reflective string lookups) before declaring done. Then run the full suite.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Search the entire repo for any stale reference to the old helper path**
+
+Run:
+
+```bash
+grep -rn "Anela.Heblo.Application.Features.BackgroundJobs.Services.HangfireJobRegistrationHelper" .
+```
+
+Expected: zero matches in source/test directories. Matches in `docs/`, `artifacts/`, or this plan file itself are allowed (and expected — they describe the history of the refactor).
+
+- [ ] **Step 2: Verify FR-2 acceptance — Application no longer carries the helper's Hangfire dependency**
+
+Run:
+
+```bash
+grep -rln "using Hangfire" backend/src/Anela.Heblo.Application/ | sort
+```
+
+Expected (post-refactor, **6 files** — helper removed, six pre-existing consumers retained):
+
+```
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/Generate/GenerateArticleJob.cs
+backend/src/Anela.Heblo.Application/Features/Article/UseCases/GenerateArticle/GenerateArticleHandler.cs
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
+backend/src/Anela.Heblo.Application/Features/Dashboard/DashboardModule.cs
+backend/src/Anela.Heblo.Application/Features/FileStorage/Infrastructure/Jobs/ProductExportDownloadJob.cs
+backend/src/Anela.Heblo.Application/Features/MeetingTasks/Infrastructure/Jobs/PlaudPollingJob.cs
+```
+
+Diff against the Task 1 Step 4 snapshot: exactly **one** entry removed — `HangfireJobRegistrationHelper.cs`. No other Application files affected.
+
+- [ ] **Step 3: Confirm `Anela.Heblo.Application.csproj` still references `Hangfire.Core` (intentional per Amendment A)**
+
+Run:
+
+```bash
+grep -n "Hangfire.Core" backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: one line `<PackageReference Include="Hangfire.Core" Version="1.8.21" />`. **Do not remove.** The six retained consumers above still need it. Removal is tracked separately (Amendment B / spec Out of Scope).
+
+- [ ] **Step 4: Full-solution build**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln -nologo -v minimal
+```
+
+Expected: `Build succeeded` with `0 Error(s)` and no new warnings versus baseline (NFR-2).
+
+- [ ] **Step 5: Run the full test suite**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --no-build --nologo
+```
+
+Expected: all tests pass. In particular, both Hangfire-collection test classes (`HangfireJobRegistrationHelperTests` at its new path, plus any other `[Collection("Hangfire")]` consumer) green. The shared `HangfireTestFixture` continues to provide the in-memory `JobStorage`.
+
+- [ ] **Step 6: Confirm no formatting drift introduced**
+
+Run:
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes --severity warn
+```
+
+Expected: exit code 0. If it reports diffs, run `dotnet format backend/Anela.Heblo.sln` to apply, then re-run `--verify-no-changes` to confirm.
+
+- [ ] **Step 7: Verify rename history is intact (NFR-4 acceptance)**
+
+Run:
+
+```bash
+git log --follow --oneline -3 -- backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+git log --follow --oneline -3 -- backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs
+```
+
+Expected: each command lists the pre-rename commit history of the moved file, proving `git log --follow` continues to work.
+
+---
+
+## Task 6: Commit
+
+Single atomic commit — the refactor is meaningful only as a complete unit. Intermediate states (after Task 2, before Task 3) do not build, so partial commits are inappropriate.
+
+**Files:** none modified in this task (only staging + commit).
+
+- [ ] **Step 1: Review the diff one last time**
+
+Run:
+
+```bash
+git status
+git diff --stat HEAD
+```
+
+Expected `git status` shows exactly:
+- `renamed:` for the helper source file (Application → API path).
+- `renamed:` for the test file (Features/BackgroundJobs → Infrastructure/Hangfire path).
+- `modified:` for `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` (one line removed).
+- The two renamed files also show small content changes (namespace lines only).
+
+No other files in the diff. If anything else appears, investigate before committing.
+
+- [ ] **Step 2: Stage the four affected files explicitly**
+
+Run:
+
+```bash
+git add \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs \
+  backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs \
+  backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs \
+  backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs \
+  backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs
+```
+
+(Both the old and new paths for the renamed files are listed so `git add` records the rename correctly even if `git mv` was simulated by a manual move + delete in some environments.)
+
+Expected: no output.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: Move HangfireJobRegistrationHelper from Application to API layer
+
+Relocates HangfireJobRegistrationHelper.cs from
+Anela.Heblo.Application/Features/BackgroundJobs/Services/ to
+Anela.Heblo.API/Infrastructure/Hangfire/ so the Application layer no
+longer takes a compile-time dependency on the Hangfire static API
+through this helper. Public surface, method signatures, reflection
+dispatch, and runtime behavior are byte-for-byte unchanged.
+
+- Source helper moved with git mv; namespace updated to
+  Anela.Heblo.API.Infrastructure.Hangfire (matches sibling adapters).
+- Tests moved to backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/
+  mirroring the new production path; using directive updated.
+- RecurringJobDiscoveryService.cs: stale using directive removed.
+- HangfireRecurringJobScheduler.cs: using retained — that namespace
+  still provides IHangfireRecurringJobScheduler.
+
+Hangfire.Core PackageReference on Anela.Heblo.Application.csproj is
+retained because FailedJobsTile, DashboardModule (JobStorage.Current),
+GenerateArticleJob, GenerateArticleHandler, ProductExportDownloadJob,
+and PlaudPollingJob still depend on it. Removing those references is
+tracked separately (spec Out of Scope; arch-review Amendment B).
+EOF
+)"
+```
+
+Expected: commit succeeds; no pre-commit hook errors. If a hook reports format/lint issues, fix and create a **new** commit (do not `--amend`).
+
+- [ ] **Step 4: Final post-commit sanity check**
+
+Run:
+
+```bash
+git log --oneline -1
+git log --follow --oneline -3 -- backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs
+```
+
+Expected:
+- Top commit is the refactor commit.
+- `git log --follow` still surfaces the original creation commit of the helper.
+
+---
+
+## Spec Coverage Self-Review
+
+| Spec / Arch-Review item | Task(s) addressing it |
+|---|---|
+| FR-1 (relocate helper file, preserve surface, namespace = `Anela.Heblo.API.Infrastructure.Hangfire`) | Task 2 Steps 2–3 |
+| FR-2 amended (helper-specific Hangfire dependency removed from Application; `Hangfire.Core` package retained for other callers) | Task 5 Steps 2–3 |
+| FR-3 (all call sites compile against new namespace; no `using Anela.Heblo.Application.Features.BackgroundJobs.Services;` referring to the helper remains) | Task 4 (`RecurringJobDiscoveryService` cleanup) + Task 5 Step 1 (repo-wide audit). Note: `HangfireRecurringJobScheduler.cs` retains the using legitimately for `IHangfireRecurringJobScheduler`. |
+| FR-4 amended (tests relocated under `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/`, namespace and using updated) | Task 3 |
+| FR-5 (runtime behavior preserved) | Task 3 Step 7 (reflection-path tests green); Task 5 Step 5 (full suite green) |
+| NFR-1 (Clean Architecture boundary restored for the helper) | Task 5 Step 2 |
+| NFR-2 (build, format, tests succeed; no new warnings) | Task 5 Steps 4–6 |
+| NFR-3 (no backwards-compat shim needed) | N/A — confirmed in Task 5 Step 1 (no external consumers found) |
+| NFR-4 (history preserved via `git mv`) | Task 2 Steps 2 & 4; Task 3 Step 3; Task 5 Step 7 |
+| Arch-review Decision 1 (namespace `Anela.Heblo.API.Infrastructure.Hangfire`) | Task 2 Step 3 |
+| Arch-review Decision 2 (keep `public static`, no accessibility change) | Task 2 Step 3 — only namespace line changed; class declaration untouched |
+| Arch-review Decision 3 (mirror test folder structure) | Task 3 Steps 3 & 5 |
+| Arch-review Risk: reflection path | Task 3 Step 7 explicitly verifies both reflection-exercising tests |
+| Arch-review Risk: hidden stale reference | Task 5 Step 1 |
+| Arch-review Risk: `git mv` not used | Task 2 Step 4 + Task 5 Step 7 verify `git log --follow` |
+| Arch-review Risk: PR reviewer expects `Hangfire.Core` removed | Commit message in Task 6 Step 3 explicitly documents the retention and points to the follow-up. |
+
+No spec / arch-review item is left without a covering task.


### PR DESCRIPTION

Moves `HangfireJobRegistrationHelper` from the Application layer to `Anela.Heblo.API/Infrastructure/Hangfire/` to restore the Clean Architecture boundary for this helper. The Application project was taking a direct compile-time dependency on the Hangfire static API (`RecurringJob.AddOrUpdate`) through this class, which belongs alongside the other Hangfire adapter code in the API project. Runtime behavior, public surface, and `git --follow` history are fully preserved.

### Changes
- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireJobRegistrationHelper.cs` — moved here from Application; namespace updated to match sibling files
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/HangfireJobRegistrationHelper.cs` — removed (moved via `git mv`)
- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/RecurringJobDiscoveryService.cs` — removed now-redundant using directive (helper now in same namespace)
- `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireJobRegistrationHelperTests.cs` — test file relocated to mirror production path; namespace and using updated
- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireJobRegistrationHelperTests.cs` — removed (moved via `git mv`)

`Hangfire.Core` on `Application.csproj` is intentionally retained — seven other Application files still depend on it. A separate cleanup is needed to evaluate moving those consumers.

---

Closes #2042

### Tokens used
15218269
