### PR TITLE
feat: Add Structured Error Logging to DataQualityStatusTile

### DIFF
--- a/artifacts/feat-arch-review-dataquality-dataqualitystatu/arch-review.r1.md
+++ b/artifacts/feat-arch-review-dataquality-dataqualitystatu/arch-review.r1.md
@@ -1,0 +1,111 @@
+# Architecture Review: Add Structured Error Logging to DataQualityStatusTile
+
+## Skip Design: true
+
+Backend-only behavioral fix. No UI, no new visual components, no design decisions required.
+
+## Architectural Fit Assessment
+
+The change is a perfect fit. It does not introduce a new pattern — it adopts the one already in use by the sibling class `DqtYesterdayStatusTile` in the same folder. The DataQuality module follows Vertical Slice organization (`Application/Features/DataQuality/DashboardTiles/`), and both tiles implement the `ITile` interface from `Anela.Heblo.Xcc.Services.Dashboard`. Registration goes through `DataQualityModule.AddDataQualityModule()` via `services.RegisterTile<DataQualityStatusTile>()`, which is the standard tile registration helper.
+
+Integration points:
+- **DI container** — `ILogger<T>` is wired by default through `Microsoft.Extensions.Logging`; no module change needed. Tile registration via `RegisterTile<T>()` already resolves all constructor dependencies through the container.
+- **Existing tests** — `DataQualityStatusTileTests` (3 tests) constructs the tile directly and must be updated to supply a logger. The sibling test uses `NullLogger<T>.Instance`; the same approach applies here.
+- **No transitive ripple** — the class is not constructed manually anywhere else (search confirms only the module registration and test construct it).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+DI container
+   │
+   ├── ILogger<DataQualityStatusTile>  (Microsoft.Extensions.Logging — default)
+   ├── IDqtRunRepository               (registered in DataQualityModule)
+   │
+   ▼
+DataQualityStatusTile (ITile)
+   │
+   └── LoadDataAsync()
+         try → repository call → shape payload
+         catch (Exception ex)
+              ↓
+         _logger.LogError(ex, "...")  ← NEW
+              ↓
+         return degraded payload (unchanged shape)
+```
+
+### Key Design Decisions
+
+#### Decision 1: Log message phrasing — fixed string vs. structured properties
+**Options considered:**
+- (A) Spec proposal: `_logger.LogError(ex, "Failed to load DataQuality status tile")` — fixed message, exception only.
+- (B) Mirror sibling exactly: include the test type as a structured property, e.g. `_logger.LogError(ex, "Failed to load DataQuality status tile for {TestType}", DqtTestType.IssuedInvoiceComparison)`.
+
+**Chosen approach:** Option B — include `{TestType}` as a structured property.
+
+**Rationale:** NFR-3 ("match conventions used by `DqtYesterdayStatusTile`") and the sibling's actual implementation use structured properties (`{TestType}`, `{TargetDate}`). The fixed-string variant in the spec drifts from that pattern. Adding `{TestType}` is zero-PII, costs nothing on the happy path, and makes log aggregation/filtering meaningful when more test types come online. (There is no `TargetDate` analogue here since this tile reads the latest run regardless of date — so the message ends at `{TestType}`.)
+
+#### Decision 2: Constructor parameter order
+**Options considered:**
+- (A) Append `logger` last: `(IDqtRunRepository repository, ILogger<DataQualityStatusTile> logger)`.
+- (B) Prepend or insert mid-list.
+
+**Chosen approach:** Option A — append last.
+
+**Rationale:** Sibling tile orders dependencies as `(repository, timeProvider, logger)` — logger last. Matches the sibling convention and minimizes call-site churn (the only direct call site is the test class).
+
+#### Decision 3: Test logger — mock vs. NullLogger
+**Options considered:**
+- (A) `NullLogger<DataQualityStatusTile>.Instance` for existing tests; add one new test using `Mock<ILogger<T>>` to verify `LogError` invocation (NFR-4).
+- (B) Switch all tests to `Mock<ILogger<T>>`.
+
+**Chosen approach:** Option A.
+
+**Rationale:** Sibling test class uses `NullLogger<T>.Instance` everywhere — no test there verifies `LogError` was called. To satisfy NFR-4 without diverging stylistically, keep the existing three tests on `NullLogger` and add one new test (the rethrow-path test, or a fourth dedicated one) that uses `Mock<ILogger<DataQualityStatusTile>>` with `Verify(...)` on `LogError`. This is a small, targeted addition rather than a wholesale rewrite. As a follow-up consideration, the sibling tile *should* probably get the same verification test — but that is out of scope per the spec.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Edits in:
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs` — add `using Microsoft.Extensions.Logging;`, add `_logger` field, update constructor, update catch block.
+- `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs` — update constructor call to pass `NullLogger<DataQualityStatusTile>.Instance`; add one test verifying `LogError` is invoked on the exception path.
+
+No changes to `DataQualityModule.cs` — the `RegisterTile<T>()` helper resolves all constructor params through the container, and `ILogger<T>` is provided by the host's default logging setup.
+
+### Interfaces and Contracts
+
+- `ITile` interface — unchanged.
+- Public method signature `LoadDataAsync(Dictionary<string, string>?, CancellationToken)` — unchanged.
+- Returned anonymous-object shape (`status`, `data`, `drillDown`) — unchanged on all branches.
+- Constructor: `DataQualityStatusTile(IDqtRunRepository repository, ILogger<DataQualityStatusTile> logger)`.
+
+### Data Flow
+
+Happy path: unchanged. Exception path: `repository throws → catch (Exception ex) → _logger.LogError(ex, "Failed to load DataQuality status tile for {TestType}", DqtTestType.IssuedInvoiceComparison) → return degraded payload`. No state mutation, no propagation, no shape change.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Existing `DataQualityStatusTileTests` (3 tests) fail to compile after constructor signature change | Low | Update test fixture constructor to pass `NullLogger<DataQualityStatusTile>.Instance` (same pattern as sibling test). Validated by `dotnet build` + `dotnet test`. |
+| DI fails to resolve `ILogger<DataQualityStatusTile>` at startup | Negligible | Default ASP.NET Core host registers `ILogger<T>` automatically; sibling tile already relies on this with no special wiring. Confirm by running the app or an integration test that resolves the tile from the container. |
+| Log message inconsistency with sibling (different phrasing/properties) confuses log search | Low–Medium | Decision 1 above — match sibling's structured-property style. Use `{TestType}` placeholder. |
+| Future maintainers grep for "Failed to load yesterday DQT status" looking for both tiles | Low | Use distinctive phrasing per tile ("Failed to load DataQuality status tile" here vs. "Failed to load yesterday DQT status" in sibling) — already what the spec proposes. Each line is independently searchable. |
+
+## Specification Amendments
+
+1. **FR-2 log message** — change from the fixed-string version to one with a structured `{TestType}` property, to align with the sibling tile's actual pattern (NFR-3):
+   ```csharp
+   _logger.LogError(ex, "Failed to load DataQuality status tile for {TestType}", DqtTestType.IssuedInvoiceComparison);
+   ```
+   Sibling tile uses two properties (`{TestType}`, `{TargetDate}`); this tile has no date dimension, so only `{TestType}` applies.
+
+2. **NFR-4 testability — concrete instruction** — keep the three existing tests on `NullLogger<DataQualityStatusTile>.Instance` (mirroring sibling), and **add one new test** that constructs the tile with a `Mock<ILogger<DataQualityStatusTile>>`, triggers the catch path, and asserts `LogError` was invoked exactly once with the expected exception. The existing `LoadDataAsync_RepositoryThrows_ReturnsErrorWithRouteKey` test stays focused on return-shape; the new test focuses on log invocation. Two narrow tests beat one wide test.
+
+3. **API / Interface Design — DI registration note** — clarify that `RegisterTile<DataQualityStatusTile>()` in `DataQualityModule.cs` requires no edit. The current spec says "if registered explicitly … confirm it still resolves" — it *is* registered explicitly, but `RegisterTile<T>()` instantiates via DI, so the new logger parameter is satisfied automatically.
+
+## Prerequisites
+
+None. No migrations, no config changes, no infrastructure. The `Microsoft.Extensions.Logging` package is already a transitive dependency (used by the sibling tile in the same assembly), and `ILogger<T>` is provided by the host's default DI registration. Implementation can start immediately.

--- a/artifacts/feat-arch-review-dataquality-dataqualitystatu/brief.md
+++ b/artifacts/feat-arch-review-dataquality-dataqualitystatu/brief.md
@@ -1,0 +1,32 @@
+## Module
+DataQuality
+
+## Finding
+`DataQualityStatusTile.LoadDataAsync` (`backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs`, lines 71–74) catches all exceptions with a bare `catch` block and no logging:
+
+```csharp
+catch
+{
+    return new { status = "error", data = (object?)null, drillDown = ... };
+}
+```
+
+The class has no `ILogger` field at all. By contrast, its sibling tile `DqtYesterdayStatusTile` (same folder) correctly injects `ILogger<DqtYesterdayStatusTile>` and logs at `Error` level before returning the degraded response.
+
+## Why it matters
+- **Observability gap**: any database exception, mapping failure, or unexpected null that hits this code path disappears silently. There is no log entry, no metric, nothing to alert on. The dashboard just shows "error" with no diagnostic trail.
+- **Inconsistency**: the two companion tiles in the same module handle errors differently, making the codebase harder to reason about and increasing the chance that future maintainers copy the wrong pattern.
+
+## Suggested fix
+Inject `ILogger<DataQualityStatusTile>` in the constructor (matching the pattern in `DqtYesterdayStatusTile`) and add a `LogError` call in the catch block:
+
+```csharp
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Failed to load DataQuality status tile");
+    return new { status = "error", data = (object?)null, drillDown = ... };
+}
+```
+
+---
+_Filed by daily arch-review routine on 2026-06-02._

--- a/artifacts/feat-arch-review-dataquality-dataqualitystatu/impl/main.r1.md
+++ b/artifacts/feat-arch-review-dataquality-dataqualitystatu/impl/main.r1.md
@@ -1,0 +1,47 @@
+All tasks complete. Here is the output summary:
+
+---
+
+# Implementation: Add Structured Error Logging to DataQualityStatusTile
+
+## What was implemented
+
+Injected `ILogger<DataQualityStatusTile>` into `DataQualityStatusTile` via constructor (appended last, matching sibling convention) and replaced the silent bare `catch` block in `LoadDataAsync` with `catch (Exception ex)` + `_logger.LogError(ex, "Failed to load DataQuality status tile for {TestType}", DqtTestType.IssuedInvoiceComparison)`. The returned degraded payload shape is unchanged.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs` — added `using Microsoft.Extensions.Logging;`, `private readonly ILogger<DataQualityStatusTile> _logger;` field, updated constructor to accept `logger` as second parameter, replaced bare `catch` with `catch (Exception ex)` + structured `LogError` call
+- `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs` — added logger usings, added `Mock<ILogger<DataQualityStatusTile>> _loggerMock` field, updated constructor call to supply `_loggerMock.Object`, added new `LoadDataAsync_RepositoryThrows_LogsErrorOnce` test verifying `LogError` is called exactly once with the thrown exception
+
+## Tests
+
+- `DataQualityStatusTileTests.cs` — 4 tests total: 3 pre-existing (no-run, success, error-return-shape) + 1 new (`LoadDataAsync_RepositoryThrows_LogsErrorOnce` using Moq `Verify` on the underlying `ILogger.Log` method at `LogLevel.Error` with `Times.Once`)
+- Full DataQuality test slice: 52/52 pass
+
+## How to verify
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~DataQualityStatusTileTests"
+# Expected: 4/4 pass
+
+dotnet build Anela.Heblo.sln
+# Expected: 0 errors, 0 warnings
+```
+
+## Notes
+
+- `DataQualityModule.cs` was intentionally not modified — `RegisterTile<DataQualityStatusTile>()` resolves the new `ILogger<T>` parameter automatically through the default .NET DI container.
+- The three pre-existing tests use `_loggerMock.Object` (Moq mock) instead of `NullLogger<T>.Instance` as they now share the same fixture; this is functionally equivalent since the mock is a no-op for non-exception code paths.
+- Log message uses `{TestType}` structured property (arch-review Amendment 1) with `DqtTestType.IssuedInvoiceComparison`, matching the sibling tile's structured-property style.
+
+## PR Summary
+
+Added structured error logging to `DataQualityStatusTile.LoadDataAsync` to close the observability gap flagged by the daily arch-review routine. The tile previously swallowed every exception silently; operators saw "error" in the dashboard with no diagnostic trail. The fix injects `ILogger<DataQualityStatusTile>` via constructor and replaces the bare `catch` with `catch (Exception ex)` + `_logger.LogError(...)` using the same pattern and conventions as the sibling `DqtYesterdayStatusTile`. Public surface and response shape are unchanged.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs` — added `_logger` field, updated constructor (logger last), replaced bare catch with structured LogError
+- `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs` — updated fixture to supply logger mock, added `LoadDataAsync_RepositoryThrows_LogsErrorOnce` Moq-verified test
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-dataquality-dataqualitystatu/spec.r1.md
+++ b/artifacts/feat-arch-review-dataquality-dataqualitystatu/spec.r1.md
@@ -1,0 +1,117 @@
+# Specification: Add Structured Error Logging to DataQualityStatusTile
+
+## Summary
+Inject `ILogger<DataQualityStatusTile>` into `DataQualityStatusTile` and replace the silent bare `catch` block in `LoadDataAsync` with structured error logging. Aligns the tile's error-handling behavior with its sibling `DqtYesterdayStatusTile` so failures become diagnosable and the DataQuality module presents a consistent pattern.
+
+## Background
+The DataQuality module exposes dashboard tiles that summarize data-health signals for operators. Each tile implements a `LoadDataAsync` method that returns a status payload consumed by the frontend. When `LoadDataAsync` throws — due to database errors, mapping failures, or unexpected nulls — tiles are expected to degrade gracefully by returning a payload with `status = "error"`.
+
+`DqtYesterdayStatusTile` does this correctly: it accepts `ILogger<DqtYesterdayStatusTile>` via constructor injection and logs the exception at `Error` level before returning the degraded payload. `DataQualityStatusTile`, located in the same folder (`backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/`), does not. Its constructor takes no logger, and its catch block (lines 71–74) swallows every exception:
+
+```csharp
+catch
+{
+    return new { status = "error", data = (object?)null, drillDown = ... };
+}
+```
+
+This creates two concrete problems:
+1. **Observability gap.** Any thrown exception in this tile vanishes — no log line, no telemetry, no signal to alert on. Operators see "error" in the dashboard with zero diagnostic trail.
+2. **Inconsistency within the same module.** Two tiles in the same folder handle the same failure mode in two different ways. Future maintainers may copy the wrong pattern, propagating the silent-failure behavior to new tiles.
+
+This was filed by the daily arch-review routine on 2026-06-02.
+
+## Functional Requirements
+
+### FR-1: Inject ILogger into DataQualityStatusTile
+The `DataQualityStatusTile` class must accept `ILogger<DataQualityStatusTile>` as a constructor parameter, stored in a private readonly field following the same convention used by `DqtYesterdayStatusTile`.
+
+**Acceptance criteria:**
+- `DataQualityStatusTile` constructor declares `ILogger<DataQualityStatusTile> logger` as a parameter.
+- Logger is stored in a private readonly field (naming consistent with `DqtYesterdayStatusTile`, e.g. `_logger`).
+- DI container resolves `DataQualityStatusTile` successfully at startup (no missing registration errors).
+- Existing constructor parameters and their order remain unchanged where possible to minimize call-site churn; if reordering is unavoidable, all call sites are updated.
+
+### FR-2: Log Exceptions in LoadDataAsync Catch Block
+Replace the bare `catch` block in `LoadDataAsync` with `catch (Exception ex)` and log the exception at `Error` level before returning the existing degraded payload.
+
+**Acceptance criteria:**
+- The catch block captures the exception as `ex`.
+- `_logger.LogError(ex, "Failed to load DataQuality status tile")` is invoked before the return statement.
+- The returned payload (shape, status value, drillDown content) is unchanged — callers and the frontend see no behavioral difference on the success-or-error contract.
+- No `throw;` is added — the tile must continue to degrade gracefully rather than propagate.
+
+### FR-3: Preserve Existing Behavior
+The change must be purely additive from the caller's perspective. The tile's public surface, return shape, and status semantics remain identical.
+
+**Acceptance criteria:**
+- No public method signatures change other than the constructor.
+- The error-path return object retains the same fields and values it has today.
+- Any existing tests covering `DataQualityStatusTile` continue to pass without modification (other than supplying a logger mock to the constructor where applicable).
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. The logger call only fires on the exception path, which is already an exceptional/rare branch. Steady-state behavior is unchanged.
+
+### NFR-2: Security
+- The log message must not leak sensitive data. The fixed message `"Failed to load DataQuality status tile"` plus the exception object (which `ILogger.LogError` serializes) is acceptable.
+- Do not log raw user identifiers, connection strings, or other PII as structured properties in this call.
+
+### NFR-3: Consistency
+The implementation must match the conventions used by `DqtYesterdayStatusTile` for: field naming (`_logger`), constructor parameter ordering convention, log level (`Error`), and message phrasing style. Where a stylistic choice exists, prefer the sibling tile's choice.
+
+### NFR-4: Testability
+A unit test must be able to verify that `LogError` is invoked when `LoadDataAsync` encounters an exception, using a mocked `ILogger<DataQualityStatusTile>`.
+
+## Data Model
+No data model changes. This is a behavioral fix in a single application-layer class.
+
+## API / Interface Design
+
+### Changed file
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs`
+
+### Constructor change
+Add `ILogger<DataQualityStatusTile> logger` to the parameter list and assign it to a private readonly `_logger` field. Other existing dependencies remain.
+
+### LoadDataAsync change (lines ~71–74)
+Replace:
+```csharp
+catch
+{
+    return new { status = "error", data = (object?)null, drillDown = ... };
+}
+```
+With:
+```csharp
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Failed to load DataQuality status tile");
+    return new { status = "error", data = (object?)null, drillDown = ... };
+}
+```
+
+### DI registration
+If `DataQualityStatusTile` is registered explicitly anywhere (e.g. `AddScoped<DataQualityStatusTile>()` or in a module registration), confirm it still resolves — `ILogger<T>` is provided by the default .NET logging container and requires no additional registration.
+
+### Public API / HTTP contract
+No change. Endpoints consuming this tile see identical request/response shapes.
+
+## Dependencies
+- `Microsoft.Extensions.Logging.Abstractions` — already a transitive dependency throughout the backend; no new package references required.
+- The sibling tile `DqtYesterdayStatusTile` serves as the reference implementation for the desired pattern.
+
+## Out of Scope
+- Refactoring or restructuring `DataQualityStatusTile` beyond the logging fix.
+- Changing the response shape returned by `LoadDataAsync` on success or error.
+- Auditing every other dashboard tile in the codebase for the same anti-pattern (may be a follow-up, but is not part of this change).
+- Adding metrics, traces, or alerting beyond the `LogError` call.
+- Changing the error-handling strategy (e.g. propagating exceptions instead of swallowing them).
+- Modifying `DqtYesterdayStatusTile`.
+- Adding new tests for unrelated tile behavior; only the new logging behavior needs test coverage.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-dataquality-dataqualitystatu/task-plan.r1.md
+++ b/artifacts/feat-arch-review-dataquality-dataqualitystatu/task-plan.r1.md
@@ -1,0 +1,8 @@
+Plan saved to `docs/superpowers/plans/2026-06-03-dataqualitystatustile-structured-error-logging.md`.
+
+Three TDD-ordered tasks:
+1. **Task 1 (RED)** — add `Mock<ILogger<DataQualityStatusTile>>` to the test fixture and a new `LoadDataAsync_RepositoryThrows_LogsErrorOnce` test that fails to compile because the constructor still takes one parameter.
+2. **Task 2 (GREEN)** — inject `ILogger<DataQualityStatusTile>` (appended last per sibling convention), replace the bare `catch` with `catch (Exception ex)` + `_logger.LogError(ex, "Failed to load DataQuality status tile for {TestType}", DqtTestType.IssuedInvoiceComparison)`. Build, run the 4 tests, format, commit.
+3. **Task 3** — full DataQuality test slice + final build + clean working tree check.
+
+No `DataQualityModule.cs` edits needed (`RegisterTile<T>()` resolves the new param through DI automatically). Self-review confirms every spec FR/NFR and all three arch-review amendments map to concrete steps.

--- a/backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs
+++ b/backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.Application.Features.Dashboard.Contracts;
 using Anela.Heblo.Domain.Features.DataQuality;
 using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
 
 namespace Anela.Heblo.Application.Features.DataQuality.DashboardTiles;
 
@@ -10,6 +11,7 @@ public class DataQualityStatusTile : ITile
     private const string DrillDownRouteKey = "dataQuality";
 
     private readonly IDqtRunRepository _repository;
+    private readonly ILogger<DataQualityStatusTile> _logger;
 
     public string Title => "Kvalita dat";
     public string Description => "Stav posledního DQT testu faktur";
@@ -20,9 +22,12 @@ public class DataQualityStatusTile : ITile
     public Type ComponentType => typeof(object);
     public string[] RequiredPermissions => Array.Empty<string>();
 
-    public DataQualityStatusTile(IDqtRunRepository repository)
+    public DataQualityStatusTile(
+        IDqtRunRepository repository,
+        ILogger<DataQualityStatusTile> logger)
     {
         _repository = repository;
+        _logger = logger;
     }
 
     public async Task<object> LoadDataAsync(Dictionary<string, string>? parameters = null, CancellationToken cancellationToken = default)
@@ -62,8 +67,13 @@ public class DataQualityStatusTile : ITile
                 drillDown = new DashboardTileDrillDown { RouteKey = DrillDownRouteKey, Enabled = true }
             };
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogError(
+                ex,
+                "Failed to load DataQuality status tile for {TestType}",
+                DqtTestType.IssuedInvoiceComparison);
+
             return new
             {
                 status = "error",

--- a/backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Anela.Heblo.Application.Features.DataQuality.DashboardTiles;
 using Anela.Heblo.Domain.Features.DataQuality;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -10,11 +12,12 @@ namespace Anela.Heblo.Tests.Features.DataQuality.DashboardTiles;
 public class DataQualityStatusTileTests
 {
     private readonly Mock<IDqtRunRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<DataQualityStatusTile>> _loggerMock = new();
     private readonly DataQualityStatusTile _tile;
 
     public DataQualityStatusTileTests()
     {
-        _tile = new DataQualityStatusTile(_repositoryMock.Object);
+        _tile = new DataQualityStatusTile(_repositoryMock.Object, _loggerMock.Object);
     }
 
     [Fact]
@@ -70,6 +73,28 @@ public class DataQualityStatusTileTests
         var drillDown = doc.RootElement.GetProperty("drillDown");
         drillDown.GetProperty("routeKey").GetString().Should().Be("dataQuality");
         drillDown.GetProperty("enabled").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_RepositoryThrows_LogsErrorOnce()
+    {
+        var thrown = new InvalidOperationException("db down");
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByTestTypeAsync(
+                DqtTestType.IssuedInvoiceComparison, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        await _tile.LoadDataAsync();
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                thrown,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     private static DqtRun CreateCompletedRun(int totalChecked, int totalMismatches)

--- a/docs/superpowers/plans/2026-06-03-dataqualitystatustile-structured-error-logging.md
+++ b/docs/superpowers/plans/2026-06-03-dataqualitystatustile-structured-error-logging.md
@@ -1,0 +1,338 @@
+# DataQualityStatusTile Structured Error Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the silent bare `catch` in `DataQualityStatusTile.LoadDataAsync` with structured `ILogger.LogError`, matching the sibling `DqtYesterdayStatusTile` pattern so failures are observable.
+
+**Architecture:** Inject `ILogger<DataQualityStatusTile>` via constructor (appended last per sibling convention), capture `Exception ex` in the catch block, and log with the structured `{TestType}` property before returning the existing degraded payload. Public surface (return shape, status semantics) is unchanged. DI works automatically — `RegisterTile<T>()` already resolves all constructor params through the container, and `ILogger<T>` is provided by the default host. The only caller is the test class, which is updated to pass `NullLogger<T>.Instance` for the three existing tests; one new test verifies `LogError` is invoked using a Moq-mocked logger.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, Moq, `Microsoft.Extensions.Logging.Abstractions` (already a transitive dependency).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs` | Modify | Add `_logger` field, accept `ILogger<DataQualityStatusTile>` in constructor, replace bare `catch` with `catch (Exception ex)` + `LogError`. |
+| `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs` | Modify | Pass `NullLogger<DataQualityStatusTile>.Instance` to the constructor in the existing fixture; add one new `[Fact]` that verifies `LogError` is invoked exactly once with the thrown exception. |
+
+No other files change. `DataQualityModule.cs` is not edited — `RegisterTile<DataQualityStatusTile>()` already wires the new constructor through the container.
+
+---
+
+### Task 1: Add Logger Verification Test (RED)
+
+**Goal:** Write a failing test asserting that `LoadDataAsync` calls `ILogger.LogError` exactly once with the original exception when the repository throws. Test fails because the production class has neither a logger field nor an invocation.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs`
+
+- [ ] **Step 1: Add the using directives for the logger types**
+
+Open `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs`. After the existing `using Anela.Heblo.Domain.Features.DataQuality;` line, ensure these usings are present:
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+```
+
+Place them in alphabetical order with the existing usings so the final block reads:
+
+```csharp
+using System.Text.Json;
+using Anela.Heblo.Application.Features.DataQuality.DashboardTiles;
+using Anela.Heblo.Domain.Features.DataQuality;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+```
+
+- [ ] **Step 2: Add a `Mock<ILogger<DataQualityStatusTile>>` field and update the constructor wiring**
+
+Replace the existing field declarations and constructor block:
+
+```csharp
+    private readonly Mock<IDqtRunRepository> _repositoryMock = new();
+    private readonly DataQualityStatusTile _tile;
+
+    public DataQualityStatusTileTests()
+    {
+        _tile = new DataQualityStatusTile(_repositoryMock.Object);
+    }
+```
+
+With:
+
+```csharp
+    private readonly Mock<IDqtRunRepository> _repositoryMock = new();
+    private readonly Mock<ILogger<DataQualityStatusTile>> _loggerMock = new();
+    private readonly DataQualityStatusTile _tile;
+
+    public DataQualityStatusTileTests()
+    {
+        _tile = new DataQualityStatusTile(_repositoryMock.Object, _loggerMock.Object);
+    }
+```
+
+Note: this temporarily breaks compilation because `DataQualityStatusTile`'s constructor still takes only one parameter. Task 2 fixes that. The whole-test-project compile success comes in Step 5 of Task 2.
+
+- [ ] **Step 3: Add the new logger-verification test**
+
+Append this `[Fact]` just below the existing `LoadDataAsync_RepositoryThrows_ReturnsErrorWithRouteKey` method and above the `private static DqtRun CreateCompletedRun(...)` helper:
+
+```csharp
+    [Fact]
+    public async Task LoadDataAsync_RepositoryThrows_LogsErrorOnce()
+    {
+        var thrown = new InvalidOperationException("db down");
+
+        _repositoryMock
+            .Setup(r => r.GetLatestByTestTypeAsync(
+                DqtTestType.IssuedInvoiceComparison, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+
+        await _tile.LoadDataAsync();
+
+        _loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                thrown,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+```
+
+Why this shape: `ILogger.LogError(ex, message, args)` is an extension method that forwards to `ILogger.Log(LogLevel.Error, ...)`. Moq cannot verify extension methods directly, so the verification targets the underlying `Log` call. Matching on `thrown` ensures the exception we threw is the one logged.
+
+- [ ] **Step 4: Run the new test to verify it does not yet compile or fails as expected**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build **fails** in `Anela.Heblo.Tests` with an error like:
+
+```
+error CS1729: 'DataQualityStatusTile' does not contain a constructor that takes 2 arguments
+```
+
+This is the "RED" signal. Do **not** commit yet — Task 2 makes the test compile and pass.
+
+---
+
+### Task 2: Inject Logger and Replace Bare Catch (GREEN)
+
+**Goal:** Update `DataQualityStatusTile` to accept `ILogger<DataQualityStatusTile>`, capture `Exception ex` in the catch block, and call `_logger.LogError(...)` with the structured `{TestType}` property. After this task, the new test from Task 1 passes and the three pre-existing tests continue to pass.
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs`
+
+- [ ] **Step 1: Add the `Microsoft.Extensions.Logging` using directive**
+
+Open `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs`. The current usings are:
+
+```csharp
+using Anela.Heblo.Application.Features.Dashboard.Contracts;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Xcc.Services.Dashboard;
+```
+
+Change them to (alphabetical with the new entry):
+
+```csharp
+using Anela.Heblo.Application.Features.Dashboard.Contracts;
+using Anela.Heblo.Domain.Features.DataQuality;
+using Anela.Heblo.Xcc.Services.Dashboard;
+using Microsoft.Extensions.Logging;
+```
+
+- [ ] **Step 2: Add the `_logger` field next to `_repository`**
+
+Replace:
+
+```csharp
+    private readonly IDqtRunRepository _repository;
+```
+
+With:
+
+```csharp
+    private readonly IDqtRunRepository _repository;
+    private readonly ILogger<DataQualityStatusTile> _logger;
+```
+
+- [ ] **Step 3: Update the constructor to accept and store the logger**
+
+Replace the existing constructor:
+
+```csharp
+    public DataQualityStatusTile(IDqtRunRepository repository)
+    {
+        _repository = repository;
+    }
+```
+
+With (logger appended last, matching sibling `DqtYesterdayStatusTile`):
+
+```csharp
+    public DataQualityStatusTile(
+        IDqtRunRepository repository,
+        ILogger<DataQualityStatusTile> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+```
+
+- [ ] **Step 4: Replace the bare catch with `catch (Exception ex)` + structured `LogError`**
+
+Replace the existing catch block (currently lines ~65–73):
+
+```csharp
+        catch
+        {
+            return new
+            {
+                status = "error",
+                data = (object?)null,
+                drillDown = new DashboardTileDrillDown { RouteKey = DrillDownRouteKey, Enabled = true }
+            };
+        }
+```
+
+With:
+
+```csharp
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to load DataQuality status tile for {TestType}",
+                DqtTestType.IssuedInvoiceComparison);
+
+            return new
+            {
+                status = "error",
+                data = (object?)null,
+                drillDown = new DashboardTileDrillDown { RouteKey = DrillDownRouteKey, Enabled = true }
+            };
+        }
+```
+
+The returned anonymous object's shape, field order, and values are byte-for-byte identical to the previous block. Only the catch signature and the logging call are new.
+
+- [ ] **Step 5: Build the solution**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: **build succeeds** with no errors. Warnings unrelated to this change are acceptable.
+
+- [ ] **Step 6: Run the DataQualityStatusTile test class**
+
+Run from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~DataQualityStatusTileTests" \
+  --no-build
+```
+
+Expected: **all 4 tests pass** — the three pre-existing tests (`LoadDataAsync_NoRun_ReturnsNoDataWithRouteKey`, `LoadDataAsync_RunWithoutMismatches_ReturnsSuccessWithRouteKey`, `LoadDataAsync_RepositoryThrows_ReturnsErrorWithRouteKey`) plus the new `LoadDataAsync_RepositoryThrows_LogsErrorOnce`.
+
+- [ ] **Step 7: Run `dotnet format` to apply analyzer/style fixes**
+
+Run from the repo root:
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs
+```
+
+Expected: command completes with exit code 0. Re-run `dotnet build` if formatter changed anything to confirm it still builds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs \
+        backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs
+git commit -m "feat: log exceptions in DataQualityStatusTile.LoadDataAsync
+
+Inject ILogger<DataQualityStatusTile> via constructor and replace the bare
+catch in LoadDataAsync with catch (Exception ex) + structured LogError,
+matching the DqtYesterdayStatusTile pattern. Adds a unit test verifying
+LogError is invoked once on the exception path."
+```
+
+---
+
+### Task 3: Final Validation
+
+**Goal:** Confirm the full test project still passes (no collateral breakage outside the touched tile) and the solution builds clean. No code changes in this task.
+
+**Files:** none.
+
+- [ ] **Step 1: Run the full DataQuality test slice**
+
+Run from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Features.DataQuality" \
+  --no-build
+```
+
+Expected: **all tests pass** (DataQuality tile tests + any other DataQuality unit tests in the project). No new failures.
+
+- [ ] **Step 2: Build the solution one more time**
+
+Run from the repo root:
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with no new errors.
+
+- [ ] **Step 3: Confirm working tree is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. If anything is unexpectedly modified, investigate before continuing.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- FR-1 (inject `ILogger<DataQualityStatusTile>` into the constructor, store in `_logger`) → Task 2 Steps 2–3.
+- FR-2 (replace bare catch with `catch (Exception ex)` and log at Error level before returning the degraded payload) → Task 2 Step 4.
+- FR-3 (purely additive from caller perspective, return shape unchanged) → Task 2 Step 4 preserves the anonymous-object literal byte-for-byte; Task 2 Step 6 reruns the existing tests that assert the shape.
+- NFR-1 (no perf impact) → covered by leaving the happy path untouched (verified by existing `NoRun` and `RunWithoutMismatches` tests in Task 2 Step 6).
+- NFR-2 (no PII / secret leakage) → only `DqtTestType` enum value is logged as a structured property, plus the exception itself. No user identifiers, no connection strings.
+- NFR-3 (consistency with sibling) → Task 2 mirrors `DqtYesterdayStatusTile` for field name (`_logger`), constructor ordering (logger last), log level (`Error`), and structured-property style (`{TestType}`).
+- NFR-4 (testability) → Task 1 Step 3 adds the explicit Moq-based `LogError` verification.
+- Arch-review Amendment 1 (use structured `{TestType}` property instead of fixed string) → Task 2 Step 4 uses `"Failed to load DataQuality status tile for {TestType}"`.
+- Arch-review Amendment 2 (keep existing tests on NullLogger / Moq mirror, add a dedicated `LogError` verification test) → Task 1 Step 2 swaps to `Mock<ILogger<T>>` (acceptable because Moq's mock acts as a no-op for the three existing return-shape tests, equivalent to NullLogger behavior for them) and Task 1 Step 3 adds the dedicated verification test. Note: arch-review preferred `NullLogger` for the three pre-existing tests; using a Moq mock that is silently called by them is functionally equivalent and avoids duplicate logger fields. The verification test (`Times.Once`) still passes because the three other tests do not trigger the catch path.
+- Arch-review Amendment 3 (no `DataQualityModule.cs` edit required) → reflected in File Structure (`DataQualityModule.cs` intentionally not modified).
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", "add appropriate error handling", "similar to Task N", or empty test stubs. Every code step has full source. Every command has expected output described.
+
+**Type consistency:**
+- `ILogger<DataQualityStatusTile>` is used identically in production (Task 2 Step 2 field, Step 3 constructor) and tests (Task 1 Step 2 field).
+- `_logger` field name matches sibling and is used consistently.
+- `DqtTestType.IssuedInvoiceComparison` matches the enum value already used by the repository call on line 32 of the production file and by every existing test fixture.
+- Constructor signature `(IDqtRunRepository repository, ILogger<DataQualityStatusTile> logger)` is the same in production declaration (Task 2 Step 3) and test instantiation (Task 1 Step 2).
+- Test method name `LoadDataAsync_RepositoryThrows_LogsErrorOnce` follows the existing `LoadDataAsync_*` xUnit naming convention in the same file.


### PR DESCRIPTION

Added structured error logging to `DataQualityStatusTile.LoadDataAsync` to close the observability gap flagged by the daily arch-review routine. The tile previously swallowed every exception silently; operators saw "error" in the dashboard with no diagnostic trail. The fix injects `ILogger<DataQualityStatusTile>` via constructor and replaces the bare `catch` with `catch (Exception ex)` + `_logger.LogError(...)` using the same pattern and conventions as the sibling `DqtYesterdayStatusTile`. Public surface and response shape are unchanged.

### Changes
- `backend/src/Anela.Heblo.Application/Features/DataQuality/DashboardTiles/DataQualityStatusTile.cs` — added `_logger` field, updated constructor (logger last), replaced bare catch with structured LogError
- `backend/test/Anela.Heblo.Tests/Features/DataQuality/DashboardTiles/DataQualityStatusTileTests.cs` — updated fixture to supply logger mock, added `LoadDataAsync_RepositoryThrows_LogsErrorOnce` Moq-verified test

---

Closes #2350

### Tokens used
6114677
