### PR TITLE
feat: GetBankStatement by Id — Dedicated MediatR Handler

### DIFF
--- a/artifacts/feat-arch-review-bank-getbankstatement-id-end/arch-review.r1.md
+++ b/artifacts/feat-arch-review-bank-getbankstatement-id-end/arch-review.r1.md
@@ -1,0 +1,205 @@
+I have enough to write the review. Key findings: (1) mapping is via AutoMapper, not static mappers; (2) `IBankStatementImportRepository.GetByIdAsync(int id)` has no CancellationToken parameter — spec FR-3 conflicts with FR-5; (3) current `NotFound` returns a body, spec's example loses it; (4) `BankStatementImportDto` already exists as the item DTO — creating `GetBankStatementByIdResponse` duplicates it; (5) handlers use a Vertical Slice folder under `Application/Features/Bank/UseCases/`.
+
+```markdown
+# Architecture Review: GetBankStatement by Id — Dedicated MediatR Handler
+
+## Skip Design: true
+
+This is a backend-only internal refactor. HTTP contract, request/response JSON shapes, and database schema are unchanged. The OpenAPI-generated TypeScript client may pick up a renamed type, but no visual or UX work is involved.
+
+## Architectural Fit Assessment
+
+The proposal aligns with the project's established Vertical Slice + MediatR + Controllers conventions:
+
+- `docs/architecture/development_guidelines.md` §ADR-003 mandates controllers as thin dispatchers and forbids business logic in controllers; the null-check → `404` decision today violates this.
+- Existing slices under `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/` (`GetBankStatementList`, `GetBankAccounts`, `ImportBankStatement`) all follow the `{Request,Response,Handler}.cs` triplet pattern; the new slice fits the same mould.
+- `IBankStatementImportRepository.GetByIdAsync(int id)` (Domain layer) is already implemented in `Persistence/Features/Bank/BankStatementImportRepository.cs:79` via `DbSet.FindAsync`. It is the right primitive for a keyed lookup but is currently unreachable from HTTP.
+- MediatR registration is centralised in `ApplicationModule.cs:61` (`AddMediatR(...RegisterServicesFromAssembly(...))`); a new handler in this assembly is auto-discovered, no DI wiring required.
+
+Main integration points: `BankStatementsController.GetBankStatement(int id)` (the call site), the existing `BankMappingProfile` (AutoMapper), and the existing `BankStatementImportDto` (already the single-item shape).
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+HTTP Client
+   │  GET /api/bank-statements/{id}
+   ▼
+BankStatementsController.GetBankStatement(id, ct)        ← thin dispatcher
+   │  _mediator.Send(new GetBankStatementByIdRequest { Id = id }, ct)
+   ▼
+GetBankStatementByIdHandler (NEW)
+   │  IBankStatementImportRepository.GetByIdAsync(request.Id)
+   │  IMapper.Map<BankStatementImportDto>(entity)        ← reuses BankMappingProfile
+   ▼
+BankStatementImportRepository.GetByIdAsync               ← unchanged
+   │  _context.BankStatements.FindAsync(id)
+   ▼
+EF Core / PostgreSQL
+```
+
+### Key Design Decisions
+
+#### Decision 1: Response type — reuse `BankStatementImportDto`, do **not** create a new `GetBankStatementByIdResponse`
+
+**Options considered:**
+1. Create `GetBankStatementByIdResponse` as a new class mirroring `BankStatementImportDto` (spec FR-2 as written).
+2. Create `GetBankStatementByIdResponse : BankStatementImportDto` (inheritance shim).
+3. Use `BankStatementImportDto` directly as the handler's response type — `IRequest<BankStatementImportDto?>`.
+
+**Chosen approach:** Option 3. The handler's contract is `IRequestHandler<GetBankStatementByIdRequest, BankStatementImportDto?>`.
+
+**Rationale:** `BankStatementImportDto` already *is* the single-item shape — it is what the current endpoint serialises (`controller.cs:162: return Ok(statement)` where `statement` is `BankStatementImportDto`). Creating a parallel type with the same fields violates DRY, expands the OpenAPI surface area, and forces FR-6's mapping question (which is moot if no second DTO exists). The `BankMappingProfile.CreateMap<BankStatementImport, BankStatementImportDto>()` already handles the mapping for the list handler — the new handler reuses it via `IMapper`. Wire-format compatibility is guaranteed because the type is literally the same one the existing endpoint returns. This also keeps `GetBankStatementListResponse` (which extends `BaseResponse` and carries pagination metadata) where it belongs — list responses only.
+
+#### Decision 2: Mapping — `IMapper` via existing AutoMapper profile, not a static mapper
+
+**Options considered:**
+1. Extract a `static BankStatementMapper.ToDto(BankStatementImport)` and call it from both handlers (spec FR-6 preference).
+2. Inject `IMapper` and reuse `BankMappingProfile.CreateMap<BankStatementImport, BankStatementImportDto>()`.
+
+**Chosen approach:** Option 2.
+
+**Rationale:** The codebase already standardises on AutoMapper for this exact transformation (`backend/src/Anela.Heblo.Application/Features/Bank/BankMappingProfile.cs:11`). Introducing a parallel static mapper alongside the AutoMapper profile splits the source of truth and creates a drift hazard. The existing list handler (`GetBankStatementListHandler.cs:55`) uses `_mapper.Map<List<BankStatementImportDto>>(items)` — the new handler does `_mapper.Map<BankStatementImportDto>(entity)` against the same profile. Zero duplication, zero changes to the list handler.
+
+#### Decision 3: `NotFound` body — preserve the existing payload
+
+**Chosen approach:** Controller returns `NotFound(new { message = $"Bank statement import with ID {id} not found" })`, not `NotFound()`.
+
+**Rationale:** The current controller (`BankStatementsController.cs:159`) returns a JSON object with a `message` field on 404. Spec FR-4's example (`return response is null ? NotFound() : Ok(response);`) silently drops that body, which is a wire-format change that NFR-3 explicitly forbids. Any client checking the 404 body would break. Preserve the message.
+
+#### Decision 4: Repository `GetByIdAsync` signature — leave it alone, do not pass `CancellationToken`
+
+**Chosen approach:** The handler calls `_repository.GetByIdAsync(request.Id)` without a cancellation token, matching the current interface.
+
+**Rationale:** Spec FR-3 says "propagate `CancellationToken` to the repository call" but FR-5 says "no signature changes". The interface today is `Task<BankStatementImport?> GetByIdAsync(int id)` with no `CancellationToken` parameter (`IBankStatementImportRepository.cs:13`). Adding one would touch both the interface and the implementation, contradicting FR-5. Following the brief's "surgical" intent: leave the repository alone. Adding cancellation support to `GetByIdAsync` is a worthwhile follow-up but out of scope for this refactor — file a separate issue. The handler still accepts and propagates `CancellationToken` on its public surface (MediatR contract); only the inner repo call drops it.
+
+#### Decision 5: Route attribute — keep `[HttpGet("{id}")]`, do **not** add `:int` constraint
+
+**Chosen approach:** Leave the route template exactly as `[HttpGet("{id}")]`.
+
+**Rationale:** Spec FR-4's code example uses `[HttpGet("{id:int}")]`, but the existing attribute is `[HttpGet("{id}")]`. Changing the constraint is a wire-level change to error behaviour for non-integer paths (today: 400 from model binding on `int id`; with `:int`: 404 from routing). NFR-3 mandates HTTP contract preservation. Keep the template literal-identical.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/Anela.Heblo.Application/Features/Bank/UseCases/
+└── GetBankStatementById/                              # NEW slice
+    ├── GetBankStatementByIdRequest.cs                  # class : IRequest<BankStatementImportDto?>
+    └── GetBankStatementByIdHandler.cs                  # uses IMapper + IBankStatementImportRepository
+
+backend/src/Anela.Heblo.API/Controllers/
+└── BankStatementsController.cs                         # MODIFIED — only GetBankStatement(int id) body
+
+backend/test/Anela.Heblo.Tests/Features/Bank/
+└── GetBankStatementByIdHandlerTests.cs                 # NEW unit tests
+    (Optional) Add controller integration test alongside existing BankStatementImportIntegrationTests.cs
+```
+
+**No new files for response DTO, no new mapper file, no new AutoMapper profile registration.** Total new C# files: 2 production + 1 test.
+
+### Interfaces and Contracts
+
+**Request (new):**
+```csharp
+namespace Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+
+public class GetBankStatementByIdRequest : IRequest<BankStatementImportDto?>
+{
+    public int Id { get; set; }
+}
+```
+- Class (not record) per project rule.
+- Nullable response signals "not found" without exceptions.
+- Reuses `BankStatementImportDto` from `Application.Features.Bank.Contracts` — no new response type.
+
+**Handler signature (new):**
+```csharp
+public class GetBankStatementByIdHandler
+    : IRequestHandler<GetBankStatementByIdRequest, BankStatementImportDto?>
+{
+    // ctor: IBankStatementImportRepository, IMapper, ILogger<...>
+}
+```
+
+**Controller (modified):**
+```csharp
+[HttpGet("{id}")]
+public async Task<ActionResult<BankStatementImportDto>> GetBankStatement(int id, CancellationToken cancellationToken)
+{
+    var response = await _mediator.Send(new GetBankStatementByIdRequest { Id = id }, cancellationToken);
+    return response is null
+        ? NotFound(new { message = $"Bank statement import with ID {id} not found" })
+        : Ok(response);
+}
+```
+- Return type stays `ActionResult<BankStatementImportDto>` (matches current declaration on line 142).
+- `CancellationToken` parameter added (the original action lacks one).
+- Top-level `try/catch (Exception)` is removed — global ASP.NET error handling already covers unhandled exceptions, and the catch was the only piece this action used. If the project enforces controller-level catches via a convention not visible here, keep the catch; otherwise drop it for consistency with `GetAccounts` (lines 28–33), which has no try/catch.
+- `using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList;` can be removed if no other action in this controller still references it (the `GetBankStatements` list endpoint still does, so keep it).
+- Add `using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;`.
+
+### Data Flow
+
+**Found path:**
+1. `GET /api/bank-statements/42` → controller action.
+2. Controller builds `GetBankStatementByIdRequest { Id = 42 }`, sends via `IMediator.Send`.
+3. MediatR routes to `GetBankStatementByIdHandler.Handle`.
+4. Handler calls `_repository.GetByIdAsync(42)` → EF `FindAsync` → entity row.
+5. Handler maps entity to `BankStatementImportDto` via `_mapper.Map<BankStatementImportDto>(entity)`.
+6. Handler returns DTO. Controller wraps in `Ok(...)`. Status `200`, body is the DTO JSON — byte-identical to today.
+
+**Not-found path:**
+1. Steps 1–3 as above.
+2. `_repository.GetByIdAsync(42)` returns `null`.
+3. Handler returns `null` (no throw, no log spam beyond an info-level "not found" log line — optional).
+4. Controller maps `null → NotFound(new { message = ... })`. Status `404`, body identical to today.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| OpenAPI/TypeScript client regenerates with a different type name and breaks frontend build. | LOW | Decision 1 reuses `BankStatementImportDto` — the generated TS type for this endpoint stays unchanged. Verify by running `npm run build` after `dotnet build`. |
+| Wire format drift on `404` body (spec example drops the `message`). | MEDIUM | Decision 3 explicitly preserves the existing 404 body. Add an integration test asserting both the status code and the `message` field. |
+| Repository signature mismatch (spec passes CT, interface has no CT). | LOW | Decision 4 — handler does not pass a CT to the repo. Document this in a follow-up issue if cancellation matters for this query. |
+| Route constraint change (`{id:int}`) accidentally introduced from spec example. | LOW | Decision 5 — keep `[HttpGet("{id}")]`. Code review checklist item. |
+| Hidden caller of `GetBankStatementListRequest { Id = ..., Take = 1 }` pattern elsewhere in code. | LOW | `grep -rn "GetBankStatementListRequest" backend/src` to verify the controller is the only consumer of the `Id` filter on the list request. If found elsewhere, leave them — out of scope. |
+| List handler's `IMapper.Map<List<BankStatementImportDto>>` path differs subtly from single-entity `IMapper.Map<BankStatementImportDto>` (e.g., null handling). | LOW | AutoMapper applies the same `CreateMap` configuration for collections and single items. Add a unit test asserting field-by-field equality between the two paths for the same entity instance. |
+
+## Specification Amendments
+
+The following amendments to `spec.r1.md` are required:
+
+1. **Remove FR-2 entirely.** Do not create `GetBankStatementByIdResponse`. The handler returns `BankStatementImportDto?` directly. See Decision 1.
+
+2. **Amend FR-3:**
+   - Handler signature becomes `IRequestHandler<GetBankStatementByIdRequest, BankStatementImportDto?>`.
+   - Repository call is `_repository.GetByIdAsync(request.Id)` — no `CancellationToken` argument, because the interface does not accept one and FR-5 forbids interface changes. See Decision 4.
+   - Mapping uses `IMapper` and the existing `BankMappingProfile`. See Decision 2.
+
+3. **Amend FR-4:**
+   - Keep route template as `[HttpGet("{id}")]` (no `:int` constraint). See Decision 5.
+   - 404 response must keep the body: `NotFound(new { message = $"Bank statement import with ID {id} not found" })`. See Decision 3.
+   - Controller's return type stays `ActionResult<BankStatementImportDto>`.
+
+4. **Remove FR-6 entirely.** No new mapper file. Both handlers use the existing `BankMappingProfile` via `IMapper`. The acceptance criterion about asserting equality between two mapping paths is folded into FR-7 unit tests.
+
+5. **Amend FR-7 test list:**
+   - `GetBankStatementByIdHandlerTests.cs` with three cases: returns DTO when entity exists, returns `null` when repo returns `null`, calls repository exactly once with the expected id.
+   - The "propagates `CancellationToken` to the repository" assertion is removed (Decision 4).
+   - Add an integration test asserting `GET /api/bank-statements/{missingId}` returns 404 **with the `message` field**, not just status 404.
+   - Add an integration test asserting `GET /api/bank-statements/{existingId}` returns a JSON body field-by-field equal to the same id queried via the list endpoint with `?id=...&take=1` — this is the wire-compatibility guarantee.
+
+6. **Amend NFR-3:** Add an explicit assertion that the OpenAPI `operationId` for `GET /api/bank-statements/{id}` and the generated TypeScript response type **do not change**. (They won't, given Decision 1, but the architect should pin this.)
+
+## Prerequisites
+
+None. This refactor requires no migrations, no config, no new infrastructure, no new NuGet packages, and no upstream coordination.
+
+Before starting:
+- Run `dotnet build` on `main` to baseline the OpenAPI/TypeScript generation output.
+- Run `npm run build` in `frontend/` to baseline the TypeScript client.
+- After implementation, re-run both and diff the generated artifacts — expected diff is zero.
+```

--- a/artifacts/feat-arch-review-bank-getbankstatement-id-end/brief.md
+++ b/artifacts/feat-arch-review-bank-getbankstatement-id-end/brief.md
@@ -1,0 +1,23 @@
+## Module
+Bank
+
+## Finding
+`BankStatementsController.GetBankStatement(int id)` (lines 142–169 of `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`) does not route through a purpose-built MediatR handler. Instead the controller constructs a `GetBankStatementListRequest` with `Id = id, Take = 1`, sends it to the list handler, calls `FirstOrDefault()` on the result, and decides whether to return `Ok` or `NotFound(...)`. The "not found → 404" decision is business logic sitting in the controller.
+
+Meanwhile `IBankStatementImportRepository.GetByIdAsync(int id)` (declared in `backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs` and implemented in `backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportRepository.cs`) goes uncalled through any handler — it is only reachable via the workaround above.
+
+## Why it matters
+The project guidelines state: *"Business logic must be in MediatR handlers, NOT in controllers."* The null-check + `NotFound` branch is a business decision (what a missing record means for callers). Placing it in the controller also misuses the list handler for a point-lookup, leaking pagination semantics (`Take=1`) into a path that has nothing to do with pagination.
+
+## Suggested fix
+Add a `GetBankStatementByIdHandler` in `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/` that calls `_repository.GetByIdAsync(id)` and returns a typed result (e.g. `null` / a populated response). The controller action becomes a thin dispatcher:
+
+```csharp
+var response = await _mediator.Send(new GetBankStatementByIdRequest(id), cancellationToken);
+return response is null ? NotFound() : Ok(response);
+```
+
+No changes to the repository interface or implementation are required — `GetByIdAsync` is already there.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-bank-getbankstatement-id-end/impl/main.r1.md
+++ b/artifacts/feat-arch-review-bank-getbankstatement-id-end/impl/main.r1.md
@@ -1,0 +1,58 @@
+All 7 tasks complete. Let me write the output summary.
+
+---
+
+# Implementation: GetBankStatement by Id — Dedicated MediatR Handler
+
+## What was implemented
+
+Replaced the controller-level workaround in `BankStatementsController.GetBankStatement(int id)` with a purpose-built MediatR handler `GetBankStatementByIdHandler`. The handler calls `IBankStatementImportRepository.GetByIdAsync` directly and returns `BankStatementImportDto?` (reusing the existing list-item DTO — no new response type). The controller became a thin dispatcher that maps `null → 404 + message body` or `value → 200 OK`.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs` — new MediatR request class, `IRequest<BankStatementImportDto?>`
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs` — new handler; calls repo, maps via AutoMapper/BankMappingProfile, returns null if not found
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` — `GetBankStatement` body replaced with thin MediatR dispatch; added `CancellationToken`, removed `try/catch`, preserved 404 message body
+- `backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs` — 4 unit tests for handler (found, null, repo-called-once, projection-equality)
+- `backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs` — 3 new controller unit tests (dispatch + 200, 404 with message body, no list request)
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs` — 2 new integration tests (200 with DTO fields, 404 with message field)
+
+## Tests
+
+- `GetBankStatementByIdHandlerTests.cs` — 4 unit tests covering handler logic (all pass)
+- `BankStatementsControllerTests.cs` — 6 tests total (3 existing + 3 new, all pass)
+- `BankStatementImportIntegrationTests.cs` — 9 tests total (7 existing + 2 new end-to-end, all pass)
+
+## How to verify
+
+```bash
+dotnet build backend/Anela.Heblo.sln
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Bank"
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~BankStatementsControllerTests"
+```
+
+## Notes
+
+- **CancellationToken not forwarded to repo** (by design): `IBankStatementImportRepository.GetByIdAsync(int id)` has no CT parameter; FR-5 forbids interface changes. The handler's `Handle()` still accepts CT (MediatR contract) — it's simply not passed to the repo.
+- **No new response DTO**: `BankStatementImportDto` is reused directly (arch review decision 1), keeping the OpenAPI/TypeScript surface unchanged.
+- **Test file cleanup**: The implementer for Task 3 added a `using Microsoft.Extensions.Logging.Abstractions;` to the test file to fix a MapperConfiguration constructor issue — reviewed and confirmed as a valid infrastructure fix (no test logic was changed).
+- **130 pre-existing frontend lint errors** remain but none were introduced by this feature.
+- Repository files (`IBankStatementImportRepository.cs`, `BankStatementImportRepository.cs`) confirmed untouched via `git diff main`.
+
+## PR Summary
+
+Replaced the `GetBankStatement(int id)` list-handler workaround with a dedicated `GetBankStatementByIdHandler` that calls `IBankStatementImportRepository.GetByIdAsync` directly, restoring the "thin controllers, business logic in handlers" invariant required by the project's architecture rules.
+
+The HTTP contract is unchanged: same route, same response shape (`BankStatementImportDto`), same 200/404 status codes, same 404 message body. No migrations, no new NuGet packages, no configuration changes.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs` — new MediatR request contract
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs` — new handler using IMapper + IBankStatementImportRepository
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` — thin dispatcher replacing the list-handler workaround
+- `backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs` — 4 handler unit tests
+- `backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs` — 3 new controller tests
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs` — 2 end-to-end HTTP tests
+
+## Status
+
+DONE

--- a/artifacts/feat-arch-review-bank-getbankstatement-id-end/spec.r1.md
+++ b/artifacts/feat-arch-review-bank-getbankstatement-id-end/spec.r1.md
@@ -1,0 +1,176 @@
+# Specification: GetBankStatement by Id — Dedicated MediatR Handler
+
+## Summary
+Replace the controller-level workaround in `BankStatementsController.GetBankStatement(int id)` with a purpose-built MediatR handler (`GetBankStatementByIdHandler`) that calls `IBankStatementImportRepository.GetByIdAsync` directly. The controller becomes a thin dispatcher: send the request, translate `null` to `404 NotFound`, or return `200 Ok`. This removes business logic from the controller, eliminates the misuse of the list handler for a point-lookup, and activates an existing-but-unused repository method.
+
+## Background
+Project guidelines mandate that **business logic must be in MediatR handlers, not controllers**. Today, `BankStatementsController.GetBankStatement(int id)` (lines 142–169 of `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`) violates this rule in two ways:
+
+1. It constructs a `GetBankStatementListRequest { Id = id, Take = 1 }`, sends it to the **list** handler, then calls `FirstOrDefault()` on the resulting collection — leaking pagination semantics into a point-lookup path.
+2. The "if null, return `NotFound`" decision is business logic embedded in the controller rather than expressed as the handler's contract.
+
+Meanwhile, `IBankStatementImportRepository.GetByIdAsync(int id)` (declared in `backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs`, implemented in `backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportRepository.cs`) is not reached by any handler. It exists, is tested at the repository level, and is the right tool — but is currently dead code from the perspective of HTTP traffic.
+
+This refactor was identified by the daily arch-review routine on 2026-06-03 and is purely internal: HTTP contract, request/response shapes visible to clients, and database schema all remain unchanged.
+
+## Functional Requirements
+
+### FR-1: New MediatR request `GetBankStatementByIdRequest`
+Define a request DTO under `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/`.
+
+- Implements `IRequest<GetBankStatementByIdResponse?>` (nullable response signals "not found").
+- Contains a single property `int Id`.
+- Per project rules, the request is a **class**, not a C# record (DTOs are classes to keep OpenAPI client generators happy).
+
+**Acceptance criteria:**
+- `GetBankStatementByIdRequest.cs` exists in the specified folder.
+- Type is a class with public parameterless constructor and `int Id { get; set; }`.
+- Type implements `IRequest<GetBankStatementByIdResponse?>`.
+
+### FR-2: New response type `GetBankStatementByIdResponse`
+Define a response DTO with the same fields currently surfaced by `GetBankStatementListResponse.Items[0]` for an `Id` lookup.
+
+- The response **must be byte-for-byte JSON-equivalent** to what `GetBankStatement(int id)` currently returns when the record is found, so the existing OpenAPI/TypeScript client and any external consumers continue to work without changes.
+- Response is a class (not a record).
+
+**Acceptance criteria:**
+- `GetBankStatementByIdResponse.cs` exists in the specified folder.
+- Property names, types, casing, and nullability mirror the item shape of `GetBankStatementListResponse.Items` exactly.
+- Manually diffing a serialized response against the current endpoint output shows no differences for the same `Id`.
+
+### FR-3: New handler `GetBankStatementByIdHandler`
+Implement `IRequestHandler<GetBankStatementByIdRequest, GetBankStatementByIdResponse?>`.
+
+Behavior:
+- Calls `IBankStatementImportRepository.GetByIdAsync(request.Id, cancellationToken)`.
+- If repository returns `null` → handler returns `null`.
+- Otherwise → maps the domain entity to `GetBankStatementByIdResponse` and returns it.
+- Mapping reuses the same projection logic used by the list handler for a single item (extract a shared mapper if duplication arises; see FR-6).
+- No I/O beyond the single repository call. No pagination, no `Take`, no `FirstOrDefault` on a list.
+
+**Acceptance criteria:**
+- Handler resides in `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/`.
+- Handler is registered automatically by the existing MediatR assembly scan (no manual DI wiring needed — verify by integration test).
+- Cancellation token is propagated to the repository call.
+- For a missing id, handler returns `null` without throwing.
+- For an existing id, the returned response matches FR-2 exactly.
+
+### FR-4: Controller becomes a thin dispatcher
+Refactor `BankStatementsController.GetBankStatement(int id)` to:
+
+```csharp
+[HttpGet("{id:int}")]
+public async Task<IActionResult> GetBankStatement(int id, CancellationToken cancellationToken)
+{
+    var response = await _mediator.Send(new GetBankStatementByIdRequest { Id = id }, cancellationToken);
+    return response is null ? NotFound() : Ok(response);
+}
+```
+
+- The controller no longer references `GetBankStatementListRequest`, `Take`, or `FirstOrDefault` for this endpoint.
+- HTTP route, verb, attributes, and authorization remain unchanged.
+- Response status codes remain `200 OK` (found) / `404 NotFound` (missing). The `NotFound()` body shape (empty vs. payload) must match the existing behavior — preserve whatever the current controller returns to avoid breaking clients.
+
+**Acceptance criteria:**
+- Diff of the controller shows only the body of `GetBankStatement(int id)` changed; route, attributes, and signature unchanged (except adding a `CancellationToken` parameter if not already present).
+- A `curl` / integration test against the endpoint returns the same status codes and JSON bodies as before for both the found and not-found cases.
+
+### FR-5: No changes to the repository
+`IBankStatementImportRepository.GetByIdAsync(int id, CancellationToken)` is used as-is. No new methods, no signature changes, no implementation changes.
+
+**Acceptance criteria:**
+- `git diff` shows zero changes under `backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs` and `backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportRepository.cs`.
+
+### FR-6: Avoid duplicating the entity → DTO mapping
+The list handler already projects `BankStatementImport` → `GetBankStatementListResponse.Items[i]`. The new handler must produce a structurally identical projection for the single-item case.
+
+- Preferred: extract a private static mapper (e.g. `BankStatementMapper.ToDto(BankStatementImport)`) in `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/` and call it from both handlers.
+- Acceptable if simpler: inline a small projection in the new handler and a follow-up issue documenting the duplication. The brief is a surgical refactor; extracting a shared mapper is in scope only if it's a trivial lift.
+
+**Acceptance criteria:**
+- The two handlers produce equivalent DTOs for the same domain entity (verified by a unit test that constructs an entity and asserts equality between `listHandler.Map(entity)` and `byIdHandler.Map(entity)`, or by sharing the mapper).
+- If a shared mapper is extracted, the list handler is updated to use it.
+
+### FR-7: Test coverage
+Add tests under `backend/test/Anela.Heblo.Tests/` (mirror the existing Bank feature test layout):
+
+- **Unit test** for `GetBankStatementByIdHandler`:
+  - Returns mapped response when repository returns an entity.
+  - Returns `null` when repository returns `null`.
+  - Propagates `CancellationToken` to the repository.
+- **Integration / controller test** for the endpoint:
+  - `GET /api/bank-statements/{existingId}` → `200 OK` with expected JSON.
+  - `GET /api/bank-statements/{missingId}` → `404 NotFound`.
+  - JSON shape matches the pre-refactor output (snapshot or field-by-field assertion).
+
+**Acceptance criteria:**
+- All new tests pass locally and in CI.
+- Existing Bank-feature tests continue to pass with no modifications, except updates necessitated by an extracted shared mapper (FR-6).
+- Coverage of the new handler ≥ 80% per the project's testing rule.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- Endpoint latency must not regress. `GetByIdAsync` is a single keyed lookup; expected to be at least as fast as the current list-handler-with-`Take=1` path.
+- No additional database round-trips introduced.
+
+### NFR-2: Security
+- No changes to authorization. Whatever `[Authorize]` / policy attributes apply to the existing endpoint apply unchanged.
+- No new inputs accepted; the `id` route parameter is already constrained to `int` and validated by ASP.NET model binding.
+
+### NFR-3: Backwards compatibility
+- HTTP contract (route, verb, request shape, response JSON shape, status codes) is unchanged.
+- OpenAPI spec and the generated TypeScript client must continue to work without regeneration changes that affect callers. If the regenerated client produces a different type name for the response (e.g. `GetBankStatementByIdResponse` vs `GetBankStatementListResponseItem`), update the small number of frontend call sites accordingly — but the wire format must remain identical.
+
+### NFR-4: Code quality
+- Conforms to project guidelines in `docs/architecture/development_guidelines.md` (Vertical Slice layout under `Features/Bank/UseCases/GetBankStatementById/`).
+- Passes `dotnet build` and `dotnet format` cleanly.
+- No new warnings introduced.
+
+## Data Model
+No data model changes. Existing entity `BankStatementImport` and existing table/columns are untouched. The new DTO `GetBankStatementByIdResponse` mirrors the existing list-item DTO and is purely a transport concern.
+
+## API / Interface Design
+
+### HTTP endpoint (unchanged externally)
+```
+GET /api/bank-statements/{id}
+→ 200 OK  + GetBankStatementByIdResponse (JSON, shape identical to current list-item response)
+→ 404 Not Found (body shape preserved from current behavior)
+```
+
+### MediatR request/response (new internal contract)
+```
+Request:  GetBankStatementByIdRequest  { int Id }                 // class, IRequest<GetBankStatementByIdResponse?>
+Response: GetBankStatementByIdResponse { …fields mirror list-item DTO… }   // class
+Handler:  GetBankStatementByIdHandler  : IRequestHandler<…>       // calls IBankStatementImportRepository.GetByIdAsync
+```
+
+### Folder layout (Vertical Slice)
+```
+backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/
+├── GetBankStatementByIdRequest.cs
+├── GetBankStatementByIdResponse.cs
+└── GetBankStatementByIdHandler.cs
+```
+(If a shared mapper is extracted, place it at `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/BankStatementMapper.cs` or similar — final location to be confirmed by the architect.)
+
+## Dependencies
+- **MediatR** — already in use across the project; no version change.
+- **Existing `IBankStatementImportRepository.GetByIdAsync`** — must remain in place.
+- **Existing OpenAPI client generation pipeline** — will regenerate types on build; verify the frontend still compiles after regeneration.
+- No new NuGet packages, no new services, no new configuration.
+
+## Out of Scope
+- Changes to `GetBankStatementListRequest` / `GetBankStatementListHandler` beyond (optionally) consuming a shared mapper extracted in FR-6.
+- Changes to other Bank endpoints (`POST`, `PUT`, list, etc.).
+- Repository interface or implementation changes.
+- Database schema changes or migrations.
+- Frontend behavior changes beyond regenerating the OpenAPI TypeScript client to pick up the (renamed) response type.
+- Adding caching, observability, or retry logic to the new handler.
+- Rewriting the controller's other actions, even if they exhibit similar smells.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-bank-getbankstatement-id-end/task-plan.r1.md
+++ b/artifacts/feat-arch-review-bank-getbankstatement-id-end/task-plan.r1.md
@@ -1,0 +1,11 @@
+Self-review pass complete. Plan saved.
+
+**Plan saved to:** `docs/superpowers/plans/2026-06-03-bank-statement-by-id-handler.md`
+
+Summary:
+- 7 tasks, TDD ordering (failing tests in Task 2 → handler in Task 3 → controller in Task 4 → more tests + validation in 5–7).
+- All locked decisions from the arch review baked into specific tasks: reuse `BankStatementImportDto`, no new mapper, preserve 404 `{message}` body, no `:int` route constraint, no CT to repo, drop the controller's `try/catch`.
+- Every step has exact file paths, complete code blocks (no "TBD" / "similar to above"), exact bash commands, and expected outputs.
+- Spec-coverage table at the end maps every FR/NFR (with arch-review amendments applied) to the task(s) that implement it.
+
+Pipeline note honored — skipping the execution-choice prompt.

--- a/backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.Bank.Contracts;
 using Anela.Heblo.Application.Features.Bank.UseCases.GetBankAccounts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
 using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList;
 using Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
 using MediatR;
@@ -139,32 +140,12 @@ public class BankStatementsController : BaseApiController
     /// <param name="id">Bank statement import ID</param>
     /// <returns>Bank statement import details</returns>
     [HttpGet("{id}")]
-    public async Task<ActionResult<BankStatementImportDto>> GetBankStatement(int id)
+    public async Task<ActionResult<BankStatementImportDto>> GetBankStatement(int id, CancellationToken cancellationToken)
     {
-        try
-        {
-            _logger.LogInformation("Getting bank statement with ID {Id}", id);
+        var response = await _mediator.Send(new GetBankStatementByIdRequest { Id = id }, cancellationToken);
 
-            var request = new GetBankStatementListRequest
-            {
-                Id = id,
-                Take = 1
-            };
-
-            var response = await _mediator.Send(request);
-            var statement = response.Items.FirstOrDefault();
-
-            if (statement == null)
-            {
-                return NotFound(new { message = $"Bank statement import with ID {id} not found" });
-            }
-
-            return Ok(statement);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving bank statement {Id}", id);
-            return StatusCode(500, new { message = "An error occurred while retrieving bank statement" });
-        }
+        return response is null
+            ? NotFound(new { message = $"Bank statement import with ID {id} not found" })
+            : Ok(response);
     }
 }

--- a/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs
@@ -1,0 +1,39 @@
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Domain.Features.Bank;
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+
+public class GetBankStatementByIdHandler : IRequestHandler<GetBankStatementByIdRequest, BankStatementImportDto?>
+{
+    private readonly IBankStatementImportRepository _repository;
+    private readonly IMapper _mapper;
+    private readonly ILogger<GetBankStatementByIdHandler> _logger;
+
+    public GetBankStatementByIdHandler(
+        IBankStatementImportRepository repository,
+        IMapper mapper,
+        ILogger<GetBankStatementByIdHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BankStatementImportDto?> Handle(GetBankStatementByIdRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Getting bank statement with ID {Id}", request.Id);
+
+        var entity = await _repository.GetByIdAsync(request.Id);
+
+        if (entity is null)
+        {
+            _logger.LogInformation("Bank statement with ID {Id} not found", request.Id);
+            return null;
+        }
+
+        return _mapper.Map<BankStatementImportDto>(entity);
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs
@@ -1,0 +1,9 @@
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+
+public class GetBankStatementByIdRequest : IRequest<BankStatementImportDto?>
+{
+    public int Id { get; set; }
+}

--- a/backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs
@@ -1,6 +1,7 @@
 using Anela.Heblo.API.Controllers;
 using Anela.Heblo.Application.Features.Bank.Contracts;
 using Anela.Heblo.Application.Features.Bank.UseCases.GetBankAccounts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -74,5 +75,80 @@ public class BankStatementsControllerTests
         var ok = Assert.IsType<OkObjectResult>(actionResult.Result);
         var payload = Assert.IsAssignableFrom<IEnumerable<BankAccountDto>>(ok.Value);
         Assert.Empty(payload);
+    }
+
+    [Fact]
+    public async Task GetBankStatement_WithExistingId_DispatchesByIdRequestAndReturnsOk()
+    {
+        // Arrange
+        var dto = new BankStatementImportDto
+        {
+            Id = 42,
+            TransferId = "T-EXISTS",
+            StatementDate = new DateTime(2026, 1, 15),
+            ImportDate = new DateTime(2026, 1, 16),
+            Account = "123456789",
+            Currency = "CZK",
+            ItemCount = 5,
+            ImportResult = "OK"
+        };
+        _mockMediator
+            .Setup(m => m.Send(It.Is<GetBankStatementByIdRequest>(r => r.Id == 42), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        // Act
+        var actionResult = await _controller.GetBankStatement(42, CancellationToken.None);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(actionResult.Result);
+        var payload = Assert.IsType<BankStatementImportDto>(ok.Value);
+        Assert.Equal(42, payload.Id);
+        Assert.Equal("T-EXISTS", payload.TransferId);
+
+        _mockMediator.Verify(
+            m => m.Send(It.Is<GetBankStatementByIdRequest>(r => r.Id == 42), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetBankStatement_WithMissingId_ReturnsNotFoundWithMessageBody()
+    {
+        // Arrange
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<GetBankStatementByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BankStatementImportDto?)null);
+
+        // Act
+        var actionResult = await _controller.GetBankStatement(99999, CancellationToken.None);
+
+        // Assert
+        var notFound = Assert.IsType<NotFoundObjectResult>(actionResult.Result);
+        Assert.NotNull(notFound.Value);
+
+        // Wire-format guarantee: the 404 body must keep the { message = "..." } shape.
+        var messageProp = notFound.Value!.GetType().GetProperty("message");
+        Assert.NotNull(messageProp);
+        var messageValue = messageProp!.GetValue(notFound.Value) as string;
+        Assert.Equal("Bank statement import with ID 99999 not found", messageValue);
+    }
+
+    [Fact]
+    public async Task GetBankStatement_DoesNotDispatchListRequest()
+    {
+        // Arrange — guarantees the old list-handler workaround is gone.
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<GetBankStatementByIdRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BankStatementImportDto?)null);
+
+        // Act
+        await _controller.GetBankStatement(7, CancellationToken.None);
+
+        // Assert — only ByIdRequest was sent; no ListRequest was constructed.
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<GetBankStatementByIdRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList.GetBankStatementListRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs
@@ -298,6 +298,65 @@ public class BankStatementImportIntegrationTests : IClassFixture<BankStatementIm
             Assert.Equal("OK", savedImport.ImportResult);
         }
     }
+
+    [Fact]
+    public async Task GetBankStatement_WithExistingId_Returns200WithDtoBody()
+    {
+        // Arrange — seed a bank statement directly through the DbContext.
+        int seededId;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<Anela.Heblo.Persistence.ApplicationDbContext>();
+            var entity = new Anela.Heblo.Domain.Features.Bank.BankStatementImport("T-INT-GET", new DateTime(2026, 3, 1))
+            {
+                Account = "ComgateCZK",
+                Currency = Anela.Heblo.Domain.Shared.CurrencyCode.CZK,
+                ItemCount = 4,
+                ImportResult = "OK"
+            };
+            context.BankStatements.Add(entity);
+            await context.SaveChangesAsync();
+            seededId = entity.Id;
+        }
+
+        // Act
+        var response = await _client.GetAsync($"/api/bank-statements/{seededId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        var dto = JsonSerializer.Deserialize<Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto>(
+            body,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(dto);
+        Assert.Equal(seededId, dto!.Id);
+        Assert.Equal("T-INT-GET", dto.TransferId);
+        Assert.Equal("ComgateCZK", dto.Account);
+        Assert.Equal("CZK", dto.Currency);
+        Assert.Equal(4, dto.ItemCount);
+        Assert.Equal("OK", dto.ImportResult);
+    }
+
+    [Fact]
+    public async Task GetBankStatement_WithMissingId_Returns404WithMessageBody()
+    {
+        // Arrange — pick an id that cannot exist.
+        const int missingId = 987654321;
+
+        // Act
+        var response = await _client.GetAsync($"/api/bank-statements/{missingId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.True(doc.RootElement.TryGetProperty("message", out var messageProp),
+            "404 response must contain a 'message' field to preserve wire format");
+        Assert.Equal($"Bank statement import with ID {missingId} not found", messageProp.GetString());
+    }
 }
 
 /// <summary>

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs
@@ -5,6 +5,7 @@ using Anela.Heblo.Domain.Features.Bank;
 using Anela.Heblo.Domain.Shared;
 using AutoMapper;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -20,7 +21,7 @@ public class GetBankStatementByIdHandlerTests
     public GetBankStatementByIdHandlerTests()
     {
         _repository = new Mock<IBankStatementImportRepository>();
-        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<BankMappingProfile>());
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<BankMappingProfile>(), NullLoggerFactory.Instance);
         _mapper = mapperConfig.CreateMapper();
         _logger = new Mock<ILogger<GetBankStatementByIdHandler>>();
         _handler = new GetBankStatementByIdHandler(_repository.Object, _mapper, _logger.Object);

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs
@@ -1,0 +1,117 @@
+using Anela.Heblo.Application.Features.Bank;
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+using Anela.Heblo.Domain.Features.Bank;
+using Anela.Heblo.Domain.Shared;
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Bank;
+
+public class GetBankStatementByIdHandlerTests
+{
+    private readonly Mock<IBankStatementImportRepository> _repository;
+    private readonly IMapper _mapper;
+    private readonly Mock<ILogger<GetBankStatementByIdHandler>> _logger;
+    private readonly GetBankStatementByIdHandler _handler;
+
+    public GetBankStatementByIdHandlerTests()
+    {
+        _repository = new Mock<IBankStatementImportRepository>();
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<BankMappingProfile>());
+        _mapper = mapperConfig.CreateMapper();
+        _logger = new Mock<ILogger<GetBankStatementByIdHandler>>();
+        _handler = new GetBankStatementByIdHandler(_repository.Object, _mapper, _logger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingId_ReturnsMappedDto()
+    {
+        // Arrange
+        var entity = new BankStatementImport("T12345", new DateTime(2026, 1, 15))
+        {
+            Account = "123456789",
+            Currency = CurrencyCode.CZK,
+            ItemCount = 7,
+            ImportResult = "OK"
+        };
+        _repository
+            .Setup(r => r.GetByIdAsync(42))
+            .ReturnsAsync(entity);
+
+        // Act
+        var result = await _handler.Handle(new GetBankStatementByIdRequest { Id = 42 }, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("T12345", result!.TransferId);
+        Assert.Equal("123456789", result.Account);
+        Assert.Equal("CZK", result.Currency);
+        Assert.Equal(7, result.ItemCount);
+        Assert.Equal("OK", result.ImportResult);
+        Assert.Null(result.ErrorType);
+    }
+
+    [Fact]
+    public async Task Handle_WithMissingId_ReturnsNull()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.GetByIdAsync(99999))
+            .ReturnsAsync((BankStatementImport?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetBankStatementByIdRequest { Id = 99999 }, CancellationToken.None);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Handle_CallsRepositoryGetByIdExactlyOnce_WithTheRequestId()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync((BankStatementImport?)null);
+
+        // Act
+        await _handler.Handle(new GetBankStatementByIdRequest { Id = 123 }, CancellationToken.None);
+
+        // Assert
+        _repository.Verify(r => r.GetByIdAsync(123), Times.Once);
+        _repository.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ProducesSameDtoAsListHandlerMapping_ForSameEntity()
+    {
+        // Arrange — guarantees no projection drift between list and by-id paths.
+        var entity = new BankStatementImport("T-SAMENESS", new DateTime(2026, 2, 1))
+        {
+            Account = "987654321",
+            Currency = CurrencyCode.EUR,
+            ItemCount = 3,
+            ImportResult = "PROCESSING_ERROR"
+        };
+        _repository.Setup(r => r.GetByIdAsync(7)).ReturnsAsync(entity);
+
+        // Act
+        var fromHandler = await _handler.Handle(new GetBankStatementByIdRequest { Id = 7 }, CancellationToken.None);
+        var fromListMapping = _mapper.Map<List<BankStatementImportDto>>(new[] { entity }).Single();
+
+        // Assert
+        Assert.NotNull(fromHandler);
+        Assert.Equal(fromListMapping.Id, fromHandler!.Id);
+        Assert.Equal(fromListMapping.TransferId, fromHandler.TransferId);
+        Assert.Equal(fromListMapping.StatementDate, fromHandler.StatementDate);
+        Assert.Equal(fromListMapping.ImportDate, fromHandler.ImportDate);
+        Assert.Equal(fromListMapping.Account, fromHandler.Account);
+        Assert.Equal(fromListMapping.Currency, fromHandler.Currency);
+        Assert.Equal(fromListMapping.ItemCount, fromHandler.ItemCount);
+        Assert.Equal(fromListMapping.ImportResult, fromHandler.ImportResult);
+        Assert.Equal(fromListMapping.ErrorType, fromHandler.ErrorType);
+    }
+}

--- a/docs/superpowers/plans/2026-06-03-bank-statement-by-id-handler.md
+++ b/docs/superpowers/plans/2026-06-03-bank-statement-by-id-handler.md
@@ -1,0 +1,764 @@
+# GetBankStatement by Id — Dedicated MediatR Handler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the controller-level workaround in `BankStatementsController.GetBankStatement(int id)` with a purpose-built MediatR handler that calls `IBankStatementImportRepository.GetByIdAsync` directly, restoring the "thin controllers, business logic in handlers" rule and activating an existing-but-unused repository method.
+
+**Architecture:** Add a Vertical Slice `Application/Features/Bank/UseCases/GetBankStatementById/` containing `GetBankStatementByIdRequest` and `GetBankStatementByIdHandler`. Handler returns `BankStatementImportDto?` (the existing list-item DTO — no new response type is introduced), mapped via the existing `BankMappingProfile` through `IMapper`. Controller becomes a thin dispatcher that converts `null → 404 + message body` or `value → 200 OK`. Repository interface and HTTP wire format are untouched.
+
+**Tech Stack:** .NET 8, MediatR, AutoMapper, EF Core, xUnit + Moq + FluentAssertions, `WebApplicationFactory<>` for integration tests.
+
+---
+
+## Background You Need
+
+Before writing code, read these so the changes fit the codebase:
+
+- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` — the controller you will change. `GetBankStatement(int id)` is at lines 141–169 and is the *only* thing in this file you will touch.
+- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementList/GetBankStatementListHandler.cs` — the handler pattern to mirror (ctor injection of `IBankStatementImportRepository`, `IMapper`, `ILogger<T>`; uses `_mapper.Map<List<BankStatementImportDto>>(items)`).
+- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs` — the single-item DTO. Already maps from `BankStatementImport` via `BankMappingProfile`. **Do not create a new response DTO.**
+- `backend/src/Anela.Heblo.Application/Features/Bank/BankMappingProfile.cs` — already contains `CreateMap<BankStatementImport, BankStatementImportDto>()`. The new handler reuses it.
+- `backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs` — line 13: `Task<BankStatementImport?> GetByIdAsync(int id)`. **No `CancellationToken` parameter.** Do not change this interface.
+- `backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs` — existing controller unit-test patterns (Moq `IMediator`, `Moq.Mock<ILogger<...>>`).
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs` — defines `BankStatementImportTestFactory : HebloWebApplicationFactory` at lines 306–end. We will reuse this factory for the integration tests (it already wires the WebApp + mocks, and tests share it via `IClassFixture<>`).
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportRepositoryTests.cs` — pattern for seeding the in-memory DB in tests using `BankStatementImportRepository.AddAsync(...)`.
+
+## Architectural Decisions (Locked, Do Not Re-litigate)
+
+These come from the architecture review and override the original spec where the spec was wrong:
+
+1. **No `GetBankStatementByIdResponse`.** Handler returns `BankStatementImportDto?`. The list-item DTO already *is* the single-item shape the existing endpoint serialises.
+2. **No new mapper file.** Use injected `IMapper` against the existing `BankMappingProfile`.
+3. **Preserve `404` body:** `NotFound(new { message = $"Bank statement import with ID {id} not found" })`. The original brief example dropped this and would be a wire-format change.
+4. **Do not pass `CancellationToken` to the repository.** Interface has no CT parameter; FR-5 forbids interface changes. The handler still accepts a CT (MediatR contract) — it just doesn't forward it to `GetByIdAsync`.
+5. **Keep `[HttpGet("{id}")]` exactly as is.** No `:int` constraint. Changing it alters routing/error behaviour for non-integer paths.
+6. **Controller return type stays `ActionResult<BankStatementImportDto>`.**
+7. **Drop the controller-level `try/catch (Exception)`** in `GetBankStatement(int id)` for consistency with `GetAccounts` (no top-level catch). Global ASP.NET error handling already covers unhandled exceptions.
+
+## File Structure
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs` | Create | MediatR request DTO. `class`, single `int Id`, `IRequest<BankStatementImportDto?>`. |
+| `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs` | Create | Calls repo `GetByIdAsync(request.Id)`, maps via `IMapper`, returns DTO or `null`. |
+| `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` | Modify (lines 141–169 only) | Replace `GetBankStatement(int id)` body. Add `CancellationToken` param. Add `using` for the new slice. |
+| `backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs` | Create | Unit tests for the handler (Moq repo + AutoMapper instance). |
+| `backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs` | Modify (append tests) | Controller unit tests asserting MediatR dispatch + 200/404 mapping with preserved message body. |
+| `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs` | Modify (append tests) | Two end-to-end tests: existing id → 200 + DTO; missing id → 404 + `{message: "..."}` body. |
+
+No changes to: `IBankStatementImportRepository.cs`, `BankStatementImportRepository.cs`, `BankMappingProfile.cs`, `BankStatementImportDto.cs`, `GetBankStatementListHandler.cs`, `GetBankStatementListRequest.cs`, `GetBankStatementListResponse.cs`.
+
+---
+
+## Task 1: Add MediatR request `GetBankStatementByIdRequest`
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs`
+
+- [ ] **Step 1: Create the request class**
+
+Create the file with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using MediatR;
+
+namespace Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+
+public class GetBankStatementByIdRequest : IRequest<BankStatementImportDto?>
+{
+    public int Id { get; set; }
+}
+```
+
+Why a class (not record): project rule — DTOs and MediatR requests are classes to keep OpenAPI client generators happy.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run:
+```bash
+dotnet build backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+```
+
+Expected: build succeeds with zero warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs
+git commit -m "feat(bank): add GetBankStatementByIdRequest MediatR contract"
+```
+
+---
+
+## Task 2: TDD — Write failing handler unit tests
+
+**Files:**
+- Create: `backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs`
+
+The handler does not exist yet. These tests will not compile until Task 3 creates it. That's intentional — RED stage of TDD.
+
+- [ ] **Step 1: Create the test file with three failing cases**
+
+Create the file with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank;
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+using Anela.Heblo.Domain.Features.Bank;
+using Anela.Heblo.Domain.Shared;
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Bank;
+
+public class GetBankStatementByIdHandlerTests
+{
+    private readonly Mock<IBankStatementImportRepository> _repository;
+    private readonly IMapper _mapper;
+    private readonly Mock<ILogger<GetBankStatementByIdHandler>> _logger;
+    private readonly GetBankStatementByIdHandler _handler;
+
+    public GetBankStatementByIdHandlerTests()
+    {
+        _repository = new Mock<IBankStatementImportRepository>();
+        var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile<BankMappingProfile>());
+        _mapper = mapperConfig.CreateMapper();
+        _logger = new Mock<ILogger<GetBankStatementByIdHandler>>();
+        _handler = new GetBankStatementByIdHandler(_repository.Object, _mapper, _logger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingId_ReturnsMappedDto()
+    {
+        // Arrange
+        var entity = new BankStatementImport("T12345", new DateTime(2026, 1, 15))
+        {
+            Account = "123456789",
+            Currency = CurrencyCode.CZK,
+            ItemCount = 7,
+            ImportResult = "OK"
+        };
+        _repository
+            .Setup(r => r.GetByIdAsync(42))
+            .ReturnsAsync(entity);
+
+        // Act
+        var result = await _handler.Handle(new GetBankStatementByIdRequest { Id = 42 }, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("T12345", result!.TransferId);
+        Assert.Equal("123456789", result.Account);
+        Assert.Equal("CZK", result.Currency);
+        Assert.Equal(7, result.ItemCount);
+        Assert.Equal("OK", result.ImportResult);
+        Assert.Null(result.ErrorType);
+    }
+
+    [Fact]
+    public async Task Handle_WithMissingId_ReturnsNull()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.GetByIdAsync(99999))
+            .ReturnsAsync((BankStatementImport?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetBankStatementByIdRequest { Id = 99999 }, CancellationToken.None);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Handle_CallsRepositoryGetByIdExactlyOnce_WithTheRequestId()
+    {
+        // Arrange
+        _repository
+            .Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync((BankStatementImport?)null);
+
+        // Act
+        await _handler.Handle(new GetBankStatementByIdRequest { Id = 123 }, CancellationToken.None);
+
+        // Assert
+        _repository.Verify(r => r.GetByIdAsync(123), Times.Once);
+        _repository.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_ProducesSameDtoAsListHandlerMapping_ForSameEntity()
+    {
+        // Arrange — guarantees no projection drift between list and by-id paths.
+        var entity = new BankStatementImport("T-SAMENESS", new DateTime(2026, 2, 1))
+        {
+            Account = "987654321",
+            Currency = CurrencyCode.EUR,
+            ItemCount = 3,
+            ImportResult = "PROCESSING_ERROR"
+        };
+        _repository.Setup(r => r.GetByIdAsync(7)).ReturnsAsync(entity);
+
+        // Act
+        var fromHandler = await _handler.Handle(new GetBankStatementByIdRequest { Id = 7 }, CancellationToken.None);
+        var fromListMapping = _mapper.Map<List<BankStatementImportDto>>(new[] { entity }).Single();
+
+        // Assert
+        Assert.NotNull(fromHandler);
+        Assert.Equal(fromListMapping.Id, fromHandler!.Id);
+        Assert.Equal(fromListMapping.TransferId, fromHandler.TransferId);
+        Assert.Equal(fromListMapping.StatementDate, fromHandler.StatementDate);
+        Assert.Equal(fromListMapping.ImportDate, fromHandler.ImportDate);
+        Assert.Equal(fromListMapping.Account, fromHandler.Account);
+        Assert.Equal(fromListMapping.Currency, fromHandler.Currency);
+        Assert.Equal(fromListMapping.ItemCount, fromHandler.ItemCount);
+        Assert.Equal(fromListMapping.ImportResult, fromHandler.ImportResult);
+        Assert.Equal(fromListMapping.ErrorType, fromHandler.ErrorType);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests — they MUST fail to compile (RED)**
+
+Run:
+```bash
+dotnet build backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj
+```
+
+Expected: compile errors mentioning `GetBankStatementByIdHandler` is not defined. **Do not proceed if it compiles** — that means the handler somehow already exists, which is a discrepancy with the plan.
+
+- [ ] **Step 3: Commit the failing test file**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs
+git commit -m "test(bank): add failing GetBankStatementByIdHandler unit tests"
+```
+
+(Yes, we commit failing tests on a feature branch. They will go green in Task 3.)
+
+---
+
+## Task 3: Implement `GetBankStatementByIdHandler` (GREEN)
+
+**Files:**
+- Create: `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs`
+
+- [ ] **Step 1: Create the handler**
+
+Create the file with this exact content:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Domain.Features.Bank;
+using AutoMapper;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+
+public class GetBankStatementByIdHandler : IRequestHandler<GetBankStatementByIdRequest, BankStatementImportDto?>
+{
+    private readonly IBankStatementImportRepository _repository;
+    private readonly IMapper _mapper;
+    private readonly ILogger<GetBankStatementByIdHandler> _logger;
+
+    public GetBankStatementByIdHandler(
+        IBankStatementImportRepository repository,
+        IMapper mapper,
+        ILogger<GetBankStatementByIdHandler> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BankStatementImportDto?> Handle(GetBankStatementByIdRequest request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Getting bank statement with ID {Id}", request.Id);
+
+        var entity = await _repository.GetByIdAsync(request.Id);
+
+        if (entity is null)
+        {
+            _logger.LogInformation("Bank statement with ID {Id} not found", request.Id);
+            return null;
+        }
+
+        return _mapper.Map<BankStatementImportDto>(entity);
+    }
+}
+```
+
+Notes:
+- The `CancellationToken` is part of the MediatR contract and is accepted, but **not** forwarded to `_repository.GetByIdAsync` — the interface doesn't accept one (locked decision #4).
+- MediatR registration is automatic via `AddMediatR(...RegisterServicesFromAssembly(...))` in `ApplicationModule.cs` — no DI wiring needed.
+
+- [ ] **Step 2: Run the unit tests — they MUST all pass (GREEN)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~GetBankStatementByIdHandlerTests"
+```
+
+Expected: 4 tests passed, 0 failed.
+
+If a test fails, **read the failure**, fix the handler, re-run. Do not modify the tests to make them pass.
+
+- [ ] **Step 3: Run `dotnet format` on the new files**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/
+```
+
+Expected: exits with no changes (or applies trivial whitespace fixes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs
+git commit -m "feat(bank): implement GetBankStatementByIdHandler with IMapper + repository"
+```
+
+---
+
+## Task 4: Refactor the controller to dispatch the new request
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` (lines 1–9 add a using; lines 141–169 replace method body)
+
+- [ ] **Step 1: Update the using directives**
+
+Open `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs`. The current line 1–8 looks like:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankAccounts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList;
+using Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+```
+
+Add the new slice's using. Do **not** remove `GetBankStatementList` — the list endpoint `GetBankStatements` still uses it. The final block must be:
+
+```csharp
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankAccounts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList;
+using Anela.Heblo.Application.Features.Bank.UseCases.ImportBankStatement;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+```
+
+- [ ] **Step 2: Replace the body of `GetBankStatement(int id)`**
+
+The current method (lines 141–169) is:
+
+```csharp
+[HttpGet("{id}")]
+public async Task<ActionResult<BankStatementImportDto>> GetBankStatement(int id)
+{
+    try
+    {
+        _logger.LogInformation("Getting bank statement with ID {Id}", id);
+
+        var request = new GetBankStatementListRequest
+        {
+            Id = id,
+            Take = 1
+        };
+
+        var response = await _mediator.Send(request);
+        var statement = response.Items.FirstOrDefault();
+
+        if (statement == null)
+        {
+            return NotFound(new { message = $"Bank statement import with ID {id} not found" });
+        }
+
+        return Ok(statement);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Error occurred while retrieving bank statement {Id}", id);
+        return StatusCode(500, new { message = "An error occurred while retrieving bank statement" });
+    }
+}
+```
+
+Replace it with:
+
+```csharp
+[HttpGet("{id}")]
+public async Task<ActionResult<BankStatementImportDto>> GetBankStatement(int id, CancellationToken cancellationToken)
+{
+    var response = await _mediator.Send(new GetBankStatementByIdRequest { Id = id }, cancellationToken);
+
+    return response is null
+        ? NotFound(new { message = $"Bank statement import with ID {id} not found" })
+        : Ok(response);
+}
+```
+
+What changed and why:
+- Route attribute `[HttpGet("{id}")]` — **unchanged** (no `:int`, locked decision #5).
+- Return type `ActionResult<BankStatementImportDto>` — **unchanged** (locked decision #6).
+- Added `CancellationToken cancellationToken` parameter (good practice; flows through to MediatR even though the inner repo call drops it — locked decision #4).
+- `try/catch (Exception)` removed (locked decision #7 — consistent with `GetAccounts` above; global error handling covers it).
+- 404 body preserved as `new { message = ... }` (locked decision #3).
+- No more `GetBankStatementListRequest`, `Take = 1`, or `FirstOrDefault()`.
+
+- [ ] **Step 3: Verify the build is clean**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds with zero new warnings.
+
+- [ ] **Step 4: Run `dotnet format` on the controller**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln --include backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
+```
+
+Expected: no changes (or trivial whitespace).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs
+git commit -m "refactor(bank): dispatch GET /api/bank-statements/{id} to dedicated handler"
+```
+
+---
+
+## Task 5: Add controller-level unit tests for the new dispatch + 404 mapping
+
+**Files:**
+- Modify (append): `backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs`
+
+- [ ] **Step 1: Update the using directives at the top of the file**
+
+The current usings at the top of `BankStatementsControllerTests.cs` are:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankAccounts;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+Add the new slice's namespace. Final usings:
+
+```csharp
+using Anela.Heblo.API.Controllers;
+using Anela.Heblo.Application.Features.Bank.Contracts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankAccounts;
+using Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementById;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+```
+
+- [ ] **Step 2: Append the new test cases inside the class**
+
+Add these three tests inside `BankStatementsControllerTests` (just before the final closing brace of the class):
+
+```csharp
+[Fact]
+public async Task GetBankStatement_WithExistingId_DispatchesByIdRequestAndReturnsOk()
+{
+    // Arrange
+    var dto = new BankStatementImportDto
+    {
+        Id = 42,
+        TransferId = "T-EXISTS",
+        StatementDate = new DateTime(2026, 1, 15),
+        ImportDate = new DateTime(2026, 1, 16),
+        Account = "123456789",
+        Currency = "CZK",
+        ItemCount = 5,
+        ImportResult = "OK"
+    };
+    _mockMediator
+        .Setup(m => m.Send(It.Is<GetBankStatementByIdRequest>(r => r.Id == 42), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(dto);
+
+    // Act
+    var actionResult = await _controller.GetBankStatement(42, CancellationToken.None);
+
+    // Assert
+    var ok = Assert.IsType<OkObjectResult>(actionResult.Result);
+    var payload = Assert.IsType<BankStatementImportDto>(ok.Value);
+    Assert.Equal(42, payload.Id);
+    Assert.Equal("T-EXISTS", payload.TransferId);
+
+    _mockMediator.Verify(
+        m => m.Send(It.Is<GetBankStatementByIdRequest>(r => r.Id == 42), It.IsAny<CancellationToken>()),
+        Times.Once);
+}
+
+[Fact]
+public async Task GetBankStatement_WithMissingId_ReturnsNotFoundWithMessageBody()
+{
+    // Arrange
+    _mockMediator
+        .Setup(m => m.Send(It.IsAny<GetBankStatementByIdRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((BankStatementImportDto?)null);
+
+    // Act
+    var actionResult = await _controller.GetBankStatement(99999, CancellationToken.None);
+
+    // Assert
+    var notFound = Assert.IsType<NotFoundObjectResult>(actionResult.Result);
+    Assert.NotNull(notFound.Value);
+
+    // Wire-format guarantee: the 404 body must keep the { message = "..." } shape.
+    var messageProp = notFound.Value!.GetType().GetProperty("message");
+    Assert.NotNull(messageProp);
+    var messageValue = messageProp!.GetValue(notFound.Value) as string;
+    Assert.Equal("Bank statement import with ID 99999 not found", messageValue);
+}
+
+[Fact]
+public async Task GetBankStatement_DoesNotDispatchListRequest()
+{
+    // Arrange — guarantees the old list-handler workaround is gone.
+    _mockMediator
+        .Setup(m => m.Send(It.IsAny<GetBankStatementByIdRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((BankStatementImportDto?)null);
+
+    // Act
+    await _controller.GetBankStatement(7, CancellationToken.None);
+
+    // Assert — only ByIdRequest was sent; no ListRequest was constructed.
+    _mockMediator.Verify(
+        m => m.Send(It.IsAny<GetBankStatementByIdRequest>(), It.IsAny<CancellationToken>()),
+        Times.Once);
+    _mockMediator.Verify(
+        m => m.Send(It.IsAny<Anela.Heblo.Application.Features.Bank.UseCases.GetBankStatementList.GetBankStatementListRequest>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+```
+
+- [ ] **Step 3: Run the controller tests — all should pass**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~BankStatementsControllerTests"
+```
+
+Expected: all tests pass (existing + 3 new = 6 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs
+git commit -m "test(bank): cover controller dispatch + 404 message body for GetBankStatement"
+```
+
+---
+
+## Task 6: Add integration tests for the end-to-end HTTP behavior
+
+**Files:**
+- Modify (append): `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs`
+
+The existing `BankStatementImportTestFactory` (defined at the bottom of that same file) already wires the WebApp with mocked `IBankClient` / `IBankStatementImportService` while keeping the real EF Core in-memory `ApplicationDbContext` and MediatR pipeline. We seed data via `ApplicationDbContext` directly and assert end-to-end through `HttpClient`.
+
+- [ ] **Step 1: Append two integration tests**
+
+Add these two tests inside the existing `BankStatementImportIntegrationTests` class (before the final closing brace, but **before** the trailing `BankStatementImportTestFactory` class definition):
+
+```csharp
+[Fact]
+public async Task GetBankStatement_WithExistingId_Returns200WithDtoBody()
+{
+    // Arrange — seed a bank statement directly through the DbContext.
+    int seededId;
+    using (var scope = _factory.Services.CreateScope())
+    {
+        var context = scope.ServiceProvider.GetRequiredService<Anela.Heblo.Persistence.ApplicationDbContext>();
+        var entity = new Anela.Heblo.Domain.Features.Bank.BankStatementImport("T-INT-GET", new DateTime(2026, 3, 1))
+        {
+            Account = "ComgateCZK",
+            Currency = Anela.Heblo.Domain.Shared.CurrencyCode.CZK,
+            ItemCount = 4,
+            ImportResult = "OK"
+        };
+        context.BankStatements.Add(entity);
+        await context.SaveChangesAsync();
+        seededId = entity.Id;
+    }
+
+    // Act
+    var response = await _client.GetAsync($"/api/bank-statements/{seededId}");
+
+    // Assert
+    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+    var body = await response.Content.ReadAsStringAsync();
+    var dto = JsonSerializer.Deserialize<Anela.Heblo.Application.Features.Bank.Contracts.BankStatementImportDto>(
+        body,
+        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+    Assert.NotNull(dto);
+    Assert.Equal(seededId, dto!.Id);
+    Assert.Equal("T-INT-GET", dto.TransferId);
+    Assert.Equal("ComgateCZK", dto.Account);
+    Assert.Equal("CZK", dto.Currency);
+    Assert.Equal(4, dto.ItemCount);
+    Assert.Equal("OK", dto.ImportResult);
+}
+
+[Fact]
+public async Task GetBankStatement_WithMissingId_Returns404WithMessageBody()
+{
+    // Arrange — pick an id that cannot exist.
+    const int missingId = 987654321;
+
+    // Act
+    var response = await _client.GetAsync($"/api/bank-statements/{missingId}");
+
+    // Assert
+    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+    var body = await response.Content.ReadAsStringAsync();
+    using var doc = JsonDocument.Parse(body);
+    Assert.True(doc.RootElement.TryGetProperty("message", out var messageProp),
+        "404 response must contain a 'message' field to preserve wire format");
+    Assert.Equal($"Bank statement import with ID {missingId} not found", messageProp.GetString());
+}
+```
+
+Note on imports: `using System.Net;`, `using System.Text.Json;`, and `using Microsoft.Extensions.DependencyInjection;` are already at the top of this file from the existing tests; no new usings required if you fully qualify the few new types as shown above. (Optionally add `using Anela.Heblo.Application.Features.Bank.Contracts;` and `using Anela.Heblo.Domain.Features.Bank;` at the top and drop the fully qualified names — purely cosmetic.)
+
+- [ ] **Step 2: Run the integration tests**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~BankStatementImportIntegrationTests.GetBankStatement"
+```
+
+Expected: both new tests pass. If the existing-id test fails because the seeded entity isn't found, the most likely cause is that the test factory is using a transient/replaced DbContext — re-read `BankStatementImportTestFactory` and `HebloWebApplicationFactory` and adjust the seeding scope.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs
+git commit -m "test(bank): integration tests for GET /api/bank-statements/{id} 200 and 404"
+```
+
+---
+
+## Task 7: Full validation sweep
+
+Final checks per project rules (CLAUDE.md "Validation before completion").
+
+- [ ] **Step 1: Backend full build**
+
+Run:
+```bash
+dotnet build backend/Anela.Heblo.sln
+```
+
+Expected: build succeeds, zero new warnings.
+
+- [ ] **Step 2: Backend formatting**
+
+Run:
+```bash
+dotnet format backend/Anela.Heblo.sln --verify-no-changes
+```
+
+Expected: exits with code 0. If it reports drift, run without `--verify-no-changes`, then re-commit the formatting fixes as `chore: dotnet format`.
+
+- [ ] **Step 3: Full test suite (Bank slice + Controller tests)**
+
+Run:
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~Bank"
+```
+
+Expected: all Bank-feature tests + all `BankStatementsControllerTests` pass. No regressions.
+
+- [ ] **Step 4: Confirm repository / interface untouched**
+
+Run:
+```bash
+git diff main -- backend/src/Anela.Heblo.Domain/Features/Bank/IBankStatementImportRepository.cs backend/src/Anela.Heblo.Persistence/Features/Bank/BankStatementImportRepository.cs
+```
+
+Expected: empty output. If anything appears, revert those files — they are out of scope (FR-5).
+
+- [ ] **Step 5: Confirm OpenAPI / TypeScript client surface for this endpoint is unchanged**
+
+The TypeScript client is auto-generated. The response type for `GET /api/bank-statements/{id}` was `BankStatementImportDto` before and remains `BankStatementImportDto` after (locked decision #1).
+
+Run:
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds. If the generated client surface changed in a way that breaks the build, the most likely cause is the controller's return-type signature drifted — check it still reads `ActionResult<BankStatementImportDto>`.
+
+- [ ] **Step 6: Frontend lint (sanity check; no FE code is intentionally being changed)**
+
+Run:
+```bash
+cd frontend && npm run lint
+```
+
+Expected: passes. No new lint errors.
+
+- [ ] **Step 7: Final commit (if formatter or generated client produced any drift)**
+
+If any tracked file was modified by the formatter or the OpenAPI client regen, commit it:
+
+```bash
+git status
+# If anything is unstaged:
+git add -A
+git commit -m "chore: apply formatter and regenerated openapi client"
+```
+
+If `git status` is clean, skip this step.
+
+---
+
+## Spec Coverage Map
+
+Cross-checking every requirement in `spec.r1.md` (with arch-review amendments applied) against the tasks above:
+
+| Requirement | Status | Task(s) |
+|-------------|--------|---------|
+| FR-1: `GetBankStatementByIdRequest` class, `IRequest<...>`, `int Id` | Covered | Task 1 |
+| FR-2: New response type | **Removed by arch review** — reuses existing `BankStatementImportDto` | Task 1 (request signature), Task 3 (handler return) |
+| FR-3: Handler calling `GetByIdAsync`, mapping to DTO, `null` for not-found, no `CancellationToken` passed to repo | Covered | Task 2 (tests), Task 3 (impl) |
+| FR-4: Thin controller dispatcher, preserved 404 body, keep `[HttpGet("{id}")]`, keep `ActionResult<BankStatementImportDto>`, drop top-level catch | Covered | Task 4 |
+| FR-5: Repository interface + impl unchanged | Verified | Task 7 Step 4 |
+| FR-6: No new mapper file — use existing `BankMappingProfile` via `IMapper` | Covered (removed by arch review) | Task 3 (handler uses `_mapper.Map<BankStatementImportDto>(entity)`) |
+| FR-7: Handler unit tests (found, missing, repo-called-once) + integration tests (200 + 404 with message body) + projection-equivalence test | Covered | Tasks 2, 5, 6 |
+| NFR-1: Performance — single keyed lookup, no extra round-trips | Covered by design | Task 3 (single `GetByIdAsync` call, no list + filter + FirstOrDefault) |
+| NFR-2: Security — unchanged authorization, same route binding | Covered | Task 4 (no auth attrs changed; route literal unchanged) |
+| NFR-3: HTTP contract + OpenAPI surface unchanged | Verified | Task 4 (route + return type), Task 5 (404 body shape test), Task 6 (integration 200/404 body assertions), Task 7 Step 5 (`npm run build`) |
+| NFR-4: Conforms to development guidelines, clean `dotnet build` + `dotnet format` | Verified | Task 7 Steps 1–2 |
+
+No spec requirement is unmapped.


### PR DESCRIPTION

Replaced the `GetBankStatement(int id)` list-handler workaround with a dedicated `GetBankStatementByIdHandler` that calls `IBankStatementImportRepository.GetByIdAsync` directly, restoring the "thin controllers, business logic in handlers" invariant required by the project's architecture rules.

The HTTP contract is unchanged: same route, same response shape (`BankStatementImportDto`), same 200/404 status codes, same 404 message body. No migrations, no new NuGet packages, no configuration changes.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdRequest.cs` — new MediatR request contract
- `backend/src/Anela.Heblo.Application/Features/Bank/UseCases/GetBankStatementById/GetBankStatementByIdHandler.cs` — new handler using IMapper + IBankStatementImportRepository
- `backend/src/Anela.Heblo.API/Controllers/BankStatementsController.cs` — thin dispatcher replacing the list-handler workaround
- `backend/test/Anela.Heblo.Tests/Features/Bank/GetBankStatementByIdHandlerTests.cs` — 4 handler unit tests
- `backend/test/Anela.Heblo.Tests/Controllers/BankStatementsControllerTests.cs` — 3 new controller tests
- `backend/test/Anela.Heblo.Tests/Features/Bank/BankStatementImportIntegrationTests.cs` — 2 end-to-end HTTP tests

---

Closes #2443

### Tokens used
14479962
