### PR TITLE
feat: Centralize MarketingAction scalar field updates via domain method

### DIFF
--- a/artifacts/feat-arch-review-marketing-title-description-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-marketing-title-description-/arch-review.r1.md
@@ -1,0 +1,270 @@
+# Architecture Review: Centralize MarketingAction scalar field updates via domain method
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The change is a textbook "Tell, Don't Ask" refinement and aligns cleanly with the codebase's stated principle "Don't create anemic domain models — put behavior in entities" (`docs/architecture/development_guidelines.md`, line 240). `MarketingAction` already encapsulates `AssociateWithProduct`, `LinkToFolder`, `SoftDelete`, `MarkOutlookSynced`, and `ClearOutlookLink` — `UpdateDetails` is the missing scalar-mutation peer that completes the entity's behavioral surface.
+
+Integration points are **scoped to a single module** (`Anela.Heblo.Domain/Features/Marketing/`, `Anela.Heblo.Application/Features/Marketing/UseCases/`) and a single persistence configuration (`Anela.Heblo.Persistence/Marketing/MarketingActionConfiguration.cs`). No module boundaries are crossed, no contracts (`Anela.Heblo.Application/Features/Marketing/Contracts`) change, and the OpenAPI surface is identical. Per the project's coding-style rule "use `class` for entities with identity and lifecycle" and "do not mutate input models in-place," tightening the setters and adding a behavior method matches the prescribed pattern.
+
+The Vertical Slice organization is preserved — all touched files live within the existing Marketing slice.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Application Layer  (Features/Marketing/UseCases)            │
+│                                                              │
+│  CreateMarketingActionHandler ─┐                             │
+│  UpdateMarketingActionHandler ─┼──► MarketingAction          │
+│  OutlookEventImportMapper      │     (Domain Layer)          │
+│    .BuildAction               ─┤                             │
+│    .ApplyChanges              ─┘                             │
+│    .HasChanges  ──► uses shared normalizer helpers           │
+└──────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────┐
+│  Domain Layer  (Domain/Features/Marketing/MarketingAction)   │
+│                                                              │
+│  ctor(title, description, type, start, end, createdByUserId, │
+│       createdByUsername, utcNow)         ── normalizes ──┐   │
+│  UpdateDetails(title, description, type, start, end,     │   │
+│                modifiedByUserId, modifiedByUsername,     │   │
+│                utcNow)                   ── normalizes ──┤   │
+│                                                          ▼   │
+│  private static NormalizeTitle(string?)   ──► trim, default  │
+│  private static NormalizeDescription(string?) ──► trim, null │
+│                                                              │
+│  Property setters: private set (EF backing-field compatible) │
+│  Parameterless ctor: private (for EF materialization)        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Constructor + UpdateDetails (not "construct-then-update")
+
+**Options considered:**
+- **A. Parameterized constructor for creation, `UpdateDetails` for mutation.** Both delegate to private static normalizers.
+- **B. Parameterless constructor with defaults, immediately followed by `UpdateDetails` everywhere.**
+- **C. Single static factory `Create(...)` plus `UpdateDetails`.**
+
+**Chosen approach:** **A.** A `public MarketingAction(string title, string? description, MarketingActionType actionType, DateTime startDate, DateTime? endDate, string createdByUserId, string? createdByUsername, DateTime utcNow)` constructor for the create paths (`CreateMarketingActionHandler`, `OutlookEventImportMapper.BuildAction`); `UpdateDetails(...)` for mutation paths (`UpdateMarketingActionHandler`, `OutlookEventImportMapper.ApplyChanges`). Both call the same private `NormalizeTitle` / `NormalizeDescription` helpers so trimming rules live in exactly one place.
+
+**Rationale:**
+- Approach B leaves a transient invalid state where `Title` is `null!` between construction and `UpdateDetails` — an anti-pattern that the spec's NFR-4 (encapsulation) is meant to prevent.
+- Approach C is functionally equivalent to A but adds a non-idiomatic factory layer; the codebase has no precedent for static `Create` factories on entities (`Article`, other Domain entities use ctors or property init).
+- Approach A matches the C# coding-style rule "prefer init setters, constructor parameters … for shared state." The created entity is valid from the first reference.
+
+#### Decision 2: `private set` on tightened properties, private parameterless ctor for EF
+
+**Options considered:** `private set` vs `internal set`; expose protected parameterless ctor vs rely on EF's backing-field discovery.
+
+**Chosen approach:** All eight properties enumerated in FR-1 (`Title`, `Description`, `ActionType`, `StartDate`, `EndDate`, `ModifiedAt`, `ModifiedByUserId`, `ModifiedByUsername`) become `{ get; private set; }`. Add a `private MarketingAction() { }` parameterless constructor for EF Core materialization.
+
+**Rationale:**
+- `private set` is the strongest narrowing that EF Core 8 still supports via its private-setter discovery, requiring no entity-configuration changes in `MarketingActionConfiguration.cs`.
+- `internal` would leak mutation back to the Application layer, defeating the purpose.
+- A private parameterless ctor is the safest pattern — EF Core can rehydrate, the application layer cannot accidentally bypass invariants by calling `new MarketingAction()` and then mutating.
+- The `[Required]` data annotation on `Title` (currently `null!`) becomes redundant — keep it for documentation, but constructor enforcement is now primary.
+
+#### Decision 3: Update `HasChanges` to apply normalization before comparison
+
+**Options considered:** Leave `HasChanges` untouched; or update it to compare normalized values.
+
+**Chosen approach:** Update `OutlookEventImportMapper.HasChanges` (lines 50–57) to compare normalized values — either route through a private `NormalizedTitle(evt)` helper or trim inline before comparison.
+
+**Rationale:**
+- **This is a correctness requirement the spec missed.** After FR-1, persisted `existing.Title` is trimmed. `ParseTitle(evt.Subject)` returns the raw (possibly-whitespace) value. The current comparison `existing.Title != ParseTitle(evt.Subject)` would then report changes on every re-import of any whitespace-bearing event, causing infinite "Updated" loops on every sync. Without this fix, the change introduces a regression that the existing test `Handle_WhenEventAlreadyImportedAndUnchanged_SkipsIt` would not catch (it uses a no-whitespace title).
+- Trim-then-compare is the smallest fix; routing through `MarketingAction`'s normalizer would require exposing the normalizer as `internal static`, which is acceptable but heavier.
+
+#### Decision 4: Handle `currentUser.Id` nullability at the call site, not in `UpdateDetails`
+
+**Options considered:** Make `modifiedByUserId` nullable in `UpdateDetails`; or guard at the call site.
+
+**Chosen approach:** Keep `UpdateDetails`'s `modifiedByUserId` as `string` (non-null) per FR-1. Each handler is already responsible for resolving the current user — `UpdateMarketingActionHandler` short-circuits with `UnauthorizedMarketingAccess` before reaching the entity (line 46–50), and `OutlookEventImportMapper.ApplyChanges` should pass a guaranteed non-null id (use `currentUser.Id ?? throw` or the system-sync user id as the existing convention demands).
+
+**Rationale:** Pushing nullability into the domain method weakens the invariant. The entity should refuse to record a modification by an unidentified actor; the application layer owns user resolution.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files in production code. Edits only:
+
+```
+backend/src/
+├── Anela.Heblo.Domain/Features/Marketing/
+│   └── MarketingAction.cs                                       (modify)
+└── Anela.Heblo.Application/Features/Marketing/UseCases/
+    ├── CreateMarketingAction/CreateMarketingActionHandler.cs    (modify)
+    ├── UpdateMarketingAction/UpdateMarketingActionHandler.cs    (modify)
+    └── ImportFromOutlook/OutlookEventImportMapper.cs            (modify — BuildAction, ApplyChanges, AND HasChanges)
+
+backend/test/Anela.Heblo.Tests/
+├── Domain/Marketing/
+│   └── MarketingActionUpdateDetailsTests.cs                     (new — FR-6)
+└── Features/Marketing/
+    └── ImportFromOutlookHandlerTests.cs                         (extend — FR-7)
+```
+
+**Test fixture refactor (mandatory side-effect)**: Eight test files currently construct `new MarketingAction { Title = ..., ... }` via object initializer. They must be updated to the new constructor. Recommend introducing a single test helper to absorb the change:
+
+```
+backend/test/Anela.Heblo.Tests/
+└── Domain/Marketing/MarketingActionTestBuilder.cs               (new — internal test helper)
+```
+
+This avoids touching ~15 test setup sites individually whenever the constructor signature evolves.
+
+### Interfaces and Contracts
+
+```csharp
+namespace Anela.Heblo.Domain.Features.Marketing;
+
+public class MarketingAction : IEntity<int>
+{
+    private MarketingAction() { } // EF Core
+
+    public MarketingAction(
+        string title,
+        string? description,
+        MarketingActionType actionType,
+        DateTime startDate,
+        DateTime? endDate,
+        string createdByUserId,
+        string? createdByUsername,
+        DateTime utcNow);
+
+    public void UpdateDetails(
+        string title,
+        string? description,
+        MarketingActionType actionType,
+        DateTime startDate,
+        DateTime? endDate,
+        string modifiedByUserId,
+        string? modifiedByUsername,
+        DateTime utcNow);
+
+    // Tightened: get; private set;
+    public string Title { get; private set; }
+    public string? Description { get; private set; }
+    public MarketingActionType ActionType { get; private set; }
+    public DateTime StartDate { get; private set; }
+    public DateTime? EndDate { get; private set; }
+    public DateTime ModifiedAt { get; private set; }
+    public string? ModifiedByUserId { get; private set; }
+    public string? ModifiedByUsername { get; private set; }
+
+    // Unchanged accessibility (out of FR-1 scope):
+    // Id, CreatedAt, CreatedByUserId, CreatedByUsername, IsDeleted,
+    // DeletedAt/By*, Outlook* fields — keep existing setters
+}
+```
+
+**Private static normalizers** (single source of truth — used by both ctor and `UpdateDetails`):
+
+```csharp
+private static string NormalizeTitle(string? raw) => (raw ?? string.Empty).Trim();
+private static string? NormalizeDescription(string? raw) => raw?.Trim();
+```
+
+**Updated `HasChanges` contract** (spec amendment — see below):
+
+```csharp
+internal static bool HasChanges(MarketingAction existing, OutlookEventDto evt, MarketingActionType actionType)
+{
+    // Compare normalized values to match what UpdateDetails will persist.
+    var normalizedTitle = ParseTitle(evt.Subject).Trim();
+    var normalizedDescription = ParseDescription(evt.BodyText)?.Trim();
+    return existing.Title != normalizedTitle
+        || existing.Description != normalizedDescription
+        || existing.StartDate != evt.StartUtc
+        || existing.EndDate != ParseEndDate(evt)
+        || existing.ActionType != actionType;
+}
+```
+
+### Data Flow
+
+**Create path (API):**
+```
+HTTP POST → CreateMarketingActionRequest → CreateMarketingActionHandler.Handle
+  → new MarketingAction(request.Title, request.Description, …, currentUser.Id, currentUser.Name, now)
+    └─ ctor normalizes Title/Description via NormalizeTitle/NormalizeDescription
+  → action.AssociateWithProduct(...)  (unchanged)
+  → action.LinkToFolder(...)          (unchanged)
+  → _outlookSync.CreateEventAsync     (unchanged)
+  → action.MarkOutlookSynced(...)     (unchanged)
+  → repository.AddAsync + SaveChangesAsync
+```
+
+**Update path (API):**
+```
+HTTP PUT → UpdateMarketingActionRequest → UpdateMarketingActionHandler.Handle
+  → repository.GetByIdAsync
+  → action.UpdateDetails(request.Title, request.Description, …, currentUser.Id, currentUser.Name, now)
+    └─ method normalizes Title/Description
+  → outlook sync (unchanged)
+  → action.ProductAssociations.Clear() + AssociateWithProduct (unchanged)
+  → action.FolderLinks.Clear() + LinkToFolder (unchanged)
+  → repository.UpdateAsync + SaveChangesAsync
+```
+
+**Outlook import (new event):**
+```
+ImportFromOutlookHandler → OutlookEventImportMapper.BuildAction
+  → new MarketingAction(ParseTitle(evt.Subject), ParseDescription(evt.BodyText), …,
+                        currentUser.Id, currentUser.Name, utcNow)
+    └─ ctor trims title (intentional behavior change)
+  → action.MarkOutlookSynced(evt.Id, utcNow)
+```
+
+**Outlook import (update):**
+```
+ImportFromOutlookHandler
+  → HasChanges(existing, evt, actionType)   ◄── now compares normalized values
+  → if changed: OutlookEventImportMapper.ApplyChanges
+       → existing.UpdateDetails(ParseTitle(evt.Subject), ParseDescription(evt.BodyText), …,
+                                currentUser.Id, currentUser.Name, utcNow)
+         └─ method trims title (intentional behavior change)
+       → existing.MarkOutlookSynced(evt.Id, utcNow)
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `HasChanges` returns true on every re-import of whitespace-bearing events, creating sync churn & noisy "Updated" counts | **CRITICAL** | Spec amendment SA-1: update `HasChanges` to compare normalized values. Add regression test: import same whitespace-titled event twice, second pass must be `Skipped`. |
+| `currentUser.Id` is `string?`; passing null to a non-null `UpdateDetails` parameter throws NRE in Outlook path | **HIGH** | At call sites, guard with `?? throw` or fall back to the established sync-user id. Document in mapper that a non-null id is required before calling `ApplyChanges`. |
+| EF Core fails to materialize entities after `private set` tightening if backing-field convention is misconfigured | **MEDIUM** | Add an integration test (or `dotnet ef migrations` smoke run) that round-trips a `MarketingAction` through the real `ApplicationDbContext`. Private setters are EF-supported, but verify. |
+| ~8 test files use object-initializer construction; signature change ripples broadly | **MEDIUM** | Introduce `MarketingActionTestBuilder` once; migrate test setups to it. Limits future churn when the entity ctor evolves. |
+| `SoftDelete` (lines 106–115 in entity) directly assigns `ModifiedAt`, `ModifiedByUserId`, `ModifiedByUsername` — within the entity, so it still compiles, but the audit-stamp logic now lives in two places | **LOW** | Out of scope per spec, but flag in code comment or follow-up: `SoftDelete` should delegate to a private `StampModification(...)` helper to keep audit assignment DRY. |
+| `Title`'s `[Required]` and `[MaxLength(200)]` annotations no longer match new ctor reality (no length enforcement in ctor) | **LOW** | Behavior unchanged from current code — neither current nor proposed code length-validates `Title`; only EF/database enforces. Leave annotations; the `Outlook` path's `ParseTitle` clips to 200 and the API path is bounded by `MaxLength` on the request DTO. |
+
+## Specification Amendments
+
+**SA-1 (CRITICAL — add to FR-3):** `OutlookEventImportMapper.HasChanges` (lines 50–57) **must** be updated in the same change to compare normalized values, otherwise re-syncing any whitespace-bearing event reports it as changed and triggers a no-op write loop. Add an acceptance criterion to FR-7:
+> Test: importing the same whitespace-titled Outlook event a second time results in `Skipped`, not `Updated`.
+
+**SA-2 (add to FR-3, FR-4):** The Outlook path must pass a non-null `modifiedByUserId` / `createdByUserId` to the entity. Specify the resolution strategy: either `currentUser.Id ?? throw new InvalidOperationException("Outlook import requires an authenticated user context")` or fall back to a documented sync-user constant. Pick one and document in the mapper.
+
+**SA-3 (clarify FR-1):** The new `MarketingAction` constructor signature (Decision 1) should be added explicitly to the spec — currently it is implied by FR-4 / FR-5 but never stated. Recommended signature documented in "Interfaces and Contracts" above.
+
+**SA-4 (clarify FR-1):** The spec lists `CreatedAt`, `CreatedByUserId`, `CreatedByUsername` as *not* in the tightened-setter set. Confirm intent: they should also become `{ get; private set; }` and be assigned only via the new constructor (otherwise creation-time invariants remain exposed). Recommendation: tighten them too, since they fall under the same encapsulation principle, but mark this as a small scope expansion.
+
+**SA-5 (clarify FR-1 null-title handling):** FR-1 says title is `(title ?? string.Empty).Trim()` but the FR-6 acceptance criterion says "null title throws **or** is replaced with empty string (per implementation choice)." Pick one in the spec — recommend the brief's behavior (replace with empty, do not throw) for consistency with current behavior (the property is declared `string` non-null but DB enforces `NOT NULL`, and an empty title would fail EF validation downstream where it's caught with a clear error).
+
+## Prerequisites
+
+None. No database migration, no configuration change, no new packages, no infrastructure work, no feature flag, no Azure Key Vault secret. The change is a pure refactor confined to the Marketing module's Domain and Application layers, with a single behavioral change (titles trimmed on Outlook import) that is the intentional fix.
+
+Validation gates per `CLAUDE.md`:
+- `dotnet build` clean
+- `dotnet format` clean
+- All existing tests in `backend/test/Anela.Heblo.Tests/{Domain,Application,Features}/Marketing/` pass after fixture updates
+- New `MarketingActionUpdateDetailsTests` (FR-6) and extended `ImportFromOutlookHandlerTests` (FR-7 + SA-1 regression case) pass

--- a/artifacts/feat-arch-review-marketing-title-description-/brief.md
+++ b/artifacts/feat-arch-review-marketing-title-description-/brief.md
@@ -1,0 +1,74 @@
+## Module
+Marketing
+
+## Finding
+
+`MarketingAction.Title` and `Description` are mutated in two independent places with different normalization rules:
+
+**API mutation path (consistent):**
+```csharp
+// CreateMarketingActionHandler.cs:52
+action.Title = request.Title.Trim();
+action.Description = request.Description?.Trim();
+
+// UpdateMarketingActionHandler.cs:61–62
+action.Title = request.Title.Trim();
+action.Description = request.Description?.Trim();
+```
+
+**Outlook import path (no `.Trim()`):**
+```csharp
+// OutlookEventImportMapper.cs:34 (BuildAction)
+Title = ParseTitle(evt.Subject),        // truncates to 200 chars, does NOT trim
+Description = ParseDescription(evt.BodyText),  // strips HTML, does NOT trim
+
+// OutlookEventImportMapper.cs:66–67 (ApplyChanges)
+existing.Title = ParseTitle(evt.Subject);
+existing.Description = ParseDescription(evt.BodyText);
+```
+
+`ParseTitle` (line 78) just clips length; it never calls `.Trim()`. `ParseDescription` (line 83) strips HTML via regex and calls `WhitespaceRegex.Replace(...).Trim()` on the stripped text, so descriptions are incidentally trimmed — but titles are not.
+
+Result: any `MarketingAction` whose title was set or updated via `ImportFromOutlook` can have leading or trailing whitespace. Actions updated through the regular API cannot. The same database column ends up with inconsistent casing/trimming depending on which code path last touched the record.
+
+The root cause is that `MarketingAction` has no `Update(...)` domain method. Instead, every mutation path reaches directly into the entity's properties. The entity already shows intent for encapsulated mutation with `SoftDelete`, `MarkOutlookSynced`, `AssociateWithProduct`, and `LinkToFolder` — the scalar-field update is the only operation left exposed as raw property assignment.
+
+## Why it matters
+
+- **Data consistency**: title comparisons, deduplication, or search that relies on exact-match can silently differ between API-managed and Outlook-imported actions.
+- **Invariant duplication**: adding a new normalization rule (e.g. strip control characters, normalize smart quotes from Outlook) requires finding and updating every mutation site rather than one place.
+- **SRP / Tell-Don't-Ask**: two separate callers (`UpdateMarketingActionHandler`, `OutlookEventImportMapper`) are responsible for knowing and applying the entity's field invariants, instead of the entity itself.
+
+## Suggested fix
+
+Add an `UpdateDetails` domain method to `MarketingAction` that centralises all scalar-field normalization and replaces the direct property assignments in both handlers:
+
+```csharp
+// MarketingAction.cs
+public void UpdateDetails(
+    string title,
+    string? description,
+    MarketingActionType actionType,
+    DateTime startDate,
+    DateTime? endDate,
+    string modifiedByUserId,
+    string? modifiedByUsername,
+    DateTime utcNow)
+{
+    Title = (title ?? string.Empty).Trim();
+    Description = description?.Trim();
+    ActionType = actionType;
+    StartDate = startDate;
+    EndDate = endDate;
+    ModifiedAt = utcNow;
+    ModifiedByUserId = modifiedByUserId;
+    ModifiedByUsername = modifiedByUsername ?? "Unknown User";
+}
+```
+
+Both `UpdateMarketingActionHandler` (lines 61–68) and `OutlookEventImportMapper.ApplyChanges` (lines 66–73) and `OutlookEventImportMapper.BuildAction` (lines 32–43) call this method instead of setting properties directly. `CreateMarketingActionHandler` initialises the object via constructor but can use the same method or an analogous constructor.
+
+The change is behavioural only for the Outlook import path (adds `.Trim()` to titles); the API paths are unchanged.
+
+---
+_Filed by daily arch-review routine on 2026-05-29._

--- a/artifacts/feat-arch-review-marketing-title-description-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-marketing-title-description-/impl/main.r1.md
@@ -1,0 +1,77 @@
+All 13 tasks passed review. Writing the implementation summary.
+
+---
+
+# Implementation: Centralize MarketingAction scalar field updates via domain method
+
+## What was implemented
+
+Added a parameterized constructor and `UpdateDetails` domain method to `MarketingAction`, both delegating to private static `NormalizeTitle`/`NormalizeDescription` helpers. Refactored all three mutation paths (Create handler, Update handler, Outlook import mapper) to use these surfaces. Tightened 11 scalar property setters to `private set`. Fixed `HasChanges` to compare normalized values (preventing a sync-loop regression). Introduced `MarketingActionTestBuilder` to absorb the constructor-ripple across test files.
+
+## Files created/modified
+
+**Production code:**
+- `backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs` — added parameterized ctor + `UpdateDetails` + private normalizers; tightened 11 setters to `private set`; narrowed parameterless ctor to `private`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs` — uses new constructor
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs` — uses `UpdateDetails`
+- `backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs` — `BuildAction` uses constructor, `ApplyChanges` uses `UpdateDetails`, `HasChanges` normalizes before comparison, SA-2 null-guards on `currentUser.Id`
+
+**Test code — new files:**
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs` — fluent builder; single place to update when entity construction surface changes
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionUpdateDetailsTests.cs` — 7 unit tests for FR-6
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionConstructorTests.cs` — 6 unit tests for SA-3
+
+**Test code — modified (migrated to builder):**
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs`
+- `backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionSyncTests.cs`
+- `backend/test/Anela.Heblo.Tests/Application/Marketing/MarketingActionDtoTests.cs`
+- `backend/test/Anela.Heblo.Tests/Marketing/OutlookCalendarSyncServiceTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs`
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs` — migrated + 3 new tests (SA-1 regression, FR-7 new event trim, FR-7 update trim)
+- `backend/test/Anela.Heblo.Tests/Features/Marketing/UpdateMarketingActionHandlerTests.cs`, `DeleteMarketingActionHandlerTests.cs`, `GetMarketingCalendarHandlerTests.cs`, `OutlookCalendarSyncServiceTokenTests.cs` — migrated to builder
+
+## Tests
+
+| Test file | Coverage |
+|-----------|----------|
+| `MarketingActionUpdateDetailsTests.cs` | 7 tests: title trim, null→empty string, null description preserved, description trim, ModifiedByUsername default, ModifiedAt assignment, scalar fields |
+| `MarketingActionConstructorTests.cs` | 6 tests: title trim, description trim, null description, username default, timestamps, scalars |
+| `ImportFromOutlookHandlerTests.cs` (new tests) | SA-1 regression (whitespace re-import → Skipped), FR-7 new event trim, FR-7 update event trim |
+
+## How to verify
+
+```bash
+cd backend
+dotnet build Anela.Heblo.sln --nologo
+dotnet test Anela.Heblo.sln --nologo --filter "FullyQualifiedName~Marketing"
+grep -rn "action\.\(Title\|Description\|ActionType\|StartDate\|EndDate\|ModifiedAt\|ModifiedByUserId\|ModifiedByUsername\|CreatedAt\|CreatedByUserId\|CreatedByUsername\)\s*=" src/Anela.Heblo.Application
+# Expected: zero matches
+```
+
+## Notes
+
+- Pre-existing Docker/Testcontainer integration test failures (36 tests) are unrelated to this change — they require a running PostgreSQL container
+- `dotnet format` produced no changes — code was already formatted
+- Four additional test files beyond the Task 1 plan needed builder migration (they used the parameterless object-initializer pattern); fixed in Task 12
+- The redundant `.Trim()` on `ParseDescription` result in `HasChanges` is a no-op (description is already trimmed by `StripHtml`) — noted as LOW severity, not blocking
+
+## PR Summary
+
+This change eliminates whitespace inconsistency in `MarketingAction.Title` by centralizing normalization in a domain method, replacing scattered direct property mutations across three call sites. Titles imported from Outlook now match titles set via the API, fixing exact-match search and deduplication bugs caused by surrounding whitespace.
+
+The implementation adds `MarketingAction(...)` constructor and `UpdateDetails(...)` method (both delegating to `NormalizeTitle`/`NormalizeDescription`), tightens 11 scalar property setters to `private set` to enforce the encapsulation boundary, and fixes `HasChanges` in the Outlook import mapper so re-importing whitespace-titled events is correctly identified as unchanged rather than triggering a no-op write loop.
+
+### Changes
+- `MarketingAction.cs` — parameterized ctor + `UpdateDetails` + private normalizers + `private set` on 11 properties
+- `CreateMarketingActionHandler.cs` — constructor call replaces object initializer
+- `UpdateMarketingActionHandler.cs` — `UpdateDetails` call replaces 8 direct property assignments
+- `OutlookEventImportMapper.cs` — `BuildAction` uses ctor, `ApplyChanges` uses `UpdateDetails`, `HasChanges` normalizes before comparison, SA-2 null-guards added
+- `MarketingActionTestBuilder.cs` (new) — fluent builder centralizing test fixture construction
+- `MarketingActionUpdateDetailsTests.cs` + `MarketingActionConstructorTests.cs` (new) — unit tests for normalization
+- 11 test files — migrated from object-initializer construction to `MarketingActionTestBuilder`
+- `ImportFromOutlookHandlerTests.cs` — 3 new tests: sync-loop regression guard + FR-7 trim on create + FR-7 trim on update
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-marketing-title-description-/spec.r1.md
+++ b/artifacts/feat-arch-review-marketing-title-description-/spec.r1.md
@@ -1,0 +1,134 @@
+# Specification: Centralize MarketingAction scalar field updates via domain method
+
+## Summary
+Add an `UpdateDetails` domain method to the `MarketingAction` entity that owns normalization (trimming) and assignment of scalar fields (title, description, action type, dates, modification audit). Refactor all three mutation paths — the create handler, update handler, and Outlook import mapper — to use this method instead of mutating properties directly, eliminating the current inconsistency where Outlook-imported titles retain leading/trailing whitespace.
+
+## Background
+`MarketingAction.Title` and `Description` are currently mutated from multiple call sites with diverging normalization. The API path (`CreateMarketingActionHandler`, `UpdateMarketingActionHandler`) trims both fields. The Outlook import path (`OutlookEventImportMapper.BuildAction` and `ApplyChanges`) only incidentally trims descriptions (via `WhitespaceRegex` in `ParseDescription`) and does not trim titles at all. As a result, two records representing the same logical action can differ by surrounding whitespace depending on which code path last touched them, breaking exact-match search, deduplication, and title comparison.
+
+The entity already encapsulates other mutations (`SoftDelete`, `MarkOutlookSynced`, `AssociateWithProduct`, `LinkToFolder`); scalar-field update is the only operation still exposed as raw property assignment. Centralizing this mutation in a domain method removes the invariant from being duplicated across call sites and gives a single location to add future normalization rules (e.g. stripping control characters, normalizing smart quotes from Outlook content).
+
+## Functional Requirements
+
+### FR-1: Add `UpdateDetails` domain method to `MarketingAction`
+Introduce a public instance method on `MarketingAction` that accepts the scalar fields a caller can change (title, description, action type, start/end dates) plus modification audit fields (user id, username, UTC timestamp). The method normalizes inputs and assigns them to backing properties atomically.
+
+**Acceptance criteria:**
+- Method signature accepts: `string title`, `string? description`, `MarketingActionType actionType`, `DateTime startDate`, `DateTime? endDate`, `string modifiedByUserId`, `string? modifiedByUsername`, `DateTime utcNow`.
+- `Title` is set to `(title ?? string.Empty).Trim()`.
+- `Description` is set to `description?.Trim()` (null preserved).
+- `ActionType`, `StartDate`, `EndDate` are assigned directly.
+- `ModifiedAt` is set to `utcNow`.
+- `ModifiedByUserId` is assigned directly.
+- `ModifiedByUsername` defaults to `"Unknown User"` when null (matches existing handler behavior).
+- Property setters for `Title`, `Description`, `ActionType`, `StartDate`, `EndDate`, `ModifiedAt`, `ModifiedByUserId`, `ModifiedByUsername` are restricted (private set or internal) so callers cannot bypass `UpdateDetails`.
+
+### FR-2: Refactor `UpdateMarketingActionHandler` to use `UpdateDetails`
+Replace the direct property assignments at `UpdateMarketingActionHandler.cs:61–68` (or whichever lines hold the mutation block) with a single call to `action.UpdateDetails(...)`.
+
+**Acceptance criteria:**
+- No direct assignment to `Title`, `Description`, `ActionType`, `StartDate`, `EndDate`, `ModifiedAt`, `ModifiedByUserId`, or `ModifiedByUsername` remains in the handler.
+- Behavior is unchanged for the API path: existing inputs produce identical persisted state.
+- Existing tests for `UpdateMarketingActionHandler` continue to pass.
+
+### FR-3: Refactor `OutlookEventImportMapper.ApplyChanges` to use `UpdateDetails`
+Replace the direct property assignments at `OutlookEventImportMapper.cs:66–73` with a call to `existing.UpdateDetails(...)`, passing the parsed title (post-`ParseTitle`) and parsed description (post-`ParseDescription`).
+
+**Acceptance criteria:**
+- Titles imported or updated from Outlook are trimmed (this is the intentional behavior change).
+- Descriptions remain effectively trimmed (no regression — `ParseDescription` already returns a trimmed string; calling `Trim()` again is a no-op).
+- Audit fields (`ModifiedAt`, `ModifiedByUserId`, `ModifiedByUsername`) are populated from the Outlook import context using the same convention the mapper currently uses (e.g. system/sync user identity).
+
+### FR-4: Refactor `OutlookEventImportMapper.BuildAction` to use `UpdateDetails` (or analogous constructor)
+The `BuildAction` path constructs a new `MarketingAction`. Either route construction through a constructor that delegates normalization to the same logic as `UpdateDetails`, or instantiate with safe defaults and immediately call `UpdateDetails`. Choose whichever keeps invariants in a single place.
+
+**Acceptance criteria:**
+- Newly built actions from Outlook have trimmed titles.
+- All scalar fields are normalized through one code path shared with `UpdateDetails`.
+- No raw property assignment remains in `BuildAction` for `Title`, `Description`, `ActionType`, `StartDate`, `EndDate`.
+
+### FR-5: Refactor `CreateMarketingActionHandler` to share normalization
+`CreateMarketingActionHandler` currently initializes a new entity (via constructor or property assignment) and then trims `Title` / `Description`. Update it to share the same normalization path used by FR-4 — either a constructor that normalizes, or instantiation followed by `UpdateDetails`.
+
+**Acceptance criteria:**
+- No raw `.Trim()` calls on `Title`/`Description` remain in the handler — normalization is delegated to the entity.
+- Behavior is unchanged for the create path: existing inputs produce identical persisted state.
+- Existing tests for `CreateMarketingActionHandler` continue to pass.
+
+### FR-6: Unit tests for `UpdateDetails`
+Add unit tests on `MarketingAction.UpdateDetails` covering normalization rules independently of any handler.
+
+**Acceptance criteria:**
+- Test: title with leading/trailing whitespace is trimmed.
+- Test: null title throws or is replaced with empty string (per implementation choice in FR-1).
+- Test: null description remains null (not converted to empty string).
+- Test: description with whitespace is trimmed.
+- Test: `ModifiedByUsername` defaults to `"Unknown User"` when null.
+- Test: `ModifiedAt` is set to the provided `utcNow`.
+- Test: all other scalar fields are assigned exactly as passed.
+
+### FR-7: Integration tests for the Outlook import behavior change
+Add or extend tests for `OutlookEventImportMapper` that confirm titles from Outlook events are trimmed in both `BuildAction` and `ApplyChanges` paths.
+
+**Acceptance criteria:**
+- Test: importing a new Outlook event with a leading/trailing whitespace subject produces a `MarketingAction` with a trimmed `Title`.
+- Test: re-importing (updating) an existing `MarketingAction` from an Outlook event with whitespace in subject results in a trimmed `Title`.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable change. `UpdateDetails` is a synchronous in-memory method call replacing inline property assignments — same allocation and CPU profile.
+
+### NFR-2: Security
+No new security surface. Field normalization is defensive (trimming) and reduces the chance of whitespace-based collisions in lookups; it does not introduce new validation gaps.
+
+### NFR-3: Backward compatibility (data)
+Existing rows with untrimmed titles are not retroactively cleaned. A row stays as-is until the next time it passes through `UpdateDetails` (any API update or Outlook re-sync), at which point its title is trimmed. No data migration is included in this work (see Out of Scope).
+
+### NFR-4: Encapsulation
+After this change, no code outside `MarketingAction` may directly assign `Title`, `Description`, `ActionType`, `StartDate`, `EndDate`, `ModifiedAt`, `ModifiedByUserId`, or `ModifiedByUsername`. This is enforced via setter accessibility (private or internal as appropriate for EF Core materialization).
+
+## Data Model
+No schema changes. The `MarketingAction` entity and its persisted columns are unchanged. Only the API surface of the entity changes:
+- Setters on the affected scalar properties are tightened (private/internal).
+- A new public method `UpdateDetails(...)` is added.
+
+EF Core materialization must continue to work — typically achieved by leaving private setters that EF can populate via its proxy/backing-field conventions.
+
+## API / Interface Design
+
+### Internal entity method
+```csharp
+public void UpdateDetails(
+    string title,
+    string? description,
+    MarketingActionType actionType,
+    DateTime startDate,
+    DateTime? endDate,
+    string modifiedByUserId,
+    string? modifiedByUsername,
+    DateTime utcNow)
+```
+
+### External (HTTP/MediatR) API
+No changes. The existing `CreateMarketingActionCommand` and `UpdateMarketingActionCommand` request/response contracts remain identical. The OpenAPI surface is unchanged.
+
+### UI
+No UI changes.
+
+## Dependencies
+- No new external services, libraries, or packages.
+- Depends on the existing `MarketingAction` entity, `MarketingActionType` enum, and the three call sites listed in the brief.
+- Existing `OutlookEventImportMapper.ParseTitle` and `ParseDescription` helpers continue to be used to pre-process raw Outlook content before it reaches `UpdateDetails`.
+
+## Out of Scope
+- Data backfill / migration to trim whitespace in already-persisted `MarketingAction.Title` values. (Recommended as a follow-up if duplicate-by-whitespace is observed in production data.)
+- Additional normalization rules beyond trimming (e.g. stripping control characters, normalizing smart quotes, Unicode normalization). The new method is the right home for these, but they are not included in this change.
+- Refactoring other domain entities that may have analogous raw-property mutation patterns.
+- Changes to `ParseTitle` / `ParseDescription` themselves. They continue to perform Outlook-specific pre-processing (HTML strip, length clip); trimming is layered on by `UpdateDetails`.
+- Audit-log changes or events emitted on update — existing behavior preserved.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-marketing-title-description-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-marketing-title-description-/task-plan.r1.md
@@ -1,0 +1,13 @@
+Plan saved to `artifacts/feat-arch-review-marketing-title-description-/plan.r1.md`.
+
+The 13-task TDD plan covers:
+
+- **Task 1** — Introduce `MarketingActionTestBuilder` and migrate 7 existing test files to absorb the upcoming ctor ripple.
+- **Tasks 2–3** — Add `UpdateDetails` and the new public constructor on `MarketingAction`, both delegating to private `NormalizeTitle` / `NormalizeDescription` helpers (TDD).
+- **Tasks 4–7** — Refactor the three call sites (`UpdateMarketingActionHandler`, `CreateMarketingActionHandler`, `OutlookEventImportMapper.BuildAction`, `OutlookEventImportMapper.ApplyChanges`). Outlook paths guard `currentUser.Id` per SA-2.
+- **Tasks 8–9** — Red/green pair for SA-1: fix `HasChanges` to compare normalized values so re-importing whitespace-titled events isn't reported as `Updated`.
+- **Tasks 10–11** — Integration tests for FR-7 (new event and update event trim behavior).
+- **Task 12** — Tighten setters to `private set`, narrow the parameterless ctor to `private` for EF Core, and switch the test builder over to the new ctor.
+- **Task 13** — Final `dotnet build` / `dotnet format` / full test suite gates plus a grep check that no direct setter access survives in `Application/`.
+
+All five arch-review amendments (SA-1 through SA-5) are mapped to specific tasks. Each task ends with a discrete commit so a failure point is easy to bisect.

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/CreateMarketingAction/CreateMarketingActionHandler.cs
@@ -46,18 +46,15 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAct
 
             var now = DateTime.UtcNow;
 
-            var action = new MarketingAction
-            {
-                Title = request.Title.Trim(),
-                Description = request.Description?.Trim(),
-                ActionType = request.ActionType,
-                StartDate = request.StartDate,
-                EndDate = request.EndDate,
-                CreatedAt = now,
-                ModifiedAt = now,
-                CreatedByUserId = currentUser.Id,
-                CreatedByUsername = currentUser.Name ?? "Unknown User",
-            };
+            var action = new MarketingAction(
+                title: request.Title,
+                description: request.Description,
+                actionType: request.ActionType,
+                startDate: request.StartDate,
+                endDate: request.EndDate,
+                createdByUserId: currentUser.Id,
+                createdByUsername: currentUser.Name,
+                utcNow: now);
 
             if (request.AssociatedProducts?.Any() == true)
                 foreach (var product in request.AssociatedProducts.Distinct())

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs
@@ -50,8 +50,14 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
 
         internal static bool HasChanges(MarketingAction existing, OutlookEventDto evt, MarketingActionType actionType)
         {
-            return existing.Title != ParseTitle(evt.Subject)
-                || existing.Description != ParseDescription(evt.BodyText)
+            // Compare against the values UpdateDetails / the constructor would
+            // persist — both trim title and description. Without this, re-importing
+            // a whitespace-bearing event would always report Updated.
+            var normalizedTitle = ParseTitle(evt.Subject).Trim();
+            var normalizedDescription = ParseDescription(evt.BodyText)?.Trim();
+
+            return existing.Title != normalizedTitle
+                || existing.Description != normalizedDescription
                 || existing.StartDate != evt.StartUtc
                 || existing.EndDate != ParseEndDate(evt)
                 || existing.ActionType != actionType;

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs
@@ -64,14 +64,20 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
             CurrentUser currentUser,
             DateTime utcNow)
         {
-            existing.Title = ParseTitle(evt.Subject);
-            existing.Description = ParseDescription(evt.BodyText);
-            existing.StartDate = evt.StartUtc;
-            existing.EndDate = ParseEndDate(evt);
-            existing.ActionType = actionType;
-            existing.ModifiedAt = utcNow;
-            existing.ModifiedByUserId = currentUser.Id;
-            existing.ModifiedByUsername = currentUser.Name ?? "Unknown User";
+            var modifiedByUserId = currentUser.Id
+                ?? throw new InvalidOperationException(
+                    "Outlook import requires an authenticated user context for modifiedByUserId.");
+
+            existing.UpdateDetails(
+                title: ParseTitle(evt.Subject),
+                description: ParseDescription(evt.BodyText),
+                actionType: actionType,
+                startDate: evt.StartUtc,
+                endDate: ParseEndDate(evt),
+                modifiedByUserId: modifiedByUserId,
+                modifiedByUsername: currentUser.Name,
+                utcNow: utcNow);
+
             existing.MarkOutlookSynced(evt.Id, utcNow);
         }
 

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/ImportFromOutlook/OutlookEventImportMapper.cs
@@ -29,18 +29,19 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook
             DateTime utcNow,
             MarketingActionType actionType)
         {
-            var action = new MarketingAction
-            {
-                Title = ParseTitle(evt.Subject),
-                Description = ParseDescription(evt.BodyText),
-                ActionType = actionType,
-                StartDate = evt.StartUtc,
-                EndDate = ParseEndDate(evt),
-                CreatedAt = utcNow,
-                ModifiedAt = utcNow,
-                CreatedByUserId = currentUser.Id!,
-                CreatedByUsername = currentUser.Name ?? "Unknown User",
-            };
+            var createdByUserId = currentUser.Id
+                ?? throw new InvalidOperationException(
+                    "Outlook import requires an authenticated user context for createdByUserId.");
+
+            var action = new MarketingAction(
+                title: ParseTitle(evt.Subject),
+                description: ParseDescription(evt.BodyText),
+                actionType: actionType,
+                startDate: evt.StartUtc,
+                endDate: ParseEndDate(evt),
+                createdByUserId: createdByUserId,
+                createdByUsername: currentUser.Name,
+                utcNow: utcNow);
 
             action.MarkOutlookSynced(evt.Id, utcNow);
 

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/UseCases/UpdateMarketingAction/UpdateMarketingActionHandler.cs
@@ -58,14 +58,15 @@ namespace Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAct
 
             var now = DateTime.UtcNow;
 
-            action.Title = request.Title.Trim();
-            action.Description = request.Description?.Trim();
-            action.ActionType = request.ActionType;
-            action.StartDate = request.StartDate;
-            action.EndDate = request.EndDate;
-            action.ModifiedAt = now;
-            action.ModifiedByUserId = currentUser.Id;
-            action.ModifiedByUsername = currentUser.Name ?? "Unknown User";
+            action.UpdateDetails(
+                title: request.Title,
+                description: request.Description,
+                actionType: request.ActionType,
+                startDate: request.StartDate,
+                endDate: request.EndDate,
+                modifiedByUserId: currentUser.Id,
+                modifiedByUsername: currentUser.Name,
+                utcNow: now);
 
             if (_options.CurrentValue.PushEnabled)
             {

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -132,5 +132,29 @@ namespace Anela.Heblo.Domain.Features.Marketing
             OutlookSyncStatus = MarketingSyncStatus.NotSynced;
             OutlookSyncError = null;
         }
+
+        public void UpdateDetails(
+            string title,
+            string? description,
+            MarketingActionType actionType,
+            DateTime startDate,
+            DateTime? endDate,
+            string modifiedByUserId,
+            string? modifiedByUsername,
+            DateTime utcNow)
+        {
+            Title = NormalizeTitle(title);
+            Description = NormalizeDescription(description);
+            ActionType = actionType;
+            StartDate = startDate;
+            EndDate = endDate;
+            ModifiedAt = utcNow;
+            ModifiedByUserId = modifiedByUserId;
+            ModifiedByUsername = modifiedByUsername ?? "Unknown User";
+        }
+
+        private static string NormalizeTitle(string? raw) => (raw ?? string.Empty).Trim();
+
+        private static string? NormalizeDescription(string? raw) => raw?.Trim();
     }
 }

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -67,6 +67,29 @@ namespace Anela.Heblo.Domain.Features.Marketing
         public virtual ICollection<MarketingActionProduct> ProductAssociations { get; set; } = new List<MarketingActionProduct>();
         public virtual ICollection<MarketingActionFolderLink> FolderLinks { get; set; } = new List<MarketingActionFolderLink>();
 
+        public MarketingAction(
+            string title,
+            string? description,
+            MarketingActionType actionType,
+            DateTime startDate,
+            DateTime? endDate,
+            string createdByUserId,
+            string? createdByUsername,
+            DateTime utcNow)
+        {
+            Title = NormalizeTitle(title);
+            Description = NormalizeDescription(description);
+            ActionType = actionType;
+            StartDate = startDate;
+            EndDate = endDate;
+            CreatedAt = utcNow;
+            ModifiedAt = utcNow;
+            CreatedByUserId = createdByUserId;
+            CreatedByUsername = createdByUsername ?? "Unknown User";
+        }
+
+        public MarketingAction() { }
+
         // Domain methods
         public void AssociateWithProduct(string productCode)
         {

--- a/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
+++ b/backend/src/Anela.Heblo.Domain/Features/Marketing/MarketingAction.cs
@@ -12,36 +12,36 @@ namespace Anela.Heblo.Domain.Features.Marketing
 
         [Required]
         [MaxLength(200)]
-        public string Title { get; set; } = null!;
+        public string Title { get; private set; } = null!;
 
         [MaxLength(5000)]
-        public string? Description { get; set; }
+        public string? Description { get; private set; }
 
-        public MarketingActionType ActionType { get; set; }
-
-        [Required]
-        public DateTime StartDate { get; set; }
-
-        public DateTime? EndDate { get; set; }
+        public MarketingActionType ActionType { get; private set; }
 
         [Required]
-        public DateTime CreatedAt { get; set; }
+        public DateTime StartDate { get; private set; }
+
+        public DateTime? EndDate { get; private set; }
 
         [Required]
-        public DateTime ModifiedAt { get; set; }
+        public DateTime CreatedAt { get; private set; }
+
+        [Required]
+        public DateTime ModifiedAt { get; private set; }
 
         [Required]
         [MaxLength(100)]
-        public string CreatedByUserId { get; set; } = null!;
+        public string CreatedByUserId { get; private set; } = null!;
 
         [MaxLength(100)]
-        public string? CreatedByUsername { get; set; }
+        public string? CreatedByUsername { get; private set; }
 
         [MaxLength(100)]
-        public string? ModifiedByUserId { get; set; }
+        public string? ModifiedByUserId { get; private set; }
 
         [MaxLength(100)]
-        public string? ModifiedByUsername { get; set; }
+        public string? ModifiedByUsername { get; private set; }
 
         public bool IsDeleted { get; set; }
         public DateTime? DeletedAt { get; set; }
@@ -88,7 +88,7 @@ namespace Anela.Heblo.Domain.Features.Marketing
             CreatedByUsername = createdByUsername ?? "Unknown User";
         }
 
-        public MarketingAction() { }
+        private MarketingAction() { }
 
         // Domain methods
         public void AssociateWithProduct(string productCode)

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/DeleteMarketingActionHandlerTests.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.DeleteMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Domain.Marketing;
 using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -23,18 +24,20 @@ public class DeleteMarketingActionHandlerTests
     private static readonly CurrentUser AuthenticatedUser =
         new("user-1", "Test User", "test@example.com", IsAuthenticated: true);
 
-    private static MarketingAction BuildExistingAction(string? outlookEventId = "event-abc") =>
-        new()
-        {
-            Id = 7,
-            Title = "To Delete",
-            ActionType = MarketingActionType.Blog,
-            StartDate = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
-            CreatedAt = DateTime.UtcNow.AddDays(-1),
-            ModifiedAt = DateTime.UtcNow.AddDays(-1),
-            CreatedByUserId = "user-1",
-            OutlookEventId = outlookEventId,
-        };
+    private static MarketingAction BuildExistingAction(string? outlookEventId = "event-abc")
+    {
+        var action = new MarketingActionTestBuilder()
+            .WithId(7)
+            .WithTitle("To Delete")
+            .WithActionType(MarketingActionType.Blog)
+            .WithStartDate(new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithCreatedAt(DateTime.UtcNow.AddDays(-1))
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-1))
+            .WithCreatedBy("user-1")
+            .WithOutlookEventId(outlookEventId)
+            .Build();
+        return action;
+    }
 
     private static DeleteMarketingActionRequest BuildRequest(int id = 7) => new() { Id = id };
 

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/MarketingActionDtoTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/MarketingActionDtoTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Anela.Heblo.Application.Features.Marketing.Contracts;
 using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Tests.Domain.Marketing;
 using FluentAssertions;
 using Xunit;
 
@@ -18,34 +19,25 @@ public class MarketingActionDtoTests
         var startDate = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
         var endDate = new DateTime(2026, 3, 31, 0, 0, 0, DateTimeKind.Utc);
 
-        var action = new MarketingAction
-        {
-            Id = 42,
-            Title = "Spring Campaign",
-            Description = "Spring product launch",
-            ActionType = MarketingActionType.Blog,
-            StartDate = startDate,
-            EndDate = endDate,
-            CreatedAt = createdAt,
-            ModifiedAt = modifiedAt,
-            CreatedByUserId = "user-1",
-            CreatedByUsername = "alice",
-            ModifiedByUserId = "user-2",
-            ModifiedByUsername = "bob",
-            OutlookSyncStatus = MarketingSyncStatus.Synced,
-            OutlookEventId = "outlook-event-99",
-            ProductAssociations = new List<MarketingActionProduct>
-            {
-                new() { ProductCodePrefix = "PROD-A" },
-                new() { ProductCodePrefix = "PROD-B" },
-                new() { ProductCodePrefix = "PROD-A" }, // duplicate — must be de-duplicated
-            },
-            FolderLinks = new List<MarketingActionFolderLink>
-            {
-                new() { FolderKey = "folder-1", FolderType = MarketingFolderType.Seasonal },
-                new() { FolderKey = "folder-2", FolderType = MarketingFolderType.Campaign },
-            },
-        };
+        var action = new MarketingActionTestBuilder()
+            .WithId(42)
+            .WithTitle("Spring Campaign")
+            .WithDescription("Spring product launch")
+            .WithActionType(MarketingActionType.Blog)
+            .WithStartDate(startDate)
+            .WithEndDate(endDate)
+            .WithCreatedAt(createdAt)
+            .WithModifiedAt(modifiedAt)
+            .WithCreatedBy("user-1", "alice")
+            .WithModifiedBy("user-2", "bob")
+            .WithOutlookSyncStatus(MarketingSyncStatus.Synced)
+            .WithOutlookEventId("outlook-event-99")
+            .Build();
+        action.ProductAssociations.Add(new MarketingActionProduct { ProductCodePrefix = "PROD-A" });
+        action.ProductAssociations.Add(new MarketingActionProduct { ProductCodePrefix = "PROD-B" });
+        action.ProductAssociations.Add(new MarketingActionProduct { ProductCodePrefix = "PROD-A" }); // duplicate — must be de-duplicated
+        action.FolderLinks.Add(new MarketingActionFolderLink { FolderKey = "folder-1", FolderType = MarketingFolderType.Seasonal });
+        action.FolderLinks.Add(new MarketingActionFolderLink { FolderKey = "folder-2", FolderType = MarketingFolderType.Campaign });
 
         // Act
         var dto = MarketingActionDto.FromEntity(action);

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/OutlookCalendarSyncServiceTokenTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/OutlookCalendarSyncServiceTokenTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Tests.Domain.Marketing;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -54,17 +55,20 @@ public class OutlookCalendarSyncServiceTokenTests
         return new HttpClient(handler.Object);
     }
 
-    private static MarketingAction BuildAction() => new()
+    private static MarketingAction BuildAction()
     {
-        Id = 1,
-        Title = "Test",
-        ActionType = MarketingActionType.Blog,
-        StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
-        CreatedAt = DateTime.UtcNow,
-        ModifiedAt = DateTime.UtcNow,
-        CreatedByUserId = "user-1",
-        OutlookEventId = "existing-event-id",
-    };
+        var action = new MarketingActionTestBuilder()
+            .WithId(1)
+            .WithTitle("Test")
+            .WithActionType(MarketingActionType.Blog)
+            .WithStartDate(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .WithOutlookEventId("existing-event-id")
+            .Build();
+        return action;
+    }
 
     [Fact]
     public async Task CreateEventAsync_UsesDelegatedToken_NotAppToken()

--- a/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Application/Marketing/UpdateMarketingActionHandlerTests.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Domain.Marketing;
 using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -23,19 +24,21 @@ public class UpdateMarketingActionHandlerTests
     private static readonly CurrentUser AuthenticatedUser =
         new("user-1", "Test User", "test@example.com", IsAuthenticated: true);
 
-    private static MarketingAction BuildExistingAction(string? outlookEventId = "existing-event-id") =>
-        new()
-        {
-            Id = 42,
-            Title = "Old Title",
-            ActionType = MarketingActionType.Blog,
-            StartDate = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
-            CreatedAt = DateTime.UtcNow.AddDays(-1),
-            ModifiedAt = DateTime.UtcNow.AddDays(-1),
-            CreatedByUserId = "user-1",
-            OutlookEventId = outlookEventId,
-            OutlookSyncStatus = outlookEventId != null ? MarketingSyncStatus.Synced : MarketingSyncStatus.NotSynced,
-        };
+    private static MarketingAction BuildExistingAction(string? outlookEventId = "existing-event-id")
+    {
+        var action = new MarketingActionTestBuilder()
+            .WithId(42)
+            .WithTitle("Old Title")
+            .WithActionType(MarketingActionType.Blog)
+            .WithStartDate(new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc))
+            .WithCreatedAt(DateTime.UtcNow.AddDays(-1))
+            .WithModifiedAt(DateTime.UtcNow.AddDays(-1))
+            .WithCreatedBy("user-1")
+            .WithOutlookEventId(outlookEventId)
+            .WithOutlookSyncStatus(outlookEventId != null ? MarketingSyncStatus.Synced : MarketingSyncStatus.NotSynced)
+            .Build();
+        return action;
+    }
 
     private static UpdateMarketingActionRequest BuildRequest(int id = 42) => new()
     {

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionAssociateWithProductTests.cs
@@ -7,17 +7,14 @@ namespace Anela.Heblo.Tests.Domain.Marketing
 {
     public class MarketingActionAssociateWithProductTests
     {
-        private static MarketingAction CreateAction()
-        {
-            return new MarketingAction
-            {
-                Title = "Test Action",
-                StartDate = DateTime.UtcNow,
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1",
-            };
-        }
+        private static MarketingAction CreateAction() =>
+            new MarketingActionTestBuilder()
+                .WithTitle("Test Action")
+                .WithStartDate(DateTime.UtcNow)
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
 
         [Fact]
         public void AssociateWithProduct_DeduplicatesAcrossCase_WhenCalledTwiceWithMixedCasing()

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionConstructorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionConstructorTests.cs
@@ -1,0 +1,117 @@
+using System;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionConstructorTests
+    {
+        private static readonly DateTime UtcNow = new(2026, 6, 3, 12, 0, 0, DateTimeKind.Utc);
+
+        [Fact]
+        public void Ctor_TrimsTitleWhitespace()
+        {
+            var action = new MarketingAction(
+                title: "  Hello  ",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                createdByUserId: "user-1",
+                createdByUsername: "alice",
+                utcNow: UtcNow);
+
+            action.Title.Should().Be("Hello");
+        }
+
+        [Fact]
+        public void Ctor_TrimsDescriptionWhenPresent()
+        {
+            var action = new MarketingAction(
+                title: "Title",
+                description: "  body  ",
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                createdByUserId: "user-1",
+                createdByUsername: "alice",
+                utcNow: UtcNow);
+
+            action.Description.Should().Be("body");
+        }
+
+        [Fact]
+        public void Ctor_PreservesNullDescription()
+        {
+            var action = new MarketingAction(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                createdByUserId: "user-1",
+                createdByUsername: null,
+                utcNow: UtcNow);
+
+            action.Description.Should().BeNull();
+        }
+
+        [Fact]
+        public void Ctor_DefaultsCreatedByUsernameToUnknownUserWhenNull()
+        {
+            var action = new MarketingAction(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                createdByUserId: "user-1",
+                createdByUsername: null,
+                utcNow: UtcNow);
+
+            action.CreatedByUsername.Should().Be("Unknown User");
+        }
+
+        [Fact]
+        public void Ctor_SetsCreatedAtAndModifiedAtToUtcNow()
+        {
+            var moment = new DateTime(2026, 7, 4, 9, 30, 0, DateTimeKind.Utc);
+
+            var action = new MarketingAction(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                createdByUserId: "user-1",
+                createdByUsername: "alice",
+                utcNow: moment);
+
+            action.CreatedAt.Should().Be(moment);
+            action.ModifiedAt.Should().Be(moment);
+        }
+
+        [Fact]
+        public void Ctor_AssignsRemainingScalarsExactlyAsPassed()
+        {
+            var start = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+            var end = new DateTime(2026, 8, 31, 23, 59, 59, DateTimeKind.Utc);
+
+            var action = new MarketingAction(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.PR,
+                startDate: start,
+                endDate: end,
+                createdByUserId: "user-42",
+                createdByUsername: "bob",
+                utcNow: UtcNow);
+
+            action.ActionType.Should().Be(MarketingActionType.PR);
+            action.StartDate.Should().Be(start);
+            action.EndDate.Should().Be(end);
+            action.CreatedByUserId.Should().Be("user-42");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionSyncTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionSyncTests.cs
@@ -6,17 +6,14 @@ namespace Anela.Heblo.Tests.Domain.Marketing
 {
     public class MarketingActionSyncTests
     {
-        private static MarketingAction CreateAction()
-        {
-            return new MarketingAction
-            {
-                Title = "Test Action",
-                StartDate = DateTime.UtcNow,
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1",
-            };
-        }
+        private static MarketingAction CreateAction() =>
+            new MarketingActionTestBuilder()
+                .WithTitle("Test Action")
+                .WithStartDate(DateTime.UtcNow)
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
 
         [Fact]
         public void MarkOutlookSynced_SetsEventIdAndStatus_WhenCalled()

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs
@@ -1,0 +1,71 @@
+using System;
+using Anela.Heblo.Domain.Features.Marketing;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    internal sealed class MarketingActionTestBuilder
+    {
+        private int _id;
+        private string _title = "Test Action";
+        private string? _description;
+        private MarketingActionType _actionType = MarketingActionType.SocialMedia;
+        private DateTime _startDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private DateTime? _endDate;
+        private DateTime _createdAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private DateTime _modifiedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private string _createdByUserId = "user-1";
+        private string? _createdByUsername;
+        private string? _modifiedByUserId;
+        private string? _modifiedByUsername;
+        private string? _outlookEventId;
+        private MarketingSyncStatus _outlookSyncStatus = MarketingSyncStatus.NotSynced;
+
+        public MarketingActionTestBuilder WithId(int id) { _id = id; return this; }
+        public MarketingActionTestBuilder WithTitle(string title) { _title = title; return this; }
+        public MarketingActionTestBuilder WithDescription(string? description) { _description = description; return this; }
+        public MarketingActionTestBuilder WithActionType(MarketingActionType type) { _actionType = type; return this; }
+        public MarketingActionTestBuilder WithStartDate(DateTime startDate) { _startDate = startDate; return this; }
+        public MarketingActionTestBuilder WithEndDate(DateTime? endDate) { _endDate = endDate; return this; }
+        public MarketingActionTestBuilder WithCreatedAt(DateTime createdAt) { _createdAt = createdAt; return this; }
+        public MarketingActionTestBuilder WithModifiedAt(DateTime modifiedAt) { _modifiedAt = modifiedAt; return this; }
+        public MarketingActionTestBuilder WithCreatedBy(string userId, string? username = null)
+        {
+            _createdByUserId = userId; _createdByUsername = username; return this;
+        }
+        public MarketingActionTestBuilder WithModifiedBy(string? userId, string? username = null)
+        {
+            _modifiedByUserId = userId; _modifiedByUsername = username; return this;
+        }
+        public MarketingActionTestBuilder WithOutlookEventId(string? eventId)
+        {
+            _outlookEventId = eventId; return this;
+        }
+        public MarketingActionTestBuilder WithOutlookSyncStatus(MarketingSyncStatus status)
+        {
+            _outlookSyncStatus = status; return this;
+        }
+
+        public MarketingAction Build()
+        {
+            // Phase 1: object initializer (will be migrated to ctor in Task 12)
+            var action = new MarketingAction
+            {
+                Id = _id,
+                Title = _title,
+                Description = _description,
+                ActionType = _actionType,
+                StartDate = _startDate,
+                EndDate = _endDate,
+                CreatedAt = _createdAt,
+                ModifiedAt = _modifiedAt,
+                CreatedByUserId = _createdByUserId,
+                CreatedByUsername = _createdByUsername,
+                ModifiedByUserId = _modifiedByUserId,
+                ModifiedByUsername = _modifiedByUsername,
+                OutlookEventId = _outlookEventId,
+                OutlookSyncStatus = _outlookSyncStatus,
+            };
+            return action;
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionTestBuilder.cs
@@ -47,24 +47,34 @@ namespace Anela.Heblo.Tests.Domain.Marketing
 
         public MarketingAction Build()
         {
-            // Phase 1: object initializer (will be migrated to ctor in Task 12)
-            var action = new MarketingAction
+            // Construct via the public ctor (FR-1). Then layer modified-audit
+            // and Id/Outlook fields on top — the latter still expose public setters.
+            var action = new MarketingAction(
+                title: _title,
+                description: _description,
+                actionType: _actionType,
+                startDate: _startDate,
+                endDate: _endDate,
+                createdByUserId: _createdByUserId,
+                createdByUsername: _createdByUsername,
+                utcNow: _createdAt);
+
+            if (_modifiedByUserId is not null || _modifiedByUsername is not null || _modifiedAt != _createdAt)
             {
-                Id = _id,
-                Title = _title,
-                Description = _description,
-                ActionType = _actionType,
-                StartDate = _startDate,
-                EndDate = _endDate,
-                CreatedAt = _createdAt,
-                ModifiedAt = _modifiedAt,
-                CreatedByUserId = _createdByUserId,
-                CreatedByUsername = _createdByUsername,
-                ModifiedByUserId = _modifiedByUserId,
-                ModifiedByUsername = _modifiedByUsername,
-                OutlookEventId = _outlookEventId,
-                OutlookSyncStatus = _outlookSyncStatus,
-            };
+                action.UpdateDetails(
+                    title: _title,
+                    description: _description,
+                    actionType: _actionType,
+                    startDate: _startDate,
+                    endDate: _endDate,
+                    modifiedByUserId: _modifiedByUserId ?? _createdByUserId,
+                    modifiedByUsername: _modifiedByUsername,
+                    utcNow: _modifiedAt);
+            }
+
+            action.Id = _id;
+            action.OutlookEventId = _outlookEventId;
+            action.OutlookSyncStatus = _outlookSyncStatus;
             return action;
         }
     }

--- a/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionUpdateDetailsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Domain/Marketing/MarketingActionUpdateDetailsTests.cs
@@ -1,0 +1,148 @@
+using System;
+using Anela.Heblo.Domain.Features.Marketing;
+using FluentAssertions;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Domain.Marketing
+{
+    public class MarketingActionUpdateDetailsTests
+    {
+        private static readonly DateTime UtcNow = new(2026, 6, 3, 12, 0, 0, DateTimeKind.Utc);
+
+        private static MarketingAction NewAction() =>
+            new MarketingActionTestBuilder().WithTitle("seed").Build();
+
+        [Fact]
+        public void UpdateDetails_TrimsLeadingAndTrailingWhitespaceFromTitle()
+        {
+            var action = NewAction();
+
+            action.UpdateDetails(
+                title: "  Spring Launch  ",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                modifiedByUserId: "user-1",
+                modifiedByUsername: "alice",
+                utcNow: UtcNow);
+
+            action.Title.Should().Be("Spring Launch");
+        }
+
+        [Fact]
+        public void UpdateDetails_ReplacesNullTitleWithEmptyString()
+        {
+            var action = NewAction();
+
+            action.UpdateDetails(
+                title: null!,
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                modifiedByUserId: "user-1",
+                modifiedByUsername: null,
+                utcNow: UtcNow);
+
+            action.Title.Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void UpdateDetails_PreservesNullDescription()
+        {
+            var action = NewAction();
+
+            action.UpdateDetails(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                modifiedByUserId: "user-1",
+                modifiedByUsername: "alice",
+                utcNow: UtcNow);
+
+            action.Description.Should().BeNull();
+        }
+
+        [Fact]
+        public void UpdateDetails_TrimsDescriptionWhenPresent()
+        {
+            var action = NewAction();
+
+            action.UpdateDetails(
+                title: "Title",
+                description: "  body  ",
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                modifiedByUserId: "user-1",
+                modifiedByUsername: "alice",
+                utcNow: UtcNow);
+
+            action.Description.Should().Be("body");
+        }
+
+        [Fact]
+        public void UpdateDetails_DefaultsModifiedByUsernameToUnknownUserWhenNull()
+        {
+            var action = NewAction();
+
+            action.UpdateDetails(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                modifiedByUserId: "user-1",
+                modifiedByUsername: null,
+                utcNow: UtcNow);
+
+            action.ModifiedByUsername.Should().Be("Unknown User");
+        }
+
+        [Fact]
+        public void UpdateDetails_SetsModifiedAtToProvidedUtcNow()
+        {
+            var action = NewAction();
+            var moment = new DateTime(2026, 7, 4, 9, 30, 0, DateTimeKind.Utc);
+
+            action.UpdateDetails(
+                title: "Title",
+                description: null,
+                actionType: MarketingActionType.Newsletter,
+                startDate: UtcNow,
+                endDate: null,
+                modifiedByUserId: "user-1",
+                modifiedByUsername: "alice",
+                utcNow: moment);
+
+            action.ModifiedAt.Should().Be(moment);
+        }
+
+        [Fact]
+        public void UpdateDetails_AssignsAllOtherScalarFieldsExactlyAsPassed()
+        {
+            var action = NewAction();
+            var start = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+            var end = new DateTime(2026, 8, 31, 23, 59, 59, DateTimeKind.Utc);
+
+            action.UpdateDetails(
+                title: "Title",
+                description: "Desc",
+                actionType: MarketingActionType.PR,
+                startDate: start,
+                endDate: end,
+                modifiedByUserId: "user-42",
+                modifiedByUsername: "bob",
+                utcNow: UtcNow);
+
+            action.ActionType.Should().Be(MarketingActionType.PR);
+            action.StartDate.Should().Be(start);
+            action.EndDate.Should().Be(end);
+            action.ModifiedByUserId.Should().Be("user-42");
+            action.ModifiedByUsername.Should().Be("bob");
+        }
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/StockWriteBackDqtComparerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/StockWriteBackDqtComparerTests.cs
@@ -10,7 +10,7 @@ public class StockWriteBackDqtComparerTests
 {
     private readonly Mock<IStockUpOperationRepository> _operationRepoMock = new();
     private readonly Mock<IStockTakingRepository> _stockTakingRepoMock = new();
-    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.Today);
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.UtcNow);
 
     private StockWriteBackDqtComparer CreateSut(TimeSpan? stuckThreshold = null) =>
         new(_operationRepoMock.Object, _stockTakingRepoMock.Object, stuckThreshold);

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/CreateMarketingActionHandlerTests.cs
@@ -8,6 +8,7 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.CreateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Domain.Marketing;
 using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -86,16 +87,15 @@ public class CreateMarketingActionHandlerTests
             Email: "test@example.com",
             IsAuthenticated: true);
 
-        var createdAction = new MarketingAction
-        {
-            Id = 42,
-            Title = request.Title,
-            ActionType = request.ActionType,
-            StartDate = request.StartDate,
-            EndDate = request.EndDate,
-            CreatedAt = DateTime.UtcNow,
-            CreatedByUserId = currentUser.Id!,
-        };
+        var createdAction = new MarketingActionTestBuilder()
+            .WithId(42)
+            .WithTitle(request.Title)
+            .WithActionType(request.ActionType)
+            .WithStartDate(request.StartDate)
+            .WithEndDate(request.EndDate)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithCreatedBy(currentUser.Id!)
+            .Build();
 
         _currentUserServiceMock.Setup(x => x.GetCurrentUser()).Returns(currentUser);
         _repositoryMock

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/GetMarketingCalendarHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/GetMarketingCalendarHandlerTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Anela.Heblo.Application.Features.Marketing.Contracts;
 using Anela.Heblo.Application.Features.Marketing.UseCases.GetMarketingCalendar;
 using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Tests.Domain.Marketing;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -28,21 +29,17 @@ public class GetMarketingCalendarHandlerTests
         var start = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
         var end = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc);
 
-        var actions = new List<MarketingAction>
-        {
-            new()
-            {
-                Id = 1,
-                Title = "June Launch",
-                ActionType = MarketingActionType.Event,
-                StartDate = new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc),
-                EndDate = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc),
-                ProductAssociations = new List<MarketingActionProduct>
-                {
-                    new() { ProductCodePrefix = "TON001" },
-                },
-            },
-        };
+        var action = new MarketingActionTestBuilder()
+            .WithId(1)
+            .WithTitle("June Launch")
+            .WithActionType(MarketingActionType.Event)
+            .WithStartDate(new DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc))
+            .WithEndDate(new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc))
+            .Build();
+
+        action.ProductAssociations.Add(new MarketingActionProduct { ProductCodePrefix = "TON001" });
+
+        var actions = new List<MarketingAction> { action };
 
         _repositoryMock
             .Setup(x => x.GetForCalendarAsync(start, end, It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
@@ -8,6 +8,7 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.ImportFromOutlook;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Domain.Marketing;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -160,19 +161,18 @@ public class ImportFromOutlookHandlerTests
         var startUtc = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc);
         var endUtc = new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc);
 
-        var existingAction = new MarketingAction
-        {
-            Id = 1,
-            OutlookEventId = "evt-existing",
-            Title = "Test Event",
-            Description = null,
-            StartDate = startUtc,
-            EndDate = endUtc,
-            ActionType = MarketingActionType.SocialMedia,
-            CreatedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow,
-            CreatedByUserId = "user-1",
-        };
+        var existingAction = new MarketingActionTestBuilder()
+            .WithId(1)
+            .WithOutlookEventId("evt-existing")
+            .WithTitle("Test Event")
+            .WithDescription(null)
+            .WithStartDate(startUtc)
+            .WithEndDate(endUtc)
+            .WithActionType(MarketingActionType.SocialMedia)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .Build();
 
         _outlookSyncMock
             .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
@@ -203,18 +203,17 @@ public class ImportFromOutlookHandlerTests
         var startUtc = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc);
         var endUtc = new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc);
 
-        var existingAction = new MarketingAction
-        {
-            Id = 5,
-            OutlookEventId = "evt-changed",
-            Title = "Old Title",
-            StartDate = startUtc,
-            EndDate = endUtc,
-            ActionType = MarketingActionType.SocialMedia,
-            CreatedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow,
-            CreatedByUserId = "user-1",
-        };
+        var existingAction = new MarketingActionTestBuilder()
+            .WithId(5)
+            .WithOutlookEventId("evt-changed")
+            .WithTitle("Old Title")
+            .WithStartDate(startUtc)
+            .WithEndDate(endUtc)
+            .WithActionType(MarketingActionType.SocialMedia)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .Build();
 
         _outlookSyncMock
             .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
@@ -245,18 +244,17 @@ public class ImportFromOutlookHandlerTests
     public async Task Handle_WhenDryRunAndEventChanged_ReportsWouldUpdateWithoutPersisting()
     {
         // Arrange
-        var existingAction = new MarketingAction
-        {
-            Id = 5,
-            OutlookEventId = "evt-changed",
-            Title = "Old Title",
-            StartDate = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc),
-            EndDate = new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc),
-            ActionType = MarketingActionType.SocialMedia,
-            CreatedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow,
-            CreatedByUserId = "user-1",
-        };
+        var existingAction = new MarketingActionTestBuilder()
+            .WithId(5)
+            .WithOutlookEventId("evt-changed")
+            .WithTitle("Old Title")
+            .WithStartDate(new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc))
+            .WithEndDate(new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc))
+            .WithActionType(MarketingActionType.SocialMedia)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .Build();
 
         _outlookSyncMock
             .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
@@ -400,19 +398,18 @@ public class ImportFromOutlookHandlerTests
         var firstResult = await _handler.Handle(BuildRequest(), CancellationToken.None);
 
         // Second call: repo returns the imported action — fields match the Outlook event exactly
-        var importedAction = new MarketingAction
-        {
-            Id = 100,
-            OutlookEventId = "evt-idem",
-            Title = "Test Event",
-            Description = null,
-            StartDate = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc),
-            EndDate = new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc),
-            ActionType = MarketingActionType.SocialMedia,
-            CreatedAt = DateTime.UtcNow,
-            ModifiedAt = DateTime.UtcNow,
-            CreatedByUserId = "user-1",
-        };
+        var importedAction = new MarketingActionTestBuilder()
+            .WithId(100)
+            .WithOutlookEventId("evt-idem")
+            .WithTitle("Test Event")
+            .WithDescription(null)
+            .WithStartDate(new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc))
+            .WithEndDate(new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc))
+            .WithActionType(MarketingActionType.SocialMedia)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .Build();
 
         _repositoryMock
             .Setup(x => x.GetByOutlookEventIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
@@ -627,4 +627,50 @@ public class ImportFromOutlookHandlerTests
         await act.Should().NotThrowAsync();
         capturedAction!.ActionType.Should().Be(MarketingActionType.SocialMedia);
     }
+
+    [Fact]
+    public async Task Handle_WhenExistingActionMatchesWhitespaceTitledEvent_SkipsIt()
+    {
+        // Regression for SA-1: after FR-1 trims persisted titles, HasChanges must
+        // compare normalized values, or it will report every whitespace-bearing
+        // re-import as Updated and trigger a no-op write loop.
+
+        // Arrange — existing record has the trimmed title; Outlook event has
+        // leading/trailing whitespace in the subject.
+        var startUtc = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc);
+        var endUtc = new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc);
+
+        var existingAction = new MarketingActionTestBuilder()
+            .WithId(7)
+            .WithOutlookEventId("evt-ws")
+            .WithTitle("Trimmed Title")
+            .WithDescription(null)
+            .WithStartDate(startUtc)
+            .WithEndDate(endUtc)
+            .WithActionType(MarketingActionType.SocialMedia)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .Build();
+
+        _outlookSyncMock
+            .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OutlookEventDto>
+            {
+                BuildEvent(id: "evt-ws", subject: "  Trimmed Title  "),
+            });
+
+        _repositoryMock
+            .Setup(x => x.GetByOutlookEventIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingAction> { existingAction });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Skipped.Should().Be(1);
+        result.Updated.Should().Be(0);
+        _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
@@ -673,4 +673,28 @@ public class ImportFromOutlookHandlerTests
         result.Updated.Should().Be(0);
         _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task Handle_WhenNewOutlookEventHasWhitespaceTitle_PersistsTrimmedTitle()
+    {
+        // Arrange
+        var evt = BuildEvent(id: "evt-trim-new", subject: "  Summer Launch  ");
+
+        _outlookSyncMock
+            .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OutlookEventDto> { evt });
+
+        MarketingAction? captured = null;
+        _repositoryMock
+            .Setup(x => x.AddAsync(It.IsAny<MarketingAction>(), It.IsAny<CancellationToken>()))
+            .Callback<MarketingAction, CancellationToken>((a, _) => captured = a)
+            .ReturnsAsync((MarketingAction a, CancellationToken _) => { a.Id = 1; return a; });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Created.Should().Be(1);
+        captured!.Title.Should().Be("Summer Launch");
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/ImportFromOutlookHandlerTests.cs
@@ -697,4 +697,45 @@ public class ImportFromOutlookHandlerTests
         result.Created.Should().Be(1);
         captured!.Title.Should().Be("Summer Launch");
     }
+
+    [Fact]
+    public async Task Handle_WhenOutlookEventChangedToWhitespaceTitle_PersistsTrimmedTitle()
+    {
+        // Arrange — existing record has an old title; Outlook event has a NEW
+        // title that is different but padded with whitespace. HasChanges must
+        // detect the change (different normalized text) and the persisted Title
+        // must be trimmed.
+        var startUtc = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc);
+        var endUtc = new DateTime(2026, 6, 10, 10, 0, 0, DateTimeKind.Utc);
+
+        var existingAction = new MarketingActionTestBuilder()
+            .WithId(11)
+            .WithOutlookEventId("evt-trim-upd")
+            .WithTitle("Old Title")
+            .WithStartDate(startUtc)
+            .WithEndDate(endUtc)
+            .WithActionType(MarketingActionType.SocialMedia)
+            .WithCreatedAt(DateTime.UtcNow)
+            .WithModifiedAt(DateTime.UtcNow)
+            .WithCreatedBy("user-1")
+            .Build();
+
+        _outlookSyncMock
+            .Setup(s => s.ListEventsAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OutlookEventDto>
+            {
+                BuildEvent(id: "evt-trim-upd", subject: "  New Title  "),
+            });
+
+        _repositoryMock
+            .Setup(x => x.GetByOutlookEventIdsAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<MarketingAction> { existingAction });
+
+        // Act
+        var result = await _handler.Handle(BuildRequest(), CancellationToken.None);
+
+        // Assert
+        result.Updated.Should().Be(1);
+        existingAction.Title.Should().Be("New Title");
+    }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Marketing/MarketingActionHandlerSyncTests.cs
@@ -11,6 +11,7 @@ using Anela.Heblo.Application.Features.Marketing.UseCases.UpdateMarketingAction;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Domain.Features.Users;
+using Anela.Heblo.Tests.Domain.Marketing;
 using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -87,21 +88,18 @@ namespace Anela.Heblo.Tests.Features.Marketing
                 monitor);
         }
 
-        private static MarketingAction BuildAction(string? outlookEventId = null)
-        {
-            return new MarketingAction
-            {
-                Id = 42,
-                Title = "Test Action",
-                ActionType = MarketingActionType.PR,
-                StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
-                EndDate = new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc),
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1",
-                OutlookEventId = outlookEventId,
-            };
-        }
+        private static MarketingAction BuildAction(string? outlookEventId = null) =>
+            new MarketingActionTestBuilder()
+                .WithId(42)
+                .WithTitle("Test Action")
+                .WithActionType(MarketingActionType.PR)
+                .WithStartDate(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc))
+                .WithEndDate(new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc))
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .WithOutlookEventId(outlookEventId)
+                .Build();
 
         private static CreateMarketingActionRequest BuildCreateRequest()
         {

--- a/backend/test/Anela.Heblo.Tests/Marketing/OutlookCalendarSyncServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Marketing/OutlookCalendarSyncServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
 using Anela.Heblo.Domain.Features.Marketing;
+using Anela.Heblo.Tests.Domain.Marketing;
 using Anela.Heblo.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -67,19 +68,18 @@ namespace Anela.Heblo.Tests.Marketing
         {
             var resolvedEndDate = endDate == DateTime.MinValue ? (DateTime?)null : (endDate ?? DefaultEndDate);
 
-            return new MarketingAction
-            {
-                Id = 42,
-                Title = "Spring Launch",
-                Description = "Big spring launch event",
-                ActionType = MarketingActionType.Newsletter,
-                StartDate = startDate ?? DefaultStartDate,
-                EndDate = resolvedEndDate,
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1",
-                OutlookEventId = outlookEventId
-            };
+            return new MarketingActionTestBuilder()
+                .WithId(42)
+                .WithTitle("Spring Launch")
+                .WithDescription("Big spring launch event")
+                .WithActionType(MarketingActionType.Newsletter)
+                .WithStartDate(startDate ?? DefaultStartDate)
+                .WithEndDate(resolvedEndDate)
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .WithOutlookEventId(outlookEventId)
+                .Build();
         }
 
         // ─── CreateEventAsync ─────────────────────────────────────────────────────
@@ -306,18 +306,17 @@ namespace Anela.Heblo.Tests.Marketing
             var responseJson = JsonSerializer.Serialize(new { id = "evt-x" });
             var handler = new FakeHttpMessageHandler(HttpStatusCode.Created, responseJson);
             var service = CreateService(handler);
-            var action = new MarketingAction
-            {
-                Id = 1,
-                Title = "Test",
-                Description = string.Empty,
-                ActionType = MarketingActionType.PR,
-                StartDate = DefaultStartDate,
-                EndDate = DefaultEndDate,
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1"
-            };
+            var action = new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test")
+                .WithDescription(string.Empty)
+                .WithActionType(MarketingActionType.PR)
+                .WithStartDate(DefaultStartDate)
+                .WithEndDate(DefaultEndDate)
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
 
             // Act
             await service.CreateEventAsync(action, CancellationToken.None);
@@ -337,18 +336,17 @@ namespace Anela.Heblo.Tests.Marketing
             var responseJson = JsonSerializer.Serialize(new { id = "evt-x" });
             var handler = new FakeHttpMessageHandler(HttpStatusCode.Created, responseJson);
             var service = CreateService(handler);
-            var action = new MarketingAction
-            {
-                Id = 1,
-                Title = "Test",
-                Description = string.Empty,
-                ActionType = MarketingActionType.PR,
-                StartDate = DefaultStartDate,
-                EndDate = DefaultEndDate,
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1"
-            };
+            var action = new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test")
+                .WithDescription(string.Empty)
+                .WithActionType(MarketingActionType.PR)
+                .WithStartDate(DefaultStartDate)
+                .WithEndDate(DefaultEndDate)
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
 
             // Act
             await service.CreateEventAsync(action, CancellationToken.None);
@@ -368,18 +366,17 @@ namespace Anela.Heblo.Tests.Marketing
             var responseJson = JsonSerializer.Serialize(new { id = "evt-x" });
             var handler = new FakeHttpMessageHandler(HttpStatusCode.Created, responseJson);
             var service = CreateService(handler);
-            var action = new MarketingAction
-            {
-                Id = 1,
-                Title = "Test",
-                Description = string.Empty,
-                ActionType = MarketingActionType.PR,
-                StartDate = DefaultStartDate,
-                EndDate = DefaultEndDate,
-                CreatedAt = DateTime.UtcNow,
-                ModifiedAt = DateTime.UtcNow,
-                CreatedByUserId = "user-1"
-            };
+            var action = new MarketingActionTestBuilder()
+                .WithId(1)
+                .WithTitle("Test")
+                .WithDescription(string.Empty)
+                .WithActionType(MarketingActionType.PR)
+                .WithStartDate(DefaultStartDate)
+                .WithEndDate(DefaultEndDate)
+                .WithCreatedAt(DateTime.UtcNow)
+                .WithModifiedAt(DateTime.UtcNow)
+                .WithCreatedBy("user-1")
+                .Build();
 
             // Act
             await service.CreateEventAsync(action, CancellationToken.None);


### PR DESCRIPTION

This change eliminates whitespace inconsistency in `MarketingAction.Title` by centralizing normalization in a domain method, replacing scattered direct property mutations across three call sites. Titles imported from Outlook now match titles set via the API, fixing exact-match search and deduplication bugs caused by surrounding whitespace.

The implementation adds `MarketingAction(...)` constructor and `UpdateDetails(...)` method (both delegating to `NormalizeTitle`/`NormalizeDescription`), tightens 11 scalar property setters to `private set` to enforce the encapsulation boundary, and fixes `HasChanges` in the Outlook import mapper so re-importing whitespace-titled events is correctly identified as unchanged rather than triggering a no-op write loop.

### Changes
- `MarketingAction.cs` — parameterized ctor + `UpdateDetails` + private normalizers + `private set` on 11 properties
- `CreateMarketingActionHandler.cs` — constructor call replaces object initializer
- `UpdateMarketingActionHandler.cs` — `UpdateDetails` call replaces 8 direct property assignments
- `OutlookEventImportMapper.cs` — `BuildAction` uses ctor, `ApplyChanges` uses `UpdateDetails`, `HasChanges` normalizes before comparison, SA-2 null-guards added
- `MarketingActionTestBuilder.cs` (new) — fluent builder centralizing test fixture construction
- `MarketingActionUpdateDetailsTests.cs` + `MarketingActionConstructorTests.cs` (new) — unit tests for normalization
- 11 test files — migrated from object-initializer construction to `MarketingActionTestBuilder`
- `ImportFromOutlookHandlerTests.cs` — 3 new tests: sync-loop regression guard + FR-7 trim on create + FR-7 trim on update

---

Closes #2116

### Tokens used
39933287
