### PR TITLE
fix: handle one-step (SinglePhase) manufacture as product, not semiproduct

### DIFF
--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs
@@ -17,6 +17,12 @@ public class ResidueDistributionCalculator : IResidueDistributionCalculator
 
     public async Task<ResidueDistribution> CalculateAsync(UpdateManufactureOrderDto order, CancellationToken cancellationToken = default)
     {
+        // Residue distribution only applies to MultiPhase orders, where leftover semiproduct is spread
+        // across the finished products. SinglePhase orders have no real semiproduct (the SemiProduct
+        // entry is a placeholder for the first product), so there is nothing to distribute.
+        if (order.ManufactureType != ManufactureType.MultiPhase)
+            return new ResidueDistribution { IsWithinAllowedThreshold = true };
+
         if (order.SemiProduct is null)
             return new ResidueDistribution { IsWithinAllowedThreshold = true };
 

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflow.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflow.cs
@@ -149,16 +149,21 @@ public class ConfirmProductCompletionWorkflow : IConfirmProductCompletionWorkflo
         var semiProduct = order.SemiProduct;
         var manufactureName = _nameBuilder.Build(order, ErpManufactureType.Product);
 
-        // Calculate direct semiproduct output total (rows where ProductCode == SemiProduct.ProductCode)
-        var directOutputTotal = order.Products
-            .Where(p => p.ProductCode == semiProduct.ProductCode)
-            .Sum(p => p.ActualQuantity ?? p.PlannedQuantity);
+        // "Direct semiproduct output" rows (ProductCode == SemiProduct.ProductCode) represent bulk
+        // semiproduct sold as-is and are excluded from the finished-product list. This concept only
+        // applies to MultiPhase orders. For SinglePhase the semiproduct is a placeholder pointing at
+        // the first product, so the sentinel would wrongly match the real product — keep all products
+        // and emit no direct output (the product is consumed from materials and received as a product).
+        var isMultiPhase = order.ManufactureType == ManufactureType.MultiPhase;
 
-        // Exclude direct semiproduct output rows from the ERP submission.
-        // These rows (ProductCode == SemiProduct.ProductCode) represent bulk semiproduct
-        // sold as-is and should not be reported as finished product output to the ERP.
+        var directOutputTotal = isMultiPhase
+            ? order.Products
+                .Where(p => p.ProductCode == semiProduct.ProductCode)
+                .Sum(p => p.ActualQuantity ?? p.PlannedQuantity)
+            : 0m;
+
         var items = order.Products
-            .Where(p => p.ProductCode != semiProduct.ProductCode)
+            .Where(p => !isMultiPhase || p.ProductCode != semiProduct.ProductCode)
             .Select(p => new SubmitManufactureRequestItem
             {
                 ProductCode = p.ProductCode,

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderDto.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Domain.Features.Manufacture;
+
 namespace Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrder;
 
 public class UpdateManufactureOrderDto
@@ -8,6 +10,7 @@ public class UpdateManufactureOrderDto
     public string CreatedByUser { get; set; } = null!;
     public string? ResponsiblePerson { get; set; }
     public DateOnly PlannedDate { get; set; }
+    public ManufactureType ManufactureType { get; set; } = ManufactureType.MultiPhase;
     public string State { get; set; } = null!;
     public DateTime StateChangedAt { get; set; }
     public string StateChangedByUser { get; set; } = null!;

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrder/UpdateManufactureOrderHandler.cs
@@ -171,6 +171,7 @@ public class UpdateManufactureOrderHandler : IRequestHandler<UpdateManufactureOr
             CreatedByUser = order.CreatedByUser,
             ResponsiblePerson = order.ResponsiblePerson,
             PlannedDate = order.PlannedDate,
+            ManufactureType = order.ManufactureType,
             State = order.State.ToString(),
             StateChangedAt = order.StateChangedAt,
             StateChangedByUser = order.StateChangedByUser,

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ResidueDistributionCalculatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ResidueDistributionCalculatorTests.cs
@@ -253,6 +253,55 @@ public class ResidueDistributionCalculatorTests
     }
 
     [Fact]
+    public async Task CalculateAsync_SinglePhaseManufactureType_ReturnsImmediatelyWithoutLookups()
+    {
+        // Single-phase order with distinct product codes (does NOT match the placeholder semiproduct).
+        // The ManufactureType guard must short-circuit before any template/catalog lookups.
+        var order = new UpdateManufactureOrderDto
+        {
+            ManufactureType = ManufactureType.SinglePhase,
+            SemiProduct = new UpdateManufactureOrderSemiProductDto
+            {
+                ProductCode = ProductCodeA, // single-phase placeholder points at the first product
+                ProductName = "Product A",
+                PlannedQuantity = 100m,
+                ActualQuantity = 100m
+            },
+            Products = new List<UpdateManufactureOrderProductDto>
+            {
+                new UpdateManufactureOrderProductDto
+                {
+                    ProductCode = ProductCodeA,
+                    ProductName = "Product A",
+                    PlannedQuantity = 60m,
+                    ActualQuantity = 60m,
+                    SemiProductCode = ProductCodeA
+                },
+                new UpdateManufactureOrderProductDto
+                {
+                    ProductCode = ProductCodeB,
+                    ProductName = "Product B",
+                    PlannedQuantity = 40m,
+                    ActualQuantity = 40m,
+                    SemiProductCode = ProductCodeB
+                }
+            }
+        };
+
+        var result = await _calculator.CalculateAsync(order);
+
+        result.IsWithinAllowedThreshold.Should().BeTrue();
+        result.Products.Should().BeEmpty();
+
+        _manufactureClientMock.Verify(
+            x => x.GetManufactureTemplateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _catalogRepositoryMock.Verify(
+            x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task CalculateAsync_AdjustedGramsPerUnit_IsAdjustedConsumptionDividedByPieces()
     {
         var order = BuildOrder(

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflowTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/Workflows/ConfirmProductCompletionWorkflowTests.cs
@@ -646,6 +646,85 @@ public class ConfirmProductCompletionWorkflowTests
         capturedSubmitRequest.DirectSemiProductOutputCode.Should().BeNull();
     }
 
+    [Fact]
+    public async Task ExecuteAsync_SinglePhaseOrder_IncludesProductMatchingSemiproductAndEmitsNoDirectOutput()
+    {
+        // Arrange — SinglePhase order. The SemiProduct is a placeholder pointing at the first product
+        // (P001), and P001 is a real finished product. It must NOT be treated as direct semiproduct
+        // output: all products go to ERP as finished products, and no direct output is emitted.
+        var productQuantities = new Dictionary<int, decimal> { { 1, 5.0m }, { 2, 3.0m } };
+        var updateStatusResponse = CreateSuccessfulUpdateStatusResponse();
+
+        var updateOrderResponse = new UpdateManufactureOrderResponse
+        {
+            Success = true,
+            Order = new UpdateManufactureOrderDto
+            {
+                OrderNumber = "MO-2024-SINGLE",
+                ManufactureType = ManufactureType.SinglePhase,
+                SemiProduct = new UpdateManufactureOrderSemiProductDto
+                {
+                    ProductCode = "P001", // placeholder == first product
+                    ProductName = "Product 1",
+                    ActualQuantity = 5.0m,
+                    PlannedQuantity = 5.0m,
+                    LotNumber = "LOT-SINGLE",
+                    ExpirationDate = DateOnly.FromDateTime(DateTime.Today.AddDays(30)),
+                },
+                Products = new List<UpdateManufactureOrderProductDto>
+                {
+                    new UpdateManufactureOrderProductDto
+                    {
+                        ProductCode = "P001",
+                        ProductName = "Product 1",
+                        ActualQuantity = 5.0m,
+                        PlannedQuantity = 5.0m,
+                    },
+                    new UpdateManufactureOrderProductDto
+                    {
+                        ProductCode = "P002",
+                        ProductName = "Product 2",
+                        ActualQuantity = 3.0m,
+                        PlannedQuantity = 3.0m,
+                    },
+                },
+            },
+        };
+
+        SubmitManufactureRequest? capturedSubmitRequest = null;
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateManufactureOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updateOrderResponse);
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<SubmitManufactureRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<SubmitManufactureResponse>, CancellationToken>(
+                (r, _) => capturedSubmitRequest = (SubmitManufactureRequest)r)
+            .ReturnsAsync(CreateSuccessfulSubmitManufactureResponse("ERP-SINGLE-001"));
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateManufactureOrderStatusRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updateStatusResponse);
+
+        _residueCalculatorMock
+            .Setup(x => x.CalculateAsync(It.IsAny<UpdateManufactureOrderDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResidueDistribution { IsWithinAllowedThreshold = true });
+
+        // Act
+        var result = await _workflow.ExecuteAsync(ValidOrderId, productQuantities, false, ValidChangeReason, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        capturedSubmitRequest.Should().NotBeNull();
+        capturedSubmitRequest!.ManufactureType.Should().Be(ErpManufactureType.Product);
+        capturedSubmitRequest.Items.Select(i => i.ProductCode)
+            .Should().BeEquivalentTo(new[] { "P001", "P002" });
+        capturedSubmitRequest.DirectSemiProductOutputAmount.Should().Be(0m);
+        capturedSubmitRequest.DirectSemiProductOutputCode.Should().BeNull();
+        capturedSubmitRequest.DirectSemiProductOutputName.Should().BeNull();
+    }
+
     #region Helper Methods
 
     private void SetupMediatorResponses(

--- a/frontend/src/components/manufacture/detail/ConfirmationDialogs.tsx
+++ b/frontend/src/components/manufacture/detail/ConfirmationDialogs.tsx
@@ -5,7 +5,7 @@ import {
   X,
   StickyNote,
 } from "lucide-react";
-import { ManufactureOrderState, ResidueDistributionDto } from "../../../api/generated/api-client";
+import { ManufactureOrderState, ManufactureType, ResidueDistributionDto } from "../../../api/generated/api-client";
 import ConfirmSemiProductQuantityModal from "../../modals/ConfirmSemiProductQuantityModal";
 import ConfirmProductCompletionModal from "../../modals/ConfirmProductCompletionModal";
 import ResolveManualActionModal from "../../modals/ResolveManualActionModal";
@@ -194,7 +194,7 @@ export const ConfirmationDialogs: React.FC<ConfirmationDialogsProps> = ({
             productName: product.productName || "",
             plannedQuantity: product.plannedQuantity || 0
           }))}
-          semiProductCode={order.semiProduct?.productCode}
+          semiProductCode={order.manufactureType !== ManufactureType.SinglePhase ? order.semiProduct?.productCode : undefined}
           isLoading={isProductCompletionLoading}
           distributionPreview={distributionPreview}
           onConfirmDistribution={onConfirmDistribution}

--- a/frontend/src/components/manufacture/detail/ProductsDataGrid.tsx
+++ b/frontend/src/components/manufacture/detail/ProductsDataGrid.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { ManufactureType } from "../../../api/generated/api-client";
 
 interface ProductsDataGridProps {
   order: any;
@@ -33,7 +34,11 @@ export const ProductsDataGrid: React.FC<ProductsDataGridProps> = ({
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {order.products.map((product: any, index: number) => {
-                const isDirectRow = product.productCode && order.semiProduct?.productCode &&
+                // Direct semiproduct output ("Přímý výstup") only exists for MultiPhase orders.
+                // For SinglePhase the semiproduct is a placeholder pointing at the first product,
+                // so this sentinel would wrongly tag the real product as a bulk/grams row.
+                const isDirectRow = order.manufactureType !== ManufactureType.SinglePhase &&
+                  product.productCode && order.semiProduct?.productCode &&
                   product.productCode === order.semiProduct.productCode;
                 return (
                   <tr key={index} className={isDirectRow ? "bg-amber-50 hover:bg-amber-100" : "hover:bg-gray-50"}>

--- a/frontend/src/components/manufacture/detail/__tests__/ProductsDataGrid.test.tsx
+++ b/frontend/src/components/manufacture/detail/__tests__/ProductsDataGrid.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ProductsDataGrid } from '../ProductsDataGrid';
+import { ManufactureType } from '../../../../api/generated/api-client';
+
+const baseProps = {
+  canEditFields: false,
+  editableProductQuantities: {},
+  onProductQuantityChange: jest.fn(),
+};
+
+describe('ProductsDataGrid', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('SinglePhase: product matching the placeholder semiproduct renders as a normal product (no "Přímý výstup" badge, no g suffix)', () => {
+    // For SinglePhase the semiproduct is a placeholder pointing at the first product,
+    // so the product must NOT be treated as a direct bulk/grams output row.
+    const order = {
+      manufactureType: ManufactureType.SinglePhase,
+      semiProduct: { productCode: 'P001' },
+      products: [
+        { productCode: 'P001', productName: 'Product 1', actualQuantity: 5 },
+      ],
+    };
+
+    render(<ProductsDataGrid {...baseProps} order={order} />);
+
+    expect(screen.queryByText('Přímý výstup')).not.toBeInTheDocument();
+    // Quantity shown in pieces (no "g" suffix that direct-output rows use)
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  test('MultiPhase: product matching the semiproduct still renders the "Přímý výstup" badge', () => {
+    const order = {
+      manufactureType: ManufactureType.MultiPhase,
+      semiProduct: { productCode: 'SP001' },
+      products: [
+        { productCode: 'SP001', productName: 'Semi Product', actualQuantity: 200 },
+      ],
+    };
+
+    render(<ProductsDataGrid {...baseProps} order={order} />);
+
+    expect(screen.getByText('Přímý výstup')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/manufacture/pages/ManufactureOrderWeeklyCalendar.tsx
+++ b/frontend/src/components/manufacture/pages/ManufactureOrderWeeklyCalendar.tsx
@@ -60,6 +60,21 @@ const getErpDocumentStatus = (
   return documentNumber ? 'success' : 'failed';
 };
 
+// Quantity shown for a product row on a calendar card. The produced (actual)
+// quantity is only meaningful once the order is completed; before that the
+// planned quantity is shown. Using actualQuantity earlier surfaces a stale or
+// zero value (e.g. after editing the planned quantity without touching actual,
+// since the update only syncs actualQuantity when it is explicitly provided).
+export const getProductDisplayQuantity = (
+  product: { plannedQuantity?: number; actualQuantity?: number | null },
+  orderState: ManufactureOrderState | undefined
+): number | undefined => {
+  if (orderState === ManufactureOrderState.Completed) {
+    return product.actualQuantity ?? product.plannedQuantity;
+  }
+  return product.plannedQuantity;
+};
+
 export const getWeightToleranceStatus = (
   weightWithinTolerance: boolean | undefined | null,
   orderState: ManufactureOrderState | undefined
@@ -624,7 +639,13 @@ const ManufactureOrderWeeklyCalendar: React.FC<ManufactureOrderWeeklyCalendarPro
                                 </div>
                                 <div className="space-y-1 flex-1">
                                   {event.products.map((product, idx) => {
-                                    const isDirect = product.productCode === event.semiProduct?.productCode;
+                                    // Direct semiproduct output only exists for MultiPhase orders.
+                                    // For SinglePhase the semiproduct is a placeholder pointing at the
+                                    // first product, so this sentinel would wrongly tag the real product
+                                    // as a bulk/grams row.
+                                    const isDirect = event.manufactureType !== ManufactureType.SinglePhase &&
+                                      product.productCode === event.semiProduct?.productCode;
+                                    const displayQuantity = getProductDisplayQuantity(product, event.state);
                                     return (
                                     <div key={idx} className={`text-xs p-2 rounded ${isDirect ? 'bg-amber-100 bg-opacity-70 border border-amber-300' : 'bg-white bg-opacity-30'}`}>
                                       <div className={`font-medium truncate ${isDirect ? 'text-amber-800' : ''}`} title={product.productName}>
@@ -632,7 +653,7 @@ const ManufactureOrderWeeklyCalendar: React.FC<ManufactureOrderWeeklyCalendarPro
                                       </div>
                                       <div className={`flex items-center justify-between ${isDirect ? 'text-amber-700' : 'text-gray-600'}`}>
                                         <span className="truncate">{product.productCode}</span>
-                                        <span>{(product.actualQuantity ?? product.plannedQuantity)?.toFixed(2)} {isDirect ? 'g' : 'ks'}</span>
+                                        <span>{displayQuantity?.toFixed(2)} {isDirect ? 'g' : 'ks'}</span>
                                       </div>
                                     </div>
                                     );

--- a/frontend/src/components/manufacture/pages/__tests__/ManufactureOrderWeeklyCalendar.quickPlanning.test.tsx
+++ b/frontend/src/components/manufacture/pages/__tests__/ManufactureOrderWeeklyCalendar.quickPlanning.test.tsx
@@ -1,6 +1,6 @@
 // Mock the ManufactureOrderState enum first
 import React from "react";
-import { getWeightToleranceStatus } from "../ManufactureOrderWeeklyCalendar";
+import { getWeightToleranceStatus, getProductDisplayQuantity } from "../ManufactureOrderWeeklyCalendar";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -92,6 +92,23 @@ describe("getWeightToleranceStatus", () => {
 
   it('returns "warning" (not "failed") for completed orders outside tolerance', () => {
     expect(getWeightToleranceStatus(false, "Completed" as any)).toBe('warning');
+  });
+});
+
+describe("getProductDisplayQuantity", () => {
+  it("shows planned quantity for non-completed orders, ignoring a stale/zero actual quantity", () => {
+    const product = { plannedQuantity: 10, actualQuantity: 0 };
+    expect(getProductDisplayQuantity(product, "Planned" as any)).toBe(10);
+    expect(getProductDisplayQuantity(product, "Draft" as any)).toBe(10);
+    expect(getProductDisplayQuantity(product, "SemiProductManufactured" as any)).toBe(10);
+  });
+
+  it("shows actual quantity for completed orders", () => {
+    expect(getProductDisplayQuantity({ plannedQuantity: 10, actualQuantity: 8 }, "Completed" as any)).toBe(8);
+  });
+
+  it("falls back to planned quantity for completed orders with no actual quantity", () => {
+    expect(getProductDisplayQuantity({ plannedQuantity: 10, actualQuantity: null }, "Completed" as any)).toBe(10);
   });
 });
 

--- a/frontend/src/components/modals/__tests__/ConfirmProductCompletionModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ConfirmProductCompletionModal.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ConfirmProductCompletionModal from '../ConfirmProductCompletionModal';
+
+const baseProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  onSubmit: jest.fn(),
+  orderId: 1,
+  isLoading: false,
+  onConfirmDistribution: jest.fn(),
+  onBackFromDistribution: jest.fn(),
+};
+
+const product = {
+  id: 1,
+  productCode: 'P001',
+  productName: 'Product 1',
+  plannedQuantity: 10,
+};
+
+describe('ConfirmProductCompletionModal', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('SinglePhase: with no semiProductCode the product is not tagged as direct output (no "Přímý výstup", no "g" suffix)', () => {
+    // The parent withholds semiProductCode for SinglePhase orders, so the product
+    // matching the placeholder semiproduct must render as a normal product.
+    render(
+      <ConfirmProductCompletionModal {...baseProps} products={[product]} semiProductCode={undefined} />
+    );
+
+    expect(screen.queryByText('Přímý výstup')).not.toBeInTheDocument();
+    // Planned quantity shown without the "g" suffix that direct-output rows use.
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.queryByText('10g')).not.toBeInTheDocument();
+  });
+
+  test('MultiPhase: product matching semiProductCode renders the "Přímý výstup" badge', () => {
+    render(
+      <ConfirmProductCompletionModal {...baseProps} products={[product]} semiProductCode="P001" />
+    );
+
+    expect(screen.getByText('Přímý výstup')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

One-step (SinglePhase) manufacture orders fake a semiproduct pointing at the first product. The sentinel `ProductCode == SemiProduct.ProductCode` (meaning "direct semiproduct bulk output") then wrongly matched the real product, so at completion the product was issued **from the Semiproducts warehouse (`V-VYDEJ-POLOTOVAR`)** instead of consuming BOM materials, and rendered as an amber "Přímý výstup" grams row in the order detail UI.

## Fix

Gate the direct-output sentinel on `ManufactureType`: `ManufactureType` is now exposed on `UpdateManufactureOrderDto`, so `ConfirmProductCompletionWorkflow` submits **all** products with no direct output for SinglePhase (materials consumed from warehouse 5, finished product received into warehouse 4, no semiproduct documents), `ResidueDistributionCalculator` early-returns for SinglePhase, and `ProductsDataGrid` only marks `isDirectRow` for MultiPhase. The Flexi adapter needed no change — its per-product path already routes ingredients to the correct warehouse by `ProductType`.

## Tests

Added workflow, residue-calculator, and `ProductsDataGrid` tests for the SinglePhase path; all 711 backend Manufacture tests pass and the frontend builds/lints clean. End-to-end Flexi document verification still needs to be run against staging (no sandbox).