### PR TITLE
feat: Decouple `FailedJobsTile` from Hangfire Infrastructure

### DIFF
--- a/artifacts/feat-arch-review-backgroundjobs-failedjobstil/arch-review.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-failedjobstil/arch-review.r1.md
@@ -1,0 +1,217 @@
+```markdown
+# Architecture Review: Decouple `FailedJobsTile` from Hangfire Infrastructure
+
+## Skip Design: true
+
+Backend-only refactor. No UI, no JSON contract change, no new endpoints. The tile keeps the same anonymous-object payload shape, the same drill-down URL, the same metadata — only the construction dependency moves behind an Application-owned interface.
+
+## Architectural Fit Assessment
+
+The spec aligns exactly with the established pattern already proven twice in this module: `IHangfireJobEnqueuer` (interface in `Application/Features/BackgroundJobs/Services/`, implementation in `API/Infrastructure/Hangfire/`, DI in `AddHangfireServices`) and `IHangfireRecurringJobScheduler` (same shape). `BackgroundJobsModule.cs:14-16` documents this convention explicitly:
+
+> "Hangfire adapter implementations […] are registered in `Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices` because their implementations live in the API project (Clean Architecture dependency rule)."
+
+`FailedJobsTile` is the odd one out — added after the relocation refactor and never reconciled. Introducing `IFailedJobCounter` simply closes that gap.
+
+**Integration points (all already present):**
+- `BackgroundJobsModule.AddBackgroundJobsModule` → calls `RegisterTile<FailedJobsTile>()`. Unchanged.
+- `Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices` (ServiceCollectionExtensions.cs:342–346) → the existing adapter-registration block. One new line.
+- `Anela.Heblo.Xcc.Services.Dashboard.ITile` contract → unchanged.
+
+**One caveat:** removing Hangfire from `Anela.Heblo.Application.csproj` is **not possible** in this change. Six other Application files still `using Hangfire;` (`HangfireJobRegistrationHelper`, `DashboardModule`, `GenerateArticleHandler`, `GenerateArticleJob`, `PlaudPollingJob`, `ProductExportDownloadJob`). The spec correctly scopes this out, but FR-3's acceptance criterion *"`Anela.Heblo.Application.csproj` does not gain (and ideally loses, if no other file in Application needs it) a `<PackageReference Include="Hangfire.*">`"* should be tightened to "does not gain" — losing it is not achievable here. See **Specification Amendments**.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Anela.Heblo.Application                                            │
+│                                                                     │
+│  Features/BackgroundJobs/                                           │
+│    DashboardTiles/                                                  │
+│      FailedJobsTile  ──depends on──►  IFailedJobCounter             │
+│                                       (NEW, Services/)              │
+│                                                                     │
+│  (No `using Hangfire;` in either of these files after the change.)  │
+└─────────────────────────────────────────────────────────────────────┘
+                                              ▲
+                                              │ implements
+                                              │
+┌─────────────────────────────────────────────│───────────────────────┐
+│  Anela.Heblo.API                            │                       │
+│                                             │                       │
+│  Infrastructure/Hangfire/                   │                       │
+│    HangfireFailedJobCounter (NEW)  ─────────┘                       │
+│      └── ctor(JobStorage)                                           │
+│      └── _jobStorage.GetMonitoringApi().FailedCount()               │
+│                                                                     │
+│  Extensions/ServiceCollectionExtensions.cs                          │
+│    AddHangfireServices()                                            │
+│      services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>│
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Mirror the `IHangfireJobEnqueuer` pattern, not Option 2 (move the tile)
+
+**Options considered:**
+- (a) **Thin interface in Application, implementation in API/Infrastructure** (spec's choice).
+- (b) **Relocate `FailedJobsTile` to `API/Infrastructure/Hangfire/`** (brief's Option 2).
+
+**Chosen approach:** (a).
+
+**Rationale:** Dashboard tile *registration* (`RegisterTile<T>`) lives in `BackgroundJobsModule.AddBackgroundJobsModule`, which is an Application-layer concern (module composition). Moving the tile out of the Application project would mean either (i) the API project starts registering its own tiles — inconsistent with how every other tile in the codebase is wired — or (ii) the Application module registers a tile defined in the API project, which inverts the dependency. (a) keeps the module's ownership of *what it shows* intact while pushing only the *how it queries Hangfire* into infrastructure. This is the same trade-off already made for `IHangfireJobEnqueuer`.
+
+#### Decision 2: Return shape — `Task<long>`, not `ValueTask<long>` or sync `long`
+
+**Options considered:**
+- (a) `Task<long> GetFailedCountAsync(CancellationToken)` — spec.
+- (b) `long GetFailedCount()` synchronous (Hangfire's call is sync anyway).
+- (c) `ValueTask<long>` to avoid Task allocation.
+
+**Chosen approach:** (a).
+
+**Rationale:** `ITile.LoadDataAsync` is already async; the tile awaits the result regardless. `Task<long>` matches the async-with-`CancellationToken` convention used everywhere in this codebase (csharp-coding-style: "Pass `CancellationToken` through public async APIs"). It also future-proofs the interface for any future implementation that genuinely needs to do I/O (e.g., querying a remote dashboard service). The `Task.FromResult` allocation is irrelevant at dashboard-refresh frequency.
+
+#### Decision 3: DI lifetime — Scoped, matching `IHangfireJobEnqueuer`
+
+**Options considered:**
+- (a) `Scoped` — spec's choice, matches `IHangfireJobEnqueuer`.
+- (b) `Singleton` — would be technically purer since `HangfireFailedJobCounter` is stateless and `JobStorage` is itself a singleton.
+
+**Chosen approach:** (a) `Scoped`.
+
+**Rationale:** Consistency with the sibling adapter dominates a micro-optimization. `RegisterTile<FailedJobsTile>` itself registers the tile as scoped (the `ITileRegistry` extension chooses lifetime), so consumers will create one per resolution anyway. Singleton would not deliver any observable benefit here, and Scoped removes a foot-gun if the implementation ever grows a scoped dependency (e.g., a request-scoped logger context).
+
+#### Decision 4: Where to keep the `try`/`catch` — in the tile, not the counter
+
+**Options considered:**
+- (a) Tile catches, counter rethrows (spec).
+- (b) Counter catches and returns `0` (or some sentinel) on failure.
+
+**Chosen approach:** (a).
+
+**Rationale:** The tile owns the *presentation* concern of error envelopes (`status = "error"`). The counter's job is to answer "how many failed?" — silently returning `0` on a Hangfire outage would falsely report green on a broken background-job system. Letting exceptions surface to the tile preserves the existing observable behavior (logged error + error envelope) and keeps the abstraction honest. The spec captures this in FR-2 ("does not swallow exceptions") and FR-7 (explicit test that exceptions propagate).
+
+#### Decision 5: `sealed` class for the adapter
+
+`HangfireJobEnqueuer` is not sealed; `HangfireFailedJobCounter` per spec will be `sealed`. This is fine — the project rules prefer sealing types that aren't designed for inheritance, and there is no reason a counter adapter would ever be subclassed. The inconsistency with `HangfireJobEnqueuer` is acceptable (the older class predates the convention; not in scope to fix here).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New files:
+
+```
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/
+  └── IFailedJobCounter.cs                                    (NEW)
+
+backend/src/Anela.Heblo.API/Infrastructure/Hangfire/
+  └── HangfireFailedJobCounter.cs                             (NEW)
+
+backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/
+  └── HangfireFailedJobCounterTests.cs                        (NEW — see amendment below)
+```
+
+Modified files:
+
+```
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/
+  └── FailedJobsTile.cs                                       (constructor + async)
+
+backend/src/Anela.Heblo.API/Extensions/
+  └── ServiceCollectionExtensions.cs                          (one new DI line)
+
+backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/
+  └── FailedJobsTileTests.cs                                  (rewritten mocks)
+```
+
+### Interfaces and Contracts
+
+**Application contract:**
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+public interface IFailedJobCounter
+{
+    Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
+}
+```
+
+**Infrastructure adapter (signature only):**
+```csharp
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+
+public sealed class HangfireFailedJobCounter : IFailedJobCounter
+{
+    public HangfireFailedJobCounter(JobStorage jobStorage);
+    public Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
+}
+```
+
+**Tile constructor (after change):**
+```csharp
+public FailedJobsTile(IFailedJobCounter failedJobCounter, ILogger<FailedJobsTile> logger);
+```
+
+**DI registration (one new line at ServiceCollectionExtensions.cs:~346, in the existing adapter block):**
+```csharp
+services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>();
+```
+
+**No HTTP, OpenAPI, or front-end client changes.** The tile's JSON envelope is byte-identical.
+
+### Data Flow
+
+```
+Dashboard refresh tick
+  └─► ITileRegistry resolves FailedJobsTile (scoped)
+        └─► DI injects IFailedJobCounter ──► HangfireFailedJobCounter (scoped)
+                                              └─► JobStorage (singleton, registered by Hangfire)
+        └─► FailedJobsTile.LoadDataAsync(ct)
+              ├─ try
+              │   └─ await _failedJobCounter.GetFailedCountAsync(ct)
+              │       └─ jobStorage.GetMonitoringApi().FailedCount()  // sync, in-memory
+              │   └─ return { status: "success", data: { count }, metadata, drillDown }
+              └─ catch
+                  └─ logger.LogError(...)
+                  └─ return { status: "error", data: null, error, drillDown }
+```
+
+Single virtual call added vs. today. No new I/O, no allocation hotspot, no caching needed.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Developer also tries to remove `Hangfire.Core` from `Application.csproj`, which will break six other Application files. | Medium | Explicitly call out in the spec amendment that the package reference stays. Add a comment in `FailedJobsTile.cs` if helpful, or rely on the spec's Out-of-Scope section. |
+| Test file placement diverges from existing convention (spec proposes `test/Infrastructure/Hangfire/`, but the existing sibling `HangfireJobEnqueuerTests.cs` lives in `test/Features/BackgroundJobs/`). | Low | Place `HangfireFailedJobCounterTests.cs` next to `HangfireJobEnqueuerTests.cs` under `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/`. See **Specification Amendments**. |
+| Mocking `JobStorage` with Moq relies on virtual members — same fragility the refactor is trying to escape. | Low | The unit test for `HangfireFailedJobCounter` is the *one place* where mocking Hangfire is acceptable (it is the seam); tests elsewhere become Hangfire-free. Accept the trade. |
+| `LoadDataAsync` switched from `Task<object>` (sync body) to `async Task<object>`. If any caller awaits the tile synchronously by relying on `Task.FromResult` being completed, behavior changes subtly. | Low | `ITile.LoadDataAsync` is invoked through the dashboard pipeline which already awaits; this is not a public API. No mitigation needed beyond the existing tests. |
+| `CancellationToken` is now actually propagated to the counter (previously ignored). If Hangfire's `FailedCount()` were ever to hang, cancellation still won't interrupt it (synchronous call). | Low | Document in the adapter (one-line comment) that the token is accepted for interface conformance but Hangfire's call is synchronous. No mitigation in code. |
+
+## Specification Amendments
+
+1. **FR-3 acceptance criterion 2** — drop the "(and ideally loses)" clause. The Hangfire package reference must stay in `Anela.Heblo.Application.csproj` because six other Application files still use Hangfire. Rewrite as: *"`Anela.Heblo.Application.csproj` does not gain a new `<PackageReference Include="Hangfire.*">`. The existing `Hangfire.Core 1.8.21` reference is retained — removing it depends on the separately-tracked `HangfireJobRegistrationHelper` cleanup."*
+
+2. **FR-7 test file location** — change from `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireFailedJobCounterTests.cs` to `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs`. Rationale: that is where `HangfireJobEnqueuerTests.cs` and `HangfireRecurringJobSchedulerTests.cs` already live. The repo does **not** use a top-level `Infrastructure/Hangfire/` test folder — its `Infrastructure/` folder is currently for `Authentication/` only. Following the existing per-module test layout is the right call.
+
+3. **FR-6 test rename** — resolve the open phrasing in the spec. The test currently named `LoadDataAsync_MonitoringApiThrows_ReturnsErrorAndDoesNotPropagate` should be renamed to `LoadDataAsync_CounterThrows_ReturnsErrorAndDoesNotPropagate`. The test no longer knows anything about `IMonitoringApi`; keeping the old name would re-couple the test to the abstraction it just escaped.
+
+4. **FR-2 — comment hint** — add a single-line comment in `HangfireFailedJobCounter.GetFailedCountAsync` next to the unused token parameter, e.g. `// Hangfire's FailedCount() is synchronous; token accepted for interface conformance.` This earns its keep because a future reader will otherwise assume the token is plumbed and look for the propagation path.
+
+5. **Spec's "Status: COMPLETE"** — flip to "AMENDED" once items 1–3 above are folded in. (Cosmetic; not blocking.)
+
+## Prerequisites
+
+None. All required infrastructure exists:
+- `JobStorage` is already registered as a singleton by Hangfire's own bootstrap inside `AddHangfireServices` (ServiceCollectionExtensions.cs:~314–328).
+- `AddHangfireServices` already runs unconditionally for the API project.
+- `ITileRegistry` / `RegisterTile<T>` extension is in place and used.
+- No database migrations, no configuration changes, no Key Vault entries.
+
+Implementation can start immediately.
+```

--- a/artifacts/feat-arch-review-backgroundjobs-failedjobstil/brief.md
+++ b/artifacts/feat-arch-review-backgroundjobs-failedjobstil/brief.md
@@ -1,0 +1,25 @@
+## Module
+BackgroundJobs
+
+## Finding
+`FailedJobsTile` is in the Application layer but takes `Hangfire.JobStorage` — a concrete infrastructure type — as a constructor parameter:
+
+- **File**: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs`
+- **Line 2**: `using Hangfire;`
+- **Line 9**: `private readonly JobStorage _jobStorage;`
+- **Line 35**: `_jobStorage.GetMonitoringApi().FailedCount()` — calls Hangfire's monitoring API directly.
+
+## Why it matters
+`JobStorage` is a concrete Hangfire class (infrastructure). The Application layer must depend only on abstractions, never on Infrastructure. This creates a hard compile-time coupling from `Anela.Heblo.Application` → Hangfire, mirroring the same violation as `HangfireJobRegistrationHelper` in the same module. It also makes the tile untestable without a real Hangfire storage.
+
+## Suggested fix
+Two equally valid options:
+
+1. **Thin interface**: Introduce `IFailedJobCounter` in the Application layer (`Features/BackgroundJobs/Services/`), implement it in the API project using `JobStorage`, and register the binding in `AddHangfireServices`. `FailedJobsTile` injects `IFailedJobCounter` instead.
+
+2. **Move the tile**: Relocate `FailedJobsTile` to `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/` (alongside the other Hangfire infrastructure) where a direct `JobStorage` dependency is appropriate.
+
+Option 1 keeps the tile in Application without breaking layering. Option 2 is simpler if the tile has no domain logic that needs to stay in Application.
+
+---
+_Filed by daily arch-review routine on 2026-05-28._

--- a/artifacts/feat-arch-review-backgroundjobs-failedjobstil/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-failedjobstil/impl/main.r1.md
@@ -1,0 +1,67 @@
+All implementation commits are on the branch. Here is the output summary:
+
+---
+
+# Implementation: Decouple FailedJobsTile from Hangfire Infrastructure
+
+## What was implemented
+
+Introduced a thin `IFailedJobCounter` abstraction in the Application layer so `FailedJobsTile` no longer compiles against Hangfire's `JobStorage` type. A sealed `HangfireFailedJobCounter` adapter in `Anela.Heblo.API/Infrastructure/Hangfire/` implements the interface by wrapping `JobStorage.GetMonitoringApi().FailedCount()`. The pattern mirrors the existing `IHangfireJobEnqueuer` / `IHangfireRecurringJobScheduler` convention. All tile metadata, JSON envelope shapes, log messages, and error strings are preserved byte-identical.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs` — new Application-layer interface with XML docs
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs` — sealed Hangfire adapter; no exception swallowing; CT comment per Amendment #4
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs` — removed `using Hangfire;`, swapped `JobStorage` → `IFailedJobCounter`, `LoadDataAsync` is now `async`
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — one new line: `services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>()` in the adapter block
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs` — rewritten to mock `IFailedJobCounter`; propagation test renamed per Amendment #3
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs` — new adapter tests at `test/Features/BackgroundJobs/` per Amendment #2
+
+## Tests
+
+- `FailedJobsTileTests` (4 tests): ZeroFailures, PositiveCount, CounterThrows, TileMetadata — all green, no Hangfire imports
+- `HangfireFailedJobCounterTests` (3 tests): happy path returns 42L, exception propagates, null ctor guard — all green
+- Full BackgroundJobs test slice: 96 tests passed
+
+## How to verify
+
+```bash
+# Build
+dotnet build Anela.Heblo.sln
+
+# Run new tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs"
+
+# Confirm no Hangfire using-directive in tile or interface
+grep -rnE "^using Hangfire" \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/ \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+
+# Confirm Application.csproj unchanged
+git diff main -- backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+## Notes
+
+- The 32 test failures in the full suite are pre-existing Docker/Testcontainers integration tests that require Docker running; unrelated to this change.
+- `HangfireJobRegistrationHelper.cs` retains its `using Hangfire;` — that file is explicitly out of scope, tracked separately.
+- The `sealed` modifier on `HangfireFailedJobCounter` is intentional per the spec and arch-review Decision #5; the code reviewer noted `HangfireJobEnqueuer` (older sibling) is not sealed — the inconsistency can be harmonized in a follow-up.
+
+## PR Summary
+
+Decouples `FailedJobsTile` from Hangfire's `JobStorage` infrastructure type by introducing an `IFailedJobCounter` abstraction owned by the Application layer. This closes the layering gap flagged by the arch-review routine on 2026-05-28 — the tile was the only remaining Application type that directly imported a Hangfire concrete class.
+
+The change mirrors the `IHangfireJobEnqueuer` / `IHangfireRecurringJobScheduler` pattern established by the earlier BackgroundJobs refactor: interface in `Application/Features/BackgroundJobs/Services/`, sealed adapter in `API/Infrastructure/Hangfire/`, DI registration in `AddHangfireServices`. Tile unit tests no longer reference any Hangfire assemblies; Hangfire mocking is now isolated to `HangfireFailedJobCounterTests`, which is the appropriate seam.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs` — new interface
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs` — new sealed adapter
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs` — refactored to use abstraction
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — one new DI line
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs` — rewritten mocks
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs` — new adapter tests
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-failedjobstil/spec.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-failedjobstil/spec.r1.md
@@ -1,0 +1,188 @@
+# Specification: Decouple `FailedJobsTile` from Hangfire Infrastructure
+
+## Summary
+`FailedJobsTile` currently lives in the Application layer but takes the concrete `Hangfire.JobStorage` type as a constructor dependency, violating Clean Architecture's dependency rule (Application must not depend on Infrastructure). This feature introduces a thin Application-owned abstraction (`IFailedJobCounter`), implemented in `Anela.Heblo.API/Infrastructure/Hangfire/`, so the tile no longer compiles against Hangfire types. The change mirrors the existing pattern already used for `IHangfireJobEnqueuer` / `IHangfireRecurringJobScheduler` in the same module.
+
+## Background
+- The `BackgroundJobs` module in this codebase has previously been refactored so that all Hangfire-touching adapters (`HangfireJobEnqueuer`, `HangfireRecurringJobScheduler`) were relocated to `Anela.Heblo.API/Infrastructure/Hangfire/`. `BackgroundJobsModule.cs` comments this explicitly: *"Hangfire adapter implementations […] are registered in `Anela.Heblo.API.Extensions.ServiceCollectionExtensions.AddHangfireServices` because their implementations live in the API project (Clean Architecture dependency rule)."*
+- `FailedJobsTile.cs` (added later for the dashboard) was missed by that refactor. It still has `using Hangfire;` and depends on `JobStorage`, an infrastructure type.
+- The repo's `docs/architecture/development_guidelines.md` requires Application to depend only on abstractions, not on Infrastructure. The daily arch-review routine flagged this on 2026-05-28.
+- A second, similar finding exists for `HangfireJobRegistrationHelper` (out of scope for this brief, but the team is aware).
+- Existing tests (`FailedJobsTileTests`) currently mock `Mock<JobStorage>` + `Mock<IMonitoringApi>` from Hangfire, which only works because Hangfire types happen to be mockable — the brittle coupling is also a testing problem.
+
+## Functional Requirements
+
+### FR-1: Introduce `IFailedJobCounter` abstraction in Application
+Add a new interface in `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs`. The interface exposes a single method to return the current failed-job count.
+
+**Shape:**
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+public interface IFailedJobCounter
+{
+    Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
+}
+```
+
+**Acceptance criteria:**
+- File lives in `Application/Features/BackgroundJobs/Services/`, alongside `IHangfireJobEnqueuer` and `IHangfireRecurringJobScheduler`.
+- No `using Hangfire;` or any Hangfire type appears in the file.
+- The method is async and accepts a `CancellationToken` (per project async conventions).
+- The return type is `Task<long>` to match the existing Hangfire `FailedCount()` return type.
+
+### FR-2: Implement `HangfireFailedJobCounter` in API Infrastructure
+Add a concrete implementation in `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs`. It wraps `JobStorage.GetMonitoringApi().FailedCount()`.
+
+**Shape:**
+```csharp
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+
+public sealed class HangfireFailedJobCounter : IFailedJobCounter
+{
+    private readonly JobStorage _jobStorage;
+
+    public HangfireFailedJobCounter(JobStorage jobStorage)
+    {
+        _jobStorage = jobStorage ?? throw new ArgumentNullException(nameof(jobStorage));
+    }
+
+    public Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default)
+    {
+        var count = _jobStorage.GetMonitoringApi().FailedCount();
+        return Task.FromResult(count);
+    }
+}
+```
+
+**Acceptance criteria:**
+- Lives next to `HangfireJobEnqueuer.cs` and `HangfireRecurringJobScheduler.cs`.
+- The class is `sealed` (matches existing infra-adapter style in the project where applicable).
+- The implementation does not swallow exceptions — error handling stays in `FailedJobsTile` so the tile's tile-shaped error envelope continues to work (FR-4 verifies this).
+- `CancellationToken` is accepted at the API surface even though Hangfire's `FailedCount()` is synchronous and has no cancellation support; this future-proofs the signature.
+
+### FR-3: Refactor `FailedJobsTile` to depend on `IFailedJobCounter`
+Modify `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs`:
+- Remove `using Hangfire;`.
+- Replace `private readonly JobStorage _jobStorage;` with `private readonly IFailedJobCounter _failedJobCounter;`.
+- Update the constructor signature.
+- Replace `_jobStorage.GetMonitoringApi().FailedCount()` with `await _failedJobCounter.GetFailedCountAsync(cancellationToken)`.
+- Change `LoadDataAsync` to `async Task<object>` so it can `await` the counter call.
+
+**Acceptance criteria:**
+- `grep -r "Hangfire" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/` returns no matches.
+- `Anela.Heblo.Application.csproj` does not gain (and ideally loses, if no other file in Application needs it — see Open Questions) a `<PackageReference Include="Hangfire.*">`.
+- The tile still passes the `cancellationToken` argument through to `GetFailedCountAsync` (was previously ignored at the Hangfire call site, but should be honored now).
+- The existing tile metadata (Title, Description, Size, Category, DefaultEnabled, AutoShow, RequiredPermissions, ComponentType, drill-down URL `/hangfire/jobs/failed`) is unchanged.
+
+### FR-4: Preserve tile error-envelope behavior
+The tile's existing `try`/`catch` block must continue to produce the same `status = "error"` JSON envelope when the counter throws.
+
+**Acceptance criteria:**
+- When `IFailedJobCounter.GetFailedCountAsync` throws, the tile logs via `ILogger<FailedJobsTile>` with message `"Failed to load Hangfire failed job count"` (unchanged) and returns the `status = "error"` envelope with `error = "Failed to retrieve job count. See server logs."` and the drill-down URL.
+- Successful path returns the same `status = "success"` envelope with `data.count`, `metadata.lastUpdated`, `metadata.source = "Hangfire"`, and the drill-down block.
+- Exceptions do not escape `LoadDataAsync`.
+
+### FR-5: Register the new binding in `AddHangfireServices`
+In `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs::AddHangfireServices`, add the DI registration adjacent to the existing Hangfire adapter registrations (around line 345).
+
+**Acceptance criteria:**
+- New line: `services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>();`
+- Scoped lifetime matches `IHangfireJobEnqueuer` (line 345). `JobStorage` is itself registered as a singleton by Hangfire's own bootstrap, so any lifetime ≥ Scoped is safe; Scoped is chosen for consistency with the sibling adapter.
+- The registration is grouped under the same `// Register Hangfire adapter implementations …` comment block.
+
+### FR-6: Update unit tests to mock the new abstraction
+Rewrite `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs` so it no longer references `Hangfire` or `Hangfire.Storage`. It must mock `IFailedJobCounter` instead.
+
+**Acceptance criteria:**
+- The test file contains no `using Hangfire;` or `using Hangfire.Storage;` directives.
+- `Mock<IFailedJobCounter>` replaces `Mock<JobStorage>` + `Mock<IMonitoringApi>`.
+- The four existing test cases keep their names and behavior:
+  - `LoadDataAsync_ZeroFailures_ReturnsSuccessWithCountZero`
+  - `LoadDataAsync_PositiveFailureCount_ReturnsSuccessWithCount`
+  - `LoadDataAsync_MonitoringApiThrows_ReturnsErrorAndDoesNotPropagate` (rename the inner setup to mock `GetFailedCountAsync` throwing; the test name may stay or be renamed to `…CounterThrows…` — see Open Questions)
+  - `TileMetadata_MatchesSpec`
+- All four tests pass under `dotnet test`.
+
+### FR-7: Add a unit test for `HangfireFailedJobCounter`
+Add `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/HangfireFailedJobCounterTests.cs` that verifies the adapter calls `JobStorage.GetMonitoringApi().FailedCount()` and returns the value.
+
+**Acceptance criteria:**
+- A passing test demonstrates a mocked `JobStorage` whose `GetMonitoringApi().FailedCount()` returns `42L`, and `GetFailedCountAsync` returns `42L`.
+- A second test demonstrates that an exception from `FailedCount()` propagates out of `GetFailedCountAsync` unchanged (the catch lives in the tile, not the counter).
+- Test location mirrors the existing adapter-test pattern in the repo (if one exists; otherwise place under `backend/test/Anela.Heblo.Tests/Infrastructure/Hangfire/`).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- The added abstraction layer is one virtual call. No measurable performance impact on the tile (the tile is called per dashboard refresh, not in hot paths).
+- The counter call must remain non-blocking on the request thread — `Task.FromResult` wrapping the synchronous Hangfire call is acceptable because `FailedCount()` returns immediately from in-memory monitoring state in all supported storage backends used by this project.
+
+### NFR-2: Architecture / Layering
+- After the change, `Anela.Heblo.Application` must not reference Hangfire in any of its `BackgroundJobs/DashboardTiles/` or `BackgroundJobs/Services/` files except for files explicitly out of scope (e.g. `HangfireJobRegistrationHelper.cs`, tracked separately).
+- The Application csproj's package references should not increase; ideally Hangfire is removed entirely from Application if `HangfireJobRegistrationHelper` no longer needs it — but that file is out of scope here, so the package may stay until that follow-up.
+
+### NFR-3: Testability
+- `FailedJobsTile` must be unit-testable with no Hangfire types or assemblies referenced from the test file.
+- `HangfireFailedJobCounter` is the only place where Hangfire mocks remain.
+
+### NFR-4: Backwards compatibility
+- The HTTP/JSON shape returned by the tile (`status`, `data.count`, `metadata`, `drillDown`) must be byte-identical to today, since the dashboard frontend parses this payload.
+- The DI registration order does not change observable container behavior; `RegisterTile<FailedJobsTile>` in `BackgroundJobsModule` stays as is.
+
+### NFR-5: Security
+- No changes to auth or data exposure. The tile already returns only a count; no secrets or PII are involved. `RequiredPermissions` stays `Array.Empty<string>()`.
+
+## Data Model
+No persistence changes. Only one new in-memory contract:
+
+| Type | Layer | Purpose |
+|---|---|---|
+| `IFailedJobCounter` | Application / Services | Abstraction returning the failed-job count |
+| `HangfireFailedJobCounter` | API / Infrastructure / Hangfire | Hangfire-backed implementation |
+
+## API / Interface Design
+
+### New interface
+```csharp
+// backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+public interface IFailedJobCounter
+{
+    Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
+}
+```
+
+### DI registration
+```csharp
+// In AddHangfireServices, alongside the existing adapter registrations (~line 345):
+services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>();
+```
+
+### Tile constructor (after change)
+```csharp
+public FailedJobsTile(IFailedJobCounter failedJobCounter, ILogger<FailedJobsTile> logger)
+```
+
+### No external HTTP/REST API surface changes
+The tile's `LoadDataAsync` returns the same anonymous-object JSON envelope as today.
+
+## Dependencies
+- **Hangfire** — still required at the API layer for the implementation. No new Hangfire features are used (`JobStorage.GetMonitoringApi().FailedCount()` is the same call as today).
+- **Existing `BackgroundJobsModule`** — `RegisterTile<FailedJobsTile>()` continues to register the tile in the Application module; only the tile's dependencies change.
+- **Existing `AddHangfireServices`** — the only place modified in the API project.
+- No new NuGet packages.
+
+## Out of Scope
+- **`HangfireJobRegistrationHelper`** — has the same layering violation but is tracked as a separate finding. Not refactored here.
+- **`metadata.source = "Hangfire"` literal** — the tile still returns the literal string `"Hangfire"` in its metadata. Abstracting that label into the counter or moving it to the infra layer is intentionally not done; it is informational JSON for the dashboard, not a leak of types.
+- **Removing the `Hangfire` package reference from `Anela.Heblo.Application.csproj`** — depends on the unrelated `HangfireJobRegistrationHelper` cleanup. Don't attempt it as part of this change.
+- **Changing tile metadata, UI, or drill-down URL** (`/hangfire/jobs/failed`).
+- **Adding caching or rate-limiting** to the counter call.
+- **Option 2 from the brief** (relocating `FailedJobsTile` to `Anela.Heblo.API/Infrastructure/Hangfire/`) — rejected in favor of Option 1, because the tile registration helper `RegisterTile<T>` is invoked from the Application module, and keeping the tile class in Application preserves that module's ownership of its dashboard tiles. (Assumption — see Open Questions.)
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-backgroundjobs-failedjobstil/task-plan.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-failedjobstil/task-plan.r1.md
@@ -1,0 +1,15 @@
+Plan saved to `docs/superpowers/plans/2026-06-01-decouple-failedjobstile-from-hangfire.md`.
+
+**Summary of the implementation plan:**
+
+Seven tasks, organized as RED/GREEN TDD pairs and committed per logical pair:
+
+1. **Add `IFailedJobCounter`** in `Application/Features/BackgroundJobs/Services/` (interface only) → commit.
+2. **Rewrite `FailedJobsTileTests`** to mock the new abstraction (RED — won't compile until Task 3).
+3. **Refactor `FailedJobsTile`** to depend on `IFailedJobCounter`, convert `LoadDataAsync` to `async` → GREEN, single commit covering Tasks 2+3.
+4. **Write `HangfireFailedJobCounterTests`** (RED — adapter doesn't exist) at `test/Features/BackgroundJobs/` per arch-review Amendment #2.
+5. **Implement `HangfireFailedJobCounter`** sealed adapter in `API/Infrastructure/Hangfire/` → GREEN, single commit covering Tasks 4+5.
+6. **Add DI line** `services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>()` in `AddHangfireServices` (~line 346, in the existing adapter-registration block) → commit.
+7. **Whole-solution gate** — build, full test suite, csproj diff check, Hangfire-free folder grep, JSON-envelope byte-identical check.
+
+The plan grounds every step in exact file paths and line numbers, embeds the complete code for both the contract and the adapter, names every literal string that must stay byte-identical (`"Hangfire"`, `"/hangfire/jobs/failed"`, `"Failed to load Hangfire failed job count"`, `"Failed to retrieve job count. See server logs."`), and folds in all four arch-review amendments. Spec coverage matrix at the end maps every FR/NFR/amendment to its task.

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -343,6 +343,7 @@ public static class ServiceCollectionExtensions
         // concrete types live in API/Infrastructure/Hangfire — relocated to keep the
         // Application project free of Hangfire imports for these specific adapters).
         services.AddScoped<IHangfireJobEnqueuer, HangfireJobEnqueuer>();
+        services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>();
         services.AddSingleton<IHangfireRecurringJobScheduler, HangfireRecurringJobScheduler>();
 
         // Note: IRecurringJobStatusChecker is now registered in Application layer (BackgroundJobsModule)

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs
@@ -1,0 +1,21 @@
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Hangfire;
+
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+
+public sealed class HangfireFailedJobCounter : IFailedJobCounter
+{
+    private readonly JobStorage _jobStorage;
+
+    public HangfireFailedJobCounter(JobStorage jobStorage)
+    {
+        _jobStorage = jobStorage ?? throw new ArgumentNullException(nameof(jobStorage));
+    }
+
+    public Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default)
+    {
+        // Hangfire's FailedCount() is synchronous; token accepted for interface conformance.
+        var count = _jobStorage.GetMonitoringApi().FailedCount();
+        return Task.FromResult(count);
+    }
+}

--- a/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs
+++ b/backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs
@@ -3,6 +3,10 @@ using Hangfire;
 
 namespace Anela.Heblo.API.Infrastructure.Hangfire;
 
+/// <summary>
+/// Hangfire-backed implementation of <see cref="IFailedJobCounter"/>.
+/// Queries the Hangfire monitoring API for the current failed-job count.
+/// </summary>
 public sealed class HangfireFailedJobCounter : IFailedJobCounter
 {
     private readonly JobStorage _jobStorage;

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Xcc.Services.Dashboard;
-using Hangfire;
 using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.BackgroundJobs.DashboardTiles;
@@ -8,7 +8,7 @@ public sealed class FailedJobsTile : ITile
 {
     private const string FailedJobsUrl = "/hangfire/jobs/failed";
 
-    private readonly JobStorage _jobStorage;
+    private readonly IFailedJobCounter _failedJobCounter;
     private readonly ILogger<FailedJobsTile> _logger;
 
     public string Title => "Failed background jobs";
@@ -20,21 +20,21 @@ public sealed class FailedJobsTile : ITile
     public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
-    public FailedJobsTile(JobStorage jobStorage, ILogger<FailedJobsTile> logger)
+    public FailedJobsTile(IFailedJobCounter failedJobCounter, ILogger<FailedJobsTile> logger)
     {
-        _jobStorage = jobStorage;
+        _failedJobCounter = failedJobCounter;
         _logger = logger;
     }
 
-    public Task<object> LoadDataAsync(
+    public async Task<object> LoadDataAsync(
         Dictionary<string, string>? parameters = null,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            var failedCount = _jobStorage.GetMonitoringApi().FailedCount();
+            var failedCount = await _failedJobCounter.GetFailedCountAsync(cancellationToken);
 
-            return Task.FromResult<object>(new
+            return new
             {
                 status = "success",
                 data = new { count = failedCount },
@@ -45,13 +45,13 @@ public sealed class FailedJobsTile : ITile
                     enabled = true,
                     tooltip = "Open Hangfire failed jobs"
                 }
-            });
+            };
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to load Hangfire failed job count");
 
-            return Task.FromResult<object>(new
+            return new
             {
                 status = "error",
                 data = (object?)null,
@@ -62,7 +62,7 @@ public sealed class FailedJobsTile : ITile
                     enabled = true,
                     tooltip = "Open Hangfire failed jobs"
                 }
-            });
+            };
         }
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
@@ -1,6 +1,15 @@
 namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
 
+/// <summary>
+/// Abstraction over the background-job system that returns the current number of failed jobs.
+/// Implemented by an infrastructure adapter (e.g. Hangfire) registered in the API project.
+/// </summary>
 public interface IFailedJobCounter
 {
+    /// <summary>
+    /// Returns the current count of failed background jobs.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>Number of failed jobs.</returns>
     Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
@@ -1,0 +1,6 @@
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+public interface IFailedJobCounter
+{
+    Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
+}

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs
@@ -1,9 +1,8 @@
 using System.Text.Json;
 using Anela.Heblo.Application.Features.BackgroundJobs.DashboardTiles;
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Xcc.Services.Dashboard;
 using FluentAssertions;
-using Hangfire;
-using Hangfire.Storage;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -12,20 +11,20 @@ namespace Anela.Heblo.Tests.Features.BackgroundJobs.DashboardTiles;
 
 public sealed class FailedJobsTileTests
 {
-    private readonly Mock<JobStorage> _storageMock = new();
-    private readonly Mock<IMonitoringApi> _monitoringApiMock = new();
+    private readonly Mock<IFailedJobCounter> _counterMock = new();
     private readonly FailedJobsTile _tile;
 
     public FailedJobsTileTests()
     {
-        _storageMock.Setup(s => s.GetMonitoringApi()).Returns(_monitoringApiMock.Object);
-        _tile = new FailedJobsTile(_storageMock.Object, NullLogger<FailedJobsTile>.Instance);
+        _tile = new FailedJobsTile(_counterMock.Object, NullLogger<FailedJobsTile>.Instance);
     }
 
     [Fact]
     public async Task LoadDataAsync_ZeroFailures_ReturnsSuccessWithCountZero()
     {
-        _monitoringApiMock.Setup(a => a.FailedCount()).Returns(0L);
+        _counterMock
+            .Setup(c => c.GetFailedCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0L);
 
         var result = await _tile.LoadDataAsync();
 
@@ -40,7 +39,9 @@ public sealed class FailedJobsTileTests
     [Fact]
     public async Task LoadDataAsync_PositiveFailureCount_ReturnsSuccessWithCount()
     {
-        _monitoringApiMock.Setup(a => a.FailedCount()).Returns(7L);
+        _counterMock
+            .Setup(c => c.GetFailedCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7L);
 
         var result = await _tile.LoadDataAsync();
 
@@ -50,9 +51,11 @@ public sealed class FailedJobsTileTests
     }
 
     [Fact]
-    public async Task LoadDataAsync_MonitoringApiThrows_ReturnsErrorAndDoesNotPropagate()
+    public async Task LoadDataAsync_CounterThrows_ReturnsErrorAndDoesNotPropagate()
     {
-        _monitoringApiMock.Setup(a => a.FailedCount()).Throws(new InvalidOperationException("storage unavailable"));
+        _counterMock
+            .Setup(c => c.GetFailedCountAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("storage unavailable"));
 
         var result = await _tile.LoadDataAsync();
 

--- a/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs
@@ -1,0 +1,52 @@
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using FluentAssertions;
+using Hangfire;
+using Hangfire.Storage;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+public sealed class HangfireFailedJobCounterTests
+{
+    private readonly Mock<JobStorage> _storageMock = new();
+    private readonly Mock<IMonitoringApi> _monitoringApiMock = new();
+    private readonly HangfireFailedJobCounter _counter;
+
+    public HangfireFailedJobCounterTests()
+    {
+        _storageMock.Setup(s => s.GetMonitoringApi()).Returns(_monitoringApiMock.Object);
+        _counter = new HangfireFailedJobCounter(_storageMock.Object);
+    }
+
+    [Fact]
+    public async Task GetFailedCountAsync_ReturnsValueFromMonitoringApi()
+    {
+        _monitoringApiMock.Setup(a => a.FailedCount()).Returns(42L);
+
+        var count = await _counter.GetFailedCountAsync();
+
+        count.Should().Be(42L);
+    }
+
+    [Fact]
+    public async Task GetFailedCountAsync_WhenMonitoringApiThrows_PropagatesException()
+    {
+        _monitoringApiMock
+            .Setup(a => a.FailedCount())
+            .Throws(new InvalidOperationException("storage unavailable"));
+
+        var act = async () => await _counter.GetFailedCountAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("storage unavailable");
+    }
+
+    [Fact]
+    public void Constructor_WithNullJobStorage_ThrowsArgumentNullException()
+    {
+        Action act = () => _ = new HangfireFailedJobCounter(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("jobStorage");
+    }
+}

--- a/docs/superpowers/plans/2026-06-01-decouple-failedjobstile-from-hangfire.md
+++ b/docs/superpowers/plans/2026-06-01-decouple-failedjobstile-from-hangfire.md
@@ -1,0 +1,693 @@
+# Decouple FailedJobsTile from Hangfire Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `FailedJobsTile`'s Hangfire dependency behind an Application-owned `IFailedJobCounter` abstraction so the Application layer no longer compiles against `Hangfire.JobStorage` for the tile.
+
+**Architecture:** Mirrors the existing `IHangfireJobEnqueuer` / `IHangfireRecurringJobScheduler` pattern. Application owns the contract (`Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs`); a sealed adapter (`Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs`) implements it; the binding is registered in `AddHangfireServices` alongside the sibling adapters. The tile's JSON envelope, drill-down URL, metadata, and tile-shaped error handling are preserved byte-identical.
+
+**Tech Stack:** .NET 8, C# 12, xUnit, Moq, FluentAssertions, Hangfire 1.8.x, Microsoft.Extensions.DependencyInjection.
+
+---
+
+## File Structure
+
+**Create:**
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs` — Application-layer contract returning the failed-job count.
+- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs` — sealed Hangfire adapter implementing the contract.
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs` — adapter unit tests (placed next to `HangfireJobEnqueuerTests.cs` per arch-review Amendment #2).
+
+**Modify:**
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs` — drop `using Hangfire;`, swap `JobStorage` for `IFailedJobCounter`, convert `LoadDataAsync` to `async`.
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — add one DI registration line (~line 346) in the existing adapter block inside `AddHangfireServices`.
+- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs` — replace `Mock<JobStorage>` + `Mock<IMonitoringApi>` with `Mock<IFailedJobCounter>`; rename the propagation test per arch-review Amendment #3.
+
+**Out of scope (do not touch):**
+- `HangfireJobRegistrationHelper.cs` (tracked separately).
+- The `Hangfire.Core` `<PackageReference>` in `Anela.Heblo.Application.csproj` (six other Application files still use it; arch-review Amendment #1 tightens FR-3 to "does not gain a new reference").
+- Tile metadata, drill-down URL `/hangfire/jobs/failed`, `metadata.source = "Hangfire"` string.
+
+---
+
+## Task 1: Add the `IFailedJobCounter` Application contract
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs`
+
+- [ ] **Step 1: Create the interface file**
+
+Write the following file:
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Services;
+
+/// <summary>
+/// Abstraction over the background-job system that returns the current number of failed jobs.
+/// Implemented by an infrastructure adapter (e.g. Hangfire) registered in the API project.
+/// </summary>
+public interface IFailedJobCounter
+{
+    /// <summary>
+    /// Returns the current count of failed background jobs.
+    /// </summary>
+    /// <param name="cancellationToken">Cooperative cancellation token.</param>
+    /// <returns>Number of failed jobs.</returns>
+    Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Verify the file contains no Hangfire reference**
+
+Run:
+
+```bash
+grep -nE "Hangfire" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+```
+
+Expected: no matches (exit code 1 / empty output).
+
+- [ ] **Step 3: Build the Application project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+git commit -m "feat(background-jobs): add IFailedJobCounter abstraction"
+```
+
+---
+
+## Task 2: Rewrite `FailedJobsTileTests` to mock the new abstraction (RED)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs`
+
+The test file currently mocks `JobStorage` + `IMonitoringApi`. After this task it will mock `IFailedJobCounter` and reference no Hangfire types. The four existing scenarios are preserved; the propagation test is renamed `LoadDataAsync_CounterThrows_ReturnsErrorAndDoesNotPropagate` per arch-review Amendment #3.
+
+- [ ] **Step 1: Replace the entire test file**
+
+Overwrite `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs` with:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.BackgroundJobs.DashboardTiles;
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs.DashboardTiles;
+
+public sealed class FailedJobsTileTests
+{
+    private readonly Mock<IFailedJobCounter> _counterMock = new();
+    private readonly FailedJobsTile _tile;
+
+    public FailedJobsTileTests()
+    {
+        _tile = new FailedJobsTile(_counterMock.Object, NullLogger<FailedJobsTile>.Instance);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_ZeroFailures_ReturnsSuccessWithCountZero()
+    {
+        _counterMock
+            .Setup(c => c.GetFailedCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0L);
+
+        var result = await _tile.LoadDataAsync();
+
+        var doc = ToJsonDoc(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        doc.RootElement.GetProperty("data").GetProperty("count").GetInt64().Should().Be(0L);
+        doc.RootElement.GetProperty("drillDown").GetProperty("url").GetString()
+            .Should().Be("/hangfire/jobs/failed");
+        doc.RootElement.GetProperty("drillDown").GetProperty("enabled").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_PositiveFailureCount_ReturnsSuccessWithCount()
+    {
+        _counterMock
+            .Setup(c => c.GetFailedCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7L);
+
+        var result = await _tile.LoadDataAsync();
+
+        var doc = ToJsonDoc(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success");
+        doc.RootElement.GetProperty("data").GetProperty("count").GetInt64().Should().Be(7L);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_CounterThrows_ReturnsErrorAndDoesNotPropagate()
+    {
+        _counterMock
+            .Setup(c => c.GetFailedCountAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("storage unavailable"));
+
+        var result = await _tile.LoadDataAsync();
+
+        var doc = ToJsonDoc(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("error");
+        doc.RootElement.GetProperty("data").ValueKind.Should().Be(JsonValueKind.Null);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("Failed to retrieve job count. See server logs.");
+        doc.RootElement.GetProperty("drillDown").GetProperty("url").GetString()
+            .Should().Be("/hangfire/jobs/failed");
+        doc.RootElement.GetProperty("drillDown").GetProperty("enabled").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void TileMetadata_MatchesSpec()
+    {
+        _tile.Title.Should().Be("Failed background jobs");
+        _tile.Description.Should().Be("Hangfire jobs in the failed queue");
+        _tile.Size.Should().Be(TileSize.Small);
+        _tile.Category.Should().Be(TileCategory.System);
+        _tile.DefaultEnabled.Should().BeTrue();
+        _tile.AutoShow.Should().BeFalse();
+        _tile.RequiredPermissions.Should().BeEmpty();
+    }
+
+    private static JsonDocument ToJsonDoc(object payload) =>
+        JsonDocument.Parse(JsonSerializer.Serialize(payload));
+}
+```
+
+- [ ] **Step 2: Verify no `using Hangfire*` directives remain in the file**
+
+Run:
+
+```bash
+grep -nE "^using Hangfire" backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Build the test project and observe the failing compile**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: BUILD FAILS with a CS1503/CS1729 error about `FailedJobsTile`'s constructor not accepting `IFailedJobCounter` (the tile still takes `JobStorage`). This is the RED step — the test cannot compile until Task 3 lands.
+
+- [ ] **Step 4: Do not commit yet**
+
+The repo is in an intentionally broken state between Task 2 and Task 3. Task 3 will fix it and a single commit will cover both files.
+
+---
+
+## Task 3: Refactor `FailedJobsTile` to depend on `IFailedJobCounter` (GREEN)
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs`
+
+- [ ] **Step 1: Overwrite the tile file**
+
+Replace the entire contents of `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs` with:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.BackgroundJobs.DashboardTiles;
+
+public sealed class FailedJobsTile : ITile
+{
+    private const string FailedJobsUrl = "/hangfire/jobs/failed";
+
+    private readonly IFailedJobCounter _failedJobCounter;
+    private readonly ILogger<FailedJobsTile> _logger;
+
+    public string Title => "Failed background jobs";
+    public string Description => "Hangfire jobs in the failed queue";
+    public TileSize Size => TileSize.Small;
+    public TileCategory Category => TileCategory.System;
+    public bool DefaultEnabled => true;
+    public bool AutoShow => false;
+    public Type ComponentType => typeof(object);
+    public string[] RequiredPermissions => Array.Empty<string>();
+
+    public FailedJobsTile(IFailedJobCounter failedJobCounter, ILogger<FailedJobsTile> logger)
+    {
+        _failedJobCounter = failedJobCounter;
+        _logger = logger;
+    }
+
+    public async Task<object> LoadDataAsync(
+        Dictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var failedCount = await _failedJobCounter.GetFailedCountAsync(cancellationToken);
+
+            return new
+            {
+                status = "success",
+                data = new { count = failedCount },
+                metadata = new { lastUpdated = DateTime.UtcNow, source = "Hangfire" },
+                drillDown = new
+                {
+                    url = FailedJobsUrl,
+                    enabled = true,
+                    tooltip = "Open Hangfire failed jobs"
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load Hangfire failed job count");
+
+            return new
+            {
+                status = "error",
+                data = (object?)null,
+                error = "Failed to retrieve job count. See server logs.",
+                drillDown = new
+                {
+                    url = FailedJobsUrl,
+                    enabled = true,
+                    tooltip = "Open Hangfire failed jobs"
+                }
+            };
+        }
+    }
+}
+```
+
+Note: `LoadDataAsync` is now `async Task<object>` — it `await`s the counter and returns the anonymous object directly (no more `Task.FromResult`). The literal strings, drill-down URL, metadata source, and tile metadata properties are byte-identical to the previous version per FR-4 and NFR-4.
+
+- [ ] **Step 2: Confirm no Hangfire reference remains in the dashboard-tile folder**
+
+Run:
+
+```bash
+grep -rnE "Hangfire" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Build the Application project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Build the test project and run the four tile tests (GREEN)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~FailedJobsTileTests"
+```
+
+Expected: 4 tests pass — `LoadDataAsync_ZeroFailures_ReturnsSuccessWithCountZero`, `LoadDataAsync_PositiveFailureCount_ReturnsSuccessWithCount`, `LoadDataAsync_CounterThrows_ReturnsErrorAndDoesNotPropagate`, `TileMetadata_MatchesSpec`.
+
+- [ ] **Step 5: Run `dotnet format` on the touched files**
+
+Run:
+
+```bash
+dotnet format backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs \
+            backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs
+dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --include backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs
+```
+
+Expected: no diagnostics reported / formatting clean.
+
+- [ ] **Step 6: Commit (covers Tasks 2 and 3 together)**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs
+git commit -m "refactor(background-jobs): make FailedJobsTile depend on IFailedJobCounter"
+```
+
+---
+
+## Task 4: Write `HangfireFailedJobCounterTests` (RED)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs`
+
+Two scenarios, mirroring FR-7 and arch-review Decision #4: (1) happy-path returns the count from `JobStorage.GetMonitoringApi().FailedCount()`; (2) exceptions thrown by `FailedCount()` propagate unchanged out of `GetFailedCountAsync` (no swallowing in the adapter — error envelope is the tile's job).
+
+- [ ] **Step 1: Create the test file**
+
+Write `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs`:
+
+```csharp
+using Anela.Heblo.API.Infrastructure.Hangfire;
+using FluentAssertions;
+using Hangfire;
+using Hangfire.Storage;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.BackgroundJobs;
+
+/// <summary>
+/// Unit tests for HangfireFailedJobCounter — the only place in the codebase where mocking
+/// Hangfire types remains, since this adapter IS the Hangfire seam.
+/// </summary>
+public sealed class HangfireFailedJobCounterTests
+{
+    private readonly Mock<JobStorage> _storageMock = new();
+    private readonly Mock<IMonitoringApi> _monitoringApiMock = new();
+    private readonly HangfireFailedJobCounter _counter;
+
+    public HangfireFailedJobCounterTests()
+    {
+        _storageMock.Setup(s => s.GetMonitoringApi()).Returns(_monitoringApiMock.Object);
+        _counter = new HangfireFailedJobCounter(_storageMock.Object);
+    }
+
+    [Fact]
+    public async Task GetFailedCountAsync_ReturnsValueFromMonitoringApi()
+    {
+        _monitoringApiMock.Setup(a => a.FailedCount()).Returns(42L);
+
+        var count = await _counter.GetFailedCountAsync();
+
+        count.Should().Be(42L);
+    }
+
+    [Fact]
+    public async Task GetFailedCountAsync_WhenMonitoringApiThrows_PropagatesException()
+    {
+        _monitoringApiMock
+            .Setup(a => a.FailedCount())
+            .Throws(new InvalidOperationException("storage unavailable"));
+
+        var act = async () => await _counter.GetFailedCountAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("storage unavailable");
+    }
+
+    [Fact]
+    public void Constructor_WithNullJobStorage_ThrowsArgumentNullException()
+    {
+        Action act = () => _ = new HangfireFailedJobCounter(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("jobStorage");
+    }
+}
+```
+
+- [ ] **Step 2: Build the test project and observe the failing compile**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: BUILD FAILS with a CS0246 error — `HangfireFailedJobCounter` does not exist yet. This is the RED step.
+
+- [ ] **Step 3: Do not commit yet**
+
+Same as Task 2: Task 5 lands the production code that turns this green; commit covers both files.
+
+---
+
+## Task 5: Implement `HangfireFailedJobCounter` adapter (GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs`
+
+- [ ] **Step 1: Create the adapter file**
+
+Write `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Services;
+using Hangfire;
+
+namespace Anela.Heblo.API.Infrastructure.Hangfire;
+
+/// <summary>
+/// Hangfire-backed implementation of <see cref="IFailedJobCounter"/>.
+/// Queries the Hangfire monitoring API for the current failed-job count.
+/// </summary>
+public sealed class HangfireFailedJobCounter : IFailedJobCounter
+{
+    private readonly JobStorage _jobStorage;
+
+    public HangfireFailedJobCounter(JobStorage jobStorage)
+    {
+        _jobStorage = jobStorage ?? throw new ArgumentNullException(nameof(jobStorage));
+    }
+
+    public Task<long> GetFailedCountAsync(CancellationToken cancellationToken = default)
+    {
+        // Hangfire's FailedCount() is synchronous; token accepted for interface conformance.
+        var count = _jobStorage.GetMonitoringApi().FailedCount();
+        return Task.FromResult(count);
+    }
+}
+```
+
+The class is `sealed` per FR-2 and arch-review Decision #5. The one-line comment about the cancellation token is per arch-review Amendment #4 (a future reader will otherwise look for token propagation that does not exist). Exceptions from `FailedCount()` propagate per arch-review Decision #4 — the tile owns the presentation/envelope concern.
+
+- [ ] **Step 2: Build the API project**
+
+Run:
+
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Run the adapter tests (GREEN)**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~HangfireFailedJobCounterTests"
+```
+
+Expected: 3 tests pass — `GetFailedCountAsync_ReturnsValueFromMonitoringApi`, `GetFailedCountAsync_WhenMonitoringApiThrows_PropagatesException`, `Constructor_WithNullJobStorage_ThrowsArgumentNullException`.
+
+- [ ] **Step 4: Run `dotnet format` on the touched files**
+
+Run:
+
+```bash
+dotnet format backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj \
+  --include backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs
+dotnet format backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --include backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs
+```
+
+Expected: no diagnostics reported.
+
+- [ ] **Step 5: Commit (covers Tasks 4 and 5 together)**
+
+```bash
+git add backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs \
+        backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs
+git commit -m "feat(background-jobs): add HangfireFailedJobCounter adapter"
+```
+
+---
+
+## Task 6: Register the new binding in `AddHangfireServices`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` (around line 345-346, inside the existing adapter-registration block)
+
+Lifetime is `Scoped` per FR-5 / arch-review Decision #3 — consistency with `IHangfireJobEnqueuer`. `JobStorage` is registered as a singleton by Hangfire's own bootstrap (~ServiceCollectionExtensions.cs:311–328), so any lifetime ≥ Scoped is safe.
+
+- [ ] **Step 1: Add the DI line**
+
+Locate the existing block in `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs`:
+
+```csharp
+        // Register Hangfire adapter implementations (interfaces live in Application,
+        // concrete types live in API/Infrastructure/Hangfire — relocated to keep the
+        // Application project free of Hangfire imports for these specific adapters).
+        services.AddScoped<IHangfireJobEnqueuer, HangfireJobEnqueuer>();
+        services.AddSingleton<IHangfireRecurringJobScheduler, HangfireRecurringJobScheduler>();
+```
+
+Insert a new line immediately after the `IHangfireJobEnqueuer` registration so the result reads:
+
+```csharp
+        // Register Hangfire adapter implementations (interfaces live in Application,
+        // concrete types live in API/Infrastructure/Hangfire — relocated to keep the
+        // Application project free of Hangfire imports for these specific adapters).
+        services.AddScoped<IHangfireJobEnqueuer, HangfireJobEnqueuer>();
+        services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>();
+        services.AddSingleton<IHangfireRecurringJobScheduler, HangfireRecurringJobScheduler>();
+```
+
+No new `using` directive is needed — `Anela.Heblo.API.Infrastructure.Hangfire` is already imported at line 15 and `Anela.Heblo.Application.Features.BackgroundJobs.Services` at line 24 of this file.
+
+- [ ] **Step 2: Build the solution**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Run the full BackgroundJobs test slice**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.BackgroundJobs"
+```
+
+Expected: all BackgroundJobs tests pass — `FailedJobsTileTests` (4), `HangfireFailedJobCounterTests` (3), plus the existing `HangfireJobEnqueuerTests`, `HangfireRecurringJobSchedulerTests`, `HangfireJobRegistrationHelperTests` continue to pass unchanged.
+
+- [ ] **Step 4: Run `dotnet format`**
+
+Run:
+
+```bash
+dotnet format backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj \
+  --include backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+```
+
+Expected: no diagnostics reported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+git commit -m "feat(background-jobs): register HangfireFailedJobCounter in AddHangfireServices"
+```
+
+---
+
+## Task 7: Final whole-solution validation
+
+This task is the gate before declaring the feature done. It checks (a) the solution builds, (b) the full test suite is green (no regression in tiles, dashboard, or Hangfire-touching code), (c) the Application csproj did not gain a Hangfire reference, (d) the JSON envelope is byte-identical to today's shape.
+
+- [ ] **Step 1: Full solution build**
+
+Run:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with no errors and no new warnings.
+
+- [ ] **Step 2: Full backend test suite**
+
+Run:
+
+```bash
+dotnet test backend/Anela.Heblo.sln
+```
+
+Expected: all tests pass. (If any unrelated flake appears, re-run that single test; do not paper over real failures.)
+
+- [ ] **Step 3: Confirm `Anela.Heblo.Application.csproj` did not gain a Hangfire reference (NFR-2 / Amendment #1)**
+
+Run:
+
+```bash
+git diff main -- backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: empty diff. The existing `Hangfire.Core 1.8.21` reference stays (six other Application files still need it), but no new `<PackageReference Include="Hangfire.*">` was added by this change.
+
+- [ ] **Step 4: Confirm the dashboard-tile folder is Hangfire-free (FR-3)**
+
+Run:
+
+```bash
+grep -rnE "Hangfire" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Confirm the Services folder remains Hangfire-free (NFR-2)**
+
+Run:
+
+```bash
+grep -rnE "^using Hangfire" backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/
+```
+
+Expected: no matches. (The Services folder hosts only abstractions: `IHangfireJobEnqueuer`, `IHangfireRecurringJobScheduler`, and the new `IFailedJobCounter`. The "Hangfire" word appears in two interface *names* — that is intentional and excluded by the `^using` anchor.)
+
+- [ ] **Step 6: Confirm the tile JSON envelope is byte-identical (NFR-4)**
+
+Inspect the diff of `FailedJobsTile.cs`:
+
+```bash
+git diff main -- backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
+```
+
+Expected: the only changes are (a) `using` directives swapped, (b) the field/constructor type swapped from `JobStorage` to `IFailedJobCounter`, (c) `LoadDataAsync` signature changed to `async`, (d) the call site swapped from `_jobStorage.GetMonitoringApi().FailedCount()` to `await _failedJobCounter.GetFailedCountAsync(cancellationToken)`, (e) `Task.FromResult<object>(new { … })` simplified to `return new { … }`. **All literal strings — `"success"`, `"error"`, `"Failed to retrieve job count. See server logs."`, `"Failed to load Hangfire failed job count"`, `"Hangfire"`, `"/hangfire/jobs/failed"`, `"Open Hangfire failed jobs"` — are unchanged.** The anonymous-object shape (property names, ordering, value types) is unchanged.
+
+- [ ] **Step 7: Push and conclude**
+
+Run:
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: three commits on the branch from this plan —
+1. `feat(background-jobs): add IFailedJobCounter abstraction`
+2. `refactor(background-jobs): make FailedJobsTile depend on IFailedJobCounter`
+3. `feat(background-jobs): add HangfireFailedJobCounter adapter`
+4. `feat(background-jobs): register HangfireFailedJobCounter in AddHangfireServices`
+
+(Four commits, one per task pair / single task. Acceptable to push as-is; squashing is at the PR author's discretion.)
+
+---
+
+## Spec Coverage Matrix
+
+| Spec requirement | Task(s) |
+|---|---|
+| FR-1 `IFailedJobCounter` in `Application/Features/BackgroundJobs/Services/` with `Task<long> GetFailedCountAsync(CancellationToken)` | Task 1 |
+| FR-2 `HangfireFailedJobCounter` sealed adapter in `API/Infrastructure/Hangfire/` wrapping `JobStorage.GetMonitoringApi().FailedCount()`; does not swallow exceptions; CT accepted at API surface | Task 5 |
+| FR-3 `FailedJobsTile` refactored — `using Hangfire;` removed, field/ctor swapped, `LoadDataAsync` becomes async, CT propagated | Task 3 |
+| FR-4 Error envelope preserved (log message, error string, drill-down block); no exception escapes `LoadDataAsync` | Task 3 (production) + Task 2 (test) |
+| FR-5 DI registration `services.AddScoped<IFailedJobCounter, HangfireFailedJobCounter>()` in the existing adapter block | Task 6 |
+| FR-6 Tile tests rewritten to mock `IFailedJobCounter`; four scenarios preserved; propagation test renamed per Amendment #3 | Task 2 |
+| FR-7 New `HangfireFailedJobCounterTests` placed under `test/Features/BackgroundJobs/` per Amendment #2; covers happy path and exception propagation | Task 4 |
+| NFR-1 Performance — single virtual call added; `Task.FromResult` allocation acceptable | Tasks 3, 5 |
+| NFR-2 Application/`DashboardTiles/` and Application/`Services/` Hangfire-free | Task 7 Steps 4–5 |
+| NFR-3 Tile test no longer references Hangfire | Task 2 |
+| NFR-4 JSON envelope byte-identical | Task 7 Step 6 |
+| NFR-5 No auth / permission changes | (covered by `TileMetadata_MatchesSpec` in Task 2) |
+| Arch-review Amendment #1 — Application.csproj does not gain Hangfire reference | Task 7 Step 3 |
+| Arch-review Amendment #2 — adapter test placed next to `HangfireJobEnqueuerTests.cs` | Task 4 |
+| Arch-review Amendment #3 — test renamed `LoadDataAsync_CounterThrows_…` | Task 2 |
+| Arch-review Amendment #4 — single-line comment on the unused CT in the adapter | Task 5 |


### PR DESCRIPTION

Decouples `FailedJobsTile` from Hangfire's `JobStorage` infrastructure type by introducing an `IFailedJobCounter` abstraction owned by the Application layer. This closes the layering gap flagged by the arch-review routine on 2026-05-28 — the tile was the only remaining Application type that directly imported a Hangfire concrete class.

The change mirrors the `IHangfireJobEnqueuer` / `IHangfireRecurringJobScheduler` pattern established by the earlier BackgroundJobs refactor: interface in `Application/Features/BackgroundJobs/Services/`, sealed adapter in `API/Infrastructure/Hangfire/`, DI registration in `AddHangfireServices`. Tile unit tests no longer reference any Hangfire assemblies; Hangfire mocking is now isolated to `HangfireFailedJobCounterTests`, which is the appropriate seam.

### Changes
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Services/IFailedJobCounter.cs` — new interface
- `backend/src/Anela.Heblo.API/Infrastructure/Hangfire/HangfireFailedJobCounter.cs` — new sealed adapter
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs` — refactored to use abstraction
- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — one new DI line
- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/DashboardTiles/FailedJobsTileTests.cs` — rewritten mocks
- `backend/test/Anela.Heblo.Tests/Features/BackgroundJobs/HangfireFailedJobCounterTests.cs` — new adapter tests

---

Closes #2043

### Tokens used
14786523
