### PR TITLE
feat: auto-assign unphased ingredients to newly created composition phase

### DIFF
--- a/frontend/src/components/catalog/detail/tabs/CompositionTab.tsx
+++ b/frontend/src/components/catalog/detail/tabs/CompositionTab.tsx
@@ -181,7 +181,15 @@ const CompositionTab: React.FC<CompositionTabProps> = ({ productCode }) => {
   const addPhase = () => {
     const next = LETTERS.split('').find((l) => !draftPhases.includes(l));
     if (!next) return; // All 26 letters used.
-    setDraftPhases((prev) => [...prev, next].sort());
+    const newPhases = [...draftPhases, next].sort();
+    setDraftOrder((current) => {
+      const list = current ?? ingredients;
+      const updated = list.map((ing) =>
+        ing.phaseLabel == null ? { ...ing, phaseLabel: next } : ing,
+      );
+      return groupByPhase(updated, newPhases);
+    });
+    setDraftPhases(newPhases);
   };
 
   const removePhase = (phase: string) => {

--- a/frontend/src/components/catalog/detail/tabs/__tests__/CompositionTab.test.tsx
+++ b/frontend/src/components/catalog/detail/tabs/__tests__/CompositionTab.test.tsx
@@ -165,6 +165,63 @@ describe('CompositionTab', () => {
     expect(screen.queryByTitle(/Odebrat fázi/i)).not.toBeInTheDocument();
   });
 
+  it('creating a phase sweeps all unphased ingredients into it', async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({ success: true });
+    mockUseUpdateOrder.mockReturnValue({ mutateAsync, isPending: false } as any);
+    mockUseProductComposition.mockReturnValue({
+      data: { ingredients: sampleIngredients },
+      isLoading: false,
+      error: null,
+    } as any);
+    render(<CompositionTab productCode="TEST001" />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: /Upravit pořadí/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Přidat fázi/i }));
+
+    // New phase header appears and unphased rows are grouped under it.
+    expect(screen.getByText('Fáze A')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Uložit/i }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).toHaveBeenCalledWith({
+      productCode: 'TEST001',
+      order: [
+        { ingredientProductCode: 'ING001', sortOrder: 1, phaseLabel: 'A' },
+        { ingredientProductCode: 'ING002', sortOrder: 2, phaseLabel: 'A' },
+      ],
+    });
+  });
+
+  it('creating a phase leaves already-phased ingredients untouched', async () => {
+    const mutateAsync = jest.fn().mockResolvedValue({ success: true });
+    mockUseUpdateOrder.mockReturnValue({ mutateAsync, isPending: false } as any);
+    mockUseProductComposition.mockReturnValue({
+      data: {
+        ingredients: [
+          { productCode: 'ING001', productName: 'Bisabolol', amount: 50.5, unit: 'g', order: 1, phaseLabel: 'A' },
+          { productCode: 'ING002', productName: 'Vitamin E', amount: 100.25, unit: 'g', order: 2, phaseLabel: null },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as any);
+    render(<CompositionTab productCode="TEST001" />, { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: /Upravit pořadí/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Přidat fázi/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Uložit/i }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).toHaveBeenCalledWith({
+      productCode: 'TEST001',
+      order: [
+        { ingredientProductCode: 'ING001', sortOrder: 1, phaseLabel: 'A' },
+        { ingredientProductCode: 'ING002', sortOrder: 2, phaseLabel: 'B' },
+      ],
+    });
+  });
+
   it('Uložit forwards phaseLabel when ingredient has a phase', async () => {
     const mutateAsync = jest.fn().mockResolvedValue({ success: true });
     mockUseUpdateOrder.mockReturnValue({ mutateAsync, isPending: false } as any);


### PR DESCRIPTION
## Summary

In the catalog detail **Složení** (composition) tab, creating a new phase now automatically moves all ingredients without a phase assignment into that phase, removing the need to drag each unphased ingredient in manually. Already-phased ingredients are left untouched, and the change is only persisted when the user clicks **Uložit** (existing save flow). This is a frontend-only change reusing the existing `groupByPhase()` helper and immutable draft-state pattern.

## Test plan

- Added two unit tests in `CompositionTab.test.tsx`: one verifying all unphased ingredients are swept into the new phase, one verifying already-phased ingredients are untouched.
- `npm test -- CompositionTab` (12/12 pass), `npm run build` and `npm run lint` are clean for the touched files.