### PR TITLE
feat: Relocate BackgroundRefresh DTOs to Application Layer

### DIFF
--- a/artifacts/feat-arch-review-backgroundjobs-backgroundref/arch-review.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-backgroundref/arch-review.r1.md
@@ -1,0 +1,176 @@
+# Architecture Review: Relocate BackgroundRefresh DTOs to Application Layer
+
+## Skip Design: true
+
+Pure backend refactor — moving three DTO files and updating their namespace + one controller's `using` directive. No UI components, screens, or visual design decisions involved.
+
+## Architectural Fit Assessment
+
+The proposal aligns perfectly with the project's mandatory rules. `docs/architecture/development_guidelines.md` is unambiguous: *"`API` project never defines or owns DTOs – it only uses them"* and *"DTO objects for API (`Request`, `Response`) live in `contracts/` of the specific module"*. The current state of these three files is a direct violation of both rules.
+
+The destination folder already exists and already follows the convention:
+
+```
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/
+├── RecurringJobDto.cs                  // namespace: ...BackgroundJobs.Contracts
+├── UpdateJobCronRequestBody.cs
+└── UpdateJobStatusRequestBody.cs
+```
+
+The exact same relocation was performed on `UpdateJobStatusRequestBody` / `UpdateJobCronRequestBody` two days ago (see `docs/superpowers/plans/2026-05-27-relocate-backgroundjobs-request-body-dtos.md`). That precedent confirms the chosen pattern and exposes no architectural surprises.
+
+Integration points:
+1. **`BackgroundRefreshController`** — the single backend consumer of the three DTO symbols (sole controller using them, no tests reference them).
+2. **NSwag/OpenAPI pipeline** (`nswag.frontend.json`) — generates the TypeScript client. The current TS client emits unqualified names (`export class RefreshTaskDto`), and NSwag's default `schemaNameGenerator` is type-name-based, not CLR-namespace-based, so the generated TS shape should be byte-identical after the move.
+3. **Project references** — `Anela.Heblo.API.csproj` already declares `<ProjectReference Include="../Anela.Heblo.Application/..."/>`. No new wiring is required.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Before:                                After:
+─────────────────────────              ─────────────────────────
+Anela.Heblo.API                        Anela.Heblo.API
+└── Controllers/                       └── Controllers/
+    ├── BackgroundRefreshController        └── BackgroundRefreshController
+    │       ▲                                      │ using
+    │       │ same namespace                       ▼
+    ├── RefreshTaskDto              ─►    Anela.Heblo.Application
+    ├── RefreshTaskStatusDto        ─►    └── Features/BackgroundJobs/
+    └── RefreshTaskExecutionLogDto  ─►        └── Contracts/
+                                                  ├── RefreshTaskDto
+                                                  ├── RefreshTaskStatusDto
+                                                  └── RefreshTaskExecutionLogDto
+                                                  (siblings of existing
+                                                   RecurringJobDto, etc.)
+```
+
+Dependency direction after the move points the correct way: API → Application (one-way), matching every other controller-to-contract relationship in the codebase.
+
+### Key Design Decisions
+
+#### Decision 1: Target namespace
+**Options considered:**
+- (a) `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` — matches `RecurringJobDto` and the request-body DTOs already there.
+- (b) A new sub-namespace like `...BackgroundJobs.Contracts.BackgroundRefresh` — visually groups the refresh-related DTOs.
+
+**Chosen approach:** (a) — `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`.
+
+**Rationale:** The module's existing convention is a flat `Contracts/` folder with one namespace per module (verified by `RecurringJobDto.cs`). Introducing a sub-namespace for three small DTOs would diverge from the established module shape and risks namespace churn if more refresh DTOs appear later. Keep it flat; rely on filename clarity.
+
+#### Decision 2: Use `git mv` to preserve history
+**Options considered:**
+- (a) Delete + create new file content (loses `git log --follow`).
+- (b) `git mv` followed by the namespace edit in a separate commit.
+- (c) `git mv` plus the namespace edit in the same commit.
+
+**Chosen approach:** (c) — `git mv` and the one-line namespace edit in a single commit per file (or one commit for all three).
+
+**Rationale:** Git's rename detection works on similarity, so editing one line in the same commit as the rename still produces a clean rename diff. This keeps the working tree consistent (no intermediate uncompilable state) and yields the smallest reviewer-visible diff.
+
+#### Decision 3: Do not touch DTO shape
+**Options considered:**
+- (a) Move only; keep all properties, attributes, and ordering verbatim.
+- (b) Take the opportunity to drop `init`-only setters or rename properties for consistency.
+
+**Chosen approach:** (a).
+
+**Rationale:** Any property change would alter the generated OpenAPI schema and force a TS client regeneration that touches more than `$ref` paths, expanding the blast radius beyond the architectural cleanup. Spec FR-4 already mandates this; the architecture concurs.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Final file layout after the change:
+
+```
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/
+├── RecurringJobDto.cs                  (unchanged)
+├── UpdateJobCronRequestBody.cs         (unchanged)
+├── UpdateJobStatusRequestBody.cs       (unchanged)
+├── RefreshTaskDto.cs                   ← moved, namespace updated
+├── RefreshTaskStatusDto.cs             ← moved, namespace updated
+└── RefreshTaskExecutionLogDto.cs       ← moved, namespace updated
+
+backend/src/Anela.Heblo.API/Controllers/
+└── BackgroundRefreshController.cs      ← single `using` added
+    (no other change)
+```
+
+### Interfaces and Contracts
+
+The three DTOs preserve their public surface verbatim. Each must declare:
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+public class RefreshTaskDto                 // unchanged body
+public class RefreshTaskStatusDto           // unchanged body
+public class RefreshTaskExecutionLogDto     // unchanged body
+```
+
+`BackgroundRefreshController.cs` adds exactly one `using` directive (preserve alphabetical ordering of existing usings):
+
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;   // new
+using Anela.Heblo.Xcc.Services.BackgroundRefresh;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+```
+
+No `[FromBody]`, action signature, or mapper-method change is required.
+
+### Data Flow
+
+Wire contract (HTTP request/response JSON) is unchanged. Only the C# type's residence changes:
+
+```
+HTTP request → BackgroundRefreshController action
+                  │
+                  ├── reads RefreshTaskConfiguration / RefreshTaskExecutionLog
+                  │   from IBackgroundRefreshTaskRegistry (Xcc)
+                  │
+                  └── MapToDto(...) →  RefreshTaskDto / RefreshTaskStatusDto /
+                                       RefreshTaskExecutionLogDto
+                                       (now resolved from Application.Contracts)
+                                              │
+                                              ▼
+                                       JSON serialization (System.Text.Json)
+                                              │
+                                              ▼
+                                       HTTP response
+```
+
+The mapper methods (`MapToDto(RefreshTaskConfiguration, ...)` and `MapToDto(RefreshTaskExecutionLog)`) remain on the controller. Moving them is **out of scope** per spec; leave them where they are.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| NSwag emits CLR namespace into schema names, breaking TS client | Low | Inspect current `frontend/src/api/generated/api-client.ts` — exported class is `RefreshTaskDto`, not `Anela_Heblo_API_Controllers_RefreshTaskDto`. NSwag config uses defaults. Regenerate after the move and diff the file; if zero meaningful changes, do not commit a regenerated client. |
+| Hidden test consumer breaks | Low | Repo-wide grep across `backend/test/` for the three symbol names returned zero hits. Run full `dotnet test` after the change as a backstop. |
+| Other code references `Anela.Heblo.API.Controllers` for these DTOs | Low | The 77 files importing that namespace do so for *other* DTOs that remain there. Grep specifically for the three symbol names anchored to a FQN form (`Anela\.Heblo\.API\.Controllers\.RefreshTask`) — must return zero matches after the change. |
+| `dotnet format` rewrites unrelated files | Low | Run with `--include` scoped to the four touched files (mirrors the precedent in the prior plan). Use `--verify-no-changes` to confirm clean state. |
+| Generated TS client subtly drifts (`$ref` ordering, JSON Schema component order) | Low | NSwag schema components are keyed by type name. After running `npm run build` in `frontend/`, diff `api-client.ts`; any non-cosmetic delta is unexpected and should be investigated, not silently committed. |
+
+## Specification Amendments
+
+None substantive; the spec is accurate. Two minor clarifications worth recording in the implementation plan:
+
+1. **FR-3 phrasing — "fully-qualified references"**: A repo-wide grep for `Anela\.Heblo\.API\.Controllers\.RefreshTask` (anchored on type name) is the precise check; the broader grep for `Anela.Heblo.API.Controllers` will surface 77 unrelated files and is not the relevant signal. The plan should anchor the grep to the three symbol names.
+
+2. **FR-5 phrasing**: NSwag's default `schemaNameGenerator` uses the CLR *type name*, not the namespace, so generated TS client output should be unchanged. The plan should still regenerate and diff (per the precedent for `UpdateJob*RequestBody`), but the expected outcome is **zero TS file changes**. Treat any non-empty diff as a flag to investigate, not as expected churn.
+
+3. **`dotnet format` scope**: Run `dotnet format --include` scoped to the four touched files (mirrors the precedent). The spec's blanket "`dotnet format` reports no changes required" should be qualified to the touched set.
+
+## Prerequisites
+
+None. Infrastructure already in place:
+
+- `Anela.Heblo.API.csproj` references `Anela.Heblo.Application.csproj` ✓ (verified)
+- `Anela.Heblo.Application/Features/BackgroundJobs/Contracts/` folder exists ✓ (verified — already contains 3 DTO siblings)
+- DTOs are already POCO classes with no problematic attributes ✓ (no `[Required]`, no `System.ComponentModel.DataAnnotations` baggage that complicated the earlier `UpdateJobStatusRequestBody` move)
+- Namespace target collision check: no existing type in `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` shares any of the three names ✓ (verified by directory listing)
+
+Implementation can start immediately.

--- a/artifacts/feat-arch-review-backgroundjobs-backgroundref/brief.md
+++ b/artifacts/feat-arch-review-backgroundjobs-backgroundref/brief.md
@@ -1,0 +1,23 @@
+## Module
+BackgroundJobs
+
+## Finding
+Three DTOs used exclusively by `BackgroundRefreshController` are defined inside the API project's `Controllers/` folder:
+
+- `backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs` — namespace `Anela.Heblo.API.Controllers`
+- `backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs` — namespace `Anela.Heblo.API.Controllers`
+- `backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs` — namespace `Anela.Heblo.API.Controllers`
+
+The development guidelines state: *"API project never defines or owns DTOs – it only uses them."*
+
+## Why it matters
+DTOs owned by the API project are invisible to the Application layer and cannot be reused by other consumers (e.g. tests, other handlers). It violates the ownership rule that keeps the API layer a thin host/composition boundary and is the exact anti-pattern the guidelines were written to prevent.
+
+## Suggested fix
+Move all three files to the BackgroundJobs module contracts folder:
+`backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/`
+
+Update namespaces from `Anela.Heblo.API.Controllers` to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` and fix the `using` in `BackgroundRefreshController`.
+
+---
+_Filed by daily arch-review routine on 2026-05-28._

--- a/artifacts/feat-arch-review-backgroundjobs-backgroundref/impl/main.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-backgroundref/impl/main.r1.md
@@ -1,0 +1,48 @@
+---
+
+# Implementation: Relocate BackgroundRefresh DTOs to Application Layer
+
+## What was implemented
+Moved three DTO files from `Anela.Heblo.API/Controllers/` into `Anela.Heblo.Application/Features/BackgroundJobs/Contracts/` using `git mv` (preserving history). Updated the namespace declaration in each file from `Anela.Heblo.API.Controllers` to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`. Added one `using` directive to `BackgroundRefreshController.cs`. Pure architectural cleanup — no behavior, wire contract, or TS client shape changed.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs` — added `using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;` (alphabetically ordered)
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs` — moved from API/Controllers, namespace updated
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs` — moved from API/Controllers, namespace updated
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs` — moved from API/Controllers, namespace updated
+
+## Tests
+No new tests written (pure relocation, no behavioral change per spec NFR-2). Backend test suite ran and passed. No test consumers of the moved DTOs existed.
+
+## How to verify
+```bash
+# Namespaces correct
+grep '^namespace ' backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTask*.cs
+
+# No Dto.cs under API project
+find backend/src/Anela.Heblo.API -name '*Dto.cs' -not -path '*/bin/*' -not -path '*/obj/*'
+
+# History preserved
+git log --follow --oneline -3 backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs
+
+# Build clean
+dotnet build backend/Anela.Heblo.sln -nologo -v quiet
+```
+
+## Notes
+- Git rename detection confirmed for all three files (commit shows `{.../Controllers → .../Contracts}` paths)
+- TS client checksum identical before/after (NSwag uses type name, not CLR namespace)
+- 237 pre-existing build warnings and 144 pre-existing lint issues are unrelated to this change
+- Pre-commit hooks passed
+
+## PR Summary
+Relocates three BackgroundRefresh DTOs (`RefreshTaskDto`, `RefreshTaskStatusDto`, `RefreshTaskExecutionLogDto`) from the API project's `Controllers/` folder into the Application layer's `BackgroundJobs/Contracts/` folder, restoring full compliance with the architectural rule that the API project never defines or owns DTOs. The controller is updated with a single `using` directive. No behavior, HTTP wire contract, or generated TypeScript client shape changes.
+
+### Changes
+- `backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs` — added one `using` directive for the new namespace
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs` — relocated (git mv), namespace updated
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs` — relocated (git mv), namespace updated
+- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs` — relocated (git mv), namespace updated
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-backgroundjobs-backgroundref/spec.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-backgroundref/spec.r1.md
@@ -1,0 +1,103 @@
+# Specification: Relocate BackgroundRefresh DTOs to Application Layer
+
+## Summary
+Move three DTOs (`RefreshTaskDto`, `RefreshTaskStatusDto`, `RefreshTaskExecutionLogDto`) currently defined in the API project's `Controllers/` folder into the BackgroundJobs module's contracts folder in the Application layer. This restores compliance with the architectural rule that the API project is a thin composition boundary and never owns DTOs.
+
+## Background
+The architecture guideline in `docs/architecture/development_guidelines.md` states: *"API project never defines or owns DTOs – it only uses them."* The BackgroundRefresh feature currently violates this rule: three DTOs consumed exclusively by `BackgroundRefreshController` live in `backend/src/Anela.Heblo.API/Controllers/` under the `Anela.Heblo.API.Controllers` namespace.
+
+This placement makes the DTOs invisible to the Application layer, blocks reuse by handlers/tests/other consumers, couples contract types to the API hosting project, and is the exact anti-pattern the guideline exists to prevent. It is also inconsistent with the rest of the BackgroundJobs module, whose other contracts already live under `Anela.Heblo.Application/Features/BackgroundJobs/Contracts/`.
+
+This is a pure architectural cleanup — no behavior, wire format, or generated OpenAPI client shape should change.
+
+## Functional Requirements
+
+### FR-1: Relocate DTO source files
+Move the following files from their current location to the BackgroundJobs module contracts folder:
+
+| From | To |
+|---|---|
+| `backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs` | `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs` |
+| `backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs` | `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs` |
+| `backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs` | `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs` |
+
+Use `git mv` (or equivalent) so history is preserved.
+
+**Acceptance criteria:**
+- The three files no longer exist under `backend/src/Anela.Heblo.API/Controllers/`.
+- The three files exist at the target paths above.
+- File-level git history is preserved (verifiable via `git log --follow`).
+
+### FR-2: Update namespaces
+Update the namespace declaration in each moved file from `Anela.Heblo.API.Controllers` to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`.
+
+**Acceptance criteria:**
+- All three moved files declare namespace `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`.
+- No file under `backend/` still references the symbols via the old `Anela.Heblo.API.Controllers` namespace.
+
+### FR-3: Update consumers
+Update every `using` directive and fully-qualified reference that currently resolves these three DTOs from `Anela.Heblo.API.Controllers` to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts`. At minimum this includes `BackgroundRefreshController`; any other consumer surfaced by a repo-wide search must also be updated.
+
+**Acceptance criteria:**
+- `BackgroundRefreshController.cs` imports `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` and compiles.
+- A repo-wide search for `RefreshTaskDto`, `RefreshTaskStatusDto`, and `RefreshTaskExecutionLogDto` shows zero references to the old namespace in source, tests, or generated configuration files (excluding generated TS client output, which will be regenerated).
+
+### FR-4: Preserve DTO contract shape
+DTO types remain classes (per project rule: DTOs are classes, never C# records), with identical property names, types, nullability, attributes, and ordering. No fields are added, removed, renamed, or retyped.
+
+**Acceptance criteria:**
+- A diff of each moved file vs. its prior version shows only the namespace change (and, if required by style, removal of an unused `using`).
+- The OpenAPI document produced by the API (`swagger.json` for the BackgroundRefresh endpoints) is byte-equivalent at the schema component level for these three types after the move, aside from any `$ref` path changes the generator derives from CLR namespaces. Generated client shape (TypeScript and any C# clients) must remain functionally equivalent.
+
+### FR-5: Regenerate API clients if needed
+If the OpenAPI generator embeds CLR namespace into schema names or generated client class names, regenerate the TypeScript client (`frontend/`) per `docs/development/api-client-generation.md` and commit the regenerated output alongside the BE change.
+
+**Acceptance criteria:**
+- `npm run build` in `frontend/` succeeds.
+- If the generated TS client changed, the regenerated files are committed.
+- If no regenerated client output changed, no frontend files are modified.
+
+## Non-Functional Requirements
+
+### NFR-1: Build & format
+- `dotnet build` of the solution succeeds with zero new warnings.
+- `dotnet format` reports no changes required.
+
+### NFR-2: Tests
+- All existing unit and integration tests under `backend/test/` pass without modification beyond namespace updates in `using` statements.
+- No new tests are required (this is a relocation with no behavioral change).
+
+### NFR-3: Backward compatibility
+- HTTP wire contract for every endpoint on `BackgroundRefreshController` is unchanged (route, verb, request body schema, response body schema, status codes).
+- No database, configuration, or environment changes.
+
+### NFR-4: Architectural compliance
+- The API project (`Anela.Heblo.API`) defines zero DTOs after the change. A reviewer scanning `backend/src/Anela.Heblo.API/` should find no `*Dto.cs` files outside of acceptable composition concerns (e.g., none).
+
+## Data Model
+No data model changes. The three DTOs retain their existing fields:
+- `RefreshTaskDto` — descriptor of a refresh task
+- `RefreshTaskStatusDto` — runtime status snapshot for a refresh task
+- `RefreshTaskExecutionLogDto` — log entry for a single execution
+
+The exact field set is preserved verbatim from the existing files.
+
+## API / Interface Design
+No API surface changes. Endpoints exposed by `BackgroundRefreshController` keep their routes, verbs, request/response shapes, and authentication requirements. Only the CLR namespace of the DTO types changes; the JSON contract is unchanged.
+
+## Dependencies
+- **Project reference:** `Anela.Heblo.API` already references `Anela.Heblo.Application` (the standard layering). No new project references are required. Verify this reference exists; if it doesn't, the move would surface a missing dependency and that must be addressed as part of the change.
+- **OpenAPI generation pipeline** (`docs/development/api-client-generation.md`) — only invoked if generated client output is affected.
+
+## Out of Scope
+- Refactoring `BackgroundRefreshController` itself (logic, routes, error handling).
+- Migrating `BackgroundRefreshController` from MVC to MediatR handlers.
+- Auditing other controllers in the API project for the same anti-pattern (each such finding gets its own brief).
+- Adding new fields or new DTOs.
+- Changing DTO conventions (e.g., switching to records, adding validation attributes).
+- Modifying tests beyond mechanical `using`-directive updates.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-backgroundjobs-backgroundref/task-plan.r1.md
+++ b/artifacts/feat-arch-review-backgroundjobs-backgroundref/task-plan.r1.md
@@ -1,0 +1,17 @@
+Plan saved to `docs/superpowers/plans/2026-06-01-relocate-backgroundrefresh-dtos.md`.
+
+## Summary
+
+The plan decomposes the pure-refactor work into 11 bite-sized tasks:
+
+1. **Pre-flight verification** — baseline namespace check, target folder/namespace confirmation, clean build, TS client checksum snapshot.
+2–4. **Move each of the three DTOs** via `git mv` + one-line namespace update, with rename-detection verification after each.
+5. **Update `BackgroundRefreshController`** with a single new `using` directive (alphabetically ordered) and verify the build now succeeds with zero warnings.
+6. **Scoped `dotnet format`** on the four touched files only, with `--verify-no-changes` confirmation.
+7. **Backend tests** — full `dotnet test` (arch review confirmed no test consumers; failures would surface hidden ones).
+8. **Regenerate TS client + diff** against the baseline SHA — expected no-op per NSwag's default `schemaNameGenerator`; commit only if diff is benign.
+9. **Frontend build + lint** plus verification that no unintended frontend file changed.
+10. **Final repo-wide grep** anchored to the three symbol names (per arch review amendment, not the broader namespace), plus confirmation no `*Dto.cs` remains under the API project and `git log --follow` works.
+11. **Single conventional-commit** with rename-detection verification.
+
+Each spec requirement (FR-1 through FR-5, NFR-1 through NFR-4) is mapped to a specific task step in the self-review table.

--- a/backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
 using Anela.Heblo.Xcc.Services.BackgroundRefresh;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.API.Controllers;
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
 
 public class RefreshTaskDto
 {

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.API.Controllers;
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
 
 public class RefreshTaskExecutionLogDto
 {

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs
@@ -1,4 +1,4 @@
-namespace Anela.Heblo.API.Controllers;
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
 
 public class RefreshTaskStatusDto
 {

--- a/docs/superpowers/plans/2026-06-01-relocate-backgroundrefresh-dtos.md
+++ b/docs/superpowers/plans/2026-06-01-relocate-backgroundrefresh-dtos.md
@@ -1,0 +1,644 @@
+# Relocate BackgroundRefresh DTOs to Application Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move three DTOs (`RefreshTaskDto`, `RefreshTaskStatusDto`, `RefreshTaskExecutionLogDto`) from `Anela.Heblo.API/Controllers/` into `Anela.Heblo.Application/Features/BackgroundJobs/Contracts/` so the API project stops owning DTOs (per `docs/architecture/development_guidelines.md`).
+
+**Architecture:** Pure relocation. Use `git mv` to preserve history, update the namespace to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` (matching existing siblings like `RecurringJobDto`), and add one `using` directive to `BackgroundRefreshController`. No DTO shape changes; HTTP wire contract and generated TS client must remain functionally identical.
+
+**Tech Stack:** .NET 8 / C# (xUnit tests), NSwag/OpenAPI generation, TypeScript client output under `frontend/src/api/generated/`.
+
+---
+
+## File Structure
+
+**Files moved (3):**
+- `backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs` → `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs`
+- `backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs` → `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs`
+- `backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs` → `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs`
+
+**Files modified (1):**
+- `backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs` — add one `using` directive (alphabetically ordered with existing imports).
+
+**Files expected to potentially regenerate (1) — likely zero meaningful diff:**
+- `frontend/src/api/generated/api-client.ts` — NSwag default `schemaNameGenerator` uses the CLR type name (not namespace); regeneration is precautionary.
+
+**No new files. No tests added** (relocation only; no behavioral change).
+
+---
+
+## Task 1: Pre-flight verification — capture current state
+
+**Files:**
+- Read only.
+
+- [ ] **Step 1: Confirm the three source files exist with current namespace**
+
+Run:
+```bash
+grep -n '^namespace ' backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs \
+                     backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs \
+                     backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs
+```
+
+Expected output (exactly):
+```
+backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs:1:namespace Anela.Heblo.API.Controllers;
+backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs:1:namespace Anela.Heblo.API.Controllers;
+backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs:1:namespace Anela.Heblo.API.Controllers;
+```
+
+If output differs, stop and re-read the spec / current files before proceeding.
+
+- [ ] **Step 2: Confirm target folder exists with sibling DTOs**
+
+Run:
+```bash
+ls backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/
+```
+
+Expected output (order may vary):
+```
+RecurringJobDto.cs
+UpdateJobCronRequestBody.cs
+UpdateJobStatusRequestBody.cs
+```
+
+If the folder does not exist, stop and check `docs/architecture/filesystem.md` — but per the architecture review this folder is already present.
+
+- [ ] **Step 3: Confirm target namespace from a sibling**
+
+Run:
+```bash
+grep -n '^namespace ' backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs
+```
+
+Expected output:
+```
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RecurringJobDto.cs:1:namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+```
+
+This is the **target namespace** used in Tasks 2–4.
+
+- [ ] **Step 4: Confirm baseline backend build**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln -nologo -v quiet
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`.
+
+If the build is broken on the current branch, stop — fix the existing failure before relocating files.
+
+- [ ] **Step 5: Capture baseline TS client checksum**
+
+Run:
+```bash
+shasum frontend/src/api/generated/api-client.ts > /tmp/api-client.before.sha
+cat /tmp/api-client.before.sha
+```
+
+Expected: a single SHA-1 line. Keep `/tmp/api-client.before.sha` — Task 8 compares against it.
+
+---
+
+## Task 2: Move `RefreshTaskDto.cs` and update namespace
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs` → `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs`
+
+- [ ] **Step 1: Move the file with `git mv` (preserves rename detection)**
+
+Run:
+```bash
+git mv \
+  backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs
+```
+
+Expected: no stdout output, exit code 0.
+
+- [ ] **Step 2: Update the namespace declaration**
+
+Edit `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs`.
+
+Replace:
+```csharp
+namespace Anela.Heblo.API.Controllers;
+```
+
+With:
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+```
+
+The remainder of the file is unchanged. Full expected final content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+public class RefreshTaskDto
+{
+    public required string TaskId { get; init; }
+    public required TimeSpan InitialDelay { get; init; }
+    public required TimeSpan RefreshInterval { get; init; }
+    public required bool Enabled { get; init; }
+    public int HydrationTier { get; init; }
+    public DateTime? NextScheduledRun { get; init; }
+    public RefreshTaskExecutionLogDto? LastExecution { get; init; }
+}
+```
+
+- [ ] **Step 3: Verify git still sees this as a rename (not delete + add)**
+
+Run:
+```bash
+git status --short
+```
+
+Expected line for this file (the `R` prefix indicates a detected rename):
+```
+R  backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs -> backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs
+```
+
+If git reports `D ... A ...` instead, the edit was too large for similarity detection — revert (`git restore --staged --worktree .`) and retry by editing only the one namespace line.
+
+---
+
+## Task 3: Move `RefreshTaskStatusDto.cs` and update namespace
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs` → `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs`
+
+- [ ] **Step 1: Move the file with `git mv`**
+
+Run:
+```bash
+git mv \
+  backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs
+```
+
+Expected: no stdout output, exit code 0.
+
+- [ ] **Step 2: Update the namespace declaration**
+
+Edit `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs`.
+
+Replace:
+```csharp
+namespace Anela.Heblo.API.Controllers;
+```
+
+With:
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+```
+
+Full expected final content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+public class RefreshTaskStatusDto
+{
+    public required string TaskId { get; init; }
+    public required bool Enabled { get; init; }
+    public string? Description { get; init; }
+    public required TimeSpan RefreshInterval { get; init; }
+    public RefreshTaskExecutionLogDto? LastExecution { get; init; }
+}
+```
+
+- [ ] **Step 3: Verify git rename detection**
+
+Run:
+```bash
+git status --short | grep RefreshTaskStatusDto
+```
+
+Expected:
+```
+R  backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs -> backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs
+```
+
+---
+
+## Task 4: Move `RefreshTaskExecutionLogDto.cs` and update namespace
+
+**Files:**
+- Move: `backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs` → `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs`
+
+- [ ] **Step 1: Move the file with `git mv`**
+
+Run:
+```bash
+git mv \
+  backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
+```
+
+Expected: no stdout output, exit code 0.
+
+- [ ] **Step 2: Update the namespace declaration**
+
+Edit `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs`.
+
+Replace:
+```csharp
+namespace Anela.Heblo.API.Controllers;
+```
+
+With:
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+```
+
+Full expected final content:
+
+```csharp
+namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+
+public class RefreshTaskExecutionLogDto
+{
+    public required string TaskId { get; init; }
+    public required DateTime StartedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+    public required string Status { get; init; }
+    public string? ErrorMessage { get; init; }
+    public TimeSpan? Duration { get; init; }
+    public Dictionary<string, object>? Metadata { get; init; }
+}
+```
+
+- [ ] **Step 3: Verify git rename detection**
+
+Run:
+```bash
+git status --short | grep RefreshTaskExecutionLogDto
+```
+
+Expected:
+```
+R  backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs -> backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
+```
+
+---
+
+## Task 5: Update `BackgroundRefreshController` to import the new namespace
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs` (lines 1–5).
+
+After Task 4 the project no longer compiles — `BackgroundRefreshController` references three symbols whose namespace just changed. This task fixes that.
+
+- [ ] **Step 1: Verify the build is currently broken (proof the change is necessary)**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.API/Anela.Heblo.API.csproj -nologo -v quiet 2>&1 | grep -E "error CS|RefreshTask"
+```
+
+Expected: errors referencing `RefreshTaskDto`, `RefreshTaskStatusDto`, and/or `RefreshTaskExecutionLogDto` (CS0246 "type or namespace … could not be found" or similar). This confirms the controller is the only consumer needing an `using` update.
+
+- [ ] **Step 2: Add the new `using` directive (alphabetically ordered)**
+
+Edit `backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs`.
+
+Replace this block at the top of the file:
+```csharp
+using Anela.Heblo.Xcc.Services.BackgroundRefresh;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+```
+
+With:
+```csharp
+using Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+using Anela.Heblo.Xcc.Services.BackgroundRefresh;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+```
+
+No other line in the file changes. The namespace `Anela.Heblo.API.Controllers` on line 5 (controller's own namespace) stays as-is — it is the controller's namespace, not a reference to a moved DTO.
+
+- [ ] **Step 3: Verify the build now succeeds**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln -nologo -v quiet
+```
+
+Expected: `Build succeeded.` with `0 Warning(s)` and `0 Error(s)`.
+
+If new warnings appear, investigate before continuing — NFR-1 requires zero new warnings.
+
+---
+
+## Task 6: Apply scoped `dotnet format` and verify zero changes
+
+**Files:**
+- The four touched files only.
+
+Per the architecture review, run `dotnet format` scoped to the four touched files (avoid rewriting unrelated files).
+
+- [ ] **Step 1: Run `dotnet format` scoped to the touched files**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs \
+            backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs \
+            backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs \
+            backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs
+```
+
+Expected: no stdout indicating fixes applied (or only trivial whitespace normalization). Exit code 0.
+
+- [ ] **Step 2: Verify formatter would now make no changes**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs \
+            backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs \
+            backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs \
+            backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs \
+  --verify-no-changes
+```
+
+Expected: exit code 0, no output. If non-zero, re-run Step 1 and recheck.
+
+---
+
+## Task 7: Run backend tests
+
+**Files:**
+- All test projects under `backend/test/` (none expected to require modification per arch review — repo-wide grep showed no test referencing these three symbols).
+
+- [ ] **Step 1: Run full backend test suite**
+
+Run:
+```bash
+dotnet test backend/Anela.Heblo.sln --no-build -nologo -v quiet
+```
+
+Expected: all tests pass (`Passed!` summary, `Failed: 0`).
+
+If a test fails with a missing-namespace error on `Anela.Heblo.API.Controllers.RefreshTask*`, that test is a hidden consumer the arch review missed. Update its `using` to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` and re-run. (Spec NFR-2 explicitly permits this kind of mechanical `using` update.)
+
+If any test fails for another reason, stop — that is unexpected for a pure namespace move and must be investigated.
+
+---
+
+## Task 8: Regenerate frontend TypeScript client and diff
+
+**Files:**
+- `frontend/src/api/generated/api-client.ts` (potentially regenerated; expected: no meaningful change).
+
+Per the architecture review, NSwag's default `schemaNameGenerator` is type-name-based — the generated TS client should be unchanged. We still regenerate and diff per the precedent set by `2026-05-27-relocate-backgroundjobs-request-body-dtos.md` and per spec FR-5.
+
+- [ ] **Step 1: Regenerate the TypeScript API client**
+
+Per `docs/development/api-client-generation.md`, the canonical command is the frontend build (which invokes the OpenAPI codegen task) or an explicit codegen target. Run the project's documented regeneration command. If unsure, use:
+
+```bash
+cd frontend && npm run build && cd ..
+```
+
+This regenerates `frontend/src/api/generated/api-client.ts` as part of the build pipeline and also fulfills the FE build check in Task 9.
+
+Expected: build succeeds with no TypeScript errors.
+
+If the project documents a more specific regen-only command in `docs/development/api-client-generation.md`, prefer that — but the build path above is sufficient.
+
+- [ ] **Step 2: Compute new checksum and diff**
+
+Run:
+```bash
+shasum frontend/src/api/generated/api-client.ts > /tmp/api-client.after.sha
+diff /tmp/api-client.before.sha /tmp/api-client.after.sha || true
+```
+
+Two possible outcomes:
+
+**Outcome A — checksums match (expected):**
+Output of `diff` is empty. The generated client is byte-identical. No frontend file is staged in this change. Move on to Task 9.
+
+**Outcome B — checksums differ:**
+Output of `diff` shows the two SHAs. Run:
+```bash
+git diff -- frontend/src/api/generated/api-client.ts | head -200
+```
+
+Inspect the diff:
+- If it consists only of `$ref` path updates, schema component reordering, or whitespace differences with no behavioral change to method signatures or class shapes, the regenerated file may be committed.
+- If method signatures, exported class shapes, or DTO field types change, **stop**: this contradicts the architecture review's assumption and indicates the move altered the public surface. Investigate before continuing — the spec mandates no contract change (FR-4, NFR-3).
+
+- [ ] **Step 3: Stage the regenerated client only if it changed**
+
+If Outcome A: do nothing.
+
+If Outcome B (and the diff is benign): run
+```bash
+git add frontend/src/api/generated/api-client.ts
+```
+
+---
+
+## Task 9: Frontend build and lint
+
+**Files:**
+- Read only (build / lint validation).
+
+Frontend build was already executed in Task 8 Step 1 (it triggers codegen). This task verifies lint and confirms no other frontend file changed.
+
+- [ ] **Step 1: Run frontend lint**
+
+Run:
+```bash
+cd frontend && npm run lint && cd ..
+```
+
+Expected: exit code 0, no lint errors.
+
+- [ ] **Step 2: Confirm no unintended frontend file changes**
+
+Run:
+```bash
+git status --short frontend/
+```
+
+Expected:
+- If TS client was unchanged (Outcome A in Task 8): no output (clean working tree under `frontend/`).
+- If TS client was regenerated (Outcome B): only `frontend/src/api/generated/api-client.ts` appears, staged from Task 8 Step 3.
+
+Any other modified file under `frontend/` is unexpected and must be investigated — the spec scopes the change strictly to BE relocation plus (optional) regenerated client.
+
+---
+
+## Task 10: Final verification — repo-wide grep for stale references
+
+**Files:**
+- Read only.
+
+Per the architecture review's specification amendment, anchor the grep to the three symbol names (not the broader `Anela.Heblo.API.Controllers` namespace, which has 77 unrelated matches).
+
+- [ ] **Step 1: Grep for stale fully-qualified references to the moved DTOs**
+
+Run:
+```bash
+git grep -nE 'Anela\.Heblo\.API\.Controllers\.RefreshTask(Dto|StatusDto|ExecutionLogDto)' \
+  -- '*.cs' '*.ts' '*.tsx' '*.json'
+```
+
+Expected: no output (exit code 1 from `grep` when no matches is normal here — `git grep` exits non-zero with no matches).
+
+If any hit appears, update that file's `using` / import to `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` (C#) or the appropriate path (TS — but TS imports DTOs from the unqualified generated module, so no TS hit is expected).
+
+- [ ] **Step 2: Confirm no `*Dto.cs` files remain under the API project**
+
+Run:
+```bash
+find backend/src/Anela.Heblo.API -name '*Dto.cs' -not -path '*/bin/*' -not -path '*/obj/*'
+```
+
+Expected: no output. (Per spec NFR-4, the API project must define zero DTOs after the change.)
+
+If hits appear, those are other DTOs that violate the same architectural rule — **do not** address them in this plan (out of scope per spec). Note them for a follow-up brief and continue.
+
+- [ ] **Step 3: Confirm the three moved files declare the new namespace**
+
+Run:
+```bash
+grep -n '^namespace ' \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
+```
+
+Expected (exactly):
+```
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs:1:namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs:1:namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs:1:namespace Anela.Heblo.Application.Features.BackgroundJobs.Contracts;
+```
+
+- [ ] **Step 4: Confirm `git log --follow` works on each moved file (history preserved)**
+
+Run:
+```bash
+git log --follow --oneline -n 3 \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs | head -3
+```
+
+Expected: at least one commit shown from before the rename. Repeat for the other two files if desired.
+
+If `git log --follow` shows only the impending move commit (after Task 11), rename detection failed — review Task 2/3/4 git status output and reset.
+
+---
+
+## Task 11: Commit the change
+
+**Files:**
+- All staged: three renames, namespace updates, one controller `using` update, optional regenerated TS client.
+
+- [ ] **Step 1: Stage the four touched backend files (renames and modifications)**
+
+Run:
+```bash
+git add \
+  backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs \
+  backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
+```
+
+(The deletions of the old paths are already staged by `git mv` in Tasks 2–4.)
+
+If Task 8 Step 3 staged `frontend/src/api/generated/api-client.ts`, it is also already in the index — leave it.
+
+- [ ] **Step 2: Verify staged diff shows renames + minimal edits**
+
+Run:
+```bash
+git status --short
+git diff --staged --stat
+```
+
+Expected `git status --short` (one rename line per DTO, one modify line for the controller):
+```
+R  backend/src/Anela.Heblo.API/Controllers/RefreshTaskDto.cs -> backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs
+R  backend/src/Anela.Heblo.API/Controllers/RefreshTaskStatusDto.cs -> backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs
+R  backend/src/Anela.Heblo.API/Controllers/RefreshTaskExecutionLogDto.cs -> backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs
+M  backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs
+```
+
+(Plus `M  frontend/src/api/generated/api-client.ts` only if Task 8 Outcome B applied.)
+
+If `git status` shows `D` and `A` instead of `R`, rename detection failed — revert (`git restore --staged --worktree .`) and retry Tasks 2–4 in tight edits.
+
+- [ ] **Step 3: Commit with a conventional-commit message**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+refactor: relocate BackgroundRefresh DTOs to Application contracts
+
+Move RefreshTaskDto, RefreshTaskStatusDto, and RefreshTaskExecutionLogDto
+from Anela.Heblo.API/Controllers/ to
+Anela.Heblo.Application/Features/BackgroundJobs/Contracts/, restoring
+compliance with the rule that the API project never owns DTOs
+(docs/architecture/development_guidelines.md). Update
+BackgroundRefreshController's using directive accordingly. No behavior,
+wire contract, or generated TypeScript client shape changes.
+EOF
+)"
+```
+
+Expected: commit succeeds, hooks pass.
+
+If a pre-commit hook fails, do **not** `--amend` — fix the underlying issue, re-stage, and create a new commit.
+
+- [ ] **Step 4: Final sanity check**
+
+Run:
+```bash
+git log --oneline -n 1
+git diff HEAD~1 --stat
+```
+
+Expected: the new commit at HEAD; `--stat` shows the four backend files (and the TS client only if Outcome B applied).
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec requirement | Implemented by |
+|---|---|
+| FR-1 Relocate DTO source files (3 files, `git mv`) | Tasks 2, 3, 4 (Step 1 each) |
+| FR-1 history preserved (`git log --follow`) | Task 10 Step 4 |
+| FR-2 Update namespaces | Tasks 2, 3, 4 (Step 2 each); verified Task 10 Step 3 |
+| FR-3 Update consumers (`BackgroundRefreshController` + any others) | Task 5 (controller); Task 7 (test consumers — none expected, repaired mechanically if any); Task 10 Step 1 (final grep) |
+| FR-4 DTO contract shape preserved | Tasks 2–4 explicit full file content; Task 8 diff check |
+| FR-5 Regenerate API clients if needed | Task 8 (regeneration + diff + conditional commit) |
+| NFR-1 Build & format | Task 5 Step 3 (build, zero warnings); Task 6 (scoped format) |
+| NFR-2 Tests pass without changes beyond `using` updates | Task 7 |
+| NFR-3 HTTP wire contract unchanged | Tasks 2–4 verbatim DTO content; Task 8 TS diff confirms no shape change |
+| NFR-4 API project defines zero DTOs after change | Task 10 Step 2 |
+
+All spec requirements have a corresponding task step.
+
+**2. Placeholder scan:** No "TBD", no "implement later", no "add error handling", no "similar to Task N". Every code block contains the actual content.
+
+**3. Type consistency:** Target namespace `Anela.Heblo.Application.Features.BackgroundJobs.Contracts` is identical across Tasks 2, 3, 4, 5, 10. DTO names (`RefreshTaskDto`, `RefreshTaskStatusDto`, `RefreshTaskExecutionLogDto`) are spelled consistently. File paths are identical everywhere they appear.
+
+**4. Architecture review amendments applied:**
+- Grep anchored to the three symbol names (Task 10 Step 1) — not the broader namespace.
+- `dotnet format` scoped to the four touched files (Task 6).
+- TS client regeneration expected to be a no-op; commit only if diff is benign (Task 8).
+
+Plan complete.


### PR DESCRIPTION
Relocates three BackgroundRefresh DTOs (`RefreshTaskDto`, `RefreshTaskStatusDto`, `RefreshTaskExecutionLogDto`) from the API project's `Controllers/` folder into the Application layer's `BackgroundJobs/Contracts/` folder, restoring full compliance with the architectural rule that the API project never defines or owns DTOs. The controller is updated with a single `using` directive. No behavior, HTTP wire contract, or generated TypeScript client shape changes.

### Changes
- `backend/src/Anela.Heblo.API/Controllers/BackgroundRefreshController.cs` — added one `using` directive for the new namespace
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskDto.cs` — relocated (git mv), namespace updated
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskStatusDto.cs` — relocated (git mv), namespace updated
- `backend/src/Anela.Heblo.Application/Features/BackgroundJobs/Contracts/RefreshTaskExecutionLogDto.cs` — relocated (git mv), namespace updated

---

Closes #2044

### Tokens used
12743749
