### PR TITLE
feat: Replace `BypassJwtValidation` magic strings with `ConfigurationConstants.BYPASS_JWT_VALIDATION`

### DIFF
--- a/artifacts/feat-arch-review-configuration-five-applicati/arch-review.r1.md
+++ b/artifacts/feat-arch-review-configuration-five-applicati/arch-review.r1.md
@@ -1,0 +1,145 @@
+# Architecture Review: Replace `BypassJwtValidation` magic strings with `ConfigurationConstants.BYPASS_JWT_VALIDATION`
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+The proposal aligns precisely with an existing, established pattern. `ConfigurationConstants` (`backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs`) is the canonical single source of truth for configuration keys used in DI module wiring. It is already consumed correctly by the API layer (`AuthenticationExtensions.cs`, `HangfireAuthenticationMiddleware.cs`, `HangfireDashboardTokenAuthorizationFilter.cs`) and by `UserManagementModule.cs` in the Application layer. The five offending modules are outliers — applying the constant restores convention compliance.
+
+Integration points:
+- **Project reference graph** — `Anela.Heblo.Application` already references `Anela.Heblo.Domain`. `UserManagementModule.cs:4` proves the using directive `Anela.Heblo.Domain.Features.Configuration;` is valid in this project. No project-reference changes required.
+- **No public API change** — the modules expose static `AddXModule(IServiceCollection, IConfiguration)` extensions; their signatures and call sites in the API composition root are untouched.
+- **Behavioral equivalence** — `ConfigurationConstants.BYPASS_JWT_VALIDATION` is a `public const string = "BypassJwtValidation"`, inlined at the call site by the compiler. IL output is identical to the literal.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.Domain                                          │
+│   Features/Configuration/ConfigurationConstants.cs          │
+│     public const string BYPASS_JWT_VALIDATION = "Bypass…"   │ ◄── single source of truth
+└─────────────────────────────────────────────────────────────┘
+                          ▲
+                          │ using Anela.Heblo.Domain.Features.Configuration;
+                          │
+┌─────────────────────────┴───────────────────────────────────┐
+│ Anela.Heblo.Application — five module files (refactor scope)│
+│   MeetingTasksModule.cs     line 21                         │
+│   MarketingModule.cs        line 38                         │
+│   KnowledgeBaseModule.cs    line 58                         │
+│   CatalogDocumentsModule.cs line 27                         │
+│   PhotobankModule.cs        line 41                         │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│ Already correct (reference pattern — do not touch)          │
+│   Application/Features/UserManagement/UserManagementModule  │
+│   API/Extensions/AuthenticationExtensions                   │
+│   API/Infrastructure/Authentication/HangfireAuth…Middleware │
+│   API/Infrastructure/Hangfire/HangfireDashboardToken…       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Use the existing constant, do not introduce a Strongly-Typed Options object
+**Options considered:**
+- A. Replace the literal with `ConfigurationConstants.BYPASS_JWT_VALIDATION` (spec proposal).
+- B. Introduce an `AuthBypassOptions` Options-pattern type bound to a configuration section, injected into modules.
+- C. Hoist the bypass-mode resolution into a shared helper `AuthModeResolver` that the five modules call.
+
+**Chosen approach:** A.
+
+**Rationale:** B and C exceed the spec scope, alter call-site shape, and require new tests. The spec is explicit: pure literal-to-constant substitution with identical runtime behavior and surgical changes. The codebase already endorses approach A via `UserManagementModule.cs:17` — copying that exact idiom keeps the five modules visually and behaviorally aligned with the existing reference implementation. Decisions B/C may be valid future work but belong in a separate brief.
+
+#### Decision 2: Preserve each call's existing argument style
+**Options considered:**
+- A. Match each file's existing argument style — positional default if the module already used positional, named (`defaultValue: false`) if it already used named.
+- B. Normalize all five call sites to the named-argument form used in `UserManagementModule.cs` and the API layer.
+
+**Chosen approach:** A.
+
+**Rationale:** Spec FR-2 requires "call signature is otherwise unchanged" and Out of Scope lists "formatting or style changes unrelated to the literal replacement." All five target files currently use the positional form `GetValue<bool>("...", false)`. Keep them positional. Do not introduce `defaultValue:` here. Style normalization is a separate, optional follow-up.
+
+#### Decision 3: Add the `using` directive only when absent
+**Options considered:**
+- A. Always add `using Anela.Heblo.Domain.Features.Configuration;` to all five files.
+- B. Add only where not already imported.
+
+**Chosen approach:** B.
+
+**Rationale:** Spec FR-1 says the directive should be added "only when not already imported transitively or directly." Inspection of the five files at audit time shows none of them currently import this namespace, so in practice the directive will be added to all five — but the rule remains: do not add a duplicate.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. No moves. No deletions. Edit in place:
+
+```
+backend/src/Anela.Heblo.Application/Features/
+├── MeetingTasks/MeetingTasksModule.cs       (edit line 21 + using)
+├── Marketing/MarketingModule.cs              (edit line 38 + using)
+├── KnowledgeBase/KnowledgeBaseModule.cs      (edit line 58 + using)
+├── CatalogDocuments/CatalogDocumentsModule.cs (edit line 27 + using)
+└── Photobank/PhotobankModule.cs              (edit line 41 + using)
+```
+
+### Interfaces and Contracts
+
+No interface, contract, or DI registration changes. The signature
+
+```csharp
+public static IServiceCollection AddXModule(this IServiceCollection services, IConfiguration configuration)
+```
+
+is preserved across all five modules.
+
+For each file, the edit is a two-token substitution plus an import:
+
+```csharp
+// Before
+var bypassJwt = configuration.GetValue<bool>("BypassJwtValidation", false);
+
+// After
+var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
+```
+
+with `using Anela.Heblo.Domain.Features.Configuration;` added to the imports block (alphabetically ordered, consistent with file's existing style).
+
+**Local variable names** vary across files (`bypassJwt`, `bypassJwtValidation`). Leave them alone — Out of Scope item #4 forbids adjacent refactors.
+
+### Data Flow
+
+Unchanged. At application startup, `Program.cs` calls each `AddXModule(builder.Services, builder.Configuration)`. Inside each module, `configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false)` reads the same configuration key (`"BypassJwtValidation"`) from the same `IConfiguration` provider chain. The boolean drives the same conditional branch selecting between real Graph-backed services and mock/no-op implementations. No runtime path changes.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Editor adds the `using` and reorders/groups other imports as a side effect | Low | Restrict the edit to inserting one line in the existing import block; do not run a "sort usings" reorganize on save. Verify the diff per file. |
+| Duplicate `using` if Domain.Features.Configuration was already imported (e.g. via another type pulled into the file later) | Low | Grep each target file's import block before editing; only add the directive when missing. (Confirmed missing in all five at audit time.) |
+| `dotnet format` rewrites unrelated whitespace in target files after the change | Low | Run `dotnet format --verify-no-changes` before the edit on the same files. If format-related noise exists pre-edit, fix it in a separate commit; the refactor commit must contain only the literal and import change. |
+| Repo-wide assertion ("zero remaining `\"BypassJwtValidation\"` outside `ConfigurationConstants.cs`") also flags documentation under `docs/superpowers/plans/*.md` and `appsettings.Development.json` | Medium | The grep assertion in spec FR-1 must be scoped to `backend/src/**/*.cs` excluding `ConfigurationConstants.cs`. Plan/spec markdown and `appsettings*.json` are legitimate occurrences (one is the actual config key in JSON, others are historical plan documents). Do not edit them. |
+| Future contributor copies the offending pattern from a remaining example before the refactor lands | Low | Land the five edits in a single commit; rebase quickly. |
+| Hidden coupling: a test that reflects on or string-matches `"BypassJwtValidation"` in source files | Low | Run `dotnet test` for the affected projects after the change; the spec already requires green tests. |
+
+## Specification Amendments
+
+1. **Scope the grep assertion to backend C# sources.** FR-1's acceptance criterion "A repo-wide search for `\"BypassJwtValidation\"` returns zero results outside `ConfigurationConstants.cs`" is too broad as written. The string legitimately appears in:
+   - `backend/src/Anela.Heblo.API/appsettings.Development.json` — actual JSON config key, must remain.
+   - `docs/superpowers/plans/2026-05-22-catalog-documents.md`, `docs/superpowers/plans/2026-05-19-fix-meeting-task-401-migrate-to-planner.md` — historical plan documents, not source of truth.
+
+   Restate the assertion as: *"A search for `\"BypassJwtValidation\"` inside `backend/src/**/*.cs` returns zero matches outside `ConfigurationConstants.cs`."*
+
+2. **Note the parallel `UseMockAuth` issue but keep it out of scope.** All five target files also use the literal `"UseMockAuth"` on the line immediately preceding the `BypassJwtValidation` read, and `ConfigurationConstants.USE_MOCK_AUTH` exists for the same purpose. The current spec correctly excludes this from scope (Out of Scope item #4: "auditing other magic-string configuration keys"). Recommend filing a follow-up brief so the same audit-and-fix discipline catches it on the next pass — otherwise the five sites remain half-converted.
+
+3. **Clarify positional vs. named default-argument style.** Add an explicit note that the refactor must preserve the existing positional `, false` form in each of the five files and must NOT normalize them to `defaultValue: false`. This forecloses an ambiguity that a contributor could otherwise resolve toward the API-layer style and inadvertently violate FR-2's "call signature otherwise unchanged" rule.
+
+4. **No new tests required.** FR-3 already states existing tests must pass. The change is IL-equivalent; new unit tests would not add signal. Make this explicit in Out of Scope.
+
+## Prerequisites
+
+None. The constant exists, the project reference exists, and the using directive is already proven valid in the same project (`UserManagementModule.cs:4`). Implementation can start immediately.

--- a/artifacts/feat-arch-review-configuration-five-applicati/brief.md
+++ b/artifacts/feat-arch-review-configuration-five-applicati/brief.md
@@ -1,0 +1,24 @@
+## Module
+Configuration
+
+## Finding
+`ConfigurationConstants.BYPASS_JWT_VALIDATION = "BypassJwtValidation"` is defined in `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs:14` precisely to give callers a single, rename-safe reference. Five Application-layer modules ignore it and use the raw string literal instead:
+
+| File | Line |
+|------|------|
+| `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` | 21 |
+| `backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs` | 38 |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` | 58 |
+| `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` | 27 |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` | 41 |
+
+By contrast the API layer (`HangfireDashboardTokenAuthorizationFilter.cs`, `AuthenticationExtensions.cs`, `HangfireAuthenticationMiddleware.cs`) and `UserManagementModule.cs` correctly use the constant.
+
+## Why it matters
+If the config key is ever renamed (e.g. during an appsettings restructure), a global find-and-replace on the constant catches all sites automatically. The five magic-string sites would silently silently start reading `false` (the `GetValue` default), disabling JWT-bypass checks without any compile-time or test-time signal. It also defeats the purpose of having a central constants file.
+
+## Suggested fix
+In each of the five files listed above, replace `"BypassJwtValidation"` with `ConfigurationConstants.BYPASS_JWT_VALIDATION` and add the necessary `using Anela.Heblo.Domain.Features.Configuration;`. No other change needed.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-configuration-five-applicati/impl/main.r1.md
+++ b/artifacts/feat-arch-review-configuration-five-applicati/impl/main.r1.md
@@ -1,0 +1,65 @@
+Both reviews passed. Here is the output summary:
+
+---
+
+# Implementation: Replace `BypassJwtValidation` magic strings with `ConfigurationConstants.BYPASS_JWT_VALIDATION`
+
+## What was implemented
+
+A pure IL-equivalent refactor across five Application-layer C# module files. Each file received:
+- One `using Anela.Heblo.Domain.Features.Configuration;` directive inserted in alphabetical position.
+- One substitution of the raw string literal `"BypassJwtValidation"` with `ConfigurationConstants.BYPASS_JWT_VALIDATION` in the `GetValue<bool>(...)` call, preserving the positional `, false` argument style.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` — line 21 literal replaced, using added
+- `backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs` — line 38 literal replaced, using added
+- `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` — line 58 literal replaced, using added
+- `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` — line 27 literal replaced, using added
+- `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` — line 41 literal replaced, using added
+
+## Tests
+
+No new tests added (per spec). Existing test suite ran via `dotnet test backend/backend.sln --no-build`. Pre-existing Docker/Testcontainer failures noted — unrelated to this change; no code-related failures.
+
+## How to verify
+
+```bash
+# Zero magic string consumers in C# sources
+grep -rn 'GetValue<bool>("BypassJwtValidation"' backend/src --include='*.cs'
+
+# Exactly one string literal (the constant definition)
+grep -rn '"BypassJwtValidation"' backend/src --include='*.cs'
+
+# All 5 constant references present
+grep -rn 'ConfigurationConstants\.BYPASS_JWT_VALIDATION' \
+  backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs \
+  backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs \
+  backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs \
+  backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs \
+  backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+
+dotnet build backend/backend.sln
+```
+
+## Notes
+
+- Local variable names (`bypassJwt` vs `bypassJwtValidation`) were preserved unchanged per spec.
+- The adjacent `UseMockAuth` raw string literal on the preceding line in each file was intentionally left untouched — out of scope per spec and arch review.
+- `appsettings.Development.json` and plan docs still contain `"BypassJwtValidation"` as expected (JSON config key and historical docs — not C# source).
+
+## PR Summary
+
+Replaced five raw `"BypassJwtValidation"` string literals in Application-layer module files with the existing `ConfigurationConstants.BYPASS_JWT_VALIDATION` constant, restoring the Domain constants file as the single source of truth for this configuration key. The API layer and `UserManagementModule` already used the constant correctly; these five modules were outliers.
+
+The change is IL-equivalent — the compiler inlines `public const string` values, so no runtime behavior differs. A future rename of the configuration key is now compile-time safe across the entire codebase.
+
+### Changes
+- `MeetingTasksModule.cs` — added using, replaced literal on line 21
+- `MarketingModule.cs` — added using, replaced literal on line 38
+- `KnowledgeBaseModule.cs` — added using, replaced literal on line 58
+- `CatalogDocumentsModule.cs` — added using, replaced literal on line 27
+- `PhotobankModule.cs` — added using, replaced literal on line 41
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-configuration-five-applicati/spec.r1.md
+++ b/artifacts/feat-arch-review-configuration-five-applicati/spec.r1.md
@@ -1,0 +1,82 @@
+# Specification: Replace `BypassJwtValidation` magic strings with `ConfigurationConstants.BYPASS_JWT_VALIDATION`
+
+## Summary
+Five Application-layer module files use the raw string literal `"BypassJwtValidation"` when reading configuration, instead of the existing `ConfigurationConstants.BYPASS_JWT_VALIDATION` constant. This change replaces those literals with the constant reference so that any future rename is centralized and compile-time safe.
+
+## Background
+`ConfigurationConstants.BYPASS_JWT_VALIDATION` is defined at `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs:14` specifically to provide a single, rename-safe reference for this configuration key. The API layer (`HangfireDashboardTokenAuthorizationFilter.cs`, `AuthenticationExtensions.cs`, `HangfireAuthenticationMiddleware.cs`) and `UserManagementModule.cs` already use the constant correctly.
+
+However, five Application-layer module files still pass the raw string `"BypassJwtValidation"` to `IConfiguration.GetValue<bool>(...)`. If the config key is ever renamed during an appsettings restructure, a search-and-replace on the constant will miss these five sites. They would silently fall back to the `GetValue<bool>` default (`false`), disabling the JWT-bypass branch without any compile-time or test-time signal. This defeats the purpose of the central constants file and is a latent maintenance hazard.
+
+The fix is purely a refactor — runtime behavior must remain identical because the literal value `"BypassJwtValidation"` matches the constant's value exactly.
+
+## Functional Requirements
+
+### FR-1: Replace magic string with constant reference in five module files
+In each of the files listed below, replace the literal `"BypassJwtValidation"` with `ConfigurationConstants.BYPASS_JWT_VALIDATION` and add the required `using Anela.Heblo.Domain.Features.Configuration;` directive if it is not already present.
+
+Target files and lines (as identified at audit time — verify before editing):
+
+| File | Line |
+|------|------|
+| `backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs` | 21 |
+| `backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs` | 38 |
+| `backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs` | 58 |
+| `backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs` | 27 |
+| `backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs` | 41 |
+
+**Acceptance criteria:**
+- In each of the five files, the literal `"BypassJwtValidation"` no longer appears.
+- Each file references `ConfigurationConstants.BYPASS_JWT_VALIDATION` in its place.
+- Each file has a `using Anela.Heblo.Domain.Features.Configuration;` directive (only added when not already imported transitively or directly).
+- A repo-wide search for `"BypassJwtValidation"` (the quoted string literal, case-sensitive) returns zero results outside `ConfigurationConstants.cs` itself.
+- No other code changes are introduced in these files (no formatting, no adjacent refactors, no comment cleanup).
+
+### FR-2: Preserve runtime behavior
+The refactor must not alter how the bypass flag is read, defaulted, or interpreted.
+
+**Acceptance criteria:**
+- The `IConfiguration.GetValue<bool>(...)` call signature in each file is otherwise unchanged (same overload, same default behavior).
+- The boolean returned for any given `appsettings.json` configuration is identical before and after the change.
+- The conditional branch that consumes the value (registering bypass vs. real JWT auth wiring) is unchanged.
+
+### FR-3: Build and tests must remain green
+The refactor must compile cleanly and not break any existing tests.
+
+**Acceptance criteria:**
+- `dotnet build` succeeds with no new warnings introduced by this change.
+- `dotnet format` reports no required changes after the edit.
+- Any existing unit/integration tests that touch these five modules continue to pass.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact expected. Constant references compile to the same string literal in IL; runtime behavior is identical.
+
+### NFR-2: Security
+No change to the security posture. The bypass flag continues to be read from configuration and continues to default to `false` when absent. This refactor reduces the risk of a future rename silently disabling JWT validation enforcement — a latent security benefit, not a regression vector.
+
+### NFR-3: Maintainability
+After this change, the configuration key `"BypassJwtValidation"` exists as a string literal in exactly one place (`ConfigurationConstants.cs`). All consumers go through the constant.
+
+## Data Model
+No data model changes.
+
+## API / Interface Design
+No API or interface changes. This is a pure internal refactor of module registration code.
+
+## Dependencies
+- The Application-layer projects already reference `Anela.Heblo.Domain` (where `ConfigurationConstants` lives), as evidenced by other Domain types being consumed throughout. No new project references are required.
+
+## Out of Scope
+- Renaming the constant or its underlying configuration key.
+- Changing the default value or semantics of the bypass flag.
+- Refactoring the surrounding module-registration logic, error handling, or DI wiring in the five files.
+- Auditing other magic-string configuration keys elsewhere in the codebase (a separate concern).
+- Adding new tests beyond verifying that existing tests still pass.
+- Formatting or style changes unrelated to the literal replacement and the `using` directive.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-configuration-five-applicati/task-plan.r1.md
+++ b/artifacts/feat-arch-review-configuration-five-applicati/task-plan.r1.md
@@ -1,0 +1,9 @@
+Plan saved to `artifacts/feat-arch-review-configuration-five-applicati/plan.r1.md`.
+
+**Summary of the plan:**
+
+- **9 tasks** covering pre-flight verification, five per-file edits, whole-solution verification, test run, and a single commit at the end.
+- **Per-file edit pattern (Tasks 2–6):** insert `using Anela.Heblo.Domain.Features.Configuration;` in alphabetical position + substitute the literal `"BypassJwtValidation"` for `ConfigurationConstants.BYPASS_JWT_VALIDATION`, preserving the positional `, false` argument style (no normalization to `defaultValue: false`).
+- **Verification (Task 7):** scoped grep matching the exact `GetValue<bool>("BypassJwtValidation"` pattern over `backend/src/**/*.cs` (per arch-review Amendment 1), plus `dotnet build`, format check, and per-file diff stat sanity.
+- **Single commit (Task 9):** per the arch review's risk-mitigation guidance — all five edits land together.
+- **Explicit scope boundaries** at the top capture every "do not" from the spec and arch review, including the `UseMockAuth` parallel issue staying out of scope, no `using` reordering, no `dotnet format` solution-wide rewrite, and no test changes.

--- a/backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/CatalogDocuments/CatalogDocumentsModule.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.CatalogDocuments.Infrastructure;
 using Anela.Heblo.Application.Features.CatalogDocuments.Services;
+using Anela.Heblo.Domain.Features.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,7 +25,7 @@ public static class CatalogDocumentsModule
             && !options.PIF.DriveId.Contains("secrets.json");
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwt = configuration.GetValue<bool>("BypassJwtValidation", false);
+        var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
 
         if (drivesConfigured && !useMockAuth && !bypassJwt)
         {

--- a/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/KnowledgeBase/KnowledgeBaseModule.cs
@@ -6,6 +6,7 @@ using Anela.Heblo.Application.Features.KnowledgeBase.Infrastructure;
 using Microsoft.Identity.Web;
 using Anela.Heblo.Application.Features.KnowledgeBase.Services.DocumentExtractors;
 using Anela.Heblo.Application.Features.KnowledgeBase.UseCases.AskQuestion;
+using Anela.Heblo.Domain.Features.Configuration;
 using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,7 +56,7 @@ public static class KnowledgeBaseModule
         configuration.GetSection("KnowledgeBase").Bind(kbOptions);
         var sharePointConfigured = kbOptions.OneDriveFolderMappings.Any(m => !string.IsNullOrWhiteSpace(m.DriveId));
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwtValidation = configuration.GetValue<bool>("BypassJwtValidation", false);
+        var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
 
         if (sharePointConfigured && !useMockAuth && !bypassJwtValidation)
         {

--- a/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Marketing/MarketingModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Anela.Heblo.Application.Features.Marketing.Configuration;
 using Anela.Heblo.Application.Features.Marketing.Services;
+using Anela.Heblo.Domain.Features.Configuration;
 using Anela.Heblo.Domain.Features.Marketing;
 using Anela.Heblo.Persistence.Marketing;
 using Microsoft.Extensions.Configuration;
@@ -35,7 +36,7 @@ namespace Anela.Heblo.Application.Features.Marketing
             // authentication is active. Mock auth has no ITokenAcquisition registered, so DI
             // validation would fail; NoOpOutlookCalendarSync is used in those environments instead.
             var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-            var bypassJwt = configuration.GetValue<bool>("BypassJwtValidation", false);
+            var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
 
             if (!useMockAuth && !bypassJwt)
             {

--- a/backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/MeetingTasks/MeetingTasksModule.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.MeetingTasks.Services;
+using Anela.Heblo.Domain.Features.Configuration;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,7 @@ public static class MeetingTasksModule
             .ValidateOnStart();
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwt = configuration.GetValue<bool>("BypassJwtValidation", false);
+        var bypassJwt = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
 
         if (!useMockAuth && !bypassJwt)
         {

--- a/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Photobank/PhotobankModule.cs
@@ -14,6 +14,7 @@ using Anela.Heblo.Application.Features.Photobank.UseCases.GetPhotos;
 using Anela.Heblo.Application.Features.Photobank.UseCases.RemovePhotoTag;
 using Anela.Heblo.Application.Features.Photobank.UseCases.UpdateRule;
 using Anela.Heblo.Application.Features.Photobank.Validators;
+using Anela.Heblo.Domain.Features.Configuration;
 using Anela.Heblo.Domain.Features.Photobank;
 using Anela.Heblo.Persistence;
 using FluentValidation;
@@ -38,7 +39,7 @@ public static class PhotobankModule
         services.AddScoped<IPhotobankTagsCache, PhotobankTagsCache>();
 
         var useMockAuth = configuration.GetValue<bool>("UseMockAuth", false);
-        var bypassJwtValidation = configuration.GetValue<bool>("BypassJwtValidation", false);
+        var bypassJwtValidation = configuration.GetValue<bool>(ConfigurationConstants.BYPASS_JWT_VALIDATION, false);
 
         if (!useMockAuth && !bypassJwtValidation)
         {


### PR DESCRIPTION

Replaced five raw `"BypassJwtValidation"` string literals in Application-layer module files with the existing `ConfigurationConstants.BYPASS_JWT_VALIDATION` constant, restoring the Domain constants file as the single source of truth for this configuration key. The API layer and `UserManagementModule` already used the constant correctly; these five modules were outliers.

The change is IL-equivalent — the compiler inlines `public const string` values, so no runtime behavior differs. A future rename of the configuration key is now compile-time safe across the entire codebase.

### Changes
- `MeetingTasksModule.cs` — added using, replaced literal on line 21
- `MarketingModule.cs` — added using, replaced literal on line 38
- `KnowledgeBaseModule.cs` — added using, replaced literal on line 58
- `CatalogDocumentsModule.cs` — added using, replaced literal on line 27
- `PhotobankModule.cs` — added using, replaced literal on line 41

---

Closes #2439

### Tokens used
7175660
