### PR TITLE
feat: Invert ExpeditionList → Logistics Picking Dependency

### DIFF
--- a/artifacts/feat-arch-review-expeditionlist-direct-depend/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-direct-depend/arch-review.r1.md
@@ -1,0 +1,353 @@
+# Architecture Review: Invert ExpeditionList → Logistics Picking Dependency
+
+## Skip Design: true
+
+This is a backend-only structural refactor. No UI, screens, or visual components are added or changed.
+
+## Architectural Fit Assessment
+
+The proposal aligns with the established consumer-owned-contract pattern (`docs/architecture/development_guidelines.md`, `ILeafletKnowledgeSource`, `ILogisticsStockOperationQueryService`, `LogisticsCatalogTransportSourceAdapter`). The boundary test scaffold in `ModuleBoundariesTests.cs` already supports a new rule at the same shape used at line 327.
+
+However, **the brief and spec mischaracterize who "the provider" is**, and this materially affects implementation:
+
+- `Anela.Heblo.Application.Features.Logistics.Picking` (`IPickingListSource`, `PrintPickingListRequest`, `PrintPickingListResult`) is a namespace-only home for these types. **No Logistics-internal code consumes any of them** (verified by grep). They are interface + DTOs with no module-side implementation.
+- The single concrete implementation lives in the **Shoptet adapter**: `backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs`.
+- DI for `IPickingListSource` is registered in `ShoptetApiAdapterServiceCollectionExtensions.cs:76`, **not** in `LogisticsModule.cs` (which contains no picking-related registrations at all).
+- The spec's FR-5 ("DI registration appears in LogisticsModule") and FR-4 ("Adapter lives under Features/Logistics/") therefore describe a topology that doesn't match reality. We need to choose explicitly between two architectures.
+
+**Additional gap discovered during exploration:** The spec missed two of the four files that import the Logistics.Picking namespace:
+
+| File | Spec mentions? | Imports Logistics.Picking |
+|---|---|---|
+| `Services/ExpeditionListService.cs` | Yes | Yes |
+| `Infrastructure/Jobs/PrintPickingListJob.cs` | Yes | Yes |
+| `Services/IExpeditionListService.cs` | **No** | Yes — `PrintPickingListRequest`/`Result` appear in the public method signature |
+| `UseCases/RunExpeditionListPrintFix/RunExpeditionListPrintFixHandler.cs` | **No** | Yes |
+
+Without fixing the two missing files, the architecture test (FR-6) will fail and the acceptance criterion in FR-3 (`grep` returns zero) cannot be met.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
++-------------------------------------------------------------+
+|  ExpeditionList module (consumer, owns the contract)        |
+|                                                             |
+|  Contracts/                                                 |
+|    IExpeditionPickingSource     <----+                      |
+|    ExpeditionPickingRequest          |                      |
+|    ExpeditionPickingResult           |                      |
+|                                       |                      |
+|  Services/                            |                      |
+|    IExpeditionListService  ----consumes (no Logistics ref)  |
+|    ExpeditionListService     ----+                          |
+|  Infrastructure/Jobs/             |                          |
+|    PrintPickingListJob       ----+                          |
+|  UseCases/RunExpeditionListPrintFix/                        |
+|    RunExpeditionListPrintFixHandler  --+                    |
++-----------------------------------------|-------------------+
+                                          |
+                                          | (DI resolves to)
+                                          v
++-------------------------------------------------------------+
+|  Logistics module (Application/Features/Logistics)          |
+|                                                             |
+|  Infrastructure/                                            |
+|    LogisticsExpeditionPickingAdapter  --- implements        |
+|       IExpeditionPickingSource                              |
+|       (translates ExpeditionPicking* <-> PrintPickingList*) |
+|       (depends on Logistics.Picking.IPickingListSource)     |
+|                                                             |
+|  Picking/  (unchanged, per "Out of Scope")                  |
+|    IPickingListSource (Logistics-namespaced)                |
+|    PrintPickingListRequest / Result                         |
+|                                                             |
+|  LogisticsModule.cs                                         |
+|    services.AddScoped<IExpeditionPickingSource,             |
+|                       LogisticsExpeditionPickingAdapter>(); |
++-------------------------------------------------------------+
+                                          ^
+                                          | (still implements)
+                                          |
++-------------------------------------------------------------+
+|  Anela.Heblo.Adapters.ShoptetApi (unchanged)                |
+|    ShoptetApiExpeditionListSource : IPickingListSource      |
+|    (binds Logistics-namespaced IPickingListSource only)     |
++-------------------------------------------------------------+
+```
+
+### Key Design Decisions
+
+#### Decision 1: Bridging adapter inside Logistics, vs. retargeting the Shoptet adapter directly
+
+**Options considered:**
+
+- **A.** Retarget `ShoptetApiExpeditionListSource` to implement the new ExpeditionList-owned interface; delete the Logistics-namespaced picking types (they have no other consumer).
+- **B.** Keep the Logistics-namespaced picking types untouched; add a thin `LogisticsExpeditionPickingAdapter` in `Logistics.Infrastructure` that implements ExpeditionList's interface and delegates to the existing Logistics-namespaced `IPickingListSource` (still implemented by `ShoptetApiExpeditionListSource`).
+
+**Chosen approach:** **B**, because the spec's "Out of Scope" section explicitly forbids touching the Logistics-namespaced types. B is a strictly additive refactor: nothing existing is renamed, no test assemblies' resolution paths change.
+
+**Rationale:** A is architecturally cleaner (one fewer hop, no duplicate near-identical DTOs) and is the structure I would recommend if the constraint were lifted — see "Specification Amendments" below. B respects the stated scope and lets the team revisit cleanup later. The adapter is sub-millisecond DTO translation; no I/O or latency cost.
+
+#### Decision 2: Interface naming — `IPickingListSource` vs. `IExpeditionPickingSource`
+
+**Options considered:**
+- Keep the name `IPickingListSource` in the new namespace (spec's choice).
+- Rename to `IExpeditionPickingSource` to mirror the `ExpeditionPicking*` DTO naming.
+
+**Chosen approach:** Rename to `IExpeditionPickingSource`.
+
+**Rationale:** C# permits two interfaces with the same simple name in different namespaces, but the bridging adapter in Logistics will need to *depend on both* (it consumes the Logistics-namespaced one and implements the ExpeditionList-namespaced one). Two `IPickingListSource` symbols in the same file force `using` aliases or fully-qualified type references and add no value. The DTO rename (`ExpeditionPickingRequest`/`Result`) is already paying this cost; finish the job.
+
+#### Decision 3: Adapter location and visibility
+
+**Chosen approach:** `backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs`, declared `internal sealed`.
+
+**Rationale:** Matches the precedent set by `LogisticsCatalogTransportSourceAdapter` (same folder, same `internal sealed` visibility). `internal` makes it impossible for any consumer to depend on the concrete type by mistake — it can only be reached via the interface.
+
+#### Decision 4: DTO shape — minimal vs. full parity
+
+**Chosen approach:** Minimal — only the fields ExpeditionList actually reads or writes today.
+
+ExpeditionList currently uses (verified against `ExpeditionListService.cs`, `PrintPickingListJob.cs`, `RunExpeditionListPrintFixHandler.cs`):
+
+Request inputs: `Carriers`, `SourceStateId`, `DesiredStateId`, `ChangeOrderState`, `SendToPrinter`.
+Result outputs: `ExportedFiles` (for cleanup), `TotalCount` (for logging/response). `OrderIds` on `PrintPickingListResult` is **not consumed** by ExpeditionList — exclude it.
+Statics on `PrintPickingListRequest` (`DefaultCarriers`, `DefaultSourceStateId`, `DefaultDesiredStateId`): these are consumed by `PrintPickingListJob` and `RunExpeditionListPrintFixHandler`. Move them onto `ExpeditionPickingRequest`.
+
+**Rationale:** YAGNI. The whole point of the inversion is that the consumer states what it needs; copying unused fields recreates the coupling we're removing.
+
+#### Decision 5: `Carriers` enum ownership
+
+**Issue not raised in the spec:** `PrintPickingListRequest.Carriers` is `IList<Carriers>` where `Carriers` is `Anela.Heblo.Domain.Features.Logistics.Carriers`. If `ExpeditionPickingRequest` keeps that property typed as `IList<Carriers>`, ExpeditionList still imports a Domain Logistics type, and the new boundary rule will flag it.
+
+**Options considered:**
+- Allowlist `Anela.Heblo.Domain.Features.Logistics.Carriers` in the new rule.
+- Define an ExpeditionList-owned `ExpeditionCarrier` enum.
+- Type the field as `IList<string>` or `IList<int>`.
+
+**Chosen approach:** Allowlist `Carriers` (and only `Carriers`) in the new ExpeditionList → Logistics rule, with a comment justifying it.
+
+**Rationale:** `Carriers` is a stable Domain enum (`Zasilkovna`, `GLS`, `PPL`, `Osobak`) used by many parts of the system; duplicating it into ExpeditionList would create a synchronization burden far worse than the dependency it removes. The boundary test pattern already supports per-rule allowlists with documented entries (`LeafletAllowlist`, `LogisticsAllowlist`). Use that mechanism rather than re-typing the field.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+New files:
+```
+backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/
+    IExpeditionPickingSource.cs
+    ExpeditionPickingRequest.cs
+    ExpeditionPickingResult.cs
+
+backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/
+    LogisticsExpeditionPickingAdapter.cs
+```
+
+Modified files:
+```
+backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/IExpeditionListService.cs
+backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs
+backend/src/Anela.Heblo.Application/Features/ExpeditionList/Infrastructure/Jobs/PrintPickingListJob.cs
+backend/src/Anela.Heblo.Application/Features/ExpeditionList/UseCases/RunExpeditionListPrintFix/RunExpeditionListPrintFixHandler.cs
+backend/src/Anela.Heblo.Application/Features/Logistics/LogisticsModule.cs
+backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs
+backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs
+```
+
+Unchanged (per "Out of Scope"):
+```
+backend/src/Anela.Heblo.Application/Features/Logistics/Picking/* (all 3 files)
+backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/Expedition/ShoptetApiExpeditionListSource.cs
+backend/src/Adapters/Anela.Heblo.Adapters.ShoptetApi/ShoptetApiAdapterServiceCollectionExtensions.cs
+backend/test/Anela.Heblo.Adapters.Shoptet.Tests/Integration/PickingListIntegrationTests.cs
+```
+
+### Interfaces and Contracts
+
+```csharp
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface IExpeditionPickingSource
+{
+    Task<ExpeditionPickingResult> CreatePickingListAsync(
+        ExpeditionPickingRequest request,
+        Func<IList<string>, Task>? onBatchFilesReady,
+        CancellationToken cancellationToken = default);
+}
+```
+
+```csharp
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public class ExpeditionPickingRequest
+{
+    public const int DefaultSourceStateId = -2;
+    public const int DefaultDesiredStateId = 26;
+
+    public IList<Carriers> Carriers { get; set; } = new List<Carriers>();
+    public int SourceStateId { get; set; } = DefaultSourceStateId;
+    public int DesiredStateId { get; set; } = DefaultDesiredStateId;
+    public bool ChangeOrderState { get; set; }
+    public bool SendToPrinter { get; set; }
+
+    public static IList<Carriers> DefaultCarriers { get; } = new List<Carriers>
+    {
+        Anela.Heblo.Domain.Features.Logistics.Carriers.Zasilkovna,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.GLS,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.PPL,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.Osobak,
+    };
+}
+```
+
+```csharp
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public class ExpeditionPickingResult
+{
+    public IList<string> ExportedFiles { get; set; } = new List<string>();
+    public int TotalCount { get; set; }
+}
+```
+
+Both DTOs are `class`, not `record` (per project DTO rule — these are returned through the MediatR/service layer and any future OpenAPI surface).
+
+Adapter skeleton:
+
+```csharp
+namespace Anela.Heblo.Application.Features.Logistics.Infrastructure;
+
+internal sealed class LogisticsExpeditionPickingAdapter
+    : ExpeditionList.Contracts.IExpeditionPickingSource
+{
+    private readonly Picking.IPickingListSource _inner;
+
+    public LogisticsExpeditionPickingAdapter(Picking.IPickingListSource inner) =>
+        _inner = inner;
+
+    public async Task<ExpeditionList.Contracts.ExpeditionPickingResult> CreatePickingListAsync(
+        ExpeditionList.Contracts.ExpeditionPickingRequest request,
+        Func<IList<string>, Task>? onBatchFilesReady,
+        CancellationToken cancellationToken = default)
+    {
+        var logisticsRequest = new Picking.PrintPickingListRequest
+        {
+            Carriers = request.Carriers,
+            SourceStateId = request.SourceStateId,
+            DesiredStateId = request.DesiredStateId,
+            ChangeOrderState = request.ChangeOrderState,
+            SendToPrinter = request.SendToPrinter,
+        };
+
+        var inner = await _inner.CreatePickingList(logisticsRequest, onBatchFilesReady, cancellationToken);
+
+        return new ExpeditionList.Contracts.ExpeditionPickingResult
+        {
+            ExportedFiles = inner.ExportedFiles,
+            TotalCount = inner.TotalCount,
+        };
+    }
+}
+```
+
+DI registration added to `LogisticsModule.AddTransportModule`:
+
+```csharp
+services.AddScoped<
+    ExpeditionList.Contracts.IExpeditionPickingSource,
+    LogisticsExpeditionPickingAdapter>();
+```
+
+### Data Flow
+
+For `PrintPickingListJob` (recurring):
+
+1. Hangfire fires job → `PrintPickingListJob.ExecuteAsync`.
+2. Job builds `ExpeditionPickingRequest` (ExpeditionList type) from `PrintPickingListOptions`.
+3. Job calls `_expeditionListService.PrintPickingListAsync(request, emailList, ct)`.
+4. `ExpeditionListService` builds batch callback, calls `_pickingSource.CreatePickingListAsync(request, callback, ct)` (resolved via DI → `LogisticsExpeditionPickingAdapter`).
+5. Adapter translates request → `PrintPickingListRequest`, calls Logistics-namespaced `IPickingListSource` (resolved → `ShoptetApiExpeditionListSource`).
+6. Shoptet adapter executes existing logic, invokes batch callback as before.
+7. Adapter translates `PrintPickingListResult` → `ExpeditionPickingResult`, returns.
+8. `ExpeditionListService` cleans up files, returns to job. Same observable behavior.
+
+For `RunExpeditionListPrintFixHandler`: same flow with `SourceStateId = FixSourceStateId`.
+
+### Module Boundary Rule
+
+Add to `ModuleBoundariesTests.cs` Rules array, modeled exactly on the line 327 rule:
+
+```csharp
+new ModuleBoundaryRule(
+    Name: "ExpeditionList -> Logistics",
+    InspectedNamespacePrefix: "Anela.Heblo.Application.Features.ExpeditionList",
+    ForbiddenNamespacePrefixes: new[]
+    {
+        "Anela.Heblo.Domain.Features.Logistics",
+        "Anela.Heblo.Application.Features.Logistics",
+        "Anela.Heblo.Persistence.Logistics",
+    },
+    Allowlist: ExpeditionListLogisticsAllowlist),
+```
+
+With (in the allowlist section near other declared lists):
+
+```csharp
+// Allowlist for ExpeditionList -> Logistics.
+// Carriers is a Domain enum (Zasilkovna/GLS/PPL/Osobak) shared widely across the codebase.
+// Re-defining it in ExpeditionList would create a synchronization burden far worse than
+// the dependency it removes.
+private static readonly HashSet<string> ExpeditionListLogisticsAllowlist = new(StringComparer.Ordinal)
+{
+    "Anela.Heblo.Application.Features.ExpeditionList.Contracts.ExpeditionPickingRequest -> Anela.Heblo.Domain.Features.Logistics.Carriers",
+};
+```
+
+Verify the test name encoding matches `EnumerateReferencedTypes` output by running the test once with a deliberate extra violation, observing the printed `Found:` block, and copying the exact entry string.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `Carriers` Domain reference leaks more boundary violations than just `ExpeditionPickingRequest.Carriers` (e.g. via the static `DefaultCarriers` getter or callers) | Medium | Run the boundary test after first compile. Any unexpected entries surface immediately; add them to the allowlist with justification or refactor the leak. |
+| Two test files (`ExpeditionListServiceOrderStateTests`, `ExpeditionListServicePrintSinkTests`) currently `Mock<IPickingListSource>` on the Logistics-namespaced interface — left untouched they will fail to compile if the production code stops accepting it | High | Update both test files to mock `IExpeditionPickingSource` and pass `ExpeditionPickingResult`. This is part of FR-7 implicitly but should be explicit in the implementation checklist. |
+| Boundary test passes vacuously when ExpeditionList types are entirely scrubbed of Logistics references but `EnumerateReferencedTypes` misses something (it only inspects member signatures, not method bodies — see the docstring at `ModuleBoundariesTests.cs:660`) | Low | Combine the test with the existing `grep` acceptance criterion in FR-3 — both must pass. The grep catches `using` imports even when the type only appears in method bodies. |
+| DI resolution order: `LogisticsExpeditionPickingAdapter` depends on `Picking.IPickingListSource`, which is registered by `AddShoptetApiAdapter`. If a test container or alternate composition omits the Shoptet adapter, resolving the ExpeditionList interface throws | Medium | Existing `ExpeditionListService` already depends transitively on this binding; the risk is unchanged. Document the dependency in the adapter file with a one-line comment. |
+| `IExpeditionListService` change is a public Application-layer signature change. Anything outside `ExpeditionList` that consumes it would break | Low | grep confirms only ExpeditionList-internal callers (`PrintPickingListJob`, `RunExpeditionListPrintFixHandler`, the two test files). Safe. |
+| `Func<IList<string>, Task>?` callback parameter shape preserved across the adapter — easy to drop accidentally | Low | Include this parameter in `IExpeditionPickingSource`. Required for the existing per-batch upload/email/printer behavior. The minimal-fields rule does **not** apply to the operation signature — only to the DTOs. |
+
+## Specification Amendments
+
+1. **FR-3 acceptance criterion is incomplete.** Add `IExpeditionListService.cs` and `RunExpeditionListPrintFixHandler.cs` to the file list. The grep check already covers them, but the prose lists only `ExpeditionListService` and `PrintPickingListJob`. Fix the prose to match the grep.
+
+2. **FR-4 / FR-5 location is wrong.** The brief and spec describe Logistics as the implementation provider. Verify with the team and update to one of:
+   - **(B)** Keep types in Logistics namespace; add `LogisticsExpeditionPickingAdapter` in `Application/Features/Logistics/Infrastructure/`; register in `LogisticsModule`. **The Shoptet adapter is the actual sink** — the Logistics-side adapter is purely a DTO translator. This is the option this review recommends.
+   - **(A — out-of-scope per spec, but architecturally cleaner)** Have `ShoptetApiExpeditionListSource` implement `IExpeditionPickingSource` directly; delete `Anela.Heblo.Application.Features.Logistics.Picking/*` (verified no other consumers). DI moves to `AddShoptetApiAdapter`. No Logistics-side adapter exists. Recommend revisiting the out-of-scope as a follow-up — keeping a dead namespace just to avoid touching it is the kind of decay this boundary rule exists to prevent.
+
+3. **Interface name.** Rename to `IExpeditionPickingSource` for consistency with `ExpeditionPickingRequest`/`Result` and to avoid two `IPickingListSource` symbols in the bridging adapter file.
+
+4. **Add an explicit FR for the `Carriers` allowlist entry.** Without it, the boundary test fails on the first run. Document the justification in the allowlist comment block.
+
+5. **FR-7 should explicitly include test-file updates.** `ExpeditionListServiceOrderStateTests.cs` and `ExpeditionListServicePrintSinkTests.cs` both depend on the Logistics-namespaced interface today and must be retargeted. They live in `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/`.
+
+6. **`PrintPickingListResult.OrderIds` is unused by ExpeditionList** — confirm and exclude from `ExpeditionPickingResult` (FR-2 says "only fields ExpeditionList reads," and the codebase confirms no reader).
+
+7. **Adapter visibility.** Mark `LogisticsExpeditionPickingAdapter` as `internal sealed` (precedent: `LogisticsCatalogTransportSourceAdapter`). Acceptance: type cannot be referenced from outside `Anela.Heblo.Application`.
+
+## Prerequisites
+
+None. This refactor is purely a code reorganization:
+
+- No DB migration.
+- No config/secrets changes (no Key Vault entries to add).
+- No infrastructure changes.
+- No NuGet additions.
+- No external API or contract changes.
+
+Standard validation gates apply per `CLAUDE.md`:
+- `dotnet build` and `dotnet format` must pass.
+- `dotnet test` must pass — specifically the ExpeditionList unit tests, the new architecture test, and `PickingListIntegrationTests` in the Shoptet adapter tests (which continues to resolve the Logistics-namespaced `IPickingListSource` and is unaffected by Option B).

--- a/artifacts/feat-arch-review-expeditionlist-direct-depend/brief.md
+++ b/artifacts/feat-arch-review-expeditionlist-direct-depend/brief.md
@@ -1,0 +1,40 @@
+## Module
+ExpeditionList
+
+## Finding
+`ExpeditionListService` and `PrintPickingListJob` directly import types from the **Logistics module's** `Picking` namespace:
+
+```csharp
+// ExpeditionListService.cs:1
+using Anela.Heblo.Application.Features.Logistics.Picking;
+// uses: IPickingListSource, PrintPickingListRequest, PrintPickingListResult
+
+// PrintPickingListJob.cs:3
+using Anela.Heblo.Application.Features.Logistics.Picking;
+// uses: PrintPickingListRequest
+```
+
+`IPickingListSource` is defined in `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/IPickingListSource.cs` — **owned by the Logistics module**, not by ExpeditionList. `PrintPickingListRequest` and `PrintPickingListResult` are also Logistics-owned types consumed directly by ExpeditionList.
+
+Per `docs/architecture/development_guidelines.md` (cross-module communication pattern):
+> "When module A needs read-only access to data in module B, the dependency must **invert**: the consumer owns the contract, the provider implements an adapter."
+
+Other module boundaries in the codebase follow this pattern correctly (e.g. `ILeafletKnowledgeSource` owned by Leaflet, `ILogisticsStockOperationQueryService` owned by the consumer). ExpeditionList does not.
+
+Additionally, `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` contains no rule for `ExpeditionList → Logistics`, so this boundary violation is invisible to CI. (The reverse direction `ExpeditionListArchive → ExpeditionList` IS enforced at line 327.)
+
+## Why it matters
+- **Module coupling**: ExpeditionList can only be tested or deployed alongside Logistics. Renaming or reshaping Logistics picking types is a change that implicitly affects ExpeditionList — with no compile-time warning.
+- **Boundary drift**: Without a test rule, future additions to ExpeditionList may add more Logistics imports without anyone noticing.
+- **Inconsistency**: Every other enforced module pair in the codebase follows the consumer-owns-contract pattern; this is the one unchecked crossing.
+
+## Suggested fix
+1. Create `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/IPickingListSource.cs` with a minimal interface owned by ExpeditionList, and matching request/result types (`ExpeditionPickingRequest`, `ExpeditionPickingResult`) with only the fields ExpeditionList actually reads.
+2. Add a Logistics-side adapter (`LogisticsExpeditionListSourceAdapter`) that implements the ExpeditionList-owned interface and delegates to the existing Logistics picking internals.
+3. Register the adapter in `LogisticsModule` (the provider registers the binding, per the pattern).
+4. Add a `ModuleBoundaryRule` in `ModuleBoundariesTests.cs` for `ExpeditionList → Logistics` with an empty allowlist.
+
+If the request/result types are too large to duplicate immediately, a minimal first step is just adding the boundary test with a documented allowlist — that at least makes the violations visible and stops them from growing.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-expeditionlist-direct-depend/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-direct-depend/impl/main.r1.md
@@ -1,0 +1,72 @@
+All 10 tasks complete. Let me write the output summary.
+
+---
+
+# Implementation: Invert ExpeditionList → Logistics Picking Dependency
+
+## What was implemented
+
+Inverted the dependency between `ExpeditionList` and `Logistics.Picking` so ExpeditionList now owns the contract and Logistics provides a translating adapter. Added a CI-enforced architecture boundary test to prevent regression.
+
+## Files created/modified
+
+### New files
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/IExpeditionPickingSource.cs` — consumer-owned interface with `CreatePickingListAsync`
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs` — minimal request DTO (class, not record); owns `DefaultCarriers` static
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingResult.cs` — minimal result DTO with `ExportedFiles` + `TotalCount` (no `OrderIds`)
+- `backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs` — `internal sealed` bridge adapter implementing `IExpeditionPickingSource`, delegating to Logistics-namespaced `IPickingListSource`
+- `backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs` — 4 unit tests covering field translation, callback passthrough, and cancellation token forwarding
+
+### Modified files
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/IExpeditionListService.cs` — uses `ExpeditionPickingRequest`/`ExpeditionPickingResult`
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs` — depends on `IExpeditionPickingSource`
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Infrastructure/Jobs/PrintPickingListJob.cs` — uses `ExpeditionPickingRequest`
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/UseCases/RunExpeditionListPrintFix/RunExpeditionListPrintFixHandler.cs` — uses `ExpeditionPickingRequest`
+- `backend/src/Anela.Heblo.Application/Features/Logistics/LogisticsModule.cs` — registers `IExpeditionPickingSource → LogisticsExpeditionPickingAdapter`
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs` — retargeted to `IExpeditionPickingSource`
+- `backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs` — retargeted to `IExpeditionPickingSource`
+- `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` — new `ExpeditionList → Logistics` rule with `Carriers` allowlist
+
+## Tests
+
+- `LogisticsExpeditionPickingAdapterTests` (4 tests) — new, testing all translation behavior
+- `ExpeditionListServiceOrderStateTests` (5 tests) — existing, retargeted to new interface
+- `ExpeditionListServicePrintSinkTests` (2 tests) — existing, retargeted to new interface
+- `ModuleBoundariesTests` (new theory case) — enforces the new boundary; proven non-vacuous by deliberate violation test
+
+All 157 targeted tests pass. Full suite: 4377 pass (38 pre-existing Docker/Testcontainers failures unrelated to this change).
+
+## How to verify
+
+```bash
+# All targeted tests
+dotnet test backend/test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ExpeditionList|FullyQualifiedName~LogisticsExpeditionPickingAdapter|FullyQualifiedName~ModuleBoundariesTests"
+
+# FR-3: no Logistics imports in ExpeditionList source
+grep -rn "Anela.Heblo.Application.Features.Logistics" \
+  backend/src/Anela.Heblo.Application/Features/ExpeditionList/
+# Expected: zero output
+```
+
+## Notes
+
+- Logistics-namespaced types (`IPickingListSource`, `PrintPickingListRequest`, `PrintPickingListResult`) are untouched per spec Out-of-Scope.
+- `Anela.Heblo.Domain.Features.Logistics.Carriers` remains referenced in `ExpeditionPickingRequest` — allowlisted in the boundary rule with justification (stable widely-used enum; duplication would create sync burden).
+- The 38 test failures in the full suite are pre-existing Docker/Testcontainers issues unrelated to this PR.
+- Commits follow TDD order: contract types → failing test → adapter implementation → DI registration → service migration → job/handler migration → architecture test.
+
+## PR Summary
+
+Inverted the `ExpeditionList → Logistics.Picking` dependency so ExpeditionList owns its contract (`IExpeditionPickingSource`, `ExpeditionPickingRequest`, `ExpeditionPickingResult`) and Logistics provides a translating adapter (`LogisticsExpeditionPickingAdapter`). Added a CI-enforced architecture boundary test with a single justified allowlist entry for the `Carriers` domain enum.
+
+The refactor follows the established consumer-owned-contract pattern already used for `ILeafletKnowledgeSource`, `ICatalogTransportSource`, and others. It removes the silent coupling that caused `ExpeditionList` to break whenever Logistics-side picking types were renamed or reshaped, and locks the inversion in so the violation cannot grow back.
+
+### Changes
+- `Features/ExpeditionList/Contracts/` — new `IExpeditionPickingSource`, `ExpeditionPickingRequest`, `ExpeditionPickingResult`
+- `Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs` — new `internal sealed` adapter; DI registration in `LogisticsModule`
+- `Features/ExpeditionList/Services/`, `Jobs/`, `UseCases/` — migrated off Logistics.Picking types (4 files)
+- `Architecture/ModuleBoundariesTests.cs` — new `ExpeditionList → Logistics` rule enforced in CI
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-expeditionlist-direct-depend/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-direct-depend/spec.r1.md
@@ -1,0 +1,162 @@
+# Specification: Invert ExpeditionList → Logistics Picking Dependency
+
+## Summary
+Refactor `ExpeditionList` so it no longer directly consumes types from the `Logistics.Picking` namespace. ExpeditionList will own the contract (`IPickingListSource` and its request/result DTOs); Logistics will provide an adapter that implements it. Add a CI-enforced architecture test to prevent regression.
+
+## Background
+The codebase follows a consistent cross-module communication pattern documented in `docs/architecture/development_guidelines.md`: when module A needs read-only access to data in module B, the dependency is inverted — the consumer owns the contract, the provider implements an adapter. Examples already in the codebase: `ILeafletKnowledgeSource` (owned by Leaflet), `ILogisticsStockOperationQueryService` (owned by the consumer).
+
+`ExpeditionList` violates this pattern in two files:
+
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/ExpeditionListService.cs:1` imports `Anela.Heblo.Application.Features.Logistics.Picking` and uses `IPickingListSource`, `PrintPickingListRequest`, `PrintPickingListResult`.
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionList/PrintPickingListJob.cs:3` imports the same namespace and uses `PrintPickingListRequest`.
+
+`IPickingListSource`, `PrintPickingListRequest`, and `PrintPickingListResult` are defined in `backend/src/Anela.Heblo.Application/Features/Logistics/Picking/` and are owned by Logistics.
+
+`backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` enforces `ExpeditionListArchive → ExpeditionList` (line 327) but has no rule covering `ExpeditionList → Logistics`, so this violation is invisible to CI and likely to grow over time.
+
+Renaming or reshaping the Logistics picking contract today silently breaks ExpeditionList with no compile-time warning at the boundary; ExpeditionList cannot be reasoned about, tested, or evolved independently.
+
+## Functional Requirements
+
+### FR-1: ExpeditionList owns a `IPickingListSource` contract
+Create `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/IPickingListSource.cs` defining an interface owned by ExpeditionList. The interface must expose only the operations ExpeditionList actually invokes today (i.e. the equivalent of the `PrintPickingList` operation currently consumed via the Logistics-owned interface).
+
+**Acceptance criteria:**
+- New file `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/IPickingListSource.cs` exists in the ExpeditionList namespace (e.g. `Anela.Heblo.Application.Features.ExpeditionList.Contracts`).
+- The interface declares only the methods/operations that `ExpeditionListService` and `PrintPickingListJob` use today; no unused members are copied over.
+- No `using Anela.Heblo.Application.Features.Logistics...` appears in the new contract file.
+
+### FR-2: ExpeditionList owns request/result DTOs
+Introduce ExpeditionList-owned request and result types (`ExpeditionPickingRequest`, `ExpeditionPickingResult`) under `backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/` that contain **only the fields ExpeditionList reads or writes** — no speculative parity with the Logistics-side types.
+
+**Acceptance criteria:**
+- `ExpeditionPickingRequest` and `ExpeditionPickingResult` are defined in the ExpeditionList contracts namespace.
+- Each field on these DTOs traces to actual consumption in `ExpeditionListService` or `PrintPickingListJob` (or to data ExpeditionList passes into the picking operation).
+- Naming uses the `Expedition*` prefix to signal ownership by ExpeditionList (per the brief's suggestion).
+- Types are classes, not C# records (per project DTO rule).
+
+### FR-3: ExpeditionListService and PrintPickingListJob use only ExpeditionList-owned types
+Replace all `Anela.Heblo.Application.Features.Logistics.Picking` references in `ExpeditionListService.cs` and `PrintPickingListJob.cs` with the ExpeditionList-owned interface and DTOs.
+
+**Acceptance criteria:**
+- `grep -r "Anela.Heblo.Application.Features.Logistics" backend/src/Anela.Heblo.Application/Features/ExpeditionList/` returns zero matches.
+- ExpeditionList still produces the same observable behavior (same picking print is triggered with the same effective input).
+- Existing unit/integration tests for ExpeditionList pass without behavioral change.
+
+### FR-4: Logistics provides an adapter for the ExpeditionList contract
+Add `LogisticsExpeditionListSourceAdapter` (or similarly named) inside the Logistics module that implements the ExpeditionList-owned `IPickingListSource` and delegates to the existing Logistics picking implementation. The adapter is the only place where the two type families meet.
+
+**Acceptance criteria:**
+- Adapter lives under `backend/src/Anela.Heblo.Application/Features/Logistics/` (Logistics owns the adapter).
+- Adapter implements the ExpeditionList-owned interface and translates between `ExpeditionPicking*` DTOs and the existing Logistics-internal types.
+- No ExpeditionList code references the adapter type directly; it is consumed only via the interface.
+
+### FR-5: Provider-side DI registration
+Register the binding `IPickingListSource (ExpeditionList) → LogisticsExpeditionListSourceAdapter` inside `LogisticsModule` (the provider registers the binding, consistent with the project's inversion pattern).
+
+**Acceptance criteria:**
+- DI registration appears in the Logistics module composition (`LogisticsModule` or its equivalent registration class), not in ExpeditionList.
+- Application starts and resolves `IPickingListSource` for ExpeditionList without runtime errors.
+- A simple resolution smoke test (existing app startup or a targeted test) confirms the binding.
+
+### FR-6: Architecture test enforces the new boundary
+Add a `ModuleBoundaryRule` in `backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs` for `ExpeditionList → Logistics` with an empty allowlist, mirroring the style of the existing `ExpeditionListArchive → ExpeditionList` rule at line 327.
+
+**Acceptance criteria:**
+- New rule exists in `ModuleBoundariesTests.cs`.
+- Allowlist is empty (no exceptions permitted).
+- Test passes after the refactor; test would fail if any `Anela.Heblo.Application.Features.ExpeditionList` source file imported `Anela.Heblo.Application.Features.Logistics.*`.
+- A deliberate temporary re-introduction of a Logistics import in ExpeditionList during local validation causes the test to fail (verifies the rule is active, not vacuously passing).
+
+### FR-7: Behavior parity
+The end-to-end picking-print flow triggered from ExpeditionList must behave identically after the refactor — same documents printed, same side effects, same error handling.
+
+**Acceptance criteria:**
+- All existing ExpeditionList tests pass unchanged.
+- The Hangfire job `PrintPickingListJob` enqueues and executes with equivalent payload and outcomes.
+- No new logged errors or warnings at startup or during the print flow under normal operation.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+The adapter is a thin translation layer. Translation overhead per call must be negligible (sub-millisecond on typical payloads) and must not introduce additional I/O, allocations on hot paths beyond DTO construction, or extra round-trips.
+
+### NFR-2: Security
+No change to security posture. The adapter must not loosen access, expose additional fields beyond what ExpeditionList already had access to, or bypass any authorization that the original Logistics types enforced.
+
+### NFR-3: Maintainability
+- No duplication beyond what the inversion requires: only fields ExpeditionList actually uses appear in its DTOs.
+- The adapter is the single translation point — no scattered conversion logic elsewhere.
+- File sizes stay within project norms (interface and DTO files small and focused, per `coding-standards`).
+
+### NFR-4: Testability
+- ExpeditionList unit tests can mock the ExpeditionList-owned `IPickingListSource` without referencing any Logistics type.
+- The architecture test runs in the standard backend test suite (`dotnet test`) with no special setup.
+
+### NFR-5: Backwards compatibility
+Internal-only refactor. No public API, persisted data, or external contract changes. No migration required.
+
+## Data Model
+No persistent data model changes.
+
+New in-process contract types (ExpeditionList-owned, under `Anela.Heblo.Application.Features.ExpeditionList.Contracts`):
+
+- `IPickingListSource` — interface exposing only the operation ExpeditionList consumes today.
+- `ExpeditionPickingRequest` — class DTO with only the fields ExpeditionList provides as input.
+- `ExpeditionPickingResult` — class DTO with only the fields ExpeditionList reads from the result.
+
+Existing Logistics-side types (`IPickingListSource`, `PrintPickingListRequest`, `PrintPickingListResult` under `Anela.Heblo.Application.Features.Logistics.Picking`) remain in place and continue to serve Logistics-internal consumers. The Logistics-side `IPickingListSource` is unaffected by this change unless analysis during implementation reveals ExpeditionList was its only external consumer (see Open Questions).
+
+## API / Interface Design
+No HTTP endpoint, MediatR contract, or UI change.
+
+Internal interfaces:
+
+```
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface IPickingListSource
+{
+    Task<ExpeditionPickingResult> PrintPickingListAsync(
+        ExpeditionPickingRequest request,
+        CancellationToken cancellationToken);
+}
+```
+
+(Exact method signature derived from current consumption in `ExpeditionListService.cs` and `PrintPickingListJob.cs`; the implementation must inspect actual call sites and mirror them.)
+
+Adapter (Logistics-side):
+
+```
+namespace Anela.Heblo.Application.Features.Logistics; // or appropriate Logistics namespace
+
+internal sealed class LogisticsExpeditionListSourceAdapter
+    : ExpeditionList.Contracts.IPickingListSource
+{
+    // delegates to existing Logistics picking implementation
+    // translates ExpeditionPicking* <-> Logistics PrintPickingList* types
+}
+```
+
+DI registration is performed in `LogisticsModule` (provider side).
+
+## Dependencies
+- Existing Logistics picking implementation (no change required to its public surface).
+- `Anela.Heblo.Tests.Architecture.ModuleBoundariesTests` infrastructure (already present, used in identical fashion at line 327).
+- DI container used by `LogisticsModule`.
+
+No new NuGet packages, external services, or infrastructure.
+
+## Out of Scope
+- Refactoring or renaming the Logistics-internal `IPickingListSource`, `PrintPickingListRequest`, `PrintPickingListResult`.
+- Auditing or fixing other (unrelated) module boundary violations.
+- Introducing inversions for any other ExpeditionList ↔ external-module crossings not named in the brief.
+- Changes to ExpeditionListArchive (separate module, governed by its own existing boundary rule).
+- UI, API surface, or persistence schema changes.
+- Adding new picking-related functionality.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-expeditionlist-direct-depend/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-direct-depend/task-plan.r1.md
@@ -1,0 +1,7 @@
+Plan saved to `artifacts/feat-arch-review-expeditionlist-direct-depend/plan.r1.md`.
+
+**Summary:**
+- 10 sequential tasks, TDD-driven for the adapter (Task 2 RED → Task 3 GREEN), with the production refactor split into surgical migrations per file (Tasks 5–7).
+- Task 9 includes a non-vacuous-rule verification step (deliberate violation must fail) to satisfy FR-6's "verifies the rule is active" acceptance criterion.
+- Full acceptance cross-check table at the end maps every spec FR/NFR and every arch-review amendment to a specific task/step.
+- Follows Option B from the arch review: adapter in `Features/Logistics/Infrastructure/`, DI in `LogisticsModule`, Logistics-namespaced types left untouched per spec Out-of-Scope; Shoptet binding unchanged.

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingRequest.cs
@@ -1,0 +1,23 @@
+using Anela.Heblo.Domain.Features.Logistics;
+
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public class ExpeditionPickingRequest
+{
+    public const int DefaultSourceStateId = -2;
+    public const int DefaultDesiredStateId = 26;
+
+    public IList<Carriers> Carriers { get; set; } = new List<Carriers>();
+    public int SourceStateId { get; set; } = DefaultSourceStateId;
+    public int DesiredStateId { get; set; } = DefaultDesiredStateId;
+    public bool ChangeOrderState { get; set; }
+    public bool SendToPrinter { get; set; }
+
+    public static IList<Carriers> DefaultCarriers { get; } = new List<Carriers>
+    {
+        Anela.Heblo.Domain.Features.Logistics.Carriers.Zasilkovna,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.GLS,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.PPL,
+        Anela.Heblo.Domain.Features.Logistics.Carriers.Osobak,
+    };
+}

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingResult.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/ExpeditionPickingResult.cs
@@ -1,0 +1,7 @@
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public class ExpeditionPickingResult
+{
+    public IList<string> ExportedFiles { get; set; } = new List<string>();
+    public int TotalCount { get; set; }
+}

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/IExpeditionPickingSource.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Contracts/IExpeditionPickingSource.cs
@@ -1,0 +1,9 @@
+namespace Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+
+public interface IExpeditionPickingSource
+{
+    Task<ExpeditionPickingResult> CreatePickingListAsync(
+        ExpeditionPickingRequest request,
+        Func<IList<string>, Task>? onBatchFilesReady,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Infrastructure/Jobs/PrintPickingListJob.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Infrastructure/Jobs/PrintPickingListJob.cs
@@ -1,6 +1,6 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
 using Anela.Heblo.Domain.Features.BackgroundJobs;
-using Anela.Heblo.Application.Features.Logistics.Picking;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -46,9 +46,9 @@ public class PrintPickingListJob : IRecurringJob
 
         try
         {
-            var request = new PrintPickingListRequest
+            var request = new ExpeditionPickingRequest
             {
-                Carriers = PrintPickingListRequest.DefaultCarriers,
+                Carriers = ExpeditionPickingRequest.DefaultCarriers,
                 SourceStateId = _options.Value.SourceStateId,
                 DesiredStateId = _options.Value.DesiredStateId,
                 ChangeOrderState = _options.Value.ChangeOrderStateByDefault,

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/ExpeditionListService.cs
@@ -1,4 +1,4 @@
-using Anela.Heblo.Application.Features.Logistics.Picking;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Xcc.Services.Email;
 using Anela.Heblo.Application.Shared.Printing;
 using Microsoft.Extensions.Logging;
@@ -8,7 +8,7 @@ namespace Anela.Heblo.Application.Features.ExpeditionList.Services;
 
 public class ExpeditionListService : IExpeditionListService
 {
-    private readonly IPickingListSource _pickingListSource;
+    private readonly IExpeditionPickingSource _pickingSource;
     private readonly IEmailSender _emailSender;
     private readonly TimeProvider _clock;
     private readonly IOptions<PrintPickingListOptions> _options;
@@ -16,14 +16,14 @@ public class ExpeditionListService : IExpeditionListService
     private readonly ILogger<ExpeditionListService> _logger;
 
     public ExpeditionListService(
-        IPickingListSource pickingListSource,
+        IExpeditionPickingSource pickingSource,
         IEmailSender emailSender,
         TimeProvider clock,
         IOptions<PrintPickingListOptions> options,
         IPrintQueueSink printQueueSink,
         ILogger<ExpeditionListService> logger)
     {
-        _pickingListSource = pickingListSource;
+        _pickingSource = pickingSource;
         _emailSender = emailSender;
         _clock = clock;
         _options = options;
@@ -31,16 +31,13 @@ public class ExpeditionListService : IExpeditionListService
         _logger = logger;
     }
 
-    public async Task<PrintPickingListResult> PrintPickingListAsync(
-        PrintPickingListRequest request,
+    public async Task<ExpeditionPickingResult> PrintPickingListAsync(
+        ExpeditionPickingRequest request,
         IList<string>? emailList = null,
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Generating new expedition list");
 
-        // Build a per-batch callback that handles upload/email/printer for each printed batch.
-        // State change in Shoptet happens inside CreatePickingList only after this callback succeeds,
-        // ensuring orders are never moved to the new state when a downstream action fails.
         Func<IList<string>, Task>? batchCallback = null;
 
         if (request.SendToPrinter || (emailList != null && emailList.Any()))
@@ -61,7 +58,7 @@ public class ExpeditionListService : IExpeditionListService
             };
         }
 
-        var result = await _pickingListSource.CreatePickingList(request, batchCallback, cancellationToken);
+        var result = await _pickingSource.CreatePickingListAsync(request, batchCallback, cancellationToken);
 
         _logger.LogDebug("Expedition list complete — {Total} orders processed", result.TotalCount);
 
@@ -70,7 +67,7 @@ public class ExpeditionListService : IExpeditionListService
         return result;
     }
 
-    private Task Cleanup(PrintPickingListResult result)
+    private Task Cleanup(ExpeditionPickingResult result)
     {
         foreach (var f in result.ExportedFiles)
         {

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/IExpeditionListService.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/Services/IExpeditionListService.cs
@@ -1,11 +1,11 @@
-using Anela.Heblo.Application.Features.Logistics.Picking;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 
 namespace Anela.Heblo.Application.Features.ExpeditionList.Services;
 
 public interface IExpeditionListService
 {
-    Task<PrintPickingListResult> PrintPickingListAsync(
-        PrintPickingListRequest request,
+    Task<ExpeditionPickingResult> PrintPickingListAsync(
+        ExpeditionPickingRequest request,
         IList<string>? emailList = null,
         CancellationToken cancellationToken = default);
 }

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionList/UseCases/RunExpeditionListPrintFix/RunExpeditionListPrintFixHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionList/UseCases/RunExpeditionListPrintFix/RunExpeditionListPrintFixHandler.cs
@@ -1,5 +1,5 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
-using Anela.Heblo.Application.Features.Logistics.Picking;
 using MediatR;
 using Microsoft.Extensions.Options;
 
@@ -22,9 +22,9 @@ public class RunExpeditionListPrintFixHandler : IRequestHandler<RunExpeditionLis
         RunExpeditionListPrintFixRequest request,
         CancellationToken cancellationToken)
     {
-        var printRequest = new PrintPickingListRequest
+        var printRequest = new ExpeditionPickingRequest
         {
-            Carriers = PrintPickingListRequest.DefaultCarriers,
+            Carriers = ExpeditionPickingRequest.DefaultCarriers,
             SourceStateId = _options.Value.FixSourceStateId,
             DesiredStateId = _options.Value.DesiredStateId,
             ChangeOrderState = _options.Value.ChangeOrderStateByDefault,

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs
@@ -1,0 +1,38 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Picking;
+
+namespace Anela.Heblo.Application.Features.Logistics.Infrastructure;
+
+// Bridge adapter: implements ExpeditionList's consumer-owned IExpeditionPickingSource
+// and delegates to the Logistics-namespaced IPickingListSource (bound to
+// ShoptetApiExpeditionListSource by AddShoptetApiAdapter).
+internal sealed class LogisticsExpeditionPickingAdapter : IExpeditionPickingSource
+{
+    private readonly IPickingListSource _inner;
+
+    public LogisticsExpeditionPickingAdapter(IPickingListSource inner) =>
+        _inner = inner;
+
+    public async Task<ExpeditionPickingResult> CreatePickingListAsync(
+        ExpeditionPickingRequest request,
+        Func<IList<string>, Task>? onBatchFilesReady,
+        CancellationToken cancellationToken = default)
+    {
+        var innerRequest = new PrintPickingListRequest
+        {
+            Carriers = request.Carriers,
+            SourceStateId = request.SourceStateId,
+            DesiredStateId = request.DesiredStateId,
+            ChangeOrderState = request.ChangeOrderState,
+            SendToPrinter = request.SendToPrinter,
+        };
+
+        var inner = await _inner.CreatePickingList(innerRequest, onBatchFilesReady, cancellationToken);
+
+        return new ExpeditionPickingResult
+        {
+            ExportedFiles = inner.ExportedFiles,
+            TotalCount = inner.TotalCount,
+        };
+    }
+}

--- a/backend/src/Anela.Heblo.Application/Features/Logistics/LogisticsModule.cs
+++ b/backend/src/Anela.Heblo.Application/Features/Logistics/LogisticsModule.cs
@@ -31,6 +31,14 @@ public static class LogisticsModule
         // DI registration is owned by the provider (Logistics), not the consumer (Catalog).
         services.AddScoped<ICatalogTransportSource, LogisticsCatalogTransportSourceAdapter>();
 
+        // Cross-module contract: Logistics provides ExpeditionList's IExpeditionPickingSource via adapter.
+        // The adapter delegates to the Logistics-namespaced IPickingListSource (bound to
+        // ShoptetApiExpeditionListSource by AddShoptetApiAdapter). DI registration is owned by
+        // the provider (Logistics), not the consumer (ExpeditionList).
+        services.AddScoped<
+            ExpeditionList.Contracts.IExpeditionPickingSource,
+            Infrastructure.LogisticsExpeditionPickingAdapter>();
+
         // Register dashboard tiles
         services.RegisterTile<InTransitBoxesTile>();
         services.RegisterTile<ReceivedBoxesTile>();

--- a/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Architecture/ModuleBoundariesTests.cs
@@ -255,6 +255,16 @@ public class ModuleBoundariesTests
         "Anela.Heblo.Application.Features.Manufacture.UseCases.SubmitManufactureStockTaking.SubmitManufactureStockTakingHandler+<Handle>d__4 -> Anela.Heblo.Domain.Features.Catalog.Stock.StockTakingRecord",
     };
 
+    // Allowlist for ExpeditionList -> Logistics.
+    // Carriers is a Domain enum (Zasilkovna/GLS/PPL/Osobak) consumed widely across the codebase.
+    // Duplicating it into ExpeditionList would create a synchronization burden far worse than
+    // the dependency it removes. The single entry below is the only Logistics-namespaced type
+    // ExpeditionList intentionally references, and it appears solely on ExpeditionPickingRequest.
+    private static readonly HashSet<string> ExpeditionListLogisticsAllowlist = new(StringComparer.Ordinal)
+    {
+        "Anela.Heblo.Application.Features.ExpeditionList.Contracts.ExpeditionPickingRequest -> Anela.Heblo.Domain.Features.Logistics.Carriers",
+    };
+
     public static TheoryData<ModuleBoundaryRule> Rules() => new()
     {
         new ModuleBoundaryRule(
@@ -422,6 +432,17 @@ public class ModuleBoundariesTests
                 "Anela.Heblo.Persistence.Catalog",
             },
             Allowlist: ManufactureCatalogAllowlist),
+
+        new ModuleBoundaryRule(
+            Name: "ExpeditionList -> Logistics",
+            InspectedNamespacePrefix: "Anela.Heblo.Application.Features.ExpeditionList",
+            ForbiddenNamespacePrefixes: new[]
+            {
+                "Anela.Heblo.Domain.Features.Logistics",
+                "Anela.Heblo.Application.Features.Logistics",
+                "Anela.Heblo.Persistence.Logistics",
+            },
+            Allowlist: ExpeditionListLogisticsAllowlist),
     };
 
     [Theory]

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServiceOrderStateTests.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
 using Anela.Heblo.Application.Shared.Printing;
-using Anela.Heblo.Application.Features.Logistics.Picking;
 using Anela.Heblo.Xcc.Services.Email;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -12,51 +12,45 @@ namespace Anela.Heblo.Tests.Features.ExpeditionList;
 
 public class ExpeditionListServiceOrderStateTests
 {
-    private readonly Mock<IPickingListSource> _pickingListSource = new();
+    private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
     private readonly Mock<IEmailSender> _emailSender = new();
     private readonly Mock<IPrintQueueSink> _printQueueSink = new();
 
     private ExpeditionListService CreateService() => new ExpeditionListService(
-        _pickingListSource.Object,
+        _pickingSource.Object,
         _emailSender.Object,
         TimeProvider.System,
         Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
         _printQueueSink.Object,
         NullLogger<ExpeditionListService>.Instance);
 
-    /// <summary>
-    /// Sets up the source mock to invoke the callback with the given files, simulating
-    /// per-batch processing inside PrintPickingListScenario.
-    /// </summary>
     private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
     {
-        _pickingListSource
-            .Setup(x => x.CreatePickingList(
-                It.IsAny<PrintPickingListRequest>(),
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
                 It.IsAny<Func<IList<string>, Task>>(),
                 It.IsAny<CancellationToken>()))
             .Returns(
-                async (PrintPickingListRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                async (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
                 {
                     if (cb != null)
                         await cb(filesToPassToCallback);
-                    return new PrintPickingListResult { ExportedFiles = new List<string>(), TotalCount = 1 };
+                    return new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 };
                 });
     }
 
     [Fact]
     public async Task PrintPickingListAsync_WhenEmailThrows_ExceptionPropagates()
     {
-        // Arrange — callback invokes email, email throws
         SetupSourceInvokingCallback(new List<string>());
         _emailSender
             .Setup(x => x.SendEmailAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("SMTP failure"));
 
-        var request = new PrintPickingListRequest { ChangeOrderState = true, SendToPrinter = false };
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = false };
         var svc = CreateService();
 
-        // Act & Assert — the exception must NOT be silently swallowed
         await Assert.ThrowsAsync<Exception>(() =>
             svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" }));
     }
@@ -64,23 +58,20 @@ public class ExpeditionListServiceOrderStateTests
     [Fact]
     public async Task PrintPickingListAsync_WhenPrinterThrows_ExceptionPropagates()
     {
-        // Arrange — callback invokes printer, printer throws
         SetupSourceInvokingCallback(new List<string>());
         _printQueueSink
             .Setup(x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Print queue failure"));
 
-        var request = new PrintPickingListRequest { ChangeOrderState = true, SendToPrinter = true };
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = true };
         var svc = CreateService();
 
-        // Act & Assert
         await Assert.ThrowsAsync<Exception>(() => svc.PrintPickingListAsync(request));
     }
 
     [Fact]
     public async Task PrintPickingListAsync_WhenAllSucceed_PrinterCalledBeforeEmail()
     {
-        // Arrange
         var callOrder = new List<string>();
         SetupSourceInvokingCallback(new List<string>());
 
@@ -94,64 +85,56 @@ public class ExpeditionListServiceOrderStateTests
             .Callback(() => callOrder.Add("email"))
             .Returns(Task.CompletedTask);
 
-        var request = new PrintPickingListRequest { ChangeOrderState = true, SendToPrinter = true };
+        var request = new ExpeditionPickingRequest { ChangeOrderState = true, SendToPrinter = true };
         var svc = CreateService();
 
-        // Act
         await svc.PrintPickingListAsync(request, emailList: new[] { "user@example.com" });
 
-        // Assert
         Assert.Equal(new[] { "printer", "email" }, callOrder);
     }
 
     [Fact]
     public async Task PrintPickingListAsync_WhenNeitherPrinterNorEmail_NullCallbackPassedToSource()
     {
-        // Arrange
         Func<IList<string>, Task>? capturedCallback = null;
-        _pickingListSource
-            .Setup(x => x.CreatePickingList(
-                It.IsAny<PrintPickingListRequest>(),
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
                 It.IsAny<Func<IList<string>, Task>>(),
                 It.IsAny<CancellationToken>()))
             .Callback(
-                (PrintPickingListRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
                     capturedCallback = cb)
-            .ReturnsAsync(new PrintPickingListResult { ExportedFiles = new List<string>() });
+            .ReturnsAsync(new ExpeditionPickingResult { ExportedFiles = new List<string>() });
 
-        var request = new PrintPickingListRequest { SendToPrinter = false };
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
         var svc = CreateService();
 
-        // Act
         await svc.PrintPickingListAsync(request, emailList: null);
 
-        // Assert — no callback built when there's nothing to do per batch
         Assert.Null(capturedCallback);
     }
 
     [Fact]
     public async Task PrintPickingListAsync_CleanupRunsAfterSuccess()
     {
-        // Arrange — real temp file so cleanup can verify deletion
         var tmpFile = Path.GetTempFileName();
-        _pickingListSource
-            .Setup(x => x.CreatePickingList(
-                It.IsAny<PrintPickingListRequest>(),
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
                 It.IsAny<Func<IList<string>, Task>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PrintPickingListResult
+            .ReturnsAsync(new ExpeditionPickingResult
             {
                 ExportedFiles = new[] { tmpFile },
                 TotalCount = 1,
             });
 
-        var request = new PrintPickingListRequest { SendToPrinter = false };
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
         var svc = CreateService();
 
-        // Act
         await svc.PrintPickingListAsync(request);
 
-        // Assert
         Assert.False(File.Exists(tmpFile));
     }
 }

--- a/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/ExpeditionList/ExpeditionListServicePrintSinkTests.cs
@@ -1,7 +1,7 @@
 using Anela.Heblo.Application.Features.ExpeditionList;
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
 using Anela.Heblo.Application.Features.ExpeditionList.Services;
 using Anela.Heblo.Application.Shared.Printing;
-using Anela.Heblo.Application.Features.Logistics.Picking;
 using Anela.Heblo.Xcc.Services.Email;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -12,12 +12,12 @@ namespace Anela.Heblo.Tests.Features.ExpeditionList;
 
 public class ExpeditionListServicePrintSinkTests
 {
-    private readonly Mock<IPickingListSource> _pickingListSource = new();
+    private readonly Mock<IExpeditionPickingSource> _pickingSource = new();
     private readonly Mock<IEmailSender> _emailSender = new();
     private readonly Mock<IPrintQueueSink> _printQueueSink = new();
 
     private ExpeditionListService CreateService() => new ExpeditionListService(
-        _pickingListSource.Object,
+        _pickingSource.Object,
         _emailSender.Object,
         TimeProvider.System,
         Options.Create(new PrintPickingListOptions { EmailSender = "test@test.com" }),
@@ -26,34 +26,31 @@ public class ExpeditionListServicePrintSinkTests
 
     private void SetupSourceInvokingCallback(IList<string> filesToPassToCallback)
     {
-        _pickingListSource
-            .Setup(x => x.CreatePickingList(
-                It.IsAny<PrintPickingListRequest>(),
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
                 It.IsAny<Func<IList<string>, Task>>(),
                 It.IsAny<CancellationToken>()))
             .Returns(
-                async (PrintPickingListRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
+                async (ExpeditionPickingRequest req, Func<IList<string>, Task>? cb, CancellationToken ct) =>
                 {
                     if (cb != null)
                         await cb(filesToPassToCallback);
-                    return new PrintPickingListResult { ExportedFiles = new List<string>(), TotalCount = 1 };
+                    return new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 };
                 });
     }
 
     [Fact]
     public async Task PrintPickingListAsync_SendToPrinterTrue_CallsSink()
     {
-        // Arrange
         var batchFiles = new List<string>();
         SetupSourceInvokingCallback(batchFiles);
 
-        var request = new PrintPickingListRequest { SendToPrinter = true };
+        var request = new ExpeditionPickingRequest { SendToPrinter = true };
         var svc = CreateService();
 
-        // Act
         await svc.PrintPickingListAsync(request);
 
-        // Assert
         _printQueueSink.Verify(
             x => x.SendAsync(batchFiles, It.IsAny<CancellationToken>()),
             Times.Once);
@@ -62,21 +59,18 @@ public class ExpeditionListServicePrintSinkTests
     [Fact]
     public async Task PrintPickingListAsync_SendToPrinterFalse_DoesNotCallSink()
     {
-        // Arrange
-        _pickingListSource
-            .Setup(x => x.CreatePickingList(
-                It.IsAny<PrintPickingListRequest>(),
+        _pickingSource
+            .Setup(x => x.CreatePickingListAsync(
+                It.IsAny<ExpeditionPickingRequest>(),
                 It.IsAny<Func<IList<string>, Task>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PrintPickingListResult { ExportedFiles = new List<string>(), TotalCount = 1 });
+            .ReturnsAsync(new ExpeditionPickingResult { ExportedFiles = new List<string>(), TotalCount = 1 });
 
-        var request = new PrintPickingListRequest { SendToPrinter = false };
+        var request = new ExpeditionPickingRequest { SendToPrinter = false };
         var svc = CreateService();
 
-        // Act
         await svc.PrintPickingListAsync(request);
 
-        // Assert
         _printQueueSink.Verify(
             x => x.SendAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
             Times.Never);

--- a/backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs
+++ b/backend/test/Anela.Heblo.Tests/Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapterTests.cs
@@ -1,0 +1,126 @@
+using Anela.Heblo.Application.Features.ExpeditionList.Contracts;
+using Anela.Heblo.Application.Features.Logistics.Infrastructure;
+using Anela.Heblo.Application.Features.Logistics.Picking;
+using Anela.Heblo.Domain.Features.Logistics;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Anela.Heblo.Tests.Features.Logistics.Infrastructure;
+
+public class LogisticsExpeditionPickingAdapterTests
+{
+    private readonly Mock<IPickingListSource> _innerSource = new();
+
+    private LogisticsExpeditionPickingAdapter CreateAdapter() =>
+        new LogisticsExpeditionPickingAdapter(_innerSource.Object);
+
+    [Fact]
+    public async Task CreatePickingListAsync_TranslatesRequestFieldsOneToOne()
+    {
+        // Arrange
+        PrintPickingListRequest? captured = null;
+        _innerSource
+            .Setup(x => x.CreatePickingList(
+                It.IsAny<PrintPickingListRequest>(),
+                It.IsAny<Func<IList<string>, Task>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((PrintPickingListRequest req, Func<IList<string>, Task>? _, CancellationToken __) => captured = req)
+            .ReturnsAsync(new PrintPickingListResult());
+
+        var request = new ExpeditionPickingRequest
+        {
+            Carriers = new List<Carriers> { Carriers.GLS, Carriers.PPL },
+            SourceStateId = 7,
+            DesiredStateId = 42,
+            ChangeOrderState = true,
+            SendToPrinter = true,
+        };
+
+        // Act
+        await CreateAdapter().CreatePickingListAsync(request, onBatchFilesReady: null);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.Carriers.Should().BeEquivalentTo(new[] { Carriers.GLS, Carriers.PPL });
+        captured.SourceStateId.Should().Be(7);
+        captured.DesiredStateId.Should().Be(42);
+        captured.ChangeOrderState.Should().BeTrue();
+        captured.SendToPrinter.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreatePickingListAsync_TranslatesResultFields()
+    {
+        // Arrange
+        var innerResult = new PrintPickingListResult
+        {
+            ExportedFiles = new List<string> { "/tmp/a.pdf", "/tmp/b.pdf" },
+            TotalCount = 12,
+            OrderIds = new List<int> { 1, 2, 3 },
+        };
+        _innerSource
+            .Setup(x => x.CreatePickingList(
+                It.IsAny<PrintPickingListRequest>(),
+                It.IsAny<Func<IList<string>, Task>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(innerResult);
+
+        // Act
+        var result = await CreateAdapter().CreatePickingListAsync(
+            new ExpeditionPickingRequest(), onBatchFilesReady: null);
+
+        // Assert
+        result.ExportedFiles.Should().BeEquivalentTo(new[] { "/tmp/a.pdf", "/tmp/b.pdf" });
+        result.TotalCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task CreatePickingListAsync_PassesCallbackThroughVerbatim()
+    {
+        // Arrange
+        Func<IList<string>, Task>? forwarded = null;
+        _innerSource
+            .Setup(x => x.CreatePickingList(
+                It.IsAny<PrintPickingListRequest>(),
+                It.IsAny<Func<IList<string>, Task>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((PrintPickingListRequest _, Func<IList<string>, Task>? cb, CancellationToken __) => forwarded = cb)
+            .ReturnsAsync(new PrintPickingListResult());
+
+        var invoked = 0;
+        Func<IList<string>, Task> outerCallback = _ => { invoked++; return Task.CompletedTask; };
+
+        // Act
+        await CreateAdapter().CreatePickingListAsync(
+            new ExpeditionPickingRequest(), outerCallback);
+
+        // Assert
+        forwarded.Should().BeSameAs(outerCallback);
+        await forwarded!(new List<string>());
+        invoked.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreatePickingListAsync_PassesCancellationTokenThrough()
+    {
+        // Arrange
+        CancellationToken captured = default;
+        _innerSource
+            .Setup(x => x.CreatePickingList(
+                It.IsAny<PrintPickingListRequest>(),
+                It.IsAny<Func<IList<string>, Task>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((PrintPickingListRequest _, Func<IList<string>, Task>? __, CancellationToken ct) => captured = ct)
+            .ReturnsAsync(new PrintPickingListResult());
+
+        using var cts = new CancellationTokenSource();
+
+        // Act
+        await CreateAdapter().CreatePickingListAsync(
+            new ExpeditionPickingRequest(), onBatchFilesReady: null, cts.Token);
+
+        // Assert
+        captured.Should().Be(cts.Token);
+    }
+}


### PR DESCRIPTION

Inverted the `ExpeditionList → Logistics.Picking` dependency so ExpeditionList owns its contract (`IExpeditionPickingSource`, `ExpeditionPickingRequest`, `ExpeditionPickingResult`) and Logistics provides a translating adapter (`LogisticsExpeditionPickingAdapter`). Added a CI-enforced architecture boundary test with a single justified allowlist entry for the `Carriers` domain enum.

The refactor follows the established consumer-owned-contract pattern already used for `ILeafletKnowledgeSource`, `ICatalogTransportSource`, and others. It removes the silent coupling that caused `ExpeditionList` to break whenever Logistics-side picking types were renamed or reshaped, and locks the inversion in so the violation cannot grow back.

### Changes
- `Features/ExpeditionList/Contracts/` — new `IExpeditionPickingSource`, `ExpeditionPickingRequest`, `ExpeditionPickingResult`
- `Features/Logistics/Infrastructure/LogisticsExpeditionPickingAdapter.cs` — new `internal sealed` adapter; DI registration in `LogisticsModule`
- `Features/ExpeditionList/Services/`, `Jobs/`, `UseCases/` — migrated off Logistics.Picking types (4 files)
- `Architecture/ModuleBoundariesTests.cs` — new `ExpeditionList → Logistics` rule enforced in CI

---

Closes #2499

### Tokens used
17165639
