### PR TITLE
feat: Eliminate `as any` Casts in `useExpeditionListArchive.ts` by Using Generated Typed Client

### DIFF
--- a/artifacts/feat-arch-review-expeditionlist-frontend-hook/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-frontend-hook/arch-review.r1.md
@@ -1,0 +1,217 @@
+Now I have enough context. Let me check the spec's scoping vs the page's handleOpen cast one more time, then produce the review.
+
+# Architecture Review: Eliminate `as any` Casts in `useExpeditionListArchive.ts`
+
+## Skip Design: true
+
+Pure type-safety refactor with no UI surface changes. Markup, copy, layout, and interaction in `ExpeditionListArchivePage.tsx` are unchanged.
+
+## Architectural Fit Assessment
+
+The proposed refactor aligns cleanly with three existing project conventions:
+
+1. **Canonical typed-client pattern** — `useArticles.ts:216–248` is the reference implementation: `getAuthenticatedApiClient()` → `new GeneratedRequest({...})` → typed method call → `try/catch { err.status }`. The spec's FR-3 mirrors this exactly.
+2. **Escape-hatch helpers** — `getApiBaseUrl()` (`client.ts:177`) and `getAuthenticatedFetch()` (`client.ts:419`) are the sanctioned public surface for URL construction and raw fetch. They already exist; FR-5 just consumes them.
+3. **Existing guardrail mechanism** — the project does **not** police this rule with ESLint; it polices it with the `MIGRATED_HOOKS` Set in `frontend/src/api/__tests__/authenticated-api-usage.test.ts:197`. FR-6 should extend this established pattern rather than introduce a parallel ESLint rule.
+
+The four typed methods (`expeditionListArchive_GetDates`, `_GetByDate`, `_Reprint`, `expeditionList_RunFix`) all delegate to `this.http.fetch(...)`, which is the same `authenticatedHttp` instance that the current `(apiClient as any).http.fetch` already reaches — so auth headers, 401 redirect, and global error toasts are preserved by construction (NFR-5 holds automatically).
+
+The fit is good, but the spec has three blind spots flagged below.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────┐
+│ ExpeditionListArchivePage.tsx        │
+│  • consumes 5 hook signatures        │
+│  • consumes local ItemDto type       │  ← signatures preserved → 0 page changes
+└────────────────┬─────────────────────┘
+                 │
+┌────────────────▼─────────────────────┐
+│ useExpeditionListArchive.ts          │
+│  • local interfaces (adapter layer)  │
+│  • 4 hooks call typed methods        │
+│  • 1 helper uses getApiBaseUrl()     │
+│  • queryFn maps Date→string,         │
+│    long?→number for consumer compat  │
+└────────────────┬─────────────────────┘
+                 │
+   ┌─────────────┴──────────────┐
+   │                            │
+┌──▼─────────────────┐  ┌──────▼──────────────┐
+│ generated/         │  │ client.ts            │
+│ ApiClient methods  │  │ getApiBaseUrl()      │
+│ (typed)            │  │ getAuthenticatedApi… │
+└──┬─────────────────┘  └──────┬──────────────┘
+   │                           │
+   │   .http.fetch ────────────▶ authenticatedHttp.fetch
+   │                              • auth header injection
+   │                              • 401 redirect
+   │                              • global toast on BaseResponse.success=false
+   └────────────────────────────▶ backend
+```
+
+### Key Design Decisions
+
+#### Decision 1: Use typed generated methods, not `getAuthenticatedFetch()`
+**Options considered:**
+- (A) Typed `client.expeditionListArchive_*` methods.
+- (B) `getApiBaseUrl()` + `getAuthenticatedFetch()` for everything.
+
+**Chosen approach:** (A) for the four RPC endpoints; (B) only for `getExpeditionListDownloadUrl` (it builds an `<a href>` URL, not a fetch).
+
+**Rationale:** Per `docs/development/api-client-generation.md:217–268`, the escape hatch exists for endpoints whose business outcomes require HTTP-status branching (e.g. 412 Precondition Failed not yet typed). None of these four endpoints branch on status — they all return `BaseResponse`-shaped success/failure envelopes. Typed methods are the documented default.
+
+#### Decision 2: Keep local response interfaces; map types inside `queryFn`
+**Options considered:**
+- (A) Re-export generated classes (spec's preferred option).
+- (B) Keep local interfaces; adapt inside the hook.
+
+**Chosen approach:** (B). The spec's claim "re-export from the generated client where structurally identical" is **incorrect** for `ExpeditionListItemDto`:
+
+| Field | Local (today) | Generated | Page consumer |
+|---|---|---|---|
+| `createdOn` | `string \| null` | `Date \| undefined` | `formatDateTime(iso: string \| null)` at `ExpeditionListArchivePage.tsx:26,253` |
+| `contentLength` | `number \| null` | `number \| undefined` | `formatFileSize(bytes: number \| null)` at `ExpeditionListArchivePage.tsx:19,256` |
+
+Backend declares `CreatedOn` as `DateTimeOffset?` (`backend/.../Contracts/ExpeditionListItemDto.cs:8`), which NSwag converts to `Date | undefined` via the `init()` method. The page's formatters were built around ISO strings and `null`-not-`undefined`. Re-exporting the generated class breaks `formatDateTime` and `formatFileSize` typing.
+
+**Rationale:** Keeping local interfaces preserves the consumer contract (zero page changes — required by NFR-1) and confines the Date↔string boundary to one place inside `queryFn`. The local interfaces become a thin DTO-mapping layer, not duplicate types.
+
+#### Decision 3: Reuse the generated `ReprintExpeditionListRequest` *class*, drop the local interface
+**Options considered:**
+- (A) Keep local interface and pass plain object literal.
+- (B) Drop local interface, import generated class, instantiate with `new`.
+
+**Chosen approach:** (B). The local interface (`useExpeditionListArchive.ts:25–27`) is consumed by the page only as `{ blobPath }` plain-object input to `mutateAsync`. Since the hook owns the mutation function signature, it can declare the input type as the generated class without breaking the call site (object-literal subtyping still works).
+
+**Rationale:** Spec FR-3 already requires `new ReprintExpeditionListRequest({ blobPath })`; keeping a parallel local interface adds noise. `useArticles.ts:222` is the canonical reference.
+
+#### Decision 4: Reuse existing test-based guardrail, do not add an ESLint rule
+**Options considered:**
+- (A) Add a new `no-restricted-syntax` rule in `.eslintrc.json` (FR-6 proposal).
+- (B) Add `"useExpeditionListArchive.ts"` to `MIGRATED_HOOKS` in `authenticated-api-usage.test.ts:197`.
+
+**Chosen approach:** (B). The project's existing convention is explicit at `authenticated-api-usage.test.ts:193`: *"This test guards against regressions in hooks that have already been migrated... Extend MIGRATED_HOOKS below as each hook is cleaned up."*
+
+**Rationale:** Two enforcement mechanisms create drift. The Jest test catches `(apiClient as any)`, `.http`, and `.baseUrl` access in plain text — exactly the same surface the proposed ESLint rule covers. Reusing it is one line of change and matches the documented workflow.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. All changes confined to:
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — rewrite the five exports.
+- `frontend/src/api/__tests__/authenticated-api-usage.test.ts` — add `"useExpeditionListArchive.ts"` to `MIGRATED_HOOKS` Set (line 197).
+- `frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx` — no functional change required (test mocks the hook module wholesale at line 8); fixture shapes already match the preserved local interfaces.
+- (Optional, per amendment A1 below) `frontend/src/pages/ExpeditionListArchivePage.tsx:64–78` — `handleOpen` cast.
+
+### Interfaces and Contracts
+
+**Keep exported (unchanged signatures, zero consumer churn):**
+```typescript
+export interface ExpeditionListItemDto {
+  blobPath: string;
+  fileName: string;
+  listId: string;
+  createdOn: string | null;
+  contentLength: number | null;
+}
+export interface GetExpeditionDatesResponse { dates: string[]; totalCount: number; page: number; pageSize: number; }
+export interface GetExpeditionListsByDateResponse { items: ExpeditionListItemDto[]; }
+export interface ReprintExpeditionListResponse { success: boolean; errorMessage: string | null; }
+```
+
+**Drop:** `ReprintExpeditionListRequest` interface — use the generated class as the mutation input type.
+
+**Import:**
+```typescript
+import {
+  ReprintExpeditionListRequest,
+  type ExpeditionListItemDto as GeneratedItemDto,
+  // ...etc. for any response classes needed for mapping
+} from "../generated/api-client";
+```
+
+### Data Flow
+
+**`useExpeditionDates(page, pageSize)`:**
+```
+queryFn → client.expeditionListArchive_GetDates(page, pageSize)
+       → returns class instance { dates?, totalCount?, page?, pageSize? }
+       → map to GetExpeditionDatesResponse: nullish-coalesce numbers (?? 0), default dates (?? [])
+       → return
+```
+
+**`useExpeditionListsByDate(date)`:**
+```
+queryFn → client.expeditionListArchive_GetByDate(date)   // encodes date internally
+       → returns { items?: GeneratedItemDto[] }
+       → map items: createdOn?.toISOString() ?? null, contentLength ?? null
+       → return GetExpeditionListsByDateResponse
+```
+
+**`useReprintExpeditionList`:**
+```
+mutationFn(input: { blobPath: string }) →
+  client.expeditionListArchive_Reprint(new ReprintExpeditionListRequest({ blobPath: input.blobPath }))
+  → on resolve: map { success: response.success ?? true, errorMessage: response.errorMessage ?? null }
+  → on reject (SwaggerException): rethrow — central toast at client.ts:312–360 already extracts errorMessage from BaseResponse
+onSuccess → queryClient.invalidateQueries({ queryKey: QUERY_KEYS.expeditionListArchive })
+```
+
+**`useRunExpeditionListPrintFix`:**
+```
+mutationFn() → client.expeditionList_RunFix()
+            → returns { totalCount?, errorMessage? }
+            → map to { totalCount: response.totalCount ?? 0, errorMessage: response.errorMessage ?? null }
+            → return — page reads result.totalCount at ExpeditionListArchivePage.tsx:98
+```
+
+**`getExpeditionListDownloadUrl(blobPath)`:**
+```
+return `${getApiBaseUrl()}/api/expedition-list-archive/download/${
+  blobPath.split("/").map(encodeURIComponent).join("/")
+}`;
+```
+No `getAuthenticatedApiClient()` call — instantiating the client just to read its base URL is wasted work.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Re-exporting generated types breaks page formatters (`Date` vs `string`, `undefined` vs `null`) | HIGH | Decision 2: keep local interfaces, map inside `queryFn`. Verified against `ExpeditionListArchivePage.tsx:26, 253, 256`. |
+| Double error toast: central handler fires on `!response.ok`, then hook re-throws and page shows `showError("Chyba tisku", msg)` | MEDIUM | Central toast already runs on `!response.ok` *today* via `authenticatedHttp.fetch`. Today's `(apiClient as any).http.fetch` path goes through the same code. So toast count is unchanged. Document this in PR for reviewer confidence. |
+| Generated class fields are optional (`?:`); destructuring `response.totalCount` yields `number \| undefined` and downstream code expects `number` | MEDIUM | All mapping uses `?? 0` / `?? null` / `?? []`. Page line 98 `result.totalCount` reads from mapped local interface, which is non-optional. |
+| `expeditionListArchive_Reprint` already throws on non-2xx via `throwException(...)` — error contract differs from today's `errorData?.errorMessage` extraction | LOW | NFR-1 ("network requests identical") still holds. User-visible toast may differ in wording (status-text vs `errorMessage`) — spec FR-3 explicitly allows this: "falling back to the generated client's standard `SwaggerException` handling is acceptable". |
+| Spec FR-6 introduces ESLint rule that overlaps with existing Jest guardrail | LOW | Decision 4: add to `MIGRATED_HOOKS` instead. |
+| **Sixth `(apiClient as any).http.fetch` exists in `ExpeditionListArchivePage.tsx:64–66`** (page-level `handleOpen`) — spec scopes only the hook file | HIGH (scope gap) | See Spec Amendments A1. |
+
+## Specification Amendments
+
+**A1 — Out-of-scope cast in `ExpeditionListArchivePage.tsx`.**
+`handleOpen` at lines 62–78 contains a sixth `(apiClient as any).http.fetch` use that the brief and spec both missed. It calls `getExpeditionListDownloadUrl(item.blobPath)` then fetches the URL as a blob. Two options — the spec must pick one explicitly:
+- **(Recommended)** Migrate it in the same change to `getAuthenticatedFetch()(url, { method: 'GET' })`. The URL is already absolute (from `getApiBaseUrl()`), so this is a one-line edit. Keeps the "no `(apiClient as any)` in this feature area" promise honest.
+- Carve it out explicitly with a sentence: "*The `handleOpen` cast in `ExpeditionListArchivePage.tsx:66` is out of scope and tracked separately.*"
+
+Otherwise the spec's NFR-2 ("zero `as any` casts") is misleading at the feature level.
+
+**A2 — Reframe FR-6 to extend the existing Jest guardrail.**
+Replace "Add an ESLint rule…" with:
+> Add `"useExpeditionListArchive.ts"` to the `MIGRATED_HOOKS` Set in `frontend/src/api/__tests__/authenticated-api-usage.test.ts:197`. Verify `npm test -- authenticated-api-usage` passes after refactor and fails if `(apiClient as any).http.fetch` is reintroduced in the file. No `.eslintrc.json` change required.
+
+**A3 — Correct the "structurally identical" claim under "Data Model".**
+Local `ExpeditionListItemDto` is **not** structurally compatible with the generated class (`createdOn: string | null` vs `Date | undefined`; `contentLength: number | null` vs `number | undefined`). Re-export is not safe; per Decision 2, the local interfaces stay as a hook-level adapter and the hook maps response shapes inside `queryFn`. Update the spec's "Decision: re-export from the generated client where structurally identical" to "Decision: keep local interfaces; map generated types inside `queryFn`."
+
+**A4 — Drop `ReprintExpeditionListRequest` from "Keep the locally-declared interfaces".**
+Per Decision 3, the request type comes from the generated client. This is the only spec-listed interface that should be removed.
+
+**A5 — Acceptance criterion for FR-5 wording.**
+Spec says "No reference to `getAuthenticatedApiClient()`." Add: "*Imports `getApiBaseUrl` from `../client` and uses only string concatenation — no client instantiation.*"
+
+## Prerequisites
+
+None. All required helpers (`getApiBaseUrl`, `getAuthenticatedFetch`, `getAuthenticatedApiClient`) already exist in `frontend/src/api/client.ts`. All required typed methods and DTO classes already exist in `frontend/src/api/generated/api-client.ts`. The existing guardrail test (`authenticated-api-usage.test.ts`) is in place and only needs a one-line `MIGRATED_HOOKS` addition. No backend changes, no OpenAPI regeneration, no migrations, no config.
+
+Implementation can start immediately.

--- a/artifacts/feat-arch-review-expeditionlist-frontend-hook/brief.md
+++ b/artifacts/feat-arch-review-expeditionlist-frontend-hook/brief.md
@@ -1,0 +1,37 @@
+## Module
+ExpeditionList
+
+## Finding
+All five query/mutation functions in `frontend/src/api/hooks/useExpeditionListArchive.ts` access internal implementation details of the generated API client by casting it to `any`:
+
+```typescript
+// lines 52, 82, 107, 135, 156 — accessing .baseUrl
+const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
+
+// lines 58–64, 84–87, 109–113, 137–150 — calling internal HTTP client
+const response = await (apiClient as any).http.fetch(fullUrl, { ... });
+```
+
+The `.http.fetch()` call bypasses the generated typed client entirely. The generated client wraps every endpoint with typed request/response shapes; calling `.http.fetch` directly means:
+- TypeScript has no type-checked request/response contract for these endpoints.
+- Any interceptor or middleware added to the generated client (e.g. auth token injection, retry logic) may or may not apply, depending on where in the client stack `.http` sits — this is opaque without reading the generator's output.
+- If the generated client's internal field is renamed (e.g. from `.http` to `.httpClient`), all five hooks break at runtime with no compile error.
+
+The `.baseUrl` cast is less severe — `docs/development/api-client-generation.md` and `CLAUDE.md` both describe the pattern `${apiClient.baseUrl}${relativeUrl}` — but `baseUrl` not being a public property forces the `as any` even for this sanctioned use.
+
+## Why it matters
+This is the only hook file in the codebase (that this review found) that uses `.http.fetch` directly. It represents a gap in API client generation coverage: these endpoints (`/dates`, `/{date}`, `/reprint`, `/run-fix`, `/download/{path}`) don't have generated typed methods, so someone hand-rolled HTTP calls against the raw client instead.
+
+The `as any` pattern erodes the type safety guarantee that the generated client exists to provide.
+
+## Suggested fix
+Two complementary steps:
+
+1. **Add the missing endpoints to the OpenAPI spec / generated client** so that `useExpeditionDates`, `useExpeditionListsByDate`, `useReprintExpeditionList`, and `useRunExpeditionListPrintFix` can call typed generated methods instead of `.http.fetch`. The `getExpeditionListDownloadUrl` helper can remain a manual URL helper since it just constructs a link, not an API call.
+
+2. **Expose `baseUrl` publicly on the generated client** (or via a helper exported from `client.ts`) so the sanctioned `${apiClient.baseUrl}${relativeUrl}` pattern doesn't require an `as any` cast. This unblocks both this file and any future hook that needs to construct an absolute URL.
+
+Until step 1 is done, the `as any` in `.http.fetch` should at minimum be replaced with a typed helper (`apiFetch(relativeUrl, init)`) that encapsulates the cast in one place rather than repeating it across every hook.
+
+---
+_Filed by daily arch-review routine on 2026-06-03._

--- a/artifacts/feat-arch-review-expeditionlist-frontend-hook/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-frontend-hook/impl/main.r1.md
@@ -1,0 +1,54 @@
+All 9 tasks complete. Here is the output summary:
+
+---
+
+# Implementation: Eliminate `as any` Casts in `useExpeditionListArchive.ts`
+
+## What was implemented
+
+Pure call-site migration replacing all 6 `(apiClient as any)` casts in the expedition list archive feature area with typed generated-client calls and public helpers. No backend changes, no OpenAPI regeneration, no new files (except a new test file).
+
+## Files created/modified
+
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — All 4 hooks migrated to typed methods (`expeditionListArchive_GetDates`, `expeditionListArchive_GetByDate`, `expeditionListArchive_Reprint`, `expeditionList_RunFix`). `getExpeditionListDownloadUrl` switched to `getApiBaseUrl()`. Local `ReprintExpeditionListRequest` interface dropped (replaced by generated class). New `RunExpeditionListPrintFixResult` interface added. `Date | undefined` → `string | null` DTO mapping in `useExpeditionListsByDate`.
+- `frontend/src/pages/ExpeditionListArchivePage.tsx` — `handleOpen` switched from `(apiClient as any).http.fetch` to `getAuthenticatedFetch()`. Import swapped from `getAuthenticatedApiClient` to `getAuthenticatedFetch`.
+- `frontend/src/api/__tests__/authenticated-api-usage.test.ts` — `"useExpeditionListArchive.ts"` added to `MIGRATED_HOOKS` Set (regression gate).
+- `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts` — New test file. Happy-path + edge-case tests for all 4 hooks: 7 tests total.
+- `frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx` — Mock updated to include `getAuthenticatedFetch: jest.fn(() => jest.fn())`.
+
+## Tests
+
+- `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts` — 7 tests covering `useExpeditionDates` (typed call + args), `useExpeditionListsByDate` (Date→string mapping, enabled guard), `useReprintExpeditionList` (instanceof check, error rethrow), `useRunExpeditionListPrintFix` (happy path, defaults).
+- `frontend/src/api/__tests__/authenticated-api-usage.test.ts` — Existing guardrail now enforces zero `(apiClient as any)` in the migrated file.
+- Full suite: **2,002 tests passing**, 248 suites.
+
+## How to verify
+
+```bash
+cd frontend
+npm run lint
+npm run build
+npm test -- --watchAll=false
+grep -nE "as any|\.http\.|\.baseUrl" src/api/hooks/useExpeditionListArchive.ts  # expect: no output
+grep -nE "\(apiClient as any\)" src/pages/ExpeditionListArchivePage.tsx           # expect: no output
+```
+
+## Notes
+
+- The arch-review's Decision 2 (keep local DTO interfaces, map inside `queryFn`) was followed — re-exporting generated types was not safe because `createdOn` is `Date | undefined` in the generated class vs. `string | null` expected by page consumers.
+- FR-6 (guardrail) was implemented via the existing `MIGRATED_HOOKS` Jest pattern (arch-review amendment A2) instead of a new ESLint rule.
+- The sixth cast in `ExpeditionListArchivePage.tsx:handleOpen` (arch-review amendment A1) was fixed in Task 7.
+
+## PR Summary
+
+Replaced all six `(apiClient as any)` casts across the expedition list archive feature area with typed generated-client calls and public helper functions. The hook file now calls `expeditionListArchive_GetDates`, `expeditionListArchive_GetByDate`, `expeditionListArchive_Reprint`, and `expeditionList_RunFix` directly on the typed client; `getExpeditionListDownloadUrl` uses `getApiBaseUrl()`; and `handleOpen` in the page component uses `getAuthenticatedFetch()`. All five hook signatures are preserved so `ExpeditionListArchivePage` needs no consumer-side changes. A new test file covers the four refactored hooks with 7 tests, and the existing `MIGRATED_HOOKS` Jest guardrail is extended to prevent future regressions.
+
+### Changes
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — four hooks migrated to typed client, download URL helper fixed, local request interface dropped
+- `frontend/src/pages/ExpeditionListArchivePage.tsx` — `handleOpen` cast removed, import swapped
+- `frontend/src/api/__tests__/authenticated-api-usage.test.ts` — MIGRATED_HOOKS extended
+- `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts` — new: 7 hook tests
+- `frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx` — mock updated for new import
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-expeditionlist-frontend-hook/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-frontend-hook/spec.r1.md
@@ -1,0 +1,141 @@
+# Specification: Eliminate `as any` Casts in `useExpeditionListArchive.ts` by Using Generated Typed Client
+
+## Summary
+Five hooks/helpers in `frontend/src/api/hooks/useExpeditionListArchive.ts` reach into private fields of the NSwag-generated `ApiClient` via `(apiClient as any).baseUrl` and `(apiClient as any).http.fetch`, bypassing the typed client entirely. Investigation shows the generated client already exposes typed methods for all four API calls (`expeditionListArchive_GetDates`, `expeditionListArchive_GetByDate`, `expeditionListArchive_Reprint`, `expeditionList_RunFix`), so this is a pure call-site migration — no backend or codegen changes are required. The remaining URL-construction helper (`getExpeditionListDownloadUrl`) will use the public `getApiBaseUrl()` helper.
+
+## Background
+`docs/development/api-client-generation.md` explicitly forbids `(apiClient as any).baseUrl` and `(apiClient as any).http.fetch`:
+
+> **❌ AVOID**: `(apiClient as any).baseUrl` and `(apiClient as any).http.fetch`
+> These reach into private fields of the NSwag-generated class. If NSwag renames those fields, the code breaks at runtime with no compile-time warning. Use `getApiBaseUrl()` and `getAuthenticatedFetch()` from `./client` instead.
+
+`useExpeditionListArchive.ts` is the only file in the codebase that still violates this rule (5 occurrences across `useExpeditionDates`, `useExpeditionListsByDate`, `useReprintExpeditionList`, `useRunExpeditionListPrintFix`, and `getExpeditionListDownloadUrl`). The arch-review routine flagged it on 2026-06-03 as a type-safety regression: there is no compile-time check that the bypassed endpoints match backend contracts, no guarantee that auth/error interceptors apply, and any rename of the generated client's internal `.http` field breaks all five call sites at runtime.
+
+Two relevant findings during scoping reduce the work to a pure refactor:
+
+1. The generated client (`frontend/src/api/generated/api-client.ts`) already contains typed methods for every backend endpoint these hooks call:
+   - `expeditionListArchive_GetDates(page, pageSize)` → `GetExpeditionDatesResponse`
+   - `expeditionListArchive_GetByDate(date)` → `GetExpeditionListsByDateResponse`
+   - `expeditionListArchive_Reprint(request)` → `ReprintExpeditionListResponse`
+   - `expeditionList_RunFix()` → `RunExpeditionListPrintFixResponse`
+   - `expeditionListArchive_Download(blobPath)` → `FileResponse`
+2. The public escape-hatch helpers `getApiBaseUrl()` and `getAuthenticatedFetch()` already exist in `frontend/src/api/client.ts`. The brief's "expose `baseUrl` publicly" suggestion is already satisfied — call sites simply need to use these helpers.
+
+The brief's premise that "these endpoints don't have generated typed methods" is incorrect; this assumption is corrected in the requirements below.
+
+## Functional Requirements
+
+### FR-1: Replace `useExpeditionDates` with typed client call
+Rewrite `useExpeditionDates(page, pageSize)` to call `getAuthenticatedApiClient().expeditionListArchive_GetDates(page, pageSize)`. Drop manual URL construction, `URLSearchParams` building, and the raw `fetch` call.
+
+**Acceptance criteria:**
+- The hook contains no `as any` cast.
+- The hook contains no string literal `"/api/expedition-list-archive/dates"`.
+- The hook calls `client.expeditionListArchive_GetDates(page, pageSize)`.
+- React Query `queryKey`, `staleTime`, and the `(page = 1, pageSize = 20)` defaults are preserved.
+- Return type remains assignable to existing `GetExpeditionDatesResponse` consumers (callers do not need code changes).
+- Loading the `ExpeditionListArchive` page in the running app fetches the same data as today and renders identically.
+
+### FR-2: Replace `useExpeditionListsByDate` with typed client call
+Rewrite `useExpeditionListsByDate(date)` to call `getAuthenticatedApiClient().expeditionListArchive_GetByDate(date)`.
+
+**Acceptance criteria:**
+- No `as any` cast in the hook.
+- No manual `encodeURIComponent` of the date — the generated client handles URL encoding.
+- `enabled: !!date` guard and `staleTime` preserved.
+- Return type assignable to existing `GetExpeditionListsByDateResponse` consumers.
+- Selecting a date in the UI loads the same items list as today.
+
+### FR-3: Replace `useReprintExpeditionList` with typed client call
+Rewrite the mutation to call `getAuthenticatedApiClient().expeditionListArchive_Reprint(new ReprintExpeditionListRequest({ blobPath }))`.
+
+**Acceptance criteria:**
+- No `as any` cast.
+- The mutation imports `ReprintExpeditionListRequest` from `../generated/api-client` and instantiates it (NSwag-generated requests require class construction, not a plain literal — see `useArticles.ts` for canonical pattern).
+- `onSuccess` query invalidation of `QUERY_KEYS.expeditionListArchive` is preserved.
+- Existing error-message extraction behavior (rejecting with `errorMessage` from the response when present, else the HTTP status) is preserved — falling back to the generated client's standard `SwaggerException` handling is acceptable provided the user-visible toast message remains equivalent.
+- Triggering "Reprint" on a list in the UI produces the same success/error UX as today.
+
+### FR-4: Replace `useRunExpeditionListPrintFix` with typed client call
+Rewrite the mutation to call `getAuthenticatedApiClient().expeditionList_RunFix()`.
+
+**Acceptance criteria:**
+- No `as any` cast.
+- The mutation returns the typed `RunExpeditionListPrintFixResponse`.
+- Existing error-handling behavior is preserved (see FR-3 caveat).
+- The "Run print fix" action in the UI behaves identically to today.
+
+### FR-5: Fix `getExpeditionListDownloadUrl` to use the public base-URL helper
+`getExpeditionListDownloadUrl(blobPath)` constructs an authenticated download URL used as an `href` for downloads — it does not need a typed RPC method. Replace `(apiClient as any).baseUrl` with `getApiBaseUrl()` from `./client`.
+
+**Acceptance criteria:**
+- No `as any` cast.
+- No reference to `getAuthenticatedApiClient()` (this helper builds a URL only — instantiating the client is unnecessary).
+- `blobPath` is still per-segment URL-encoded (`blobPath.split("/").map(encodeURIComponent).join("/")`) so multi-segment paths like `2026/06/03/file.pdf` resolve correctly.
+- The download link in the UI opens the same file as today.
+
+### FR-6: Lint rule / guardrail (regression prevention)
+Add an ESLint rule (or extend an existing one) to fail builds when source files in `frontend/src/` contain `(apiClient as any)` or any cast that reads `.http` / `.baseUrl` off the generated client. Scoped to `frontend/src/**/*.{ts,tsx}` excluding `frontend/src/api/generated/**`.
+
+**Acceptance criteria:**
+- A new lint rule (e.g. `no-restricted-syntax` matching `TSAsExpression > TSAnyKeyword` paired with an identifier matching `apiClient`, or a custom rule) flags any future reintroduction.
+- `npm run lint` passes after the refactor.
+- Manually reintroducing `(apiClient as any).http.fetch` in a sandbox file causes `npm run lint` to fail with a clear error message naming the violation and pointing to the sanctioned helpers.
+
+## Non-Functional Requirements
+
+### NFR-1: Behavior parity
+No user-visible behavioral change. All five call sites must produce the same network requests (same HTTP method, path, query string, body, headers) and the same React Query cache keys before and after the change.
+
+### NFR-2: Type safety
+After the refactor, `tsc --noEmit` (run as part of `npm run build`) must succeed. The hook file must contain zero `as any` casts and zero references to `.http` or `.baseUrl` on the generated client.
+
+### NFR-3: Test coverage
+Existing unit/integration tests that touch this hook file must continue to pass. If no tests exist for these hooks today (the file appears uncovered based on naming conventions), add minimal RTL/React Query tests for at least `useExpeditionDates` and `useReprintExpeditionList` that mock the generated client and assert the typed methods are called with the expected arguments. Target: each refactored hook has ≥1 happy-path test.
+
+### NFR-4: Bundle size
+No measurable bundle-size increase. The refactor removes manual `fetch` code and reuses methods that are already in the generated client bundle, so net size should be neutral or slightly smaller.
+
+### NFR-5: Auth interceptor coverage
+After the change, all five endpoints must go through `getAuthenticatedApiClient()`'s `authenticatedHttp.fetch`, which means they get: auth-header injection, 401 redirect handling, global error-toast handling, and E2E test cookie credentials. Today, `(apiClient as any).http.fetch` already happens to use the same `authenticatedHttp` (because `getAuthenticatedApiClient()` passes it to `new ApiClient(...)`), so behavior should be equivalent — but this becomes guaranteed-by-type rather than guaranteed-by-coincidence.
+
+## Data Model
+No data-model changes. All DTOs already exist in both the backend (`backend/src/Anela.Heblo.Application/Features/ExpeditionList*`) and the generated TypeScript client.
+
+The hook file's locally-declared interfaces (`ExpeditionListItemDto`, `GetExpeditionDatesResponse`, `GetExpeditionListsByDateResponse`, `ReprintExpeditionListRequest`, `ReprintExpeditionListResponse`) duplicate types that already exist in `frontend/src/api/generated/api-client.ts`. The refactor must:
+- Keep the locally-declared interfaces **for now** (so consuming components compile unchanged), OR
+- Re-export the generated types under the same names if structural compatibility holds.
+
+Decision: re-export from the generated client where structurally identical; keep local types only if structural differences exist (e.g. `string` vs `Date`). The local DTOs were almost certainly hand-written because someone bypassed the generated client — they should drop in cleanly.
+
+## API / Interface Design
+No API surface changes. All five hook signatures stay identical so consumers (`ExpeditionListArchivePage` and similar) need zero changes:
+
+```typescript
+useExpeditionDates(page?: number, pageSize?: number): UseQueryResult<GetExpeditionDatesResponse>
+useExpeditionListsByDate(date: string): UseQueryResult<GetExpeditionListsByDateResponse>
+useReprintExpeditionList(): UseMutationResult<ReprintExpeditionListResponse, Error, ReprintExpeditionListRequest>
+useRunExpeditionListPrintFix(): UseMutationResult<RunExpeditionListPrintFixResponse, Error, void>
+getExpeditionListDownloadUrl(blobPath: string): string
+```
+
+## Dependencies
+- `frontend/src/api/client.ts` — `getAuthenticatedApiClient`, `getApiBaseUrl`, `QUERY_KEYS` (all existing exports, no changes required).
+- `frontend/src/api/generated/api-client.ts` — `ApiClient` typed methods + `ReprintExpeditionListRequest` (existing, regenerated on build).
+- `@tanstack/react-query` — `useQuery`, `useMutation`, `useQueryClient` (unchanged).
+- ESLint configuration in `frontend/` for FR-6.
+
+No new packages, no backend changes, no OpenAPI changes.
+
+## Out of Scope
+- **OpenAPI/NSwag changes.** The brief suggested adding endpoints to the OpenAPI spec, but the endpoints are already generated. No backend or codegen work is required.
+- **Making `baseUrl` a public property of `ApiClient`.** Not needed; `getApiBaseUrl()` already exposes it via the public helper exported from `client.ts`.
+- **A new `apiFetch(relativeUrl, init)` typed wrapper.** The brief proposed this as a stopgap; with FR-1 through FR-5 the wrapper is unnecessary because no call site needs hand-rolled `fetch` anymore. `getAuthenticatedFetch()` already covers the escape-hatch case.
+- **Refactoring other hooks.** This file is the only known offender per the arch-review.
+- **Migrating download to streamed/typed `expeditionListArchive_Download`.** `getExpeditionListDownloadUrl` is consumed as an `href` for browser-initiated downloads, not a programmatic stream read. Converting it to a fetched blob would change UX (no native download progress, blob-URL lifecycle management) and is not required by the brief.
+- **End-to-end Playwright coverage of the archive flow.** Not in this change; existing E2E coverage (if any) must continue to pass.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-expeditionlist-frontend-hook/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlist-frontend-hook/task-plan.r1.md
@@ -1,0 +1,16 @@
+Plan saved to `docs/superpowers/plans/2026-06-04-expeditionlist-frontend-hook-cleanup.md`.
+
+## Summary
+
+**Approach:** Pure call-site migration in 9 TDD-driven, bite-sized tasks. The plan follows the arch-review's recommendations over the spec's where they conflict:
+
+1. **Task 1+2 — `useExpeditionDates`:** Failing happy-path test → typed `expeditionListArchive_GetDates(page, pageSize)` call → mapping `?? 0` / `?? []` defaults.
+2. **Task 3 — `useExpeditionListsByDate`:** Date → ISO-string and `undefined` → `null` mapping inside `queryFn` (arch-review Decision 2 — local interface kept, generated DTO is structurally incompatible).
+3. **Task 4 — `useReprintExpeditionList`:** Drops the local `ReprintExpeditionListRequest` interface (arch-review amendment A4), imports the generated class, calls `new ReprintExpeditionListRequest({...})`, preserves query invalidation.
+4. **Task 5 — `useRunExpeditionListPrintFix`:** Typed `expeditionList_RunFix()` with `totalCount ?? 0` mapping.
+5. **Task 6 — `getExpeditionListDownloadUrl`:** Uses `getApiBaseUrl()`, no client instantiation (arch-review amendment A5).
+6. **Task 7 — `handleOpen` in `ExpeditionListArchivePage.tsx`:** Swaps `(apiClient as any).http.fetch` for `getAuthenticatedFetch()` (arch-review amendment A1 — sixth cast the spec missed).
+7. **Task 8 — Guardrail:** Extends `MIGRATED_HOOKS` in `authenticated-api-usage.test.ts` (arch-review amendment A2 — reuses existing Jest gate instead of adding ESLint). Includes a sandbox-revert sanity check to prove the gate fires.
+8. **Task 9 — Final validation:** Full lint + build + test suite + manual browser sanity check on the archive page.
+
+**No backend, no OpenAPI regeneration, no new files except one test file.** Hook signatures preserved so `ExpeditionListArchivePage.tsx` and its tests need no consumer-side rewrite.

--- a/docs/superpowers/plans/2026-06-04-expeditionlist-frontend-hook-cleanup.md
+++ b/docs/superpowers/plans/2026-06-04-expeditionlist-frontend-hook-cleanup.md
@@ -1,0 +1,983 @@
+# Eliminate `as any` Casts in `useExpeditionListArchive.ts` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all five `(apiClient as any)` casts in `frontend/src/api/hooks/useExpeditionListArchive.ts` (plus a sixth one in `frontend/src/pages/ExpeditionListArchivePage.tsx`) with typed generated-client calls and the public `getApiBaseUrl()` / `getAuthenticatedFetch()` helpers, then extend the existing `MIGRATED_HOOKS` Jest guardrail so the rule cannot regress.
+
+**Architecture:** Pure call-site migration — no backend, no OpenAPI regeneration, no new files. Four React Query hooks switch from hand-rolled `fetch` to `getAuthenticatedApiClient().expeditionListArchive_*` / `expeditionList_RunFix()`. One URL builder switches to `getApiBaseUrl()`. One page-level blob-fetch switches to `getAuthenticatedFetch()`. Hook return types stay byte-compatible with today's consumer (`ExpeditionListArchivePage`) by mapping the generated DTOs' `Date | undefined` / `number | undefined` to the page-friendly `string | null` / `number | null` inside each `queryFn`. The `MIGRATED_HOOKS` Set in `frontend/src/api/__tests__/authenticated-api-usage.test.ts` is extended with the migrated file, locking the rule.
+
+**Tech Stack:** TypeScript, React 18, `@tanstack/react-query` v5, NSwag-generated `ApiClient`, Jest + React Testing Library (`renderHook` / `waitFor`), `jest.mock` for module-level mocking.
+
+---
+
+## File Structure
+
+**Modify:**
+- `frontend/src/api/hooks/useExpeditionListArchive.ts` — rewrite all four hooks and the URL helper. Drop `ReprintExpeditionListRequest` local interface. Keep the other four local interfaces (they are the consumer-facing contract).
+- `frontend/src/pages/ExpeditionListArchivePage.tsx:62-78` — replace `(apiClient as any).http.fetch(url, ...)` in `handleOpen` with `getAuthenticatedFetch()(url, ...)`. Drop the now-unused `getAuthenticatedApiClient` import; add `getAuthenticatedFetch` import.
+- `frontend/src/api/__tests__/authenticated-api-usage.test.ts:197` — add `"useExpeditionListArchive.ts"` to the `MIGRATED_HOOKS` Set.
+
+**Create:**
+- `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts` — happy-path tests for the four hooks. Uses the `useArticles.test.ts` mocking pattern (`jest.mock("../../client", () => ({...}))`).
+
+**Untouched but verified:**
+- `frontend/src/api/client.ts` — `getAuthenticatedApiClient`, `getApiBaseUrl`, `getAuthenticatedFetch`, `QUERY_KEYS` already exist. No changes.
+- `frontend/src/api/generated/api-client.ts` — `expeditionListArchive_GetDates` (line 2712), `expeditionListArchive_GetByDate` (2754), `expeditionListArchive_Reprint` (2832), `expeditionList_RunFix` (2870), and the `ReprintExpeditionListRequest` class (17604) already exist. No regeneration needed.
+- `frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx` — mocks the hook module wholesale (line 8) so signature-preserving refactors do not break it. Verify it still passes.
+
+---
+
+## Important Reference Patterns
+
+The canonical reference for "typed-client mutation with class-instance request" is `useArticles.ts:216-248`:
+
+```typescript
+mutationFn: async (payload: SubmitArticleFeedbackPayload): Promise<SubmitArticleFeedbackResult> => {
+  const client = getAuthenticatedApiClient();
+  const request = new SubmitArticleFeedbackRequest({
+    articleId,
+    precisionScore: payload.precisionScore,
+    // ...
+  });
+
+  try {
+    const response = await client.articles_SubmitFeedback(articleId, request);
+    return { /* map fields with ?? defaults */ };
+  } catch (e: unknown) {
+    const err = e as { status?: number };
+    if (err.status === 409) { /* typed branch */ }
+    throw e;
+  }
+},
+```
+
+The canonical reference for "Jest test of a hook that mocks `../../client` wholesale and asserts on the typed-method mock" is `useArticles.test.ts:1-80` (already-loaded scaffolding pattern).
+
+The canonical reference for `MIGRATED_HOOKS` enforcement (the regression gate) is `authenticated-api-usage.test.ts:194-247` — already loaded in the codebase as `MIGRATED_HOOKS = new Set(["useArticles.ts"])`.
+
+---
+
+## Validation Commands (run after each task that touches code)
+
+From `frontend/`:
+
+```bash
+npm run lint
+npm run build           # includes tsc --noEmit
+npm test -- --watchAll=false useExpeditionListArchive
+npm test -- --watchAll=false authenticated-api-usage
+npm test -- --watchAll=false ExpeditionListArchivePage
+```
+
+The final validation also runs the full test suite (`npm test -- --watchAll=false`).
+
+---
+
+## Task 1: Create the test scaffold + first failing test for `useExpeditionDates`
+
+**Files:**
+- Create: `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts`
+
+- [ ] **Step 1: Create the test file with shared scaffolding and a failing test for `useExpeditionDates`**
+
+Create `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts`:
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import {
+  useExpeditionDates,
+  useExpeditionListsByDate,
+  useReprintExpeditionList,
+  useRunExpeditionListPrintFix,
+} from '../useExpeditionListArchive';
+import { ReprintExpeditionListRequest } from '../../generated/api-client';
+import * as clientModule from '../../client';
+
+jest.mock('../../client', () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  getApiBaseUrl: jest.fn(() => 'https://api.example.test'),
+  getAuthenticatedFetch: jest.fn(),
+  QUERY_KEYS: {
+    expeditionListArchive: ['expedition-list-archive'],
+  },
+}));
+
+const mockGetAuthenticatedApiClient =
+  clientModule.getAuthenticatedApiClient as jest.MockedFunction<
+    typeof clientModule.getAuthenticatedApiClient
+  >;
+
+const createWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    children,
+  );
+};
+
+describe('useExpeditionDates', () => {
+  let mockGetDates: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDates = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionListArchive_GetDates: mockGetDates,
+    } as any);
+  });
+
+  it('calls expeditionListArchive_GetDates with the given page and pageSize and returns the mapped response', async () => {
+    mockGetDates.mockResolvedValue({
+      dates: ['2024-12-10', '2024-12-09'],
+      totalCount: 2,
+      page: 3,
+      pageSize: 50,
+    });
+
+    const { result } = renderHook(() => useExpeditionDates(3, 50), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetDates).toHaveBeenCalledTimes(1);
+    expect(mockGetDates).toHaveBeenCalledWith(3, 50);
+    expect(result.current.data).toEqual({
+      dates: ['2024-12-10', '2024-12-09'],
+      totalCount: 2,
+      page: 3,
+      pageSize: 50,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+Run from `frontend/`:
+
+```bash
+npm test -- --watchAll=false useExpeditionListArchive
+```
+
+Expected: FAIL. The hook today calls `(apiClient as any).http.fetch(...)`, not `expeditionListArchive_GetDates`. The mock `getAuthenticatedApiClient` returns an object without `http.fetch`, so the test fails with an undefined property access. (If the test instead passes for the wrong reason — e.g. because `mockGetDates` is never invoked but `result.current.isSuccess` becomes false — that is still a failure of the `expect(mockGetDates).toHaveBeenCalled` assertion.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+git commit -m "test: add failing test for useExpeditionDates typed client migration"
+```
+
+---
+
+## Task 2: Migrate `useExpeditionDates` to the typed client
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:46-74`
+
+- [ ] **Step 1: Rewrite the `useExpeditionDates` hook to call the typed method**
+
+In `frontend/src/api/hooks/useExpeditionListArchive.ts`, replace lines 46-74 with:
+
+```typescript
+export const useExpeditionDates = (page: number = 1, pageSize: number = 20) => {
+  return useQuery<GetExpeditionDatesResponse>({
+    queryKey: expeditionArchiveKeys.dates(page, pageSize),
+    queryFn: async (): Promise<GetExpeditionDatesResponse> => {
+      const client = getAuthenticatedApiClient();
+      const response = await client.expeditionListArchive_GetDates(page, pageSize);
+      return {
+        dates: response.dates ?? [],
+        totalCount: response.totalCount ?? 0,
+        page: response.page ?? page,
+        pageSize: response.pageSize ?? pageSize,
+      };
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+};
+```
+
+The local `GetExpeditionDatesResponse` interface at lines 14-19 stays — it is the consumer contract (`number`, not `number | undefined`). The `?? page` / `?? pageSize` defaults preserve the page/pageSize echoed back to consumers if the backend ever omits them.
+
+- [ ] **Step 2: Run the test to confirm it PASSES**
+
+Run from `frontend/`:
+
+```bash
+npm test -- --watchAll=false useExpeditionListArchive
+```
+
+Expected: PASS. `useExpeditionDates` test green.
+
+- [ ] **Step 3: Verify the typed import is still satisfied (no unused imports yet — manual fetch helpers are still used by the other hooks)**
+
+This step is "no-op verify" — do not modify imports yet. The hooks that still use `(apiClient as any)` need their imports until they too are migrated. Confirm the file compiles:
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/hooks/useExpeditionListArchive.ts
+git commit -m "refactor(expedition-archive): migrate useExpeditionDates to typed client"
+```
+
+---
+
+## Task 3: Migrate `useExpeditionListsByDate` to the typed client (with Date → ISO-string mapping)
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:76-98`
+
+- [ ] **Step 1: Add a failing test for the mapping behavior**
+
+Append to `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts`:
+
+```typescript
+describe('useExpeditionListsByDate', () => {
+  let mockGetByDate: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetByDate = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionListArchive_GetByDate: mockGetByDate,
+    } as any);
+  });
+
+  it('passes the date through to the typed method and maps Date/undefined to string/null', async () => {
+    mockGetByDate.mockResolvedValue({
+      items: [
+        {
+          blobPath: '2024/12/10/file.pdf',
+          fileName: 'expedice-2024-12-10.pdf',
+          listId: 'L-1',
+          createdOn: new Date('2024-12-10T10:00:00.000Z'),
+          contentLength: 1024,
+        },
+        {
+          blobPath: '2024/12/10/other.pdf',
+          fileName: 'expedice-other.pdf',
+          listId: 'L-2',
+          createdOn: undefined,
+          contentLength: undefined,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useExpeditionListsByDate('2024-12-10'), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetByDate).toHaveBeenCalledWith('2024-12-10');
+    expect(result.current.data).toEqual({
+      items: [
+        {
+          blobPath: '2024/12/10/file.pdf',
+          fileName: 'expedice-2024-12-10.pdf',
+          listId: 'L-1',
+          createdOn: '2024-12-10T10:00:00.000Z',
+          contentLength: 1024,
+        },
+        {
+          blobPath: '2024/12/10/other.pdf',
+          fileName: 'expedice-other.pdf',
+          listId: 'L-2',
+          createdOn: null,
+          contentLength: null,
+        },
+      ],
+    });
+  });
+
+  it('does not call the API when date is empty (enabled: !!date)', async () => {
+    renderHook(() => useExpeditionListsByDate(''), { wrapper: createWrapper });
+    // Give React Query a microtask to evaluate `enabled`
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGetByDate).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+```bash
+npm test -- --watchAll=false useExpeditionListsByDate
+```
+
+Expected: FAIL. The hook today does not call `expeditionListArchive_GetByDate`.
+
+- [ ] **Step 3: Rewrite `useExpeditionListsByDate`**
+
+Replace lines 76-98 of `frontend/src/api/hooks/useExpeditionListArchive.ts` with:
+
+```typescript
+export const useExpeditionListsByDate = (date: string) => {
+  return useQuery<GetExpeditionListsByDateResponse>({
+    queryKey: expeditionArchiveKeys.itemsByDate(date),
+    queryFn: async (): Promise<GetExpeditionListsByDateResponse> => {
+      const client = getAuthenticatedApiClient();
+      const response = await client.expeditionListArchive_GetByDate(date);
+      return {
+        items: (response.items ?? []).map((item) => ({
+          blobPath: item.blobPath ?? '',
+          fileName: item.fileName ?? '',
+          listId: item.listId ?? '',
+          createdOn: item.createdOn ? item.createdOn.toISOString() : null,
+          contentLength: item.contentLength ?? null,
+        })),
+      };
+    },
+    enabled: !!date,
+    staleTime: 1000 * 60 * 5,
+  });
+};
+```
+
+The local interfaces `ExpeditionListItemDto` and `GetExpeditionListsByDateResponse` at lines 6-23 stay — see arch-review Decision 2.
+
+- [ ] **Step 4: Run the test to confirm it PASSES**
+
+```bash
+npm test -- --watchAll=false useExpeditionListsByDate
+```
+
+Expected: PASS for both new assertions and the previous `useExpeditionDates` test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/hooks/useExpeditionListArchive.ts frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+git commit -m "refactor(expedition-archive): migrate useExpeditionListsByDate to typed client with DTO mapping"
+```
+
+---
+
+## Task 4: Migrate `useReprintExpeditionList` — drop the local request interface
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:25-27` (delete the local `ReprintExpeditionListRequest` interface)
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:100-128` (rewrite the mutation)
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:1-2` (add import of `ReprintExpeditionListRequest` from `../generated/api-client`)
+
+- [ ] **Step 1: Add a failing test for `useReprintExpeditionList`**
+
+Append to `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts`:
+
+```typescript
+describe('useReprintExpeditionList', () => {
+  let mockReprint: jest.Mock;
+  let mockInvalidateQueries: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReprint = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionListArchive_Reprint: mockReprint,
+    } as any);
+  });
+
+  it('instantiates ReprintExpeditionListRequest, calls the typed method, and returns the mapped response', async () => {
+    mockReprint.mockResolvedValue({ success: true, errorMessage: null });
+
+    const { result } = renderHook(() => useReprintExpeditionList(), {
+      wrapper: createWrapper,
+    });
+
+    const response = await result.current.mutateAsync({ blobPath: '2024/12/10/file.pdf' });
+
+    expect(mockReprint).toHaveBeenCalledTimes(1);
+    const calledWith = mockReprint.mock.calls[0][0];
+    expect(calledWith).toBeInstanceOf(ReprintExpeditionListRequest);
+    expect(calledWith.blobPath).toBe('2024/12/10/file.pdf');
+    expect(response).toEqual({ success: true, errorMessage: null });
+  });
+
+  it('rethrows SwaggerException-like errors so callers can surface a toast', async () => {
+    mockReprint.mockRejectedValue({ status: 500, message: 'Internal Server Error' });
+
+    const { result } = renderHook(() => useReprintExpeditionList(), {
+      wrapper: createWrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ blobPath: '2024/12/10/file.pdf' }),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+```bash
+npm test -- --watchAll=false useReprintExpeditionList
+```
+
+Expected: FAIL. The hook today builds a plain JSON body via `(apiClient as any).http.fetch(...)`, not a `ReprintExpeditionListRequest` instance.
+
+- [ ] **Step 3: Update imports at the top of `useExpeditionListArchive.ts`**
+
+Replace line 2 of `frontend/src/api/hooks/useExpeditionListArchive.ts`:
+
+```typescript
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+```
+
+with:
+
+```typescript
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+import { ReprintExpeditionListRequest } from "../generated/api-client";
+```
+
+- [ ] **Step 4: Delete the local `ReprintExpeditionListRequest` interface**
+
+Remove lines 25-27 of `frontend/src/api/hooks/useExpeditionListArchive.ts`:
+
+```typescript
+export interface ReprintExpeditionListRequest {
+  blobPath: string;
+}
+```
+
+The hook will accept a plain object literal `{ blobPath: string }` as input (typed inline in the mutation signature). Consumers in `ExpeditionListArchivePage.tsx` already pass `{ blobPath: reprintConfirm.blobPath }` (line 107) — no consumer change needed.
+
+- [ ] **Step 5: Rewrite the mutation body**
+
+Replace the (now-shifted) `useReprintExpeditionList` block with:
+
+```typescript
+export const useReprintExpeditionList = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ReprintExpeditionListResponse, Error, { blobPath: string }>({
+    mutationFn: async (input): Promise<ReprintExpeditionListResponse> => {
+      const client = getAuthenticatedApiClient();
+      const request = new ReprintExpeditionListRequest({ blobPath: input.blobPath });
+      const response = await client.expeditionListArchive_Reprint(request);
+      return {
+        success: response.success ?? true,
+        errorMessage: response.errorMessage ?? null,
+      };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.expeditionListArchive });
+    },
+  });
+};
+```
+
+Note: the locally-declared `ReprintExpeditionListResponse` interface (lines 29-32 of the original file, now shifted up) stays — consumers expect `success: boolean` (non-optional) and `errorMessage: string | null` (not `undefined`). The mapping reconciles this.
+
+- [ ] **Step 6: Run tests to confirm PASS**
+
+```bash
+npm test -- --watchAll=false useReprintExpeditionList
+```
+
+Expected: both new tests pass. Also confirm previously-green tests still pass:
+
+```bash
+npm test -- --watchAll=false useExpeditionListArchive
+```
+
+Expected: all tests so far pass.
+
+- [ ] **Step 7: Verify the page test still passes (signature shape preserved)**
+
+```bash
+npm test -- --watchAll=false ExpeditionListArchivePage
+```
+
+Expected: PASS. The page test mocks the hook module wholesale (line 8 of `ExpeditionListArchivePage.test.tsx`), and the page itself still passes `{ blobPath }` to `mutateAsync` — fully structurally compatible with the new mutation input type `{ blobPath: string }`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/api/hooks/useExpeditionListArchive.ts frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+git commit -m "refactor(expedition-archive): migrate useReprintExpeditionList to typed client, drop local request interface"
+```
+
+---
+
+## Task 5: Migrate `useRunExpeditionListPrintFix` to the typed client
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:130-152`
+
+- [ ] **Step 1: Add a failing test**
+
+Append to `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts`:
+
+```typescript
+describe('useRunExpeditionListPrintFix', () => {
+  let mockRunFix: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRunFix = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionList_RunFix: mockRunFix,
+    } as any);
+  });
+
+  it('calls expeditionList_RunFix and returns the mapped response', async () => {
+    mockRunFix.mockResolvedValue({ totalCount: 7, errorMessage: null });
+
+    const { result } = renderHook(() => useRunExpeditionListPrintFix(), {
+      wrapper: createWrapper,
+    });
+
+    const response = await result.current.mutateAsync();
+
+    expect(mockRunFix).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({ totalCount: 7, errorMessage: null });
+  });
+
+  it('defaults totalCount to 0 and errorMessage to null when the backend omits them', async () => {
+    mockRunFix.mockResolvedValue({});
+
+    const { result } = renderHook(() => useRunExpeditionListPrintFix(), {
+      wrapper: createWrapper,
+    });
+
+    const response = await result.current.mutateAsync();
+    expect(response).toEqual({ totalCount: 0, errorMessage: null });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it FAILS**
+
+```bash
+npm test -- --watchAll=false useRunExpeditionListPrintFix
+```
+
+Expected: FAIL — current implementation does not call `expeditionList_RunFix`.
+
+- [ ] **Step 3: Add the consumer-side response type next to other local interfaces (top of the hook file)**
+
+Add a new local interface just after `ReprintExpeditionListResponse`:
+
+```typescript
+export interface RunExpeditionListPrintFixResult {
+  totalCount: number;
+  errorMessage: string | null;
+}
+```
+
+The page reads `result.totalCount` at `ExpeditionListArchivePage.tsx:98`. The generated `RunExpeditionListPrintFixResponse` has `totalCount?: number | undefined` — the mapping reconciles this to `number`.
+
+- [ ] **Step 4: Rewrite the mutation**
+
+Replace lines 130-152 of `frontend/src/api/hooks/useExpeditionListArchive.ts` with:
+
+```typescript
+export const useRunExpeditionListPrintFix = () => {
+  return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+    mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
+      const client = getAuthenticatedApiClient();
+      const response = await client.expeditionList_RunFix();
+      return {
+        totalCount: response.totalCount ?? 0,
+        errorMessage: response.errorMessage ?? null,
+      };
+    },
+  });
+};
+```
+
+- [ ] **Step 5: Run tests to confirm PASS**
+
+```bash
+npm test -- --watchAll=false useRunExpeditionListPrintFix
+```
+
+Expected: PASS.
+
+```bash
+npm test -- --watchAll=false ExpeditionListArchivePage
+```
+
+Expected: PASS. The page test at `ExpeditionListArchivePage.test.tsx:78` mocks `mutateAsync` to resolve `{ totalCount: 5 }` and the page reads `result.totalCount`. The interface change (anonymous `useMutation` payload → named `RunExpeditionListPrintFixResult`) is structurally compatible.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/api/hooks/useExpeditionListArchive.ts frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+git commit -m "refactor(expedition-archive): migrate useRunExpeditionListPrintFix to typed client"
+```
+
+---
+
+## Task 6: Fix `getExpeditionListDownloadUrl` to use the public `getApiBaseUrl()` helper
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:154-159`
+- Modify: `frontend/src/api/hooks/useExpeditionListArchive.ts:2` (add `getApiBaseUrl` to existing import)
+
+There is no clean unit-test seam for a pure URL builder (`getApiBaseUrl()` is module-mocked), and the existing page test does not exercise the URL. This task relies on `tsc` + lint + the `MIGRATED_HOOKS` guardrail (Task 8) to catch regressions, plus the manual sanity check in Task 9.
+
+- [ ] **Step 1: Extend the `../client` import**
+
+Replace line 2 of `frontend/src/api/hooks/useExpeditionListArchive.ts`:
+
+```typescript
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+```
+
+with:
+
+```typescript
+import { getAuthenticatedApiClient, getApiBaseUrl, QUERY_KEYS } from "../client";
+```
+
+(If the line was already extended in Task 4 with `ReprintExpeditionListRequest` on a separate line, leave that line untouched and only modify the `../client` import line.)
+
+- [ ] **Step 2: Rewrite `getExpeditionListDownloadUrl`**
+
+Replace lines 154-159 of `frontend/src/api/hooks/useExpeditionListArchive.ts` with:
+
+```typescript
+export const getExpeditionListDownloadUrl = (blobPath: string): string => {
+  const encodedPath = blobPath.split("/").map(encodeURIComponent).join("/");
+  return `${getApiBaseUrl()}/api/expedition-list-archive/download/${encodedPath}`;
+};
+```
+
+No `getAuthenticatedApiClient()` call — instantiating the client just to read its base URL is wasted work (arch-review Decision section, FR-5 amendment A5).
+
+- [ ] **Step 3: Verify the file compiles**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/hooks/useExpeditionListArchive.ts
+git commit -m "refactor(expedition-archive): use getApiBaseUrl() for download URL"
+```
+
+---
+
+## Task 7: Fix `handleOpen` cast in `ExpeditionListArchivePage.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/ExpeditionListArchivePage.tsx:1-15` (swap imports)
+- Modify: `frontend/src/pages/ExpeditionListArchivePage.tsx:62-78` (swap fetch call)
+
+The page test at `ExpeditionListArchivePage.test.tsx` does not exercise `handleOpen`, so this task uses build + manual sanity check as its verification. (`getAuthenticatedFetch` already has the same auth-header / E2E-cookie behavior as `(apiClient as any).http.fetch` — see `client.ts:419-431`.)
+
+- [ ] **Step 1: Update imports at the top of `ExpeditionListArchivePage.tsx`**
+
+Read lines 1-15 of `frontend/src/pages/ExpeditionListArchivePage.tsx`. Replace the line:
+
+```typescript
+import { getAuthenticatedApiClient, QUERY_KEYS } from "../api/client";
+```
+
+with:
+
+```typescript
+import { getAuthenticatedFetch, QUERY_KEYS } from "../api/client";
+```
+
+`getAuthenticatedApiClient` is only used inside `handleOpen` today (the rest of the page consumes hooks). After this swap it is no longer needed.
+
+- [ ] **Step 2: Rewrite `handleOpen` to use `getAuthenticatedFetch()`**
+
+Replace lines 62-78 of `frontend/src/pages/ExpeditionListArchivePage.tsx`:
+
+```typescript
+  const handleOpen = async (item: ExpeditionListItemDto) => {
+    const url = getExpeditionListDownloadUrl(item.blobPath);
+    const apiClient = getAuthenticatedApiClient();
+    try {
+      const response = await (apiClient as any).http.fetch(url, { method: 'GET' });
+      if (!response.ok) {
+        showError('Chyba', `Nepodařilo se otevřít soubor (${response.status}).`);
+        return;
+      }
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
+    } catch {
+      showError('Chyba', 'Nepodařilo se otevřít soubor.');
+    }
+  };
+```
+
+with:
+
+```typescript
+  const handleOpen = async (item: ExpeditionListItemDto) => {
+    const url = getExpeditionListDownloadUrl(item.blobPath);
+    try {
+      const response = await getAuthenticatedFetch()(url, { method: 'GET' });
+      if (!response.ok) {
+        showError('Chyba', `Nepodařilo se otevřít soubor (${response.status}).`);
+        return;
+      }
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
+    } catch {
+      showError('Chyba', 'Nepodařilo se otevřít soubor.');
+    }
+  };
+```
+
+- [ ] **Step 3: Run the page tests to confirm nothing broke**
+
+```bash
+cd frontend && npm test -- --watchAll=false ExpeditionListArchivePage
+```
+
+Expected: PASS. The test mocks `../../api/client` (line 20 of `ExpeditionListArchivePage.test.tsx`) — the import surface change (`getAuthenticatedApiClient` → `getAuthenticatedFetch`) means the test mock should now include `getAuthenticatedFetch`. **Check whether the existing mock needs `getAuthenticatedFetch: jest.fn()` added.** If the test does not reference it and only the page's imports changed (without test code calling it), Jest's automatic-property handling keeps it green; but if the test fails because of the missing mock property, add it.
+
+If the test fails because of a missing `getAuthenticatedFetch` on the mock, edit `frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx:20-25`:
+
+```typescript
+jest.mock("../../api/client", () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  QUERY_KEYS: {
+    expeditionListArchive: ["expedition-list-archive"],
+  },
+}));
+```
+
+→
+
+```typescript
+jest.mock("../../api/client", () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  getAuthenticatedFetch: jest.fn(() => jest.fn()),
+  QUERY_KEYS: {
+    expeditionListArchive: ["expedition-list-archive"],
+  },
+}));
+```
+
+Re-run the test and confirm PASS.
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors. (`getAuthenticatedApiClient` is no longer used in the page — TypeScript will flag it as an unused import if it remains. The import-line replacement in Step 1 already removes it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/ExpeditionListArchivePage.tsx frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx
+git commit -m "refactor(expedition-archive): replace (apiClient as any).http.fetch in handleOpen with getAuthenticatedFetch"
+```
+
+(If the test file was not modified, omit it from the `git add`.)
+
+---
+
+## Task 8: Extend the `MIGRATED_HOOKS` guardrail
+
+**Files:**
+- Modify: `frontend/src/api/__tests__/authenticated-api-usage.test.ts:197`
+
+This is the regression gate. After this task, any future `(apiClient as any)`, `as any).http`, or `as any).baseUrl` reintroduction in `useExpeditionListArchive.ts` fails CI.
+
+- [ ] **Step 1: Add the migrated hook file to the `MIGRATED_HOOKS` Set**
+
+In `frontend/src/api/__tests__/authenticated-api-usage.test.ts`, replace line 197:
+
+```typescript
+    const MIGRATED_HOOKS = new Set(["useArticles.ts"]);
+```
+
+with:
+
+```typescript
+    const MIGRATED_HOOKS = new Set([
+      "useArticles.ts",
+      "useExpeditionListArchive.ts",
+    ]);
+```
+
+- [ ] **Step 2: Run the guardrail test to confirm it PASSES with the migrated file**
+
+```bash
+cd frontend && npm test -- --watchAll=false authenticated-api-usage
+```
+
+Expected: PASS — `useExpeditionListArchive.ts` no longer contains `(apiClient as any)` patterns, so adding it to `MIGRATED_HOOKS` is safe.
+
+- [ ] **Step 3: Sandbox verification — the guardrail catches regressions**
+
+Temporarily reintroduce a forbidden pattern in `frontend/src/api/hooks/useExpeditionListArchive.ts` at the top of the file (just under the imports):
+
+```typescript
+// SANDBOX — DO NOT COMMIT
+const _sandbox = () => {
+  const apiClient = getAuthenticatedApiClient();
+  return (apiClient as any).baseUrl;
+};
+```
+
+Run the guardrail test:
+
+```bash
+cd frontend && npm test -- --watchAll=false authenticated-api-usage
+```
+
+Expected: FAIL with a message naming `useExpeditionListArchive.ts` and the `(apiClient as any)` pattern at the sandbox line. This proves the guardrail works.
+
+**Then revert the sandbox change:**
+
+```bash
+git checkout -- frontend/src/api/hooks/useExpeditionListArchive.ts
+```
+
+Re-run the guardrail test:
+
+```bash
+cd frontend && npm test -- --watchAll=false authenticated-api-usage
+```
+
+Expected: PASS again.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/__tests__/authenticated-api-usage.test.ts
+git commit -m "test: extend MIGRATED_HOOKS guardrail to cover useExpeditionListArchive"
+```
+
+---
+
+## Task 9: Final validation
+
+**Files:** None modified.
+
+- [ ] **Step 1: Run the full lint pass**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: 0 errors. If lint complains about unused imports in `useExpeditionListArchive.ts` or `ExpeditionListArchivePage.tsx` (the most likely surface after the migration), remove them. Re-run.
+
+- [ ] **Step 2: Run the full build (includes `tsc --noEmit`)**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: build succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Run the full Jest test suite**
+
+```bash
+cd frontend && npm test -- --watchAll=false
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Final visual confirmation that the hook file has zero `as any` casts**
+
+```bash
+cd frontend && grep -nE "as any|\.http\.|\.baseUrl" src/api/hooks/useExpeditionListArchive.ts
+```
+
+Expected: **no output** (zero matches). If anything matches, it is a regression — revisit the offending hook.
+
+```bash
+cd frontend && grep -nE "\(apiClient as any\)" src/pages/ExpeditionListArchivePage.tsx
+```
+
+Expected: **no output** (zero matches).
+
+- [ ] **Step 5: Manual sanity check in the browser**
+
+From the repo root:
+
+```bash
+./scripts/start-dev-servers.sh   # or whichever script CLAUDE.md / docs/development/setup.md prescribes
+```
+
+Open the **Archiv expedičních listů** page. Verify:
+
+1. Date list loads (left sidebar populated).
+2. Selecting a date loads the items table on the right.
+3. Clicking **Otevřít** on a row opens the PDF in a new tab.
+4. Clicking **Přetisk** → confirming → shows a success toast and the items list refreshes.
+5. Clicking **Spustit tisk oprav** shows a success toast with a total count.
+
+If any step fails, the network tab should show the same HTTP verb/path/body as before the refactor — debug from there.
+
+- [ ] **Step 6: Final commit (only if any cleanup edits were made in Step 1)**
+
+If Step 1 forced any additional cleanup edits (unused imports etc), commit them:
+
+```bash
+git add -A
+git commit -m "chore: clean up unused imports after expedition-archive migration"
+```
+
+Otherwise skip.
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Requirement | Task |
+|---|---|
+| FR-1: `useExpeditionDates` no `as any`, typed call, signatures preserved | Tasks 1+2 |
+| FR-2: `useExpeditionListsByDate` no `as any`, typed call, `enabled: !!date`, signatures preserved | Task 3 |
+| FR-3: `useReprintExpeditionList` uses `new ReprintExpeditionListRequest(...)`, query invalidation preserved | Task 4 |
+| FR-4: `useRunExpeditionListPrintFix` no `as any`, typed call | Task 5 |
+| FR-5: `getExpeditionListDownloadUrl` uses `getApiBaseUrl()`, no client instantiation, per-segment encoding | Task 6 |
+| FR-6 (amended A2): extend `MIGRATED_HOOKS` Jest guardrail | Task 8 |
+| NFR-1: behavior parity — same HTTP method/path/body, same React Query keys | Implicit in all refactor tasks; guarded by tests in Tasks 2-5 + page test in Tasks 4, 5, 7 |
+| NFR-2: zero `as any` casts in the hook file + zero in `ExpeditionListArchivePage.tsx` `handleOpen` (amendment A1) | Tasks 2-7; verified explicitly in Task 9 Step 4 |
+| NFR-3: ≥1 happy-path test per refactored hook | Tasks 1, 3, 4, 5 |
+| NFR-4: bundle size neutral or smaller | Implicit — refactor removes hand-rolled fetch code, reuses existing methods |
+| NFR-5: auth interceptor coverage guaranteed-by-type | Implicit; arch-review confirms `authenticatedHttp.fetch` is preserved by construction |
+| Data model: keep local interfaces, map inside `queryFn` (amendment A3); drop only `ReprintExpeditionListRequest` (amendment A4) | Tasks 3, 4 |
+
+### Placeholder scan
+
+No "TBD", "TODO", "Add appropriate error handling" anywhere. Every step shows the exact code or command.
+
+### Type consistency
+
+- `useReprintExpeditionList` mutation input is `{ blobPath: string }` everywhere (Task 4 declaration + Task 4 Step 5 mutation signature + page consumer at `ExpeditionListArchivePage.tsx:107` already passes `{ blobPath: reprintConfirm.blobPath }`).
+- `useRunExpeditionListPrintFix` returns `RunExpeditionListPrintFixResult` everywhere (Task 5 declaration + Step 4 mutation signature + page consumer at `ExpeditionListArchivePage.tsx:98` reads `result.totalCount`).
+- `ExpeditionListItemDto.createdOn` is `string | null` everywhere (declaration in untouched lines 6-12, mapping in Task 3 Step 3 produces `string | null`, page consumer at `ExpeditionListArchivePage.tsx:253` calls `formatDateTime(item.createdOn)` which accepts `string | null`).
+- `ExpeditionListItemDto.contentLength` is `number | null` everywhere (same chain as above; consumer at `ExpeditionListArchivePage.tsx:256` calls `formatFileSize(item.contentLength)` which accepts `number | null`).
+- `getApiBaseUrl()` is imported in Task 6 Step 1 and used in Task 6 Step 2.
+- `getAuthenticatedFetch()` is imported in Task 7 Step 1 and used in Task 7 Step 2.
+- `ReprintExpeditionListRequest` is the generated class everywhere it appears post-migration (imported in Task 4 Step 3, instantiated in Task 4 Step 5, asserted on in Task 4 Step 1 test).

--- a/frontend/src/api/__tests__/authenticated-api-usage.test.ts
+++ b/frontend/src/api/__tests__/authenticated-api-usage.test.ts
@@ -194,7 +194,10 @@ describe("Authenticated API Usage", () => {
   it("should not use (as any) type casting patterns for API clients", () => {
     // Hooks that have been fully migrated away from (apiClient as any) patterns.
     // Add new hook file names here (basename only) when they are migrated.
-    const MIGRATED_HOOKS = new Set(["useArticles.ts"]);
+    const MIGRATED_HOOKS = new Set([
+      "useArticles.ts",
+      "useExpeditionListArchive.ts",
+    ]);
 
     const hookFiles = getTypeScriptFiles(apiHooksDir);
     const violations: Array<{ file: string; line: number; content: string }> =

--- a/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+++ b/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
@@ -73,3 +73,69 @@ describe('useExpeditionDates', () => {
     });
   });
 });
+
+describe('useExpeditionListsByDate', () => {
+  let mockGetByDate: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetByDate = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionListArchive_GetByDate: mockGetByDate,
+    } as any);
+  });
+
+  it('passes the date through to the typed method and maps Date/undefined to string/null', async () => {
+    mockGetByDate.mockResolvedValue({
+      items: [
+        {
+          blobPath: '2024/12/10/file.pdf',
+          fileName: 'expedice-2024-12-10.pdf',
+          listId: 'L-1',
+          createdOn: new Date('2024-12-10T10:00:00.000Z'),
+          contentLength: 1024,
+        },
+        {
+          blobPath: '2024/12/10/other.pdf',
+          fileName: 'expedice-other.pdf',
+          listId: 'L-2',
+          createdOn: undefined,
+          contentLength: undefined,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useExpeditionListsByDate('2024-12-10'), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetByDate).toHaveBeenCalledWith('2024-12-10');
+    expect(result.current.data).toEqual({
+      items: [
+        {
+          blobPath: '2024/12/10/file.pdf',
+          fileName: 'expedice-2024-12-10.pdf',
+          listId: 'L-1',
+          createdOn: '2024-12-10T10:00:00.000Z',
+          contentLength: 1024,
+        },
+        {
+          blobPath: '2024/12/10/other.pdf',
+          fileName: 'expedice-other.pdf',
+          listId: 'L-2',
+          createdOn: null,
+          contentLength: null,
+        },
+      ],
+    });
+  });
+
+  it('does not call the API when date is empty (enabled: !!date)', async () => {
+    renderHook(() => useExpeditionListsByDate(''), { wrapper: createWrapper });
+    // Give React Query a microtask to evaluate `enabled`
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGetByDate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+++ b/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
@@ -139,3 +139,43 @@ describe('useExpeditionListsByDate', () => {
     expect(mockGetByDate).not.toHaveBeenCalled();
   });
 });
+
+describe('useReprintExpeditionList', () => {
+  let mockReprint: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReprint = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionListArchive_Reprint: mockReprint,
+    } as any);
+  });
+
+  it('instantiates ReprintExpeditionListRequest, calls the typed method, and returns the mapped response', async () => {
+    mockReprint.mockResolvedValue({ success: true, errorMessage: null });
+
+    const { result } = renderHook(() => useReprintExpeditionList(), {
+      wrapper: createWrapper,
+    });
+
+    const response = await result.current.mutateAsync({ blobPath: '2024/12/10/file.pdf' });
+
+    expect(mockReprint).toHaveBeenCalledTimes(1);
+    const calledWith = mockReprint.mock.calls[0][0];
+    expect(calledWith).toBeInstanceOf(ReprintExpeditionListRequest);
+    expect(calledWith.blobPath).toBe('2024/12/10/file.pdf');
+    expect(response).toEqual({ success: true, errorMessage: null });
+  });
+
+  it('rethrows SwaggerException-like errors so callers can surface a toast', async () => {
+    mockReprint.mockRejectedValue({ status: 500, message: 'Internal Server Error' });
+
+    const { result } = renderHook(() => useReprintExpeditionList(), {
+      wrapper: createWrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ blobPath: '2024/12/10/file.pdf' }),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+});

--- a/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+++ b/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
@@ -179,3 +179,39 @@ describe('useReprintExpeditionList', () => {
     ).rejects.toMatchObject({ status: 500 });
   });
 });
+
+describe('useRunExpeditionListPrintFix', () => {
+  let mockRunFix: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRunFix = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionList_RunFix: mockRunFix,
+    } as any);
+  });
+
+  it('calls expeditionList_RunFix and returns the mapped response', async () => {
+    mockRunFix.mockResolvedValue({ totalCount: 7, errorMessage: null });
+
+    const { result } = renderHook(() => useRunExpeditionListPrintFix(), {
+      wrapper: createWrapper,
+    });
+
+    const response = await result.current.mutateAsync();
+
+    expect(mockRunFix).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({ totalCount: 7, errorMessage: null });
+  });
+
+  it('defaults totalCount to 0 and errorMessage to null when the backend omits them', async () => {
+    mockRunFix.mockResolvedValue({});
+
+    const { result } = renderHook(() => useRunExpeditionListPrintFix(), {
+      wrapper: createWrapper,
+    });
+
+    const response = await result.current.mutateAsync();
+    expect(response).toEqual({ totalCount: 0, errorMessage: null });
+  });
+});

--- a/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
+++ b/frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts
@@ -1,0 +1,75 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import {
+  useExpeditionDates,
+  useExpeditionListsByDate,
+  useReprintExpeditionList,
+  useRunExpeditionListPrintFix,
+} from '../useExpeditionListArchive';
+import { ReprintExpeditionListRequest } from '../../generated/api-client';
+import * as clientModule from '../../client';
+
+jest.mock('../../client', () => ({
+  getAuthenticatedApiClient: jest.fn(),
+  getApiBaseUrl: jest.fn(() => 'https://api.example.test'),
+  getAuthenticatedFetch: jest.fn(),
+  QUERY_KEYS: {
+    expeditionListArchive: ['expedition-list-archive'],
+  },
+}));
+
+const mockGetAuthenticatedApiClient =
+  clientModule.getAuthenticatedApiClient as jest.MockedFunction<
+    typeof clientModule.getAuthenticatedApiClient
+  >;
+
+const createWrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    children,
+  );
+};
+
+describe('useExpeditionDates', () => {
+  let mockGetDates: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDates = jest.fn();
+    mockGetAuthenticatedApiClient.mockReturnValue({
+      expeditionListArchive_GetDates: mockGetDates,
+    } as any);
+  });
+
+  it('calls expeditionListArchive_GetDates with the given page and pageSize and returns the mapped response', async () => {
+    mockGetDates.mockResolvedValue({
+      dates: ['2024-12-10', '2024-12-09'],
+      totalCount: 2,
+      page: 3,
+      pageSize: 50,
+    });
+
+    const { result } = renderHook(() => useExpeditionDates(3, 50), {
+      wrapper: createWrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetDates).toHaveBeenCalledTimes(1);
+    expect(mockGetDates).toHaveBeenCalledWith(3, 50);
+    expect(result.current.data).toEqual({
+      dates: ['2024-12-10', '2024-12-09'],
+      totalCount: 2,
+      page: 3,
+      pageSize: 50,
+    });
+  });
+});

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -63,21 +63,18 @@ export const useExpeditionDates = (page: number = 1, pageSize: number = 20) => {
 export const useExpeditionListsByDate = (date: string) => {
   return useQuery<GetExpeditionListsByDateResponse>({
     queryKey: expeditionArchiveKeys.itemsByDate(date),
-    queryFn: async () => {
-      const apiClient = getAuthenticatedApiClient();
-      const relativeUrl = `/api/expedition-list-archive/${encodeURIComponent(date)}`;
-      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
-
-      const response = await (apiClient as any).http.fetch(fullUrl, {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      return await response.json();
+    queryFn: async (): Promise<GetExpeditionListsByDateResponse> => {
+      const client = getAuthenticatedApiClient();
+      const response = await client.expeditionListArchive_GetByDate(date);
+      return {
+        items: (response.items ?? []).map((item) => ({
+          blobPath: item.blobPath ?? '',
+          fileName: item.fileName ?? '',
+          listId: item.listId ?? '',
+          createdOn: item.createdOn ? item.createdOn.toISOString() : null,
+          contentLength: item.contentLength ?? null,
+        })),
+      };
     },
     enabled: !!date,
     staleTime: 1000 * 60 * 5,

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+import { ReprintExpeditionListRequest } from "../generated/api-client";
 
 // --- Types ---
 
@@ -20,10 +21,6 @@ export interface GetExpeditionDatesResponse {
 
 export interface GetExpeditionListsByDateResponse {
   items: ExpeditionListItemDto[];
-}
-
-export interface ReprintExpeditionListRequest {
-  blobPath: string;
 }
 
 export interface ReprintExpeditionListResponse {
@@ -84,26 +81,15 @@ export const useExpeditionListsByDate = (date: string) => {
 export const useReprintExpeditionList = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<ReprintExpeditionListResponse, Error, ReprintExpeditionListRequest>({
-    mutationFn: async (request: ReprintExpeditionListRequest) => {
-      const apiClient = getAuthenticatedApiClient();
-      const relativeUrl = `/api/expedition-list-archive/reprint`;
-      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
-
-      const response = await (apiClient as any).http.fetch(fullUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ blobPath: request.blobPath }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => null);
-        throw new Error(
-          errorData?.errorMessage ?? `HTTP error! status: ${response.status}`
-        );
-      }
-
-      return await response.json();
+  return useMutation<ReprintExpeditionListResponse, Error, { blobPath: string }>({
+    mutationFn: async (input): Promise<ReprintExpeditionListResponse> => {
+      const client = getAuthenticatedApiClient();
+      const request = new ReprintExpeditionListRequest({ blobPath: input.blobPath });
+      const response = await client.expeditionListArchive_Reprint(request);
+      return {
+        success: response.success ?? true,
+        errorMessage: response.errorMessage ?? null,
+      };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.expeditionListArchive });

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -46,28 +46,15 @@ const expeditionArchiveKeys = {
 export const useExpeditionDates = (page: number = 1, pageSize: number = 20) => {
   return useQuery<GetExpeditionDatesResponse>({
     queryKey: expeditionArchiveKeys.dates(page, pageSize),
-    queryFn: async () => {
-      const apiClient = getAuthenticatedApiClient();
-      const relativeUrl = `/api/expedition-list-archive/dates`;
-      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
-
-      const params = new URLSearchParams();
-      params.append("page", page.toString());
-      params.append("pageSize", pageSize.toString());
-
-      const response = await (apiClient as any).http.fetch(
-        `${fullUrl}?${params.toString()}`,
-        {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      return await response.json();
+    queryFn: async (): Promise<GetExpeditionDatesResponse> => {
+      const client = getAuthenticatedApiClient();
+      const response = await client.expeditionListArchive_GetDates(page, pageSize);
+      return {
+        dates: response.dates ?? [],
+        totalCount: response.totalCount ?? 0,
+        page: response.page ?? page,
+        pageSize: response.pageSize ?? pageSize,
+      };
     },
     staleTime: 1000 * 60 * 5,
   });

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -28,6 +28,11 @@ export interface ReprintExpeditionListResponse {
   errorMessage: string | null;
 }
 
+export interface RunExpeditionListPrintFixResult {
+  totalCount: number;
+  errorMessage: string | null;
+}
+
 // --- Query Keys ---
 
 const expeditionArchiveKeys = {
@@ -98,25 +103,14 @@ export const useReprintExpeditionList = () => {
 };
 
 export const useRunExpeditionListPrintFix = () => {
-  return useMutation({
-    mutationFn: async () => {
-      const apiClient = getAuthenticatedApiClient();
-      const relativeUrl = `/api/expedition-list/run-fix`;
-      const fullUrl = `${(apiClient as any).baseUrl}${relativeUrl}`;
-
-      const response = await (apiClient as any).http.fetch(fullUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => null);
-        throw new Error(
-          errorData?.errorMessage ?? `HTTP error! status: ${response.status}`
-        );
-      }
-
-      return await response.json();
+  return useMutation<RunExpeditionListPrintFixResult, Error, void>({
+    mutationFn: async (): Promise<RunExpeditionListPrintFixResult> => {
+      const client = getAuthenticatedApiClient();
+      const response = await client.expeditionList_RunFix();
+      return {
+        totalCount: response.totalCount ?? 0,
+        errorMessage: response.errorMessage ?? null,
+      };
     },
   });
 };

--- a/frontend/src/api/hooks/useExpeditionListArchive.ts
+++ b/frontend/src/api/hooks/useExpeditionListArchive.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getAuthenticatedApiClient, QUERY_KEYS } from "../client";
+import { getAuthenticatedApiClient, getApiBaseUrl, QUERY_KEYS } from "../client";
 import { ReprintExpeditionListRequest } from "../generated/api-client";
 
 // --- Types ---
@@ -116,8 +116,6 @@ export const useRunExpeditionListPrintFix = () => {
 };
 
 export const getExpeditionListDownloadUrl = (blobPath: string): string => {
-  const apiClient = getAuthenticatedApiClient();
-  const baseUrl = (apiClient as any).baseUrl;
   const encodedPath = blobPath.split("/").map(encodeURIComponent).join("/");
-  return `${baseUrl}/api/expedition-list-archive/download/${encodedPath}`;
+  return `${getApiBaseUrl()}/api/expedition-list-archive/download/${encodedPath}`;
 };

--- a/frontend/src/pages/ExpeditionListArchivePage.tsx
+++ b/frontend/src/pages/ExpeditionListArchivePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { FileText, Printer, ExternalLink, ChevronLeft, ChevronRight, Play, RefreshCw } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { getAuthenticatedApiClient, QUERY_KEYS } from "../api/client";
+import { getAuthenticatedFetch, QUERY_KEYS } from "../api/client";
 import {
   useExpeditionDates,
   useExpeditionListsByDate,
@@ -61,9 +61,8 @@ const ExpeditionListArchivePage: React.FC = () => {
 
   const handleOpen = async (item: ExpeditionListItemDto) => {
     const url = getExpeditionListDownloadUrl(item.blobPath);
-    const apiClient = getAuthenticatedApiClient();
     try {
-      const response = await (apiClient as any).http.fetch(url, { method: 'GET' });
+      const response = await getAuthenticatedFetch()(url, { method: 'GET' });
       if (!response.ok) {
         showError('Chyba', `Nepodařilo se otevřít soubor (${response.status}).`);
         return;

--- a/frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx
+++ b/frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx
@@ -19,6 +19,7 @@ jest.mock("../../api/hooks/useRecurringJobs", () => ({
 
 jest.mock("../../api/client", () => ({
   getAuthenticatedApiClient: jest.fn(),
+  getAuthenticatedFetch: jest.fn(() => jest.fn()),
   QUERY_KEYS: {
     expeditionListArchive: ["expedition-list-archive"],
   },


### PR DESCRIPTION

Replaced all six `(apiClient as any)` casts across the expedition list archive feature area with typed generated-client calls and public helper functions. The hook file now calls `expeditionListArchive_GetDates`, `expeditionListArchive_GetByDate`, `expeditionListArchive_Reprint`, and `expeditionList_RunFix` directly on the typed client; `getExpeditionListDownloadUrl` uses `getApiBaseUrl()`; and `handleOpen` in the page component uses `getAuthenticatedFetch()`. All five hook signatures are preserved so `ExpeditionListArchivePage` needs no consumer-side changes. A new test file covers the four refactored hooks with 7 tests, and the existing `MIGRATED_HOOKS` Jest guardrail is extended to prevent future regressions.

### Changes
- `frontend/src/api/hooks/useExpeditionListArchive.ts` — four hooks migrated to typed client, download URL helper fixed, local request interface dropped
- `frontend/src/pages/ExpeditionListArchivePage.tsx` — `handleOpen` cast removed, import swapped
- `frontend/src/api/__tests__/authenticated-api-usage.test.ts` — MIGRATED_HOOKS extended
- `frontend/src/api/hooks/__tests__/useExpeditionListArchive.test.ts` — new: 7 hook tests
- `frontend/src/pages/__tests__/ExpeditionListArchivePage.test.tsx` — mock updated for new import

---

Closes #2500

### Tokens used
13820310
