### PR TITLE
feat: Remove dead `ComponentType` property from `ITile` contract

### DIFF
--- a/artifacts/feat-arch-review-dashboard-itile-componenttyp/arch-review.r1.md
+++ b/artifacts/feat-arch-review-dashboard-itile-componenttyp/arch-review.r1.md
@@ -1,0 +1,223 @@
+```markdown
+# Architecture Review: Remove dead `ComponentType` property from `ITile` contract
+
+## Skip Design: true
+
+This is a backend-only refactor. No new or changed UI components, screens, or visual design — the frontend already ignores the value (`DashboardTileDto` does not carry it, and `TileContent.tsx` resolves components by `tileId`). No design work required.
+
+## Architectural Fit Assessment
+
+The change strengthens existing architectural conventions:
+
+- **Vertical Slice + Clean Architecture boundary stays intact.** `ITile`, `TileMetadata`, `TileData` live in `Anela.Heblo.Xcc.Services.Dashboard` (cross-cutting infrastructure). Concrete tiles live in feature slices under `Application/Features/*/DashboardTiles/`. The mapping point — `GetTileDataHandler` — is the single place that translates the cross-cutting carrier into the wire DTO. Today it drops `ComponentType`; after this change there is nothing to drop.
+- **DTO-vs-internal-type discipline (CLAUDE.md project rule) is reinforced.** `DashboardTileDto` (the wire contract) is a class with no `ComponentType` and is unchanged. The internal carrier types lose a member that no consumer ever reads.
+- **Single-responsibility for the contract.** `ITile` is meant to describe *what tile content the backend provides*. Frontend component wiring belongs to the frontend (and already lives there, in `TileContent.tsx`'s `tileId` switch). Removing `ComponentType` realigns `ITile` with its real responsibility.
+
+Integration points touched:
+1. **Contract layer** — `ITile`, `TileMetadata`, `TileData` in `backend/src/Anela.Heblo.Xcc/Services/Dashboard/`.
+2. **Registry mapping** — `TileRegistry.ToMetadata` in the same folder (the spec missed this site — see Specification Amendments).
+3. **Use-case handler** — `GetTileDataHandler` in `Application/Features/Dashboard/UseCases/GetTileData/`.
+4. **Tile implementations** — 19 concrete tile classes across 7 feature slices.
+5. **Tests** — fixtures, validation tests, registry tests, and 3 per-tile metadata assertions.
+
+There is no transitive impact: no migration, no Key Vault change, no OpenAPI client change (`DashboardTileDto` is the OpenAPI surface and is untouched), no frontend change.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+                       Before                                       After
+─────────────────────────────────────────────────  ───────────────────────────────────────────────
+ITile.ComponentType ─┐                             ITile (no ComponentType)
+                     │                              │
+TileRegistry.ToMetadata ──► TileMetadata.ComponentType   TileRegistry.ToMetadata ──► TileMetadata
+                                  │                                                       │
+GetTileDataHandler ──► TileData.ComponentType            GetTileDataHandler ──► TileData
+                                  │                                                       │
+                                  X  (dropped, never reaches DTO)                         │
+DashboardTileDto (no ComponentType field) ──► JSON       DashboardTileDto ──► JSON  (unchanged shape)
+```
+
+The three carriers each shed one member; the mapping site simply has one fewer line. No new components, no new abstractions.
+
+### Key Design Decisions
+
+#### Decision 1: Remove rather than redesign
+**Options considered:**
+- (a) Remove the property entirely (this spec).
+- (b) Add `ComponentType` to `DashboardTileDto` and wire it to the frontend so the backend can drive component selection.
+- (c) Replace with a `string ComponentKey` to avoid leaking CLR `Type` over the wire.
+
+**Chosen approach:** (a) — remove.
+
+**Rationale:** The frontend already has authoritative component-to-`tileId` mapping in `TileContent.tsx`. There is no product requirement that says "the backend should choose the frontend component." Adding such a coupling (option b/c) would invert the current — and correct — separation of concerns: backend owns data, frontend owns rendering. Removal is the only option that matches existing intent.
+
+#### Decision 2: Treat all 19 implementations as a single mechanical change
+**Options considered:**
+- (a) One commit that updates contract + registry + all tiles + tests + handler together.
+- (b) Phased removal (interface first with default implementation, then per-slice cleanup).
+
+**Chosen approach:** (a).
+
+**Rationale:** The spec's NFR-4 explicitly *welcomes* compile-time discovery of touch points. C# interfaces cannot carry a default implementation without leaking complexity into every implementer, and a phased approach buys nothing: the change is purely mechanical, fully covered by `dotnet build`, and there is no consumer of the property to coordinate with. The same PR also satisfies the surgical-changes rule in CLAUDE.md — nothing adjacent is improved.
+
+#### Decision 3: Delete tests that *assert* the property; mechanically update tests that *set* it
+**Options considered:**
+- (a) Delete only the lines that touch `ComponentType`, keeping the surrounding test alive.
+- (b) Delete the entire test method when it only asserts `ComponentType`.
+
+**Chosen approach:** (a) — delete the asserting *line*, not the test method.
+
+**Rationale:** In `ManualActionRequiredTileTests`, `ManufactureConditionsTileTests`, and `WeatherForecastTileTests`, the assertions live inside a multi-assert "metadata properties have correct values" test that also asserts `Title`, `Size`, `Category`, etc. Deleting one `Assert`/`Should()` line keeps the surrounding coverage intact. Per the testing rule, we fix what's wrong, not delete passing coverage.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. No moved files. Edits only.
+
+```
+backend/
+├── src/
+│   ├── Anela.Heblo.Xcc/Services/Dashboard/
+│   │   ├── ITile.cs                          [edit] remove ComponentType property
+│   │   ├── TileMetadata.cs                   [edit] remove ComponentType positional param
+│   │   ├── TileData.cs                       [edit] remove ComponentType property
+│   │   └── TileRegistry.cs                   [edit] line 67 — drop from ToMetadata factory
+│   │
+│   └── Anela.Heblo.Application/Features/
+│       ├── Dashboard/UseCases/GetTileData/
+│       │   └── GetTileDataHandler.cs         [edit] line 84 — drop ComponentType = tile.ComponentType
+│       │
+│       ├── Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs    [edit]
+│       ├── BackgroundJobs/DashboardTiles/FailedJobsTile.cs            [edit]
+│       ├── Catalog/DashboardTiles/InventorySummaryTileBase.cs         [edit]
+│       ├── Catalog/DashboardTiles/InventoryCountTileBase.cs           [edit]
+│       ├── Catalog/DashboardTiles/LowStockAlertTile.cs                [edit]
+│       ├── DataQuality/DashboardTiles/DataQualityStatusTile.cs        [edit]
+│       ├── DataQuality/DashboardTiles/DqtYesterdayStatusTile.cs       [edit]
+│       ├── Logistics/DashboardTiles/CriticalGiftPackagesTile.cs       [edit]
+│       ├── Logistics/DashboardTiles/TransportBoxBaseTile.cs           [edit]
+│       ├── Manufacture/DashboardTiles/ManualActionRequiredTile.cs     [edit]
+│       ├── Manufacture/DashboardTiles/ManufactureConditionsTile.cs    [edit]
+│       ├── Manufacture/DashboardTiles/UpcomingProductionTile.cs       [edit]
+│       ├── Purchase/DashboardTiles/LowStockEfficiencyTile.cs          [edit]
+│       ├── Purchase/DashboardTiles/PurchaseOrdersInTransitTile.cs     [edit]
+│       └── WeatherForecast/DashboardTiles/WeatherForecastTile.cs      [edit]
+│       (plus BackgroundTaskStatusTile.cs in Xcc/Services/Dashboard/Tiles/)
+│
+└── test/Anela.Heblo.Tests/Features/
+    ├── Dashboard/Fixtures/TestTiles.cs                                [edit] 5 sites
+    ├── Dashboard/TileExtensionsTests.cs                               [edit] 2 sites
+    ├── Dashboard/TileRegistryTests.cs                                 [edit] line 93 — drop TrackedTile.ComponentType
+    ├── Dashboard/TileRegistryValidationTests.cs                       [edit] 3 sites
+    ├── Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs    [edit] drop assert at line 35
+    ├── Manufacture/DashboardTiles/ManufactureConditionsTileTests.cs   [edit] drop assert at line 41
+    └── WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs     [edit] drop assert at line 33
+```
+
+**Tile subclasses to verify:** `InventorySummaryTileBase` and `InventoryCountTileBase` are base classes with multiple subclasses (e.g. `ProductInventorySummaryTile`, `MaterialInventoryCountTile`, `ReceivedBoxesTile`, etc.). Removing `ComponentType` from the base type removes it from all subclasses for free — confirm none of the subclasses override it (the grep shows only base classes define it).
+
+### Interfaces and Contracts
+
+**`ITile` (after):**
+```csharp
+public interface ITile
+{
+    string Title { get; }
+    string Description { get; }
+    TileSize Size { get; }
+    TileCategory Category { get; }
+    bool DefaultEnabled { get; }
+    bool AutoShow { get; }
+    string[] RequiredPermissions { get; }
+
+    Task<object> LoadDataAsync(
+        Dictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**`TileMetadata` (after):**
+```csharp
+public sealed record TileMetadata(
+    string TileId,
+    string Title,
+    string Description,
+    TileSize Size,
+    TileCategory Category,
+    bool DefaultEnabled,
+    bool AutoShow,
+    string[] RequiredPermissions);
+```
+
+This is a **positional-record signature change**. Every call site that constructs `TileMetadata` (today only `TileRegistry.ToMetadata`) must be updated in the same change. Because it is a `record` (not a DTO crossing the OpenAPI generator) the project rule "DTOs are classes, never records" does not apply — `TileMetadata` is an internal carrier.
+
+**`TileData` (after):** drop the `ComponentType` property and its `typeof(object)` initializer; leave the rest as-is (still a mutable class because `GetTileDataHandler` populates it via object initializer).
+
+**`DashboardTileDto`:** unchanged. This guarantees byte-identical JSON output and zero impact on the auto-generated TypeScript client.
+
+### Data Flow
+
+```
+HTTP GET /api/dashboard/tile-data
+   │
+   ▼
+GetTileDataHandler.Handle
+   │
+   ├──► IMediator.Send(GetUserSettingsRequest)        ── user's visible tiles
+   │
+   └──► For each visible tile (Parallel.ForEachAsync):
+         │
+         ├──► ITileRegistry.GetTileMetadata(tileId)   ── returns TileMetadata (no ComponentType)
+         │
+         ├──► ITileRegistry.GetTileDataAsync(tileId)  ── calls tile.LoadDataAsync(...)
+         │
+         └──► Build TileData { …, Data = data }       ── no ComponentType to copy
+   │
+   ▼
+Project TileData → DashboardTileDto                   ── identical to today
+   │
+   ▼
+JSON response                                          ── byte-identical
+```
+
+No new flow paths, no parallelism changes, no error-handling differences.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missed `ITile` implementer outside the 19 found by grep — solution fails to build. | Low | The interface change forces a compile error at every implementer. `dotnet build` is the gate. The CLAUDE.md "validation before completion" checklist already mandates `dotnet build`. |
+| `TileMetadata` is a positional record — adding/removing a parameter is a breaking signature change. | Low | Single producer (`TileRegistry.ToMetadata` line 59-68); no consumers construct it. Compiler catches any third-party construction. |
+| Test `TileRegistryTests.TrackedTile` uses `typeof(TrackedTile)` (the *only* non-`typeof(object)` use in the codebase) — could indicate a test that actually exercises the property. | Low | The line is metadata setup, not an assertion target; the test class tracks scope disposal, not component types. Mechanical removal is safe. Verify by reading the surrounding test before removing. |
+| Frontend coincidentally serializes/deserializes `componentType` through some hand-rolled fetch path. | Very low | Confirmed via grep: the only frontend `componentType` references are in `MessageDeliveryIcon.tsx` and `ErrorBoundary.tsx`, neither of which touches the dashboard. |
+| OpenAPI client regeneration produces a diff because `TileMetadata`/`TileData` accidentally leak through Swagger. | Very low | Only `DashboardTileDto` is exposed via controllers. Internal carriers are not serialized through the API. Run `npm run build` after change to confirm the TS client is unchanged. |
+| Subclass of `InventorySummaryTileBase` / `InventoryCountTileBase` re-declares `ComponentType` and gets orphaned. | Low | Confirmed by grep: only the base classes carry the property. No `override`/`new` redeclarations exist. |
+
+## Specification Amendments
+
+The spec is largely complete, but three additions are needed for the implementer to finish in one pass:
+
+1. **Add `TileRegistry.ToMetadata` to FR-3.** The spec correctly removes the property from the `TileMetadata` record but does not name the call site that constructs it. `Xcc/Services/Dashboard/TileRegistry.cs:67` passes `tile.ComponentType` into the constructor and must be updated when the record's positional signature changes. Failing to update this is a compile error rather than a silent bug, but listing the site keeps the PR diff coherent.
+
+2. **Explicitly include `BackgroundTaskStatusTile.cs`** under FR-2. It lives in `Anela.Heblo.Xcc/Services/Dashboard/Tiles/` (the Xcc project), not in `Application/Features/`. An implementer following "every tile under `Application/Features/*/DashboardTiles/`" could miss it. The grep above is authoritative — 19 production tile files in total (one in Xcc, 18 in Application).
+
+3. **Clarify FR-7 with the three assert sites.** The spec says "tests that assert on `ComponentType` … must be deleted, since the property is being removed entirely." Override this with: *delete the asserting line, not the test method*. The three sites — `ManualActionRequiredTileTests.cs:35`, `ManufactureConditionsTileTests.cs:41`, `WeatherForecastTileTests.cs:33` — are single asserts inside multi-assert `Metadata_HasCorrectValues` tests. Removing the line preserves the surrounding metadata-shape coverage; removing the method would silently lose that coverage.
+
+These are clarifications, not scope changes. No new requirements.
+
+## Prerequisites
+
+None. The change has zero infrastructure dependencies:
+
+- No database migration.
+- No Azure Key Vault secret to add (per CLAUDE.md secret rule, this is irrelevant here — no secrets are touched).
+- No configuration change (`appsettings*.json` unchanged).
+- No OpenAPI regeneration needed: `DashboardTileDto` is the only contract surface and is unchanged; the auto-generated TypeScript client will produce a no-op diff.
+- No feature flag (per project rules, none needed for an internal refactor with byte-identical wire output).
+- No coordination with frontend, no deployment ordering, no Docker image dependency.
+
+The implementer can land this in a single PR. Validation gates per CLAUDE.md: `dotnet build` + `dotnet format` + `dotnet test` + `npm run build` + `npm run lint`. The nightly E2E suite will exercise the unchanged dashboard endpoints and provide post-merge confirmation.
+```

--- a/artifacts/feat-arch-review-dashboard-itile-componenttyp/brief.md
+++ b/artifacts/feat-arch-review-dashboard-itile-componenttyp/brief.md
@@ -1,0 +1,28 @@
+## Module
+Dashboard
+
+## Finding
+
+`ITile` declares a `Type ComponentType { get; }` property (`Xcc/Services/Dashboard/ITile.cs`, line 10). Every implementation in the codebase sets it to `typeof(object)` with a comment saying it is not needed:
+
+- `PurchaseOrdersInTransitTile.cs:17` — `public Type ComponentType => typeof(object); // Frontend component type not needed for backend`
+- `TransportBoxBaseTile.cs:17` — same
+- All other tiles examined follow the same pattern
+
+The value is carried through the entire stack:
+- `TileMetadata` record (`Xcc/Services/Dashboard/TileMetadata.cs`, line 11): `Type ComponentType`
+- `TileData` class (`Xcc/Services/Dashboard/TileData.cs`, line 12): `public Type ComponentType { get; set; } = typeof(object);`
+- `GetTileDataHandler` maps it into `TileData` (`Application/.../GetTileData/GetTileDataHandler.cs`, line ~84): `ComponentType = tile.ComponentType`
+
+But `DashboardTileDto` (`Application/Features/Dashboard/Contracts/DashboardTileDto.cs`) has no `ComponentType` field. The value is populated at every intermediate step and then silently dropped when mapping to the DTO — it never reaches the API response or the frontend.
+
+## Why it matters
+
+The property pollutes the `ITile` contract (every tile author must implement a property that does nothing), inflates `TileMetadata` and `TileData`, and creates a false impression that the backend manages frontend component wiring. It is pure noise.
+
+## Suggested fix
+
+Remove `ComponentType` from `ITile`, `TileMetadata`, `TileData`, and every tile implementation. The frontend already resolves the correct component from `tileId` via the `switch` in `TileContent.tsx` — no backend involvement needed.
+
+---
+_Filed by daily arch-review routine on 2026-06-01._

--- a/artifacts/feat-arch-review-dashboard-itile-componenttyp/impl/main.r1.md
+++ b/artifacts/feat-arch-review-dashboard-itile-componenttyp/impl/main.r1.md
@@ -1,0 +1,84 @@
+All tasks complete. Writing the output artifact.
+
+---
+
+# Implementation: Remove dead `ComponentType` property from `ITile` contract
+
+## What was implemented
+
+Removed the unused `Type ComponentType` property from the `ITile` interface and all related carrier types, factory methods, handlers, and tests. The property was set to `typeof(object)` in every implementation, was never mapped to `DashboardTileDto`, and never crossed the API boundary. This is a pure dead-code removal with byte-identical wire output.
+
+## Files created/modified
+
+**Contract layer (3 files):**
+- `backend/src/Anela.Heblo.Xcc/Services/Dashboard/ITile.cs` — removed `Type ComponentType { get; }` declaration
+- `backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileMetadata.cs` — removed `Type ComponentType` positional record parameter (8 → 7 params, renumbered)
+- `backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileData.cs` — removed `public Type ComponentType { get; set; } = typeof(object);` property
+
+**Registry and handler (2 files):**
+- `backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileRegistry.cs` — removed `tile.ComponentType` argument from `ToMetadata` factory
+- `backend/src/Anela.Heblo.Application/Features/Dashboard/UseCases/GetTileData/GetTileDataHandler.cs` — removed `ComponentType = tile.ComponentType,` from `TileData` initializer
+
+**Production tile implementations (16 files):**
+- `BackgroundTaskStatusTile.cs`, `InvoiceImportStatisticsTile.cs`, `FailedJobsTile.cs`, `InventorySummaryTileBase.cs`, `InventoryCountTileBase.cs`, `LowStockAlertTile.cs`, `DataQualityStatusTile.cs`, `DqtYesterdayStatusTile.cs`, `CriticalGiftPackagesTile.cs`, `TransportBoxBaseTile.cs`, `ManualActionRequiredTile.cs`, `ManufactureConditionsTile.cs`, `UpcomingProductionTile.cs`, `LowStockEfficiencyTile.cs`, `PurchaseOrdersInTransitTile.cs`, `WeatherForecastTile.cs`
+
+**Tests (10 files):**
+- `TestTiles.cs` — removed from 5 private tile classes (`replace_all`)
+- `TileExtensionsTests.cs` — removed from 2 private test tiles
+- `TileRegistryTests.cs` — removed from `TrackedTile`
+- `TileRegistryValidationTests.cs` — removed from 3 private validation tiles
+- `GetAvailableTilesHandlerTests.cs` — removed `typeof(object)` from 3 `TileMetadata` constructor calls
+- `GetTileDataHandlerTests.cs` — removed `typeof(object)` from 3 `TileMetadata` constructor calls
+- `GetUserSettingsHandlerTests.cs` — removed `typeof(object)` from 1 `MakeTile()` helper call
+- `ManualActionRequiredTileTests.cs` — removed `Assert.Equal(typeof(object), _tile.ComponentType)` assertion line
+- `ManufactureConditionsTileTests.cs` — removed `_tile.ComponentType.Should().Be(typeof(object))` assertion line
+- `WeatherForecastTileTests.cs` — removed `_tile.ComponentType.Should().Be(typeof(object))` assertion line
+
+## Tests
+
+All 31 changed files are backend-only. Validation results:
+- `dotnet build`: 0 errors (pre-existing 233 warnings unchanged)
+- `dotnet test` (dashboard subset): 115/115 passed; 3 per-tile metadata test classes 23/23 passed
+- Full suite: 40 failures are pre-existing Docker/testcontainer integration tests, unrelated to this change
+- `grep -rn "ComponentType" --include="*.cs"`: 0 hits
+
+## How to verify
+
+```bash
+cd /path/to/repo
+grep -rn "ComponentType" --include="*.cs" backend/src/ backend/test/
+# Expected: zero output
+
+dotnet build
+# Expected: 0 errors
+
+dotnet test --filter "FullyQualifiedName~Dashboard" backend/test/Anela.Heblo.Tests/
+# Expected: 115/115 passed
+```
+
+## Notes
+
+The plan's baseline grep listed 35 hits but missed 7 additional `TileMetadata` constructor call sites in 3 test files (`GetAvailableTilesHandlerTests.cs`, `GetTileDataHandlerTests.cs`, `GetUserSettingsHandlerTests.cs`). These were caught by the code quality reviewer and fixed in a second implementer pass. The final commit touches 31 files (vs. 28 in the plan) due to these additional sites.
+
+`DashboardTileDto` was not modified. The JSON shape returned by dashboard endpoints is byte-identical.
+
+## PR Summary
+
+Removes the dead `Type ComponentType` property from the `ITile` interface, `TileMetadata` record, `TileData` class, all 16 production tile implementations, and all consuming sites in the registry, handler, and test suite. The property was set to `typeof(object)` everywhere, never propagated to `DashboardTileDto`, and never reached the frontend — pure boilerplate that imposed a compile-time obligation on every new tile author.
+
+`DashboardTileDto` is unchanged: the dashboard API JSON shape is byte-identical and the auto-generated TypeScript client regenerates as a no-op.
+
+### Changes
+- `ITile.cs` — removed `Type ComponentType { get; }` interface member
+- `TileMetadata.cs` — removed positional `Type ComponentType` parameter (record signature simplified to 8 params)
+- `TileData.cs` — removed `Type ComponentType` mutable property
+- `TileRegistry.cs` — dropped `tile.ComponentType` from `ToMetadata` factory call
+- `GetTileDataHandler.cs` — dropped `ComponentType = tile.ComponentType` from `TileData` initializer
+- 16 production tile classes — removed `ComponentType => typeof(object)` expression-body property
+- 7 test files — removed property declarations from private/fixture tile classes and `typeof(object)` arguments from `TileMetadata` constructor calls
+- 3 test files — removed single `ComponentType` assertion line from multi-assert metadata test methods (surrounding assertions preserved)
+
+## Status
+DONE_WITH_CONCERNS
+
+**Concern:** The plan's baseline grep enumerated exactly 35 expected hits but missed 7 additional `TileMetadata(...)` constructor call sites (not property declarations, so grep for `ComponentType` wouldn't catch them). The code quality review caught these. Future plans for positional-record parameter removals should also grep for constructor call argument patterns, not only property/field declarations.

--- a/artifacts/feat-arch-review-dashboard-itile-componenttyp/spec.r1.md
+++ b/artifacts/feat-arch-review-dashboard-itile-componenttyp/spec.r1.md
@@ -1,0 +1,138 @@
+# Specification: Remove dead `ComponentType` property from `ITile` contract
+
+## Summary
+Remove the unused `Type ComponentType` property from the dashboard `ITile` contract and all carrier types (`TileMetadata`, `TileData`) plus every tile implementation. The value is set to `typeof(object)` everywhere, propagates through three layers, and is then silently dropped before reaching the API DTO — pure dead code that adds boilerplate to every new tile.
+
+## Background
+The dashboard subsystem exposes tiles via the `ITile` contract in `Xcc/Services/Dashboard/ITile.cs`. The contract declares `Type ComponentType { get; }`, which was originally intended to let the backend signal which React component should render a given tile. In practice the frontend never received this value:
+
+- `DashboardTileDto` (the wire contract) has no `ComponentType` field, so the value never crosses the API boundary.
+- `TileContent.tsx` already resolves the React component from `tileId` via a `switch` statement, so the frontend has no need for a backend-supplied type.
+- Every tile implementation (e.g. `PurchaseOrdersInTransitTile.cs:17`, `TransportBoxBaseTile.cs:17`) sets the value to `typeof(object)` accompanied by a comment explaining the property is not needed.
+
+The property therefore satisfies no functional need but imposes a compile-time obligation on every new tile author, inflates two carrier types (`TileMetadata`, `TileData`), and creates the false impression that the backend manages frontend component wiring. This finding was filed by the daily architecture review routine on 2026-06-01.
+
+## Functional Requirements
+
+### FR-1: Remove `ComponentType` from the `ITile` contract
+Delete the `Type ComponentType { get; }` declaration from `Xcc/Services/Dashboard/ITile.cs`.
+
+**Acceptance criteria:**
+- `ITile.cs` no longer declares any member named `ComponentType`.
+- The file compiles and existing XML doc / member comments remain coherent (no orphaned doc references to `ComponentType`).
+
+### FR-2: Remove `ComponentType` from every tile implementation
+Remove the `ComponentType` property (and its accompanying inline comment) from every concrete class that currently implements `ITile`. Known sites from the brief:
+- `PurchaseOrdersInTransitTile.cs:17`
+- `TransportBoxBaseTile.cs:17`
+- Any other tile classes that follow the same pattern (an exhaustive search of implementers of `ITile` must be performed).
+
+**Acceptance criteria:**
+- `grep -r "ComponentType"` across the backend solution returns zero hits in dashboard tile code.
+- All tile classes still implement `ITile` and the solution builds.
+- No tile class loses unrelated behavior.
+
+### FR-3: Remove `ComponentType` from `TileMetadata`
+Delete the `Type ComponentType` member from the `TileMetadata` record at `Xcc/Services/Dashboard/TileMetadata.cs:11`. Update every constructor call / `with`-expression that supplied this value.
+
+**Acceptance criteria:**
+- `TileMetadata` no longer exposes a `ComponentType` member.
+- All call sites that constructed `TileMetadata` are updated; solution builds.
+
+### FR-4: Remove `ComponentType` from `TileData`
+Delete the `public Type ComponentType { get; set; } = typeof(object);` member from `TileData` at `Xcc/Services/Dashboard/TileData.cs:12`. Update any object initializer or assignment that wrote to this property.
+
+**Acceptance criteria:**
+- `TileData` no longer exposes a `ComponentType` member.
+- All call sites that constructed or mutated `TileData` are updated; solution builds.
+
+### FR-5: Remove the mapping in `GetTileDataHandler`
+Remove the `ComponentType = tile.ComponentType` assignment from `Application/.../GetTileData/GetTileDataHandler.cs` (around line 84). Verify no other handler or mapper performs an equivalent assignment.
+
+**Acceptance criteria:**
+- `GetTileDataHandler` no longer references `ComponentType`.
+- A repository-wide search for `ComponentType` in the `Application` project returns zero hits related to dashboard tiles.
+
+### FR-6: Preserve external behavior
+The change is a pure refactor — no observable behavior may change for API consumers or the frontend.
+
+**Acceptance criteria:**
+- `DashboardTileDto` is unchanged (it already lacked `ComponentType`).
+- The JSON shape returned by the dashboard endpoint(s) is byte-identical before and after the change for an equivalent dataset.
+- `TileContent.tsx` and other frontend code are not modified.
+- Backend unit tests covering tile retrieval still pass without modification (or with only mechanical updates removing now-deleted `ComponentType` setup).
+
+### FR-7: Update tests that reference `ComponentType`
+Any unit or integration test that constructs `TileMetadata`, `TileData`, or a fake `ITile` and sets `ComponentType` must be updated to drop that field. Tests that *assert* on `ComponentType` (if any exist) must be deleted, since the property is being removed entirely.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds.
+- `dotnet test` succeeds with no skipped or commented-out tests left behind.
+- No test asserts on `ComponentType` after the change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. Removing a `Type` reference from a few in-memory carriers may marginally reduce allocations but is not a measurable goal.
+
+### NFR-2: Security
+No security impact. The property carries no sensitive data and is not used in any authorization decision.
+
+### NFR-3: Maintainability
+Primary motivation. After this change:
+- New tile authors no longer need to learn about or implement a placeholder `ComponentType`.
+- Reviewers no longer need to scrutinize the value supplied.
+- The mental model of the contract — "backend supplies data, frontend chooses how to render it" — is consistent across the codebase.
+
+### NFR-4: Backward compatibility
+The dashboard wire contract (`DashboardTileDto`) is unchanged, so frontend and any external API consumers are unaffected. Internal C# consumers of `ITile`, `TileMetadata`, or `TileData` will break at compile time if they reference `ComponentType`; this is desired (compile-time discovery of all touch points).
+
+## Data Model
+No persistent-data changes. The affected types are runtime carriers only:
+
+- `ITile` — interface in `Xcc/Services/Dashboard/`; loses `ComponentType` property.
+- `TileMetadata` — record in `Xcc/Services/Dashboard/`; loses `ComponentType` member.
+- `TileData` — class in `Xcc/Services/Dashboard/`; loses `ComponentType` property.
+- `DashboardTileDto` — unchanged (already does not contain `ComponentType`).
+
+No database schema, no migration, no Key Vault changes.
+
+## API / Interface Design
+No API surface changes. The HTTP response for dashboard tile endpoints is unchanged because `DashboardTileDto` already omitted `ComponentType`. No new endpoints, no new events, no UI flow changes.
+
+Internal C# interface change:
+
+```csharp
+// Before
+public interface ITile {
+    string TileId { get; }
+    // ... other members ...
+    Type ComponentType { get; }
+}
+
+// After
+public interface ITile {
+    string TileId { get; }
+    // ... other members ...
+}
+```
+
+Equivalent removals in `TileMetadata` and `TileData`.
+
+## Dependencies
+- No new external libraries.
+- No version bumps.
+- No infrastructure changes.
+- Depends on the existing dashboard module and the OpenAPI client generation pipeline (which will regenerate cleanly because `DashboardTileDto` is unchanged).
+
+## Out of Scope
+- Refactoring the frontend `TileContent.tsx` switch statement or replacing it with a registry-based component lookup.
+- Adding any backend-driven component selection mechanism (the explicit conclusion is that the backend does not need this concern).
+- Cleaning up other unrelated dead members on `ITile`, `TileMetadata`, or `TileData` even if discovered during the change — file a separate finding instead.
+- Changes to `DashboardTileDto` or any other wire contract.
+- Adjusting the daily architecture review routine.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-dashboard-itile-componenttyp/task-plan.r1.md
+++ b/artifacts/feat-arch-review-dashboard-itile-componenttyp/task-plan.r1.md
@@ -1,0 +1,10 @@
+Plan saved to `artifacts/feat-arch-review-dashboard-itile-componenttyp/plan.r1.md`.
+
+**Summary:** A 7-task implementation plan covering removal of `ComponentType` across 19 production files and 7 test files. The plan is structured around the single hard constraint of this refactor — removing a member from the `ITile` interface and the `TileMetadata` positional record breaks all consumers at compile time, so intermediate builds will not succeed. Tasks 1–6 are coordinated edit units; Task 7 runs `dotnet build` + `dotnet format` + `dotnet test` + `npm run build` + `npm run lint` as the single validation gate, then commits all 28 files together. The plan includes:
+
+- Pre-flight grep with the exact 35 expected hits (19 in `src/`, 16 in `test/`)
+- File-by-file `old_string`/`new_string` snippets with line numbers
+- Use of `replace_all: true` for the multi-site fixture files (`TestTiles.cs`, `TileExtensionsTests.cs`, `TileRegistryValidationTests.cs`)
+- Per arch-review Decision 3: only the asserting *line* is removed from the three `Metadata_*HasCorrectValues` tests, not the test methods
+- Explicit verification that `DashboardTileDto` and the generated TypeScript client are unchanged (guarantees FR-6 byte-identical JSON)
+- Self-review table mapping every spec FR/NFR to its implementing task

--- a/backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Analytics/DashboardTiles/InvoiceImportStatisticsTile.cs
@@ -15,7 +15,6 @@ public class InvoiceImportStatisticsTile : ITile
     public TileCategory Category => TileCategory.Finance;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public InvoiceImportStatisticsTile(

--- a/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/BackgroundJobs/DashboardTiles/FailedJobsTile.cs
@@ -19,7 +19,6 @@ public sealed class FailedJobsTile : ITile
     public TileCategory Category => TileCategory.System;
     public bool DefaultEnabled => true;
     public bool AutoShow => false;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public FailedJobsTile(IFailedJobCounter failedJobCounter, ILogger<FailedJobsTile> logger)

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventoryCountTileBase.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventoryCountTileBase.cs
@@ -29,7 +29,6 @@ public abstract class InventoryCountTileBase : ITile
     public TileCategory Category => TileCategory.Warehouse;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/InventorySummaryTileBase.cs
@@ -26,7 +26,6 @@ public abstract class InventorySummaryTileBase : ITile
     public TileCategory Category => TileCategory.Warehouse;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/LowStockAlertTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/DashboardTiles/LowStockAlertTile.cs
@@ -32,7 +32,6 @@ public class LowStockAlertTile : ITile
     public TileCategory Category => TileCategory.Warehouse;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)

--- a/backend/src/Anela.Heblo.Application/Features/Dashboard/UseCases/GetTileData/GetTileDataHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Dashboard/UseCases/GetTileData/GetTileDataHandler.cs
@@ -81,7 +81,6 @@ public class GetTileDataHandler : IRequestHandler<GetTileDataRequest, GetTileDat
                         Category = tile.Category,
                         DefaultEnabled = tile.DefaultEnabled,
                         AutoShow = tile.AutoShow,
-                        ComponentType = tile.ComponentType,
                         RequiredPermissions = tile.RequiredPermissions,
                         Data = data
                     }));

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs
@@ -17,7 +17,6 @@ public class DataQualityStatusTile : ITile
     public TileCategory Category => TileCategory.DataQuality;
     public bool DefaultEnabled => true;
     public bool AutoShow => false;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public DataQualityStatusTile(IDqtRunRepository repository)

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DqtYesterdayStatusTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DqtYesterdayStatusTile.cs
@@ -20,7 +20,6 @@ public class DqtYesterdayStatusTile : ITile
     public TileCategory Category => TileCategory.DataQuality;
     public bool DefaultEnabled => true;
     public bool AutoShow => false;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public DqtYesterdayStatusTile(

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/CriticalGiftPackagesTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/CriticalGiftPackagesTile.cs
@@ -28,7 +28,6 @@ public class CriticalGiftPackagesTile : ITile
     public TileCategory Category => TileCategory.Warehouse;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/TransportBoxBaseTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/DashboardTiles/TransportBoxBaseTile.cs
@@ -14,7 +14,6 @@ public abstract class TransportBoxBaseTile : ITile
     public TileCategory Category => TileCategory.Warehouse;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     protected abstract TransportBoxState[] FilterStates { get; }

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManualActionRequiredTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManualActionRequiredTile.cs
@@ -16,7 +16,6 @@ public class ManualActionRequiredTile : ITile
     public TileCategory Category => TileCategory.Manufacture;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public ManualActionRequiredTile(

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManufactureConditionsTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/ManufactureConditionsTile.cs
@@ -17,7 +17,6 @@ public class ManufactureConditionsTile : ITile
     public TileCategory Category => TileCategory.Manufacture;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public ManufactureConditionsTile(

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/DashboardTiles/UpcomingProductionTile.cs
@@ -14,7 +14,6 @@ public abstract class UpcomingProductionTile : ITile
     public TileCategory Category => TileCategory.Manufacture;
     public bool DefaultEnabled => true;
     public bool AutoShow => true; // Feature tile - user choice
-    public Type ComponentType => typeof(object); // Frontend component type not needed for backend
     public string[] RequiredPermissions => Array.Empty<string>();
 
     protected abstract DateOnly ReferenceDate { get; set; }

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/DashboardTiles/LowStockEfficiencyTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/DashboardTiles/LowStockEfficiencyTile.cs
@@ -27,7 +27,6 @@ public class LowStockEfficiencyTile : ITile
     public TileCategory Category => TileCategory.Purchase;
     public bool DefaultEnabled => true;
     public bool AutoShow => true;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)

--- a/backend/src/Anela.Heblo.Application/Features/Purchase/DashboardTiles/PurchaseOrdersInTransitTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Purchase/DashboardTiles/PurchaseOrdersInTransitTile.cs
@@ -15,7 +15,6 @@ public class PurchaseOrdersInTransitTile : ITile
     public TileCategory Category => TileCategory.Purchase;
     public bool DefaultEnabled => true;
     public bool AutoShow => false; // Manual show
-    public Type ComponentType => typeof(object); // Frontend component type not needed for backend
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public PurchaseOrdersInTransitTile(IPurchaseOrderRepository purchaseOrderRepository)

--- a/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/WeatherForecast/DashboardTiles/WeatherForecastTile.cs
@@ -16,7 +16,6 @@ public class WeatherForecastTile : ITile
     public TileCategory Category => TileCategory.Manufacture;
     public bool DefaultEnabled => false;
     public bool AutoShow => false;
-    public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public WeatherForecastTile(IWeatherForecastClient weatherClient, ILogger<WeatherForecastTile> logger)

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/ITile.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/ITile.cs
@@ -9,7 +9,6 @@ public interface ITile
     TileCategory Category { get; }
     bool DefaultEnabled { get; }
     bool AutoShow { get; }
-    Type ComponentType { get; }
     string[] RequiredPermissions { get; }
 
     // Data loading

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileData.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileData.cs
@@ -9,7 +9,6 @@ public class TileData
     public TileCategory Category { get; set; }
     public bool DefaultEnabled { get; set; }
     public bool AutoShow { get; set; }
-    public Type ComponentType { get; set; } = typeof(object);
     public string[] RequiredPermissions { get; set; } = Array.Empty<string>();
     public object Data { get; set; } = new();
 }

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileMetadata.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileMetadata.cs
@@ -8,5 +8,4 @@ public sealed record TileMetadata(
     TileCategory Category,
     bool DefaultEnabled,
     bool AutoShow,
-    Type ComponentType,
     string[] RequiredPermissions);

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileRegistry.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/TileRegistry.cs
@@ -64,7 +64,6 @@ public class TileRegistry : ITileRegistry
         tile.Category,
         tile.DefaultEnabled,
         tile.AutoShow,
-        tile.ComponentType,
         tile.RequiredPermissions);
 
     public IEnumerable<string> GetRegisteredTileIds()

--- a/backend/src/Anela.Heblo.Xcc/Services/Dashboard/Tiles/BackgroundTaskStatusTile.cs
+++ b/backend/src/Anela.Heblo.Xcc/Services/Dashboard/Tiles/BackgroundTaskStatusTile.cs
@@ -14,7 +14,6 @@ public class BackgroundTaskStatusTile : ITile
     public TileCategory Category => TileCategory.System;
     public bool DefaultEnabled => true;
     public bool AutoShow => true; // System tile - auto-show
-    public Type ComponentType => typeof(object); // Frontend component type not needed for backend
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public BackgroundTaskStatusTile(IBackgroundRefreshTaskRegistry taskRegistry)

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/Fixtures/TestTiles.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/Fixtures/TestTiles.cs
@@ -11,7 +11,6 @@ public class NewAutoShowTile : ITile
     public TileCategory Category { get; init; } = TileCategory.Finance;
     public bool DefaultEnabled { get; init; } = true;
     public bool AutoShow { get; init; } = true;
-    public Type ComponentType { get; init; } = typeof(object);
     public string[] RequiredPermissions { get; init; } = Array.Empty<string>();
 
     public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -29,7 +28,6 @@ public class ManualTile : ITile
     public TileCategory Category { get; init; } = TileCategory.Finance;
     public bool DefaultEnabled { get; init; } = true;
     public bool AutoShow { get; init; } = false;
-    public Type ComponentType { get; init; } = typeof(object);
     public string[] RequiredPermissions { get; init; } = Array.Empty<string>();
 
     public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -47,7 +45,6 @@ public class AutoTile1 : ITile
     public TileCategory Category { get; init; } = TileCategory.Finance;
     public bool DefaultEnabled { get; init; } = true;
     public bool AutoShow { get; init; } = true;
-    public Type ComponentType { get; init; } = typeof(object);
     public string[] RequiredPermissions { get; init; } = Array.Empty<string>();
 
     public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -65,7 +62,6 @@ public class AutoTile2 : ITile
     public TileCategory Category { get; init; } = TileCategory.Finance;
     public bool DefaultEnabled { get; init; } = true;
     public bool AutoShow { get; init; } = true;
-    public Type ComponentType { get; init; } = typeof(object);
     public string[] RequiredPermissions { get; init; } = Array.Empty<string>();
 
     public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -85,7 +81,6 @@ public class TestTileWithData : ITile
     public TileCategory Category { get; init; } = TileCategory.Finance;
     public bool DefaultEnabled { get; init; } = true;
     public bool AutoShow { get; init; } = false;
-    public Type ComponentType { get; init; } = typeof(object);
     public string[] RequiredPermissions { get; init; } = Array.Empty<string>();
 
     public TestTileWithData(string tileId)

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/GetAvailableTilesHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/GetAvailableTilesHandlerTests.cs
@@ -44,8 +44,8 @@ public class GetAvailableTilesHandlerTests
 
         var tiles = new List<TileMetadata>
         {
-            new TileMetadata("test1", "Test Tile 1", "Description 1", TileSize.Small, TileCategory.Finance, true, false, typeof(object), new[] { "read" }),
-            new TileMetadata("test2", "Test Tile 2", "Description 2", TileSize.Large, TileCategory.Finance, false, true, typeof(object), new[] { "admin", "write" })
+            new TileMetadata("test1", "Test Tile 1", "Description 1", TileSize.Small, TileCategory.Finance, true, false, new[] { "read" }),
+            new TileMetadata("test2", "Test Tile 2", "Description 2", TileSize.Large, TileCategory.Finance, false, true, new[] { "admin", "write" })
         };
 
         _tileRegistryMock
@@ -89,7 +89,7 @@ public class GetAvailableTilesHandlerTests
 
         var tiles = new List<TileMetadata>
         {
-            new TileMetadata("testtilenoermissions", "Test Tile", "Description", TileSize.Medium, TileCategory.System, true, false, typeof(object), Array.Empty<string>())
+            new TileMetadata("testtilenoermissions", "Test Tile", "Description", TileSize.Medium, TileCategory.System, true, false, Array.Empty<string>())
         };
 
         _tileRegistryMock

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/GetTileDataHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/GetTileDataHandlerTests.cs
@@ -133,7 +133,7 @@ public class GetTileDataHandlerTests
         _tileRegistryMock
             .Setup(x => x.GetTileMetadata(tileId))
             .Returns(new TileMetadata(tileId, "Throwing Tile", "Desc", TileSize.Medium,
-                TileCategory.Finance, true, false, typeof(object), Array.Empty<string>()));
+                TileCategory.Finance, true, false, Array.Empty<string>()));
 
         _tileRegistryMock
             .Setup(x => x.GetTileDataAsync(tileId, It.IsAny<Dictionary<string, string>?>()))
@@ -167,7 +167,7 @@ public class GetTileDataHandlerTests
             var capturedId = id;
             _tileRegistryMock.Setup(x => x.GetTileMetadata(capturedId))
                 .Returns(new TileMetadata(capturedId, $"Title {capturedId}", "Desc", TileSize.Small,
-                    TileCategory.System, true, false, typeof(object), Array.Empty<string>()));
+                    TileCategory.System, true, false, Array.Empty<string>()));
             _tileRegistryMock
                 .Setup(x => x.GetTileDataAsync(capturedId, It.IsAny<Dictionary<string, string>?>()))
                 .ReturnsAsync(new { Id = capturedId });
@@ -202,7 +202,7 @@ public class GetTileDataHandlerTests
         _tileRegistryMock
             .Setup(x => x.GetTileMetadata(tileId))
             .Returns(new TileMetadata(tileId, "Analytics", "Analytics description", TileSize.Large,
-                TileCategory.Finance, true, true, typeof(object), new[] { "read", "analytics" }));
+                TileCategory.Finance, true, true, new[] { "read", "analytics" }));
 
         _tileRegistryMock
             .Setup(x => x.GetTileDataAsync(tileId, null))
@@ -253,7 +253,7 @@ public class GetTileDataHandlerTests
             var capturedId = id;
             _tileRegistryMock.Setup(x => x.GetTileMetadata(capturedId))
                 .Returns(new TileMetadata(capturedId, "Slow", "Slow tile", TileSize.Small,
-                    TileCategory.System, true, false, typeof(object), Array.Empty<string>()));
+                    TileCategory.System, true, false, Array.Empty<string>()));
             _tileRegistryMock
                 .Setup(x => x.GetTileDataAsync(capturedId, It.IsAny<Dictionary<string, string>?>()))
                 .Returns(async () =>

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/GetUserSettingsHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/GetUserSettingsHandlerTests.cs
@@ -265,7 +265,7 @@ public class GetUserSettingsHandlerTests
 
     private static TileMetadata MakeTile(string tileId, bool defaultEnabled = true, bool autoShow = true) =>
         new(tileId, tileId, $"{tileId} description", TileSize.Medium, TileCategory.Finance,
-            defaultEnabled, autoShow, typeof(object), Array.Empty<string>());
+            defaultEnabled, autoShow, Array.Empty<string>());
 
     private static UserDashboardSettings CreateExistingUserSettings(string userId)
     {

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/TileExtensionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/TileExtensionsTests.cs
@@ -15,7 +15,6 @@ public class TileExtensionsTests
         public TileCategory Category => TileCategory.System;
         public bool DefaultEnabled => false;
         public bool AutoShow => false;
-        public Type ComponentType => typeof(object);
         public string[] RequiredPermissions => Array.Empty<string>();
         public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
             => Task.FromResult<object>("data");
@@ -29,7 +28,6 @@ public class TileExtensionsTests
         public TileCategory Category => TileCategory.System;
         public bool DefaultEnabled => false;
         public bool AutoShow => false;
-        public Type ComponentType => typeof(object);
         public string[] RequiredPermissions => Array.Empty<string>();
         public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
             => Task.FromResult<object>("data");

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/TileRegistryTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/TileRegistryTests.cs
@@ -90,7 +90,6 @@ public class TrackedTile : ITile, IDisposable
     public TileCategory Category => TileCategory.System;
     public bool DefaultEnabled => true;
     public bool AutoShow => false;
-    public Type ComponentType => typeof(TrackedTile);
     public string[] RequiredPermissions => Array.Empty<string>();
 
     public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)

--- a/backend/test/Anela.Heblo.Tests/Features/Dashboard/TileRegistryValidationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Dashboard/TileRegistryValidationTests.cs
@@ -25,7 +25,6 @@ public class TileRegistryValidationTests
         public TileCategory Category => TileCategory.System;
         public bool DefaultEnabled => false;
         public bool AutoShow => false;
-        public Type ComponentType => typeof(object);
         public string[] RequiredPermissions => Array.Empty<string>();
         public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
             => Task.FromResult<object>("alpha");
@@ -40,7 +39,6 @@ public class TileRegistryValidationTests
         public TileCategory Category => TileCategory.System;
         public bool DefaultEnabled => false;
         public bool AutoShow => false;
-        public Type ComponentType => typeof(object);
         public string[] RequiredPermissions => Array.Empty<string>();
         public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
             => Task.FromResult<object>("dup");
@@ -54,7 +52,6 @@ public class TileRegistryValidationTests
         public TileCategory Category => TileCategory.System;
         public bool DefaultEnabled => false;
         public bool AutoShow => false;
-        public Type ComponentType => typeof(object);
         public string[] RequiredPermissions => Array.Empty<string>();
         public Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
             => Task.FromResult<object>("none");

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManualActionRequiredTileTests.cs
@@ -32,7 +32,6 @@ public class ManualActionRequiredTileTests
         Assert.Equal(TileCategory.Manufacture, _tile.Category);
         Assert.True(_tile.DefaultEnabled);
         Assert.True(_tile.AutoShow);
-        Assert.Equal(typeof(object), _tile.ComponentType);
         Assert.Empty(_tile.RequiredPermissions);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManufactureConditionsTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/DashboardTiles/ManufactureConditionsTileTests.cs
@@ -38,7 +38,6 @@ public class ManufactureConditionsTileTests
         _tile.Category.Should().Be(TileCategory.Manufacture);
         _tile.DefaultEnabled.Should().BeTrue();
         _tile.AutoShow.Should().BeTrue();
-        _tile.ComponentType.Should().Be(typeof(object));
         _tile.RequiredPermissions.Should().BeEmpty();
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/WeatherForecast/DashboardTiles/WeatherForecastTileTests.cs
@@ -30,7 +30,6 @@ public sealed class WeatherForecastTileTests
         _tile.Category.Should().Be(TileCategory.Manufacture);
         _tile.DefaultEnabled.Should().BeFalse();
         _tile.AutoShow.Should().BeFalse();
-        _tile.ComponentType.Should().Be(typeof(object));
         _tile.RequiredPermissions.Should().BeEmpty();
     }
 


### PR DESCRIPTION

Removes the dead `Type ComponentType` property from the `ITile` interface, `TileMetadata` record, `TileData` class, all 16 production tile implementations, and all consuming sites in the registry, handler, and test suite. The property was set to `typeof(object)` everywhere, never propagated to `DashboardTileDto`, and never reached the frontend — pure boilerplate that imposed a compile-time obligation on every new tile author.

`DashboardTileDto` is unchanged: the dashboard API JSON shape is byte-identical and the auto-generated TypeScript client regenerates as a no-op.

### Changes
- `ITile.cs` — removed `Type ComponentType { get; }` interface member
- `TileMetadata.cs` — removed positional `Type ComponentType` parameter (record signature simplified to 8 params)
- `TileData.cs` — removed `Type ComponentType` mutable property
- `TileRegistry.cs` — dropped `tile.ComponentType` from `ToMetadata` factory call
- `GetTileDataHandler.cs` — dropped `ComponentType = tile.ComponentType` from `TileData` initializer
- 16 production tile classes — removed `ComponentType => typeof(object)` expression-body property
- 7 test files — removed property declarations from private/fixture tile classes and `typeof(object)` arguments from `TileMetadata` constructor calls
- 3 test files — removed single `ComponentType` assertion line from multi-assert metadata test methods (surrounding assertions preserved)

---

Closes #2243

### Tokens used
20592995
