### PR TITLE
feat: Decouple GridLayouts Application Handlers from Npgsql

### DIFF
--- a/artifacts/feat-arch-review-gridlayouts-application-hand/arch-review.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-application-hand/arch-review.r1.md
@@ -1,0 +1,253 @@
+I have enough context. Producing the architecture review now.
+
+# Architecture Review: Decouple GridLayouts Application Handlers from Npgsql
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change restores the Clean Architecture dependency direction (Application → Domain only) without introducing any new patterns. The proposal is well-aligned with what already exists:
+
+- `IGridLayoutRepository` is defined in `Anela.Heblo.Domain.Features.GridLayouts` — the right place for the new exception.
+- `GridLayoutRepository` lives in `Anela.Heblo.Persistence.GridLayouts` and uses EF Core (`ApplicationDbContext`). It is the natural boundary to translate driver exceptions.
+- The codebase already has `PostgresExceptionLoggingInterceptor` in `Persistence/Infrastructure/` whose `UnwrapPostgresException` recursion is the exact pattern needed for the translation. We should mirror that logic instead of inventing a new one.
+
+Two **integration points** matter:
+
+1. **EF Core wrapping.** The repository calls `_context.SaveChangesAsync()` and `FirstOrDefaultAsync`. In production these can surface either a direct `NpgsqlException` (connection-level) or a `DbUpdateException` whose `InnerException` is `PostgresException` (constraint violations). The translation must handle both — the current handlers only `catch (Exception ex) when (ex is PostgresException or NpgsqlException)`, which means today they only catch the connection-level case; `DbUpdateException` wrapping is **already a latent bug** not addressed by the brief. Spec FR-2 hints at this in passing; this review elevates it.
+2. **`SqlState` logging in handlers.** All three handlers currently log a structured `{SqlState}` field extracted from `PostgresException`. Strict preservation of this log shape (NFR-1) is impossible if the handler may not import `Npgsql`. There are three options — see Decision 2.
+
+Three other Application files still import `Npgsql` (`Photobank/PhotobankRepository.cs`, `PackingMaterials/ConsumptionCalculationService.cs`, `Smartsupp/.../ProcessWebhookEventHandler.cs`). The brief explicitly scopes this work to GridLayouts; they remain out of scope but should be noted as the next candidates for the same refactor.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.API (MVC controllers)                                    │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │ MediatR send
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Application                                              │
+│   GridLayouts handlers                                               │
+│     catch (GridLayoutPersistenceException ex)  ← domain exception    │
+│       → log with ex.SqlState                                         │
+│       → return MediatR response with ErrorCodes.DatabaseError        │
+│   ✗ no "using Npgsql;"                                               │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │ IGridLayoutRepository (domain)
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Domain.Features.GridLayouts                              │
+│   IGridLayoutRepository (existing)                                   │
+│   GridLayout (existing)                                              │
+│   GridLayoutPersistenceException  ← NEW                              │
+│     - Message (string)                                               │
+│     - SqlState (string?) ← extracted at translation time             │
+│     - InnerException (Exception)                                     │
+│   ✗ no infrastructure references                                     │
+└────────────────────────────────┬─────────────────────────────────────┘
+                                 │ implemented by
+                                 ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Persistence.GridLayouts                                  │
+│   GridLayoutRepository (EF Core)                                     │
+│     each method wraps DbContext call in                              │
+│     PostgresExceptionTranslator.Translate(...)                       │
+│   ── Persistence.Infrastructure ──                                   │
+│   PostgresExceptionLoggingInterceptor (existing, untouched)          │
+│   PostgresExceptionTranslator  ← NEW (or static helper)              │
+│     - reuses unwrap recursion from the interceptor                   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Where to perform the Npgsql → domain translation
+
+**Options considered:**
+- (A) Inline `try/catch` in every repository method.
+- (B) A private static helper (`PostgresExceptionTranslator.Translate`) in `Persistence/Infrastructure/` that the repository wraps each operation with.
+- (C) A `SaveChangesInterceptor` that throws the domain exception on save failure.
+
+**Chosen approach:** (B) — a small static translator in `Anela.Heblo.Persistence.Infrastructure.PostgresExceptionTranslator`.
+
+**Rationale:** Inline try/catch (A) duplicates the unwrap logic three times in one file and risks drift with future repository methods. Interceptor-only (C) does not cover read paths (`FirstOrDefaultAsync`) where connection-level `NpgsqlException` is still possible. The static helper centralizes the unwrap recursion (same shape as `PostgresExceptionLoggingInterceptor.UnwrapPostgresException`), keeps the repository readable, and is trivially unit-testable. Future feature modules that need the same translation can reuse it (or copy the pattern for their own domain exception).
+
+#### Decision 2: How to preserve the `{SqlState}` log field in handlers without re-importing Npgsql
+
+**Options considered:**
+- (A) Drop `{SqlState}` from handler logs — rely on `PostgresExceptionLoggingInterceptor` to log it once at the persistence boundary.
+- (B) Expose `SqlState` as a nullable `string` property on `GridLayoutPersistenceException`, populated at translation time.
+- (C) Leave handlers walking the `InnerException` chain — but this still requires importing `Npgsql.PostgresException` to read `.SqlState`, defeating the refactor.
+
+**Chosen approach:** (B) — add `public string? SqlState { get; }` to `GridLayoutPersistenceException`.
+
+**Rationale:** (C) defeats the goal. (A) is tempting (the interceptor already logs SqlState) but it changes the log shape — observability dashboards or queries that grep handler log lines for `SqlState=...` would silently break, and NFR-1 says "Error logs preserve their level, template, and structured fields." (B) preserves the field exactly. `SqlState` is a plain string in the SQL standard (`23505`, `23503`, etc.), so storing it as a string introduces zero coupling to Npgsql in the Domain layer.
+
+**Spec amendment required** — see Specification Amendments below.
+
+#### Decision 3: How to test the translation (FR-8) without a live PostgreSQL
+
+**Options considered:**
+- (A) `Testcontainers.PostgreSQL` (already referenced in `Anela.Heblo.Tests.csproj`) — spin a real Postgres container and force a constraint violation.
+- (B) Test double: a derived `TestApplicationDbContext` that overrides `SaveChangesAsync` to throw a `new NpgsqlException("...")`.
+- (C) Extract a thin `IGridLayoutQueries` seam to inject failures.
+
+**Chosen approach:** (B) — derived `ApplicationDbContext` test double, with `Microsoft.EntityFrameworkCore.InMemory` for the happy-path seed and an override that throws on demand.
+
+**Rationale:** (A) is more realistic but adds container startup time to the unit test suite and is overkill for a translation test. (C) is invasive for one test. (B) matches spec FR-8's "test double or in-memory substitute" wording, runs fast, and `NpgsqlException` has a public `(string message)` constructor that the existing handler tests already use. The test asserts the **boundary contract** (input: NpgsqlException; output: GridLayoutPersistenceException with InnerException preserved) — that is exactly what we want to lock in.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Domain/
+  Features/GridLayouts/
+    GridLayoutPersistenceException.cs              ← NEW (FR-1)
+
+backend/src/Anela.Heblo.Persistence/
+  Infrastructure/
+    PostgresExceptionLoggingInterceptor.cs         (unchanged)
+    PostgresExceptionTranslator.cs                 ← NEW (Decision 1)
+  GridLayouts/
+    GridLayoutRepository.cs                        ← MODIFIED (FR-2)
+
+backend/src/Anela.Heblo.Application/
+  Features/GridLayouts/UseCases/
+    GetGridLayout/GetGridLayoutHandler.cs          ← MODIFIED (FR-3)
+    SaveGridLayout/SaveGridLayoutHandler.cs        ← MODIFIED (FR-4)
+    ResetGridLayout/ResetGridLayoutHandler.cs      ← MODIFIED (FR-5)
+
+backend/test/Anela.Heblo.Tests/
+  Features/GridLayouts/
+    GetGridLayoutHandlerTests.cs                   ← MODIFIED (FR-7)
+    SaveGridLayoutHandlerTests.cs                  ← MODIFIED (FR-7)
+    ResetGridLayoutHandlerTests.cs                 ← MODIFIED (FR-7)
+  Persistence/GridLayouts/                         ← NEW directory
+    GridLayoutRepositoryTranslationTests.cs        ← NEW (FR-8)
+```
+
+### Interfaces and Contracts
+
+**`GridLayoutPersistenceException`** (Domain — final shape):
+```csharp
+namespace Anela.Heblo.Domain.Features.GridLayouts;
+
+public class GridLayoutPersistenceException : Exception
+{
+    public string? SqlState { get; }
+
+    public GridLayoutPersistenceException(string message, string? sqlState, Exception inner)
+        : base(message, inner)
+    {
+        SqlState = sqlState;
+    }
+}
+```
+- `class`, not `record` — exceptions follow CLR identity semantics; matches BCL convention.
+- Constructor takes `(message, sqlState, inner)`. `sqlState` is nullable because connection-level `NpgsqlException` without a `PostgresException` inside has no SqlState.
+- No XML doc tags required, but `<exception>` tags on `IGridLayoutRepository` methods are recommended.
+
+**`PostgresExceptionTranslator`** (Persistence/Infrastructure — sketch):
+```csharp
+internal static class PostgresExceptionTranslator
+{
+    // Returns null when ex is not a Npgsql/Postgres family exception → caller rethrows untouched.
+    public static GridLayoutPersistenceException? TryTranslateGridLayout(Exception ex, string operationDescription) { ... }
+}
+```
+- Reuses the same unwrap recursion as `PostgresExceptionLoggingInterceptor.UnwrapPostgresException`.
+- Recognizes: direct `PostgresException`, direct `NpgsqlException`, `DbUpdateException` whose inner is `PostgresException` (or deeper).
+- Returns `null` for anything else (so `OperationCanceledException`, `DbUpdateConcurrencyException` without Pg inner, etc. propagate unchanged — FR-2 acceptance criterion).
+
+**`IGridLayoutRepository`** (Domain — unchanged signatures, new exception contract):
+```csharp
+public interface IGridLayoutRepository
+{
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
+    Task<GridLayout?> GetAsync(string userId, string gridKey, CancellationToken cancellationToken = default);
+    // ... same for UpsertAsync, DeleteAsync
+}
+```
+
+**MediatR responses** (`GetGridLayoutResponse`, `SaveGridLayoutResponse`, `ResetGridLayoutResponse`) — **unchanged**.
+
+### Data Flow
+
+**Happy path (read):**
+```
+Controller → MediatR → GetGridLayoutHandler.Handle
+  → _repository.GetAsync (Domain interface)
+  → GridLayoutRepository.GetAsync (Persistence)
+  → EF Core FirstOrDefaultAsync
+  → returns entity (or null) → DTO → GetGridLayoutResponse
+```
+
+**Error path (PostgreSQL failure, e.g. SqlState 42P01 "relation does not exist"):**
+```
+EF Core FirstOrDefaultAsync throws NpgsqlException (or DbUpdateException wrapping PostgresException)
+  → caught in GridLayoutRepository wrapper
+  → PostgresExceptionTranslator.TryTranslateGridLayout(ex, "GetGridLayout") returns GridLayoutPersistenceException(message, sqlState, ex)
+  → rethrown
+  → caught in GetGridLayoutHandler as GridLayoutPersistenceException
+  → _logger.LogError(ex, "Database error reading GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}", userId, request.GridKey, ex.SqlState)
+  → returns GetGridLayoutResponse { Layout = null }   ← identical to today
+```
+
+**Pass-through path (non-Pg failure):**
+```
+DbUpdateConcurrencyException (no Pg inner), OperationCanceledException, etc.
+  → wrapper sees translator return null → rethrows original
+  → handler does NOT catch → propagates to global exception middleware
+  → identical to today
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Adding `SqlState` to `GridLayoutPersistenceException` is a spec deviation (FR-1 specifies only `(string, Exception)` constructor). | Medium | Captured in Specification Amendments below; the alternative drops a structured log field and violates NFR-1. |
+| `DbUpdateException` wrapping of `PostgresException` is **not** caught by today's handlers but **will be** translated by the new repository wrapper — this is a behavior change (in the better direction, but a change). | Medium | Call this out in the PR description as an intentional bug fix discovered during the refactor. Add a translation test for the `DbUpdateException(inner: PostgresException)` shape so the regression coverage is explicit. |
+| Translator misses an exception shape (e.g. deeply nested aggregate exceptions) and lets Npgsql leak past the boundary back to the handler — handler catches `GridLayoutPersistenceException` only and unhandled exception escapes. | Medium | Reuse the same recursive unwrap pattern as `PostgresExceptionLoggingInterceptor` (already battle-tested in this repo). Add a unit test for the `DbUpdateException → PostgresException` nested case. |
+| FR-6 (remove Npgsql PackageReference from `Anela.Heblo.Application.csproj`) is **unsatisfiable as written**: there is no direct `<PackageReference Include="Npgsql" />` in that csproj — Npgsql arrives transitively through `Anela.Heblo.Persistence`'s reference to `Npgsql.EntityFrameworkCore.PostgreSQL`. | Low | Reinterpret FR-6 as "no `using Npgsql;` in any Application-layer source file under `Features/GridLayouts/`" (verified by grep). The transitive runtime dependency is unavoidable while Application references Persistence — out of scope. |
+| Three other Application files (`Photobank/PhotobankRepository.cs`, `PackingMaterials/ConsumptionCalculationService.cs`, `Smartsupp/.../ProcessWebhookEventHandler.cs`) still import Npgsql. Reviewers may expect them in this PR. | Low | Brief explicitly scopes to GridLayouts; mention these as follow-up tickets in the PR description so they don't get lost. |
+| New `PostgresExceptionTranslator` overlaps in spirit with the existing `PostgresExceptionLoggingInterceptor`. Future maintainers might wonder why both exist. | Low | Place the translator next to the interceptor in `Persistence/Infrastructure/` and add a one-line comment on each explaining the distinct purpose (logging vs. domain translation). |
+
+## Specification Amendments
+
+1. **FR-1 — extend the exception shape.** Change the exception to expose `SqlState`:
+   ```csharp
+   public class GridLayoutPersistenceException : Exception
+   {
+       public string? SqlState { get; }
+       public GridLayoutPersistenceException(string message, string? sqlState, Exception inner)
+           : base(message, inner) { SqlState = sqlState; }
+   }
+   ```
+   **Why:** handlers log `{SqlState}` as a structured field today (NFR-1 requires log shape preservation), and any handler-side extraction of `SqlState` from the inner exception chain would require re-importing `Npgsql.PostgresException`, defeating the refactor.
+
+2. **FR-2 — extend acceptance criteria to cover EF wrapping.** Add: "If a thrown exception is `DbUpdateException` whose inner exception chain contains a `PostgresException`, it is also translated to `GridLayoutPersistenceException`." The current handler `catch (Exception ex) when (ex is PostgresException or NpgsqlException)` does **not** catch this case today, so the new repository wrapper actually broadens the caught surface. Frame this as a deliberate, documented improvement in the PR — not silent behavior change.
+
+3. **FR-6 — reinterpret.** No direct `<PackageReference>` for Npgsql exists in `Anela.Heblo.Application.csproj`; the Npgsql assembly is transitive via `Anela.Heblo.Persistence` → `Npgsql.EntityFrameworkCore.PostgreSQL`, and that cannot be removed while Application references Persistence. Restate FR-6 as: *"`grep -r "using Npgsql" backend/src/Anela.Heblo.Application/Features/GridLayouts` returns no matches; no Npgsql type appears in any file under `Application/Features/GridLayouts/`."* No csproj change is required.
+
+4. **FR-7 — clarify the log assertion update.** The existing tests assert `It.IsAny<NpgsqlException>()` in the logger verification. They must be changed to `It.IsAny<GridLayoutPersistenceException>()`. Make this explicit in FR-7 acceptance criteria so reviewers don't miss the verification update.
+
+5. **FR-8 — specify the test double mechanism.** Use a derived `ApplicationDbContext` that overrides `SaveChangesAsync` (and exposes a way to throw on the read path) to throw `new NpgsqlException("…")`. Two test cases: (a) direct `NpgsqlException` translation, (b) `DbUpdateException` wrapping a `PostgresException` translation — both assert the resulting `GridLayoutPersistenceException.InnerException` equals the original. The `PostgresException` constructor is parameter-heavy; if constructing one is awkward, the test for case (b) can use `new DbUpdateException("test", new NpgsqlException("inner"))` since `NpgsqlException` is `PostgresException`'s base.
+
+## Prerequisites
+
+None. All required infrastructure exists:
+
+- `Anela.Heblo.Domain.Features.GridLayouts` namespace exists.
+- `Anela.Heblo.Persistence.Infrastructure` namespace exists (sibling to the new `PostgresExceptionTranslator`).
+- `Anela.Heblo.Tests.csproj` already references `Moq`, `FluentAssertions`, `Microsoft.EntityFrameworkCore.InMemory`, and (unused for this PR but available) `Testcontainers.PostgreSql`.
+- No database migrations, configuration, feature flags, secrets, or infrastructure changes are required.
+- No frontend changes; OpenAPI client generation produces no new types since DTOs and response shapes are unchanged.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-gridlayouts-application-hand/brief.md
+++ b/artifacts/feat-arch-review-gridlayouts-application-hand/brief.md
@@ -1,0 +1,32 @@
+## Module
+GridLayouts
+
+## Finding
+All three MediatR handlers in the GridLayouts module directly import and catch `NpgsqlException` and `PostgresException` from the Npgsql package — which is a concrete infrastructure (PostgreSQL driver) dependency:
+
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — `using Npgsql;` (line 7), catch block lines 45–51
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs` — `using Npgsql;` (line 9), catch block lines 44–50
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs` — `using Npgsql;` (line 5), catch block lines 34–40
+
+Clean Architecture requires that the Application layer depends only on domain abstractions. `IGridLayoutRepository` is the right abstraction; `NpgsqlException` is a leaking infrastructure detail that belongs exclusively in the Persistence layer.
+
+## Why it matters
+- Gives the Application layer a compile-time dependency on the Npgsql assembly, violating the Application → Domain dependency direction.
+- Makes the repository contract non-substitutable: an in-memory or SQLite test double cannot produce `NpgsqlException`, so the catch block is dead in unit tests and the handlers behave differently under mocking than in production.
+- The existing unit tests themselves import `NpgsqlException` (`GetGridLayoutHandlerTests.cs` line 8, `SaveGridLayoutHandlerTests.cs` line 9, `ResetGridLayoutHandlerTests.cs` line 5), coupling the test suite to the driver.
+
+## Suggested fix
+Introduce a domain exception in `Domain/Features/GridLayouts/`:
+
+```csharp
+public class GridLayoutPersistenceException : Exception
+{
+    public GridLayoutPersistenceException(string message, Exception inner)
+        : base(message, inner) { }
+}
+```
+
+Have `GridLayoutRepository` (Persistence layer) catch `NpgsqlException`/`PostgresException` and rethrow as `GridLayoutPersistenceException`. The three handlers then catch only the domain exception — zero Npgsql dependency in Application or its tests.
+
+---
+_Filed by daily arch-review routine on 2026-05-29._

--- a/artifacts/feat-arch-review-gridlayouts-application-hand/impl/main.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-application-hand/impl/main.r1.md
@@ -1,0 +1,94 @@
+All 13 tasks complete. Here is the output artifact:
+
+---
+
+# Implementation: Decouple GridLayouts Application Handlers from Npgsql
+
+## What was implemented
+
+Removed the direct Npgsql dependency from the three GridLayouts MediatR handlers by:
+1. Adding a `GridLayoutPersistenceException` domain exception with a nullable `SqlState` string property so handlers can preserve their `{SqlState}` log field without importing Npgsql.
+2. Adding a `PostgresExceptionTranslator` static class in `Persistence/Infrastructure` that mirrors the recursive unwrap pattern from `PostgresExceptionLoggingInterceptor`, catching direct `NpgsqlException`, `DbUpdateException` wrapping `NpgsqlException`, and returning `null` for all other exception types (pass-through).
+3. Wrapping all three `GridLayoutRepository` methods with the translator.
+4. Updating all three handlers to catch `GridLayoutPersistenceException` instead of the Npgsql union type.
+5. Updating all three handler test files to throw and assert `GridLayoutPersistenceException`.
+6. Adding XML `<exception>` doc tags to `IGridLayoutRepository`.
+
+## Files created/modified
+
+**Created:**
+- `backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs` — domain exception with `SqlState` property (FR-1, amended shape)
+- `backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionTranslator.cs` — static translator wrapping Npgsql → domain exception (FR-2 support)
+- `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs` — 5 unit tests for the translator
+- `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs` — 4 repository-level tests using `ThrowingApplicationDbContext` (FR-8)
+
+**Modified:**
+- `backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs` — wrapped GetAsync, UpsertAsync, DeleteAsync with translator; inlined internal calls to avoid double-wrapping
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — removed `using Npgsql;`, catches `GridLayoutPersistenceException`
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs` — same
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs` — same
+- `backend/src/Anela.Heblo.Domain/Features/GridLayouts/IGridLayoutRepository.cs` — added `<exception>` XML docs
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` — replaced `NpgsqlException` with `GridLayoutPersistenceException`
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs` — same
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs` — same
+
+## Tests
+
+- `PostgresExceptionTranslatorTests.cs` — 5 tests: direct NpgsqlException, DbUpdateException wrapping, OperationCanceledException passthrough, DbUpdateConcurrencyException passthrough, generic exception passthrough
+- `GridLayoutRepositoryTranslationTests.cs` — 4 tests: UpsertAsync NpgsqlException, UpsertAsync DbUpdateException wrapping, UpsertAsync non-Pg passthrough, DeleteAsync NpgsqlException
+- Handler tests (3 files) — 7 tests updated to use `GridLayoutPersistenceException`
+- **Total: 16 GridLayout tests, all passing**
+
+## How to verify
+
+```bash
+# Grep check (FR-6 reinterpretation)
+grep -r "using Npgsql" backend/src/Anela.Heblo.Application/Features/GridLayouts
+# Expected: no output
+
+# Build
+dotnet build Anela.Heblo.sln
+# Expected: 0 errors
+
+# Format
+dotnet format Anela.Heblo.sln --verify-no-changes
+# Expected: exit code 0
+
+# All 16 GridLayout tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GridLayout" --no-build
+# Expected: 16 passed
+```
+
+## Notes
+
+**Deviations from original spec (all per arch-review amendments):**
+- `GridLayoutPersistenceException` constructor takes three args `(string, string?, Exception)` not two — needed to preserve `{SqlState}` structured log field in handlers without re-importing Npgsql (Spec Amendment 1).
+- `PostgresExceptionTranslator` is `public` not `internal` — no `InternalsVisibleTo` pattern existed in the project, so public visibility was chosen per the plan's decision rule.
+- FR-6 satisfied by grep verification only (no csproj change) — no direct `<PackageReference Include="Npgsql" />` exists in Application.csproj; Npgsql arrives transitively via Persistence → `Npgsql.EntityFrameworkCore.PostgreSQL`.
+- `DbUpdateException` wrapping `PostgresException` is now also translated — this was a **latent bug fix**: the original catch `when (ex is PostgresException or NpgsqlException)` did not catch EF Core save-path constraint violations. Call this out in the PR.
+
+**Pre-existing quality concerns surfaced by code reviewer (not introduced by this PR, out of scope):**
+- `GetGridLayoutHandler`: `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto()` silently swallows malformed JSON — pre-existing, separate ticket needed
+- `SaveGridLayoutHandler`: `JsonSerializer.Serialize(payload)` not wrapped — pre-existing, separate ticket needed
+- Three other Application files still import Npgsql (`Photobank/PhotobankRepository.cs`, `PackingMaterials/ConsumptionCalculationService.cs`, `Smartsupp/.../ProcessWebhookEventHandler.cs`) — explicitly out of scope per spec
+
+## PR Summary
+
+Removes the direct Npgsql dependency from all three GridLayouts MediatR handlers (Get/Save/Reset), restoring Clean Architecture's dependency direction (Application → Domain only). The fix introduces a `GridLayoutPersistenceException` domain type with a nullable `SqlState` property so handlers keep their existing `{SqlState}` log field, a static `PostgresExceptionTranslator` in the Persistence layer that mirrors the existing `PostgresExceptionLoggingInterceptor` unwrap recursion, and wraps all three `GridLayoutRepository` methods at the persistence boundary.
+
+As a deliberate side-effect, the repository wrapper now also catches `DbUpdateException` wrapping a `PostgresException` (constraint violations from `SaveChangesAsync`), which the original handler `catch (Exception ex) when (ex is PostgresException or NpgsqlException)` silently missed — this is a latent bug fix, not a silent behavior change.
+
+### Changes
+- `GridLayoutPersistenceException.cs` — new domain exception with `SqlState` string property
+- `PostgresExceptionTranslator.cs` — new static helper in Persistence/Infrastructure translating Npgsql family exceptions to the domain type
+- `GridLayoutRepository.cs` — wraps GetAsync/UpsertAsync/DeleteAsync; inlines previously-delegated GetAsync calls to avoid double-wrapping
+- `GetGridLayoutHandler.cs`, `SaveGridLayoutHandler.cs`, `ResetGridLayoutHandler.cs` — removed `using Npgsql;`, catches `GridLayoutPersistenceException`
+- `IGridLayoutRepository.cs` — added `<exception>` XML doc tags
+- Handler tests (3) — replaced `NpgsqlException` with `GridLayoutPersistenceException` in mock setups and logger verifications
+- New translator unit tests (5) and repository-level integration tests (4) using `ThrowingApplicationDbContext`
+
+## Status
+DONE_WITH_CONCERNS
+
+Concerns: Code quality reviewer identified 2 HIGH-severity pre-existing issues in unchanged code (`JsonSerializer` error handling gaps in Get and Save handlers). These were intentionally left unfixed to keep this PR surgical (spec NFR-1: zero behavioral changes). Follow-up tickets should address them separately.

--- a/artifacts/feat-arch-review-gridlayouts-application-hand/spec.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-application-hand/spec.r1.md
@@ -1,0 +1,171 @@
+# Specification: Decouple GridLayouts Application Handlers from Npgsql
+
+## Summary
+The GridLayouts MediatR handlers in the Application layer currently catch `NpgsqlException` and `PostgresException` directly, creating a compile-time dependency on the Npgsql PostgreSQL driver. This work introduces a `GridLayoutPersistenceException` domain exception, translates infrastructure exceptions inside the Persistence-layer repository, and updates handlers and their unit tests to depend only on the domain abstraction — restoring the Clean Architecture dependency direction.
+
+## Background
+Clean Architecture in this repo dictates that the Application layer depends only on the Domain layer (abstractions). The current implementation violates this in three places:
+
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — `using Npgsql;` line 7, catch block lines 45–51
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs` — `using Npgsql;` line 9, catch block lines 44–50
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs` — `using Npgsql;` line 5, catch block lines 34–40
+
+Consequences of the leak:
+- The `Anela.Heblo.Application` assembly takes a transitive dependency on the Npgsql package.
+- The `IGridLayoutRepository` abstraction is no longer truly substitutable — a non-PostgreSQL implementation (in-memory, SQLite, test double) cannot reproduce `NpgsqlException`, so the catch branches are dead under unit tests but live in production.
+- Unit tests at `backend/test/Anela.Heblo.Tests/Features/GridLayouts/*` import Npgsql to construct exception instances for mocking, propagating the coupling into the test suite.
+
+This is a refactor with no user-visible behavior change: the same error path must continue to return the same MediatR response (preserved status code, error code, and message). The fix was filed by the daily arch-review routine on 2026-05-29.
+
+## Functional Requirements
+
+### FR-1: Introduce `GridLayoutPersistenceException` domain exception
+Add a new exception type in the Domain layer that the Application layer can catch without referencing infrastructure types.
+
+**Location:** `backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs`
+
+**Shape:**
+```csharp
+namespace Anela.Heblo.Domain.Features.GridLayouts;
+
+public class GridLayoutPersistenceException : Exception
+{
+    public GridLayoutPersistenceException(string message, Exception inner)
+        : base(message, inner) { }
+}
+```
+
+**Acceptance criteria:**
+- Class lives in `Anela.Heblo.Domain.Features.GridLayouts` namespace.
+- Has a single constructor taking `(string message, Exception inner)` and forwards both to `Exception`.
+- No dependency on Npgsql, EF Core, or any infrastructure package.
+- Project compiles after the type is added.
+
+### FR-2: Translate Npgsql exceptions in the Persistence-layer repository
+The `GridLayoutRepository` implementation must catch `NpgsqlException`/`PostgresException` at the persistence boundary and rethrow them as `GridLayoutPersistenceException`, preserving the inner exception for diagnostics.
+
+**Acceptance criteria:**
+- Every repository method that today can surface `NpgsqlException`/`PostgresException` to its caller wraps the call site and rethrows `GridLayoutPersistenceException(originalMessage, ex)`.
+- The wrapper does not swallow other exception types (e.g. `OperationCanceledException`, `DbUpdateConcurrencyException`) — they continue to propagate unchanged unless they are themselves Npgsql exceptions.
+- Repository methods that already wrap with EF Core (`DbUpdateException`) keep their existing behavior, but `DbUpdateException.InnerException as PostgresException` is also translated to `GridLayoutPersistenceException` when the inner is a PostgreSQL error. (See Open Questions if EF wrapping is encountered.)
+- The Persistence layer keeps its Npgsql reference; no other layer gains one.
+
+### FR-3: Remove Npgsql from `GetGridLayoutHandler`
+Update `GetGridLayoutHandler.cs` to catch `GridLayoutPersistenceException` instead of `NpgsqlException`/`PostgresException`.
+
+**Acceptance criteria:**
+- `using Npgsql;` is removed from the file.
+- The catch block (current lines 45–51) catches `GridLayoutPersistenceException`.
+- The MediatR response returned from the catch block is byte-for-byte equivalent to today's response (same `ErrorCode`, same `Message`, same HTTP semantics downstream).
+- Logging inside the catch preserves the current log level and message template, with the exception still attached for full stack trace.
+
+### FR-4: Remove Npgsql from `SaveGridLayoutHandler`
+Same as FR-3 applied to `SaveGridLayoutHandler.cs` (current catch block lines 44–50).
+
+**Acceptance criteria:**
+- `using Npgsql;` removed.
+- `GridLayoutPersistenceException` is the only persistence-related exception caught.
+- MediatR response unchanged.
+- Log output unchanged in level, template, and exception attachment.
+
+### FR-5: Remove Npgsql from `ResetGridLayoutHandler`
+Same as FR-3 applied to `ResetGridLayoutHandler.cs` (current catch block lines 34–40).
+
+**Acceptance criteria:**
+- `using Npgsql;` removed.
+- `GridLayoutPersistenceException` is the only persistence-related exception caught.
+- MediatR response unchanged.
+- Log output unchanged in level, template, and exception attachment.
+
+### FR-6: Remove Npgsql package reference from `Anela.Heblo.Application.csproj`
+Once handlers and Application-layer code no longer reference Npgsql types, remove the `<PackageReference>` for `Npgsql` (and any transitive Npgsql-only references) from the Application project file, unless another component in the project still needs it.
+
+**Acceptance criteria:**
+- `grep -r "using Npgsql" backend/src/Anela.Heblo.Application` returns no matches.
+- `Anela.Heblo.Application.csproj` no longer declares a direct `Npgsql` package reference (if such a reference exists today purely for the GridLayouts handlers).
+- Solution still builds with `dotnet build`.
+- If other Application features rely on Npgsql, leave the reference in place and note this in Open Questions.
+
+### FR-7: Update GridLayouts handler unit tests to use `GridLayoutPersistenceException`
+Modify the three test files so they no longer import or construct `NpgsqlException`:
+
+- `backend/test/.../GridLayouts/.../GetGridLayoutHandlerTests.cs` (currently imports Npgsql at line 8)
+- `backend/test/.../GridLayouts/.../SaveGridLayoutHandlerTests.cs` (line 9)
+- `backend/test/.../GridLayouts/.../ResetGridLayoutHandlerTests.cs` (line 5)
+
+**Acceptance criteria:**
+- No `using Npgsql;` directive in any GridLayouts test file.
+- Mocks of `IGridLayoutRepository` that previously threw `NpgsqlException`/`PostgresException` now throw `GridLayoutPersistenceException` with a representative message and inner exception.
+- The error-path tests still assert the same MediatR response (same error code, same message, same status).
+- All previously passing GridLayouts handler tests still pass.
+
+### FR-8: Add a repository-level test for Npgsql → domain translation
+Add at least one test in the persistence test layer that verifies a thrown `NpgsqlException` (or `PostgresException`, whichever is realistically surfaced by EF Core / direct ADO.NET in this codebase) is translated into `GridLayoutPersistenceException` by the repository.
+
+**Acceptance criteria:**
+- One new test exists alongside other `GridLayoutRepository` tests (or is added if none exist) that asserts:
+  - Given a repository method invocation whose underlying call throws `NpgsqlException`,
+  - When the method is invoked,
+  - Then a `GridLayoutPersistenceException` is thrown, and `InnerException` is the original `NpgsqlException`.
+- The test does not require a live PostgreSQL connection — it uses a test double or in-memory substitute for the underlying data context.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavior preservation
+This is a refactor with **zero behavioral changes** observable through the HTTP API or MediatR pipeline. The same input produces the same response code, body, and side effects as before. Error logs preserve their level, template, and structured fields.
+
+### NFR-2: Build & static checks
+- `dotnet build` passes with no warnings introduced by this change.
+- `dotnet format` passes.
+- No new analyzer warnings.
+
+### NFR-3: Test coverage
+- All existing GridLayouts tests continue to pass.
+- New repository translation test (FR-8) is added.
+- Coverage on the three handlers does not drop.
+- E2E suite is not in PR CI (per project facts) — not required to run for this PR, but should not be broken in nightly.
+
+### NFR-4: Dependency direction
+After the change:
+- `Anela.Heblo.Application` has no direct or transitive code-level dependency on `Npgsql` (project file does not declare it, source files do not import it).
+- `Anela.Heblo.Domain` has no dependency on Npgsql or EF Core.
+- The Npgsql dependency is confined to `Anela.Heblo.Persistence` (and any infrastructure-only assemblies).
+
+### NFR-5: Performance
+No performance impact. Exception translation adds at most one wrapping allocation on the already-exceptional error path; the happy path is unchanged.
+
+## Data Model
+No database schema changes. No new tables, columns, or migrations.
+
+New runtime type:
+- `Anela.Heblo.Domain.Features.GridLayouts.GridLayoutPersistenceException` — domain exception, properties: `Message` (string), `InnerException` (Exception, the original Npgsql/Postgres exception).
+
+## API / Interface Design
+No public HTTP API contract changes. No new endpoints. No changes to request/response DTOs.
+
+Internal interface contract (`IGridLayoutRepository`):
+- Existing method signatures are unchanged.
+- New documented exception contract: methods may throw `GridLayoutPersistenceException` to indicate a persistence failure. (Optionally add XML doc `<exception>` tags to the interface methods — recommended but not strictly required.)
+
+MediatR error responses returned by handlers remain identical in shape and content.
+
+## Dependencies
+- **Npgsql** — remains in the Persistence project; removed from Application (FR-6).
+- **MediatR** — handlers remain MediatR-based; no version change.
+- **EF Core (Npgsql provider)** — unchanged in Persistence.
+- **xUnit / Moq (or current mocking library)** — used in the test updates; no library swap.
+- No external services involved.
+- No feature flag needed; this is a pure code refactor.
+
+## Out of Scope
+- Refactoring other modules' handlers that may catch infrastructure exceptions (this brief is scoped to GridLayouts only).
+- Introducing a generic cross-module persistence exception hierarchy (e.g. `DomainPersistenceException` base). If a future arch-review finds the same anti-pattern elsewhere, that is a separate ticket.
+- Changing the MediatR response shape, error codes, or HTTP status codes returned by these handlers.
+- Adding new retry / circuit-breaker logic around persistence failures.
+- Database migrations or schema changes.
+- Updating frontend code — no client-visible contract changes.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-gridlayouts-application-hand/task-plan.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-application-hand/task-plan.r1.md
@@ -1,0 +1,15 @@
+Plan saved to `docs/superpowers/plans/2026-06-02-decouple-gridlayouts-app-handlers-from-npgsql.md`.
+
+**Summary of the plan (13 tasks):**
+
+1. **Task 1** — Create `GridLayoutPersistenceException` (Domain) with `SqlState` property per arch-review Spec Amendment 1.
+2. **Task 2** — Create `PostgresExceptionTranslator` in `Persistence/Infrastructure/`, mirroring the unwrap recursion from `PostgresExceptionLoggingInterceptor`.
+3. **Task 3** — Add 5 translator unit tests (direct Npgsql, `DbUpdateException` wrapping, non-Pg passthrough cases).
+4. **Task 4** — Wrap `GridLayoutRepository.GetAsync/UpsertAsync/DeleteAsync` with the translator.
+5. **Task 5** — Add 4 repository-level translation tests using `ThrowingApplicationDbContext` (satisfies FR-8 with both `NpgsqlException` and `DbUpdateException` wrapping, plus passthrough verification).
+6. **Tasks 6–8** — Refactor the three handlers to catch `GridLayoutPersistenceException` and drop `using Npgsql;` (log templates byte-for-byte preserved, SqlState read from domain exception).
+7. **Tasks 9–11** — Update the three handler test files to throw/verify `GridLayoutPersistenceException` instead of `NpgsqlException` (per Spec Amendment 4).
+8. **Task 12** — Optional: add `<exception>` XML docs to `IGridLayoutRepository`.
+9. **Task 13** — Final verification: grep checks (FR-6 reinterpretation), full solution build, `dotnet format`, full test run (expect 16 passing GridLayouts tests).
+
+Key spec amendments documented inline: `SqlState` property on the exception (FR-1), `DbUpdateException` wrapping coverage (FR-2 — flagged as deliberate latent-bug fix), FR-6 reinterpreted as grep verification only (no csproj change). The plan also includes PR-description notes for the engineer to surface the latent-bug fix and out-of-scope follow-ups.

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
@@ -4,7 +4,6 @@ using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Npgsql;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
 
@@ -42,12 +41,11 @@ public class GetGridLayoutHandler : IRequestHandler<GetGridLayoutRequest, GetGri
 
             return new GetGridLayoutResponse { Layout = dto };
         }
-        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        catch (GridLayoutPersistenceException ex)
         {
-            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
             _logger.LogError(ex,
                 "Database error reading GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
-                userId, request.GridKey, pgEx?.SqlState);
+                userId, request.GridKey, ex.SqlState);
             return new GetGridLayoutResponse { Layout = null };
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs
@@ -3,7 +3,6 @@ using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Npgsql;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
 
@@ -31,12 +30,11 @@ public class ResetGridLayoutHandler : IRequestHandler<ResetGridLayoutRequest, Re
             await _repository.DeleteAsync(userId, request.GridKey, cancellationToken);
             return new ResetGridLayoutResponse();
         }
-        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        catch (GridLayoutPersistenceException ex)
         {
-            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
             _logger.LogError(ex,
                 "Database error resetting GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
-                userId, request.GridKey, pgEx?.SqlState);
+                userId, request.GridKey, ex.SqlState);
             return new ResetGridLayoutResponse(ErrorCodes.DatabaseError);
         }
     }

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs
@@ -5,7 +5,6 @@ using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Npgsql;
 
 namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
 
@@ -41,12 +40,11 @@ public class SaveGridLayoutHandler : IRequestHandler<SaveGridLayoutRequest, Save
             await _repository.UpsertAsync(userId, request.GridKey, json, cancellationToken);
             return new SaveGridLayoutResponse();
         }
-        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        catch (GridLayoutPersistenceException ex)
         {
-            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
             _logger.LogError(ex,
                 "Database error saving GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
-                userId, request.GridKey, pgEx?.SqlState);
+                userId, request.GridKey, ex.SqlState);
             return new SaveGridLayoutResponse(ErrorCodes.DatabaseError);
         }
     }

--- a/backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs
@@ -1,0 +1,12 @@
+namespace Anela.Heblo.Domain.Features.GridLayouts;
+
+public class GridLayoutPersistenceException : Exception
+{
+    public string? SqlState { get; }
+
+    public GridLayoutPersistenceException(string message, string? sqlState, Exception inner)
+        : base(message, inner)
+    {
+        SqlState = sqlState;
+    }
+}

--- a/backend/src/Anela.Heblo.Domain/Features/GridLayouts/IGridLayoutRepository.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/GridLayouts/IGridLayoutRepository.cs
@@ -2,7 +2,18 @@ namespace Anela.Heblo.Domain.Features.GridLayouts;
 
 public interface IGridLayoutRepository
 {
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
     Task<GridLayout?> GetAsync(string userId, string gridKey, CancellationToken cancellationToken = default);
+
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
     Task UpsertAsync(string userId, string gridKey, string layoutJson, CancellationToken cancellationToken = default);
+
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
     Task DeleteAsync(string userId, string gridKey, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs
+++ b/backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 
 namespace Anela.Heblo.Persistence.GridLayouts;
@@ -16,40 +17,79 @@ public class GridLayoutRepository : IGridLayoutRepository
 
     public async Task<GridLayout?> GetAsync(string userId, string gridKey, CancellationToken cancellationToken = default)
     {
-        return await _context.GridLayouts
-            .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
+        try
+        {
+            return await _context.GridLayouts
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var translated = PostgresExceptionTranslator.TryTranslateGridLayout(ex, nameof(GetAsync));
+            if (translated is not null)
+            {
+                throw translated;
+            }
+            throw;
+        }
     }
 
     public async Task UpsertAsync(string userId, string gridKey, string layoutJson, CancellationToken cancellationToken = default)
     {
-        var existing = await GetAsync(userId, gridKey, cancellationToken);
+        try
+        {
+            var existing = await _context.GridLayouts
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
 
-        if (existing is not null)
-        {
-            existing.LayoutJson = layoutJson;
-            existing.LastModified = _timeProvider.GetUtcNow().DateTime;
-        }
-        else
-        {
-            _context.GridLayouts.Add(new GridLayout
+            if (existing is not null)
             {
-                UserId = userId,
-                GridKey = gridKey,
-                LayoutJson = layoutJson,
-                LastModified = _timeProvider.GetUtcNow().DateTime
-            });
-        }
+                existing.LayoutJson = layoutJson;
+                existing.LastModified = _timeProvider.GetUtcNow().DateTime;
+            }
+            else
+            {
+                _context.GridLayouts.Add(new GridLayout
+                {
+                    UserId = userId,
+                    GridKey = gridKey,
+                    LayoutJson = layoutJson,
+                    LastModified = _timeProvider.GetUtcNow().DateTime
+                });
+            }
 
-        await _context.SaveChangesAsync(cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var translated = PostgresExceptionTranslator.TryTranslateGridLayout(ex, nameof(UpsertAsync));
+            if (translated is not null)
+            {
+                throw translated;
+            }
+            throw;
+        }
     }
 
     public async Task DeleteAsync(string userId, string gridKey, CancellationToken cancellationToken = default)
     {
-        var existing = await GetAsync(userId, gridKey, cancellationToken);
-        if (existing is not null)
+        try
         {
-            _context.GridLayouts.Remove(existing);
-            await _context.SaveChangesAsync(cancellationToken);
+            var existing = await _context.GridLayouts
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
+
+            if (existing is not null)
+            {
+                _context.GridLayouts.Remove(existing);
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            var translated = PostgresExceptionTranslator.TryTranslateGridLayout(ex, nameof(DeleteAsync));
+            if (translated is not null)
+            {
+                throw translated;
+            }
+            throw;
         }
     }
 }

--- a/backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionTranslator.cs
+++ b/backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionTranslator.cs
@@ -1,0 +1,43 @@
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Npgsql;
+
+namespace Anela.Heblo.Persistence.Infrastructure;
+
+/// <summary>
+/// Translates Npgsql/PostgreSQL exceptions surfaced by EF Core into the domain-layer
+/// <see cref="GridLayoutPersistenceException"/>, keeping driver types out of the Application layer.
+/// Distinct from <see cref="PostgresExceptionLoggingInterceptor"/>: the interceptor enriches save-failure
+/// logs at the boundary; this helper produces a domain exception so handlers can catch a domain type.
+/// </summary>
+public static class PostgresExceptionTranslator
+{
+    /// <summary>
+    /// Returns a <see cref="GridLayoutPersistenceException"/> wrapping <paramref name="exception"/> when
+    /// the chain contains a <see cref="NpgsqlException"/> (which includes <see cref="PostgresException"/>),
+    /// or <c>null</c> for anything else so the caller can rethrow unchanged.
+    /// </summary>
+    public static GridLayoutPersistenceException? TryTranslateGridLayout(Exception exception, string operation)
+    {
+        var npgsqlEx = FindNpgsqlException(exception);
+        if (npgsqlEx is null)
+        {
+            return null;
+        }
+
+        var sqlState = (npgsqlEx as PostgresException)?.SqlState;
+        return new GridLayoutPersistenceException(
+            $"GridLayout persistence error during {operation}: {exception.Message}",
+            sqlState,
+            exception);
+    }
+
+    private static NpgsqlException? FindNpgsqlException(Exception? exception)
+    {
+        return exception switch
+        {
+            null => null,
+            NpgsqlException npg => npg,
+            _ => FindNpgsqlException(exception.InnerException)
+        };
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
@@ -5,7 +5,6 @@ using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.GridLayouts;
@@ -62,7 +61,10 @@ public class GetGridLayoutHandlerTests
         _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
         _repositoryMock
             .Setup(x => x.GetAsync("user-1", "test-grid", default))
-            .ThrowsAsync(new NpgsqlException("relation \"GridLayouts\" does not exist"));
+            .ThrowsAsync(new GridLayoutPersistenceException(
+                "GridLayout persistence error during GetAsync: relation \"GridLayouts\" does not exist",
+                sqlState: "42P01",
+                new InvalidOperationException("simulated underlying driver exception")));
 
         var handler = CreateHandler();
         var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
@@ -73,7 +75,7 @@ public class GetGridLayoutHandlerTests
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error reading GridLayout")),
-                It.IsAny<NpgsqlException>(),
+                It.IsAny<GridLayoutPersistenceException>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs
@@ -4,7 +4,6 @@ using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.GridLayouts;
@@ -36,7 +35,10 @@ public class ResetGridLayoutHandlerTests
         _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
         _repositoryMock
             .Setup(x => x.DeleteAsync("user-1", "test-grid", default))
-            .ThrowsAsync(new NpgsqlException("relation \"GridLayouts\" does not exist"));
+            .ThrowsAsync(new GridLayoutPersistenceException(
+                "GridLayout persistence error during DeleteAsync: relation \"GridLayouts\" does not exist",
+                sqlState: "42P01",
+                new InvalidOperationException("simulated underlying driver exception")));
 
         var handler = CreateHandler();
         var response = await handler.Handle(new ResetGridLayoutRequest { GridKey = "test-grid" }, default);
@@ -48,7 +50,7 @@ public class ResetGridLayoutHandlerTests
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error resetting GridLayout")),
-                It.IsAny<NpgsqlException>(),
+                It.IsAny<GridLayoutPersistenceException>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs
@@ -6,7 +6,6 @@ using Anela.Heblo.Domain.Features.GridLayouts;
 using Anela.Heblo.Domain.Features.Users;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Npgsql;
 using Xunit;
 
 namespace Anela.Heblo.Tests.Features.GridLayouts;
@@ -56,7 +55,10 @@ public class SaveGridLayoutHandlerTests
         _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
         _repositoryMock
             .Setup(x => x.UpsertAsync("user-1", "test-grid", It.IsAny<string>(), default))
-            .ThrowsAsync(new NpgsqlException("relation \"GridLayouts\" does not exist"));
+            .ThrowsAsync(new GridLayoutPersistenceException(
+                "GridLayout persistence error during UpsertAsync: relation \"GridLayouts\" does not exist",
+                sqlState: "42P01",
+                new InvalidOperationException("simulated underlying driver exception")));
 
         var request = new SaveGridLayoutRequest { GridKey = "test-grid", Columns = new List<GridColumnStateDto>() };
 
@@ -70,7 +72,7 @@ public class SaveGridLayoutHandlerTests
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error saving GridLayout")),
-                It.IsAny<NpgsqlException>(),
+                It.IsAny<GridLayoutPersistenceException>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs
@@ -1,0 +1,119 @@
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.GridLayouts;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Anela.Heblo.Tests.Persistence.GridLayouts;
+
+public class GridLayoutRepositoryTranslationTests
+{
+    private sealed class ThrowingApplicationDbContext : ApplicationDbContext
+    {
+        public Exception? ThrowOnSaveChanges { get; set; }
+
+        public ThrowingApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+        {
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnSaveChanges is not null)
+            {
+                throw ThrowOnSaveChanges;
+            }
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static ThrowingApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"GridLayoutTranslationTests_{Guid.NewGuid()}")
+            .Options;
+        return new ThrowingApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenSaveChangesThrowsNpgsqlException_ThrowsGridLayoutPersistenceException()
+    {
+        // Arrange
+        using var context = CreateContext();
+        var npgsqlEx = new NpgsqlException("connection terminated");
+        context.ThrowOnSaveChanges = npgsqlEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.UpsertAsync("user-1", "grid-1", "{}", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<GridLayoutPersistenceException>();
+        thrown.Which.InnerException.Should().BeSameAs(npgsqlEx);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenSaveChangesThrowsDbUpdateExceptionWrappingNpgsql_ThrowsGridLayoutPersistenceException()
+    {
+        // Arrange
+        using var context = CreateContext();
+        var npgsqlInner = new NpgsqlException("duplicate key");
+        var dbUpdateEx = new DbUpdateException("An error occurred while saving.", npgsqlInner);
+        context.ThrowOnSaveChanges = dbUpdateEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.UpsertAsync("user-1", "grid-1", "{}", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<GridLayoutPersistenceException>();
+        thrown.Which.InnerException.Should().BeSameAs(dbUpdateEx);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenSaveChangesThrowsNonPgException_RethrowsOriginal()
+    {
+        // Arrange
+        using var context = CreateContext();
+        var unrelatedEx = new InvalidOperationException("unrelated failure");
+        context.ThrowOnSaveChanges = unrelatedEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.UpsertAsync("user-1", "grid-1", "{}", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+        thrown.Which.Should().BeSameAs(unrelatedEx);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenSaveChangesThrowsNpgsqlException_ThrowsGridLayoutPersistenceException()
+    {
+        // Arrange
+        using var context = CreateContext();
+        context.GridLayouts.Add(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "grid-1",
+            LayoutJson = "{}",
+            LastModified = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        var npgsqlEx = new NpgsqlException("connection terminated");
+        context.ThrowOnSaveChanges = npgsqlEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.DeleteAsync("user-1", "grid-1", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<GridLayoutPersistenceException>();
+        thrown.Which.InnerException.Should().BeSameAs(npgsqlEx);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs
@@ -1,0 +1,81 @@
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Anela.Heblo.Tests.Persistence.GridLayouts;
+
+public class PostgresExceptionTranslatorTests
+{
+    [Fact]
+    public void TryTranslateGridLayout_GivenDirectNpgsqlException_ReturnsTranslatedExceptionWithOriginalAsInner()
+    {
+        // Arrange
+        var inner = new NpgsqlException("connection refused");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(inner, "Get");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InnerException.Should().BeSameAs(inner);
+        result.Message.Should().Contain("Get");
+        result.SqlState.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenDbUpdateExceptionWrappingNpgsqlException_ReturnsTranslatedException()
+    {
+        // Arrange
+        var npgsqlInner = new NpgsqlException("duplicate key value violates unique constraint");
+        var outer = new DbUpdateException("An error occurred while saving the entity changes.", npgsqlInner);
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(outer, "Upsert");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InnerException.Should().BeSameAs(outer);
+        result.Message.Should().Contain("Upsert");
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenOperationCanceledException_ReturnsNull()
+    {
+        // Arrange
+        var ex = new OperationCanceledException("cancelled by caller");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(ex, "Get");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenDbUpdateConcurrencyExceptionWithoutNpgsqlInner_ReturnsNull()
+    {
+        // Arrange
+        var ex = new DbUpdateConcurrencyException("Concurrency token mismatch.");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(ex, "Upsert");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenPlainInvalidOperationException_ReturnsNull()
+    {
+        // Arrange
+        var ex = new InvalidOperationException("something else");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(ex, "Get");
+
+        // Assert
+        result.Should().BeNull();
+    }
+}

--- a/docs/superpowers/plans/2026-06-02-decouple-gridlayouts-app-handlers-from-npgsql.md
+++ b/docs/superpowers/plans/2026-06-02-decouple-gridlayouts-app-handlers-from-npgsql.md
@@ -1,0 +1,1331 @@
+# Decouple GridLayouts Application Handlers from Npgsql — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the `using Npgsql;` directives from the three GridLayouts MediatR handlers (and their tests) by introducing a domain-layer `GridLayoutPersistenceException` and translating Npgsql/Postgres exceptions at the persistence boundary, restoring the Clean Architecture dependency direction (Application → Domain only).
+
+**Architecture:** Add `GridLayoutPersistenceException` in `Anela.Heblo.Domain.Features.GridLayouts` with a nullable `SqlState` string property so handlers can preserve their existing `{SqlState}` log field without re-importing Npgsql. Introduce a static `PostgresExceptionTranslator` in `Anela.Heblo.Persistence.Infrastructure` that mirrors the unwrap recursion already used by `PostgresExceptionLoggingInterceptor`, then wrap each `GridLayoutRepository` method with it. Update the three handlers and their unit tests to catch the new domain exception. No public API or behavioral change.
+
+**Tech Stack:** .NET 8, C#, EF Core 8 (Npgsql provider), MediatR 12, xUnit, Moq, FluentAssertions, `Microsoft.EntityFrameworkCore.InMemory` for repository-level tests.
+
+---
+
+## File Map
+
+**Create:**
+- `backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs` — domain exception type (FR-1, amended by arch-review to include `SqlState`).
+- `backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionTranslator.cs` — static helper that detects Npgsql/Postgres family exceptions anywhere in the chain and produces a `GridLayoutPersistenceException`. Returns `null` for non-Pg exceptions so callers rethrow untouched.
+- `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs` — pure unit tests for the translator (covers direct `NpgsqlException`, `DbUpdateException` wrapping, and non-Pg passthrough).
+- `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs` — repository-level integration test using a derived `ApplicationDbContext` that throws on demand (FR-8).
+
+**Modify:**
+- `backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs` — wrap each of `GetAsync`, `UpsertAsync`, `DeleteAsync` with the translator (FR-2).
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — remove `using Npgsql;`, catch `GridLayoutPersistenceException`, log `ex.SqlState` (FR-3).
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs` — same as Get (FR-4).
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs` — same as Get (FR-5).
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` — replace `NpgsqlException` mock throws and log verifications with `GridLayoutPersistenceException` (FR-7).
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs` — same (FR-7).
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs` — same (FR-7).
+
+**Do NOT modify (per arch-review):**
+- `Anela.Heblo.Application.csproj` — there is no direct `<PackageReference Include="Npgsql" />` to remove. Npgsql is transitive via `Anela.Heblo.Persistence` → `Npgsql.EntityFrameworkCore.PostgreSQL`. FR-6 is satisfied by verifying `grep -r "using Npgsql" backend/src/Anela.Heblo.Application/Features/GridLayouts` returns no matches.
+- `PostgresExceptionLoggingInterceptor.cs` — keep as-is; the new translator lives next to it with a distinct purpose.
+- The three Application files outside GridLayouts that also `using Npgsql;` (`Photobank/PhotobankRepository.cs`, `PackingMaterials/ConsumptionCalculationService.cs`, `Smartsupp/.../ProcessWebhookEventHandler.cs`) — explicitly out of scope per the spec.
+
+---
+
+## Task 1: Create `GridLayoutPersistenceException` in the Domain layer
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs`
+
+- [ ] **Step 1: Create the exception class file**
+
+Write the file exactly as below (final shape from arch-review Decision 2 / Spec Amendment 1):
+
+```csharp
+namespace Anela.Heblo.Domain.Features.GridLayouts;
+
+public class GridLayoutPersistenceException : Exception
+{
+    public string? SqlState { get; }
+
+    public GridLayoutPersistenceException(string message, string? sqlState, Exception inner)
+        : base(message, inner)
+    {
+        SqlState = sqlState;
+    }
+}
+```
+
+Notes:
+- `class`, not `record` — matches BCL exception convention.
+- `SqlState` is nullable because connection-level `NpgsqlException` without an inner `PostgresException` has no SqlState.
+- The constructor takes `(message, sqlState, inner)` — three parameters. The original spec FR-1 said two; arch-review Spec Amendment 1 elevates this to three so handlers can preserve the `{SqlState}` log field without re-importing Npgsql.
+- No `using` directives needed — `Exception` is in the implicitly-imported `System` namespace.
+
+- [ ] **Step 2: Verify the Domain project compiles**
+
+Run from repo root:
+
+```bash
+dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj
+```
+
+Expected: `Build succeeded.` with 0 errors, 0 warnings.
+
+If a warning appears about the exception not being serializable (CA-style analyzer), ignore it — the codebase does not enable those analyzers; verify by checking `backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj` does not enable `EnableNETAnalyzers` for that rule. Do **not** add `[Serializable]` or serialization constructors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/GridLayouts/GridLayoutPersistenceException.cs
+git commit -m "feat: add GridLayoutPersistenceException domain exception"
+```
+
+---
+
+## Task 2: Create `PostgresExceptionTranslator` in the Persistence/Infrastructure layer
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionTranslator.cs`
+
+This is a small static helper that detects whether an exception thrown by EF Core is a Npgsql-family exception (directly, or wrapped in `DbUpdateException` etc.) and produces a `GridLayoutPersistenceException`. Mirrors the unwrap recursion used in `PostgresExceptionLoggingInterceptor.UnwrapPostgresException` (lines 61–70 of that file).
+
+- [ ] **Step 1: Write the translator class file**
+
+```csharp
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Npgsql;
+
+namespace Anela.Heblo.Persistence.Infrastructure;
+
+/// <summary>
+/// Translates Npgsql/PostgreSQL exceptions surfaced by EF Core into the domain-layer
+/// <see cref="GridLayoutPersistenceException"/>, keeping driver types out of the Application layer.
+/// Distinct from <see cref="PostgresExceptionLoggingInterceptor"/>: the interceptor enriches save-failure
+/// logs at the boundary; this helper produces a domain exception so handlers can catch a domain type.
+/// </summary>
+internal static class PostgresExceptionTranslator
+{
+    /// <summary>
+    /// Returns a <see cref="GridLayoutPersistenceException"/> wrapping <paramref name="exception"/> when
+    /// the chain contains a <see cref="NpgsqlException"/> (which includes <see cref="PostgresException"/>),
+    /// or <c>null</c> for anything else so the caller can rethrow unchanged.
+    /// </summary>
+    public static GridLayoutPersistenceException? TryTranslateGridLayout(Exception exception, string operation)
+    {
+        var npgsqlEx = FindNpgsqlException(exception);
+        if (npgsqlEx is null)
+        {
+            return null;
+        }
+
+        var sqlState = (npgsqlEx as PostgresException)?.SqlState;
+        return new GridLayoutPersistenceException(
+            $"GridLayout persistence error during {operation}: {exception.Message}",
+            sqlState,
+            exception);
+    }
+
+    private static NpgsqlException? FindNpgsqlException(Exception? exception)
+    {
+        return exception switch
+        {
+            null => null,
+            NpgsqlException npg => npg,
+            _ => FindNpgsqlException(exception.InnerException)
+        };
+    }
+}
+```
+
+Notes:
+- `internal` access — only the Persistence assembly uses it. (`Anela.Heblo.Persistence` already exposes `InternalsVisibleTo("Anela.Heblo.Tests")` indirectly via tests project references; if a test needs to call it, the test references `Anela.Heblo.Persistence` directly. If the internal access blocks tests, change to `public` in Step 3 below — but try `internal` first.)
+- Since `PostgresException : NpgsqlException`, the single `FindNpgsqlException` recursion finds both: a direct `NpgsqlException`, a direct `PostgresException`, and a `DbUpdateException { InnerException: NpgsqlException }`.
+- The wrapper preserves the original exception in `InnerException`, so `PostgresExceptionLoggingInterceptor` (already attached) still has its enriched log line, and full stack trace remains available.
+
+- [ ] **Step 2: Verify the Persistence project compiles**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+```
+
+Expected: `Build succeeded.` with 0 errors, 0 warnings.
+
+- [ ] **Step 3: If the test project cannot see `PostgresExceptionTranslator`, expose `InternalsVisibleTo`**
+
+Run a quick check:
+
+```bash
+grep -r "InternalsVisibleTo" backend/src/Anela.Heblo.Persistence
+```
+
+If `Anela.Heblo.Tests` is not listed, add the following to `backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj` inside an `<ItemGroup>`:
+
+```xml
+<ItemGroup>
+  <InternalsVisibleTo Include="Anela.Heblo.Tests" />
+</ItemGroup>
+```
+
+If you prefer not to modify the csproj, change `internal static class PostgresExceptionTranslator` to `public static class PostgresExceptionTranslator` in `PostgresExceptionTranslator.cs`. Either choice is acceptable — pick `InternalsVisibleTo` if the file already exists with that pattern elsewhere in the project, otherwise `public`. Do not do both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/Infrastructure/PostgresExceptionTranslator.cs
+# If you modified the csproj in Step 3, also:
+git add backend/src/Anela.Heblo.Persistence/Anela.Heblo.Persistence.csproj
+git commit -m "feat: add PostgresExceptionTranslator for domain exception mapping"
+```
+
+---
+
+## Task 3: Add translator unit tests (TDD)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs`
+
+- [ ] **Step 1: Create the test directory and write the failing tests**
+
+```bash
+mkdir -p backend/test/Anela.Heblo.Tests/Persistence/GridLayouts
+```
+
+Write `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Anela.Heblo.Tests.Persistence.GridLayouts;
+
+public class PostgresExceptionTranslatorTests
+{
+    [Fact]
+    public void TryTranslateGridLayout_GivenDirectNpgsqlException_ReturnsTranslatedExceptionWithOriginalAsInner()
+    {
+        // Arrange
+        var inner = new NpgsqlException("connection refused");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(inner, "Get");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InnerException.Should().BeSameAs(inner);
+        result.Message.Should().Contain("Get");
+        result.SqlState.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenDbUpdateExceptionWrappingNpgsqlException_ReturnsTranslatedException()
+    {
+        // Arrange
+        var npgsqlInner = new NpgsqlException("duplicate key value violates unique constraint");
+        var outer = new DbUpdateException("An error occurred while saving the entity changes.", npgsqlInner);
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(outer, "Upsert");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InnerException.Should().BeSameAs(outer);
+        result.Message.Should().Contain("Upsert");
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenOperationCanceledException_ReturnsNull()
+    {
+        // Arrange
+        var ex = new OperationCanceledException("cancelled by caller");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(ex, "Get");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenDbUpdateConcurrencyExceptionWithoutNpgsqlInner_ReturnsNull()
+    {
+        // Arrange
+        var ex = new DbUpdateConcurrencyException("Concurrency token mismatch.");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(ex, "Upsert");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryTranslateGridLayout_GivenPlainInvalidOperationException_ReturnsNull()
+    {
+        // Arrange
+        var ex = new InvalidOperationException("something else");
+
+        // Act
+        var result = PostgresExceptionTranslator.TryTranslateGridLayout(ex, "Get");
+
+        // Assert
+        result.Should().BeNull();
+    }
+}
+```
+
+Notes:
+- We assert `InnerException.Should().BeSameAs(outer)` — i.e., the **outer** exception thrown by EF Core is preserved, not the unwrapped inner `NpgsqlException`. This preserves the full chain for diagnostics; the translator extracts `SqlState` from the unwrapped Pg exception but keeps the original throw as inner.
+- We do **not** construct a real `PostgresException` (constructor surface is awkward and Npgsql-version-sensitive). `SqlState` extraction is validated via the handler-level tests' log assertions in Tasks 8–10 and through visual inspection of the one-line property pass-through.
+
+- [ ] **Step 2: Run the tests and confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~PostgresExceptionTranslatorTests" --no-restore
+```
+
+Expected: 5 passing tests.
+
+If you get a compile error about `PostgresExceptionTranslator` being inaccessible, recheck Task 2 Step 3 (either `InternalsVisibleTo` or change visibility to `public`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/PostgresExceptionTranslatorTests.cs
+git commit -m "test: add unit tests for PostgresExceptionTranslator"
+```
+
+---
+
+## Task 4: Wire the translator into `GridLayoutRepository`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs`
+
+- [ ] **Step 1: Rewrite the file to wrap each operation**
+
+Replace the entire file contents with:
+
+```csharp
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anela.Heblo.Persistence.GridLayouts;
+
+public class GridLayoutRepository : IGridLayoutRepository
+{
+    private readonly ApplicationDbContext _context;
+    private readonly TimeProvider _timeProvider;
+
+    public GridLayoutRepository(ApplicationDbContext context, TimeProvider timeProvider)
+    {
+        _context = context;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<GridLayout?> GetAsync(string userId, string gridKey, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.GridLayouts
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var translated = PostgresExceptionTranslator.TryTranslateGridLayout(ex, nameof(GetAsync));
+            if (translated is not null)
+            {
+                throw translated;
+            }
+            throw;
+        }
+    }
+
+    public async Task UpsertAsync(string userId, string gridKey, string layoutJson, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var existing = await _context.GridLayouts
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
+
+            if (existing is not null)
+            {
+                existing.LayoutJson = layoutJson;
+                existing.LastModified = _timeProvider.GetUtcNow().DateTime;
+            }
+            else
+            {
+                _context.GridLayouts.Add(new GridLayout
+                {
+                    UserId = userId,
+                    GridKey = gridKey,
+                    LayoutJson = layoutJson,
+                    LastModified = _timeProvider.GetUtcNow().DateTime
+                });
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var translated = PostgresExceptionTranslator.TryTranslateGridLayout(ex, nameof(UpsertAsync));
+            if (translated is not null)
+            {
+                throw translated;
+            }
+            throw;
+        }
+    }
+
+    public async Task DeleteAsync(string userId, string gridKey, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var existing = await _context.GridLayouts
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.GridKey == gridKey, cancellationToken);
+
+            if (existing is not null)
+            {
+                _context.GridLayouts.Remove(existing);
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            var translated = PostgresExceptionTranslator.TryTranslateGridLayout(ex, nameof(DeleteAsync));
+            if (translated is not null)
+            {
+                throw translated;
+            }
+            throw;
+        }
+    }
+}
+```
+
+Notes:
+- I inlined the previous `await GetAsync(...)` call in `UpsertAsync` and `DeleteAsync` to avoid double-wrapping (otherwise a `GridLayoutPersistenceException` thrown inside `GetAsync` would be caught again by the outer wrapper — also a `GridLayoutPersistenceException`, so technically harmless, but the duplicate `try/catch` is noise).
+- The repository continues to surface `OperationCanceledException`, `DbUpdateConcurrencyException` without a Pg inner, and any other exception type unchanged (translator returns `null`, we rethrow).
+- The catch is `catch (Exception ex)` — broad on purpose because the translator is the gate. The translator returning `null` is the explicit pass-through.
+
+- [ ] **Step 2: Run the existing repository-adjacent tests to confirm nothing else broke**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GridLayout" --no-restore
+```
+
+Expected: existing GridLayout handler tests still pass against the old assumptions (they mock `IGridLayoutRepository` directly, so they don't exercise this file). New translator tests still pass. No GridLayoutRepository tests yet (Task 5 adds them).
+
+If any handler test fails because it asserts `It.IsAny<NpgsqlException>()` in the logger verification, leave it failing for now — Tasks 8–10 will fix those. Note which test names fail.
+
+- [ ] **Step 3: Build the full backend to confirm no other consumer broke**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors. Warnings related to Npgsql usage in the three handler files are still present (will be removed in Tasks 6–8).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Persistence/GridLayouts/GridLayoutRepository.cs
+git commit -m "feat: translate Npgsql exceptions in GridLayoutRepository to domain exception"
+```
+
+---
+
+## Task 5: Add repository-level translation tests (FR-8)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs`
+
+Uses a derived `ApplicationDbContext` that throws on the read or save path. Built on `Microsoft.EntityFrameworkCore.InMemory` for a working baseline, then selectively short-circuits to throw the desired exception.
+
+- [ ] **Step 1: Write the failing tests**
+
+Write `backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs`:
+
+```csharp
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Persistence;
+using Anela.Heblo.Persistence.GridLayouts;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Anela.Heblo.Tests.Persistence.GridLayouts;
+
+public class GridLayoutRepositoryTranslationTests
+{
+    private sealed class ThrowingApplicationDbContext : ApplicationDbContext
+    {
+        public Exception? ThrowOnSaveChanges { get; set; }
+
+        public ThrowingApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+        {
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnSaveChanges is not null)
+            {
+                throw ThrowOnSaveChanges;
+            }
+            return base.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static ThrowingApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: $"GridLayoutTranslationTests_{Guid.NewGuid()}")
+            .Options;
+        return new ThrowingApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenSaveChangesThrowsNpgsqlException_ThrowsGridLayoutPersistenceException()
+    {
+        // Arrange
+        using var context = CreateContext();
+        var npgsqlEx = new NpgsqlException("connection terminated");
+        context.ThrowOnSaveChanges = npgsqlEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.UpsertAsync("user-1", "grid-1", "{}", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<GridLayoutPersistenceException>();
+        thrown.Which.InnerException.Should().BeSameAs(npgsqlEx);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenSaveChangesThrowsDbUpdateExceptionWrappingNpgsql_ThrowsGridLayoutPersistenceException()
+    {
+        // Arrange
+        using var context = CreateContext();
+        var npgsqlInner = new NpgsqlException("duplicate key");
+        var dbUpdateEx = new DbUpdateException("An error occurred while saving.", npgsqlInner);
+        context.ThrowOnSaveChanges = dbUpdateEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.UpsertAsync("user-1", "grid-1", "{}", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<GridLayoutPersistenceException>();
+        thrown.Which.InnerException.Should().BeSameAs(dbUpdateEx);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenSaveChangesThrowsNonPgException_RethrowsOriginal()
+    {
+        // Arrange
+        using var context = CreateContext();
+        var unrelatedEx = new InvalidOperationException("unrelated failure");
+        context.ThrowOnSaveChanges = unrelatedEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.UpsertAsync("user-1", "grid-1", "{}", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<InvalidOperationException>();
+        thrown.Which.Should().BeSameAs(unrelatedEx);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenSaveChangesThrowsNpgsqlException_ThrowsGridLayoutPersistenceException()
+    {
+        // Arrange
+        using var context = CreateContext();
+        // Seed an entity so DeleteAsync reaches SaveChanges (otherwise it short-circuits).
+        context.GridLayouts.Add(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "grid-1",
+            LayoutJson = "{}",
+            LastModified = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync();
+
+        var npgsqlEx = new NpgsqlException("connection terminated");
+        context.ThrowOnSaveChanges = npgsqlEx;
+
+        var repository = new GridLayoutRepository(context, TimeProvider.System);
+
+        // Act
+        Func<Task> act = () => repository.DeleteAsync("user-1", "grid-1", CancellationToken.None);
+
+        // Assert
+        var thrown = await act.Should().ThrowAsync<GridLayoutPersistenceException>();
+        thrown.Which.InnerException.Should().BeSameAs(npgsqlEx);
+    }
+}
+```
+
+Notes:
+- The `ThrowingApplicationDbContext` only overrides `SaveChangesAsync` because: (a) the read path through `DbSet<T>.FirstOrDefaultAsync` against the in-memory provider returns null without throwing; (b) overriding `Set<TEntity>()` to throw is brittle across EF Core 8 internals. Save-path coverage is the meaningful boundary — the spec FR-8 acceptance lists "a repository method invocation whose underlying call throws `NpgsqlException`" and `SaveChangesAsync` is the canonical such path.
+- We seed an entity before `DeleteAsync` so the code path reaches `SaveChangesAsync` rather than short-circuiting on the "no existing entity" branch.
+- Test 3 (`UpsertAsync_WhenSaveChangesThrowsNonPgException_RethrowsOriginal`) directly verifies FR-2 acceptance criterion: "The wrapper does not swallow other exception types — they continue to propagate unchanged".
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GridLayoutRepositoryTranslationTests" --no-restore
+```
+
+Expected: 4 passing tests.
+
+If a test fails because `ApplicationDbContext.SaveChangesAsync` is not virtual, check whether the base class exposes the overload taking `CancellationToken` as virtual — in EF Core 8 it is. If it's somehow non-virtual, override the parameterless `SaveChanges()` and `int SaveChanges(bool acceptAllChangesOnSuccess)` too. The repository only awaits `SaveChangesAsync(CancellationToken)`, so that single override is sufficient.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Persistence/GridLayouts/GridLayoutRepositoryTranslationTests.cs
+git commit -m "test: add repository-level translation tests for GridLayoutRepository"
+```
+
+---
+
+## Task 6: Refactor `GetGridLayoutHandler` to catch the domain exception
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file contents with:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
+
+public class GetGridLayoutHandler : IRequestHandler<GetGridLayoutRequest, GetGridLayoutResponse>
+{
+    private readonly IGridLayoutRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<GetGridLayoutHandler> _logger;
+
+    public GetGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService, ILogger<GetGridLayoutHandler> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<GetGridLayoutResponse> Handle(GetGridLayoutRequest request, CancellationToken cancellationToken)
+    {
+        var user = _currentUserService.GetCurrentUser();
+        var userId = user.Id ?? user.Email
+            ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
+
+        try
+        {
+            var entity = await _repository.GetAsync(userId, request.GridKey, cancellationToken);
+
+            if (entity is null)
+            {
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
+            var dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto();
+            dto.GridKey = entity.GridKey;
+            dto.LastModified = entity.LastModified;
+
+            return new GetGridLayoutResponse { Layout = dto };
+        }
+        catch (GridLayoutPersistenceException ex)
+        {
+            _logger.LogError(ex,
+                "Database error reading GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, ex.SqlState);
+            return new GetGridLayoutResponse { Layout = null };
+        }
+    }
+}
+```
+
+Diff vs. before:
+- Removed `using Npgsql;` (line 7).
+- Changed `catch (Exception ex) when (ex is PostgresException or NpgsqlException)` to `catch (GridLayoutPersistenceException ex)`.
+- Removed the local `var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;`.
+- `ex.SqlState` now comes from the domain exception (`string?`). Log template, level, and structured fields are byte-for-byte identical.
+- Return value (`new GetGridLayoutResponse { Layout = null }`) is unchanged.
+
+- [ ] **Step 2: Build to confirm the handler compiles without Npgsql**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: 0 errors. Warnings about unused Npgsql import disappear (this file used to have one).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
+git commit -m "refactor: catch GridLayoutPersistenceException in GetGridLayoutHandler"
+```
+
+---
+
+## Task 7: Refactor `SaveGridLayoutHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file contents with:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+
+public class SaveGridLayoutHandler : IRequestHandler<SaveGridLayoutRequest, SaveGridLayoutResponse>
+{
+    private readonly IGridLayoutRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<SaveGridLayoutHandler> _logger;
+
+    public SaveGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService, ILogger<SaveGridLayoutHandler> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<SaveGridLayoutResponse> Handle(SaveGridLayoutRequest request, CancellationToken cancellationToken)
+    {
+        var user = _currentUserService.GetCurrentUser();
+        var userId = user.Id ?? user.Email
+            ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
+
+        var payload = new GridLayoutDto
+        {
+            GridKey = request.GridKey,
+            Columns = request.Columns
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+
+        try
+        {
+            await _repository.UpsertAsync(userId, request.GridKey, json, cancellationToken);
+            return new SaveGridLayoutResponse();
+        }
+        catch (GridLayoutPersistenceException ex)
+        {
+            _logger.LogError(ex,
+                "Database error saving GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, ex.SqlState);
+            return new SaveGridLayoutResponse(ErrorCodes.DatabaseError);
+        }
+    }
+}
+```
+
+Diff vs. before:
+- Removed `using Npgsql;` (line 9).
+- Same pattern as `GetGridLayoutHandler`: catch the domain exception, drop the `as PostgresException` cast.
+- `SaveGridLayoutResponse(ErrorCodes.DatabaseError)` return path unchanged.
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/SaveGridLayout/SaveGridLayoutHandler.cs
+git commit -m "refactor: catch GridLayoutPersistenceException in SaveGridLayoutHandler"
+```
+
+---
+
+## Task 8: Refactor `ResetGridLayoutHandler`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file contents with:
+
+```csharp
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Users;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+
+public class ResetGridLayoutHandler : IRequestHandler<ResetGridLayoutRequest, ResetGridLayoutResponse>
+{
+    private readonly IGridLayoutRepository _repository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<ResetGridLayoutHandler> _logger;
+
+    public ResetGridLayoutHandler(IGridLayoutRepository repository, ICurrentUserService currentUserService, ILogger<ResetGridLayoutHandler> logger)
+    {
+        _repository = repository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    public async Task<ResetGridLayoutResponse> Handle(ResetGridLayoutRequest request, CancellationToken cancellationToken)
+    {
+        var user = _currentUserService.GetCurrentUser();
+        var userId = user.Id ?? user.Email
+            ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
+
+        try
+        {
+            await _repository.DeleteAsync(userId, request.GridKey, cancellationToken);
+            return new ResetGridLayoutResponse();
+        }
+        catch (GridLayoutPersistenceException ex)
+        {
+            _logger.LogError(ex,
+                "Database error resetting GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, ex.SqlState);
+            return new ResetGridLayoutResponse(ErrorCodes.DatabaseError);
+        }
+    }
+}
+```
+
+Diff vs. before:
+- Removed `using Npgsql;` (line 5).
+- Catches `GridLayoutPersistenceException` instead of the Npgsql union.
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/ResetGridLayout/ResetGridLayoutHandler.cs
+git commit -m "refactor: catch GridLayoutPersistenceException in ResetGridLayoutHandler"
+```
+
+---
+
+## Task 9: Update `GetGridLayoutHandlerTests`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file contents with:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.GetGridLayout;
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.GridLayouts;
+
+public class GetGridLayoutHandlerTests
+{
+    private readonly Mock<IGridLayoutRepository> _repositoryMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserMock = new();
+    private readonly Mock<ILogger<GetGridLayoutHandler>> _loggerMock = new();
+
+    private GetGridLayoutHandler CreateHandler() =>
+        new(_repositoryMock.Object, _currentUserMock.Object, _loggerMock.Object);
+
+    [Fact]
+    public async Task Handle_WhenNoSavedLayout_ReturnsNull()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync((GridLayout?)null);
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSavedLayoutExists_ReturnsDeserializedDto()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+
+        var payload = new { columns = new[] { new { id = "col1", order = 0, width = 120, hidden = false } } };
+        var json = JsonSerializer.Serialize(payload);
+
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = json,
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.NotNull(response.Layout);
+        Assert.Single(response.Layout!.Columns);
+        Assert.Equal("col1", response.Layout.Columns[0].Id);
+        Assert.Equal(120, response.Layout.Columns[0].Width);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDatabaseThrows_ReturnsNullLayoutAndLogsError()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock
+            .Setup(x => x.GetAsync("user-1", "test-grid", default))
+            .ThrowsAsync(new GridLayoutPersistenceException(
+                "GridLayout persistence error during GetAsync: relation \"GridLayouts\" does not exist",
+                sqlState: "42P01",
+                new InvalidOperationException("simulated underlying driver exception")));
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error reading GridLayout")),
+                It.IsAny<GridLayoutPersistenceException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}
+```
+
+Diff vs. before:
+- Removed `using Npgsql;` (line 8).
+- The error-path test now throws `GridLayoutPersistenceException(...)` from the repository mock.
+- The inner exception in the test can be any non-Npgsql exception (we use `InvalidOperationException`) — what matters is that the test asserts the handler catches a `GridLayoutPersistenceException` and produces the same response. Using `NpgsqlException` here would defeat the refactor's intent (test would still reference Npgsql).
+- The logger `Verify` now asserts `It.IsAny<GridLayoutPersistenceException>()` — per arch-review Spec Amendment 4.
+- The MediatR response assertion (`Assert.Null(response.Layout)`) is unchanged.
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetGridLayoutHandlerTests" --no-restore
+```
+
+Expected: 3 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
+git commit -m "test: switch GetGridLayoutHandlerTests to GridLayoutPersistenceException"
+```
+
+---
+
+## Task 10: Update `SaveGridLayoutHandlerTests`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file contents with:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.GridLayouts.Contracts;
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.SaveGridLayout;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.GridLayouts;
+
+public class SaveGridLayoutHandlerTests
+{
+    private readonly Mock<IGridLayoutRepository> _repositoryMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserMock = new();
+    private readonly Mock<ILogger<SaveGridLayoutHandler>> _loggerMock = new();
+
+    private SaveGridLayoutHandler CreateHandler() =>
+        new(_repositoryMock.Object, _currentUserMock.Object, _loggerMock.Object);
+
+    [Fact]
+    public async Task Handle_CallsUpsertWithSerializedColumns()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+
+        string? capturedJson = null;
+        _repositoryMock
+            .Setup(x => x.UpsertAsync("user-1", "test-grid", It.IsAny<string>(), default))
+            .Callback<string, string, string, CancellationToken>((_, _, json, _) => capturedJson = json)
+            .Returns(Task.CompletedTask);
+
+        var request = new SaveGridLayoutRequest
+        {
+            GridKey = "test-grid",
+            Columns = new List<GridColumnStateDto>
+            {
+                new() { Id = "col1", Order = 0, Width = 150, Hidden = false },
+                new() { Id = "col2", Order = 1, Width = null, Hidden = true }
+            }
+        };
+
+        var handler = CreateHandler();
+        await handler.Handle(request, default);
+
+        _repositoryMock.Verify(x => x.UpsertAsync("user-1", "test-grid", It.IsAny<string>(), default), Times.Once);
+        Assert.NotNull(capturedJson);
+        var parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(capturedJson!);
+        Assert.True(parsed!.ContainsKey("columns"));
+    }
+
+    [Fact]
+    public async Task Handle_WhenDatabaseThrows_ReturnsDatabaseErrorAndLogsError()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock
+            .Setup(x => x.UpsertAsync("user-1", "test-grid", It.IsAny<string>(), default))
+            .ThrowsAsync(new GridLayoutPersistenceException(
+                "GridLayout persistence error during UpsertAsync: relation \"GridLayouts\" does not exist",
+                sqlState: "42P01",
+                new InvalidOperationException("simulated underlying driver exception")));
+
+        var request = new SaveGridLayoutRequest { GridKey = "test-grid", Columns = new List<GridColumnStateDto>() };
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(request, default);
+
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.DatabaseError, response.ErrorCode);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error saving GridLayout")),
+                It.IsAny<GridLayoutPersistenceException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}
+```
+
+Diff vs. before:
+- Removed `using Npgsql;` (line 9).
+- The error-path test throws `GridLayoutPersistenceException` instead of `NpgsqlException`.
+- Logger `Verify` asserts `It.IsAny<GridLayoutPersistenceException>()`.
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~SaveGridLayoutHandlerTests" --no-restore
+```
+
+Expected: 2 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/GridLayouts/SaveGridLayoutHandlerTests.cs
+git commit -m "test: switch SaveGridLayoutHandlerTests to GridLayoutPersistenceException"
+```
+
+---
+
+## Task 11: Update `ResetGridLayoutHandlerTests`
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs`
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the entire file contents with:
+
+```csharp
+using Anela.Heblo.Application.Features.GridLayouts.UseCases.ResetGridLayout;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.GridLayouts;
+using Anela.Heblo.Domain.Features.Users;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.GridLayouts;
+
+public class ResetGridLayoutHandlerTests
+{
+    private readonly Mock<IGridLayoutRepository> _repositoryMock = new();
+    private readonly Mock<ICurrentUserService> _currentUserMock = new();
+    private readonly Mock<ILogger<ResetGridLayoutHandler>> _loggerMock = new();
+
+    private ResetGridLayoutHandler CreateHandler() =>
+        new(_repositoryMock.Object, _currentUserMock.Object, _loggerMock.Object);
+
+    [Fact]
+    public async Task Handle_CallsDeleteWithCorrectUserAndGrid()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.DeleteAsync("user-1", "test-grid", default)).Returns(Task.CompletedTask);
+
+        var handler = CreateHandler();
+        await handler.Handle(new ResetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        _repositoryMock.Verify(x => x.DeleteAsync("user-1", "test-grid", default), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDatabaseThrows_ReturnsDatabaseErrorAndLogsError()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock
+            .Setup(x => x.DeleteAsync("user-1", "test-grid", default))
+            .ThrowsAsync(new GridLayoutPersistenceException(
+                "GridLayout persistence error during DeleteAsync: relation \"GridLayouts\" does not exist",
+                sqlState: "42P01",
+                new InvalidOperationException("simulated underlying driver exception")));
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new ResetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.False(response.Success);
+        Assert.Equal(ErrorCodes.DatabaseError, response.ErrorCode);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Database error resetting GridLayout")),
+                It.IsAny<GridLayoutPersistenceException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}
+```
+
+Diff vs. before:
+- Removed `using Npgsql;` (line 7).
+- Error-path test throws and asserts `GridLayoutPersistenceException`.
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ResetGridLayoutHandlerTests" --no-restore
+```
+
+Expected: 2 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/GridLayouts/ResetGridLayoutHandlerTests.cs
+git commit -m "test: switch ResetGridLayoutHandlerTests to GridLayoutPersistenceException"
+```
+
+---
+
+## Task 12: Optional — annotate `IGridLayoutRepository` with `<exception>` XML docs
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Domain/Features/GridLayouts/IGridLayoutRepository.cs`
+
+Per spec API/Interface Design: "Optionally add XML doc `<exception>` tags to the interface methods — recommended but not strictly required." We add them — costs nothing, helps consumers.
+
+- [ ] **Step 1: Rewrite the interface file**
+
+```csharp
+namespace Anela.Heblo.Domain.Features.GridLayouts;
+
+public interface IGridLayoutRepository
+{
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
+    Task<GridLayout?> GetAsync(string userId, string gridKey, CancellationToken cancellationToken = default);
+
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
+    Task UpsertAsync(string userId, string gridKey, string layoutJson, CancellationToken cancellationToken = default);
+
+    /// <exception cref="GridLayoutPersistenceException">
+    /// Thrown when the underlying persistence layer fails (e.g. PostgreSQL error).
+    /// </exception>
+    Task DeleteAsync(string userId, string gridKey, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Build to confirm**
+
+```bash
+dotnet build backend/src/Anela.Heblo.Domain/Anela.Heblo.Domain.csproj
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Domain/Features/GridLayouts/IGridLayoutRepository.cs
+git commit -m "docs: document GridLayoutPersistenceException on IGridLayoutRepository"
+```
+
+---
+
+## Task 13: Final verification — grep, build, format, full test run
+
+This task gates the change against the spec's NFRs and FR-6 reinterpretation.
+
+- [ ] **Step 1: Confirm no `using Npgsql;` remains under `Application/Features/GridLayouts/`**
+
+```bash
+grep -r "using Npgsql" backend/src/Anela.Heblo.Application/Features/GridLayouts
+```
+
+Expected: no output (exit code 1 from grep).
+
+If the grep tool prints any line, return to Task 6/7/8 and remove the lingering directive. Do **not** modify the three out-of-scope Application files (`Photobank/PhotobankRepository.cs`, `PackingMaterials/ConsumptionCalculationService.cs`, `Smartsupp/.../ProcessWebhookEventHandler.cs`) — they remain as follow-up work per the spec.
+
+- [ ] **Step 2: Confirm no `using Npgsql;` remains under `test/.../Features/GridLayouts/`**
+
+```bash
+grep -r "using Npgsql" backend/test/Anela.Heblo.Tests/Features/GridLayouts
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Confirm Npgsql is still allowed in the test files that legitimately need it**
+
+```bash
+grep -rn "using Npgsql" backend/test/Anela.Heblo.Tests/Persistence/GridLayouts
+```
+
+Expected output:
+- `PostgresExceptionTranslatorTests.cs` — uses `Npgsql` to construct test `NpgsqlException` instances (correct, this is a persistence-layer test).
+- `GridLayoutRepositoryTranslationTests.cs` — same (correct).
+
+- [ ] **Step 4: Build the entire backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: `Build succeeded.` with 0 errors. Zero **new** warnings introduced by this change (the codebase may have pre-existing warnings; verify by comparing warning count with the count from the base branch if uncertain — `git stash && dotnet build && git stash pop && dotnet build` and compare).
+
+- [ ] **Step 5: Format**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exit code 0 (no formatting changes needed). If the command reports unformatted files, run `dotnet format backend/Anela.Heblo.sln` and commit the formatting fixes with `chore: dotnet format`.
+
+- [ ] **Step 6: Run the full GridLayouts test suite (handlers + persistence)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GridLayout" --no-restore
+```
+
+Expected: all GridLayouts tests pass. Total count = 3 (Get) + 2 (Save) + 2 (Reset) + 5 (translator unit) + 4 (repository integration) = **16 passing tests**.
+
+If any pre-existing handler test fails, re-read its assertion against the rewritten file in Tasks 9–11 — most failures will be `It.IsAny<NpgsqlException>()` not being updated to `It.IsAny<GridLayoutPersistenceException>()`. Other failures should be investigated, not silenced.
+
+- [ ] **Step 7: Run the full backend test suite**
+
+```bash
+dotnet test backend/Anela.Heblo.sln --no-restore
+```
+
+Expected: all tests pass (no regressions in other modules). This guards against the small chance that another assembly indirectly depended on the old `NpgsqlException` propagation from `IGridLayoutRepository`.
+
+- [ ] **Step 8: Final commit (only if Steps 1–7 introduced any formatting or trivial fixes; otherwise skip)**
+
+```bash
+# Only run if a previous step required follow-up edits.
+git status
+git add -A
+git commit -m "chore: final cleanup after GridLayouts Npgsql decoupling"
+```
+
+If git status shows no pending changes, do not create an empty commit.
+
+---
+
+## Notes for the PR description (for the engineer wrapping up)
+
+When opening the PR, include these notes (they correspond to arch-review Risks and Spec Amendments):
+
+1. **Latent bug fix:** Today's `catch (Exception ex) when (ex is PostgresException or NpgsqlException)` in the three handlers does **not** catch `DbUpdateException` that wraps a `PostgresException` (constraint violations from `SaveChangesAsync` would have bubbled past the handler). The new repository wrapper translates that case too. This is an intentional, deliberate improvement — frame it as a fix discovered during the refactor.
+
+2. **FR-6 reinterpretation:** No direct `<PackageReference Include="Npgsql" />` exists in `Anela.Heblo.Application.csproj`; Npgsql is transitive via `Anela.Heblo.Persistence` → `Npgsql.EntityFrameworkCore.PostgreSQL`. FR-6 is satisfied by the `grep -r "using Npgsql"` check on `Application/Features/GridLayouts/` returning no matches. No csproj change.
+
+3. **Spec FR-1 amendment:** `GridLayoutPersistenceException` exposes a nullable `SqlState` property to preserve the `{SqlState}` structured log field (NFR-1 log shape preservation). The constructor is `(string message, string? sqlState, Exception inner)`.
+
+4. **Out-of-scope follow-ups:** Three other Application files still import Npgsql — `Photobank/PhotobankRepository.cs`, `PackingMaterials/ConsumptionCalculationService.cs`, `Smartsupp/.../ProcessWebhookEventHandler.cs`. The spec scopes this PR to GridLayouts; these are next candidates for the same pattern.
+
+---
+
+## Self-Review Notes (from the plan author)
+
+Spec coverage check:
+- FR-1 → Task 1 (with amended shape).
+- FR-2 → Tasks 2 + 4 (translator + repository wiring), Task 5 (FR-2 acceptance "wrapper does not swallow other exception types" tested explicitly).
+- FR-3 → Task 6.
+- FR-4 → Task 7.
+- FR-5 → Task 8.
+- FR-6 → Task 13 Step 1 (grep verification, no csproj change per arch-review).
+- FR-7 → Tasks 9 + 10 + 11 (with logger `Verify` updated per Spec Amendment 4).
+- FR-8 → Task 3 (translator unit) + Task 5 (repository integration via `ThrowingApplicationDbContext`).
+- NFR-1 (behavior preservation) → handler rewrites in Tasks 6–8 keep response shape, error codes, and log templates byte-for-byte identical.
+- NFR-2 (build/static checks) → Task 13 Steps 4 + 5.
+- NFR-3 (test coverage) → Tasks 3, 5, 9, 10, 11; total 16 GridLayouts tests after the change.
+- NFR-4 (dependency direction) → Task 13 Step 1 grep verification.
+- NFR-5 (performance) → trivially satisfied; happy path unchanged.
+
+Type consistency check:
+- `GridLayoutPersistenceException` constructor signature `(string message, string? sqlState, Exception inner)` is used identically in Tasks 1 (declaration), 2 (instantiation in translator), 9, 10, 11 (instantiation in test mocks).
+- `PostgresExceptionTranslator.TryTranslateGridLayout(Exception, string)` signature is used identically in Tasks 2 (declaration), 3 (translator tests), 4 (repository call sites).
+- `ThrowingApplicationDbContext.ThrowOnSaveChanges` property name used consistently in Task 5.


### PR DESCRIPTION

Removes the direct Npgsql dependency from all three GridLayouts MediatR handlers (Get/Save/Reset), restoring Clean Architecture's dependency direction (Application → Domain only). The fix introduces a `GridLayoutPersistenceException` domain type with a nullable `SqlState` property so handlers keep their existing `{SqlState}` log field, a static `PostgresExceptionTranslator` in the Persistence layer that mirrors the existing `PostgresExceptionLoggingInterceptor` unwrap recursion, and wraps all three `GridLayoutRepository` methods at the persistence boundary.

As a deliberate side-effect, the repository wrapper now also catches `DbUpdateException` wrapping a `PostgresException` (constraint violations from `SaveChangesAsync`), which the original handler `catch (Exception ex) when (ex is PostgresException or NpgsqlException)` silently missed — this is a latent bug fix, not a silent behavior change.

### Changes
- `GridLayoutPersistenceException.cs` — new domain exception with `SqlState` string property
- `PostgresExceptionTranslator.cs` — new static helper in Persistence/Infrastructure translating Npgsql family exceptions to the domain type
- `GridLayoutRepository.cs` — wraps GetAsync/UpsertAsync/DeleteAsync; inlines previously-delegated GetAsync calls to avoid double-wrapping
- `GetGridLayoutHandler.cs`, `SaveGridLayoutHandler.cs`, `ResetGridLayoutHandler.cs` — removed `using Npgsql;`, catches `GridLayoutPersistenceException`
- `IGridLayoutRepository.cs` — added `<exception>` XML doc tags
- Handler tests (3) — replaced `NpgsqlException` with `GridLayoutPersistenceException` in mock setups and logger verifications
- New translator unit tests (5) and repository-level integration tests (4) using `ThrowingApplicationDbContext`

---

Closes #2072

### Tokens used
25337408
