### PR TITLE
fix: allow CatalogDetail modal body to scroll on small screens

### DIFF
--- a/frontend/src/components/pages/CatalogDetail.tsx
+++ b/frontend/src/components/pages/CatalogDetail.tsx
@@ -180,7 +180,7 @@ const CatalogDetail: React.FC<CatalogDetailProps> = ({
         </div>
 
         {/* Content */}
-        <div className="p-6 flex-1 overflow-hidden">
+        <div className="p-6 flex-1 overflow-y-auto">
           {detailLoading ? (
             <div className="flex items-center justify-center h-64">
               <div className="flex items-center space-x-2">


### PR DESCRIPTION
The CatalogDetail modal body used \`overflow-hidden\`, so on short or zoomed viewports any tab content exceeding \`max-h-[95vh]\` was clipped with no scrollbar — e.g. the Složení (composition) tab showed only a few ingredient rows with no way to reach the rest. Switching the body wrapper to \`overflow-y-auto\` gives overflowing content a scroll escape hatch while the fixed header and footer stay in place. Wide/tall layouts are unchanged since content still fits within 95vh and the existing internal tab scrolling continues to work.