### PR TITLE
feat: Relocate CombinedPrintQueueSink to Application Layer

### DIFF
--- a/artifacts/feat-arch-review-expeditionlist-combinedprint/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-combinedprint/arch-review.r1.md
@@ -1,0 +1,200 @@
+I have enough grounding. Verified: spec aligns with reality — `CombinedPrintQueueSink.cs` only exists under API (not yet in Application), peer `FileSystemPrintQueueSink` is at the proposed target, `InternalsVisibleTo("Anela.Heblo.Tests")` is wired in `AssemblyInfo.cs:3` and `.csproj:46`, and `Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2` is already a direct Application dependency (so `[FromKeyedServices]` works without new package refs). One detail to flag: `ServiceCollectionExtensions.cs:27` already has `using Anela.Heblo.Application.Features.ExpeditionList.Services;` — so after relocation the `using Anela.Heblo.API.Features.ExpeditionList;` at line 24 becomes dead and must be removed.
+
+```markdown
+# Architecture Review: Relocate CombinedPrintQueueSink to Application Layer
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This change is a **pure structural correction** that restores Clean Architecture compliance for the print-sink slice. It is fully aligned with existing patterns — in fact, it eliminates the only deviation from them.
+
+**Existing convention (verified in repo):**
+- Pure Application-layer sinks (filesystem I/O, composition) live in `Anela.Heblo.Application/Features/ExpeditionList/Services/` (e.g. `FileSystemPrintQueueSink.cs`).
+- Infrastructure-bound sinks live in dedicated adapter projects: `Anela.Heblo.Adapters.Azure/Features/ExpeditionList/AzureBlobPrintQueueSink.cs`, `Anela.Heblo.Adapters.Cups/Features/ExpeditionList/CupsPrintQueueSink.cs`.
+- The `IPrintQueueSink` contract is owned by `Anela.Heblo.Application.Shared.Printing`.
+- The API project's role is HTTP shell + composition root (registration in `Extensions/ServiceCollectionExtensions.AddPrintQueueSink`).
+
+**The outlier:** `CombinedPrintQueueSink` — a composite that holds no infrastructure dependency, only Application abstractions and DI metadata — sits in the API project. It is the single sink implementation that violates the layering rule. Moving it removes that violation without touching any other slice.
+
+**Integration points:**
+1. `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs:420` — DI registration of the concrete type. The required `using Anela.Heblo.Application.Features.ExpeditionList.Services;` is **already present** at line 27 (it imports `FileSystemPrintQueueSink`), so no new `using` is needed; only the now-dead `using Anela.Heblo.API.Features.ExpeditionList;` at line 24 must be removed.
+2. `Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs` — single `using` swap; `InternalsVisibleTo("Anela.Heblo.Tests")` is already configured on `Anela.Heblo.Application` via both `AssemblyInfo.cs:3` and `Anela.Heblo.Application.csproj:46`, so `internal sealed` visibility carries over cleanly.
+
+No call site beyond DI exists; the type is only constructed by the container.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Anela.Heblo.API (HTTP shell + composition root)                │
+│                                                                │
+│   Extensions/ServiceCollectionExtensions.cs                    │
+│     AddPrintQueueSink(cfg)                                     │
+│       switch (cfg["ExpeditionList:PrintSink"])                 │
+│         "Combined" → registers CombinedPrintQueueSink ─────────┼──┐
+└────────────────────────────────────────────────────────────────┘  │
+                                                                    │
+┌────────────────────────────────────────────────────────────────┐  │
+│ Anela.Heblo.Application                                        │  │
+│                                                                │  │
+│   Shared/Printing/                                             │  │
+│     IPrintQueueSink                  ◄─── implemented by ──┐   │  │
+│                                                            │   │  │
+│   Features/ExpeditionList/Services/                        │   │  │
+│     FileSystemPrintQueueSink (existing)            ────────┤   │  │
+│     CombinedPrintQueueSink   (MOVED HERE)          ────────┼───┼──┘
+│       │                                                    │   │
+│       ├─ [FromKeyedServices("azure")] IPrintQueueSink ─────┤   │
+│       └─ [FromKeyedServices("cups")]  IPrintQueueSink ─────┤   │
+└────────────────────────────────────────────────────────────────┘  
+                                                            ▲  ▲
+            ┌───────────────────────────────────────────────┘  │
+            │                                                  │
+┌───────────┴────────────────┐    ┌────────────────────────────┴─┐
+│ Anela.Heblo.Adapters.Azure │    │ Anela.Heblo.Adapters.Cups    │
+│   AzureBlobPrintQueueSink  │    │   CupsPrintQueueSink         │
+└────────────────────────────┘    └──────────────────────────────┘
+```
+
+### Key Design Decisions
+
+#### Decision 1: Target namespace
+
+**Options considered:**
+- `Anela.Heblo.Application.Features.ExpeditionList.Services` (peer of `FileSystemPrintQueueSink`).
+- `Anela.Heblo.Application.Features.ExpeditionList` (parent, one level up).
+- `Anela.Heblo.Application.Shared.Printing` (next to the interface).
+
+**Chosen approach:** `Anela.Heblo.Application.Features.ExpeditionList.Services`.
+
+**Rationale:** Mirrors `FileSystemPrintQueueSink` exactly — same folder, same namespace, same vertical slice. The composite is feature-specific (it expresses the ExpeditionList print strategy), not a cross-cutting primitive, so it belongs in the feature slice, not in `Shared/Printing`.
+
+#### Decision 2: Keep `internal sealed` visibility
+
+**Options considered:**
+- Keep `internal sealed` (current).
+- Promote to `public` to make registration cleaner.
+
+**Chosen approach:** Keep `internal sealed`.
+
+**Rationale:** Visibility broadening is explicitly out of scope per the spec. The DI registration in `ServiceCollectionExtensions.AddPrintQueueSink` lives in the same solution and can reference internals of `Anela.Heblo.Application` either via the existing project reference (concrete-type registration only requires the type to be accessible at the registration call site — and since the API project references Application, `internal` types of Application are **not** visible to API). **This is a real concern** — see the Risks section. Resolution: add `InternalsVisibleTo("Anela.Heblo.API")` to the Application project, **or** widen the class to `internal` → `public sealed` only in the unlikely event that approach 1 is unacceptable. The brief explicitly suggests keeping `internal`; the cleanest fix is therefore the `InternalsVisibleTo` grant.
+
+#### Decision 3: Keep DI registration in API project
+
+**Options considered:**
+- Move `AddPrintQueueSink` extension to Application (e.g., an `ExpeditionListModule`).
+- Leave it in `Anela.Heblo.API.Extensions.ServiceCollectionExtensions`.
+
+**Chosen approach:** Leave it in API.
+
+**Rationale:** Out of scope per the brief ("Refactoring `AddPrintQueueSink` is not addressed here"). The composition root is the conventional home for sink-selection logic that mixes adapter packages (`AddAzurePrintQueueSink`, `AddCupsPrinting`) — moving it would force Application to take a dependency on adapter projects, inverting the layering. Status quo is correct.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+```
+backend/src/
+├── Anela.Heblo.API/
+│   ├── Extensions/ServiceCollectionExtensions.cs        ← edit (remove using, keep registration)
+│   └── Features/ExpeditionList/                         ← DELETE the file; remove the folder if empty
+│       └── CombinedPrintQueueSink.cs                    ← REMOVED
+└── Anela.Heblo.Application/
+    ├── AssemblyInfo.cs                                  ← ADD InternalsVisibleTo("Anela.Heblo.API") (see Risk #1)
+    └── Features/ExpeditionList/Services/
+        ├── FileSystemPrintQueueSink.cs                  ← unchanged (reference template)
+        └── CombinedPrintQueueSink.cs                    ← NEW FILE (relocated)
+
+backend/test/Anela.Heblo.Tests/
+└── Features/ExpeditionList/
+    └── CombinedPrintQueueSinkTests.cs                   ← edit using only
+```
+
+### Interfaces and Contracts
+
+No interface changes. The contract `IPrintQueueSink` in `Anela.Heblo.Application.Shared.Printing` is untouched. The class's public surface (constructor signature with two `[FromKeyedServices]` parameters and `SendAsync(IEnumerable<string>, CancellationToken)`) is byte-identical.
+
+New file canonical form:
+
+```csharp
+using Anela.Heblo.Application.Shared.Printing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Anela.Heblo.Application.Features.ExpeditionList.Services;
+
+internal sealed class CombinedPrintQueueSink : IPrintQueueSink
+{
+    private readonly IPrintQueueSink _azureSink;
+    private readonly IPrintQueueSink _cupsSink;
+
+    public CombinedPrintQueueSink(
+        [FromKeyedServices("azure")] IPrintQueueSink azureSink,
+        [FromKeyedServices("cups")] IPrintQueueSink cupsSink)
+    {
+        _azureSink = azureSink;
+        _cupsSink = cupsSink;
+    }
+
+    public async Task SendAsync(IEnumerable<string> filePaths, CancellationToken cancellationToken = default)
+    {
+        var paths = filePaths.ToList();
+        await _azureSink.SendAsync(paths, cancellationToken);
+        await _cupsSink.SendAsync(paths, cancellationToken);
+    }
+}
+```
+
+### Data Flow
+
+Unchanged at runtime. For `ExpeditionList:PrintSink = "Combined"`:
+
+1. App startup → `Program.cs` → `AddPrintQueueSink(IConfiguration)`.
+2. The `"Combined"` branch registers: keyed `"azure"` → `AzureBlobPrintQueueSink`; keyed `"cups"` → `CupsPrintQueueSink`; non-keyed `IPrintQueueSink` → `CombinedPrintQueueSink`.
+3. At request time, an `IPrintQueueSink` consumer (e.g., `ExpeditionListService`) is injected with `CombinedPrintQueueSink`, whose constructor resolves the two keyed children.
+4. `SendAsync(paths)` materializes `paths` once via `.ToList()`, awaits `azureSink.SendAsync` then `cupsSink.SendAsync` — fail-fast on Azure, no try/catch around the second call.
+
+The IL emitted and the DI resolution graph are identical pre- and post-move.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **API project cannot see `internal sealed` type in Application.** Today the class is `internal` in API itself, so DI registration compiles. After the move, `services.AddScoped<IPrintQueueSink, CombinedPrintQueueSink>()` in API will fail to compile because `CombinedPrintQueueSink` becomes `internal` to Application. | **High** — build break | Add `[assembly: InternalsVisibleTo("Anela.Heblo.API")]` to `backend/src/Anela.Heblo.Application/AssemblyInfo.cs` and add `<InternalsVisibleTo Include="Anela.Heblo.API" />` to `Anela.Heblo.Application.csproj` (mirrors the existing `Anela.Heblo.Tests` entry). This is the cleanest fix and preserves the spec's "stays `internal sealed`" constraint. **The spec misses this prerequisite — see Spec Amendment #1.** |
+| Stale dead `using Anela.Heblo.API.Features.ExpeditionList;` left at `ServiceCollectionExtensions.cs:24` after the move. | Low — `dotnet build` warning at most; `dotnet format` may auto-remove. | Explicitly delete line 24. No other type from that namespace is referenced (verified — the only inhabitant was `CombinedPrintQueueSink`). |
+| Empty folder `backend/src/Anela.Heblo.API/Features/ExpeditionList/` left behind. | Low — cosmetic only. | Delete the directory after the file removal (the spec mandates this in FR-1). |
+| Test assembly references the old namespace via more than the import (e.g., a `[assembly:]` attribute, snapshot, or generated file). | Low — none found by grep; only one `using` and the type name itself appear in the test file. | Single-namespace `using` swap is sufficient. Confirmed by `grep -rn CombinedPrintQueueSink backend/`. |
+| Behavioral drift introduced "incidentally" during the move (e.g., reordering of `await`, dropping `.ToList()`). | Medium — silent regression in print fan-out. | The four existing unit tests (`SendAsync_BothSucceed_*`, `_AzureThrows_*`, `_AzureSucceedsCupsThrows_*`, `_SinglePassEnumerable_*`) cover the exact contract; they remain unmodified and must pass post-move. Treat any test edit as a code smell. |
+| `ExpeditionListServicePrintSinkTests` (which exercises the registration path) regresses. | Low | Spec already lists it as a required gate (NFR-4). Re-run after the change. |
+
+## Specification Amendments
+
+### Amendment 1 (REQUIRED): Add `InternalsVisibleTo("Anela.Heblo.API")` to Application
+
+The spec implicitly assumes that `internal sealed CombinedPrintQueueSink` will be accessible from `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs::AddPrintQueueSink` after the move. **It will not** — `internal` types in Application are invisible to API. Today this compiles only because the class lives in the API assembly.
+
+Add a new functional requirement:
+
+> **FR-6: Grant `InternalsVisibleTo` for API project.**
+> Add `[assembly: InternalsVisibleTo("Anela.Heblo.API")]` to `backend/src/Anela.Heblo.Application/AssemblyInfo.cs` and `<InternalsVisibleTo Include="Anela.Heblo.API" />` to the `<ItemGroup>` containing the existing `Anela.Heblo.Tests` entry in `Anela.Heblo.Application.csproj`.
+>
+> **Acceptance criteria:**
+> - `Anela.Heblo.API` compiles after the relocation without changing the visibility of `CombinedPrintQueueSink`.
+> - The class remains `internal sealed`.
+> - Both `AssemblyInfo.cs` (for the source-level attribute) and the `.csproj` (for the MSBuild SDK form) are updated to mirror the existing pattern for `Anela.Heblo.Tests`.
+
+### Amendment 2 (clarifying, non-binding): FR-3 wording
+
+The spec says the `using Anela.Heblo.API.Features.ExpeditionList;` line "is removed if no other type from that namespace is referenced." This is verified — `grep` shows `CombinedPrintQueueSink` is the only inhabitant of that namespace and the only API reference to it is the DI registration. The conditional language can be hardened to **"must be removed"** since the prerequisite is satisfied.
+
+## Prerequisites
+
+Before opening the PR:
+
+1. **InternalsVisibleTo grant** (per Amendment 1) must be applied in the **same commit** as the file move, or the API project will not compile. This is the only non-trivial prerequisite.
+2. No migrations, no configuration changes, no infrastructure changes, no Azure Key Vault changes.
+3. No new NuGet packages (verified — `Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2` is already a direct dependency of `Anela.Heblo.Application` per `Anela.Heblo.Application.csproj:18`, so `[FromKeyedServices]` resolves without a new reference).
+4. Validation gates: `dotnet build`, `dotnet format` (zero changes), `dotnet test` (full `Anela.Heblo.Tests` suite — at minimum `CombinedPrintQueueSinkTests` and `ExpeditionListServicePrintSinkTests` must be green). No FE or E2E work in scope.
+```

--- a/artifacts/feat-arch-review-expeditionlist-combinedprint/brief.md
+++ b/artifacts/feat-arch-review-expeditionlist-combinedprint/brief.md
@@ -1,0 +1,35 @@
+## Module
+ExpeditionList
+
+## Finding
+`CombinedPrintQueueSink` — a class that implements `IPrintQueueSink` and contains composite sink logic — is placed in the **API project** under `backend/src/Anela.Heblo.API/Features/ExpeditionList/CombinedPrintQueueSink.cs` (25 lines).
+
+The class has no HTTP/controller responsibility whatsoever: it wraps two `IPrintQueueSink` implementations and delegates `SendAsync` to both. It is registered in the DI container as the non-keyed `IPrintQueueSink` when `PrintSink = "Combined"` is configured.
+
+```csharp
+// API/Features/ExpeditionList/CombinedPrintQueueSink.cs
+internal sealed class CombinedPrintQueueSink : IPrintQueueSink
+{
+    public CombinedPrintQueueSink(
+        [FromKeyedServices("azure")] IPrintQueueSink azureSink,
+        [FromKeyedServices("cups")] IPrintQueueSink cupsSink) { ... }
+
+    public async Task SendAsync(IEnumerable<string> filePaths, ...) { ... }
+}
+```
+
+Every other `IPrintQueueSink` implementation lives in the Application layer (`Services/FileSystemPrintQueueSink.cs`, adapters in `Persistence/` or adapter projects). Only controllers belong in the API project per `docs/architecture/development_guidelines.md`.
+
+## Why it matters
+The API layer is supposed to be a thin HTTP shell — controllers, middleware, auth filters. Placing business-logic adapters there:
+- Breaks Clean Architecture's dependency rule: the API project should depend on Application, not contain Application logic.
+- Makes the sink untestable without the full API assembly being loaded.
+- Sets a precedent that makes the API project a dumping ground for anything that touches DI.
+
+The parallel sink implementations (`FileSystemPrintQueueSink`, `AzureBlobPrintQueueSink`, `CupsPrintQueueSink`) all live in Application or adapter projects — this is the one outlier.
+
+## Suggested fix
+Move `CombinedPrintQueueSink` to `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs` and update the `internal sealed` visibility to `internal` (same as today). The DI registration in the API project's `Program.cs` can still reference it via the Application assembly — or if registration logic needs to stay in the API layer, expose a factory method in `ExpeditionListModule`.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-expeditionlist-combinedprint/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-combinedprint/impl/main.r1.md
@@ -1,0 +1,55 @@
+Committed. Here is the output summary:
+
+---
+
+# Implementation: Relocate CombinedPrintQueueSink to Application Layer
+
+## What was implemented
+
+`CombinedPrintQueueSink` was moved from the API project (`Anela.Heblo.API/Features/ExpeditionList/`) to the Application project (`Anela.Heblo.Application/Features/ExpeditionList/Services/`), restoring Clean Architecture compliance. No logic was changed — only the file location, namespace, and `using` statements moved.
+
+## Files created/modified
+
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs` — new file, updated namespace to `Anela.Heblo.Application.Features.ExpeditionList.Services`
+- `backend/src/Anela.Heblo.API/Features/ExpeditionList/CombinedPrintQueueSink.cs` — deleted (directory also removed)
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed dead `using Anela.Heblo.API.Features.ExpeditionList;`
+- `backend/src/Anela.Heblo.Application/AssemblyInfo.cs` — added `[assembly: InternalsVisibleTo("Anela.Heblo.API")]`
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — added `<InternalsVisibleTo Include="Anela.Heblo.API" />`
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs` — updated `using` to new namespace only
+
+## Tests
+
+`CombinedPrintQueueSinkTests` — all 4 test cases pass:
+- `SendAsync_BothSucceed_CallsBothSinksWithSamePaths`
+- `SendAsync_AzureThrows_CupsNeverCalledAndExceptionPropagates`
+- `SendAsync_AzureSucceedsCupsThrows_ExceptionPropagates`
+- `SendAsync_SinglePassEnumerable_BothSinksReceiveAllPaths`
+
+## How to verify
+
+```bash
+dotnet build Anela.Heblo.sln   # 0 errors
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj --filter "FullyQualifiedName~CombinedPrintQueueSink"   # 4/4 passed
+grep -r "IPrintQueueSink" backend/src/Anela.Heblo.API/   # only ServiceCollectionExtensions.cs
+```
+
+## Notes
+
+The arch-review amendment (FR-6) was required: `internal sealed` in Application is invisible to the API project without `InternalsVisibleTo`. Both `AssemblyInfo.cs` and `.csproj` were updated to mirror the existing pattern for `Anela.Heblo.Tests`.
+
+## PR Summary
+
+Moves `CombinedPrintQueueSink` from the API project into `Anela.Heblo.Application/Features/ExpeditionList/Services/` — the correct layer for a pure Application-level composite adapter. The API project previously held the only `IPrintQueueSink` implementation not in its proper layer; after this change, the API project contains no sink implementations, only DI wiring.
+
+The only non-obvious prerequisite: the class stays `internal sealed`, so `InternalsVisibleTo("Anela.Heblo.API")` was added to `AssemblyInfo.cs` and `Anela.Heblo.Application.csproj` to let the API's composition root register the type without widening visibility.
+
+### Changes
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs` — relocated file, namespace updated
+- `backend/src/Anela.Heblo.API/Features/ExpeditionList/CombinedPrintQueueSink.cs` — deleted
+- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed dead `using`
+- `backend/src/Anela.Heblo.Application/AssemblyInfo.cs` — added `InternalsVisibleTo("Anela.Heblo.API")`
+- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — added `<InternalsVisibleTo Include="Anela.Heblo.API" />`
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs` — updated `using` to new namespace
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-expeditionlist-combinedprint/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-combinedprint/spec.r1.md
@@ -1,0 +1,109 @@
+# Specification: Relocate CombinedPrintQueueSink to Application Layer
+
+## Summary
+`CombinedPrintQueueSink` is an `IPrintQueueSink` composite adapter that currently lives in the API project, violating Clean Architecture by placing Application-layer logic in the HTTP shell. This change relocates the class to the Application project alongside its peer sink implementations (`FileSystemPrintQueueSink`) with no behavioral changes — only the file location, namespace, and `using` statements move.
+
+## Background
+The repo follows Clean Architecture: the API project (`Anela.Heblo.API`) is a thin HTTP shell — controllers, middleware, auth filters — while business-logic services and adapters live in `Anela.Heblo.Application` or dedicated adapter projects. `docs/architecture/development_guidelines.md` codifies this rule.
+
+`CombinedPrintQueueSink` is a 25-line internal sealed class implementing `IPrintQueueSink` (defined in `Anela.Heblo.Application.Shared.Printing`). It wraps two keyed `IPrintQueueSink` services (`"azure"` and `"cups"`) and forwards `SendAsync` to both. It has no HTTP, controller, MVC, or middleware responsibility. It is registered in the API's `ServiceCollectionExtensions.AddPrintQueueSink` when `ExpeditionList:PrintSink = "Combined"`.
+
+Every other `IPrintQueueSink` implementation already lives in the appropriate layer:
+- `FileSystemPrintQueueSink` → `Anela.Heblo.Application/Features/ExpeditionList/Services/`
+- `AzureBlobPrintQueueSink` → `Anela.Heblo.Adapters.Azure/Features/ExpeditionList/`
+- `CupsPrintQueueSink` → `Anela.Heblo.Adapters.Cups/Features/ExpeditionList/`
+
+`CombinedPrintQueueSink` is the only outlier sitting in the API project. Filed by the daily arch-review routine on 2026-06-03.
+
+## Functional Requirements
+
+### FR-1: Move file to Application project
+Move `backend/src/Anela.Heblo.API/Features/ExpeditionList/CombinedPrintQueueSink.cs` to `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs`. The new location mirrors the placement of `FileSystemPrintQueueSink.cs`.
+
+**Acceptance criteria:**
+- File exists at `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs`.
+- File no longer exists under `backend/src/Anela.Heblo.API/Features/ExpeditionList/`.
+- The `Anela.Heblo.API/Features/ExpeditionList/` directory is removed if it becomes empty.
+
+### FR-2: Update namespace
+Change the namespace from `Anela.Heblo.API.Features.ExpeditionList` to `Anela.Heblo.Application.Features.ExpeditionList.Services`, matching `FileSystemPrintQueueSink`.
+
+**Acceptance criteria:**
+- File declares `namespace Anela.Heblo.Application.Features.ExpeditionList.Services;`.
+- Class remains `internal sealed class CombinedPrintQueueSink : IPrintQueueSink` (no visibility change).
+- Constructor, fields, and `SendAsync` implementation are byte-for-byte equivalent to the current code.
+- `using Anela.Heblo.Application.Shared.Printing;` and `using Microsoft.Extensions.DependencyInjection;` are preserved (the latter is required for `[FromKeyedServices]`).
+
+### FR-3: Update DI registration call site
+The current registration in `Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs::AddPrintQueueSink` references `CombinedPrintQueueSink` via `using Anela.Heblo.API.Features.ExpeditionList;`. Update the `using` to point to the new namespace. The registration line itself (`services.AddScoped<IPrintQueueSink, CombinedPrintQueueSink>();`) does not change.
+
+**Acceptance criteria:**
+- `ServiceCollectionExtensions.cs` imports `Anela.Heblo.Application.Features.ExpeditionList.Services` (either explicitly or via the existing `Anela.Heblo.Application.Features.ExpeditionList.Services` using already present for `FileSystemPrintQueueSink`).
+- The `using Anela.Heblo.API.Features.ExpeditionList;` line is removed if no other type from that namespace is referenced.
+- The `"Combined"` switch branch in `AddPrintQueueSink` continues to register `IPrintQueueSink` → `CombinedPrintQueueSink` with the same scoped lifetime and same keyed-service dependencies.
+- DI resolution at runtime returns a `CombinedPrintQueueSink` instance when `ExpeditionList:PrintSink = "Combined"`.
+
+### FR-4: Update test file
+`backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs` currently imports the type via `using Anela.Heblo.API.Features.ExpeditionList;`. Update this `using` to the new namespace. No test logic changes.
+
+**Acceptance criteria:**
+- Test file imports `Anela.Heblo.Application.Features.ExpeditionList.Services`.
+- All four existing test cases (`SendAsync_BothSucceed_*`, `SendAsync_AzureThrows_*`, `SendAsync_AzureSucceedsCupsThrows_*`, `SendAsync_SinglePassEnumerable_*`) pass without modification to their bodies.
+- The `internal sealed` class remains test-accessible via the existing `InternalsVisibleTo("Anela.Heblo.Tests")` declaration in `Anela.Heblo.Application/AssemblyInfo.cs` and `Anela.Heblo.Application.csproj`.
+
+### FR-5: Preserve behavior end-to-end
+No functional behavior changes. The sink's contract — sequential `await azureSink.SendAsync(paths)` then `await cupsSink.SendAsync(paths)`, with `paths` materialized once via `.ToList()` for single-pass enumerables — must be byte-identical.
+
+**Acceptance criteria:**
+- Manual diff of pre-move vs post-move class body shows zero changes to logic.
+- All existing `CombinedPrintQueueSinkTests` pass.
+- Integration: with `ExpeditionList:PrintSink = "Combined"` configured, the application starts and `IPrintQueueSink` resolves to `CombinedPrintQueueSink` with both keyed sinks injected.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No runtime performance change is expected. This is a compile-time relocation; the IL produced for `CombinedPrintQueueSink.SendAsync` and its DI resolution path are unaffected.
+
+### NFR-2: Security
+No security impact. The class does not handle authentication, authorization, user input, secrets, or external network calls directly — it merely fans out to two already-registered sinks.
+
+### NFR-3: Architecture compliance
+After the change, the `Anela.Heblo.API` project must contain no `IPrintQueueSink` implementations. The API project's role as a thin HTTP shell is restored for this slice.
+
+**Acceptance criteria:**
+- `grep -r "IPrintQueueSink" backend/src/Anela.Heblo.API/` returns only references in DI wiring (`ServiceCollectionExtensions.cs`), not concrete implementations.
+
+### NFR-4: Build & test gates
+The standard project gates must pass after the change:
+- `dotnet build` succeeds for the solution.
+- `dotnet format` reports no changes needed (or all changes applied).
+- `dotnet test` passes for `Anela.Heblo.Tests` — specifically the `CombinedPrintQueueSinkTests` class and any test that exercises the print sink registration (`ExpeditionListServicePrintSinkTests`).
+
+## Data Model
+Not applicable. No domain entities, DTOs, persistence schemas, or migrations are touched.
+
+## API / Interface Design
+Not applicable. No public HTTP API, MediatR request, or external contract is added, removed, or modified. The class's public surface (`SendAsync(IEnumerable<string>, CancellationToken)`) is unchanged.
+
+The `IPrintQueueSink` interface itself remains in `Anela.Heblo.Application.Shared.Printing` and is untouched.
+
+## Dependencies
+- **Project references:** No project reference changes required. `Anela.Heblo.Application` already references `Microsoft.Extensions.DependencyInjection.Abstractions` (transitively or directly — verified by `FileSystemPrintQueueSink` using `IOptions<>` from the same family). The `[FromKeyedServices]` attribute lives in `Microsoft.Extensions.DependencyInjection.Abstractions` and is available in .NET 8.
+- **InternalsVisibleTo:** Already configured for `Anela.Heblo.Application` → `Anela.Heblo.Tests` (`Anela.Heblo.Application/AssemblyInfo.cs:3`, `Anela.Heblo.Application.csproj:46`). No additional config needed.
+- **Configuration:** The `ExpeditionList:PrintSink = "Combined"` configuration value continues to control activation. No config schema changes.
+- **Related specs (historical):** `docs/superpowers/specs/2026-03-25-combined-print-queue-sink-design.md` and `docs/superpowers/plans/2026-03-25-combined-print-queue-sink.md` describe the original feature; both predate this relocation and do not need updating beyond optional reference notes.
+
+## Out of Scope
+- **Behavior changes:** No change to how the combined sink dispatches to its child sinks. Sequential `await` (Azure first, then CUPS) is preserved exactly. If Azure throws, CUPS is still skipped.
+- **Parallel dispatch:** Switching to `Task.WhenAll` for parallel Azure+CUPS calls is **not** part of this work.
+- **Error-isolation policy:** Changing the fail-fast semantics (e.g., attempting CUPS even if Azure fails) is **not** part of this work.
+- **Refactoring `AddPrintQueueSink`:** The note in `ServiceCollectionExtensions.cs` about `AddAzurePrintQueueSink` registering a non-keyed sink as an unused side effect is **not** addressed here.
+- **Renaming the class, the keyed names (`"azure"`, `"cups"`), or the configuration key (`ExpeditionList:PrintSink`):** all stay as-is.
+- **Visibility broadening:** The class stays `internal sealed`. No `public` exposure.
+- **Tests beyond the import statement:** Test logic, assertions, and mocking setup are unchanged.
+- **Other arch-review findings:** This brief covers only `CombinedPrintQueueSink`. The broader pattern of locating `IPrintQueueSink` implementations is incidentally reinforced but no audit of related code is performed.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-expeditionlist-combinedprint/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-combinedprint/task-plan.r1.md
@@ -1,0 +1,14 @@
+Plan saved to `artifacts/feat-arch-review-expeditionlist-combinedprint/plan.r1.md`.
+
+The plan covers all six FRs (FR-1 through FR-5 from the spec plus FR-6 from the arch-review amendment for `InternalsVisibleTo`) and all four NFRs across six tasks:
+
+1. **Task 1** — Establish green baseline (build + run existing tests + snapshot the source for byte-equivalence + grep verifications).
+2. **Task 2** — Grant `InternalsVisibleTo("Anela.Heblo.API")` on the Application assembly (separate commit, runtime no-op, unblocks the move).
+3. **Task 3** — Create the relocated file in Application (don't delete the old one yet — both copies live in different namespaces, no symbol clash).
+4. **Task 4** — Delete the old file + folder, remove dead `using` at `ServiceCollectionExtensions.cs:24`.
+5. **Task 5** — Swap the test file's `using` line, run the full test gate, commit Tasks 3+4+5 atomically.
+6. **Task 6** — NFR-3 architecture-compliance grep gates + final build/format verification.
+
+Key plan decisions: two commits (the `InternalsVisibleTo` grant alone, then the atomic move); byte-diff check between old and new class bodies in Task 3 Step 2 to guarantee zero behavioral drift; explicit out-of-scope guardrails listed at the end (no parallelization, no visibility broadening, no `.ToList()` removal, no `await` reordering, no test body edits).
+
+Skipping the execution-handoff prompt per the pipeline note.

--- a/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs
@@ -21,7 +21,6 @@ using Anela.Heblo.Adapters.Azure.Features.ExpeditionList;
 using Anela.Heblo.Adapters.Azure;
 using Anela.Heblo.Adapters.Cups;
 using Anela.Heblo.Adapters.Cups.Features.ExpeditionList;
-using Anela.Heblo.API.Features.ExpeditionList;
 using Anela.Heblo.API.PDFPrints;
 using Anela.Heblo.Application.Features.BackgroundJobs.Services;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;

--- a/backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
+++ b/backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Anela.Heblo.Tests" />
+    <InternalsVisibleTo Include="Anela.Heblo.API" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/Anela.Heblo.Application/AssemblyInfo.cs
+++ b/backend/src/Anela.Heblo.Application/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Anela.Heblo.Tests")]
+[assembly: InternalsVisibleTo("Anela.Heblo.API")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Shared.Printing;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Anela.Heblo.API.Features.ExpeditionList;
+namespace Anela.Heblo.Application.Features.ExpeditionList.Services;
 
 internal sealed class CombinedPrintQueueSink : IPrintQueueSink
 {

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.API.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Services;
 using Anela.Heblo.Application.Shared.Printing;
 using Moq;
 


### PR DESCRIPTION

Moves `CombinedPrintQueueSink` from the API project into `Anela.Heblo.Application/Features/ExpeditionList/Services/` — the correct layer for a pure Application-level composite adapter. The API project previously held the only `IPrintQueueSink` implementation not in its proper layer; after this change, the API project contains no sink implementations, only DI wiring.

The only non-obvious prerequisite: the class stays `internal sealed`, so `InternalsVisibleTo("Anela.Heblo.API")` was added to `AssemblyInfo.cs` and `Anela.Heblo.Application.csproj` to let the API's composition root register the type without widening visibility.

### Changes
- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/CombinedPrintQueueSink.cs` — relocated file, namespace updated
- `backend/src/Anela.Heblo.API/Features/ExpeditionList/CombinedPrintQueueSink.cs` — deleted
- `backend/src/Anela.Heblo.API/Extensions/ServiceCollectionExtensions.cs` — removed dead `using`
- `backend/src/Anela.Heblo.Application/AssemblyInfo.cs` — added `InternalsVisibleTo("Anela.Heblo.API")`
- `backend/src/Anela.Heblo.Application/Anela.Heblo.Application.csproj` — added `<InternalsVisibleTo Include="Anela.Heblo.API" />`
- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/CombinedPrintQueueSinkTests.cs` — updated `using` to new namespace

---

Closes #2498

### Tokens used
7354319
