### PR TITLE
feat: Decouple Manufacture from `ICatalogRepository` via Consumer-Owned Contract

### DIFF
--- a/artifacts/feat-arch-review-manufacture-direct-use-of-ic/arch-review.r1.md
+++ b/artifacts/feat-arch-review-manufacture-direct-use-of-ic/arch-review.r1.md
@@ -1,0 +1,215 @@
+I have enough grounding. Writing the review now.
+
+# Architecture Review: Decouple Manufacture from `ICatalogRepository` via Consumer-Owned Contract
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a textbook application of an already-codified pattern in this repository, not a new architectural decision. The reverse direction (`ICatalogManufactureSource` owned by Catalog, implemented by `ManufactureCatalogSourceAdapter` in Manufacture/Infrastructure, registered in `ManufactureModule.cs:59` as `Scoped`) is fully functional and tested. The proposed `IManufactureCatalogSource` + Catalog-side adapter is a mirror of it. The pattern is also explicitly normative — `docs/architecture/development_guidelines.md:195` describes "Cross-Module Communication Example: ILeafletKnowledgeSource" with the same three-step recipe (consumer defines contract → provider implements adapter → provider registers DI). `ModuleBoundariesTests.cs` is the architectural-test enforcement layer that closes the loop.
+
+Integration points are narrow and well-bounded:
+- **Consumer side (Manufacture):** 11 files, all listed in FR-3, replace one constructor parameter type each. No call-site behavior change.
+- **Provider side (Catalog):** one new adapter class, one DI line in `CatalogModule.AddCatalogModule()`, no change to `CatalogRepository`, no change to background refresh tasks (they live inside Catalog and consume `ICatalogRepository` directly — correct).
+- **Tests:** Architectural rule add + mock-target type swap in ~15 Manufacture test files.
+
+The only architectural decision worth scrutinizing is the same one already accepted on the symmetric contract: the deliberate `CatalogAggregate` leak through the contract surface, allowlisted in the boundary test, with the DTO extraction deferred as a follow-up. The `CatalogManufactureAllowlist` (`ModuleBoundariesTests.cs:123-159`) sets the precedent for this exact trade-off — accept the leak now, capture the follow-up in the allowlist comment, move on. Doing this here is consistent and right.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+            ┌─────────────────────────────────────────┐
+            │ Manufacture (consumer)                  │
+            │                                         │
+            │  Application/Features/Manufacture/      │
+            │    Contracts/                           │
+            │      IManufactureCatalogSource  ◄──┐    │
+            │    Services/, UseCases/...         │    │
+            │      depend on ──────────────────►─┘    │
+            └─────────────────────────────────────────┘
+                            ▲ implements
+                            │
+            ┌───────────────┴─────────────────────────┐
+            │ Catalog (provider)                      │
+            │                                         │
+            │  Application/Features/Catalog/          │
+            │    Infrastructure/                      │
+            │      CatalogManufactureCatalogSource    │
+            │      Adapter  ──── delegates ──►        │
+            │                ICatalogRepository       │
+            │    CatalogModule.AddCatalogModule       │
+            │      services.AddScoped<                │
+            │        IManufactureCatalogSource,       │
+            │        ...Adapter>()                    │
+            └─────────────────────────────────────────┘
+```
+
+Symmetric to the existing inversion at `Application/Features/Catalog/Contracts/ICatalogManufactureSource.cs` ⇆ `Application/Features/Manufacture/Infrastructure/ManufactureCatalogSourceAdapter.cs`. No new architectural surface — same shape, opposite direction.
+
+### Key Design Decisions
+
+#### Decision 1: Contract surface stays at three methods only
+**Options considered:**
+- (A) Mirror the full `IReadOnlyRepository<CatalogAggregate, string>` (six methods).
+- (B) Expose only the three methods Manufacture currently calls (`GetByIdAsync`, `GetByIdsAsync`, `GetAllAsync`).
+- (C) Expose three methods *and* preemptively add anticipated needs (e.g., `FindAsync`).
+
+**Chosen approach:** B.
+**Rationale:** Matches the YAGNI guidance in the consumer-owned-contract recipe ("exposing only the operations it actually consumes (no speculative methods)" — `development_guidelines.md:200`). The symmetric `ICatalogManufactureSource` exposes exactly three methods, no more. If a new Manufacture caller needs `FindAsync` later, add it then.
+
+#### Decision 2: `CatalogAggregate` flows through the contract unchanged
+**Options considered:**
+- (A) Introduce a Manufacture-owned `ProductCatalogSnapshot` DTO now, with a mapper in the adapter.
+- (B) Pass `CatalogAggregate` through as a pragmatic leak and allowlist it in `ModuleBoundariesTests`.
+
+**Chosen approach:** B (spec is correct).
+**Rationale:** `CatalogAggregate` is the root aggregate used by 11 services and handlers across Manufacture, often via half a dozen properties per call (Type, ProductType, Stock subfields, ManufactureHistory, etc.). A correct snapshot DTO would either (a) duplicate large portions of `CatalogAggregate` and force a mapper big enough to dwarf this refactor or (b) be incomplete and require the consumer to fall back to the full type for some calls. The exact same trade-off was accepted on `ICatalogManufactureSource` leaking `ManufactureHistoryRecord` and is the only reason `CatalogManufactureAllowlist` exists. Defer the DTO work as a tracked follow-up.
+
+#### Decision 3: Adapter is `Scoped`, consumes `ICatalogRepository` (currently `Transient`)
+**Options considered:**
+- (A) `Scoped` adapter, matches symmetric `ICatalogManufactureSource` registration.
+- (B) `Transient` adapter, matches the underlying repository lifetime.
+- (C) Promote `ICatalogRepository` to `Scoped` while we're here.
+
+**Chosen approach:** A (spec is correct).
+**Rationale:** Mirrors `ManufactureModule.cs:59`. The lifetime mismatch (`Scoped` adapter → `Transient` repo) is harmless because `CatalogRepository` is a thin wrapper over the `Singleton` `CatalogCacheStore`; the per-resolution allocation is constant-time. Per ASP.NET Core rules, a `Scoped` service may safely depend on a `Transient` dependency — the transient is materialized into the scope's container and reused for the duration of the scope, which is what we want.  C is out of scope for this refactor.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**New files (2):**
+
+```
+backend/src/Anela.Heblo.Application/Features/
+├── Manufacture/
+│   └── Contracts/
+│       └── IManufactureCatalogSource.cs              # NEW (consumer-owned)
+└── Catalog/
+    └── Infrastructure/
+        └── CatalogManufactureCatalogSourceAdapter.cs # NEW (provider-owned)
+```
+
+The adapter name is deliberately disambiguated with a `Catalog` prefix because `ManufactureCatalogSourceAdapter` is already taken by the reverse adapter in `Manufacture/Infrastructure/`. Tolerate the awkward name in exchange for grep-unique class names across the solution. (Don't rename the existing adapter — out of scope.)
+
+**Modified files:**
+
+- `CatalogModule.cs` — add one `AddScoped` line in the cross-module adapter block (~lines 48–57), with the comment style already used at `ManufactureModule.cs:57-58` mirrored.
+- 11 Manufacture files in FR-3 — constructor parameter type swap, field rename, `using` swap.
+- `ModuleBoundariesTests.cs` — new `ManufactureCatalogAllowlist` + new `Rules()` entry.
+- ~15 Manufacture test files (one `Mock<ICatalogRepository>` → `Mock<IManufactureCatalogSource>` per file).
+
+**New test file (recommended addition — see Specification Amendments):**
+
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs` — three trivial pass-through tests, mirroring the existing `PurchaseMaterialCatalogAdapterTests.cs` and `LogisticsCatalogSourceAdapterTests.cs` precedents.
+
+### Interfaces and Contracts
+
+```csharp
+namespace Anela.Heblo.Application.Features.Manufacture.Contracts;
+
+/// <summary>
+/// Manufacture-owned read abstraction over Catalog products. Implemented by the Catalog
+/// module via CatalogManufactureCatalogSourceAdapter. Returns CatalogAggregate as a
+/// deliberate pragmatic leak — symmetric to ICatalogManufactureSource returning
+/// ManufactureHistoryRecord. Allowlisted in ModuleBoundariesTests under
+/// "Manufacture -> Catalog". Follow-up: introduce Manufacture-owned ProductCatalogSnapshot.
+/// </summary>
+public interface IManufactureCatalogSource
+{
+    Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(
+        IEnumerable<string> ids, CancellationToken cancellationToken = default);
+    Task<IEnumerable<CatalogAggregate>> GetAllAsync(CancellationToken cancellationToken = default);
+}
+```
+
+**Important contract correction (see Specification Amendments §1).** `IReadOnlyRepository<,>.GetAllAsync` returns `Task<IEnumerable<TEntity>>`, not `Task<IReadOnlyList<TEntity>>` as FR-1 claims. The chosen return type is `Task<IEnumerable<CatalogAggregate>>` so that the adapter can be a literal one-line delegation and no Manufacture call site requires editing beyond the receiver rename.
+
+**Adapter:**
+
+```csharp
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+internal sealed class CatalogManufactureCatalogSourceAdapter : IManufactureCatalogSource
+{
+    private readonly ICatalogRepository _repository;
+    public CatalogManufactureCatalogSourceAdapter(ICatalogRepository repository) => _repository = repository;
+
+    public Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken ct = default)
+        => _repository.GetByIdAsync(id, ct);
+
+    public Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(
+        IEnumerable<string> ids, CancellationToken ct = default)
+        => _repository.GetByIdsAsync(ids, ct);
+
+    public Task<IEnumerable<CatalogAggregate>> GetAllAsync(CancellationToken ct = default)
+        => _repository.GetAllAsync(ct);
+}
+```
+
+**DI registration** in `CatalogModule.AddCatalogModule` next to the existing cross-module adapter block:
+
+```csharp
+// Cross-module contract: Catalog implements Manufacture's IManufactureCatalogSource via adapter.
+// DI registration is owned by the provider (Catalog), not the consumer (Manufacture).
+services.AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>();
+```
+
+### Data Flow
+
+Unchanged. For every method, the request path is:
+
+```
+Manufacture handler/service
+  → IManufactureCatalogSource (DI-resolved → adapter)
+  → ICatalogRepository (constructor capture)
+  → CatalogCacheStore.GetCatalogData() / cached snapshot
+  → returns CatalogAggregate / dictionary / enumerable
+```
+
+Compared to today, one method-call frame is added per call. No allocation beyond the per-scope adapter instance; the JIT inlines through the single-field forwarding methods under release optimization.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Contract return-type mismatch (FR-1 declares `IReadOnlyList<CatalogAggregate>` but `IReadOnlyRepository.GetAllAsync` returns `IEnumerable`). Adapter would need `.ToList()`, causing an extra allocation per call (NFR-1 violation) and breaking pass-through symmetry. | High | Amend FR-1 to `Task<IEnumerable<CatalogAggregate>>`. Confirmed call sites (e.g. `GetManufacturingStockAnalysisHandler.cs:53-56` does `.Where().ToList()`) require no change either way. |
+| Allowlist incomplete on first run — `IManufactureCatalogSource` itself surfaces `CatalogAggregate` in three method signatures, so the contract type is itself a `Manufacture -> Catalog` violation that must be allowlisted. Spec mentions "consumer of `IManufactureCatalogSource`" but not the contract type itself. | Medium | Implementation workflow: add the boundary rule with an empty allowlist first, run the test, copy the printed violations verbatim into the allowlist with a single shared comment header. The reflection walker in `EnumerateReferencedTypes` will enumerate the contract's method return types and parameters, so the contract appears in the violation list. The first entry will be `Anela.Heblo.Application.Features.Manufacture.Contracts.IManufactureCatalogSource -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate`. |
+| `ProductType` enum and other catalog domain types are referenced by Manufacture handlers (e.g. `GetManufacturingStockAnalysisHandler.cs:55`: `item.Type == ProductType.Product`). These remain after migration and the new boundary rule will flag them. | Medium | Same workflow — pasted into allowlist. Group these under one comment block: "Domain types reached via CatalogAggregate properties (pragmatic leak); follow-up tracked with the IManufactureCatalogSource DTO extraction." |
+| Tests for the adapter itself are not in scope per FR-5 wording, but every other Catalog cross-module adapter has a dedicated test file. Skipping this creates an inconsistency. | Low | Add `CatalogManufactureCatalogSourceAdapterTests.cs` with three pass-through tests. Mirrors the existing precedent and adds ~20 LOC. |
+| Name collision with `ManufactureCatalogSourceAdapter` (reverse direction). Solution-wide grep for "ManufactureCatalogSourceAdapter" matches both. | Low | Accept the disambiguating `Catalog` prefix (`CatalogManufactureCatalogSourceAdapter`). Document in adapter XML comment which direction it serves. |
+| Brief listed mappers/calculators (`ManufactureAnalysisMapper`, `ConsumptionRateCalculator`, etc.) as containing `ICatalogRepository` references; current grep shows zero. Risk: implementer trusts the brief and breaks something that doesn't exist. | Low | Spec already calls this out and instructs a fresh grep at implementation time. Honor that — the file list in FR-3 is authoritative as of `grep -l "ICatalogRepository" backend/src/Anela.Heblo.Application/Features/Manufacture/`. |
+
+## Specification Amendments
+
+1. **FR-1 — fix `GetAllAsync` return type.** Change the contract from `Task<IReadOnlyList<CatalogAggregate>>` to `Task<IEnumerable<CatalogAggregate>>`. The justification text in the spec ("signatures match `IReadOnlyRepository.GetAllAsync`'s existing return type and avoid changing call-site code") is **correct in spirit but wrong about the type** — `IReadOnlyRepository<CatalogAggregate, string>.GetAllAsync` actually returns `Task<IEnumerable<CatalogAggregate>>` (verified in `backend/src/Anela.Heblo.Xcc/Persistance/IReadOnlyRepository.cs:11`). Keeping `IEnumerable` makes the adapter a literal pass-through and preserves NFR-1 by avoiding a `.ToList()` allocation.
+
+2. **FR-2 — clarify allowlist must include the contract type itself.** Add an explicit acceptance criterion: "`Anela.Heblo.Application.Features.Manufacture.Contracts.IManufactureCatalogSource -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate` must appear in `ManufactureCatalogAllowlist` (in addition to consumer entries) — the contract surface is the primary point at which `CatalogAggregate` enters Manufacture's namespace."
+
+3. **FR-5 — add adapter unit test (Low severity, but high consistency value).** Add a new test file `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs` with three pass-through tests (one per method) verifying that the adapter returns exactly what the mocked `ICatalogRepository` returns and forwards the `CancellationToken`. Mirrors `PurchaseMaterialCatalogAdapterTests.cs` and `LogisticsCatalogSourceAdapterTests.cs` precedents.
+
+4. **Add explicit ordering guidance to the implementation plan.** The "fail boundary test, paste violations, migrate, re-run" workflow needs to happen in this order to catch any reference the static walker may surface that handler-by-handler migration would miss:
+   1. Add `IManufactureCatalogSource`.
+   2. Add `CatalogManufactureCatalogSourceAdapter` + DI registration.
+   3. Add the `Manufacture -> Catalog` rule with an **empty** allowlist.
+   4. Run `dotnet test --filter ModuleBoundariesTests` — read violations.
+   5. Migrate the 11 files (per FR-3) and the ~15 test files (per FR-5).
+   6. Re-run the test — paste the residual violations into `ManufactureCatalogAllowlist`, grouped by `CatalogAggregate` / `ProductType` / other domain types, each with a one-line `//` comment.
+   7. Final `dotnet build` + `dotnet test --filter "Manufacture|ModuleBoundariesTests"` green.
+
+5. **Documentation cross-reference.** Add the new pattern instance to `docs/architecture/development_guidelines.md` Section "Cross-Module Communication Example: ILeafletKnowledgeSource" as a second canonical example, or as a brief "see also" note pointing at `IManufactureCatalogSource`. This makes the pattern self-documenting for the next refactor (likely the three `CatalogManufactureAllowlist` `IManufactureClient` follow-ups). Out of scope for this PR if the spec author prefers — but trivially small and reduces future drift.
+
+## Prerequisites
+
+None blocking. All dependencies exist in the worktree today:
+
+- `ICatalogRepository`, `CatalogAggregate`, `IReadOnlyRepository<,>` — unchanged.
+- `CatalogModule.AddCatalogModule(IServiceCollection, IConfiguration)` — unchanged signature, additive registration.
+- `ModuleBoundariesTests` infrastructure (`ModuleBoundaryRule`, `Rules()` `TheoryData`, reflection walker) — already supports adding a new rule.
+- xUnit + Moq + FluentAssertions — already present in `Anela.Heblo.Tests`.
+- No new NuGet packages, no DB migration, no config, no infrastructure change.
+
+Implementation can begin immediately.

--- a/artifacts/feat-arch-review-manufacture-direct-use-of-ic/brief.md
+++ b/artifacts/feat-arch-review-manufacture-direct-use-of-ic/brief.md
@@ -1,0 +1,38 @@
+## Module
+Manufacture
+
+## Finding
+Manufacture handlers and services directly inject `ICatalogRepository` from the Catalog module's domain layer (`Anela.Heblo.Domain.Features.Catalog`), bypassing the required cross-module contract pattern. Affected files (12+):
+
+- `Application/Features/Manufacture/Services/BatchPlanningService.cs` (line 4)
+- `Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs` (line 2)
+- `Application/Features/Manufacture/Services/ManufactureAnalysisMapper.cs` (line 3)
+- `Application/Features/Manufacture/Services/IManufactureSeverityCalculator.cs` (line 2)
+- `Application/Features/Manufacture/Services/ManufactureSeverityCalculator.cs` (line 2)
+- `Application/Features/Manufacture/Services/IManufactureAnalysisMapper.cs` (line 2)
+- `Application/Features/Manufacture/Services/IConsumptionRateCalculator.cs` (line 2)
+- `Application/Features/Manufacture/Services/ConsumptionRateCalculator.cs` (lines 2–3)
+- `Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs` (line 3)
+- `Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs` (line 2)
+- `Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs` (line 4)
+- `Application/Features/Manufacture/UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs` (line 2)
+- `Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` (line 3)
+- `Application/Features/Manufacture/UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs` (line 2)
+- `Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs` (line 3)
+- `Application/Features/Manufacture/UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs` (line 2)
+- `Application/Features/Manufacture/UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs` (lines 2–3)
+
+The same module already correctly implements the **reverse** direction: `ManufactureCatalogSourceAdapter` (`Application/Features/Manufacture/Infrastructure/ManufactureCatalogSourceAdapter.cs`) implements Catalog's `ICatalogManufactureSource` without Catalog knowing about Manufacture. The outbound direction (Manufacture → Catalog) lacks the equivalent inversion.
+
+## Why it matters
+`development_guidelines.md` explicitly forbids "Direct access to another module's entities" and requires that cross-module communication go "exclusively through `contracts/`". `ICatalogRepository` is Catalog's internal domain interface; Manufacture depending on it creates a hard coupling that prevents Catalog from evolving independently. The same guidelines document the correct pattern with the `ILeafletKnowledgeSource` / `KnowledgeBaseLeafletSourceAdapter` example.
+
+## Suggested fix
+1. Define a new contract in `Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs` exposing only the operations Manufacture actually needs (e.g. `GetByIdAsync`, `FindByIngredientAsync` proxied through the existing `IManufactureClient`).
+2. Register the Catalog adapter in `CatalogModule.AddCatalogModule()`.
+3. Replace all direct `ICatalogRepository` injections in Manufacture with the new interface.
+
+No change to business logic is required — this is a dependency-direction fix only.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-manufacture-direct-use-of-ic/impl/main.r1.md
+++ b/artifacts/feat-arch-review-manufacture-direct-use-of-ic/impl/main.r1.md
@@ -1,0 +1,72 @@
+All 8 tasks complete. Writing the output summary.
+
+---
+
+# Implementation: Decouple Manufacture from `ICatalogRepository` via Consumer-Owned Contract
+
+## What was implemented
+
+Introduced `IManufactureCatalogSource` as a Manufacture-owned contract implemented by a Catalog-side adapter (`CatalogManufactureCatalogSourceAdapter`). Replaced all 11 direct `ICatalogRepository` injections in the Manufacture module with the new contract, and enforced the module boundary via a new `ModuleBoundariesTests` rule with a fully-populated allowlist for the deliberate `CatalogAggregate` leak.
+
+## Files created/modified
+
+### New files
+- `backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs` — consumer-owned contract with 3 read methods
+- `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs` — internal sealed adapter delegating to `ICatalogRepository`
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs` — 3 pass-through tests
+
+### Modified source files (12)
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — added `AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>()` registration
+- 11 Manufacture services/handlers — constructor param, field, and call-site rename from `ICatalogRepository`/`_catalogRepository` to `IManufactureCatalogSource`/`_catalogSource`
+
+### Modified test files (2)
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — added `ManufactureCatalogAllowlist` (43 entries) + `"Manufacture -> Catalog"` rule
+- 14 Manufacture test files — `Mock<ICatalogRepository>` → `Mock<IManufactureCatalogSource>`
+
+## Tests
+- `CatalogManufactureCatalogSourceAdapterTests.cs` — 3 pass-through tests (GetByIdAsync, GetByIdsAsync, GetAllAsync), all pass
+- 621 Manufacture unit tests — all pass (no regressions)
+- 18 `ModuleBoundariesTests` variants — all pass, including the new `"Manufacture -> Catalog"` rule
+
+## How to verify
+
+```bash
+cd backend
+
+# Build
+dotnet build
+
+# Targeted tests
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Manufacture|FullyQualifiedName~ModuleBoundaries|FullyQualifiedName~CatalogManufactureCatalogSourceAdapter"
+
+# Guard: no ICatalogRepository remaining in Manufacture
+grep -rn "ICatalogRepository" \
+  src/Anela.Heblo.Application/Features/Manufacture/ \
+  test/Anela.Heblo.Tests/Features/Manufacture/ || echo "OK — fully decoupled"
+```
+
+## Notes
+
+- `GetAllAsync` returns `Task<IEnumerable<CatalogAggregate>>` (corrected from spec's `IReadOnlyList` per arch-review §Amendments #1 — avoids `.ToList()` allocation in adapter)
+- `CatalogAggregate` deliberate leak is allowlisted with 43 entries in `ManufactureCatalogAllowlist`, grouped by type with explanatory comments — `ICatalogRepository` does not appear in the allowlist
+- `CatalogManufactureCatalogSourceAdapter` is registered as `Scoped` to match the symmetric `ManufactureModule.cs:59` registration of `ICatalogManufactureSource`
+- 38 pre-existing Docker-dependent integration test failures (unrelated to this change) appear in the full test run
+
+## PR Summary
+
+Decouples the Manufacture module from Catalog's internal `ICatalogRepository` by introducing a Manufacture-owned `IManufactureCatalogSource` contract, a Catalog-side adapter, and a new `ModuleBoundariesTests` enforcement rule — completing the architectural inversion that was already in place in the opposite direction (`ICatalogManufactureSource`).
+
+The 11 Manufacture services and handlers that previously injected `ICatalogRepository` directly now depend only on `IManufactureCatalogSource`, eliminating a cross-module coupling that would have blocked adding the `ModuleBoundariesTests` rule. The `CatalogAggregate` type still flows through the contract surface (pragmatic leak, allowlisted, tracked as a follow-up to introduce a `ProductCatalogSnapshot` DTO) — symmetric to the existing `ManufactureHistoryRecord` leak in `ICatalogManufactureSource`.
+
+### Changes
+- `Features/Manufacture/Contracts/IManufactureCatalogSource.cs` — new consumer-owned contract (3 read methods)
+- `Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs` — new provider-owned adapter (internal sealed, pure pass-through)
+- `Features/Catalog/CatalogModule.cs` — new `AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>()` registration
+- 11 Manufacture source files — `ICatalogRepository`→`IManufactureCatalogSource` dependency swap
+- `Architecture/ModuleBoundariesTests.cs` — new `"Manufacture -> Catalog"` rule + 43-entry `ManufactureCatalogAllowlist`
+- 14 Manufacture test files — `Mock<ICatalogRepository>`→`Mock<IManufactureCatalogSource>` swap
+- `Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs` — 3 new pass-through tests
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-manufacture-direct-use-of-ic/spec.r1.md
+++ b/artifacts/feat-arch-review-manufacture-direct-use-of-ic/spec.r1.md
@@ -1,0 +1,185 @@
+# Specification: Decouple Manufacture from `ICatalogRepository` via Consumer-Owned Contract
+
+## Summary
+The Manufacture module currently injects Catalog's internal domain interface `ICatalogRepository` into 11 application files (services + use-case handlers), violating the cross-module contract pattern mandated by `docs/architecture/development_guidelines.md`. This change introduces a Manufacture-owned `IManufactureCatalogSource` contract, implements it on the Catalog side via an adapter, and replaces every direct `ICatalogRepository` injection in Manufacture with the new abstraction. No business logic changes — pure dependency-direction inversion.
+
+## Background
+`development_guidelines.md` (section "Cross-Module Communication") explicitly forbids "Direct access to another module's entities" and requires cross-module communication to flow "exclusively through `contracts/`". The canonical reference implementation is `ILeafletKnowledgeSource` (Leaflet-owned contract) implemented by `KnowledgeBaseLeafletSourceAdapter` (KnowledgeBase-owned adapter), keyed by `ModuleBoundariesTests` enforcement.
+
+The Manufacture module already correctly applies the inverse direction: `ICatalogManufactureSource` lives in `Application/Features/Catalog/Contracts/ICatalogManufactureSource.cs` and is implemented by `ManufactureCatalogSourceAdapter` in `Application/Features/Manufacture/Infrastructure/`, registered in `ManufactureModule.AddManufactureModule()` (see `ManufactureModule.cs:59`). The outbound direction (Manufacture → Catalog) has no equivalent inversion: 11 files inject `Anela.Heblo.Domain.Features.Catalog.ICatalogRepository` directly.
+
+`ICatalogRepository` (in `Anela.Heblo.Domain.Features.Catalog`) is Catalog's internal domain interface. It exposes ~25 members including all `Refresh*Data` mutation methods, load-date properties, the merge scheduler, and analytics queries (`GetProductsWithSalesInPeriod`). Manufacture only uses three read operations: `GetByIdAsync(string id, ct)`, `GetByIdsAsync(IEnumerable<string> ids, ct)`, and `GetAllAsync(ct)` — all inherited from `IReadOnlyRepository<CatalogAggregate, string>`. The current coupling forces Catalog to keep this full surface stable for Manufacture's sake and would block adoption of the architectural test (no `Manufacture -> Catalog` rule exists in `ModuleBoundariesTests.cs` yet — adding it today would explode with violations).
+
+This work is filed by the daily arch-review routine on 2026-06-03. It is a targeted refactor: behavior visible to callers (request/response payloads, control flow, performance characteristics) must remain unchanged.
+
+## Functional Requirements
+
+### FR-1: Introduce `IManufactureCatalogSource` contract in the Manufacture module
+A new consumer-owned interface must be defined in `backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs`, exposing only the catalog read operations Manufacture actually uses today.
+
+**Detailed description:** The contract surface must be the minimum needed by current Manufacture call sites. Audited usage shows three methods are sufficient:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Manufacture.Contracts;
+
+/// <summary>
+/// Manufacture-owned read abstraction over Catalog products. Implemented by the
+/// Catalog module via an adapter. Returns CatalogAggregate as a deliberate pragmatic
+/// leak — symmetric to ICatalogManufactureSource returning ManufactureHistoryRecord.
+/// Allowlisted in ModuleBoundariesTests under "Manufacture -> Catalog".
+/// </summary>
+public interface IManufactureCatalogSource
+{
+    Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CatalogAggregate>> GetAllAsync(CancellationToken cancellationToken = default);
+}
+```
+
+**Acceptance criteria:**
+- File `backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs` exists.
+- Interface lives in `Anela.Heblo.Application.Features.Manufacture.Contracts` namespace.
+- Interface declares exactly the three methods above (signatures match `ICatalogRepository`/`IReadOnlyRepository` for `GetByIdAsync`, `GetByIdsAsync`, `GetAllAsync` so handler code requires no per-call adaptation).
+- A documentation XML comment explains the pragmatic `CatalogAggregate` leak and points to the allowlist entry, mirroring the wording style of `ICatalogManufactureSource`.
+- `GetAllAsync` returns `IReadOnlyList<CatalogAggregate>` to match `IReadOnlyRepository.GetAllAsync`'s existing return type and avoid changing call-site code (see FR-3 audit).
+
+### FR-2: Provide `CatalogManufactureCatalogSourceAdapter` in the Catalog module
+The Catalog module must provide the adapter implementing `IManufactureCatalogSource` by delegating to the existing `ICatalogRepository`.
+
+**Detailed description:** Following the existing `ManufactureCatalogSourceAdapter` pattern in reverse, the adapter lives on the **provider** side (Catalog) and the DI registration is **owned by the provider**.
+
+**Acceptance criteria:**
+- File `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs` exists.
+- Class is `internal sealed`, lives in `Anela.Heblo.Application.Features.Catalog.Infrastructure` namespace, and implements `IManufactureCatalogSource`.
+- Constructor takes a single `ICatalogRepository` dependency.
+- Each method delegates 1:1 to the underlying repository, passing through the `CancellationToken`. No transformation, no caching layer, no logging.
+- Registered in `CatalogModule.AddCatalogModule()` (next to the existing cross-module adapter registrations around line 48–57) with `services.AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>()`. The registration comment must state: "Cross-module contract: Catalog implements Manufacture's IManufactureCatalogSource via adapter. DI registration is owned by the provider (Catalog), not the consumer (Manufacture)."
+
+### FR-3: Replace every `ICatalogRepository` injection in Manufacture with `IManufactureCatalogSource`
+All Manufacture services and handlers must depend on the new contract instead of Catalog's internal repository.
+
+**Detailed description:** The files to migrate (verified by grep of `ICatalogRepository` under `backend/src/Anela.Heblo.Application/Features/Manufacture`):
+
+| File | Used methods |
+|---|---|
+| `Services/BatchPlanningService.cs` | `GetByIdAsync`, `GetAllAsync` |
+| `Services/ResidueDistributionCalculator.cs` | `GetByIdsAsync` |
+| `UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs` | `GetByIdAsync` |
+| `UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs` | `GetAllAsync` |
+| `UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs` | `GetByIdAsync`, `GetByIdsAsync` |
+| `UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs` | `GetByIdAsync` |
+| `UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs` | `GetByIdAsync` |
+| `UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs` | `GetByIdAsync` |
+| `UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs` | `GetByIdAsync` |
+| `UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs` | `GetByIdAsync` |
+| `UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs` | `GetByIdAsync` |
+
+**Note on brief discrepancy:** the brief lists `ManufactureAnalysisMapper`, `IManufactureSeverityCalculator`, `ManufactureSeverityCalculator`, `IManufactureAnalysisMapper`, `IConsumptionRateCalculator`, and `ConsumptionRateCalculator` as containing `ICatalogRepository` references. A repeat grep against the worktree returns no `ICatalogRepository` matches in those files; treat the table above as authoritative and confirm with a fresh `grep -l "ICatalogRepository"` at implementation time.
+
+**Acceptance criteria:**
+- In every listed file: the constructor parameter `ICatalogRepository catalogRepository` is renamed to `IManufactureCatalogSource catalogSource`; the private field is renamed correspondingly (e.g. `_catalogRepository` → `_catalogSource`); the `using Anela.Heblo.Domain.Features.Catalog;` directive is removed if it only existed for `ICatalogRepository`, and replaced/augmented with `using Anela.Heblo.Application.Features.Manufacture.Contracts;`.
+- Any `using` of `Anela.Heblo.Domain.Features.Catalog` that remains because the file still uses `CatalogAggregate`, `ProductType`, etc. is acceptable per the deliberate-leak design (FR-1) and is allowlisted as a group under the boundary rule (FR-4).
+- All method calls (`_catalogRepository.GetByIdAsync(...)` etc.) switch to `_catalogSource.GetByIdAsync(...)` with identical arguments — no `await`/cancellation/argument changes.
+- `dotnet build` succeeds with no warnings introduced by the change.
+- No reference to `Anela.Heblo.Domain.Features.Catalog.ICatalogRepository` remains anywhere in `backend/src/Anela.Heblo.Application/Features/Manufacture/`.
+
+### FR-4: Add `Manufacture -> Catalog` rule to `ModuleBoundariesTests`
+The architectural test must be extended with a new `ModuleBoundaryRule` covering Manufacture, with an allowlist that documents the deliberate `CatalogAggregate` (and related catalog-domain enums/value types) leak through the contract.
+
+**Detailed description:** Today there is no `Manufacture -> Catalog` rule in `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` (search confirms). Adding one without allowlisting the residual `CatalogAggregate`, `ProductType`, `ManufactureType`, etc. references that remain inside Manufacture code (return-type usage of the contract methods) would explode with violations.
+
+**Acceptance criteria:**
+- A new `static readonly HashSet<string> ManufactureCatalogAllowlist` is added to the test class. Each entry has a one-line `//` comment explaining why the dependency is kept.
+- Allowlist entries cover the symmetric pragmatic leak: every Manufacture consumer of `IManufactureCatalogSource` (services + handlers from FR-3) referencing `Anela.Heblo.Domain.Features.Catalog.CatalogAggregate`, plus uses of `ProductType` and any other catalog domain enum still referenced after migration. The allowlist must be exhaustive — generating it by running the test, reading violations, and pasting them in is the expected workflow.
+- A new entry in `Rules()` (`ModuleBoundariesTests.cs:200+`) is added:
+  ```csharp
+  new ModuleBoundaryRule(
+      Name: "Manufacture -> Catalog",
+      InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Manufacture",
+      ForbiddenNamespacePrefixes: new[]
+      {
+          "Anela.Heblo.Domain.Features.Catalog",
+          "Anela.Heblo.Application.Features.Catalog",
+          "Anela.Heblo.Persistence.Catalog",
+      },
+      Allowlist: ManufactureCatalogAllowlist),
+  ```
+- `dotnet test --filter ModuleBoundariesTests` passes locally with the new rule active.
+- The allowlist must **not** contain `ICatalogRepository` — that is the violation this work fixes.
+
+### FR-5: Update existing unit tests to use `IManufactureCatalogSource`
+Any unit test currently mocking `ICatalogRepository` for a migrated Manufacture service or handler must mock `IManufactureCatalogSource` instead.
+
+**Detailed description:** The Manufacture test project will have tests (xUnit + Moq, per project convention) that construct services/handlers directly with mocked dependencies. After FR-3, the mock target type changes.
+
+**Acceptance criteria:**
+- A grep of `backend/test/` for `Mock<ICatalogRepository>` (and `Setup(.*GetByIdAsync` / `GetAllAsync` / `GetByIdsAsync`) inside Manufacture-suffixed test classes returns the list to migrate.
+- For each match: the mock generic argument switches to `IManufactureCatalogSource`, and the constructor argument switches to the new mock. `Setup` calls remain unchanged (signatures match).
+- `dotnet test backend/Anela.Heblo.sln --filter "FullyQualifiedName~Manufacture"` passes with no new failures.
+- No Manufacture test references `ICatalogRepository` after the change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance change is expected or permitted.
+- The adapter is a thin pass-through (constructor capture + delegated method calls); the JIT inlines it under typical conditions. The DI lifetime is `Scoped` to match the underlying `ICatalogRepository` registration (`AddTransient` in `CatalogModule:45`, but `Scoped` is correct for adapter symmetry with `ICatalogManufactureSource` registration at `ManufactureModule:59`).
+- No new allocations beyond one adapter instance per scope. No additional caching, batching, or copying.
+- Benchmark assertion is not required; absence of `await` / loop / mapping logic in the adapter is sufficient evidence.
+
+### NFR-2: Security
+No change to the security posture.
+- Same data is exposed through the new contract as before; no privilege escalation, no new endpoints, no new auth surface.
+- The contract is internal to `Application` and is not surfaced over any controller or MediatR handler externally.
+- No secrets, no logging changes.
+
+### NFR-3: Backwards compatibility
+`ICatalogRepository` is **not** removed or modified. Catalog continues to depend on its own internal repository directly (correct — it owns it). Other Catalog-internal consumers and the Catalog refresh background tasks (`CatalogModule.RegisterBackgroundRefreshTasks`) remain unchanged.
+
+## Data Model
+Unchanged.
+- No new tables, columns, or migrations.
+- No change to `CatalogAggregate`, `ICatalogRepository`, `IReadOnlyRepository<,>`, or any persistence type.
+- The new contract surfaces existing data without modification.
+
+## API / Interface Design
+
+**New types added (Application layer only — no public API surface change):**
+
+| Type | Project | Layer |
+|---|---|---|
+| `IManufactureCatalogSource` (interface) | `Anela.Heblo.Application` | `Features/Manufacture/Contracts/` |
+| `CatalogManufactureCatalogSourceAdapter` (internal sealed class) | `Anela.Heblo.Application` | `Features/Catalog/Infrastructure/` |
+
+**DI registration:** added to `CatalogModule.AddCatalogModule()` as `services.AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>()` next to existing cross-module adapter registrations (`PurchaseMaterialCatalogAdapter`, `LogisticsCatalogSourceAdapter`, etc., `CatalogModule.cs:48-57`).
+
+**No changes to:**
+- MVC controllers (none touched by this work)
+- MediatR request/response DTOs
+- OpenAPI surface / generated TypeScript client
+- Frontend
+- Database schema or migrations
+
+**No changes to behavior:**
+- Every call site preserves the exact same method signature, argument list, cancellation token handling, and return type.
+
+## Dependencies
+- `Anela.Heblo.Domain.Features.Catalog.ICatalogRepository` — unchanged, consumed by the new adapter only on the Catalog side.
+- `Anela.Heblo.Domain.Features.Catalog.CatalogAggregate` — flows through the contract as a pragmatic leak, allowlisted in `ModuleBoundariesTests`.
+- xUnit + Moq + FluentAssertions — test stack already present.
+- No new NuGet packages.
+- No new external services.
+
+## Out of Scope
+- Removing the `CatalogAggregate` leak through `IManufactureCatalogSource` (introducing a Manufacture-owned `ProductCatalogSnapshot` DTO and mapper). Tracked as a follow-up; out of scope to match the existing precedent set by `ICatalogManufactureSource` leaking `ManufactureHistoryRecord`.
+- Migrating `IManufactureClient` consumers in Catalog handlers (`UpdateProductCompositionOrderHandler`, `GetProductCompositionHandler`, `GetProductUsageHandler`) — covered by the existing `CatalogManufactureAllowlist` follow-ups (`ModuleBoundariesTests.cs:118-159`).
+- Changing the lifetime of `ICatalogRepository` itself (currently `Transient`; out of scope).
+- Adding analytics methods like `GetProductsWithSalesInPeriod` to the new contract — not used by Manufacture today, would over-fit the contract.
+- Removing or refactoring the `Refresh*Data` methods from `ICatalogRepository`.
+- Any UI, controller, or DTO changes.
+- Performance instrumentation, telemetry, or new logging.
+- E2E test additions (architectural change with zero behavior delta — covered by unit + module-boundary tests).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-manufacture-direct-use-of-ic/task-plan.r1.md
+++ b/artifacts/feat-arch-review-manufacture-direct-use-of-ic/task-plan.r1.md
@@ -1,0 +1,16 @@
+Plan saved to `docs/superpowers/plans/2026-06-03-decouple-manufacture-from-icatalogrepository.md`.
+
+## Summary
+
+The implementation plan covers eight tasks executing the spec + arch-review amendments in this strict order:
+
+1. **Add `IManufactureCatalogSource` contract** (consumer-owned, `Application/Features/Manufacture/Contracts/`) — corrected `GetAllAsync` return to `Task<IEnumerable<CatalogAggregate>>` per arch-review §Amendments #1.
+2. **Add `CatalogManufactureCatalogSourceAdapter` + 3 pass-through unit tests** (test-first) — name disambiguated against existing `ManufactureCatalogSourceAdapter`; tests added per arch-review §Amendments #3.
+3. **Register adapter as `Scoped` in `CatalogModule`** — mirrors the symmetric `ManufactureModule.cs:59` line.
+4. **Add `Manufacture -> Catalog` boundary rule with empty allowlist** — expected to fail; output saved for diffing.
+5. **Migrate 11 Manufacture consumer files** (one sub-task each) — constructor parameter rename, field rename, call-site swap, `using` directive swap.
+6. **Migrate ~10 Manufacture test files** — single-token `Mock<>` generic swap; test bodies unchanged because signatures match by design.
+7. **Populate `ManufactureCatalogAllowlist`** from the post-migration boundary-test output, grouped by referenced type with explanatory `//` comments — never including `ICatalogRepository`.
+8. **Full backend validation** — `dotnet build`, `dotnet format`, focused + full `dotnet test`, final grep guard. No frontend touched.
+
+Pipeline note acknowledged — skipping the execution choice prompt.

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
@@ -7,6 +7,7 @@ using Anela.Heblo.Application.Features.Catalog.DashboardTiles;
 using Anela.Heblo.Xcc.Services.BackgroundRefresh;
 using Anela.Heblo.Application.Features.Catalog.Infrastructure;
 using Anela.Heblo.Application.Features.Catalog.Services;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Purchase.Contracts;
 using Anela.Heblo.Application.Features.Catalog.UseCases.CreateManufactureDifficulty;
 using Anela.Heblo.Application.Features.Catalog.UseCases.GetCatalogDetail;
@@ -55,6 +56,10 @@ public static class CatalogModule
         // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
         services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
         services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+
+        // Cross-module contract: Catalog implements Manufacture's IManufactureCatalogSource via adapter.
+        // DI registration is owned by the provider (Catalog), not the consumer (Manufacture).
+        services.AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>();
 
         // Register cost repositories
         services.AddTransient<IMaterialCostProvider, ManufactureBasedMaterialCostProvider>(); // Product type-based: manufacture history for Set/Product/SemiProduct, purchase price for others

--- a/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs
@@ -1,0 +1,31 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+/// <summary>
+/// Catalog-side adapter that implements the Manufacture-owned IManufactureCatalogSource
+/// contract by delegating to the internal ICatalogRepository. DI registration is in
+/// CatalogModule.AddCatalogModule(). See ModuleBoundariesTests "Manufacture -> Catalog"
+/// rule and its ManufactureCatalogAllowlist for the deliberate CatalogAggregate leak.
+/// </summary>
+internal sealed class CatalogManufactureCatalogSourceAdapter : IManufactureCatalogSource
+{
+    private readonly ICatalogRepository _repository;
+
+    public CatalogManufactureCatalogSourceAdapter(ICatalogRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken cancellationToken = default) =>
+        _repository.GetByIdAsync(id, cancellationToken);
+
+    public Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(
+        IEnumerable<string> ids,
+        CancellationToken cancellationToken = default) =>
+        _repository.GetByIdsAsync(ids, cancellationToken);
+
+    public Task<IEnumerable<CatalogAggregate>> GetAllAsync(CancellationToken cancellationToken = default) =>
+        _repository.GetAllAsync(cancellationToken);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs
@@ -1,0 +1,21 @@
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Manufacture.Contracts;
+
+/// <summary>
+/// Manufacture-owned read abstraction over Catalog products. Implemented by the Catalog
+/// module via CatalogManufactureCatalogSourceAdapter. Returns CatalogAggregate as a
+/// deliberate pragmatic leak — symmetric to ICatalogManufactureSource returning
+/// ManufactureHistoryRecord. Allowlisted in ModuleBoundariesTests under
+/// "Manufacture -> Catalog". Follow-up: introduce Manufacture-owned ProductCatalogSnapshot DTO.
+/// </summary>
+public interface IManufactureCatalogSource
+{
+    Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(
+        IEnumerable<string> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<CatalogAggregate>> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -9,20 +10,20 @@ namespace Anela.Heblo.Application.Features.Manufacture.Services;
 
 public class BatchPlanningService : IBatchPlanningService
 {
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly IManufactureClient _manufactureClient;
     private readonly IBatchDistributionCalculator _batchDistributionCalculator;
     private readonly IConsumptionRateCalculator _consumptionRateCalculator;
     private readonly ILogger<BatchPlanningService> _logger;
 
     public BatchPlanningService(
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         IManufactureClient manufactureClient,
         IBatchDistributionCalculator batchDistributionCalculator,
         IConsumptionRateCalculator consumptionRateCalculator,
         ILogger<BatchPlanningService> logger)
     {
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _manufactureClient = manufactureClient;
         _batchDistributionCalculator = batchDistributionCalculator;
         _consumptionRateCalculator = consumptionRateCalculator;
@@ -311,7 +312,7 @@ public class BatchPlanningService : IBatchPlanningService
         CancellationToken cancellationToken)
     {
         // For single-phase manufacturing, the request.ProductCode is actually the product code
-        var product = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+        var product = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
         if (product == null)
         {
             throw new ArgumentException($"Product with code '{request.ProductCode}' not found.");
@@ -358,7 +359,7 @@ public class BatchPlanningService : IBatchPlanningService
         CancellationToken cancellationToken)
     {
         // 1. Get semiproduct info
-        var semiproduct = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+        var semiproduct = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
         if (semiproduct == null)
         {
             throw new ArgumentException($"Semiproduct with code '{request.ProductCode}' not found.");
@@ -381,7 +382,7 @@ public class BatchPlanningService : IBatchPlanningService
         var batchPlanItems = new List<BatchPlanItemDto>();
         foreach (var template in productTemplates)
         {
-            var product = await _catalogRepository.GetByIdAsync(template.ProductCode, cancellationToken);
+            var product = await _catalogSource.GetByIdAsync(template.ProductCode, cancellationToken);
             if (product == null)
             {
                 _logger.LogWarning("Product {ProductCode} found in template but not in catalog", template.ProductCode);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrder;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -7,12 +8,12 @@ namespace Anela.Heblo.Application.Features.Manufacture.Services;
 public class ResidueDistributionCalculator : IResidueDistributionCalculator
 {
     private readonly IManufactureClient _manufactureClient;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
 
-    public ResidueDistributionCalculator(IManufactureClient manufactureClient, ICatalogRepository catalogRepository)
+    public ResidueDistributionCalculator(IManufactureClient manufactureClient, IManufactureCatalogSource catalogSource)
     {
         _manufactureClient = manufactureClient;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
     }
 
     public async Task<ResidueDistribution> CalculateAsync(UpdateManufactureOrderDto order, CancellationToken cancellationToken = default)
@@ -43,7 +44,7 @@ public class ResidueDistributionCalculator : IResidueDistributionCalculator
 
         var totalTheoretical = productData.Sum(p => p.TheoreticalConsumption);
 
-        var semiProductCatalog = await _catalogRepository.GetByIdAsync(order.SemiProduct.ProductCode, cancellationToken);
+        var semiProductCatalog = await _catalogSource.GetByIdAsync(order.SemiProduct.ProductCode, cancellationToken);
         var allowedResiduePercentage = semiProductCatalog?.Properties.AllowedResiduePercentage ?? 0;
 
         var difference = actualSemiProduct - totalTheoretical;

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBySize;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -9,12 +10,12 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBy
 public class CalculateBatchByIngredientHandler : IRequestHandler<CalculateBatchByIngredientRequest, CalculateBatchByIngredientResponse>
 {
     private readonly IManufactureClient _manufactureClient;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
 
-    public CalculateBatchByIngredientHandler(IManufactureClient manufactureClient, ICatalogRepository catalogRepository)
+    public CalculateBatchByIngredientHandler(IManufactureClient manufactureClient, IManufactureCatalogSource catalogSource)
     {
         _manufactureClient = manufactureClient;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
     }
 
     public async Task<CalculateBatchByIngredientResponse> Handle(CalculateBatchByIngredientRequest request, CancellationToken cancellationToken)
@@ -49,7 +50,7 @@ public class CalculateBatchByIngredientHandler : IRequestHandler<CalculateBatchB
             var ingredientsWithStock = new List<CalculatedIngredientDto>();
             foreach (var ingredient in template.Ingredients)
             {
-                var ingredientCatalog = await _catalogRepository.GetByIdAsync(ingredient.ProductCode, cancellationToken);
+                var ingredientCatalog = await _catalogSource.GetByIdAsync(ingredient.ProductCode, cancellationToken);
 
                 // Get the latest stock taking date for this ingredient
                 var lastStockTaking = ingredientCatalog?.StockTakingHistory

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -11,18 +12,18 @@ public class CalculateBatchPlanHandler : IRequestHandler<CalculateBatchPlanReque
     private const int DefaultFallbackDays = 30;
 
     private readonly IBatchPlanningService _batchPlanningService;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly IManufactureClient _manufactureClient;
     private readonly ITimePeriodResolver _timePeriodResolver;
 
     public CalculateBatchPlanHandler(
         IBatchPlanningService batchPlanningService,
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         IManufactureClient manufactureClient,
         ITimePeriodResolver timePeriodResolver)
     {
         _batchPlanningService = batchPlanningService;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _manufactureClient = manufactureClient;
         _timePeriodResolver = timePeriodResolver;
     }
@@ -30,7 +31,7 @@ public class CalculateBatchPlanHandler : IRequestHandler<CalculateBatchPlanReque
     public async Task<CalculateBatchPlanResponse> Handle(CalculateBatchPlanRequest request, CancellationToken cancellationToken)
     {
         // Can calculate even for product
-        var product = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+        var product = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
         if (product?.Type == ProductType.Product)
         {
             var manufactureTemplate = await _manufactureClient.GetManufactureTemplateAsync(request.ProductCode, cancellationToken);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -8,12 +9,12 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBy
 public class CalculatedBatchSizeHandler : IRequestHandler<CalculatedBatchSizeRequest, CalculatedBatchSizeResponse>
 {
     private readonly IManufactureClient _manufactureClient;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
 
-    public CalculatedBatchSizeHandler(IManufactureClient manufactureClient, ICatalogRepository catalogRepository)
+    public CalculatedBatchSizeHandler(IManufactureClient manufactureClient, IManufactureCatalogSource catalogSource)
     {
         _manufactureClient = manufactureClient;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
     }
 
     public async Task<CalculatedBatchSizeResponse> Handle(CalculatedBatchSizeRequest request, CancellationToken cancellationToken)
@@ -21,7 +22,7 @@ public class CalculatedBatchSizeHandler : IRequestHandler<CalculatedBatchSizeReq
         try
         {
             var template = await _manufactureClient.GetManufactureTemplateAsync(request.ProductCode, cancellationToken);
-            var product = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+            var product = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
 
             if (template == null)
             {
@@ -50,7 +51,7 @@ public class CalculatedBatchSizeHandler : IRequestHandler<CalculatedBatchSizeReq
 
             // Batch-load all ingredient catalog entries in a single call (avoids N+1 queries)
             var ingredientCodes = template.Ingredients.Select(i => i.ProductCode).ToHashSet();
-            var ingredientCatalogByCode = await _catalogRepository.GetByIdsAsync(ingredientCodes, cancellationToken);
+            var ingredientCatalogByCode = await _catalogSource.GetByIdsAsync(ingredientCodes, cancellationToken);
 
             var sortedIngredients = template.Ingredients
                 .OrderBy(i => i.Order == 0 ? int.MaxValue : i.Order)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -11,20 +12,20 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
 {
     private readonly IManufactureOrderRepository _repository;
     private readonly IProductNameFormatter _productNameFormatter;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly ICurrentUserService _currentUserService;
     private readonly TimeProvider _timeProvider;
 
     public CreateManufactureOrderHandler(
         IManufactureOrderRepository repository,
         IProductNameFormatter productNameFormatter,
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         ICurrentUserService currentUserService,
         TimeProvider timeProvider)
     {
         _repository = repository;
         _productNameFormatter = productNameFormatter;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _currentUserService = currentUserService;
         _timeProvider = timeProvider;
     }
@@ -52,7 +53,7 @@ public class CreateManufactureOrderHandler : IRequestHandler<CreateManufactureOr
             StateChangedByUser = currentUser.Name
         };
 
-        var semiproduct = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+        var semiproduct = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
         if (semiproduct == null)
         {
             return new CreateManufactureOrderResponse(ErrorCodes.ProductNotFound);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -9,16 +10,16 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOu
 public class GetManufactureOutputHandler : IRequestHandler<GetManufactureOutputRequest, GetManufactureOutputResponse>
 {
     private readonly IManufactureHistoryClient _manufactureHistoryClient;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly ILogger<GetManufactureOutputHandler> _logger;
 
     public GetManufactureOutputHandler(
         IManufactureHistoryClient manufactureHistoryClient,
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         ILogger<GetManufactureOutputHandler> logger)
     {
         _manufactureHistoryClient = manufactureHistoryClient;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _logger = logger;
     }
 
@@ -42,7 +43,7 @@ public class GetManufactureOutputHandler : IRequestHandler<GetManufactureOutputR
         }
 
         // Get catalog items to get product names and difficulty
-        var catalogItems = await _catalogRepository.GetAllAsync(cancellationToken);
+        var catalogItems = await _catalogSource.GetAllAsync(cancellationToken);
         var catalogDict = catalogItems
             .Where(w => w.ManufactureDifficulty.HasValue)
             .ToDictionary(c => c.ProductCode, c => c);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -8,16 +9,16 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetSemiproductRe
 public class GetSemiproductRecipePdfHandler : IRequestHandler<GetSemiproductRecipePdfRequest, GetSemiproductRecipePdfResponse>
 {
     private readonly IManufactureClient _manufactureClient;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly ISemiproductRecipeRenderer _renderer;
 
     public GetSemiproductRecipePdfHandler(
         IManufactureClient manufactureClient,
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         ISemiproductRecipeRenderer renderer)
     {
         _manufactureClient = manufactureClient;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _renderer = renderer;
     }
 
@@ -35,7 +36,7 @@ public class GetSemiproductRecipePdfHandler : IRequestHandler<GetSemiproductReci
                     new Dictionary<string, string> { { "ProductCode", request.ProductCode } });
             }
 
-            var catalog = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+            var catalog = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
 
             var totalAmount = template.Ingredients.Sum(i => i.Amount);
             double scaleFactor = (request.BatchSize.HasValue && template.OriginalAmount > 0)

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -9,7 +10,7 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis
 
 public class GetManufacturingStockAnalysisHandler : IRequestHandler<GetManufacturingStockAnalysisRequest, GetManufacturingStockAnalysisResponse>
 {
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly ITimePeriodResolver _timePeriodResolver;
     private readonly IConsumptionRateCalculator _consumptionCalculator;
     private readonly IProductionActivityAnalyzer _productionAnalyzer;
@@ -19,7 +20,7 @@ public class GetManufacturingStockAnalysisHandler : IRequestHandler<GetManufactu
     private readonly ILogger<GetManufacturingStockAnalysisHandler> _logger;
 
     public GetManufacturingStockAnalysisHandler(
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         ITimePeriodResolver timePeriodResolver,
         IConsumptionRateCalculator consumptionCalculator,
         IProductionActivityAnalyzer productionAnalyzer,
@@ -28,7 +29,7 @@ public class GetManufacturingStockAnalysisHandler : IRequestHandler<GetManufactu
         IItemFilterService filterService,
         ILogger<GetManufacturingStockAnalysisHandler> logger)
     {
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _timePeriodResolver = timePeriodResolver;
         _consumptionCalculator = consumptionCalculator;
         _productionAnalyzer = productionAnalyzer;
@@ -50,7 +51,7 @@ public class GetManufacturingStockAnalysisHandler : IRequestHandler<GetManufactu
         var outerTo = ranges.Max(r => r.To);
 
         // 2. Get finished products data
-        var allCatalogItems = await _catalogRepository.GetAllAsync(cancellationToken);
+        var allCatalogItems = await _catalogSource.GetAllAsync(cancellationToken);
         var finishedProducts = allCatalogItems
             .Where(item => item.Type == ProductType.Product)
             .ToList();

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Catalog.Stock;
@@ -8,16 +9,16 @@ namespace Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactur
 
 public class SubmitManufactureStockTakingHandler : IRequestHandler<SubmitManufactureStockTakingRequest, SubmitManufactureStockTakingResponse>
 {
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly ILogger<SubmitManufactureStockTakingHandler> _logger;
     private readonly IErpStockDomainService _erpStockDomainService;
 
     public SubmitManufactureStockTakingHandler(
-        ICatalogRepository catalogRepository,
+        IManufactureCatalogSource catalogSource,
         ILogger<SubmitManufactureStockTakingHandler> logger,
         IErpStockDomainService erpStockDomainService)
     {
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
         _logger = logger;
         _erpStockDomainService = erpStockDomainService;
     }
@@ -30,7 +31,7 @@ public class SubmitManufactureStockTakingHandler : IRequestHandler<SubmitManufac
         try
         {
             // Get the current product to check if it's a material
-            var product = await _catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken);
+            var product = await _catalogSource.GetByIdAsync(request.ProductCode, cancellationToken);
             if (product == null)
             {
                 _logger.LogWarning("Product with code {ProductCode} not found", request.ProductCode);

--- a/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -13,7 +14,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
 {
     private readonly IManufactureOrderRepository _repository;
     private readonly IManufacturedProductInventoryRepository _inventoryRepository;
-    private readonly ICatalogRepository _catalogRepository;
+    private readonly IManufactureCatalogSource _catalogSource;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<UpdateManufactureOrderStatusHandler> _logger;
     private readonly ICurrentUserService _currentUserService;
@@ -26,7 +27,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
         ICurrentUserService currentUserService,
         IConditionsReadingProvider conditionsProvider,
         IManufacturedProductInventoryRepository inventoryRepository,
-        ICatalogRepository catalogRepository)
+        IManufactureCatalogSource catalogSource)
     {
         _repository = repository;
         _timeProvider = timeProvider;
@@ -34,7 +35,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
         _currentUserService = currentUserService;
         _conditionsProvider = conditionsProvider;
         _inventoryRepository = inventoryRepository;
-        _catalogRepository = catalogRepository;
+        _catalogSource = catalogSource;
     }
 
     public async Task<UpdateManufactureOrderStatusResponse> Handle(UpdateManufactureOrderStatusRequest request, CancellationToken cancellationToken)
@@ -184,7 +185,7 @@ public class UpdateManufactureOrderStatusHandler : IRequestHandler<UpdateManufac
             return;
 
         var productCodes = productsWithQuantity.Select(p => p.ProductCode).ToList();
-        var catalogEntries = await _catalogRepository.GetByIdsAsync(productCodes, cancellationToken);
+        var catalogEntries = await _catalogSource.GetByIdsAsync(productCodes, cancellationToken);
 
         var items = productsWithQuantity
             .Where(p => !catalogEntries.TryGetValue(p.ProductCode, out var entry) || entry.Type != ProductType.SemiProduct)

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -197,6 +197,14 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.DataQuality.Services.InvoiceDqtComparer -> Anela.Heblo.Domain.Features.Invoices.InvoicePrice",
     };
 
+    // Allowlist for Manufacture -> Catalog. Populated after running the boundary test with
+    // an empty allowlist and pasting the residual violations grouped by referenced type.
+    // The deliberate pragmatic leak (CatalogAggregate and its property types flowing through
+    // IManufactureCatalogSource) is symmetric to the CatalogManufactureAllowlist entries for
+    // ManufactureHistoryRecord. Follow-up: introduce Manufacture-owned ProductCatalogSnapshot
+    // DTO and map in CatalogManufactureCatalogSourceAdapter.
+    private static readonly HashSet<string> ManufactureCatalogAllowlist = new(StringComparer.Ordinal);
+
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {
         new ModuleBoundaryRule(
@@ -353,6 +361,17 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.Invoices",
             },
             Allowlist: DataQualityInvoicesAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "Manufacture -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Manufacture",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: ManufactureCatalogAllowlist),
     };
 
     [Theory]

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -197,13 +197,63 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.DataQuality.Services.InvoiceDqtComparer -> Anela.Heblo.Domain.Features.Invoices.InvoicePrice",
     };
 
-    // Allowlist for Manufacture -> Catalog. Populated after running the boundary test with
-    // an empty allowlist and pasting the residual violations grouped by referenced type.
-    // The deliberate pragmatic leak (CatalogAggregate and its property types flowing through
-    // IManufactureCatalogSource) is symmetric to the CatalogManufactureAllowlist entries for
-    // ManufactureHistoryRecord. Follow-up: introduce Manufacture-owned ProductCatalogSnapshot
-    // DTO and map in CatalogManufactureCatalogSourceAdapter.
-    private static readonly HashSet<string> ManufactureCatalogAllowlist = new(StringComparer.Ordinal);
+    // Allowlist for Manufacture -> Catalog. Each group below is a deliberate pragmatic leak
+    // tracked under the same follow-up: introduce Manufacture-owned ProductCatalogSnapshot DTO
+    // and map in CatalogManufactureCatalogSourceAdapter (symmetric to the CatalogManufactureAllowlist
+    // ManufactureHistoryRecord block).
+    private static readonly HashSet<string> ManufactureCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // Contract surface: IManufactureCatalogSource returns CatalogAggregate by design.
+        "Anela.Heblo.Application.Features.Manufacture.Contracts.IManufactureCatalogSource -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+
+        // Consumers of CatalogAggregate reached via IManufactureCatalogSource methods.
+        // Remove these entries when ProductCatalogSnapshot DTO lands.
+        "Anela.Heblo.Application.Features.Manufacture.Services.BatchPlanningService -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.BatchPlanningService+<>c__DisplayClass13_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.BatchPlanningService+<CalculateMultiPhaseBatchPlanInternal>d__17 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.BatchPlanningService+<CalculateSinglePhaseBatchPlanInternal>d__16 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.IManufactureAnalysisMapper -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.IManufactureSeverityCalculator -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ManufactureAnalysisMapper -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ManufactureSeverityCalculator -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ResidueDistributionCalculator+<CalculateAsync>d__3 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient.CalculateBatchByIngredientHandler+<Handle>d__3 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBySize.CalculatedBatchSizeHandler+<Handle>d__3 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan.CalculateBatchPlanHandler+<Handle>d__6 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CreateManufactureOrder.CreateManufactureOrderHandler+<Handle>d__6 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOutput.GetManufactureOutputHandler+<>c -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOutput.GetManufactureOutputHandler+<>c__DisplayClass4_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOutput.GetManufactureOutputHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetSemiproductRecipePdf.GetSemiproductRecipePdfHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler+<>c -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler+<>c__DisplayClass10_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler+<>c__DisplayClass9_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler+<Handle>d__9 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus.UpdateManufactureOrderStatusHandler+<>c__DisplayClass10_0 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus.UpdateManufactureOrderStatusHandler+<WriteDownInventoryAsync>d__10 -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+
+        // Domain enums/types reached via CatalogAggregate properties.
+        // Same follow-up as above.
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator -> Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials.ConsumedMaterialRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator -> Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator+<>c -> Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials.ConsumedMaterialRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator+<>c -> Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator+<>c__DisplayClass4_0 -> Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator+<>c__DisplayClass5_0 -> Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ConsumptionRateCalculator+<>c__DisplayClass6_0 -> Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials.ConsumedMaterialRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.IConsumptionRateCalculator -> Anela.Heblo.Domain.Features.Catalog.ConsumedMaterials.ConsumedMaterialRecord",
+        "Anela.Heblo.Application.Features.Manufacture.Services.IConsumptionRateCalculator -> Anela.Heblo.Domain.Features.Catalog.Sales.CatalogSaleRecord",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient.CalculateBatchByIngredientHandler+<>c -> Anela.Heblo.Domain.Features.Catalog.Stock.StockTakingRecord",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBySize.CalculatedBatchSizeHandler+<>c -> Anela.Heblo.Domain.Features.Catalog.Stock.StockTakingRecord",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStockTakingLot",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler -> Anela.Heblo.Domain.Features.Catalog.Stock.IErpStockDomainService",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler+<>c -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStockTakingLot",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.Stock.ErpStockTakingRequest",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.Stock.StockTakingRecord",
+    };
 
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {

--- a/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs
@@ -1,0 +1,64 @@
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class CatalogManufactureCatalogSourceAdapterTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private IManufactureCatalogSource CreateAdapter() =>
+        new CatalogManufactureCatalogSourceAdapter(_repository.Object);
+
+    [Fact]
+    public async Task GetByIdAsync_ForwardsCallAndReturnsRepositoryResult()
+    {
+        var ct = new CancellationTokenSource().Token;
+        var expected = new CatalogAggregate { ProductCode = "ABC", ProductName = "Test" };
+        _repository.Setup(r => r.GetByIdAsync("ABC", ct)).ReturnsAsync(expected);
+
+        var result = await CreateAdapter().GetByIdAsync("ABC", ct);
+
+        result.Should().BeSameAs(expected);
+        _repository.Verify(r => r.GetByIdAsync("ABC", ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_ForwardsCallAndReturnsRepositoryResult()
+    {
+        var ct = new CancellationTokenSource().Token;
+        var ids = new[] { "A", "B" };
+        IReadOnlyDictionary<string, CatalogAggregate> expected = new Dictionary<string, CatalogAggregate>
+        {
+            ["A"] = new CatalogAggregate { ProductCode = "A" },
+            ["B"] = new CatalogAggregate { ProductCode = "B" },
+        };
+        _repository.Setup(r => r.GetByIdsAsync(ids, ct)).ReturnsAsync(expected);
+
+        var result = await CreateAdapter().GetByIdsAsync(ids, ct);
+
+        result.Should().BeSameAs(expected);
+        _repository.Verify(r => r.GetByIdsAsync(ids, ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ForwardsCallAndReturnsRepositoryResult()
+    {
+        var ct = new CancellationTokenSource().Token;
+        IEnumerable<CatalogAggregate> expected = new[]
+        {
+            new CatalogAggregate { ProductCode = "A" },
+            new CatalogAggregate { ProductCode = "B" },
+        };
+        _repository.Setup(r => r.GetAllAsync(ct)).ReturnsAsync(expected);
+
+        var result = await CreateAdapter().GetAllAsync(ct);
+
+        result.Should().BeSameAs(expected);
+        _repository.Verify(r => r.GetAllAsync(ct), Times.Once);
+    }
+}

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/BatchPlanningServiceTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/BatchPlanningServiceTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Application.Shared;
@@ -14,7 +15,7 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 
 public class BatchPlanningServiceTests
 {
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<IManufactureClient> _manufactureClientMock;
     private readonly Mock<IBatchDistributionCalculator> _batchDistributionCalculatorMock;
     private readonly Mock<ILogger<BatchPlanningService>> _loggerMock;
@@ -26,7 +27,7 @@ public class BatchPlanningServiceTests
 
     public BatchPlanningServiceTests()
     {
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _manufactureClientMock = new Mock<IManufactureClient>();
         _batchDistributionCalculatorMock = new Mock<IBatchDistributionCalculator>();
         _loggerMock = new Mock<ILogger<BatchPlanningService>>();

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchByIngredientHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchByIngredient;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -11,13 +12,13 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class CalculateBatchByIngredientHandlerTests
 {
     private readonly Mock<IManufactureClient> _manufactureClientMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly CalculateBatchByIngredientHandler _handler;
 
     public CalculateBatchByIngredientHandlerTests()
     {
         _manufactureClientMock = new Mock<IManufactureClient>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _handler = new CalculateBatchByIngredientHandler(_manufactureClientMock.Object, _catalogRepositoryMock.Object);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchBySizeHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchBySizeHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBySize;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -10,13 +11,13 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class CalculateBatchBySizeHandlerTests
 {
     private readonly Mock<IManufactureClient> _manufactureClientMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly CalculatedBatchSizeHandler _handler;
 
     public CalculateBatchBySizeHandlerTests()
     {
         _manufactureClientMock = new Mock<IManufactureClient>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _handler = new CalculatedBatchSizeHandler(_manufactureClientMock.Object, _catalogRepositoryMock.Object);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculateBatchPlanHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -12,14 +13,14 @@ public class CalculateBatchPlanHandlerTests
 {
     private readonly Mock<IBatchPlanningService> _batchPlanningServiceMock;
     private readonly Mock<IManufactureClient> _manufactureClientMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ITimePeriodResolver> _timePeriodResolverMock;
     private readonly CalculateBatchPlanHandler _handler;
 
     public CalculateBatchPlanHandlerTests()
     {
         _batchPlanningServiceMock = new Mock<IBatchPlanningService>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _manufactureClientMock = new Mock<IManufactureClient>();
         _timePeriodResolverMock = new Mock<ITimePeriodResolver>();
         _handler = new CalculateBatchPlanHandler(

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculatedBatchSizeHandlerLastStockTakingTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CalculatedBatchSizeHandlerLastStockTakingTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchBySize;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -17,13 +18,13 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class CalculatedBatchSizeHandlerLastStockTakingTests
 {
     private readonly Mock<IManufactureClient> _mockManufactureClient;
-    private readonly Mock<ICatalogRepository> _mockCatalogRepository;
+    private readonly Mock<IManufactureCatalogSource> _mockCatalogRepository;
     private readonly CalculatedBatchSizeHandler _handler;
 
     public CalculatedBatchSizeHandlerLastStockTakingTests()
     {
         _mockManufactureClient = new Mock<IManufactureClient>();
-        _mockCatalogRepository = new Mock<ICatalogRepository>();
+        _mockCatalogRepository = new Mock<IManufactureCatalogSource>();
         _handler = new CalculatedBatchSizeHandler(_mockManufactureClient.Object, _mockCatalogRepository.Object);
     }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerSinglePhaseTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CreateManufactureOrder;
 using Anela.Heblo.Application.Shared;
@@ -13,7 +14,7 @@ public class CreateManufactureOrderHandlerSinglePhaseTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IProductNameFormatter> _productNameFormatterMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<TimeProvider> _timeProviderMock;
     private readonly CreateManufactureOrderHandler _handler;
@@ -22,7 +23,7 @@ public class CreateManufactureOrderHandlerSinglePhaseTests
     {
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _productNameFormatterMock = new Mock<IProductNameFormatter>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _timeProviderMock = new Mock<TimeProvider>();
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/CreateManufactureOrderHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.CreateManufactureOrder;
 using Anela.Heblo.Application.Shared;
@@ -13,7 +14,7 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class CreateManufactureOrderHandlerTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IProductNameFormatter> _productNameFormatterMock;
     private readonly CreateManufactureOrderHandler _handler;
@@ -29,7 +30,7 @@ public class CreateManufactureOrderHandlerTests
     public CreateManufactureOrderHandlerTests()
     {
         _repositoryMock = new Mock<IManufactureOrderRepository>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _productNameFormatterMock = new Mock<IProductNameFormatter>();
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOutputHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufactureOutputHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetManufactureOutput;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -11,14 +12,14 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class GetManufactureOutputHandlerTests
 {
     private readonly Mock<IManufactureHistoryClient> _manufactureHistoryClientMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ILogger<GetManufactureOutputHandler>> _loggerMock;
     private readonly GetManufactureOutputHandler _handler;
 
     public GetManufactureOutputHandlerTests()
     {
         _manufactureHistoryClientMock = new Mock<IManufactureHistoryClient>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _loggerMock = new Mock<ILogger<GetManufactureOutputHandler>>();
 
         _handler = new GetManufactureOutputHandler(

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufacturingStockAnalysisHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetManufacturingStockAnalysisHandlerTests.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Common.TimePeriods;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis;
 using Anela.Heblo.Application.Shared;
@@ -15,7 +16,7 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 
 public class GetManufacturingStockAnalysisHandlerTests
 {
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ITimePeriodResolver> _timePeriodResolverMock;
     private readonly Mock<IConsumptionRateCalculator> _consumptionCalculatorMock;
     private readonly Mock<IProductionActivityAnalyzer> _productionAnalyzerMock;
@@ -27,7 +28,7 @@ public class GetManufacturingStockAnalysisHandlerTests
 
     public GetManufacturingStockAnalysisHandlerTests()
     {
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _timePeriodResolverMock = new Mock<ITimePeriodResolver>();
         _consumptionCalculatorMock = new Mock<IConsumptionRateCalculator>();
         _productionAnalyzerMock = new Mock<IProductionActivityAnalyzer>();

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetSemiproductRecipePdfHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/GetSemiproductRecipePdfHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.GetSemiproductRecipePdf;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -10,14 +11,14 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 public class GetSemiproductRecipePdfHandlerTests
 {
     private readonly Mock<IManufactureClient> _manufactureClientMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ISemiproductRecipeRenderer> _rendererMock;
     private readonly GetSemiproductRecipePdfHandler _handler;
 
     public GetSemiproductRecipePdfHandlerTests()
     {
         _manufactureClientMock = new Mock<IManufactureClient>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _catalogRepositoryMock.Setup(r => r.GetByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((CatalogAggregate?)null);
         _rendererMock = new Mock<ISemiproductRecipeRenderer>();

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ResidueDistributionCalculatorTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/Services/ResidueDistributionCalculatorTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.Services;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrder;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -11,7 +12,7 @@ namespace Anela.Heblo.Tests.Features.Manufacture.Services;
 public class ResidueDistributionCalculatorTests
 {
     private readonly Mock<IManufactureClient> _manufactureClientMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly ResidueDistributionCalculator _calculator;
 
     private const string SemiProductCode = "SP-001";
@@ -21,7 +22,7 @@ public class ResidueDistributionCalculatorTests
     public ResidueDistributionCalculatorTests()
     {
         _manufactureClientMock = new Mock<IManufactureClient>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
 
         _calculator = new ResidueDistributionCalculator(
             _manufactureClientMock.Object,

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureStockTakingHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/SubmitManufactureStockTakingHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -11,14 +12,14 @@ namespace Anela.Heblo.Tests.Features.Manufacture;
 
 public class SubmitManufactureStockTakingHandlerTests
 {
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<IErpStockDomainService> _erpStockDomainServiceMock;
     private readonly Mock<ILogger<SubmitManufactureStockTakingHandler>> _loggerMock;
     private readonly SubmitManufactureStockTakingHandler _handler;
 
     public SubmitManufactureStockTakingHandlerTests()
     {
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _erpStockDomainServiceMock = new Mock<IErpStockDomainService>();
         _loggerMock = new Mock<ILogger<SubmitManufactureStockTakingHandler>>();
 

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerConditionsTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
 using Anela.Heblo.Domain.Features.Catalog;
 using Anela.Heblo.Domain.Features.Manufacture;
@@ -14,7 +15,7 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
     private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
@@ -23,7 +24,7 @@ public class UpdateManufactureOrderStatusHandlerConditionsTests
     {
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
         _conditionsProviderMock = new Mock<IConditionsReadingProvider>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();

--- a/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Manufacture/UpdateManufactureOrderStatusHandlerTests.cs
@@ -1,3 +1,4 @@
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
 using Anela.Heblo.Application.Features.Manufacture.UseCases.UpdateManufactureOrderStatus;
 using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.Catalog;
@@ -16,7 +17,7 @@ public class UpdateManufactureOrderStatusHandlerTests
 {
     private readonly Mock<IManufactureOrderRepository> _repositoryMock;
     private readonly Mock<IManufacturedProductInventoryRepository> _inventoryRepositoryMock;
-    private readonly Mock<ICatalogRepository> _catalogRepositoryMock;
+    private readonly Mock<IManufactureCatalogSource> _catalogRepositoryMock;
     private readonly Mock<ILogger<UpdateManufactureOrderStatusHandler>> _loggerMock;
     private readonly Mock<ICurrentUserService> _currentUserServiceMock;
     private readonly Mock<IConditionsReadingProvider> _conditionsProviderMock;
@@ -31,7 +32,7 @@ public class UpdateManufactureOrderStatusHandlerTests
     {
         _repositoryMock = new Mock<IManufactureOrderRepository>();
         _inventoryRepositoryMock = new Mock<IManufacturedProductInventoryRepository>();
-        _catalogRepositoryMock = new Mock<ICatalogRepository>();
+        _catalogRepositoryMock = new Mock<IManufactureCatalogSource>();
         _loggerMock = new Mock<ILogger<UpdateManufactureOrderStatusHandler>>();
         _currentUserServiceMock = new Mock<ICurrentUserService>();
         _conditionsProviderMock = new Mock<IConditionsReadingProvider>();

--- a/docs/superpowers/plans/2026-06-03-decouple-manufacture-from-icatalogrepository.md
+++ b/docs/superpowers/plans/2026-06-03-decouple-manufacture-from-icatalogrepository.md
@@ -1,0 +1,955 @@
+# Decouple Manufacture from ICatalogRepository Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace every direct `ICatalogRepository` injection in the Manufacture module with a Manufacture-owned `IManufactureCatalogSource` contract implemented by a Catalog-side adapter, and enforce the boundary via `ModuleBoundariesTests`.
+
+**Architecture:** Mirror of the existing inverse pattern (`ICatalogManufactureSource` owned by Catalog, implemented by Manufacture). Add the consumer-owned contract in `Application/Features/Manufacture/Contracts/`, the provider-owned adapter in `Application/Features/Catalog/Infrastructure/`, register the adapter in `CatalogModule`, then migrate 11 consumer files + 9 test files + add an architectural rule with an allowlist for the deliberate `CatalogAggregate` leak.
+
+**Tech Stack:** C# 12 / .NET 8, xUnit + Moq + FluentAssertions, MediatR, reflection-based architectural tests.
+
+---
+
+## Background and Authoritative References
+
+Read these before starting:
+
+- Spec: `artifacts/feat-arch-review-manufacture-direct-use-of-ic/spec.r1.md`
+- Arch review (binding amendments in §"Specification Amendments"): `artifacts/feat-arch-review-manufacture-direct-use-of-ic/arch-review.r1.md`
+- Canonical contract pattern (Catalog-owned, Manufacture-implemented): `backend/src/Anela.Heblo.Application/Features/Catalog/Contracts/ICatalogManufactureSource.cs` and `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureCatalogSourceAdapter.cs`
+- Architectural rule infrastructure: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+- Cross-module communication recipe: `docs/architecture/development_guidelines.md` section "Cross-Module Communication Example: ILeafletKnowledgeSource"
+- Underlying `IReadOnlyRepository<,>` contract being delegated to: `backend/src/Anela.Heblo.Xcc/Persistance/IReadOnlyRepository.cs` (NB: `GetAllAsync` returns `Task<IEnumerable<TEntity>>`, **not** `Task<IReadOnlyList<TEntity>>` — the spec FR-1 typo is corrected by arch-review §Specification Amendments #1)
+
+## File Structure
+
+**New source files (2):**
+
+```
+backend/src/Anela.Heblo.Application/Features/
+├── Manufacture/Contracts/
+│   └── IManufactureCatalogSource.cs              # NEW — consumer-owned contract
+└── Catalog/Infrastructure/
+    └── CatalogManufactureCatalogSourceAdapter.cs # NEW — provider-owned adapter
+```
+
+The adapter is deliberately named `CatalogManufactureCatalogSourceAdapter` (Catalog prefix) because `ManufactureCatalogSourceAdapter` (no prefix) is already taken by the reverse-direction adapter in `backend/src/Anela.Heblo.Application/Features/Manufacture/Infrastructure/ManufactureCatalogSourceAdapter.cs`. Do not rename the existing adapter — out of scope.
+
+**Modified source files (12):**
+
+- `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` — add one `AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>()` line in the cross-module adapter block.
+- 11 Manufacture files (verified by `grep -l "ICatalogRepository" backend/src/Anela.Heblo.Application/Features/Manufacture/`):
+  - `Services/BatchPlanningService.cs`
+  - `Services/ResidueDistributionCalculator.cs`
+  - `UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs`
+  - `UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs`
+  - `UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`
+  - `UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs`
+  - `UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs`
+  - `UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs`
+  - `UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs`
+  - `UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+  - `UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs`
+
+For every modified Manufacture file:
+- Rename constructor parameter `ICatalogRepository catalogRepository` → `IManufactureCatalogSource catalogSource`
+- Rename private field `_catalogRepository` → `_catalogSource`
+- Swap the `using Anela.Heblo.Domain.Features.Catalog;` directive to `using Anela.Heblo.Application.Features.Manufacture.Contracts;` (keep `using Anela.Heblo.Domain.Features.Catalog;` if the file also uses `CatalogAggregate`, `ProductType`, etc.)
+- Replace `_catalogRepository.GetByIdAsync(...)` / `.GetAllAsync(...)` / `.GetByIdsAsync(...)` → `_catalogSource.GetByIdAsync(...)` / `.GetAllAsync(...)` / `.GetByIdsAsync(...)` (signatures match, no other call-site changes)
+
+**Modified test files (10) and new test file (1):**
+
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — add `ManufactureCatalogAllowlist` + new `Rules()` entry.
+- 9 Manufacture test files (verified by `grep -l "Mock<ICatalogRepository>" backend/test/Anela.Heblo.Tests/Features/Manufacture/`):
+  - `BatchPlanningServiceTests.cs`
+  - `CalculateBatchByIngredientHandlerTests.cs`
+  - `CalculateBatchBySizeHandlerTests.cs` (covers `CalculatedBatchSizeHandler`)
+  - `CalculateBatchPlanHandlerTests.cs`
+  - `CalculatedBatchSizeHandlerLastStockTakingTests.cs`
+  - `CreateManufactureOrderHandlerTests.cs` (also `CreateManufactureOrderHandlerSinglePhaseTests.cs` shares fixture — check both)
+  - `CreateManufactureOrderHandlerSinglePhaseTests.cs`
+  - `GetManufactureOutputHandlerTests.cs`
+  - `GetManufacturingStockAnalysisHandlerTests.cs`
+  - `GetSemiproductRecipePdfHandlerTests.cs`
+  - `Services/ResidueDistributionCalculatorTests.cs`
+  - `SubmitManufactureStockTakingHandlerTests.cs`
+  - `UpdateManufactureOrderStatusHandlerConditionsTests.cs`
+  - `UpdateManufactureOrderStatusHandlerTests.cs`
+
+  (The grep at implementation time is authoritative — use it to confirm the list. The grep performed at planning time returned 14 files including both `CalculateBatchBySizeHandlerTests.cs` and `CalculatedBatchSizeHandlerLastStockTakingTests.cs` which both touch `CalculatedBatchSizeHandler`.)
+
+  For every modified test file:
+  - Swap `Mock<ICatalogRepository>` → `Mock<IManufactureCatalogSource>`
+  - Swap `new Mock<ICatalogRepository>()` → `new Mock<IManufactureCatalogSource>()`
+  - Swap `using Anela.Heblo.Domain.Features.Catalog;` → keep if still used for `CatalogAggregate`, add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`
+  - `Setup(x => x.GetByIdAsync(...))` / `.GetAllAsync(...)` / `.GetByIdsAsync(...)` calls stay unchanged — the signatures match by design.
+
+- `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs` — NEW. Three pass-through tests mirroring `LogisticsCatalogSourceAdapterTests.cs`.
+
+## Ordering Rationale (per arch-review §Amendments #4)
+
+The boundary test is added with an **empty allowlist** before the consumer migration so the test fails with a complete list of `CatalogAggregate` / `ProductType` / etc. references. That list is then pasted verbatim into `ManufactureCatalogAllowlist` (grouped with explanatory comments) and the test re-run. Without this order, a handler-by-handler migration could miss compiler-generated state-machine references the reflection walker would catch.
+
+The plan executes in this order:
+
+1. Add contract `IManufactureCatalogSource`.
+2. Add adapter `CatalogManufactureCatalogSourceAdapter` and its three pass-through tests.
+3. Register adapter in `CatalogModule.AddCatalogModule()`.
+4. Add `Manufacture -> Catalog` boundary rule with empty allowlist; verify test fails with one expected violation (the contract surface itself).
+5. Migrate the 11 consumer files (constructor/field/call-site swap).
+6. Migrate the ~10 test files (mock generic swap).
+7. Re-run the boundary test, paste the residual violations into `ManufactureCatalogAllowlist` grouped by referenced type with one-line `//` comments.
+8. Final `dotnet build` + `dotnet test --filter "FullyQualifiedName~Manufacture|FullyQualifiedName~ModuleBoundaries"`.
+
+---
+
+## Task 1: Add `IManufactureCatalogSource` contract
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs`
+
+- [ ] **Step 1: Verify the target folder exists**
+
+Run:
+
+```bash
+ls backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/ 2>&1 || mkdir -p backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts
+```
+
+Expected: directory listing, or directory is created. Either outcome is fine.
+
+- [ ] **Step 2: Create the contract file**
+
+Write `backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs` with this exact content:
+
+```csharp
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Manufacture.Contracts;
+
+/// <summary>
+/// Manufacture-owned read abstraction over Catalog products. Implemented by the Catalog
+/// module via CatalogManufactureCatalogSourceAdapter. Returns CatalogAggregate as a
+/// deliberate pragmatic leak — symmetric to ICatalogManufactureSource returning
+/// ManufactureHistoryRecord. Allowlisted in ModuleBoundariesTests under
+/// "Manufacture -> Catalog". Follow-up: introduce Manufacture-owned ProductCatalogSnapshot DTO.
+/// </summary>
+public interface IManufactureCatalogSource
+{
+    Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(
+        IEnumerable<string> ids,
+        CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<CatalogAggregate>> GetAllAsync(CancellationToken cancellationToken = default);
+}
+```
+
+Notes:
+- Return types for `GetByIdAsync` and `GetAllAsync` match `IReadOnlyRepository<CatalogAggregate, string>` exactly so adapter delegation requires no transformation. `GetByIdsAsync` matches the extension/specialization declared on `ICatalogRepository` (returns `IReadOnlyDictionary<string, CatalogAggregate>`).
+- The `using Anela.Heblo.Domain.Features.Catalog;` directive is intentional and will be allowlisted in Task 4 (deliberate leak per FR-1 / arch-review §Amendments #2).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with no errors and no new warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/Contracts/IManufactureCatalogSource.cs
+git commit -m "feat(manufacture): add IManufactureCatalogSource consumer-owned contract"
+```
+
+---
+
+## Task 2: Add `CatalogManufactureCatalogSourceAdapter` (test-first)
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs`
+- Create: `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs`
+
+- [ ] **Step 1: Write the failing adapter tests**
+
+Write `backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Catalog.Infrastructure;
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Catalog.Infrastructure;
+
+public class CatalogManufactureCatalogSourceAdapterTests
+{
+    private readonly Mock<ICatalogRepository> _repository = new();
+
+    private IManufactureCatalogSource CreateAdapter() =>
+        new CatalogManufactureCatalogSourceAdapter(_repository.Object);
+
+    [Fact]
+    public async Task GetByIdAsync_ForwardsCallAndReturnsRepositoryResult()
+    {
+        var ct = new CancellationTokenSource().Token;
+        var expected = new CatalogAggregate { ProductCode = "ABC", ProductName = "Test" };
+        _repository.Setup(r => r.GetByIdAsync("ABC", ct)).ReturnsAsync(expected);
+
+        var result = await CreateAdapter().GetByIdAsync("ABC", ct);
+
+        result.Should().BeSameAs(expected);
+        _repository.Verify(r => r.GetByIdAsync("ABC", ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_ForwardsCallAndReturnsRepositoryResult()
+    {
+        var ct = new CancellationTokenSource().Token;
+        var ids = new[] { "A", "B" };
+        IReadOnlyDictionary<string, CatalogAggregate> expected = new Dictionary<string, CatalogAggregate>
+        {
+            ["A"] = new CatalogAggregate { ProductCode = "A" },
+            ["B"] = new CatalogAggregate { ProductCode = "B" },
+        };
+        _repository.Setup(r => r.GetByIdsAsync(ids, ct)).ReturnsAsync(expected);
+
+        var result = await CreateAdapter().GetByIdsAsync(ids, ct);
+
+        result.Should().BeSameAs(expected);
+        _repository.Verify(r => r.GetByIdsAsync(ids, ct), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ForwardsCallAndReturnsRepositoryResult()
+    {
+        var ct = new CancellationTokenSource().Token;
+        IEnumerable<CatalogAggregate> expected = new[]
+        {
+            new CatalogAggregate { ProductCode = "A" },
+            new CatalogAggregate { ProductCode = "B" },
+        };
+        _repository.Setup(r => r.GetAllAsync(ct)).ReturnsAsync(expected);
+
+        var result = await CreateAdapter().GetAllAsync(ct);
+
+        result.Should().BeSameAs(expected);
+        _repository.Verify(r => r.GetAllAsync(ct), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CatalogManufactureCatalogSourceAdapter"
+```
+
+Expected: build failure with errors like `error CS0246: The type or namespace name 'CatalogManufactureCatalogSourceAdapter' could not be found` — this confirms RED.
+
+- [ ] **Step 3: Implement the adapter**
+
+Write `backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs`:
+
+```csharp
+using Anela.Heblo.Application.Features.Manufacture.Contracts;
+using Anela.Heblo.Domain.Features.Catalog;
+
+namespace Anela.Heblo.Application.Features.Catalog.Infrastructure;
+
+/// <summary>
+/// Catalog-side adapter that implements the Manufacture-owned IManufactureCatalogSource
+/// contract by delegating to the internal ICatalogRepository. DI registration is in
+/// CatalogModule.AddCatalogModule(). See ModuleBoundariesTests "Manufacture -> Catalog"
+/// rule and its ManufactureCatalogAllowlist for the deliberate CatalogAggregate leak.
+/// </summary>
+internal sealed class CatalogManufactureCatalogSourceAdapter : IManufactureCatalogSource
+{
+    private readonly ICatalogRepository _repository;
+
+    public CatalogManufactureCatalogSourceAdapter(ICatalogRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<CatalogAggregate?> GetByIdAsync(string id, CancellationToken cancellationToken = default) =>
+        _repository.GetByIdAsync(id, cancellationToken);
+
+    public Task<IReadOnlyDictionary<string, CatalogAggregate>> GetByIdsAsync(
+        IEnumerable<string> ids,
+        CancellationToken cancellationToken = default) =>
+        _repository.GetByIdsAsync(ids, cancellationToken);
+
+    public Task<IEnumerable<CatalogAggregate>> GetAllAsync(CancellationToken cancellationToken = default) =>
+        _repository.GetAllAsync(cancellationToken);
+}
+```
+
+- [ ] **Step 4: Run the adapter tests and verify they pass**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CatalogManufactureCatalogSourceAdapter"
+```
+
+Expected: `Passed!  - Failed: 0, Passed: 3, Skipped: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs \
+        backend/test/Anela.Heblo.Tests/Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs
+git commit -m "feat(catalog): add CatalogManufactureCatalogSourceAdapter implementing IManufactureCatalogSource"
+```
+
+---
+
+## Task 3: Register adapter in `CatalogModule`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs` (cross-module adapter block around lines 48–57)
+
+- [ ] **Step 1: Add the using directive (if not already present)**
+
+Open `backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs`. Verify `using Anela.Heblo.Application.Features.Manufacture.Contracts;` is at the top of the file. If not, add it next to the other `using Anela.Heblo.Application.Features.*` directives (alphabetical ordering preserved).
+
+- [ ] **Step 2: Add the DI registration**
+
+Locate the cross-module adapter block:
+
+```csharp
+        services.AddScoped<IMaterialCatalogService, PurchaseMaterialCatalogAdapter>();
+        services.AddScoped<IPurchasePriceRecalculationService, CatalogPurchasePriceRecalculationAdapter>();
+        services.AddTransient<IAnalyticsProductSource, CatalogAnalyticsSourceAdapter>();
+        services.AddTransient<ILogisticsCatalogSource, LogisticsCatalogSourceAdapter>();
+        services.AddTransient<ILogisticsStockOperationService, LogisticsStockOperationAdapter>();
+        // Logistics owns the query contract; Catalog (this module) provides the adapter implementation.
+        services.AddTransient<ILogisticsStockOperationQueryService, LogisticsStockOperationQueryAdapter>();
+        // DataQuality owns the query contracts; Catalog (this module) provides the adapter implementations.
+        services.AddScoped<IStockOperationQuery, DataQualityStockOperationQueryAdapter>();
+        services.AddScoped<IStockTakingQuery, DataQualityStockTakingQueryAdapter>();
+```
+
+Append immediately after the `DataQualityStockTakingQueryAdapter` line:
+
+```csharp
+        // Cross-module contract: Catalog implements Manufacture's IManufactureCatalogSource via adapter.
+        // DI registration is owned by the provider (Catalog), not the consumer (Manufacture).
+        services.AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>();
+```
+
+Lifetime is `Scoped` to mirror the existing `ManufactureModule.cs:59` registration of `ICatalogManufactureSource`. The underlying `ICatalogRepository` is `Transient` (per `CatalogModule.cs:45`), which is safe for a `Scoped` consumer per ASP.NET Core DI rules (the transient is materialized into the scope and reused for the scope's lifetime).
+
+- [ ] **Step 3: Build and verify**
+
+Run:
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with no errors and no new warnings. (No tests for DI registration itself; a smoke test for the registration is the end-to-end `dotnet test` after Task 7 — if the DI graph is broken, every Manufacture handler test that instantiates from DI will fail.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Catalog/CatalogModule.cs
+git commit -m "feat(catalog): register CatalogManufactureCatalogSourceAdapter in CatalogModule"
+```
+
+---
+
+## Task 4: Add `Manufacture -> Catalog` boundary rule with empty allowlist (expected to fail)
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Add the empty allowlist constant**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Add this allowlist constant immediately above the `public static TheoryData<ModuleBoundaryRule> Rules()` method (around line 200, right after `DataQualityInvoicesAllowlist`):
+
+```csharp
+    // Allowlist for Manufacture -> Catalog. Populated after running the boundary test with
+    // an empty allowlist and pasting the residual violations grouped by referenced type.
+    // The deliberate pragmatic leak (CatalogAggregate and its property types flowing through
+    // IManufactureCatalogSource) is symmetric to the CatalogManufactureAllowlist entries for
+    // ManufactureHistoryRecord. Follow-up: introduce Manufacture-owned ProductCatalogSnapshot
+    // DTO and map in CatalogManufactureCatalogSourceAdapter.
+    private static readonly HashSet<string> ManufactureCatalogAllowlist = new(StringComparer.Ordinal);
+```
+
+- [ ] **Step 2: Add the boundary rule to `Rules()`**
+
+Append this entry to the `TheoryData<ModuleBoundaryRule>` returned by `Rules()` (after the existing `"DataQuality -> Invoices"` entry, before the closing `};`):
+
+```csharp
+        new ModuleBoundaryRule(
+            Name: "Manufacture -> Catalog",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.Manufacture",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Catalog",
+                "Anela.Heblo.Application.Features.Catalog",
+                "Anela.Heblo.Persistence.Catalog",
+            },
+            Allowlist: ManufactureCatalogAllowlist),
+```
+
+- [ ] **Step 3: Run the boundary test — expect failure**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces" --logger "console;verbosity=detailed"
+```
+
+Expected: the test for the `"Manufacture -> Catalog"` rule **fails** with a long list of violations. The failure message will start with `Manufacture -> Catalog: consumer types must not reference provider-owned namespaces.` followed by lines like:
+
+```
+  Anela.Heblo.Application.Features.Manufacture.UseCases.<X>.<Y>Handler -> Anela.Heblo.Domain.Features.Catalog.ICatalogRepository (via ctor parameter ...)
+  Anela.Heblo.Application.Features.Manufacture.UseCases.<X>.<Y>Handler -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate (via ...)
+  Anela.Heblo.Application.Features.Manufacture.Contracts.IManufactureCatalogSource -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate (via method GetByIdAsync return)
+  ...
+```
+
+Note: at this point all 11 handlers still inject `ICatalogRepository`, so the `ICatalogRepository` and the existing `CatalogAggregate`/`ProductType` references will dominate. **Save the full output of this run** — we will diff it against the post-migration output to identify the residual (allowlisted) violations in Task 7. Pipe to a file if useful:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces" --logger "console;verbosity=detailed" > /tmp/boundary-pre-migration.txt 2>&1; grep -E "Manufacture -> Catalog|via " /tmp/boundary-pre-migration.txt | head -100
+```
+
+- [ ] **Step 4: Commit (the failing-test scaffolding is intentional and will be made green by Tasks 5–7)**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test(arch): add Manufacture -> Catalog boundary rule (allowlist populated in follow-up commits)"
+```
+
+---
+
+## Task 5: Migrate Manufacture services and handlers off `ICatalogRepository`
+
+This task has 11 file edits, each following an identical pattern. For each file, apply: constructor parameter rename, field rename, call-site receiver rename, and `using` directive swap. Wait until the end to run the full test suite — the boundary test will still fail until Task 7 populates the allowlist, but the build must stay green throughout.
+
+**Files (verify with a fresh `grep -l "ICatalogRepository" backend/src/Anela.Heblo.Application/Features/Manufacture/` at the start):**
+- Modify all 11 files listed in the File Structure section.
+
+### Task 5.1: `Services/BatchPlanningService.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/BatchPlanningService.cs`:
+
+Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;` at the top (keep `using Anela.Heblo.Domain.Features.Catalog;` because the file still uses `CatalogAggregate`).
+
+Replace the field block:
+
+```csharp
+    private readonly ICatalogRepository _catalogRepository;
+```
+
+with:
+
+```csharp
+    private readonly IManufactureCatalogSource _catalogSource;
+```
+
+Replace the constructor parameter:
+
+```csharp
+    public BatchPlanningService(
+        ICatalogRepository catalogRepository,
+        IManufactureClient manufactureClient,
+        IBatchDistributionCalculator batchDistributionCalculator,
+        IConsumptionRateCalculator consumptionRateCalculator,
+        ILogger<BatchPlanningService> logger)
+    {
+        _catalogRepository = catalogRepository;
+```
+
+with:
+
+```csharp
+    public BatchPlanningService(
+        IManufactureCatalogSource catalogSource,
+        IManufactureClient manufactureClient,
+        IBatchDistributionCalculator batchDistributionCalculator,
+        IConsumptionRateCalculator consumptionRateCalculator,
+        ILogger<BatchPlanningService> logger)
+    {
+        _catalogSource = catalogSource;
+```
+
+Replace every body occurrence of `_catalogRepository.` with `_catalogSource.` (verify with grep there are no other references after the change).
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.2: `Services/ResidueDistributionCalculator.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/Services/ResidueDistributionCalculator.cs`:
+
+Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`. Keep `using Anela.Heblo.Domain.Features.Catalog;` (used for `ProductType`).
+
+Replace field:
+
+```csharp
+    private readonly ICatalogRepository _catalogRepository;
+```
+
+with:
+
+```csharp
+    private readonly IManufactureCatalogSource _catalogSource;
+```
+
+Replace constructor:
+
+```csharp
+    public ResidueDistributionCalculator(IManufactureClient manufactureClient, ICatalogRepository catalogRepository)
+    {
+        _manufactureClient = manufactureClient;
+        _catalogRepository = catalogRepository;
+    }
+```
+
+with:
+
+```csharp
+    public ResidueDistributionCalculator(IManufactureClient manufactureClient, IManufactureCatalogSource catalogSource)
+    {
+        _manufactureClient = manufactureClient;
+        _catalogSource = catalogSource;
+    }
+```
+
+Replace body: `_catalogRepository.GetByIdAsync(...)` → `_catalogSource.GetByIdAsync(...)`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.3: `UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchPlan/CalculateBatchPlanHandler.cs`:
+
+Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`. Keep `using Anela.Heblo.Domain.Features.Catalog;` (used for `ProductType`).
+
+Replace field `private readonly ICatalogRepository _catalogRepository;` with `private readonly IManufactureCatalogSource _catalogSource;`.
+
+Replace the constructor parameter and assignment exactly as in Task 5.1.
+
+Replace `_catalogRepository.GetByIdAsync(request.ProductCode, cancellationToken)` with `_catalogSource.GetByIdAsync(request.ProductCode, cancellationToken)`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.4: `UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetStockAnalysis/GetManufacturingStockAnalysisHandler.cs`:
+
+Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`. Keep `using Anela.Heblo.Domain.Features.Catalog;` (used for `ProductType`).
+
+Replace field `private readonly ICatalogRepository _catalogRepository;` with `private readonly IManufactureCatalogSource _catalogSource;`.
+
+Replace the constructor's first parameter from `ICatalogRepository catalogRepository` to `IManufactureCatalogSource catalogSource`, and the assignment `_catalogRepository = catalogRepository;` to `_catalogSource = catalogSource;`.
+
+Replace `_catalogRepository.GetAllAsync(cancellationToken)` with `_catalogSource.GetAllAsync(cancellationToken)`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.5: `UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CreateManufactureOrder/CreateManufactureOrderHandler.cs`:
+
+Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`. Keep `using Anela.Heblo.Domain.Features.Catalog;` if other catalog types are referenced (review imports).
+
+Replace field `private readonly ICatalogRepository _catalogRepository;` with `private readonly IManufactureCatalogSource _catalogSource;`.
+
+Replace constructor parameter `ICatalogRepository catalogRepository` → `IManufactureCatalogSource catalogSource` and the matching assignment.
+
+Replace every `_catalogRepository.` with `_catalogSource.` in the body (this file uses both `GetByIdAsync` and `GetByIdsAsync`).
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.6: `UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculateBatchByIngredient/CalculateBatchByIngredientHandler.cs`:
+
+Same pattern as Task 5.3 (`GetByIdAsync` only). Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`; swap field, ctor param, and assignment; replace `_catalogRepository.` with `_catalogSource.`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.7: `UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetManufactureOutput/GetManufactureOutputHandler.cs`:
+
+Same pattern as Task 5.3 (`GetByIdAsync` only). Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;`; swap field, ctor param, and assignment; replace `_catalogRepository.` with `_catalogSource.`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.8: `UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/CalculatedBatchSize/CalculatedBatchSizeHandler.cs`:
+
+Same pattern as Task 5.3 (`GetByIdAsync` only). Swap field, ctor param, assignment, call site.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.9: `UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/SubmitManufactureStockTaking/SubmitManufactureStockTakingHandler.cs`:
+
+Same pattern as Task 5.3. Swap field, ctor param, assignment, call site (`GetByIdAsync`).
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.10: `UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/UpdateManufactureOrderStatus/UpdateManufactureOrderStatusHandler.cs`:
+
+Same pattern as Task 5.3. Swap field, ctor param, assignment, call site (`GetByIdAsync`).
+
+- [ ] **Step 2: Build**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green.
+
+### Task 5.11: `UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs`
+
+- [ ] **Step 1: Apply the edits**
+
+In `backend/src/Anela.Heblo.Application/Features/Manufacture/UseCases/GetSemiproductRecipePdf/GetSemiproductRecipePdfHandler.cs`:
+
+Same pattern as Task 5.3. Swap field, ctor param, assignment, call site (`GetByIdAsync`).
+
+- [ ] **Step 2: Verify no remaining `ICatalogRepository` references in Manufacture source**
+
+Run:
+
+```bash
+grep -rln "ICatalogRepository" backend/src/Anela.Heblo.Application/Features/Manufacture/ || echo "OK — no references remain"
+```
+
+Expected: `OK — no references remain`.
+
+- [ ] **Step 3: Final build for source side**
+
+```bash
+cd backend && dotnet build src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: green, no new warnings.
+
+- [ ] **Step 4: Commit Task 5 changes**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Manufacture/
+git commit -m "refactor(manufacture): replace ICatalogRepository injections with IManufactureCatalogSource"
+```
+
+---
+
+## Task 6: Migrate Manufacture unit tests to mock `IManufactureCatalogSource`
+
+This task swaps mock generic type in 9–10 test files. Pattern is identical per file; the test bodies do not change because all three method signatures match between the new contract and `ICatalogRepository`.
+
+**Files (re-verify with `grep -l "Mock<ICatalogRepository>" backend/test/Anela.Heblo.Tests/Features/Manufacture/` at the start):**
+- `BatchPlanningServiceTests.cs`
+- `CalculateBatchByIngredientHandlerTests.cs`
+- `CalculateBatchBySizeHandlerTests.cs`
+- `CalculateBatchPlanHandlerTests.cs`
+- `CalculatedBatchSizeHandlerLastStockTakingTests.cs`
+- `CreateManufactureOrderHandlerTests.cs`
+- `CreateManufactureOrderHandlerSinglePhaseTests.cs`
+- `GetManufactureOutputHandlerTests.cs`
+- `GetManufacturingStockAnalysisHandlerTests.cs`
+- `GetSemiproductRecipePdfHandlerTests.cs`
+- `Services/ResidueDistributionCalculatorTests.cs`
+- `SubmitManufactureStockTakingHandlerTests.cs`
+- `UpdateManufactureOrderStatusHandlerConditionsTests.cs`
+- `UpdateManufactureOrderStatusHandlerTests.cs`
+
+- [ ] **Step 1: Refresh the file list**
+
+Run:
+
+```bash
+grep -lr "Mock<ICatalogRepository>" backend/test/Anela.Heblo.Tests/Features/Manufacture/
+```
+
+Expected: 9–14 files (the planning-time count was 14 but only those that mock `ICatalogRepository` need editing — there is overlap because some Manufacture tests touch `ICatalogRepository` in non-`Mock<>` contexts; treat the `Mock<ICatalogRepository>` matches as authoritative).
+
+- [ ] **Step 2: For each file, apply the swap**
+
+In every file matching the grep:
+
+1. Add `using Anela.Heblo.Application.Features.Manufacture.Contracts;` near the top of the file (preserve alphabetical ordering of `using` directives where the file already follows it). Keep `using Anela.Heblo.Domain.Features.Catalog;` if `CatalogAggregate` or any other Catalog type is still referenced.
+2. Replace every occurrence of `Mock<ICatalogRepository>` with `Mock<IManufactureCatalogSource>` (this covers both the field declaration and the `new Mock<ICatalogRepository>()` assignment). All other code stays unchanged — Mock setup signatures (`Setup(x => x.GetByIdAsync(...))`, `Setup(x => x.GetAllAsync(...))`, `Setup(x => x.GetByIdsAsync(...))`) match by construction.
+
+Tip: per-file `sed` is fine and safe because the only token that changes is the generic argument:
+
+```bash
+sed -i '' 's/Mock<ICatalogRepository>/Mock<IManufactureCatalogSource>/g' <file>
+```
+
+For the `using` directive add, edit each file manually after the bulk-sed run.
+
+- [ ] **Step 3: Verify no Manufacture test still references `ICatalogRepository`**
+
+Run:
+
+```bash
+grep -rln "ICatalogRepository" backend/test/Anela.Heblo.Tests/Features/Manufacture/ || echo "OK"
+```
+
+Expected: `OK` (no matches). If matches remain, they are likely leftover `using` directives — remove them if the file no longer references any type from `Anela.Heblo.Domain.Features.Catalog`.
+
+- [ ] **Step 4: Run Manufacture tests**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Manufacture"
+```
+
+Expected: all Manufacture tests pass. No new failures, no skips that weren't already present.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Manufacture/
+git commit -m "test(manufacture): swap Mock<ICatalogRepository> to Mock<IManufactureCatalogSource>"
+```
+
+---
+
+## Task 7: Populate `ManufactureCatalogAllowlist` with the residual deliberate-leak references
+
+After Tasks 5–6, the boundary test still fails — but the violations are now exclusively the deliberate `CatalogAggregate` / `ProductType` / etc. leaks flowing through the new contract, which is the intended end state.
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`
+
+- [ ] **Step 1: Capture the residual violation list**
+
+Run:
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ModuleBoundariesTests.Consumer_types_should_not_reference_provider_owned_namespaces" --logger "console;verbosity=detailed" 2>&1 | tee /tmp/boundary-post-migration.txt
+```
+
+Expected output: the `Manufacture -> Catalog` rule fails with violations of the form:
+
+```
+  Anela.Heblo.Application.Features.Manufacture.Contracts.IManufactureCatalogSource -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate (via method GetByIdAsync return)
+  Anela.Heblo.Application.Features.Manufacture.Services.BatchPlanningService -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate (via ...)
+  Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler -> Anela.Heblo.Domain.Features.Catalog.ProductType (via ...)
+  ...
+```
+
+Extract the unique `Consumer -> Provider` pairs (strip the `(via ...)` suffix and dedupe):
+
+```bash
+grep -E "Anela\.Heblo\.Application\.Features\.Manufacture.* -> Anela\.Heblo\." /tmp/boundary-post-migration.txt \
+  | sed -E 's/ \(via .*\)//' \
+  | sort -u
+```
+
+- [ ] **Step 2: Populate the allowlist**
+
+Open `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs`. Replace the empty `ManufactureCatalogAllowlist` set with a populated version. Group entries by the referenced type with a single `//` comment block per group. Use this skeleton (replace `<...>` placeholders with the actual full type names from Step 1's output):
+
+```csharp
+    // Allowlist for Manufacture -> Catalog. Each group below is a deliberate pragmatic leak
+    // tracked under the same follow-up: introduce Manufacture-owned ProductCatalogSnapshot DTO
+    // and map in CatalogManufactureCatalogSourceAdapter (symmetric to the CatalogManufactureAllowlist
+    // ManufactureHistoryRecord block).
+    private static readonly HashSet<string> ManufactureCatalogAllowlist = new(StringComparer.Ordinal)
+    {
+        // Contract surface: IManufactureCatalogSource returns CatalogAggregate by design.
+        "Anela.Heblo.Application.Features.Manufacture.Contracts.IManufactureCatalogSource -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+
+        // Consumers of CatalogAggregate reached via IManufactureCatalogSource.GetByIdAsync /
+        // GetByIdsAsync / GetAllAsync. Remove these entries when ProductCatalogSnapshot DTO lands.
+        "Anela.Heblo.Application.Features.Manufacture.Services.BatchPlanningService -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.Services.ResidueDistributionCalculator -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.CalculateBatchPlan.CalculateBatchPlanHandler -> Anela.Heblo.Domain.Features.Catalog.CatalogAggregate",
+        // ... paste remaining "<consumer> -> ...CatalogAggregate" entries here from Step 1 output ...
+
+        // Domain enums reached via CatalogAggregate properties (ProductType, ManufactureType, etc.).
+        // Same follow-up as above.
+        "Anela.Heblo.Application.Features.Manufacture.UseCases.GetStockAnalysis.GetManufacturingStockAnalysisHandler -> Anela.Heblo.Domain.Features.Catalog.ProductType",
+        // ... paste remaining domain-enum / value-type entries here ...
+    };
+```
+
+Critical rules for the allowlist:
+
+- **Do NOT add `ICatalogRepository`** — that is the violation this work fixes. If `ICatalogRepository` appears in Step 1's output, the migration in Task 5 is incomplete; go back and finish it.
+- Paste **every** unique entry from Step 1 — do not selectively prune. The reflection walker enumerates fields, properties, constructor params, method params and returns, attribute types, and generic arguments; missing an entry will fail CI.
+- Compiler-generated nested types (`+<>c__DisplayClassN_M`, `+<MethodName>d__N`) are auto-handled by the `DeclaringType` check (see `ModuleBoundariesTests.cs:385-391`), so you do not normally need entries for them — but if Step 1's output shows one, paste it (it costs nothing and survives codegen drift).
+- Order entries within each group alphabetically for review-friendliness.
+
+- [ ] **Step 3: Re-run the boundary test**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~ModuleBoundariesTests"
+```
+
+Expected: all `ModuleBoundariesTests` pass, including the `Manufacture -> Catalog` rule. If any violation remains: append it to the allowlist with the matching group's comment header, then re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+git commit -m "test(arch): populate ManufactureCatalogAllowlist with deliberate CatalogAggregate leak entries"
+```
+
+---
+
+## Task 8: Full backend validation
+
+- [ ] **Step 1: Solution build**
+
+```bash
+cd backend && dotnet build
+```
+
+Expected: green with no errors and no new warnings introduced by this change. (Compare warning count against `main`'s baseline if uncertain.)
+
+- [ ] **Step 2: Solution format**
+
+```bash
+cd backend && dotnet format --verify-no-changes
+```
+
+Expected: no formatting changes required. If the command reports diffs, run `dotnet format` without `--verify-no-changes`, review the diffs, and amend Task 8 with the formatting commit. (Should not be needed for the small token changes done here.)
+
+- [ ] **Step 3: Full Manufacture + arch test run**
+
+```bash
+cd backend && dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Manufacture|FullyQualifiedName~ModuleBoundaries|FullyQualifiedName~CatalogManufactureCatalogSourceAdapter"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Full test suite (sanity check for unintended impact)**
+
+```bash
+cd backend && dotnet test
+```
+
+Expected: same pass/fail count as `main`. No new failures introduced by this change. Skipped/flaky tests pre-existing on `main` are tolerated.
+
+- [ ] **Step 5: Confirm no `Anela.Heblo.Domain.Features.Catalog.ICatalogRepository` references remain in Manufacture (final guard)**
+
+```bash
+grep -rn "ICatalogRepository" backend/src/Anela.Heblo.Application/Features/Manufacture/ backend/test/Anela.Heblo.Tests/Features/Manufacture/ || echo "OK — fully decoupled"
+```
+
+Expected: `OK — fully decoupled`.
+
+- [ ] **Step 6: (No frontend changes — skip)**
+
+This change is backend-only with no DTO, controller, OpenAPI, or React impact. No `npm run build`, no `npm run lint`, no E2E run required. The OpenAPI client regeneration step (auto-run on backend build) is a no-op because no controller signatures changed.
+
+---
+
+## Self-Review Checklist (for the plan author)
+
+- **Spec coverage:** All five functional requirements have a dedicated task:
+  - FR-1 → Task 1 (with arch-review §Amendments #1 return-type correction applied).
+  - FR-2 → Task 2 (adapter) + Task 3 (DI registration, with arch-review §Amendments #3 adapter tests added).
+  - FR-3 → Task 5 (11 sub-tasks for 11 files).
+  - FR-4 → Tasks 4 + 7 (rule added with empty allowlist first, populated after migration per arch-review §Amendments #4).
+  - FR-5 → Task 6 (test mock swap) + Task 2 (new adapter tests per arch-review §Amendments #3).
+
+- **Non-functional requirements:** NFR-1 (performance) is preserved — adapter is a literal pass-through (no `.ToList()`, no LINQ). NFR-2 (security) is unchanged — no auth, logging, or surface changes. NFR-3 (backwards compat) is preserved — `ICatalogRepository` is untouched.
+
+- **Out of scope items honored:** No DTO extraction, no `IManufactureClient` follow-up, no `ICatalogRepository` lifetime change, no analytics method additions, no controller/DTO/frontend changes.
+
+- **Arch-review amendment #5 (docs cross-reference):** Intentionally not included in this plan. The arch review marks it as optional and "out of scope for this PR if the spec author prefers." Keeping the diff surgical.
+
+- **Type/method signature consistency:** All call-site receivers swap to `_catalogSource`; all method names (`GetByIdAsync`, `GetByIdsAsync`, `GetAllAsync`) are reused identically across tasks. Adapter return type for `GetAllAsync` is `Task<IEnumerable<CatalogAggregate>>` consistently in Task 1 (contract), Task 2 (adapter + test), and Task 5.4 (call site `_catalogSource.GetAllAsync(...)` is assigned to `var allCatalogItems` which then `.Where(...).ToList()` — no signature change at call site).
+
+- **No placeholders:** Each step has either exact code, exact commands, or both. No "TBD", no "add validation", no "similar to Task N" without inlined repetition. The one exception is Task 7 Step 2's `// ... paste remaining ... entries here ...` markers — these are required because the allowlist content is generated from the failing test run in Step 1, not knowable at plan time. The list of *what to paste from* (the grep command in Step 1) and the *grouping rules* (Step 2 body) are fully specified.


### PR DESCRIPTION

Decouples the Manufacture module from Catalog's internal `ICatalogRepository` by introducing a Manufacture-owned `IManufactureCatalogSource` contract, a Catalog-side adapter, and a new `ModuleBoundariesTests` enforcement rule — completing the architectural inversion that was already in place in the opposite direction (`ICatalogManufactureSource`).

The 11 Manufacture services and handlers that previously injected `ICatalogRepository` directly now depend only on `IManufactureCatalogSource`, eliminating a cross-module coupling that would have blocked adding the `ModuleBoundariesTests` rule. The `CatalogAggregate` type still flows through the contract surface (pragmatic leak, allowlisted, tracked as a follow-up to introduce a `ProductCatalogSnapshot` DTO) — symmetric to the existing `ManufactureHistoryRecord` leak in `ICatalogManufactureSource`.

### Changes
- `Features/Manufacture/Contracts/IManufactureCatalogSource.cs` — new consumer-owned contract (3 read methods)
- `Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapter.cs` — new provider-owned adapter (internal sealed, pure pass-through)
- `Features/Catalog/CatalogModule.cs` — new `AddScoped<IManufactureCatalogSource, CatalogManufactureCatalogSourceAdapter>()` registration
- 11 Manufacture source files — `ICatalogRepository`→`IManufactureCatalogSource` dependency swap
- `Architecture/ModuleBoundariesTests.cs` — new `"Manufacture -> Catalog"` rule + 43-entry `ManufactureCatalogAllowlist`
- 14 Manufacture test files — `Mock<ICatalogRepository>`→`Mock<IManufactureCatalogSource>` swap
- `Features/Catalog/Infrastructure/CatalogManufactureCatalogSourceAdapterTests.cs` — 3 new pass-through tests

---

Closes #2432

### Tokens used
24264532
