### PR TITLE
feat: Replace Magic String "OK" with `ImportStatus.Success` Constant in `BankStatementImportDto`

### DIFF
--- a/artifacts/feat-arch-review-bank-bankstatementimportdto-/arch-review.r1.md
+++ b/artifacts/feat-arch-review-bank-bankstatementimportdto-/arch-review.r1.md
@@ -1,0 +1,162 @@
+# Architecture Review: Replace Magic String `"OK"` with `ImportStatus.Success` in `BankStatementImportDto`
+
+## Skip Design: true
+
+Backend-only, single-expression refactor. No UI components, screens, or visual behavior are touched. The serialized DTO shape and generated TypeScript client are unchanged by design.
+
+## Architectural Fit Assessment
+
+The change is a strict alignment to an **already-established convention** in the Bank module. `Anela.Heblo.Domain/Features/Bank/ImportStatus.cs` is the canonical source of import-status string constants, and it is consumed correctly at every other site in the module:
+
+- `BankStatementImportRepository.cs:49` — filters with `ImportStatus.Success`
+- `ImportBankStatementHandler.cs:89, 104, 113` — writes and counts using the constants
+- `BankStatementImportRepositoryTests.cs:393, 395, 415, 417` — test setup uses the constants
+
+The Application layer already has a `ProjectReference` to `Anela.Heblo.Domain` (`Anela.Heblo.Application.csproj:40`), so the proposed `using` introduces **no new project, package, or module dependency** and respects Clean Architecture layering (Application → Domain). `BankStatementImportDto` is the lone outlier; the refactor closes a known scattered-literal hazard and restores symmetry with the rest of the module.
+
+Integration points: zero. The change is a compile-time constant substitution; the emitted IL is identical.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+Anela.Heblo.Domain
+└── Features/Bank
+    └── ImportStatus.cs                  (canonical constants — unchanged)
+        ├── Success           = "OK"
+        ├── ProcessingError   = "PROCESSING_ERROR"
+        └── UnknownError      = "UNKNOWN_ERROR"
+                ▲
+                │ (existing project reference, no new dep)
+                │
+Anela.Heblo.Application
+└── Features/Bank
+    └── Contracts/
+        └── BankStatementImportDto.cs    (← single edit site)
+            └── ErrorType =>
+                ImportResult != ImportStatus.Success ? ImportResult : null;
+```
+
+No new components, no new files in `src/`. One test file may be touched (see Specification Amendments).
+
+### Key Design Decisions
+
+#### Decision 1: Reference the Domain constant directly from the Application DTO
+
+**Options considered:**
+1. Reference `ImportStatus.Success` directly from the DTO (proposed in spec).
+2. Mirror the constant inside the Application/Contracts layer to "decouple" the DTO from Domain.
+3. Promote `ImportStatus` to a strong type (enum or smart enum) and migrate all consumers.
+
+**Chosen approach:** Option 1 — direct reference.
+
+**Rationale:**
+- Option 2 reintroduces the exact problem we are fixing: two copies of the string `"OK"` that can drift. The Application layer already depends on Domain; no architectural rule justifies a second copy.
+- Option 3 is explicitly out of scope per `spec.r1.md` and would force changes across the entire Bank module, the persistence projection (`BankStatementImportRepository`), and the generated TS client. That is a separate, larger refactor.
+- Option 1 matches what every other Bank-module call site already does, making the DTO consistent with `BankStatementImportRepository.cs:49` and `ImportBankStatementHandler.cs:89`.
+
+#### Decision 2: Keep the DTO a `class`, keep `ErrorType` as an expression-bodied computed property
+
+**Options considered:**
+1. Leave the DTO shape and member style exactly as-is.
+2. Convert to `record` or promote `ErrorType` to a stored property mapped by AutoMapper.
+
+**Chosen approach:** Option 1.
+
+**Rationale:**
+- The repo rule "DTOs are classes, never C# records" (CLAUDE.md, `docs/architecture/development_guidelines.md`) forbids `record` for DTOs because the OpenAPI generator mishandles record parameter order. The TS client must stay byte-identical.
+- `ErrorType` is a derived view of `ImportResult`; making it stored would create a second field that can desynchronize from `ImportResult` and would change the AutoMapper profile (currently asserted valid by `BankMappingProfileTests.Profile_Configuration_IsValid`).
+- The surgical-changes rule (CLAUDE.md) explicitly forbids adjacent cleanup.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files in `src/`. Single edit:
+
+- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs`
+  - Add `using Anela.Heblo.Domain.Features.Bank;` at the top.
+  - Change line 13 to `public string? ErrorType => ImportResult != ImportStatus.Success ? ImportResult : null;`.
+
+Test edit (see Specification Amendments below):
+
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs`
+  - Replace literal `"OK"` on lines 37 and 42 with `ImportStatus.Success` so the test does not silently break if the constant is renormalized in the future.
+
+### Interfaces and Contracts
+
+Public surface is unchanged:
+
+```csharp
+public class BankStatementImportDto
+{
+    public int Id { get; set; }
+    public string TransferId { get; set; } = null!;
+    public DateTime StatementDate { get; set; }
+    public DateTime ImportDate { get; set; }
+    public string Account { get; set; } = null!;
+    public string Currency { get; set; } = null!;
+    public int ItemCount { get; set; }
+    public string ImportResult { get; set; } = null!;
+    public string? ErrorType { get; }   // computed; behavior unchanged
+}
+```
+
+The OpenAPI TS client must regenerate to a no-op diff. This is a verification gate, not a deliverable.
+
+### Data Flow
+
+Unchanged. For the read path (e.g. `GET /api/bank-statements/{id}` via `BankStatementsController.cs:142`):
+
+```
+Persistence (BankStatementImport entity, ImportResult: "OK" | "PROCESSING_ERROR: ..." | …)
+   │
+   ▼  AutoMapper (BankMappingProfile)
+   │
+BankStatementImportDto
+   │   ImportResult: same string
+   │   ErrorType:    derived at access time
+   │                 == null              when ImportResult == ImportStatus.Success
+   │                 == ImportResult      otherwise
+   ▼
+JSON serialization → TS client (unchanged shape)
+```
+
+The comparison previously written as `ImportResult != "OK"` is now written as `ImportResult != ImportStatus.Success`. Because `ImportStatus.Success` is a `const string` of value `"OK"`, the compiler inlines the comparison and the emitted IL is equivalent.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Generated TS client picks up a diff (e.g. import re-ordering, schema noise) | Low | Run the OpenAPI client regeneration locally and confirm zero diff under `frontend/src/api/` for `BankStatementImportDto`. NFR-3 in the spec already mandates this verification. |
+| `dotnet format` reorders the new `using` directive in a way that introduces churn elsewhere | Low | Place the new `using` in alphabetical order relative to existing usings before running `dotnet format`. Limit format scope to the edited file. |
+| Existing test `BankMappingProfileTests` keeps the literal `"OK"` and silently misclassifies if `ImportStatus.Success` is renormalized later | Medium | Update lines 37 and 42 to reference `ImportStatus.Success`. See Specification Amendments. |
+| Reviewer perceives the change as too small to test | Low | The spec already requires both-branch coverage. The existing `BankMappingProfileTests` covers both branches via AutoMapper; reuse it rather than introducing a parallel direct-instantiation unit test. |
+| Persistence projection in `BankStatementImportRepository.cs:49` is an EF `IQueryable` filter — it must not change | Low | The DTO edit is in `Application/Contracts`. The repository file is not touched. NFR/surgical rule already enforces this. |
+
+## Specification Amendments
+
+1. **Extend test scope to cover the existing mapping test file.**
+   The spec's FR-3 and NFR-3 (lines: "all existing Bank-module tests pass without modification") understate the work. `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs` already exercises both branches of `ErrorType` (`Map_BankStatementImport_To_Dto_When_ImportResult_Is_OK_…` and `…_Is_Not_OK_…`), but it uses the literal `"OK"` on lines 37 and 42. The spec's own test-strategy bullet states: *"Tests must reference `ImportStatus.Success` (not the literal `\"OK\"`) so they remain correct if the constant value is renormalized in the future."* These two test lines must be updated. The diff therefore covers two files, not one:
+   - `BankStatementImportDto.cs` (production change)
+   - `BankMappingProfileTests.cs` (lines 37 and 42: replace `"OK"` with `ImportStatus.Success`; the file already imports `Anela.Heblo.Domain.Features.Bank` on line 3)
+
+   This does not violate the surgical-changes rule because the change is directly motivated by the same refactor goal. Amend FR-3 to read "*Diff is limited to `BankStatementImportDto.cs` and the test assertions in `BankMappingProfileTests.cs` that previously used the literal `\"OK\"`.*"
+
+2. **No new test file is required.**
+   The spec's Test Strategy reads as if a fresh unit test for `BankStatementImportDto` is to be added. The existing `BankMappingProfileTests` already covers both branches via the mapping pipeline (which is the actual production code path: Entity → DTO via AutoMapper, then property access). Adding a second direct-instantiation test would duplicate coverage. Recommend amending Test Strategy to: "*Reuse existing `BankMappingProfileTests` cases; update them to reference `ImportStatus.Success`. Do not add a new test file.*"
+
+3. **NFR-3 clarification: `dotnet format` scope.**
+   Run `dotnet format` scoped to the two edited files (e.g. `dotnet format --include backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs`) to avoid incidental reformatting elsewhere.
+
+## Prerequisites
+
+None. All required infrastructure exists:
+
+- `Anela.Heblo.Domain.Features.Bank.ImportStatus` is present and stable.
+- `Anela.Heblo.Application` already references `Anela.Heblo.Domain`.
+- The `BankMappingProfileTests` test class and AutoMapper profile are wired up.
+- No migration, configuration, feature-flag, secret, or infrastructure change is required.
+
+Implementation can start immediately.

--- a/artifacts/feat-arch-review-bank-bankstatementimportdto-/brief.md
+++ b/artifacts/feat-arch-review-bank-bankstatementimportdto-/brief.md
@@ -1,0 +1,36 @@
+## Module
+Bank
+
+## Finding
+`backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs`, line 13:
+
+```csharp
+public string? ErrorType => ImportResult != "OK" ? ImportResult : null;
+```
+
+The string `"OK"` is the same value as `ImportStatus.Success`, which is already declared as a named constant in `backend/src/Anela.Heblo.Domain/Features/Bank/ImportStatus.cs`:
+
+```csharp
+public static class ImportStatus
+{
+    public const string Success = "OK";
+    ...
+}
+```
+
+Every other consumer in the module uses `ImportStatus.Success` (e.g. `BankStatementImportRepository.cs` line 49, `ImportBankStatementHandler.cs` line 89). `BankStatementImportDto` is the one outlier that bypasses the constant.
+
+## Why it matters
+If `ImportStatus.Success` is ever changed (e.g. normalised to lowercase or a richer value), `ErrorType` will silently start misclassifying successful imports as errors. The constant exists precisely to prevent this kind of scattered literal.
+
+## Suggested fix
+Reference the constant from the DTO. The Application layer already depends on the Domain layer, so no new dependency is introduced:
+
+```csharp
+using Anela.Heblo.Domain.Features.Bank;
+
+public string? ErrorType => ImportResult != ImportStatus.Success ? ImportResult : null;
+```
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-bank-bankstatementimportdto-/impl/main.r1.md
+++ b/artifacts/feat-arch-review-bank-bankstatementimportdto-/impl/main.r1.md
@@ -1,0 +1,41 @@
+---
+
+# Implementation: Replace `"OK"` literal with `ImportStatus.Success` in `BankStatementImportDto`
+
+## What was implemented
+
+Replaced the magic string `"OK"` in `BankStatementImportDto.ErrorType` with the existing `ImportStatus.Success` domain constant, and updated the two corresponding test assertions in `BankMappingProfileTests.cs` to use the same constant. Behavior is unchanged — `ImportStatus.Success` is `const string Success = "OK"`, so emitted IL is equivalent.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs` — added `using Anela.Heblo.Domain.Features.Bank;` and replaced `"OK"` with `ImportStatus.Success` in `ErrorType`
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs` — replaced the two `"OK"` literals (test setup and assertion in the success-branch test) with `ImportStatus.Success`
+
+## Tests
+
+- `BankMappingProfileTests.cs` — all 3 existing tests (`Profile_Configuration_IsValid`, `…_Is_OK_Sets_ErrorType_To_Null`, `…_Is_Not_OK_Sets_ErrorType_To_ImportResult`) pass after both edits
+- Full Bank-module test scope passes with no regressions
+- TS client: no diff under `frontend/src/api/` (no-op verified)
+
+## How to verify
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Bank" --nologo
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+## Notes
+
+No deviations. The second test's `ImportResult = "Failed"` was intentionally left as a literal per the surgical-changes rule — it is an arbitrary non-success value, not a named constant.
+
+## PR Summary
+
+Replaces the lone magic string `"OK"` in `BankStatementImportDto.ErrorType` with the existing `ImportStatus.Success` domain constant, closing a scattered-literal hazard where every other Bank-module consumer already uses the constant. Also updates the two test assertions in `BankMappingProfileTests` that previously compared against the literal, so they will stay correct if the constant is ever renormalized in the future.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs` — added `using Anela.Heblo.Domain.Features.Bank;` and replaced `"OK"` with `ImportStatus.Success` in the `ErrorType` expression
+- `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs` — replaced two `"OK"` literals with `ImportStatus.Success` in the success-branch test setup and assertion
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-bank-bankstatementimportdto-/spec.r1.md
+++ b/artifacts/feat-arch-review-bank-bankstatementimportdto-/spec.r1.md
@@ -1,0 +1,127 @@
+# Specification: Replace Magic String "OK" with `ImportStatus.Success` Constant in `BankStatementImportDto`
+
+## Summary
+The `ErrorType` computed property on `BankStatementImportDto` compares `ImportResult` to the literal string `"OK"` instead of referencing the existing `ImportStatus.Success` constant. This refactor replaces the magic string with the named constant so that any future change to `ImportStatus.Success` propagates correctly.
+
+## Background
+The Bank module maintains a single source of truth for import status values in `Anela.Heblo.Domain/Features/Bank/ImportStatus.cs`:
+
+```csharp
+public static class ImportStatus
+{
+    public const string Success = "OK";
+    public const string ProcessingError = "PROCESSING_ERROR";
+    public const string UnknownError = "UNKNOWN_ERROR";
+}
+```
+
+All other consumers in the module (e.g. `BankStatementImportRepository.cs:49`, `ImportBankStatementHandler.cs:89`) use this constant. The outlier is `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs:13`:
+
+```csharp
+public string? ErrorType => ImportResult != "OK" ? ImportResult : null;
+```
+
+If `ImportStatus.Success` is ever renormalized (e.g. lowercased to `"ok"` or expanded to a richer value), every other site updates in lockstep while this DTO would silently misclassify successful imports as errors. The constant exists precisely to prevent this scattered-literal hazard. The Application layer already depends on the Domain layer, so the reference introduces no new dependency.
+
+## Functional Requirements
+
+### FR-1: Replace literal `"OK"` with `ImportStatus.Success`
+The `ErrorType` computed property in `BankStatementImportDto` must reference the `ImportStatus.Success` constant from the Domain layer instead of the literal string `"OK"`.
+
+**Acceptance criteria:**
+- `BankStatementImportDto.cs` no longer contains the literal string `"OK"`.
+- `BankStatementImportDto.cs` imports `Anela.Heblo.Domain.Features.Bank` and uses `ImportStatus.Success` in the `ErrorType` expression.
+- For any `ImportResult` equal to `ImportStatus.Success`, `ErrorType` returns `null` (unchanged behavior).
+- For any `ImportResult` not equal to `ImportStatus.Success`, `ErrorType` returns the `ImportResult` value (unchanged behavior).
+
+### FR-2: Preserve observable behavior of `ErrorType`
+The refactor is behavior-preserving. No serialization shape, property name, nullability, or value semantics may change.
+
+**Acceptance criteria:**
+- The public surface of `BankStatementImportDto` (property names, types, nullability) is unchanged.
+- The DTO remains a `class` (not converted to a `record`), per the project-specific rule that DTOs are classes for OpenAPI client compatibility.
+- Generated TypeScript client output for `BankStatementImportDto` is unchanged.
+
+### FR-3: No unrelated changes
+Per the "Surgical changes" rule in `CLAUDE.md`, only the single expression and its required `using` directive are modified. No reformatting, renaming, or adjacent cleanup elsewhere in the file or module.
+
+**Acceptance criteria:**
+- Diff is limited to `BankStatementImportDto.cs`.
+- The only changes are: (a) addition of the `using Anela.Heblo.Domain.Features.Bank;` directive, and (b) the body of the `ErrorType` expression.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No measurable performance impact. The change is a compile-time constant reference substitution; the emitted IL is equivalent to the prior string literal comparison.
+
+### NFR-2: Security
+No security impact. No new data flows, no external dependencies, no authentication or authorization touched.
+
+### NFR-3: Build & Quality Gates
+- `dotnet build` succeeds for the full solution.
+- `dotnet format` reports no remaining issues for the edited file.
+- All existing Bank-module tests pass without modification.
+- The OpenAPI TypeScript client regeneration produces no diff for `BankStatementImportDto`.
+
+### NFR-4: Backwards Compatibility
+The constant value `ImportStatus.Success = "OK"` is unchanged in this work item. Any serialized payloads or persisted `ImportResult` values containing `"OK"` continue to be classified as success and yield `ErrorType == null`.
+
+## Data Model
+No data model changes.
+
+Affected type:
+- `BankStatementImportDto` (Application layer DTO) — only the body of the `ErrorType` computed property changes.
+
+Referenced type (unchanged):
+- `ImportStatus` (Domain layer static class) — provides `Success`, `ProcessingError`, `UnknownError` constants.
+
+## API / Interface Design
+No API surface change. The DTO continues to expose:
+
+```csharp
+public class BankStatementImportDto
+{
+    public int Id { get; set; }
+    public string TransferId { get; set; } = null!;
+    public DateTime StatementDate { get; set; }
+    public DateTime ImportDate { get; set; }
+    public string Account { get; set; } = null!;
+    public string Currency { get; set; } = null!;
+    public int ItemCount { get; set; }
+    public string ImportResult { get; set; } = null!;
+    public string? ErrorType { get; } // computed; behavior unchanged
+}
+```
+
+After the change, line 13 becomes:
+
+```csharp
+public string? ErrorType => ImportResult != ImportStatus.Success ? ImportResult : null;
+```
+
+with a new `using Anela.Heblo.Domain.Features.Bank;` directive at the top of the file.
+
+## Dependencies
+- **Existing dependency:** `Anela.Heblo.Application` → `Anela.Heblo.Domain` (already in place; no new project reference required).
+- **No new NuGet packages.**
+- **No configuration, migration, infrastructure, or feature-flag changes.**
+
+## Test Strategy
+- Add or extend a unit test for `BankStatementImportDto` covering both branches of `ErrorType`:
+  - When `ImportResult == ImportStatus.Success` → `ErrorType` is `null`.
+  - When `ImportResult` is any non-success value (e.g. `ImportStatus.ProcessingError`, `ImportStatus.UnknownError`, or an arbitrary string) → `ErrorType` equals `ImportResult`.
+- Tests must reference `ImportStatus.Success` (not the literal `"OK"`) so they remain correct if the constant value is renormalized in the future.
+- Run `dotnet test` for the affected test project(s) and confirm no regressions in the Bank module.
+
+## Out of Scope
+- Changing the value of `ImportStatus.Success` itself (e.g. lowercasing, enum migration).
+- Converting `ImportStatus` from a static class of string constants to an enum or a strong type.
+- Auditing other modules for similar magic-string occurrences.
+- Reformatting, renaming, or otherwise modifying `BankStatementImportDto` beyond the targeted line and its `using` directive.
+- Changes to `BankStatementImportRepository`, `ImportBankStatementHandler`, or any other Bank module consumer.
+- Generated client regeneration as a deliverable (it should be a no-op; verify only).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-bank-bankstatementimportdto-/task-plan.r1.md
+++ b/artifacts/feat-arch-review-bank-bankstatementimportdto-/task-plan.r1.md
@@ -1,0 +1,3 @@
+Plan saved to `docs/superpowers/plans/2026-06-03-bank-importdto-importstatus-constant.md`.
+
+**Summary:** Six-task TDD-style refactor plan. Two files touched: `BankStatementImportDto.cs` (add `using Anela.Heblo.Domain.Features.Bank;`, replace `"OK"` with `ImportStatus.Success`) and `BankMappingProfileTests.cs` (update lines 37 and 42 setup/assertion to reference the constant; leave the `"Failed"` non-success test untouched per surgical-changes rule). Tasks cover baseline-test pass, production edit + test, test-assertion update + test, scoped `dotnet format` + full build + Bank-scope test, TS client no-op verification, and a single focused commit. All spec FRs/NFRs and arch-review amendments (1, 2, 3) are mapped to specific task steps in the self-review table.

--- a/backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs
@@ -1,3 +1,5 @@
+using Anela.Heblo.Domain.Features.Bank;
+
 namespace Anela.Heblo.Application.Features.Bank.Contracts;
 
 public class BankStatementImportDto
@@ -10,5 +12,5 @@ public class BankStatementImportDto
     public string Currency { get; set; } = null!;
     public int ItemCount { get; set; }
     public string ImportResult { get; set; } = null!;
-    public string? ErrorType => ImportResult != "OK" ? ImportResult : null;
+    public string? ErrorType => ImportResult != ImportStatus.Success ? ImportResult : null;
 }

--- a/backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs
@@ -34,12 +34,12 @@ public class BankMappingProfileTests
         var mapper = CreateMapper();
         var source = new BankStatementImport("transfer-1", new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc))
         {
-            ImportResult = "OK",
+            ImportResult = ImportStatus.Success,
         };
 
         var dto = mapper.Map<BankStatementImportDto>(source);
 
-        dto.ImportResult.Should().Be("OK");
+        dto.ImportResult.Should().Be(ImportStatus.Success);
         dto.ErrorType.Should().BeNull();
     }
 

--- a/docs/superpowers/plans/2026-06-03-bank-importdto-importstatus-constant.md
+++ b/docs/superpowers/plans/2026-06-03-bank-importdto-importstatus-constant.md
@@ -1,0 +1,368 @@
+# Replace Magic String `"OK"` with `ImportStatus.Success` in `BankStatementImportDto` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the literal string `"OK"` in `BankStatementImportDto.ErrorType` with the existing `ImportStatus.Success` domain constant so the DTO stays in lockstep with every other Bank-module consumer if that constant is ever renormalized.
+
+**Architecture:** Pure refactor — substitute a `const string` reference for an inline string literal in a single Application-layer DTO expression, then propagate the same substitution into the two existing mapping-test assertions. No new files, no new dependencies (Application already references Domain), no API or serialization changes. Emitted IL is equivalent because `ImportStatus.Success` is a compile-time constant.
+
+**Tech Stack:** .NET 8, C#, AutoMapper, xUnit + FluentAssertions for tests.
+
+---
+
+## Background — Why This Refactor
+
+The Bank module declares import-status constants in one place:
+
+```csharp
+// backend/src/Anela.Heblo.Domain/Features/Bank/ImportStatus.cs
+public static class ImportStatus
+{
+    public const string Success = "OK";
+    public const string ProcessingError = "PROCESSING_ERROR";
+    public const string UnknownError = "UNKNOWN_ERROR";
+}
+```
+
+Every other consumer in the module references `ImportStatus.Success` (e.g. `BankStatementImportRepository.cs:49`, `ImportBankStatementHandler.cs:89`). The lone outlier today is:
+
+```csharp
+// backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs:13
+public string? ErrorType => ImportResult != "OK" ? ImportResult : null;
+```
+
+If `ImportStatus.Success` were ever changed (e.g. lowercased to `"ok"`), every other site would update via the constant — this DTO would silently start misclassifying every successful import as an error. The two existing tests in `BankMappingProfileTests.cs` would also silently keep passing for the wrong reason because they assert against the literal `"OK"` on lines 37 and 42.
+
+## File Structure
+
+This refactor touches **two files only**. No new files, no deletions.
+
+- **Modify:** `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs`
+  - Add `using Anela.Heblo.Domain.Features.Bank;` directive.
+  - Replace the literal `"OK"` in the `ErrorType` expression with `ImportStatus.Success`.
+- **Modify:** `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs`
+  - Replace the two literal `"OK"` occurrences (lines 37 and 42) with `ImportStatus.Success`. The file already imports `Anela.Heblo.Domain.Features.Bank` on line 3, so no `using` change is required.
+
+## Refactor-Style TDD Approach
+
+The existing mapping test (`BankMappingProfileTests.Map_BankStatementImport_To_Dto_When_ImportResult_Is_OK_Sets_ErrorType_To_Null`) already covers the success branch via the real production code path (Entity → AutoMapper → DTO → property access). A new direct-instantiation unit test would duplicate that coverage; per the architecture review's Specification Amendment #2, we **reuse the existing test**.
+
+For a behavior-preserving refactor, the existing test acts as the safety net. The TDD rhythm is:
+
+1. Confirm the existing tests pass on the baseline (no false starts).
+2. Make the production change. Re-run tests → they must still pass.
+3. Update the test assertions to reference the constant. Re-run tests → they must still pass.
+4. Run quality gates (`dotnet format` scoped to the two files, `dotnet build`).
+5. Commit a single focused change.
+
+---
+
+### Task 1: Establish baseline — confirm existing tests pass
+
+**Files:**
+- Read: `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs`
+
+- [ ] **Step 1: Run the existing Bank mapping tests as a baseline**
+
+Run from the repo root:
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Bank.BankMappingProfileTests" \
+  --nologo
+```
+
+Expected: All three tests pass — `Profile_Configuration_IsValid`, `Map_BankStatementImport_To_Dto_When_ImportResult_Is_OK_Sets_ErrorType_To_Null`, and `Map_BankStatementImport_To_Dto_When_ImportResult_Is_Not_OK_Sets_ErrorType_To_ImportResult`.
+
+If anything fails on the baseline, **stop**. Do not modify production code until the baseline is green; investigate and resolve first.
+
+---
+
+### Task 2: Update the DTO to reference `ImportStatus.Success`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs`
+
+The current file (read it first to confirm exact contents):
+
+```csharp
+namespace Anela.Heblo.Application.Features.Bank.Contracts;
+
+public class BankStatementImportDto
+{
+    public int Id { get; set; }
+    public string TransferId { get; set; } = null!;
+    public DateTime StatementDate { get; set; }
+    public DateTime ImportDate { get; set; }
+    public string Account { get; set; } = null!;
+    public string Currency { get; set; } = null!;
+    public int ItemCount { get; set; }
+    public string ImportResult { get; set; } = null!;
+    public string? ErrorType => ImportResult != "OK" ? ImportResult : null;
+}
+```
+
+- [ ] **Step 1: Add the `using` directive**
+
+Use the Edit tool. Replace the file-opening line:
+
+Old:
+```csharp
+namespace Anela.Heblo.Application.Features.Bank.Contracts;
+```
+
+New:
+```csharp
+using Anela.Heblo.Domain.Features.Bank;
+
+namespace Anela.Heblo.Application.Features.Bank.Contracts;
+```
+
+Rationale: the new directive goes above the file-scoped `namespace` declaration, consistent with the project's other Bank-module files (e.g. `BankMappingProfile.cs` and `BankMappingProfileTests.cs`).
+
+- [ ] **Step 2: Replace the literal `"OK"` with `ImportStatus.Success`**
+
+Use the Edit tool.
+
+Old:
+```csharp
+    public string? ErrorType => ImportResult != "OK" ? ImportResult : null;
+```
+
+New:
+```csharp
+    public string? ErrorType => ImportResult != ImportStatus.Success ? ImportResult : null;
+```
+
+- [ ] **Step 3: Re-run the Bank mapping tests — must still pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Bank.BankMappingProfileTests" \
+  --nologo
+```
+
+Expected: All three tests still pass. Because `ImportStatus.Success` is `const string Success = "OK"`, the runtime comparison is identical to the prior literal — the refactor is behavior-preserving and the assertions in the test file (which still compare against the literal `"OK"`) continue to hold.
+
+If any test fails, **stop and investigate**. Likely causes: typo, wrong `using` directive, or accidental edit to another expression.
+
+---
+
+### Task 3: Update the existing mapping tests to reference the constant
+
+**Files:**
+- Modify: `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs`
+
+The current file's relevant region (lines 31–44):
+
+```csharp
+    [Fact]
+    public void Map_BankStatementImport_To_Dto_When_ImportResult_Is_OK_Sets_ErrorType_To_Null()
+    {
+        var mapper = CreateMapper();
+        var source = new BankStatementImport("transfer-1", new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc))
+        {
+            ImportResult = "OK",
+        };
+
+        var dto = mapper.Map<BankStatementImportDto>(source);
+
+        dto.ImportResult.Should().Be("OK");
+        dto.ErrorType.Should().BeNull();
+    }
+```
+
+The file already has `using Anela.Heblo.Domain.Features.Bank;` on line 3, so no import change is needed.
+
+- [ ] **Step 1: Replace the `ImportResult = "OK"` setup literal**
+
+Use the Edit tool.
+
+Old:
+```csharp
+            ImportResult = "OK",
+```
+
+New:
+```csharp
+            ImportResult = ImportStatus.Success,
+```
+
+- [ ] **Step 2: Replace the `dto.ImportResult.Should().Be("OK")` assertion**
+
+Use the Edit tool.
+
+Old:
+```csharp
+        dto.ImportResult.Should().Be("OK");
+```
+
+New:
+```csharp
+        dto.ImportResult.Should().Be(ImportStatus.Success);
+```
+
+- [ ] **Step 3: Do not touch the second test (`…_Is_Not_OK_…`)**
+
+The second test on lines 46–59 uses `ImportResult = "Failed"` to exercise the not-success branch. `"Failed"` is intentionally an arbitrary non-success value, not a named import-status constant. Per the surgical-changes rule, leave it as-is. Do **not** replace it with `ImportStatus.ProcessingError` or similar — that would change the test's semantic from "any non-success value flows through" to "this specific named status flows through."
+
+- [ ] **Step 4: Re-run the Bank mapping tests — must still pass**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Bank.BankMappingProfileTests" \
+  --nologo
+```
+
+Expected: All three tests still pass. The test now references `ImportStatus.Success` symbolically, so if the underlying constant value is ever renormalized in a future change, the test will adapt automatically rather than silently passing against a stale literal.
+
+---
+
+### Task 4: Quality gates — format and build
+
+**Files:**
+- No file modifications expected; this task verifies the two edits cleanly satisfy formatter and compiler.
+
+- [ ] **Step 1: Run `dotnet format` scoped to the two edited files**
+
+Per the architecture review's NFR-3 clarification, scope the formatter narrowly to avoid incidental reformatting:
+
+```bash
+dotnet format backend/Anela.Heblo.sln \
+  --include backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs \
+            backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs \
+  --verify-no-changes
+```
+
+Expected: Exit code `0` and no diff. If `--verify-no-changes` reports a change, drop the `--verify-no-changes` flag, re-run, then `git diff` the two files to confirm only the new `using` directive (and possibly its position relative to other usings) was adjusted. Adjacent unrelated reformatting is a violation of the surgical-changes rule — back out and redo the edit.
+
+- [ ] **Step 2: Build the full solution**
+
+```bash
+dotnet build backend/Anela.Heblo.sln --nologo
+```
+
+Expected: `Build succeeded.` with `0 Error(s)`. Warnings count must not increase vs. baseline. If a CS0246 (`type or namespace not found`) appears on `ImportStatus`, the `using` directive in `BankStatementImportDto.cs` is missing or misspelled — fix and re-build.
+
+- [ ] **Step 3: Run the full Bank-module test scope to confirm no regressions outside the mapping tests**
+
+```bash
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~Anela.Heblo.Tests.Features.Bank" \
+  --no-build --nologo
+```
+
+Expected: All tests in `Anela.Heblo.Tests.Features.Bank` pass. This covers `BankMappingProfileTests`, `BankStatementImportRepositoryTests`, and any other Bank-module test classes — the refactor must not destabilize any of them.
+
+---
+
+### Task 5: Verify the OpenAPI / TypeScript client regenerates to a no-op
+
+**Files:**
+- Inspect (no edits expected): `frontend/src/api/` for any file referencing `BankStatementImportDto`.
+
+Per `spec.r1.md` FR-2 and NFR-3, the generated TS client surface for `BankStatementImportDto` must be byte-identical. The DTO's public shape (property names, types, nullability) is unchanged by the refactor, so this is a verification gate only.
+
+- [ ] **Step 1: Confirm whether the TS client is regenerated by the build**
+
+Read `docs/development/api-client-generation.md` to confirm whether `dotnet build` regenerates the TS client automatically or whether a separate command is required. Do not skip this check — if the project regenerates on build, Task 4 Step 2 already produced any diff; if it requires a separate command, run it now.
+
+If a separate generation command exists (commonly `npm run generate-api` or similar), run it from the appropriate directory as documented.
+
+- [ ] **Step 2: Inspect for unintended client diff**
+
+```bash
+git status --short frontend/
+git diff --stat frontend/src/api/
+```
+
+Expected: No changes under `frontend/src/api/`. If any diff appears in a file that mentions `BankStatementImportDto`, **stop**. Investigate whether the generator picked up the new `using` directive as a schema change — if so, the refactor would breach FR-2 and must be re-examined. If the diff is unrelated noise (e.g. timestamp comments, formatting), confirm it matches existing client-generation behavior on `main` and is not caused by this refactor.
+
+---
+
+### Task 6: Commit
+
+**Files:**
+- Stage: `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs`
+- Stage: `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs`
+
+- [ ] **Step 1: Final sanity check of the staged diff**
+
+```bash
+git diff --stat backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs \
+                backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs
+git diff backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs \
+        backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs
+```
+
+Expected diff content:
+- `BankStatementImportDto.cs`: one added `using Anela.Heblo.Domain.Features.Bank;` line and one changed expression body. No other lines touched.
+- `BankMappingProfileTests.cs`: two changed lines — the `ImportResult = "OK"` setup and the `dto.ImportResult.Should().Be("OK")` assertion in the first test. The second test (`…_Is_Not_OK_…`) is untouched.
+
+If the diff contains anything else (other Bank files, reformatted whitespace elsewhere, the second test changed, etc.), **stop and revert the unintended changes** before committing.
+
+- [ ] **Step 2: Stage and commit**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs \
+        backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs
+
+git commit -m "$(cat <<'EOF'
+refactor: replace "OK" literal with ImportStatus.Success in BankStatementImportDto
+
+Aligns the BankStatementImportDto.ErrorType expression with every other
+Bank-module consumer that already references ImportStatus.Success.
+Updates the existing BankMappingProfileTests assertion that used the
+literal "OK" so the test stays correct if the constant is ever
+renormalized in the future.
+EOF
+)"
+```
+
+Expected: Commit succeeds. Any pre-commit hook must pass without modification — if it fails, fix the underlying issue (do not use `--no-verify`) and create a new commit.
+
+- [ ] **Step 3: Verify clean working tree**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+
+| Spec requirement | Implemented in |
+|---|---|
+| FR-1: `BankStatementImportDto` references `ImportStatus.Success` and no longer contains the literal `"OK"` | Task 2, Steps 1–2 |
+| FR-1 acceptance: `ImportResult == ImportStatus.Success` ⇒ `ErrorType == null` | Existing test re-run in Task 2 Step 3 and Task 3 Step 4 |
+| FR-1 acceptance: `ImportResult != ImportStatus.Success` ⇒ `ErrorType == ImportResult` | Existing `…_Is_Not_OK_…` test, re-run in Task 2 Step 3 and Task 3 Step 4 |
+| FR-2: Public surface, nullability, class-not-record, TS client unchanged | Task 5 verification |
+| FR-3 (as amended by arch review): Diff limited to the DTO and the test assertions previously using `"OK"` | Task 6 Step 1 (diff sanity check) |
+| NFR-1: No performance impact | Implicit — `const string` substitution emits equivalent IL |
+| NFR-2: No security impact | Implicit — no new data flows |
+| NFR-3: `dotnet build` succeeds, `dotnet format` clean, Bank tests pass, TS client no-op | Tasks 4 and 5 |
+| NFR-4: Existing `"OK"` payloads still classified as success | Existing test re-run in Task 3 Step 4 |
+| Test Strategy (as amended): Reuse `BankMappingProfileTests`, update assertions to reference `ImportStatus.Success`, do not add a new test file | Task 3 |
+| Arch Amendment 1: Update the two literal `"OK"` test lines (37, 42) | Task 3 Steps 1–2 |
+| Arch Amendment 2: No new test file | Honored — no new file is created |
+| Arch Amendment 3: Format scope limited to the two edited files | Task 4 Step 1 |
+
+No gaps.
+
+**2. Placeholder scan**
+
+Searched the plan for: TBD, TODO, implement later, fill in details, add appropriate error handling, handle edge cases, write tests for the above, similar to Task N. None present. Every code step contains the exact `Old` / `New` text the engineer needs to apply.
+
+**3. Type / symbol consistency**
+
+- `ImportStatus.Success` used consistently in Tasks 2, 3, and 6 — matches the canonical declaration in `backend/src/Anela.Heblo.Domain/Features/Bank/ImportStatus.cs`.
+- `using Anela.Heblo.Domain.Features.Bank;` namespace matches the file header of `ImportStatus.cs`.
+- Test class name `BankMappingProfileTests` and method names `Map_BankStatementImport_To_Dto_When_ImportResult_Is_OK_Sets_ErrorType_To_Null` / `…_Is_Not_OK_…` match the on-disk file verbatim.
+- Test project path `backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj` matches the actual project structure.
+- Solution path `backend/Anela.Heblo.sln` used consistently in `dotnet format` and `dotnet build`.
+
+No inconsistencies.


### PR DESCRIPTION

Replaces the lone magic string `"OK"` in `BankStatementImportDto.ErrorType` with the existing `ImportStatus.Success` domain constant, closing a scattered-literal hazard where every other Bank-module consumer already uses the constant. Also updates the two test assertions in `BankMappingProfileTests` that previously compared against the literal, so they will stay correct if the constant is ever renormalized in the future.

### Changes
- `backend/src/Anela.Heblo.Application/Features/Bank/Contracts/BankStatementImportDto.cs` — added `using Anela.Heblo.Domain.Features.Bank;` and replaced `"OK"` with `ImportStatus.Success` in the `ErrorType` expression
- `backend/test/Anela.Heblo.Tests/Features/Bank/BankMappingProfileTests.cs` — replaced two `"OK"` literals with `ImportStatus.Success` in the success-branch test setup and assertion

---

Closes #2445

### Tokens used
5350264
