### PR TITLE
feat: Graceful Handling of Malformed `LayoutJson` in `GetGridLayoutHandler`

### DIFF
--- a/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/arch-review.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/arch-review.r1.md
@@ -1,0 +1,204 @@
+# Architecture Review: Graceful Handling of Malformed `LayoutJson` in `GetGridLayoutHandler`
+
+## Skip Design: true
+
+This is a backend-only defensive-coding change inside an existing MediatR handler. No new UI, no new visual components, no schema changes, no public contract changes. The frontend already handles `{ layout: null }` for the "no saved layout" case, so no design work is implied.
+
+## Architectural Fit Assessment
+
+The change fits cleanly into existing patterns:
+
+- **Vertical Slice Architecture** — All work stays inside `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/` and its mirror test folder. No cross-module impact, no contract changes (`GridLayoutDto`, `GetGridLayoutResponse`, `IGridLayoutRepository` untouched).
+- **Existing error handling style** — The handler already uses an outer `try { ... } catch (Exception ex) when (ex is PostgresException or NpgsqlException)` block that logs and returns `{ Layout = null }`. The new path is a *narrower inner* catch around just the deserialize call, returning the same fallback shape. This is structurally consistent with the established failure-mode handling.
+- **Established `JsonException` handling convention** — The codebase already follows a `catch (JsonException ex)` + structured log pattern in several places (`OrgChartService.cs:65`, `MeetingUserDirectory.cs:75`, `ClaudeMeetingTaskExtractor.cs:72`, several Smartsupp handlers, `JsonResponseParser.cs`). The proposed handler matches that convention: typed catch, structured log, no payload echoed.
+- **Integration point with the frontend** — The response shape is preserved exactly, so the existing FE fallback to default column order works without any FE-side change.
+
+The single subtle deviation from current behavior is the spec's choice to treat `JsonSerializer.Deserialize(...)` returning `null` (legal JSON value `"null"`) as "no usable layout" rather than the current `?? new GridLayoutDto()` fallback. This is a deliberate, documented spec amendment (see Specification Amendments below) and the right call: returning an empty `GridLayoutDto` from valid-but-null JSON would surface a `GridKey = ""` payload, which is worse than `Layout = null`.
+
+## Proposed Architecture
+
+### Component Overview
+
+No new components. The change is internal to one handler.
+
+```
+GetGridLayoutHandler.Handle
+├── resolve userId  (unchanged — throws InvalidOperationException if missing)
+└── try (outer — DB failure path, unchanged)
+    ├── entity = repository.GetAsync(...)
+    ├── if entity is null → return { Layout = null }                    [unchanged]
+    ├── try (inner — NEW)
+    │   ├── dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)
+    │   └── if dto is null → return { Layout = null }                   [spec amendment]
+    │   catch (JsonException ex)
+    │   ├── _logger.LogWarning(ex, "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout", userId, request.GridKey)
+    │   └── return { Layout = null }
+    ├── dto.GridKey = entity.GridKey                                    [unchanged]
+    ├── dto.LastModified = entity.LastModified                          [unchanged]
+    └── return { Layout = dto }                                         [unchanged]
+    catch (PostgresException or NpgsqlException) → logError, return { Layout = null }  [unchanged]
+```
+
+### Key Design Decisions
+
+#### Decision 1: Inner try around deserialize vs. extending the outer catch
+
+**Options considered:**
+- A. Add `or JsonException` to the existing outer `catch (Exception ex) when (...)` filter.
+- B. Wrap only `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` in a dedicated inner `try`/`catch (JsonException ex)`.
+
+**Chosen approach:** B (matches the spec).
+
+**Rationale:**
+- The outer catch logs at `Error` severity with DB-specific context (`SqlState`). Deserialization failures are not DB faults — conflating them would either emit misleading "Database error" log messages, or force a branch inside the catch on exception type. Either way, log fidelity drops.
+- Severity is semantically different: DB exception = `Error` (system fault), `JsonException` = `Warning` (corrupt-but-recoverable user-preference data). A single outer catch cannot cleanly express both severities.
+- An inner catch makes the "deserialize is a distinct, fallible step" explicit at the call site, which matches the existing convention in `OrgChartService.cs:65–69` and several Smartsupp handlers.
+
+#### Decision 2: Treat `Deserialize(...)` returning `null` the same as `JsonException`
+
+**Options considered:**
+- A. Keep the current `?? new GridLayoutDto()` fallback — a literal JSON `"null"` payload yields an empty DTO with `GridKey` set from the entity.
+- B. Treat `dto is null` as "no usable saved layout" and return `{ Layout = null }`.
+
+**Chosen approach:** B (per spec FR-1 / API design section).
+
+**Rationale:** A returns a synthesized DTO with zero columns and an entity-derived `GridKey`, which the FE would interpret as "the user has an explicit layout with no columns" — that's a worse failure mode than "no saved layout exists". B unifies both pathological cases ("malformed" and "literal null") under one well-defined fallback that the FE already handles correctly.
+
+#### Decision 3: Log level `Warning` with no payload echo
+
+**Options considered:**
+- A. Log at `Error` with the raw `LayoutJson` content.
+- B. Log at `Warning` with only `{UserId}` and `{GridKey}` structured properties plus the exception.
+
+**Chosen approach:** B.
+
+**Rationale:** Corruption events are recoverable per-user-per-grid and do not indicate a system fault — `Warning` is the correct severity. Echoing `LayoutJson` into the log would offer marginal debugging value (the `JsonException.Message` already includes the offending character/position) while broadening the surface area for accidental information leakage. Operators can locate the corrupt row by `UserId + GridKey` and inspect it directly.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edits confined to:
+
+```
+backend/
+├── src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/
+│   └── GetGridLayoutHandler.cs                              ← MODIFY
+└── test/Anela.Heblo.Tests/Features/GridLayouts/
+    └── GetGridLayoutHandlerTests.cs                         ← MODIFY (add 2 tests)
+```
+
+No changes to `Contracts/`, repository, entity, module registration, or the `SaveGridLayoutHandler` / `ResetGridLayoutHandler` siblings.
+
+### Interfaces and Contracts
+
+No interface changes. All public surfaces are stable:
+
+- `IRequestHandler<GetGridLayoutRequest, GetGridLayoutResponse>` — unchanged.
+- `GetGridLayoutResponse { GridLayoutDto? Layout }` — unchanged.
+- `IGridLayoutRepository.GetAsync` — unchanged.
+- `GridLayoutDto`, `GridColumnStateDto` — unchanged.
+
+### Implementation sketch (handler)
+
+```csharp
+public async Task<GetGridLayoutResponse> Handle(GetGridLayoutRequest request, CancellationToken cancellationToken)
+{
+    var user = _currentUserService.GetCurrentUser();
+    var userId = user.Id ?? user.Email
+        ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
+
+    try
+    {
+        var entity = await _repository.GetAsync(userId, request.GridKey, cancellationToken);
+        if (entity is null)
+        {
+            return new GetGridLayoutResponse { Layout = null };
+        }
+
+        GridLayoutDto? dto;
+        try
+        {
+            dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex,
+                "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout",
+                userId, request.GridKey);
+            return new GetGridLayoutResponse { Layout = null };
+        }
+
+        if (dto is null)
+        {
+            return new GetGridLayoutResponse { Layout = null };
+        }
+
+        dto.GridKey = entity.GridKey;
+        dto.LastModified = entity.LastModified;
+        return new GetGridLayoutResponse { Layout = dto };
+    }
+    catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+    {
+        var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
+        _logger.LogError(ex,
+            "Database error reading GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+            userId, request.GridKey, pgEx?.SqlState);
+        return new GetGridLayoutResponse { Layout = null };
+    }
+}
+```
+
+### Data Flow
+
+Read path for a corrupt row (the new case):
+
+```
+FE GET /api/grid-layouts/{gridKey}
+  → MediatR → GetGridLayoutHandler.Handle
+    → ICurrentUserService.GetCurrentUser → userId
+    → IGridLayoutRepository.GetAsync(userId, gridKey) → GridLayout entity (LayoutJson = "{not json")
+    → JsonSerializer.Deserialize<GridLayoutDto>(...) throws JsonException
+      → ILogger.LogWarning(ex, "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout", userId, gridKey)
+      → return { Layout = null }
+  → Controller → 200 OK { layout: null }
+  → FE falls back to default column order (existing behavior)
+```
+
+All other paths (no row, valid JSON, DB error, missing Id+Email) are byte-for-byte identical to today.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Behavior change for stored literal JSON `"null"` — today returns an empty `GridLayoutDto` with the entity's `GridKey` and `LastModified`; under the spec it returns `Layout = null`. | Low | Documented as Decision 2 above. In practice no caller writes literal `"null"` — `SaveGridLayoutHandler.cs:37` always serializes a populated `GridLayoutDto`. FE treats both responses identically (falls back to defaults). |
+| Silent loss of layout for a user whose row genuinely corrupted, with no upstream signal to operators. | Low | `Warning`-level structured log with `UserId` + `GridKey` is sufficient signal at expected event volume. Spec explicitly defers metrics/alerting to out-of-scope. |
+| Hiding a real upstream bug (e.g., a future incompatible `GridLayoutDto` change causing widespread deserialization failure). | Low | A widespread regression would manifest as a spike in the `Malformed LayoutJson` warning, which is searchable by message phrase. The spec pins the message phrase in tests (FR-2), so the search target is stable. |
+| Test brittleness from asserting on log message contents. | Low | Existing DB-error test (`Handle_WhenDatabaseThrows_ReturnsNullLayoutAndLogsError`) already uses the same `Moq.Verify` shape (`v.ToString()!.Contains(...)`). New tests should mirror that exact pattern. |
+| Inner `try` accidentally swallows non-deserialize exceptions. | Negligible | Catch is typed (`JsonException`) — `NpgsqlException`, `OperationCanceledException`, etc., still propagate to the outer scope as intended. |
+| Future maintainer extending the catch to `catch (Exception)`. | Low | Add a one-line comment on the `catch (JsonException ex)` to flag the intentional narrowness, or rely on the typed catch + tests to enforce the contract. Spec does not require a comment; recommend only if a maintainer finds it surprising. |
+
+## Specification Amendments
+
+1. **Make the "deserialized dto is null" branch explicit in the spec acceptance criteria.** The spec's API/Interface Design section captures this in the target control flow, but FR-1's acceptance criteria phrase the outcome only in terms of `JsonException`. Add an acceptance criterion to FR-1:
+
+   > When `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` returns `null` (e.g., the stored payload is the literal JSON value `"null"`), `Handle` returns `GetGridLayoutResponse { Layout = null }` and does **not** log a warning (this is not a corruption event — it's a degenerate-but-valid value).
+
+   Rationale: the spec already chose this behavior (Open Questions notes the deliberate divergence from `?? new GridLayoutDto()`), but the test plan in FR-4 should reflect it. Recommend adding a third test `Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog` to pin the no-warning behavior; otherwise a future refactor could quietly start logging on this path.
+
+2. **Log message phrasing — keep the FR-2 "contains the phrase `Malformed LayoutJson`" assertion, but adopt the brief's exact template** (`"Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout"`) verbatim in the implementation. The spec's flow diagram and the brief use slightly different prose; aligning on the brief's exact string keeps the log search target unambiguous and matches the existing DB-error log's stylistic pattern (`"Database error reading GridLayout for user={UserId} gridKey={GridKey} ..."`).
+
+3. **No other spec changes required.** FR-1 through FR-5 are correctly scoped, the NFRs are accurate, and the Out of Scope list correctly defers schema versioning, repair, telemetry counters, and sibling-handler edits.
+
+## Prerequisites
+
+None. The change requires no:
+
+- Database migrations or schema changes.
+- New configuration values, environment variables, or Key Vault secrets.
+- New NuGet packages — `System.Text.Json` and `Microsoft.Extensions.Logging.Abstractions` are already referenced.
+- New service registrations — `GridLayoutsModule.cs` relies on MediatR assembly scanning; the handler signature is unchanged.
+- New infrastructure or external dependencies.
+- Frontend coordination — response shape is identical.
+
+Implementation can start immediately against the current `main`.

--- a/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/brief.md
+++ b/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/brief.md
@@ -1,0 +1,44 @@
+## Module
+GridLayouts
+
+## Finding
+`GetGridLayoutHandler.Handle` deserializes `entity.LayoutJson` at line 39:
+
+```csharp
+// GetGridLayoutHandler.cs:39
+var dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto();
+```
+
+If `entity.LayoutJson` contains malformed or empty JSON, `JsonSerializer.Deserialize` throws `JsonException`. The existing catch block directly below (lines 45–51) only filters `PostgresException or NpgsqlException` — a `JsonException` escapes unhandled and surfaces as an unhandled 500 to the caller, breaking any grid that uses this layout key.
+
+## Why it matters
+Under normal operation the stored JSON is always written by `SaveGridLayoutHandler`, so corruption is unlikely. However it can occur when:
+- A DB migration script touches the `LayoutJson` column incorrectly.
+- An old row predates a schema change to `GridLayoutDto`.
+- Manual DB editing during debugging.
+
+A deserialization failure in a user-preference store should be treated as "no saved layout exists" (graceful fallback to default column order), not a server error. The handler already returns `null` for missing rows and for DB errors — deserialise failures should follow the same path.
+
+## Suggested fix
+Wrap deserialization in a `JsonException` catch that logs a warning and falls back to `null`:
+
+```csharp
+GridLayoutDto? dto = null;
+try
+{
+    dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson);
+}
+catch (JsonException ex)
+{
+    _logger.LogWarning(ex,
+        "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout",
+        userId, request.GridKey);
+}
+
+return new GetGridLayoutResponse { Layout = dto };
+```
+
+No change needed to `SaveGridLayoutHandler` or `ResetGridLayoutHandler` — they do not deserialize.
+
+---
+_Filed by daily arch-review routine on 2026-05-29._

--- a/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/impl/main.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/impl/main.r1.md
@@ -1,0 +1,49 @@
+Commit `76963665` is on the branch, diff is confined to exactly the two files required by FR-5.
+
+---
+
+# Implementation: Graceful Handling of Malformed LayoutJson in GetGridLayoutHandler
+
+## What was implemented
+
+Added an inner `try/catch (JsonException)` around `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` in `GetGridLayoutHandler.Handle`. When deserialization fails (malformed JSON or empty string), the handler logs a `Warning` with `UserId` + `GridKey` and returns `{ Layout = null }`. A legal JSON `"null"` deserialization result (which `JsonSerializer` returns without throwing) is also folded into the same `null` fallback — but without logging, since it is a degenerate-but-valid value rather than a corruption event. The `?? new GridLayoutDto()` fallback is removed and replaced by an explicit `if (dto is null)` guard. All existing paths (missing row, valid JSON, DB error, missing user claim) are unchanged.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — inner try/catch for JsonException + null guard after deserialization
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` — three new [Fact] tests for the malformed, empty, and literal-null cases
+
+## Tests
+
+**`GetGridLayoutHandlerTests.cs`** — 6 tests total (3 existing, 3 new):
+- `Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning` — corrupt JSON (`{not json`) returns null layout, Warning logged with JsonException
+- `Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning` — empty string returns null layout, Warning logged with JsonException
+- `Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog` — literal JSON `"null"` returns null layout, no warning logged
+
+All 6 tests pass. Build: 0 errors.
+
+## How to verify
+
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetGridLayoutHandlerTests"
+# Expected: 6 passed, 0 failed
+```
+
+## Notes
+
+No deviations from spec. The arch-review amendment (explicit `if (dto is null)` branch with no log; log message matches the brief's exact template verbatim) is implemented as specified.
+
+## PR Summary
+
+Gracefully handles malformed `LayoutJson` in `GetGridLayoutHandler` so a corrupt user-preference row falls back to "no saved layout" instead of surfacing a 500. Previously, `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` would let `JsonException` escape through the outer DB-error catch filter, reaching the unhandled-exception middleware. The fix wraps only the deserialize call in a typed `catch (JsonException)`, logs a `Warning` with `UserId` + `GridKey`, and returns `{ Layout = null }` — the same shape the frontend already handles for the "no saved layout" case.
+
+A legal JSON `"null"` value (which deserializes to `null` without throwing) is also folded into the null-layout fallback via an explicit `if (dto is null)` guard, replacing the previous `?? new GridLayoutDto()` which would have silently emitted a DTO with zero columns.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — inner try/catch (JsonException) around deserialization + null guard; removes `?? new GridLayoutDto()` fallback
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` — three new xUnit tests covering malformed JSON, empty string, and literal-null JSON payloads
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/spec.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/spec.r1.md
@@ -1,0 +1,165 @@
+# Specification: Graceful Handling of Malformed `LayoutJson` in `GetGridLayoutHandler`
+
+## Summary
+`GetGridLayoutHandler.Handle` currently lets `JsonException` escape when deserializing a corrupted `entity.LayoutJson`, surfacing a 500 to the client and breaking the affected grid. This feature wraps deserialization in a guarded block that logs a warning and returns a `null` layout, aligning the behavior with the existing "no saved layout" / "database error" fallback paths.
+
+## Background
+`GetGridLayoutHandler` (`backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`) returns a user's saved grid configuration (column order, widths, visibility) for a given `GridKey`. Two failure modes are already handled gracefully:
+
+1. **Missing row** — returns `GetGridLayoutResponse { Layout = null }` (handler line 34–37).
+2. **Database error** (`PostgresException`/`NpgsqlException`) — logs an error and returns `GetGridLayoutResponse { Layout = null }` (handler line 45–52).
+
+A third failure mode is **unhandled**: malformed JSON in the `LayoutJson` column. `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` at line 39 throws `JsonException` on:
+
+- Invalid JSON syntax (truncated, partially written data).
+- Empty string (`JsonException: "The input does not contain any JSON tokens"`).
+- Type mismatch caused by a `GridLayoutDto` schema change incompatible with previously stored payloads.
+
+Under normal operation `SaveGridLayoutHandler` writes well-formed payloads, but corruption can occur via:
+
+- An incorrect DB migration touching `LayoutJson`.
+- Old rows predating a breaking change to `GridLayoutDto`.
+- Manual DB edits during debugging or incident recovery.
+
+A corrupt user-preference row should degrade to "no saved layout" so the grid falls back to its default column configuration, not produce a 500 that blocks the user from viewing the page.
+
+## Functional Requirements
+
+### FR-1: Catch `JsonException` during `LayoutJson` deserialization
+`GetGridLayoutHandler.Handle` must catch `JsonException` thrown by `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` and treat it as "no saved layout exists".
+
+**Acceptance criteria:**
+- When `entity.LayoutJson` is malformed (invalid JSON, empty string, or schema-incompatible payload), `Handle` returns `GetGridLayoutResponse { Layout = null }`.
+- No `JsonException` propagates out of `Handle`.
+- The existing DB error path (`PostgresException`/`NpgsqlException`) continues to behave as before.
+- The "no saved layout" path (entity is `null`) continues to behave as before.
+- The happy path (well-formed JSON) returns the populated `GridLayoutDto` with `GridKey` and `LastModified` set from the entity, identical to current behavior.
+
+### FR-2: Log a warning on deserialization failure
+The handler must emit a structured warning log when deserialization fails, with enough context to investigate.
+
+**Acceptance criteria:**
+- Log level is `Warning` (not `Error`) — corrupt user-preference data is recoverable and does not indicate a system fault.
+- Log message contains the phrase `Malformed LayoutJson` (used for log search and for asserting in tests).
+- Structured log properties include `UserId` (the resolved `user.Id ?? user.Email`) and `GridKey` (from the request).
+- The original `JsonException` is passed as the exception argument to `ILogger.LogWarning` so its message and stack trace are captured.
+- Logging follows the same `ILogger<GetGridLayoutHandler>` instance already injected into the handler.
+
+### FR-3: Preserve current behavior for the other three code paths
+The change must be additive — no behavioral change to:
+
+- Returning `null` when no row exists.
+- Returning a populated `GridLayoutDto` when JSON is valid (with `GridKey` and `LastModified` copied from the entity, and a non-null result even when the JSON itself deserializes to `null` — current code uses `?? new GridLayoutDto()` as a fallback).
+- Logging and returning `null` on Postgres/Npgsql exceptions.
+- The `InvalidOperationException` thrown when the authenticated user has neither `Id` nor `Email`.
+
+**Acceptance criteria:**
+- All three existing tests in `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` continue to pass without modification:
+  - `Handle_WhenNoSavedLayout_ReturnsNull`
+  - `Handle_WhenSavedLayoutExists_ReturnsDeserializedDto`
+  - `Handle_WhenDatabaseThrows_ReturnsNullLayoutAndLogsError`
+
+### FR-4: Test coverage for the new path
+Add xUnit tests that pin the new behavior.
+
+**Acceptance criteria:**
+- A test `Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning`:
+  - Arranges the repository to return a `GridLayout` whose `LayoutJson` is invalid (e.g. `"{not json"`).
+  - Asserts the response's `Layout` is `null`.
+  - Asserts `ILogger.Log` was invoked once at `LogLevel.Warning` with a message containing `"Malformed LayoutJson"` and the underlying `JsonException`.
+- A test `Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning` covers the empty-string variant.
+- Tests use the existing `Mock<IGridLayoutRepository>`, `Mock<ICurrentUserService>`, `Mock<ILogger<GetGridLayoutHandler>>` setup pattern already in the file.
+
+### FR-5: No changes outside the read path
+`SaveGridLayoutHandler` and `ResetGridLayoutHandler` do not deserialize `LayoutJson` and must not be modified by this change.
+
+**Acceptance criteria:**
+- Diff is confined to `GetGridLayoutHandler.cs` and `GetGridLayoutHandlerTests.cs`.
+- No changes to `GridLayoutDto`, `GridLayout` entity, the repository interface/implementation, or any contract DTOs.
+- No changes to the public API surface (request/response shapes are unchanged).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- The added `try`/`catch` is on the happy path's hot loop only when an exception is thrown; the normal-flow cost is a single Try-block entry which is negligible.
+- No additional I/O, allocations, or async overhead introduced.
+
+### NFR-2: Security
+- The warning log must not include the raw `LayoutJson` content (could contain user-specific UI state — low sensitivity, but no reason to log payloads).
+- Standard structured logging guarantees apply: no tokens, no PII beyond `UserId`/`GridKey` (already used in the existing error log).
+- No new attack surface — the change only narrows an existing failure mode.
+
+### NFR-3: Observability
+- A warning log per malformed row is appropriate volume — these events should be rare (manual DB edits, migration errors, schema breaks). A spike would indicate a real incident worth investigating.
+- Operators can search by `UserId`/`GridKey` to identify affected rows for cleanup or re-save.
+
+### NFR-4: Compatibility
+- No database schema changes.
+- No API contract changes — callers see identical response shape.
+- Frontend continues to receive `{ layout: null }` and falls back to default column order, which it already does for the "no saved layout" case.
+
+## Data Model
+No changes. Reference entities/DTOs:
+
+- **`GridLayout`** (entity) — persisted row with `UserId`, `GridKey`, `LayoutJson` (string), `LastModified`.
+- **`GridLayoutDto`** (`backend/src/Anela.Heblo.Application/Features/GridLayouts/Contracts/GridLayoutDto.cs`) — wire format with `GridKey`, `Columns: List<GridColumnStateDto>`, `LastModified`.
+- **`GetGridLayoutResponse`** — wraps `Layout: GridLayoutDto?`.
+
+## API / Interface Design
+No interface changes.
+
+**Current control flow (relevant slice):**
+
+```
+Handle(request, ct)
+  ├─ resolve userId (throws InvalidOperationException if missing)
+  └─ try
+       ├─ entity = repository.GetAsync(userId, gridKey, ct)
+       ├─ if entity is null → return { Layout = null }
+       ├─ dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new()
+       ├─ dto.GridKey = entity.GridKey
+       ├─ dto.LastModified = entity.LastModified
+       └─ return { Layout = dto }
+     catch (PostgresException or NpgsqlException) → log Error, return { Layout = null }
+```
+
+**Target control flow:**
+
+```
+Handle(request, ct)
+  ├─ resolve userId (throws InvalidOperationException if missing)
+  └─ try
+       ├─ entity = repository.GetAsync(userId, gridKey, ct)
+       ├─ if entity is null → return { Layout = null }
+       ├─ GridLayoutDto? dto
+       │   try
+       │     dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)
+       │   catch (JsonException ex)
+       │     log Warning "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout"
+       │     return { Layout = null }
+       ├─ if dto is null → return { Layout = null }                  // preserves "?? new GridLayoutDto()" semantics below
+       ├─ dto.GridKey = entity.GridKey
+       ├─ dto.LastModified = entity.LastModified
+       └─ return { Layout = dto }
+     catch (PostgresException or NpgsqlException) → log Error, return { Layout = null }
+```
+
+**Assumption (noted in Open Questions):** When `JsonSerializer.Deserialize` legally returns `null` for the literal JSON value `"null"`, the brief's suggested fix returns `null` (no fallback `new GridLayoutDto()`). The current code uses `?? new GridLayoutDto()` for that case. This spec follows the brief and treats a `null` deserialization result the same as malformed JSON (returns `Layout = null`), since both indicate "no usable saved layout".
+
+## Dependencies
+- `System.Text.Json` (already referenced).
+- `Microsoft.Extensions.Logging.Abstractions` (already injected as `ILogger<GetGridLayoutHandler>`).
+- No new NuGet packages, services, or infrastructure.
+
+## Out of Scope
+- Detecting or rewriting corrupted rows (no automatic repair, no migration to clean up bad data).
+- Surfacing the corruption to the client (response shape unchanged; frontend cannot distinguish "no saved layout" from "corrupt saved layout").
+- Adding metrics/telemetry counters for corruption events — the warning log is sufficient signal.
+- Changes to `SaveGridLayoutHandler` or `ResetGridLayoutHandler`.
+- Schema-versioning `GridLayoutDto` or adding a `SchemaVersion` field to stored JSON.
+- Auditing/alerting pipelines for the new warning log.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/task-plan.r1.md
+++ b/artifacts/feat-arch-review-gridlayouts-getgridlayouthan/task-plan.r1.md
@@ -1,0 +1,10 @@
+Plan saved to `docs/superpowers/plans/2026-06-02-grid-layout-malformed-json.md`.
+
+**Summary:** Four tasks, TDD-driven, all confined to `GetGridLayoutHandler.cs` and its test file:
+
+1. **Task 1** — Add the malformed-JSON test (`"{not json"`), watch it fail, add the inner `try`/`catch (JsonException)` with the `LogWarning("Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout", ...)` template, watch it pass.
+2. **Task 2** — Add the empty-string test (`string.Empty`); already covered by Task 1's catch — passes without further code changes.
+3. **Task 3** — Add the literal-`"null"` test, watch it fail with NRE (because Task 1 dropped the `?? new GridLayoutDto()` fallback), add the explicit `if (dto is null) return null` guard, watch it pass. The full method body is shown in this step.
+4. **Task 4** — `dotnet build`, `dotnet format`, re-run the test class, diff-scope sanity check (must only touch the two files per FR-5), commit.
+
+Spec coverage is mapped at the bottom of the plan: every FR-1..5 and NFR-1..4 ties to a specific task/step. The arch-review amendments (explicit `dto is null` branch with no log; exact log template phrasing) are baked into Task 3 and Task 1 respectively.

--- a/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs
@@ -36,7 +36,24 @@ public class GetGridLayoutHandler : IRequestHandler<GetGridLayoutRequest, GetGri
                 return new GetGridLayoutResponse { Layout = null };
             }
 
-            var dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto();
+            GridLayoutDto? dto;
+            try
+            {
+                dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout",
+                    userId, request.GridKey);
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
+            if (dto is null)
+            {
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
             dto.GridKey = entity.GridKey;
             dto.LastModified = entity.LastModified;
 

--- a/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
@@ -77,4 +77,82 @@ public class GetGridLayoutHandlerTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = "{not json",
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Malformed LayoutJson")),
+                It.IsAny<JsonException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = string.Empty,
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Malformed LayoutJson")),
+                It.IsAny<JsonException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = "null",
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
 }

--- a/docs/superpowers/plans/2026-06-02-grid-layout-malformed-json.md
+++ b/docs/superpowers/plans/2026-06-02-grid-layout-malformed-json.md
@@ -1,0 +1,413 @@
+# Graceful Handling of Malformed `LayoutJson` in `GetGridLayoutHandler` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` in `GetGridLayoutHandler` with a typed `try`/`catch (JsonException)` that logs a warning and returns `{ Layout = null }`, so corrupt `LayoutJson` rows fall back to "no saved layout" instead of surfacing a 500.
+
+**Architecture:** Single MediatR handler edit (`GetGridLayoutHandler.Handle`). An inner `try` around just the deserialize call catches `JsonException` and emits a `LogWarning` with `UserId` + `GridKey`; a `null` deserialization result (legal JSON `"null"`) is also folded into the same fallback but without a log. The outer `PostgresException`/`NpgsqlException` block and the "entity is null" early return are preserved untouched. Frontend already handles `{ layout: null }` so no FE change is needed.
+
+**Tech Stack:** .NET 8, C#, xUnit, Moq, MediatR, `System.Text.Json`, `Microsoft.Extensions.Logging`.
+
+---
+
+## File Structure
+
+- **Modify:** `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`
+  - One handler method (`Handle`). Add inner `try`/`catch (JsonException)` around the deserialize call. Add explicit `null` check after deserialize. Remove the existing `?? new GridLayoutDto()` fallback.
+
+- **Modify:** `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs`
+  - Add three new `[Fact]` tests:
+    - `Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning`
+    - `Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning`
+    - `Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog`
+  - Reuse existing `Mock<IGridLayoutRepository>`, `Mock<ICurrentUserService>`, `Mock<ILogger<GetGridLayoutHandler>>` setup.
+
+No other files are touched. No new packages, no DI changes, no schema or contract changes.
+
+---
+
+## Task 1: TDD — Malformed JSON path (catch `JsonException`, log warning, return null)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` (append a new `[Fact]`)
+- Modify: `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` (replace the deserialize line with an inner try/catch)
+
+- [ ] **Step 1: Write the failing test**
+
+Append this `[Fact]` to `GetGridLayoutHandlerTests.cs` immediately after the existing `Handle_WhenDatabaseThrows_ReturnsNullLayoutAndLogsError` test (just before the closing `}` of the test class):
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = "{not json",
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Malformed LayoutJson")),
+                It.IsAny<JsonException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning"
+```
+
+Expected: **FAIL.** The handler currently lets `JsonException` propagate past the inner code (the outer catch only filters `PostgresException`/`NpgsqlException`), so the test will fail with a `JsonException` ("'{' is invalid after a property name") instead of asserting null.
+
+- [ ] **Step 3: Implement the inner try/catch in the handler**
+
+Open `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`.
+
+Replace the single line:
+
+```csharp
+            var dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson) ?? new GridLayoutDto();
+```
+
+with the following block (note: `?? new GridLayoutDto()` is deliberately dropped — the spec/arch review treat literal-null JSON as "no usable layout"; that branch is added in Task 3):
+
+```csharp
+            GridLayoutDto? dto;
+            try
+            {
+                dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout",
+                    userId, request.GridKey);
+                return new GetGridLayoutResponse { Layout = null };
+            }
+```
+
+After this edit, the lines `dto.GridKey = entity.GridKey;` and `dto.LastModified = entity.LastModified;` will produce a CS8602 nullable warning (because `dto` is now `GridLayoutDto?`). That warning is fixed in Task 3 by adding the explicit `if (dto is null)` guard. For this task it is acceptable to leave the warning temporarily — only run the targeted test from Step 4, not the full build. The warning will be resolved before any commit-blocking validation (Task 4 step 4 runs `dotnet build`).
+
+- [ ] **Step 4: Run the new test to verify it now passes**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning"
+```
+
+Expected: **PASS.**
+
+- [ ] **Step 5: Run the three pre-existing tests to confirm no regression**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetGridLayoutHandlerTests"
+```
+
+Expected: **All 4 tests pass** (`Handle_WhenNoSavedLayout_ReturnsNull`, `Handle_WhenSavedLayoutExists_ReturnsDeserializedDto`, `Handle_WhenDatabaseThrows_ReturnsNullLayoutAndLogsError`, `Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning`). Spec FR-3 requires the original three to continue passing without modification.
+
+Do **not** commit yet — the file still has a nullable-warning and the literal-null path is not handled. Continue to Task 2.
+
+---
+
+## Task 2: TDD — Empty-string `LayoutJson` (covered by the same catch)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` (append a new `[Fact]`)
+
+- [ ] **Step 1: Write the test**
+
+Append this `[Fact]` immediately after `Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = string.Empty,
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Malformed LayoutJson")),
+                It.IsAny<JsonException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+```
+
+- [ ] **Step 2: Run the new test to verify it passes**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning"
+```
+
+Expected: **PASS.** `JsonSerializer.Deserialize<GridLayoutDto>(string.Empty)` throws `JsonException` ("The input does not contain any JSON tokens"), which is caught by the inner block added in Task 1. No additional implementation change is required.
+
+- [ ] **Step 3: Run all `GetGridLayoutHandlerTests` to confirm no regression**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetGridLayoutHandlerTests"
+```
+
+Expected: **All 5 tests pass.**
+
+Do **not** commit yet — proceed to Task 3 to handle the literal-null branch and clear the nullable warning.
+
+---
+
+## Task 3: TDD — Literal JSON `"null"` returns `Layout = null` and does **not** log
+
+**Why:** `JsonSerializer.Deserialize<GridLayoutDto>("null")` returns `null` without throwing. The pre-change code papered this over with `?? new GridLayoutDto()`, which would emit a synthesized DTO with the entity's `GridKey` and zero columns — the FE would interpret that as "explicit layout with no columns", a worse failure mode than "no saved layout". Per arch-review Decision 2 and Amendment 1, the new behavior is `Layout = null` **with no log** (this is a degenerate-but-valid JSON value, not a corruption event).
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` (append a new `[Fact]`)
+- Modify: `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` (add `if (dto is null) return null` guard)
+
+- [ ] **Step 1: Write the failing test**
+
+Append this `[Fact]` immediately after `Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning`:
+
+```csharp
+    [Fact]
+    public async Task Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog()
+    {
+        _currentUserMock.Setup(x => x.GetCurrentUser()).Returns(new CurrentUser("user-1", "Test", "test@test.com", true));
+        _repositoryMock.Setup(x => x.GetAsync("user-1", "test-grid", default)).ReturnsAsync(new GridLayout
+        {
+            UserId = "user-1",
+            GridKey = "test-grid",
+            LayoutJson = "null",
+            LastModified = DateTime.UtcNow
+        });
+
+        var handler = CreateHandler();
+        var response = await handler.Handle(new GetGridLayoutRequest { GridKey = "test-grid" }, default);
+
+        Assert.Null(response.Layout);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog"
+```
+
+Expected: **FAIL.** After Task 1 the handler holds `dto = null` (the `?? new GridLayoutDto()` fallback was removed) and proceeds to `dto.GridKey = entity.GridKey;`, which throws `NullReferenceException`. The test will fail with NRE (not with an assertion mismatch), confirming the null-deserialize branch is unhandled.
+
+- [ ] **Step 3: Add the explicit null guard after deserialize**
+
+Open `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` and locate the inner try/catch block added in Task 1.
+
+Insert this block immediately after the closing `}` of the `catch (JsonException ex)` and before the `dto.GridKey = entity.GridKey;` line:
+
+```csharp
+            if (dto is null)
+            {
+                return new GetGridLayoutResponse { Layout = null };
+            }
+```
+
+After this edit, the `Handle` method body should read (the inner try/catch and null-guard are the only new code; everything else is unchanged from the original):
+
+```csharp
+    public async Task<GetGridLayoutResponse> Handle(GetGridLayoutRequest request, CancellationToken cancellationToken)
+    {
+        var user = _currentUserService.GetCurrentUser();
+        var userId = user.Id ?? user.Email
+            ?? throw new InvalidOperationException("Authenticated user must have either Id or Email claim.");
+
+        try
+        {
+            var entity = await _repository.GetAsync(userId, request.GridKey, cancellationToken);
+
+            if (entity is null)
+            {
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
+            GridLayoutDto? dto;
+            try
+            {
+                dto = JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Malformed LayoutJson for user={UserId} gridKey={GridKey}; returning null layout",
+                    userId, request.GridKey);
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
+            if (dto is null)
+            {
+                return new GetGridLayoutResponse { Layout = null };
+            }
+
+            dto.GridKey = entity.GridKey;
+            dto.LastModified = entity.LastModified;
+
+            return new GetGridLayoutResponse { Layout = dto };
+        }
+        catch (Exception ex) when (ex is PostgresException or NpgsqlException)
+        {
+            var pgEx = ex as PostgresException ?? ex.InnerException as PostgresException;
+            _logger.LogError(ex,
+                "Database error reading GridLayout for user={UserId} gridKey={GridKey} SqlState={SqlState}",
+                userId, request.GridKey, pgEx?.SqlState);
+            return new GetGridLayoutResponse { Layout = null };
+        }
+    }
+```
+
+- [ ] **Step 4: Run the new test to verify it now passes**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog"
+```
+
+Expected: **PASS.**
+
+- [ ] **Step 5: Run all `GetGridLayoutHandlerTests` to confirm full coverage**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetGridLayoutHandlerTests"
+```
+
+Expected: **All 6 tests pass** (the original 3 + the 3 new ones).
+
+---
+
+## Task 4: Project-level validation — build, format, full test suite
+
+**Files:** (no edits — verification only, except for any auto-formatting performed by `dotnet format`)
+
+- [ ] **Step 1: Build the backend solution**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: **Build succeeded** with zero new warnings. The CS8602 nullable warning that existed transiently after Task 1 must be gone (the `if (dto is null)` guard added in Task 3 narrows `dto` to non-null before the property assignments).
+
+- [ ] **Step 2: Run `dotnet format` on the touched files**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs \
+            backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
+```
+
+Expected: Exits cleanly. If it rewrites whitespace, re-run the targeted tests from Step 3 below to confirm nothing broke.
+
+- [ ] **Step 3: Run the targeted test class one more time**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetGridLayoutHandlerTests"
+```
+
+Expected: **All 6 tests pass.**
+
+- [ ] **Step 4: Sanity-check the diff is confined to the two files**
+
+Run:
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: Exactly two modified files:
+- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs`
+- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs`
+
+If any other file appears (in particular `SaveGridLayoutHandler.cs`, `ResetGridLayoutHandler.cs`, `GridLayoutDto.cs`, `IGridLayoutRepository.cs`, or any contract DTO), revert it — spec FR-5 requires the diff to be confined to these two files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs \
+        backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs
+git commit -m "$(cat <<'EOF'
+fix: gracefully handle malformed LayoutJson in GetGridLayoutHandler
+
+Wrap JsonSerializer.Deserialize in a typed try/catch (JsonException);
+log a Warning with UserId + GridKey and return Layout = null instead of
+letting the exception surface as a 500. Treat a null deserialization
+result (literal JSON "null") the same way but without a log, since it is
+a degenerate-but-valid value and not a corruption event.
+
+Adds three xUnit tests covering the malformed, empty, and literal-null
+payloads. No public contract, schema, or sibling-handler changes.
+EOF
+)"
+```
+
+---
+
+## Spec Coverage Map
+
+| Spec requirement | Task(s) |
+|------------------|---------|
+| FR-1: Catch `JsonException` during deserialization | Task 1, Step 3 |
+| FR-1 (arch amendment): `dto is null` → `Layout = null` without log | Task 3, Step 3 |
+| FR-2: Warning log with phrase "Malformed LayoutJson", `UserId`, `GridKey`, exception attached | Task 1, Step 3 (implementation) + Task 1, Step 1 (test pin) |
+| FR-3: No regression in the existing three paths (missing row / happy / DB error) | Task 1, Step 5; Task 4, Step 3 |
+| FR-4: Test `Handle_WhenLayoutJsonIsMalformed_ReturnsNullLayoutAndLogsWarning` | Task 1, Step 1 |
+| FR-4: Test `Handle_WhenLayoutJsonIsEmpty_ReturnsNullLayoutAndLogsWarning` | Task 2, Step 1 |
+| FR-4 (arch amendment): Test `Handle_WhenLayoutJsonIsLiteralNull_ReturnsNullLayoutAndDoesNotLog` | Task 3, Step 1 |
+| FR-5: Diff confined to `GetGridLayoutHandler.cs` + its test file | Task 4, Step 4 |
+| NFR-1 Performance: no extra I/O, only try-block entry on happy path | Implicit in Task 1/3 implementation (no allocations added) |
+| NFR-2 Security: no `LayoutJson` payload echo, only `UserId` + `GridKey` in log | Task 1, Step 3 (log template uses only `{UserId}` and `{GridKey}`) |
+| NFR-3 Observability: warning-level, searchable phrase, exception attached | Task 1, Step 3 |
+| NFR-4 Compatibility: no schema or contract change | Task 4, Step 4 (diff scope check) |


### PR DESCRIPTION

Gracefully handles malformed `LayoutJson` in `GetGridLayoutHandler` so a corrupt user-preference row falls back to "no saved layout" instead of surfacing a 500. Previously, `JsonSerializer.Deserialize<GridLayoutDto>(entity.LayoutJson)` would let `JsonException` escape through the outer DB-error catch filter, reaching the unhandled-exception middleware. The fix wraps only the deserialize call in a typed `catch (JsonException)`, logs a `Warning` with `UserId` + `GridKey`, and returns `{ Layout = null }` — the same shape the frontend already handles for the "no saved layout" case.

A legal JSON `"null"` value (which deserializes to `null` without throwing) is also folded into the null-layout fallback via an explicit `if (dto is null)` guard, replacing the previous `?? new GridLayoutDto()` which would have silently emitted a DTO with zero columns.

### Changes
- `backend/src/Anela.Heblo.Application/Features/GridLayouts/UseCases/GetGridLayout/GetGridLayoutHandler.cs` — inner try/catch (JsonException) around deserialization + null guard; removes `?? new GridLayoutDto()` fallback
- `backend/test/Anela.Heblo.Tests/Features/GridLayouts/GetGridLayoutHandlerTests.cs` — three new xUnit tests covering malformed JSON, empty string, and literal-null JSON payloads

---

Closes #2073

### Tokens used
7729136
