### PR TITLE
feat: Correct DataQuality Feature Documentation Schedule Section

### DIFF
--- a/artifacts/feat-arch-review-dataquality-feature-doc-desc/arch-review.r1.md
+++ b/artifacts/feat-arch-review-dataquality-feature-doc-desc/arch-review.r1.md
@@ -1,0 +1,136 @@
+# Architecture Review: Correct DataQuality Feature Documentation Schedule Section
+
+## Skip Design: true
+
+No UI/UX work — Markdown copy edits to an existing feature doc. No new components, screens, or visual decisions.
+
+## Architectural Fit Assessment
+
+The change aligns cleanly with the project's documentation conventions:
+
+- `docs/features/data-quality-dqt.md` is the canonical per-feature reference for the DataQuality module (matches the `docs/features/` convention recorded in `CLAUDE.md`).
+- The doc is reference-style (sections for Overview, Schedule, API, Architecture, Known constraints) — not a tutorial, not a changelog. The fix preserves that shape.
+- The source of truth for runtime behavior is `InvoiceDqtJob.cs` and the surrounding Hangfire infrastructure under `Anela.Heblo.API/Infrastructure/Hangfire/` + `Anela.Heblo.Domain/Features/BackgroundJobs/`. No other doc, ADR, or memory file restates the cadence, so this is the single point where the drift must be repaired.
+- Integration points are zero (no code, no migration, no API surface). The only "consumer" of the change is human readers of the doc.
+
+The only architectural choice that matters here is **what to assert about timezone**, because both the brief ("05:00 UTC") and the spec ("server time") are imprecise vs. what the code actually does.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+docs/features/data-quality-dqt.md   ← single file edited
+            ▲
+            │ (factual claims must trace to)
+            │
+backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/
+   InvoiceDqtJob.cs                 ← source of truth for cadence, window, names
+backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs
+                                    ← source of truth for default TimeZoneId
+```
+
+No new components. No relationships change.
+
+### Key Design Decisions
+
+#### Decision 1: Timezone wording in the Schedule section
+
+**Options considered:**
+1. "daily at 05:00 UTC" — what the brief proposed.
+2. "daily at 05:00 server time" — what the spec hedged to.
+3. "daily at 05:00 Europe/Prague" — what the code actually does.
+
+**Chosen approach:** Option 3. State **"daily at 05:00 Europe/Prague"**.
+
+**Rationale:** `InvoiceDqtJob.Metadata` does not override `TimeZoneId`, so it inherits `RecurringJobMetadata.DefaultTimeZoneId = "Europe/Prague"` (`backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs:36`). The Hangfire registration pipeline (`HangfireJobRegistrationHelper.cs:83`) passes that as a `TimeZoneInfo` to `RecurringJob.AddOrUpdate`, so the cron `0 5 * * *` fires at 05:00 Prague local time. "UTC" is wrong (would actually fire at 07:00 Prague in winter). "Server time" is ambiguous — the doc is for humans reasoning about operational windows and should name the timezone explicitly. "Europe/Prague" is unambiguous, matches the IANA ID used in code, and stays correct across DST.
+
+#### Decision 2: Where the daily-window fact lives
+
+**Options considered:**
+1. State the window only in the Schedule section and drop the "Known constraints" bullet entirely (FR-4 option b).
+2. Keep a constraint bullet that re-states the window.
+
+**Chosen approach:** Option 1 — drop the bullet (FR-4 option b).
+
+**Rationale:** The current "Known constraints" bullet about the comparison window is not a constraint — it is the scheduled job's normal operating envelope, which belongs in Schedule. The other two bullets in that section ("Flexi `Code` field…", "Large date ranges hold both sets in memory…") are genuine constraints that surprise readers. Re-stating the daily window there duplicates the Schedule section and re-creates the same drift risk the bug exposed. One fact, one home.
+
+#### Decision 3: Treat the doc as describing the scheduled job, not the comparer
+
+**Options considered:**
+1. Edit Schedule/Overview/Architecture to describe the scheduled job's behavior (daily, one day).
+2. Edit to describe the comparer's *capability* (arbitrary date range) and separately note what the schedule pins it to.
+
+**Chosen approach:** Option 1, with a one-line acknowledgement that the manual trigger can use any range (already implied by `POST /api/data-quality/runs`, no rewording needed beyond what FR-1 already preserves).
+
+**Rationale:** The bug was about the *scheduled* behavior. Expanding scope to re-document the comparer's range flexibility violates the "surgical change" rule (NFR-3) and the project's "touch only what the task requires" guidance. The spec already captured this correctly.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+Single file edited:
+
+- `docs/features/data-quality-dqt.md`
+
+No new files. No code, tests, migrations, or build configuration touched. Do not create a changelog, ADR, or memory entry for this fix — it is doc-debt repayment, not a decision.
+
+### Interfaces and Contracts
+
+No code interfaces change. The doc-to-code contract that must hold after the edit:
+
+| Doc claim | Authoritative source |
+|-----------|---------------------|
+| Cadence: daily at 05:00 Europe/Prague | `InvoiceDqtJob.Metadata.CronExpression` + `RecurringJobMetadata.DefaultTimeZoneId` |
+| Job identity: `daily-invoice-dqt` / `InvoiceDqtJob` | `InvoiceDqtJob.Metadata.JobName`, class name |
+| Window: previous calendar day (single day) | `InvoiceDqtJob.ExecuteAsync` lines 44, 48 |
+| Manual trigger: `POST /api/data-quality/runs` | `DataQualityController` (already in the doc's API table) |
+
+Every other factual claim in the file is out of scope.
+
+### Data Flow
+
+Unchanged. No data, no requests, no jobs are altered.
+
+For the reader-flow the doc serves (what FR-1…FR-5 actually fix):
+
+```
+Reader debugging "where are today's DQT results?"
+    │
+    ▼
+Reads Schedule section
+    │
+    ├── Before fix: looks for results on Monday → wrong day, wrong window → false alarm
+    │
+    └── After fix: knows job ran ~05:00 Prague, covers yesterday only → checks correct run
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Future schedule change re-introduces the same drift (cron edited without doc edit) | MEDIUM | Out of scope to enforce here; flag to user as a follow-up candidate (e.g. a test or PR-check that asserts doc claims against `InvoiceDqtJob.Metadata`). Do **not** add such a test as part of this change. |
+| Writing "CEST" or "UTC" instead of "Europe/Prague" reintroduces a subtler inaccuracy | HIGH | Decision 1 above pins the wording. Reviewer should grep the diff for `CEST`, `UTC`, `CET`, `server time` and reject any of them. |
+| Scope creep: editing the comparer narrative, the in-memory constraint, or the Flexi `Code` bullet | MEDIUM | NFR-3 ("surgical change") plus FR-5's grep check. Diff should be limited to the five edit points enumerated in FR-1…FR-4. |
+| Reader assumes "previous calendar day" means Europe/Prague calendar day | LOW | True (the job uses `DateTime.Today` which is server-local, and the container TZ is Europe/Prague). No extra wording needed; the timezone in the Schedule line carries enough context. |
+
+## Specification Amendments
+
+1. **FR-1 / FR-2 timezone wording.** Replace the spec's phrasing "*05:00 (server time — see Open Questions on timezone phrasing)*" with **"05:00 Europe/Prague"**, and remove the now-stale "Open Questions" hedge. Justification: `InvoiceDqtJob` does not override `RecurringJobMetadata.TimeZoneId`, which defaults to `Europe/Prague` (`RecurringJobMetadata.cs:36`). The brief's suggested "05:00 UTC" is also wrong and should not be carried over.
+
+2. **FR-4 resolution.** Adopt option (b) — **delete** the "*The weekly job compares the previous 7 days by default.*" bullet rather than rewriting it. The Schedule section already carries the single-day fact after FR-1; a constraint bullet duplicating it is the same anti-pattern that produced the original drift. The spec leaves this as an "either/or"; pin it.
+
+3. **FR-5 grep list.** Extend the check tokens to include `CEST`, `CET`, `UTC` (in the schedule context only — the API table or unrelated prose may legitimately use UTC elsewhere if present). Any survivor of those terms describing the scheduled job's clock is a defect.
+
+4. **NFR-1 traceability addition.** Add `RecurringJobMetadata.DefaultTimeZoneId` to the list of authoritative sources, alongside `InvoiceDqtJob.cs`. The timezone claim does not live in `InvoiceDqtJob` and the spec should not pretend otherwise.
+
+5. **No new sections.** The spec is otherwise complete. Do not add an ADR, decision log, or memory entry — this is doc-debt repayment, not a design decision.
+
+## Prerequisites
+
+None. This change is fully self-contained:
+
+- No migration, config, secret, or infrastructure change.
+- No build, test, or deployment step required beyond the project's standard "doc-only PR" path.
+- `dotnet build` / `dotnet format` / `npm run build` / `npm run lint` from `CLAUDE.md`'s validation gate are not applicable (no code touched); a Markdown render check (visual scan of the rendered file) is sufficient.
+- No coordination with other in-flight work — the surrounding DataQuality commits on this branch's history (drill-down route unification, scheduled run persistence, `InvoiceDqtComparer` decoupling) are independent and do not affect cadence or window semantics.

--- a/artifacts/feat-arch-review-dataquality-feature-doc-desc/brief.md
+++ b/artifacts/feat-arch-review-dataquality-feature-doc-desc/brief.md
@@ -1,0 +1,41 @@
+## Module
+DataQuality
+
+## Finding
+`docs/features/data-quality-dqt.md` (lines 34–36) documents the invoice DQT job as weekly:
+
+> **Automatic**: every Monday at 23:00 CEST via Hangfire recurring job (`InvoiceDqtJob`)
+> …
+> The weekly job compares the previous 7 days by default.
+
+The actual implementation in `InvoiceDqtJob` (`backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/InvoiceDqtJob.cs`, lines 15–22) contradicts this on every dimension:
+
+```csharp
+CronExpression = "0 5 * * *",  // Daily at 5:00 AM — not weekly/Monday at 23:00
+Description = "Compares issued invoices between Shoptet and ABRA Flexi for the previous day"
+```
+
+And the job body (lines 44–45) confirms the single-day window:
+
+```csharp
+var yesterday = DateOnly.FromDateTime(DateTime.Today.AddDays(-1));
+var run = DqtRun.Start(DqtTestType.IssuedInvoiceComparison, yesterday, yesterday, DqtTriggerType.Scheduled);
+```
+
+## Why it matters
+- **Operational confusion**: anyone reading the doc to understand when the job runs, or how wide a date range it covers, will reach wrong conclusions. This matters for debugging missing results or scheduling manual re-runs.
+- **Stale documentation as a hazard**: the discrepancy suggests the schedule was changed (from weekly to daily) but the doc was not updated. As the gap widens over time it becomes harder to trust any part of the feature doc.
+
+## Suggested fix
+Update `docs/features/data-quality-dqt.md` — Schedule section — to reflect the actual behaviour:
+
+```
+- **Automatic**: daily at 05:00 UTC via Hangfire recurring job (`InvoiceDqtJob`)
+- Each run covers the previous calendar day.
+- **Manual trigger**: `POST /api/data-quality/runs`
+```
+
+Also update the "Known constraints" bullet that mentions "The weekly job compares the previous 7 days by default."
+
+---
+_Filed by daily arch-review routine on 2026-06-02._

--- a/artifacts/feat-arch-review-dataquality-feature-doc-desc/impl/main.r1.md
+++ b/artifacts/feat-arch-review-dataquality-feature-doc-desc/impl/main.r1.md
@@ -1,0 +1,46 @@
+All tasks complete. Here is the output summary:
+
+---
+
+# Implementation: Correct DataQuality Feature Documentation Schedule Section
+
+## What was implemented
+
+Four surgical edits to `docs/features/data-quality-dqt.md` to align the Schedule, Overview, Architecture, and Known constraints sections with the actual `InvoiceDqtJob` implementation. The document previously described a weekly Monday 23:00 CEST job covering 7 days; it now accurately reflects the daily 05:00 Europe/Prague job covering the previous calendar day.
+
+## Files created/modified
+
+- `docs/features/data-quality-dqt.md` — four edits: Overview word change, Schedule bullet rewrite, Architecture word change, stale Known constraints bullet deleted
+
+## Tests
+
+No tests — documentation-only change. Verification performed via grep sweeps confirming zero stale terms and three positive `daily` assertions.
+
+## How to verify
+
+```bash
+cd /path/to/worktree
+grep -in "weekly\|monday\|23:00\|7 days\|CEST\|CET\|UTC\|server time" docs/features/data-quality-dqt.md
+# → zero matches
+
+grep -n "daily" docs/features/data-quality-dqt.md
+# → 3 matches: line 5 (Overview), line 34 (Schedule), line 55 (Architecture)
+
+awk '/^## Known constraints/,/^## /{print}' docs/features/data-quality-dqt.md | grep -c '^- '
+# → 2
+```
+
+## Notes
+
+No deviations from spec. Timezone stated as `Europe/Prague` (traced to `RecurringJobMetadata.DefaultTimeZoneId`). Known constraints bullet deleted per arch-review Decision 2 (not rewritten). No code, build, test, or deployment changes.
+
+## PR Summary
+
+Aligns the DataQuality feature doc with the actual `InvoiceDqtJob` schedule. The doc described a weekly Monday 23:00 CEST job covering the previous 7 days; the code runs daily at 05:00 Europe/Prague (cron `0 5 * * *`) covering only the previous calendar day. Stale wording in four locations (Overview, Schedule, Architecture, Known constraints) is corrected with minimal, surgical edits.
+
+### Changes
+- `docs/features/data-quality-dqt.md` — Overview: `weekly` → `daily`; Schedule bullet: rewritten with correct cadence, timezone, job name, and window; Architecture `InvoiceDqtJob` bullet: `weekly` → `daily`; Known constraints: stale "previous 7 days" bullet removed
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-dataquality-feature-doc-desc/spec.r1.md
+++ b/artifacts/feat-arch-review-dataquality-feature-doc-desc/spec.r1.md
@@ -1,0 +1,88 @@
+# Specification: Correct DataQuality Feature Documentation Schedule Section
+
+## Summary
+Update `docs/features/data-quality-dqt.md` so its schedule and constraints sections match the actual `InvoiceDqtJob` implementation. The doc currently describes a weekly Monday 23:00 CEST run covering the previous 7 days, but the code runs daily at 05:00 covering only the previous calendar day. This is a documentation-only change — no code is modified.
+
+## Background
+A daily architecture review (`brief.md`, filed 2026-06-02) flagged a contradiction between the feature documentation and the implementation:
+
+- **Doc** (`docs/features/data-quality-dqt.md` lines 5, 34, 55, 76) claims a **weekly** Hangfire job running **Mondays at 23:00 CEST** with a **7-day default window**.
+- **Code** (`backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/InvoiceDqtJob.cs` lines 15–22, 44, 48) defines a **daily** job at `0 5 * * *` (05:00 server time) named `daily-invoice-dqt` / "Daily Invoice Data Quality Test", and the job body invokes `DqtRun.Start(..., yesterday, yesterday, ...)`, covering exactly one day (the previous calendar day).
+
+The drift suggests the schedule was changed from weekly to daily without updating the documentation. Stale docs in this area are operationally hazardous: anyone using the doc to debug missing results, reason about coverage windows, or schedule manual re-runs will reach wrong conclusions.
+
+## Functional Requirements
+
+### FR-1: Correct the "Schedule" section
+Replace the contents of the **Schedule** section in `docs/features/data-quality-dqt.md` (lines 32–35) so it accurately describes the implemented behavior.
+
+**Acceptance criteria:**
+- Section states the job runs **daily at 05:00** (server time — see Open Questions on timezone phrasing).
+- Section identifies the recurring job by its actual `JobName` (`daily-invoice-dqt`) and class (`InvoiceDqtJob`).
+- Section states each run covers the **previous calendar day** (a single day).
+- Manual trigger bullet (`POST /api/data-quality/runs`) is preserved.
+- No mention of "weekly", "Monday", or "23:00 CEST" remains in this section.
+
+### FR-2: Correct the "Overview" section
+The Overview paragraph (line 5) currently ends with *"…runs automatically on a weekly Hangfire schedule."* Update it to reflect the daily schedule.
+
+**Acceptance criteria:**
+- The Overview paragraph no longer uses the word "weekly" for the Hangfire schedule.
+- The wording stays consistent with the updated Schedule section (daily).
+
+### FR-3: Correct the "Architecture" section bullet for `InvoiceDqtJob`
+Line 55 currently reads: *"`InvoiceDqtJob` — Hangfire `IRecurringJob` that schedules weekly runs"*. Update so it does not say "weekly".
+
+**Acceptance criteria:**
+- Bullet describes `InvoiceDqtJob` as the Hangfire `IRecurringJob` that schedules **daily** runs (or equivalent wording matching FR-1).
+
+### FR-4: Correct the "Known constraints" bullet about the default window
+The constraint bullet (line 76) currently reads: *"The weekly job compares the previous 7 days by default."* This is wrong on both the cadence and the window size.
+
+**Acceptance criteria:**
+- The bullet either (a) is replaced with one stating the scheduled job compares only the previous calendar day, or (b) is removed if FR-1 already conveys the same information, to avoid duplication.
+- No remaining "previous 7 days" wording in the document.
+
+### FR-5: Sweep for any other "weekly" / "Monday" / "7 days" references
+Ensure no other location in `docs/features/data-quality-dqt.md` still implies a weekly cadence or a multi-day default window.
+
+**Acceptance criteria:**
+- `grep -i -n "weekly\|monday\|23:00\|7 days\|seven days"` over the file returns no matches that describe the scheduled job's cadence or window.
+- Any remaining matches (e.g. in unrelated explanatory text) are deliberate and accurate.
+
+## Non-Functional Requirements
+
+### NFR-1: Accuracy
+Every factual claim in the updated sections must be traceable to either `InvoiceDqtJob.cs` (cadence, window, job name, description) or to the API surface that's already documented elsewhere in the same file. No new claims that are not backed by code.
+
+### NFR-2: Style consistency
+- Match the existing Markdown structure (heading levels, bullet style, code-fence usage) used elsewhere in the file.
+- Keep the section terse — this is a reference doc, not a tutorial.
+- Use the same tone as the surrounding sections; do not introduce changelog-style remarks (e.g. "previously this was weekly") in the doc itself.
+
+### NFR-3: Surgical change
+Per project coding behavior rules, touch only the lines required by FR-1 through FR-5. Do not rewrite or restyle unrelated sections, even if they could be improved.
+
+## Data Model
+Not applicable — documentation-only change.
+
+## API / Interface Design
+Not applicable — no API changes. The existing `POST /api/data-quality/runs` manual trigger is referenced by the doc but not modified.
+
+## Dependencies
+- Read-only reference: `backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/InvoiceDqtJob.cs` — source of truth for cadence, window, job name, and description.
+- File to edit: `docs/features/data-quality-dqt.md`.
+- No code, build, test, or deployment dependencies.
+
+## Out of Scope
+- Any change to `InvoiceDqtJob.cs` or its cron expression. If the *intent* was actually weekly and the code is the bug, that is a separate decision and a separate change — this spec only aligns the doc with current code.
+- Any change to other DataQuality docs, comparison logic, or schema.
+- Backfilling historical run data or revisiting the trigger types (`Scheduled` vs `Manual`).
+- Reviewing or updating the manual trigger payload shape.
+- Updating any unrelated "Known constraints" bullets (e.g. the Flexi `Code` field bullet, the in-memory sizing bullet).
+- Translation or localization of the doc.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-dataquality-feature-doc-desc/task-plan.r1.md
+++ b/artifacts/feat-arch-review-dataquality-feature-doc-desc/task-plan.r1.md
@@ -1,0 +1,15 @@
+Plan saved to `docs/superpowers/plans/2026-06-03-data-quality-dqt-doc-schedule-fix.md`.
+
+**Summary of the plan:**
+
+- Six tasks, all touching the single file `docs/features/data-quality-dqt.md`.
+- Task 1 — Overview line: `weekly` → `daily` (one word).
+- Task 2 — Schedule section: rewrite the automatic-trigger bullet to `daily at 05:00 Europe/Prague via Hangfire recurring job daily-invoice-dqt (InvoiceDqtJob). Each run covers the previous calendar day.`
+- Task 3 — Architecture bullet for `InvoiceDqtJob`: `weekly runs` → `daily runs`.
+- Task 4 — Delete the stale "Known constraints" bullet (per arch-review Decision 2: removal, not rewrite).
+- Task 5 — Full-file grep sweep over the extended token list (`weekly`, `Monday`, `23:00`, `7 days`, `seven days`, `CEST`, `CET`, `UTC`, `server time`) — expects zero matches — plus positive assertions for `daily` and a Markdown render check.
+- Task 6 — Verify the staged diff is exactly the four edit points, then a single conventional commit and push.
+
+The plan locks in the architecture review's three amendments: timezone is stated as `Europe/Prague` (traced to `RecurringJobMetadata.DefaultTimeZoneId`), FR-4 is resolved as deletion, and FR-5's grep list is extended. No code, build, test, or deployment steps are required.
+
+Per the pipeline note, skipping the execution-handoff prompt.

--- a/docs/features/data-quality-dqt.md
+++ b/docs/features/data-quality-dqt.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The DQT feature runs automated data quality checks that compare issued invoices between Shoptet and Abra Flexi for a defined time period. It surfaces mismatches on a dashboard tile and a dedicated `/data-quality` page, and runs automatically on a weekly Hangfire schedule.
+The DQT feature runs automated data quality checks that compare issued invoices between Shoptet and Abra Flexi for a defined time period. It surfaces mismatches on a dashboard tile and a dedicated `/data-quality` page, and runs automatically on a daily Hangfire schedule.
 
 ## How it works
 
@@ -31,7 +31,7 @@ Item-level comparison matches lines by product code. Items without a product cod
 
 ## Schedule
 
-- **Automatic**: every Monday at 23:00 CEST via Hangfire recurring job (`InvoiceDqtJob`)
+- **Automatic**: daily at 05:00 Europe/Prague via Hangfire recurring job `daily-invoice-dqt` (`InvoiceDqtJob`). Each run covers the previous calendar day.
 - **Manual trigger**: `POST /api/data-quality/runs`
 
 ## API
@@ -52,7 +52,7 @@ Item-level comparison matches lines by product code. Items without a product cod
 **Application** (`Anela.Heblo.Application/Features/DataQuality/`):
 - `InvoiceDqtComparer` — fetches both sources and produces `InvoiceDqtComparisonResult`
 - `InvoiceDqtJobRunner` — orchestrates a full run: creates `DqtRun`, calls comparer, persists results, updates status
-- `InvoiceDqtJob` — Hangfire `IRecurringJob` that schedules weekly runs
+- `InvoiceDqtJob` — Hangfire `IRecurringJob` that schedules daily runs
 - Use cases: `GetDqtRuns`, `GetDqtRunDetail`, `RunDqt`
 
 **Persistence** (`Anela.Heblo.Persistence/DataQuality/`):
@@ -73,5 +73,4 @@ Item-level comparison matches lines by product code. Items without a product cod
 ## Known constraints
 
 - Flexi item `Code` field is not reliably preserved on read-back; `PriceList` (`code:PRODUCT-CODE`) is used as the authoritative product identifier instead.
-- The weekly job compares the previous 7 days by default.
 - Large date ranges (thousands of invoices) hold both full sets in memory simultaneously.

--- a/docs/superpowers/plans/2026-06-03-data-quality-dqt-doc-schedule-fix.md
+++ b/docs/superpowers/plans/2026-06-03-data-quality-dqt-doc-schedule-fix.md
@@ -1,0 +1,383 @@
+# DataQuality Doc Schedule Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the Schedule, Overview, Architecture and Known-constraints wording in `docs/features/data-quality-dqt.md` with the actual `InvoiceDqtJob` implementation (daily 05:00 Europe/Prague, single-day window).
+
+**Architecture:** Documentation-only, surgical edit to one Markdown file. No code, build, test, deployment, migration, secret, or config changes. Every factual claim traces to `InvoiceDqtJob.cs` (cadence, window, job name/description) and `RecurringJobMetadata.cs` (default timezone).
+
+**Tech Stack:** Markdown. No tools beyond a text editor, `grep`, and `git`.
+
+---
+
+## Context
+
+### Source of truth (read-only — do not modify)
+
+- `backend/src/Anela.Heblo.Application/Features/DataQuality/Infrastructure/Jobs/InvoiceDqtJob.cs`
+  - Line 17 — `JobName = "daily-invoice-dqt"`
+  - Line 18 — `DisplayName = "Daily Invoice Data Quality Test"`
+  - Line 19 — `Description = "Compares issued invoices between Shoptet and ABRA Flexi for the previous day"`
+  - Line 20 — `CronExpression = "0 5 * * *"` (daily at 05:00)
+  - Line 44 — `var yesterday = DateOnly.FromDateTime(DateTime.Today.AddDays(-1));`
+  - Line 48 — `DqtRun.Start(DqtTestType.IssuedInvoiceComparison, yesterday, yesterday, DqtTriggerType.Scheduled);` — window is `[yesterday, yesterday]`, i.e. one calendar day.
+  - `Metadata` does **not** set `TimeZoneId`, so it inherits the default.
+- `backend/src/Anela.Heblo.Domain/Features/BackgroundJobs/RecurringJobMetadata.cs`
+  - Line 36 — `public const string DefaultTimeZoneId = "Europe/Prague";`
+  - Line 41 — `public string TimeZoneId { get; init; } = DefaultTimeZoneId;`
+
+### File to edit
+
+- `docs/features/data-quality-dqt.md` — five edit points, enumerated below.
+
+### Decisions locked by the architecture review
+
+| Decision | Pinned value | Source |
+|----------|--------------|--------|
+| Timezone wording | `Europe/Prague` (not "UTC", not "server time", not "CET/CEST") | arch-review Decision 1 |
+| Daily-window fact location | Schedule section only; **delete** the duplicate "Known constraints" bullet | arch-review Decision 2 + FR-4 option (b) |
+| Scope | The doc describes the *scheduled* job's behavior; do not re-document the comparer's arbitrary-range capability | arch-review Decision 3 |
+
+### Out of scope (do not touch)
+
+- The Mismatch types table, the API table, the Architecture bullets other than the single `InvoiceDqtJob` line, the Flexi `Code` bullet, and the in-memory sizing bullet.
+- `InvoiceDqtJob.cs` cron or window — this plan does **not** change behavior.
+- Any new ADR, changelog, memory entry, or test asserting doc-vs-code.
+
+---
+
+## File Structure
+
+Only one file changes. No new files. No deletions.
+
+| Path | Action | Lines touched (pre-edit) | Responsibility after edit |
+|------|--------|--------------------------|---------------------------|
+| `docs/features/data-quality-dqt.md` | Modify | 5, 32–35, 55, 76 | Accurately describes the daily 05:00 Europe/Prague job covering yesterday |
+
+---
+
+## Task 1: Fix the Overview paragraph (FR-2)
+
+**Files:**
+- Modify: `docs/features/data-quality-dqt.md:5`
+
+Removes the "weekly Hangfire schedule" phrase so the Overview matches what the scheduled job actually does. Wording stays terse and consistent with the Schedule section produced in Task 2.
+
+- [ ] **Step 1: Apply the edit**
+
+Replace the exact string:
+
+```
+The DQT feature runs automated data quality checks that compare issued invoices between Shoptet and Abra Flexi for a defined time period. It surfaces mismatches on a dashboard tile and a dedicated `/data-quality` page, and runs automatically on a weekly Hangfire schedule.
+```
+
+with:
+
+```
+The DQT feature runs automated data quality checks that compare issued invoices between Shoptet and Abra Flexi for a defined time period. It surfaces mismatches on a dashboard tile and a dedicated `/data-quality` page, and runs automatically on a daily Hangfire schedule.
+```
+
+(Single word change: `weekly` → `daily`. Nothing else on this line changes.)
+
+- [ ] **Step 2: Verify the edit**
+
+Run:
+
+```bash
+grep -n "weekly Hangfire schedule\|daily Hangfire schedule" docs/features/data-quality-dqt.md
+```
+
+Expected:
+
+- Exactly **one** match, containing `daily Hangfire schedule`, on the Overview line.
+- **No** match containing `weekly Hangfire schedule`.
+
+- [ ] **Step 3: Stage the change (do not commit yet — Task 6 commits the full diff)**
+
+```bash
+git add docs/features/data-quality-dqt.md
+```
+
+---
+
+## Task 2: Rewrite the Schedule section (FR-1)
+
+**Files:**
+- Modify: `docs/features/data-quality-dqt.md:32-35`
+
+Replaces the incorrect "every Monday at 23:00 CEST" bullet with the actual cadence (daily 05:00 Europe/Prague), the actual window (previous calendar day), and the actual job identity (`daily-invoice-dqt` / `InvoiceDqtJob`). Manual-trigger bullet is preserved verbatim.
+
+- [ ] **Step 1: Apply the edit**
+
+Replace the exact block:
+
+```
+## Schedule
+
+- **Automatic**: every Monday at 23:00 CEST via Hangfire recurring job (`InvoiceDqtJob`)
+- **Manual trigger**: `POST /api/data-quality/runs`
+```
+
+with:
+
+```
+## Schedule
+
+- **Automatic**: daily at 05:00 Europe/Prague via Hangfire recurring job `daily-invoice-dqt` (`InvoiceDqtJob`). Each run covers the previous calendar day.
+- **Manual trigger**: `POST /api/data-quality/runs`
+```
+
+Notes:
+
+- The job name `daily-invoice-dqt` comes from `InvoiceDqtJob.Metadata.JobName` (line 17 of the source file).
+- The timezone is `Europe/Prague` because `InvoiceDqtJob.Metadata` does not set `TimeZoneId`, so it inherits `RecurringJobMetadata.DefaultTimeZoneId`.
+- Do not add a parenthetical like "(formerly weekly)" or any changelog-style remark — NFR-2 forbids changelog tone in the doc.
+
+- [ ] **Step 2: Verify the edit**
+
+Run:
+
+```bash
+grep -in "Monday\|23:00\|CEST\|CET\|UTC\|server time\|weekly" docs/features/data-quality-dqt.md
+```
+
+Expected: **zero** matches anywhere in the file.
+
+Then run:
+
+```bash
+grep -n "daily at 05:00 Europe/Prague" docs/features/data-quality-dqt.md
+grep -n "daily-invoice-dqt" docs/features/data-quality-dqt.md
+grep -n "previous calendar day" docs/features/data-quality-dqt.md
+```
+
+Expected: each of the three greps returns exactly one match, all on the Schedule line.
+
+- [ ] **Step 3: Stage the change**
+
+```bash
+git add docs/features/data-quality-dqt.md
+```
+
+---
+
+## Task 3: Fix the Architecture bullet for `InvoiceDqtJob` (FR-3)
+
+**Files:**
+- Modify: `docs/features/data-quality-dqt.md:55`
+
+Updates the single-line description of `InvoiceDqtJob` in the Architecture section so it no longer says "weekly". Other Architecture bullets are out of scope.
+
+- [ ] **Step 1: Apply the edit**
+
+Replace the exact line:
+
+```
+- `InvoiceDqtJob` — Hangfire `IRecurringJob` that schedules weekly runs
+```
+
+with:
+
+```
+- `InvoiceDqtJob` — Hangfire `IRecurringJob` that schedules daily runs
+```
+
+(Single word change: `weekly` → `daily`. Indentation, bullet style, and backticks unchanged.)
+
+- [ ] **Step 2: Verify the edit**
+
+Run:
+
+```bash
+grep -n "InvoiceDqtJob.*IRecurringJob" docs/features/data-quality-dqt.md
+```
+
+Expected: exactly one match, containing `daily runs`, not `weekly runs`.
+
+- [ ] **Step 3: Stage the change**
+
+```bash
+git add docs/features/data-quality-dqt.md
+```
+
+---
+
+## Task 4: Delete the stale "Known constraints" bullet (FR-4)
+
+**Files:**
+- Modify: `docs/features/data-quality-dqt.md:76`
+
+Per the architecture review (Decision 2 + Specification Amendment 2), the "weekly job compares the previous 7 days" bullet is replaced by **removal**, not rewriting. The single-day fact lives in the Schedule section (Task 2); restating it here re-creates the duplication that caused the original drift. The bullet is also factually wrong on both cadence and window.
+
+- [ ] **Step 1: Apply the edit**
+
+Delete the exact line (including the leading `- ` and trailing newline):
+
+```
+- The weekly job compares the previous 7 days by default.
+```
+
+After the edit, the "Known constraints" section must contain exactly two bullets (in this order):
+
+```
+- Flexi item `Code` field is not reliably preserved on read-back; `PriceList` (`code:PRODUCT-CODE`) is used as the authoritative product identifier instead.
+- Large date ranges (thousands of invoices) hold both full sets in memory simultaneously.
+```
+
+Do not reword either surviving bullet.
+
+- [ ] **Step 2: Verify the edit**
+
+Run:
+
+```bash
+grep -in "7 days\|seven days\|previous 7\|weekly job" docs/features/data-quality-dqt.md
+```
+
+Expected: **zero** matches.
+
+Then run:
+
+```bash
+awk '/^## Known constraints/,/^## /{print}' docs/features/data-quality-dqt.md | grep -c '^- '
+```
+
+Expected output: `2` (exactly two bullets remain in the Known constraints section).
+
+- [ ] **Step 3: Stage the change**
+
+```bash
+git add docs/features/data-quality-dqt.md
+```
+
+---
+
+## Task 5: Full-file sweep for stale schedule/cadence terms (FR-5)
+
+**Files:**
+- Read-only audit: `docs/features/data-quality-dqt.md`
+
+Architecture review extended FR-5's grep token list to also catch `CEST`, `CET`, `UTC`, and `server time`. This task is the final gate before commit: it confirms no residual phrasing still describes the scheduled job as anything other than daily 05:00 Europe/Prague covering yesterday.
+
+- [ ] **Step 1: Run the cadence-term sweep**
+
+Run:
+
+```bash
+grep -in "weekly\|Monday\|23:00\|7 days\|seven days\|CEST\|CET\|UTC\|server time" docs/features/data-quality-dqt.md
+```
+
+Expected: **zero** matches.
+
+If any line matches, inspect it:
+
+- If it describes the **scheduled job's** clock, cadence, or window — it is a defect. Fix it (return to the relevant Task 1–4) before continuing.
+- If it appears in unrelated explanatory text (none is expected in this file, but check) and is factually accurate — leave it. Note in the commit body why it survived.
+
+- [ ] **Step 2: Confirm the positive assertions are still present**
+
+Run:
+
+```bash
+grep -n "daily" docs/features/data-quality-dqt.md
+```
+
+Expected: at least three matches, covering:
+
+1. The Overview paragraph (`daily Hangfire schedule`).
+2. The Schedule bullet (`daily at 05:00 Europe/Prague`).
+3. The Architecture bullet (`daily runs`).
+
+If any of the three is missing, re-run the relevant Task 1–3 step.
+
+- [ ] **Step 3: Visual render check**
+
+Open `docs/features/data-quality-dqt.md` in your editor's Markdown preview (or run any local Markdown renderer) and confirm:
+
+- Headings render at the same levels as before.
+- The Schedule section has exactly two bullets.
+- The Known constraints section has exactly two bullets.
+- No stray blank lines were introduced between bullets in the edited sections.
+
+No CLI command is asserted here because there is no project-standard Markdown renderer; this is a human-eyes scan per the architecture review's "Markdown render check" prerequisite.
+
+---
+
+## Task 6: Commit and push
+
+**Files:**
+- Commit: `docs/features/data-quality-dqt.md` (already staged across Tasks 1–4)
+
+Single commit covering all five edit points. The project's standard validation gate (`dotnet build`, `dotnet format`, `npm run build`, `npm run lint`) does **not** apply — no code changed. The architecture review explicitly notes that a Markdown render check (done in Task 5 Step 3) is sufficient.
+
+- [ ] **Step 1: Confirm the staged diff matches expectations**
+
+Run:
+
+```bash
+git diff --cached docs/features/data-quality-dqt.md
+```
+
+Expected: a diff that contains exactly these changes and nothing else:
+
+1. Line 5 — `weekly Hangfire schedule` → `daily Hangfire schedule`.
+2. Lines 32–35 — Schedule section bullet rewritten (timezone, job name, window).
+3. Line 55 — `schedules weekly runs` → `schedules daily runs`.
+4. Line 76 — `- The weekly job compares the previous 7 days by default.` removed.
+
+If the diff contains any other change (reflow, whitespace-only edits to unrelated lines, restyling), revert it before committing — NFR-3 mandates a surgical change.
+
+- [ ] **Step 2: Confirm no other files are staged**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: a single line, `M  docs/features/data-quality-dqt.md`. If any other file appears as staged or modified, stop and investigate before committing.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git commit -m "docs(data-quality): align schedule section with daily InvoiceDqtJob
+
+The Overview, Schedule, Architecture, and Known constraints sections of
+docs/features/data-quality-dqt.md described a weekly Monday 23:00 CEST job
+covering the previous 7 days. The implementation runs daily at 05:00
+Europe/Prague (cron 0 5 * * *) and compares the previous calendar day
+only. Update the doc to match the code; no behavior changes."
+```
+
+- [ ] **Step 4: Push the branch**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: push succeeds against the existing upstream branch (`feat-arch-review-dataquality-feature-doc-desc`). If the branch has no upstream, use `git push -u origin HEAD` instead.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|------------------|------|
+| FR-1 Schedule section rewrite | Task 2 |
+| FR-2 Overview paragraph | Task 1 |
+| FR-3 Architecture bullet | Task 3 |
+| FR-4 Known constraints bullet (deletion path, per arch-review Amendment 2) | Task 4 |
+| FR-5 Full-file sweep (extended grep tokens per arch-review Amendment 3) | Task 5 |
+| NFR-1 Accuracy / traceability | Context block + arch-review Decision 1 (timezone source pinned to `RecurringJobMetadata.DefaultTimeZoneId`, per arch-review Amendment 4) |
+| NFR-2 Style consistency | Task 2 Step 1 note ("no changelog-style remarks"); each edit preserves existing bullet style |
+| NFR-3 Surgical change | Task 6 Step 1 ("revert any other diff") and Task 6 Step 2 (status must show only the one file) |
+
+**Placeholder scan:** none — every step has an exact string to find, an exact replacement, and a verification command with expected output.
+
+**Type / identifier consistency:** the job name (`daily-invoice-dqt`), class name (`InvoiceDqtJob`), timezone (`Europe/Prague`), cron (`0 5 * * *`), and window phrase (`previous calendar day`) are used identically across Tasks 2, 5, and 6.


### PR DESCRIPTION

Aligns the DataQuality feature doc with the actual `InvoiceDqtJob` schedule. The doc described a weekly Monday 23:00 CEST job covering the previous 7 days; the code runs daily at 05:00 Europe/Prague (cron `0 5 * * *`) covering only the previous calendar day. Stale wording in four locations (Overview, Schedule, Architecture, Known constraints) is corrected with minimal, surgical edits.

### Changes
- `docs/features/data-quality-dqt.md` — Overview: `weekly` → `daily`; Schedule bullet: rewritten with correct cadence, timezone, job name, and window; Architecture `InvoiceDqtJob` bullet: `weekly` → `daily`; Known constraints: stale "previous 7 days" bullet removed

---

Closes #2351

### Tokens used
5307601
