### PR TITLE
feat: Replace Direct Environment Variable Access with IConfiguration in GetConfigurationHandler

### DIFF
--- a/artifacts/feat-arch-review-configuration-getconfigurati/arch-review.r1.md
+++ b/artifacts/feat-arch-review-configuration-getconfigurati/arch-review.r1.md
@@ -1,0 +1,150 @@
+# Architecture Review: Replace Direct Environment Variable Access with IConfiguration in GetConfigurationHandler
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a pure surgical refactor inside a single Vertical Slice (`Features/Configuration`). The change strengthens existing patterns rather than introducing new ones:
+
+- The handler already depends on `IConfiguration` (constructor at `GetConfigurationHandler.cs:19`) and uses it correctly for `UseMockAuth` (`GetConfigurationHandler.cs:66`). Routing the `APP_VERSION` read through the same injected abstraction removes a one-off deviation.
+- The .NET host’s default `AddEnvironmentVariables()` registration ensures `_configuration[ConfigurationConstants.APP_VERSION]` returns the same value as the current `System.Environment.GetEnvironmentVariable(...)` call in every environment (Development, Staging, Production, Test). Behavioral parity holds.
+- The repo already has a precedent for `ConfigurationBuilder().AddInMemoryCollection(...)` in unit tests (`backend/test/Anela.Heblo.Tests/Xcc/BackgroundRefresh/RefreshTaskConfigurationTests.cs:13-23`), so the new tests will mirror an established convention.
+- No domain-model, MediatR contract, controller, or DI registration changes. `ApplicationConfiguration.CreateWithDefaults` (`backend/src/Anela.Heblo.Domain/Features/Configuration/ApplicationConfiguration.cs:24`) and `ConfigurationConstants.APP_VERSION` (`backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs:9`) stay untouched.
+
+Integration points are minimal: only `GetConfigurationHandler.GetVersionFromSources()` changes.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+GetConfigurationRequest (MediatR)
+        │
+        ▼
+GetConfigurationHandler  ── depends on ──► IConfiguration  ◄── env vars (APP_VERSION),
+        │                                       ▲              appsettings, KeyVault
+        │                                       │
+        │                                       └── registered by host (Program.cs)
+        ▼
+GetVersionFromSources()    ── reads ──► _configuration[APP_VERSION]   (was: System.Environment.GetEnvironmentVariable)
+        │                  ── reflects ──► Assembly.GetExecutingAssembly() informational/version attrs
+        ▼
+ApplicationConfiguration.CreateWithDefaults(version, env, useMockAuth)
+        │
+        ▼
+GetConfigurationResponse   (unchanged DTO)
+```
+
+No new components, services, or registrations. The only edge that changes is the configuration-read edge inside `GetVersionFromSources()`.
+
+### Key Design Decisions
+
+#### Decision 1: Read APP_VERSION via indexer (`_configuration[KEY]`) rather than `GetValue<string>`
+**Options considered:**
+- A. `_configuration[ConfigurationConstants.APP_VERSION]` — returns `string?`, mirrors the direct env-var API the handler is replacing.
+- B. `_configuration.GetValue<string?>(ConfigurationConstants.APP_VERSION)` — symmetric with the `UseMockAuth` read at line 66.
+
+**Chosen approach:** Option A (indexer).
+
+**Rationale:** The replaced call already returned `string?`. The indexer is the idiomatic `IConfiguration` accessor for a flat key that is intentionally optional (the fallback chain expects nulls). `GetValue<T>` adds conversion machinery that is not needed here. Both approaches resolve env vars identically — this is purely about readability and minimal diff.
+
+#### Decision 2: Keep the three-step fallback chain intact and in place
+**Options considered:**
+- A. Leave `GetVersionFromSources()` as a private method; swap only the first read.
+- B. Extract a `IVersionProvider` abstraction with a default implementation, register in DI, inject into the handler.
+
+**Chosen approach:** Option A.
+
+**Rationale:** YAGNI. No other consumer needs a version provider, and the spec scopes the change to a single-file refactor (`NFR-4: surgical change`, `NFR-2: no new dependencies`). Introducing a new abstraction expands blast radius for zero current benefit.
+
+#### Decision 3: Add a dedicated unit-test file alongside the existing integration tests
+**Options considered:**
+- A. New `GetConfigurationHandlerTests.cs` next to `GetConfigurationEndpointTests.cs`.
+- B. Augment the existing `GetConfigurationEndpointTests.cs` with handler-level cases.
+
+**Chosen approach:** Option A.
+
+**Rationale:** The existing file is an integration test fixture (`[Collection("WebApp")]`, `IClassFixture<HebloWebApplicationFactory>`) that exercises the live HTTP pipeline. The new tests are handler-level unit tests that construct `GetConfigurationHandler` directly with an in-memory `IConfiguration`. Mixing the two concerns in one file would muddy the test category boundary. The repo already separates unit and integration handler tests (e.g., `Features/Journal/*HandlerTests.cs`).
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+**Modify** (1 file):
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs`
+  - In `GetVersionFromSources()`, replace line 76:
+    ```csharp
+    var version = Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION);
+    ```
+    with:
+    ```csharp
+    var version = _configuration[ConfigurationConstants.APP_VERSION];
+    ```
+  - Adjust the adjacent log message wording if it references “environment variable” to keep it accurate (e.g., “Version resolved from configuration: {Version}”). This is the only allowed adjacent edit — it’s required for correctness, not cleanup.
+  - Do **not** touch `using` directives: the file does not have a `using System;` declaration (`Environment` resolves via SDK `ImplicitUsings`), and `System.Reflection` remains needed by the assembly-version branches.
+
+**Create** (1 file):
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — handler-level unit tests with in-memory `IConfiguration`.
+
+**Do not touch:**
+- `ConfigurationConstants.cs`, `ApplicationConfiguration.cs`, `GetConfigurationRequest.cs`, `GetConfigurationResponse.cs`, `ConfigurationModule.cs`, `Program.cs`, or `GetConfigurationEndpointTests.cs`.
+
+### Interfaces and Contracts
+
+No interface changes. `IRequestHandler<GetConfigurationRequest, GetConfigurationResponse>` contract is unchanged. The handler’s constructor signature, MediatR routing, and HTTP endpoint binding all remain identical.
+
+Internally, the contract of `GetVersionFromSources()` (private, returns `string?`) is preserved: same return type, same null semantics, same precedence order.
+
+### Data Flow
+
+For a typical `GET /api/configuration` request:
+
+1. MediatR dispatches `GetConfigurationRequest` to `GetConfigurationHandler.Handle`.
+2. `BuildApplicationConfiguration()` calls `GetVersionFromSources()`.
+3. `GetVersionFromSources()` now consults `_configuration[APP_VERSION]`. The `IConfiguration` provider chain (in order of precedence, last wins for the same key): `appsettings.json` → `appsettings.{Environment}.json` → User Secrets (Dev only) → **Environment Variables** → Azure Key Vault.
+   - In Production/Staging containers, `APP_VERSION` is set as an env var by CI/CD, so the env-var provider wins — identical to today.
+   - In Test (`HebloWebApplicationFactory`), the env var is absent, so the call returns null and the fallback proceeds.
+4. If null/empty, fall back to `AssemblyInformationalVersionAttribute`; if still null/empty, fall back to `Assembly.GetExecutingAssembly().GetName().Version`.
+5. `ApplicationConfiguration.CreateWithDefaults(version, env, useMockAuth)` applies the `"1.0.0"` default if all three sources returned null.
+6. Response DTO is populated and returned. No change to the HTTP response shape.
+
+**Required unit-test cases** (satisfying FR-3):
+| # | Configuration setup | Expected `Version` |
+|---|---------------------|--------------------|
+| 1 | `{ "APP_VERSION": "2.5.1-ci.42" }` in-memory | `"2.5.1-ci.42"` |
+| 2 | `{ "APP_VERSION": "" }` in-memory | Assembly informational version (or assembly version) — assert non-null & not equal to default `"1.0.0"` (the test-host assembly always has one) |
+| 3 | empty in-memory dictionary | Same as case 2 |
+| 4 | `APP_VERSION` not set, `UseMockAuth = true` | sanity check that `UseMockAuth` is still wired correctly (regression guard for the surgical change) |
+
+Use `Microsoft.Extensions.Hosting.HostEnvironment` (or `Moq`/`NSubstitute` for `IHostEnvironment`) and `NullLogger<GetConfigurationHandler>.Instance` for the other constructor dependencies.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `IConfiguration` provider chain in some environment doesn’t actually include env vars, so APP_VERSION silently disappears in Production | HIGH | Verify `Program.cs` calls `AddEnvironmentVariables()` (default for `Host.CreateDefaultBuilder`/`WebApplication.CreateBuilder`); confirm KV-loaded secrets don’t define `APP_VERSION` (they don’t — KV uses prefixed secret names per CLAUDE.md). Add one assertion to the existing `GetConfiguration_ShouldReturnValidVersion` integration test only if non-trivial. |
+| Adjacent log-message edit drifts beyond the surgical scope | LOW | Limit the message change to the one log line whose text becomes inaccurate. No formatting passes, no unrelated tidy-ups. |
+| Reflection-based fallback branches (assembly informational version / assembly version) remain hard to unit-test deterministically because `Assembly.GetExecutingAssembly()` always returns the Application assembly | LOW | Accept this as a residual limitation outside this finding’s scope. Tests can still observe the *fallthrough* (non-null, non-empty string returned) without pinning the exact assembly value. Document this in the test file with a one-line comment if needed for clarity. |
+| New test file inadvertently pulls in `WebApplicationFactory` boot cost via shared `using` namespaces | LOW | Construct the SUT directly: `new GetConfigurationHandler(configuration, hostEnvironment, NullLogger<GetConfigurationHandler>.Instance)`. No `[Collection("WebApp")]`, no `IClassFixture`. |
+| Hidden caller relies on `Environment.GetEnvironmentVariable` side effect (e.g., concurrent set/get races) | NEGLIGIBLE | `IConfiguration` reads are thread-safe; no side effects. Confirmed by reading the handler — the call is a pure read. |
+
+## Specification Amendments
+
+The spec is sound and self-consistent. Two minor clarifications worth pinning before implementation:
+
+1. **Log-message update is in-scope.** The current log line at `GetConfigurationHandler.cs:79` reads `"Version found from APP_VERSION environment variable: {Version}"`. After the refactor, the value may come from any configuration source (appsettings, KV, env var). The log message should change to reflect this (suggested: `"Version found from configuration ({Key}): {Version}"` or `"Version resolved from configuration: {Version}"`). Treat this as part of the surgical change, not as adjacent-code cleanup. Update `NFR-4` mentally to permit this one line.
+
+2. **Assembly-fallback testability is *not* a goal of this change.** Spec FR-3 acceptance criterion (c) says “informational version absent — falls back to assembly version.” In practice `Assembly.GetExecutingAssembly()` will always return a non-null informational version when run from the standard test build. Recommended phrasing tweak: the test should assert “when `APP_VERSION` is absent, the returned version is non-null and not equal to the `DEFAULT_VERSION` constant,” which proves the fallback fired without trying to pin which assembly attribute won. This avoids a brittle test tied to MSBuild output.
+
+3. **Test project package dependency.** `Microsoft.Extensions.Configuration` (the package providing `ConfigurationBuilder` and `AddInMemoryCollection`) is **already transitively available** in `Anela.Heblo.Tests` via the project reference to `Anela.Heblo.Application` and the explicit `Microsoft.Extensions.Hosting.Abstractions` reference (`backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj:29`). The conditional clause in spec **Dependencies** (“add it to the test project only”) will not need to fire. Verified by the existing precedent in `RefreshTaskConfigurationTests.cs:21-23`.
+
+## Prerequisites
+
+None. All required infrastructure is in place:
+- `IConfiguration` is already injected into the handler.
+- `Program.cs` already wires environment variables into the configuration provider chain via the default host builder.
+- `ConfigurationConstants.APP_VERSION` already exists.
+- The test project already supports `Microsoft.Extensions.Configuration` patterns (verified above).
+- CI/CD pipeline injection of `APP_VERSION` as an env var is unaffected and unchanged.
+
+Implementation can start immediately.

--- a/artifacts/feat-arch-review-configuration-getconfigurati/brief.md
+++ b/artifacts/feat-arch-review-configuration-getconfigurati/brief.md
@@ -1,0 +1,33 @@
+## Module
+Configuration
+
+## Finding
+`GetConfigurationHandler` (`backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs`) injects `IConfiguration` and uses it correctly for `UseMockAuth` (line 66). However, the version resolution at line 76 calls `System.Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION)` directly, bypassing `IConfiguration` entirely:
+
+```csharp
+// line 66 — correct: uses IConfiguration abstraction
+var useMockAuth = _configuration.GetValue<bool>(ConfigurationConstants.USE_MOCK_AUTH, false);
+
+// line 76 — inconsistent: bypasses IConfiguration, calls OS API directly
+var version = Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION);
+```
+
+`IConfiguration` already aggregates environment variables (via `AddEnvironmentVariables()` in the host builder), so `_configuration[ConfigurationConstants.APP_VERSION]` would return the same value through the established abstraction layer.
+
+## Why it matters
+1. **Testability gap.** Unit tests cannot mock `System.Environment.GetEnvironmentVariable()`. Testing the three-level version fallback chain (env var → informational version → assembly version) requires setting real process-level environment variables, which is fragile in parallel test runs.
+2. **Inconsistency.** The handler mixes two different mechanisms for reading configuration. A future developer will not expect `IConfiguration`-injected but APP_VERSION read via OS API.
+3. **DI contract violation.** The handler constructor advertises `IConfiguration` as its configuration source; the direct `System.Environment` call is an undeclared hidden dependency.
+
+## Suggested fix
+Replace the direct OS call with the injected `IConfiguration`:
+
+```csharp
+// In GetVersionFromSources():
+var version = _configuration[ConfigurationConstants.APP_VERSION];
+```
+
+`IConfiguration` resolves environment variables in the same priority order (env vars override appsettings), so behaviour is identical in all environments. Remove the `Environment.GetEnvironmentVariable` call and its `using` is no longer needed for that purpose.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-configuration-getconfigurati/impl/main.r1.md
+++ b/artifacts/feat-arch-review-configuration-getconfigurati/impl/main.r1.md
@@ -1,0 +1,49 @@
+Committed successfully. Here is the output artifact:
+
+---
+
+# Implementation: GetConfigurationHandler IConfiguration Refactor
+
+## What was implemented
+
+Replaced the direct `System.Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION)` call in `GetVersionFromSources()` with `_configuration[ConfigurationConstants.APP_VERSION]`, routing the version read through the already-injected `IConfiguration` abstraction. The adjacent log message was updated from "environment variable" to "configuration" to stay accurate. Four new unit tests verify the full version-resolution fallback chain using in-memory configuration.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs` — line 76: swapped `Environment.GetEnvironmentVariable(...)` for `_configuration[...]`; line 79: updated log message
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — new file with 4 unit tests using `ConfigurationBuilder().AddInMemoryCollection()` and `NSubstitute` for `IHostEnvironment`
+
+## Tests
+
+- `GetConfigurationHandlerTests.cs` (4 new unit tests):
+  - `Handle_ReturnsVersionFromConfiguration_WhenAppVersionIsSet` — verifies config-sourced version is returned verbatim
+  - `Handle_FallsBackToAssemblyVersion_WhenAppVersionIsEmpty` — verifies fallback fires; asserts non-null and not DEFAULT_VERSION
+  - `Handle_FallsBackToAssemblyVersion_WhenAppVersionIsAbsent` — same, for absent key
+  - `Handle_ReturnsCorrectUseMockAuth_WhenAppVersionIsSet` — regression guard confirming `UseMockAuth` wiring is unbroken
+- All 9 configuration tests pass (5 existing integration + 4 new unit)
+
+## How to verify
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Features.Configuration"
+# Expected: Passed 9, Failed 0
+```
+
+## Notes
+
+- The `async Task` without `await` in `Handle()` is pre-existing and out of scope per NFR-4 (surgical change). Not touched.
+- The `System.Reflection` using directive is retained — still needed for the assembly fallback branches.
+- No new NuGet packages or DI registrations introduced.
+
+## PR Summary
+
+Removes the one remaining direct `System.Environment.GetEnvironmentVariable()` call from `GetConfigurationHandler`, replacing it with the already-injected `IConfiguration` instance. The `.NET` host wires environment variables into `IConfiguration` by default, so runtime behavior is identical in all environments; the change eliminates a hidden OS-level dependency and makes the version-resolution fallback chain unit-testable without manipulating process-level state.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs` — swap env-var call for `_configuration` indexer; update one log message for accuracy
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — 4 new handler-level unit tests covering config version, fallback, and UseMockAuth regression guard
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-configuration-getconfigurati/spec.r1.md
+++ b/artifacts/feat-arch-review-configuration-getconfigurati/spec.r1.md
@@ -1,0 +1,84 @@
+# Specification: Replace Direct Environment Variable Access with IConfiguration in GetConfigurationHandler
+
+## Summary
+Refactor `GetConfigurationHandler` to read the application version through the injected `IConfiguration` abstraction instead of calling `System.Environment.GetEnvironmentVariable()` directly. This restores consistency with the rest of the handler, eliminates a hidden DI dependency, and makes the version-resolution fallback chain unit-testable without manipulating process-level environment variables.
+
+## Background
+`GetConfigurationHandler` (`backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs`) injects `IConfiguration` and uses it correctly for the `UseMockAuth` setting (line 66). However, the version resolution helper at line 76 bypasses the injected abstraction and calls `System.Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION)` directly.
+
+Because the .NET host already registers environment variables as a configuration source via `AddEnvironmentVariables()`, `_configuration[ConfigurationConstants.APP_VERSION]` returns the same value through the established abstraction. The current code therefore has no functional benefit but introduces three concrete problems:
+
+1. **Testability gap** — `System.Environment.GetEnvironmentVariable()` cannot be mocked. Verifying the three-level fallback chain (env var → assembly informational version → assembly version) requires setting real process-level env vars, which is fragile in parallel test runs.
+2. **Inconsistency** — Two different mechanisms read configuration inside the same handler.
+3. **DI contract violation** — The constructor advertises `IConfiguration` as the configuration source; the direct OS call is an undeclared hidden dependency.
+
+This finding was filed by the daily arch-review routine on 2026-06-03.
+
+## Functional Requirements
+
+### FR-1: Read APP_VERSION through IConfiguration
+The `GetVersionFromSources()` helper inside `GetConfigurationHandler` MUST read the `APP_VERSION` value via the injected `IConfiguration` instance instead of `System.Environment.GetEnvironmentVariable()`.
+
+**Acceptance criteria:**
+- `GetConfigurationHandler.cs` no longer contains any call to `System.Environment.GetEnvironmentVariable()` or `Environment.GetEnvironmentVariable()`.
+- The handler reads the version using `_configuration[ConfigurationConstants.APP_VERSION]` (or equivalent `IConfiguration` accessor).
+- The `using System;` directive remains only if other parts of the file still need it; otherwise it is removed.
+- The `ConfigurationConstants.APP_VERSION` constant remains unchanged.
+
+### FR-2: Preserve existing version fallback semantics
+The refactor MUST NOT change observable behavior. The three-level fallback chain (env-var/configuration value → assembly informational version → assembly version) MUST continue to resolve in the same order with the same precedence.
+
+**Acceptance criteria:**
+- When `APP_VERSION` is set in the environment or in any registered configuration source with a non-empty value, the handler returns that value.
+- When `APP_VERSION` is missing or empty, the handler falls through to the assembly informational version.
+- When the informational version is missing or empty, the handler falls through to the assembly version.
+- An integration test or unit test demonstrates each branch of the fallback chain.
+
+### FR-3: Unit-testable version resolution
+The refactored handler MUST be testable using a mocked or in-memory `IConfiguration` instance — no process-level environment variable manipulation should be required for unit tests of the version-resolution logic.
+
+**Acceptance criteria:**
+- A new or updated unit test for `GetConfigurationHandler` exercises the version-resolution path by configuring an in-memory `IConfiguration` (e.g., `ConfigurationBuilder().AddInMemoryCollection(...)`).
+- Tests cover at minimum: (a) version present in configuration, (b) version absent — falls back to informational version, (c) informational version absent — falls back to assembly version.
+- Tests run cleanly under parallel xUnit execution without `[Collection]` serialization workarounds related to environment variables.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavioral parity
+No change in runtime behavior across Development, Staging, or Production environments. The `IConfiguration` provider chain registered by the host (appsettings → appsettings.{Environment} → environment variables → user secrets in Dev) MUST resolve `APP_VERSION` identically to the previous direct OS call in all deployed configurations.
+
+### NFR-2: No new dependencies
+The change MUST NOT introduce new NuGet packages, new DI registrations, or new constants. It is a pure in-file refactor.
+
+### NFR-3: Validation gates
+The following project-mandated checks MUST pass before merge:
+- `dotnet build` — clean.
+- `dotnet format` — no formatting violations introduced.
+- All existing tests that touch `GetConfigurationHandler` continue to pass.
+- New unit tests for the version fallback chain pass.
+
+### NFR-4: Surgical change
+Only `GetConfigurationHandler.cs` and its associated test file(s) should be modified. Do not touch adjacent code, comments, formatting, or unrelated handlers.
+
+## Data Model
+No data-model changes. The DTO returned by the handler (`GetConfigurationResponse` or equivalent) is unchanged. Its `Version` property continues to be populated by the same fallback chain.
+
+## API / Interface Design
+No public API changes. The MediatR request/response contract (`GetConfigurationQuery` → response DTO) is unchanged. The HTTP endpoint that exposes this query is unchanged. Only the internal implementation of `GetVersionFromSources()` (or equivalently named private helper) changes.
+
+## Dependencies
+- `Microsoft.Extensions.Configuration.Abstractions` — already referenced; provides `IConfiguration`.
+- Host builder must continue to call `AddEnvironmentVariables()` (already the case in `Program.cs`). This is a precondition, not a new dependency.
+- Test project must reference `Microsoft.Extensions.Configuration` (for `ConfigurationBuilder` / `AddInMemoryCollection`) — verify it does; if not, add it to the test project only.
+
+## Out of Scope
+- Refactoring other handlers that may also bypass `IConfiguration`. (Out of scope for this finding; track separately if discovered.)
+- Changing the version-resolution fallback order or adding new sources (e.g., file-based version stamps).
+- Modifying `ConfigurationConstants.APP_VERSION` or its consumers elsewhere.
+- Touching the deployment pipeline or how `APP_VERSION` is injected into the Docker container / Azure Web App.
+- Adding integration tests beyond what is required to cover the fallback chain.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-configuration-getconfigurati/task-plan.r1.md
+++ b/artifacts/feat-arch-review-configuration-getconfigurati/task-plan.r1.md
@@ -1,0 +1,14 @@
+Plan saved to `docs/superpowers/plans/2026-06-03-getconfigurationhandler-iconfiguration-refactor.md`.
+
+**Plan summary:**
+
+- **3 tasks, TDD-ordered:**
+  1. Write 4 failing unit tests in a new `GetConfigurationHandlerTests.cs` using in-memory `IConfiguration` + NSubstitute + `NullLogger<T>` — the first test (`Handle_ReturnsVersionFromConfiguration_WhenAppVersionIsSet`) establishes RED because the current `Environment.GetEnvironmentVariable` call ignores in-memory configuration.
+  2. Refactor `GetConfigurationHandler.cs:76` to swap `Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION)` for `_configuration[ConfigurationConstants.APP_VERSION]`, plus update the now-inaccurate log message at line 79 (the only allowed adjacent edit per the arch-review amendment).
+  3. Validation gates: `dotnet build`, `dotnet format --verify-no-changes`, Configuration test slice (9 tests), grep guard confirming no remaining `Environment.GetEnvironmentVariable` in the handler.
+
+- **Scope:** exactly 2 files touched (1 modified, 1 new). No `using` changes, no package additions, no DI/constant changes, no `Program.cs` edits.
+
+- **Acceptance mapping:** all four FRs and four NFRs from `spec.r1.md` map to specific task steps via the table at the end of the plan.
+
+Plan complete. Per the pipeline note in the brief, the execution handoff prompt is skipped — the plan file content will be captured automatically as the artifact.

--- a/backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs
@@ -73,10 +73,10 @@ public class GetConfigurationHandler : IRequestHandler<GetConfigurationRequest, 
     private string? GetVersionFromSources()
     {
         // 1. Try environment variable first (CI/CD pipeline)
-        var version = Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION);
+        var version = _configuration[ConfigurationConstants.APP_VERSION];
         if (!string.IsNullOrEmpty(version))
         {
-            _logger.LogDebug("Version found from APP_VERSION environment variable: {Version}", version);
+            _logger.LogDebug("Version resolved from configuration: {Version}", version);
             return version;
         }
 

--- a/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
@@ -1,0 +1,89 @@
+using Anela.Heblo.Application.Features.Configuration;
+using Anela.Heblo.Domain.Features.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Anela.Heblo.Tests.Features.Configuration;
+
+public class GetConfigurationHandlerTests
+{
+    private static GetConfigurationHandler CreateHandler(Dictionary<string, string?> configData)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns("Test");
+
+        return new GetConfigurationHandler(configuration, environment, NullLogger<GetConfigurationHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsVersionFromConfiguration_WhenAppVersionIsSet()
+    {
+        // Arrange
+        var handler = CreateHandler(new Dictionary<string, string?>
+        {
+            [ConfigurationConstants.APP_VERSION] = "2.5.1-ci.42"
+        });
+
+        // Act
+        var response = await handler.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        response.Version.Should().Be("2.5.1-ci.42");
+    }
+
+    [Fact]
+    public async Task Handle_FallsBackToAssemblyVersion_WhenAppVersionIsEmpty()
+    {
+        // Arrange
+        var handler = CreateHandler(new Dictionary<string, string?>
+        {
+            [ConfigurationConstants.APP_VERSION] = ""
+        });
+
+        // Act
+        var response = await handler.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        // When APP_VERSION is empty, should fall back to assembly version (non-null, not the hardcoded "1.0.0" default)
+        response.Version.Should().NotBeNullOrEmpty().And.NotBe(ConfigurationConstants.DEFAULT_VERSION);
+    }
+
+    [Fact]
+    public async Task Handle_FallsBackToAssemblyVersion_WhenAppVersionIsAbsent()
+    {
+        // Arrange
+        var handler = CreateHandler(new Dictionary<string, string?>());
+
+        // Act
+        var response = await handler.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        // When APP_VERSION is absent, should fall back to assembly informational version or assembly version
+        response.Version.Should().NotBeNullOrEmpty().And.NotBe(ConfigurationConstants.DEFAULT_VERSION);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsCorrectUseMockAuth_WhenAppVersionIsSet()
+    {
+        // Arrange — regression guard: surgical change must not break UseMockAuth wiring
+        var handler = CreateHandler(new Dictionary<string, string?>
+        {
+            [ConfigurationConstants.APP_VERSION] = "1.2.3",
+            [ConfigurationConstants.USE_MOCK_AUTH] = "true"
+        });
+
+        // Act
+        var response = await handler.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        response.Version.Should().Be("1.2.3");
+        response.UseMockAuth.Should().BeTrue();
+    }
+}

--- a/docs/superpowers/plans/2026-06-03-getconfigurationhandler-iconfiguration-refactor.md
+++ b/docs/superpowers/plans/2026-06-03-getconfigurationhandler-iconfiguration-refactor.md
@@ -1,0 +1,363 @@
+# GetConfigurationHandler IConfiguration Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the direct `System.Environment.GetEnvironmentVariable(APP_VERSION)` call inside `GetConfigurationHandler.GetVersionFromSources()` with an `IConfiguration` lookup, restoring consistency with the rest of the handler and making the version fallback chain unit-testable without process-level env-var mutation.
+
+**Architecture:** Pure surgical refactor inside one Vertical Slice (`Features/Configuration`). The handler already injects `IConfiguration`; we route the `APP_VERSION` read through the same abstraction (indexer syntax). The .NET host already registers env vars as a configuration source via `AddEnvironmentVariables()`, so behavior is preserved in every deployed environment. No new components, abstractions, or DI registrations. A new unit-test file exercises the version-resolution fallback chain with an in-memory `IConfiguration`.
+
+**Tech Stack:** .NET 8, C#, xUnit, FluentAssertions, NSubstitute, `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Hosting.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`.
+
+---
+
+## File Structure
+
+**Modify (1 file):**
+
+- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs`
+  - Line 76: swap `Environment.GetEnvironmentVariable(...)` for `_configuration[...]`.
+  - Line 79: update the `_logger.LogDebug` text so it no longer claims the value came from “environment variable” (the value may now legitimately originate from any provider in the chain: appsettings → env vars → Key Vault).
+  - No `using` changes — the file does not have a `using System;` directive; `Environment` resolves via SDK `ImplicitUsings`. `System.Reflection` stays in use for the assembly-version fallback.
+
+**Create (1 file):**
+
+- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — handler-level unit tests. Constructs the SUT directly (no `WebApplicationFactory`, no `[Collection("WebApp")]`), feeds in-memory `IConfiguration`, mocks `IHostEnvironment` with NSubstitute, uses `NullLogger<GetConfigurationHandler>.Instance`.
+
+**Do NOT touch:**
+
+- `ConfigurationConstants.cs`, `ApplicationConfiguration.cs`, `GetConfigurationRequest.cs`, `GetConfigurationResponse.cs`, `ConfigurationModule.cs`, `Program.cs`, `GetConfigurationEndpointTests.cs`, or any other handler / module.
+
+**Package dependencies:** No new packages. `Microsoft.Extensions.Configuration` (for `ConfigurationBuilder` / `AddInMemoryCollection`), `Microsoft.Extensions.Logging.Abstractions` (for `NullLogger<T>`), and `Microsoft.Extensions.Hosting.Abstractions` (for `IHostEnvironment`) are all transitively available in `Anela.Heblo.Tests` via the existing project references to `Anela.Heblo.Application` and the explicit `Microsoft.Extensions.Hosting.Abstractions` reference at `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj:29`. NSubstitute is already referenced at line 17 of that csproj.
+
+---
+
+## Working Directory
+
+All commands assume the worktree root:
+
+```
+/Users/pajgrtondrej/Work/GitHub/Anela.Heblo/.worktrees/feat-arch-review-configuration-getconfigurati
+```
+
+---
+
+### Task 1: Write failing unit tests for GetConfigurationHandler
+
+**Files:**
+
+- Create: `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs`
+
+- [ ] **Step 1: Create the new unit-test file with four failing tests**
+
+Write the file with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Configuration;
+using Anela.Heblo.Domain.Features.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Anela.Heblo.Tests.Features.Configuration;
+
+/// <summary>
+/// Unit tests for <see cref="GetConfigurationHandler"/>.
+/// Verifies that version resolution honors <see cref="IConfiguration"/> rather than
+/// reading process-level environment variables directly. Assembly-attribute fallback
+/// branches are exercised by absence rather than pinning a specific value, because
+/// <see cref="System.Reflection.Assembly.GetExecutingAssembly"/> always resolves to
+/// the Application assembly under the standard test build.
+/// </summary>
+public class GetConfigurationHandlerTests
+{
+    private const string TestEnvironmentName = "Test";
+
+    [Fact]
+    public async Task Handle_ReturnsVersionFromConfiguration_WhenAppVersionIsSet()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [ConfigurationConstants.APP_VERSION] = "2.5.1-ci.42",
+        });
+        var sut = CreateHandler(configuration);
+
+        // Act
+        var response = await sut.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        response.Version.Should().Be("2.5.1-ci.42");
+    }
+
+    [Fact]
+    public async Task Handle_FallsBackToAssemblyVersion_WhenAppVersionIsEmptyString()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [ConfigurationConstants.APP_VERSION] = string.Empty,
+        });
+        var sut = CreateHandler(configuration);
+
+        // Act
+        var response = await sut.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert: The assembly under test always exposes a non-empty informational or
+        // assembly version, so the fallback must fire and produce a non-default value.
+        response.Version.Should().NotBeNullOrEmpty();
+        response.Version.Should().NotBe(ConfigurationConstants.DEFAULT_VERSION);
+    }
+
+    [Fact]
+    public async Task Handle_FallsBackToAssemblyVersion_WhenAppVersionIsAbsent()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(new Dictionary<string, string?>());
+        var sut = CreateHandler(configuration);
+
+        // Act
+        var response = await sut.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        response.Version.Should().NotBeNullOrEmpty();
+        response.Version.Should().NotBe(ConfigurationConstants.DEFAULT_VERSION);
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesUseMockAuthFromConfiguration()
+    {
+        // Arrange
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [ConfigurationConstants.USE_MOCK_AUTH] = "true",
+        });
+        var sut = CreateHandler(configuration);
+
+        // Act
+        var response = await sut.Handle(new GetConfigurationRequest(), CancellationToken.None);
+
+        // Assert
+        response.UseMockAuth.Should().BeTrue();
+        response.Environment.Should().Be(TestEnvironmentName);
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+    private static GetConfigurationHandler CreateHandler(IConfiguration configuration)
+    {
+        var environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(TestEnvironmentName);
+        return new GetConfigurationHandler(
+            configuration,
+            environment,
+            NullLogger<GetConfigurationHandler>.Instance);
+    }
+}
+```
+
+Notes for the engineer:
+
+- `Dictionary<string, string?>` matches the signature of `AddInMemoryCollection(IEnumerable<KeyValuePair<string, string?>>)` in `Microsoft.Extensions.Configuration` 8.x and avoids the `configData!` null-forgiving operator used in the older `RefreshTaskConfigurationTests` file.
+- `NullLogger<T>.Instance` lives in `Microsoft.Extensions.Logging.Abstractions`, transitively referenced via `Anela.Heblo.Application`.
+- `GetConfigurationRequest` is a parameterless `IRequest<GetConfigurationResponse>` (confirmed at `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationRequest.cs:8`). `new GetConfigurationRequest()` is correct.
+- xUnit `Using Include="Xunit"` is already configured globally in `Anela.Heblo.Tests.csproj` (line 35), so no `using Xunit;` is required.
+
+- [ ] **Step 2: Build the test project to confirm the test file compiles**
+
+Run:
+
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: **build succeeds**. If compilation fails (e.g., missing `using` or unknown symbol), fix only the test file — do not touch production code.
+
+- [ ] **Step 3: Run the new tests to verify the configuration-driven test fails**
+
+Run:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --no-build \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Configuration.GetConfigurationHandlerTests"
+```
+
+Expected:
+
+- `Handle_ReturnsVersionFromConfiguration_WhenAppVersionIsSet` — **FAIL** (the current handler reads `Environment.GetEnvironmentVariable`, ignores in-memory `IConfiguration`, and falls through to the assembly version, so `response.Version` will not equal `"2.5.1-ci.42"`).
+- `Handle_FallsBackToAssemblyVersion_WhenAppVersionIsEmptyString` — likely **PASS** today (current code already falls through when the env var is unset).
+- `Handle_FallsBackToAssemblyVersion_WhenAppVersionIsAbsent` — likely **PASS** today.
+- `Handle_PropagatesUseMockAuthFromConfiguration` — likely **PASS** today.
+
+The RED state for TDD is established by the first test. Do not proceed to Task 2 until you have observed the failure with output similar to `Expected response.Version to be "2.5.1-ci.42", but found "...".`.
+
+If the first test unexpectedly **passes** (e.g., a stray `APP_VERSION` env var is leaking into the test process), stop and investigate before continuing — the refactor’s value depends on this test discriminating between the env-var read and the configuration read.
+
+- [ ] **Step 4: Commit the failing test (RED checkpoint)**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
+git commit -m "test: add GetConfigurationHandler unit tests for IConfiguration-driven version resolution"
+```
+
+---
+
+### Task 2: Refactor GetConfigurationHandler to read APP_VERSION via IConfiguration
+
+**Files:**
+
+- Modify: `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs:73-82`
+
+- [ ] **Step 1: Swap the env-var read for an IConfiguration indexer read**
+
+Open `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs`. In the `GetVersionFromSources()` method (currently lines 73-102), replace **only** the first fallback branch.
+
+Find these lines (current state, lines 73-82):
+
+```csharp
+    private string? GetVersionFromSources()
+    {
+        // 1. Try environment variable first (CI/CD pipeline)
+        var version = Environment.GetEnvironmentVariable(ConfigurationConstants.APP_VERSION);
+        if (!string.IsNullOrEmpty(version))
+        {
+            _logger.LogDebug("Version found from APP_VERSION environment variable: {Version}", version);
+            return version;
+        }
+```
+
+Replace with:
+
+```csharp
+    private string? GetVersionFromSources()
+    {
+        // 1. Try configuration first — populated by the host's provider chain
+        //    (appsettings → env vars → Key Vault). CI/CD injects APP_VERSION as an env var.
+        var version = _configuration[ConfigurationConstants.APP_VERSION];
+        if (!string.IsNullOrEmpty(version))
+        {
+            _logger.LogDebug("Version resolved from configuration ({Key}): {Version}", ConfigurationConstants.APP_VERSION, version);
+            return version;
+        }
+```
+
+Do **not** touch the assembly-informational-version branch (lines 83-91 in the current file) or the assembly-version branch (lines 92-98). Do **not** add or remove any `using` directives. Do **not** reformat surrounding code.
+
+- [ ] **Step 2: Run the new unit tests to verify they all pass (GREEN)**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Configuration.GetConfigurationHandlerTests"
+```
+
+Expected: all **four** tests PASS, including `Handle_ReturnsVersionFromConfiguration_WhenAppVersionIsSet`.
+
+If any test still fails, stop. Re-read the diff in `GetConfigurationHandler.cs` and confirm the indexer call references the injected `_configuration` field (not a parameter, not `IConfiguration`-typed local). Do **not** modify the tests to make them pass.
+
+- [ ] **Step 3: Run the existing GetConfiguration integration tests to confirm no regression**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Configuration.GetConfigurationEndpointTests"
+```
+
+Expected: all five existing endpoint tests PASS (`GetConfiguration_ShouldReturnSuccessAndCorrectContentType`, `GetConfiguration_ShouldReturnValidConfigurationResponse`, `GetConfiguration_ShouldIncludeMockAuthFlag`, `GetConfiguration_ShouldReturnTestEnvironment`, `GetConfiguration_ShouldReturnValidVersion`).
+
+- [ ] **Step 4: Commit the refactor**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs
+git commit -m "refactor: read APP_VERSION via IConfiguration in GetConfigurationHandler"
+```
+
+---
+
+### Task 3: Validation gates (build, format, full test pass)
+
+**Files:** none modified in this task — only verification.
+
+- [ ] **Step 1: Run dotnet build on the full backend solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: clean build with zero errors. Treat any **new** warning introduced by these changes as a failure (existing pre-baseline warnings are out of scope per CLAUDE.md surgical-change guidance).
+
+- [ ] **Step 2: Run dotnet format and confirm no diff**
+
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exits 0 with no “formatted N files” output. If it reports changes:
+
+1. Run `dotnet format backend/Anela.Heblo.sln` (no flag) to apply.
+2. Inspect the resulting diff with `git diff`. Only formatting changes inside the two files touched by this plan are acceptable. If `dotnet format` rewrites unrelated files, revert those — do not include adjacent-code cleanup.
+3. Re-run `dotnet format backend/Anela.Heblo.sln --verify-no-changes` to confirm clean.
+4. Amend the previous commit only if formatting changes belong to `GetConfigurationHandler.cs`:
+   ```bash
+   git add backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs
+   git commit --amend --no-edit
+   ```
+   Otherwise create a separate `chore: dotnet format` commit scoped to the test file:
+   ```bash
+   git add backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs
+   git commit -m "chore: dotnet format GetConfigurationHandlerTests"
+   ```
+
+- [ ] **Step 3: Run the Configuration test slice end-to-end**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Configuration"
+```
+
+Expected: 9 tests total (4 new unit tests + 5 existing endpoint tests), all passing.
+
+- [ ] **Step 4: Confirm no stray `Environment.GetEnvironmentVariable` remains in the handler**
+
+```bash
+grep -n "Environment.GetEnvironmentVariable" backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs || echo "clean"
+```
+
+Expected output: `clean`. If any match is reported, return to Task 2 — the refactor is incomplete and FR-1 acceptance criteria are not met.
+
+- [ ] **Step 5: Confirm both files are committed and the worktree is clean**
+
+```bash
+git status
+git log --oneline -5
+```
+
+Expected: `git status` reports a clean working tree. `git log` shows the two new commits (`test:` and `refactor:` — optionally a third `chore: dotnet format`) on top of the branch tip.
+
+---
+
+## Acceptance Mapping (Spec → Tasks)
+
+| Spec requirement | Covered by |
+|---|---|
+| FR-1: `GetConfigurationHandler` no longer calls `Environment.GetEnvironmentVariable`; reads via `_configuration[...]` | Task 2 Step 1 + Task 3 Step 4 grep guard |
+| FR-1: `using System;` only kept if needed; `ConfigurationConstants.APP_VERSION` unchanged | File never contained `using System;` (verified during planning); constant is not in the modify list |
+| FR-2: Three-level fallback order preserved (config → informational version → assembly version) | Task 2 Step 1 (only line 76 changes; the two reflection branches stay verbatim); Task 1 Step 1 tests 2 and 3 (`Handle_FallsBackToAssemblyVersion_*`) |
+| FR-3: Unit-testable via in-memory `IConfiguration`; no process env-var manipulation | Task 1 (all four tests use `ConfigurationBuilder().AddInMemoryCollection(...)`) |
+| NFR-1: Behavioral parity across environments | Task 2 Step 3 (existing endpoint tests pass unchanged) |
+| NFR-2: No new packages / DI registrations / constants | Task list touches exactly two files; no `.csproj` edits |
+| NFR-3: `dotnet build`, `dotnet format`, all existing tests pass | Task 3 Steps 1–3 |
+| NFR-4: Surgical change | Touched files limited to one handler + one new test file; log-message text adjusted only because the previous wording becomes factually wrong (covered by arch-review amendment 1) |
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** all four FRs and four NFRs map to specific task steps (table above). The arch-review amendment about the log-message text update is encoded in Task 2 Step 1 (new wording: `"Version resolved from configuration ({Key}): {Version}"`).
+- **Placeholders:** none. Every code block contains the exact code; every command contains the exact arguments; every expectation states the exact outcome.
+- **Type consistency:** `GetConfigurationHandler` constructor signature `(IConfiguration, IHostEnvironment, ILogger<GetConfigurationHandler>)` is referenced identically in Task 1 (`CreateHandler` helper) and Task 2 (no constructor changes). `Dictionary<string, string?>` is used consistently in all four test setups. `ConfigurationConstants.APP_VERSION`, `ConfigurationConstants.USE_MOCK_AUTH`, and `ConfigurationConstants.DEFAULT_VERSION` are all real constants (verified at `backend/src/Anela.Heblo.Domain/Features/Configuration/ConfigurationConstants.cs:9,13,17`).
+- **TDD discipline:** Task 1 establishes RED with at least one observably failing test before Task 2 produces GREEN. The refactor does not modify tests to make them pass.
+- **Surgical scope:** exactly one production line (plus the adjacent log message that becomes inaccurate) and one new test file. No `using` churn, no formatting drift outside the touched files, no adjacent cleanup.


### PR DESCRIPTION

Removes the one remaining direct `System.Environment.GetEnvironmentVariable()` call from `GetConfigurationHandler`, replacing it with the already-injected `IConfiguration` instance. The `.NET` host wires environment variables into `IConfiguration` by default, so runtime behavior is identical in all environments; the change eliminates a hidden OS-level dependency and makes the version-resolution fallback chain unit-testable without manipulating process-level state.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Configuration/GetConfigurationHandler.cs` — swap env-var call for `_configuration` indexer; update one log message for accuracy
- `backend/test/Anela.Heblo.Tests/Features/Configuration/GetConfigurationHandlerTests.cs` — 4 new handler-level unit tests covering config version, fallback, and UseMockAuth regression guard

---

Closes #2441

### Tokens used
6057310
