### PR TITLE
feat: Fix Journal search pagination & sorting (auto-refetch on query key change)

### DIFF
--- a/artifacts/feat-arch-review-journal-search-mode-paginati/arch-review.r1.md
+++ b/artifacts/feat-arch-review-journal-search-mode-paginati/arch-review.r1.md
@@ -1,0 +1,192 @@
+I have enough context to write the architecture review. The fix matches established patterns in the codebase (`useInvoiceDetails`, `useManufactureDifficulty`, `useTransportBoxes`, `useManufactureOrderDetailQuery`, `useArticleTraceQuery`, and `useManufactureOrders` all use `enabled: boolean = true|false` as a hook parameter that gates `useQuery.enabled`). `useSearchJournalEntries` has exactly one production call site (`JournalList.tsx`), so the API change has minimal blast radius.
+
+# Architecture Review: Fix Journal search pagination & sorting (auto-refetch on query-key change)
+
+## Skip Design: true
+
+## Architectural Fit Assessment
+
+This is a surgical frontend bug fix that aligns cleanly with existing patterns in the codebase. There are no architectural concerns:
+
+- **Convention precedent is solid.** The proposed `enabled: boolean = false` parameter is a well-established pattern in this repo. See `useInvoiceDetails(invoiceId, enabled = true)` (`useInvoiceClassification.ts:178`), `useManufactureDifficulty(..., enabled = true)`, `useManufactureOrderDetailQuery(id, enabled = true)`, `useArticleTraceQuery(id, enabled)`, and `useTransportBoxes` — all expose an `enabled` flag wired to `useQuery({ enabled })`. The new signature `useSearchJournalEntries(params, enabled = false)` slots in naturally; the only deviation is the default (`false` vs. the more common `true`), which is correct given the original "no request on mount" intent of the search hook.
+- **Blast radius is bounded.** `useSearchJournalEntries` has exactly **one** production call site (`JournalList.tsx:189`). `useJournalEntriesByProduct` calls `journal_SearchJournalEntries` directly inside its own `useQuery`, so it is unaffected. Test files at `useJournal.test.ts:198, 385` and `JournalList.test.tsx:118, 238, 269, 310` rely on the existing one-arg signature; adding an optional second arg with a backward-compatible default does not break them.
+- **No data-model, contract, or boundary impact.** Frontend-only change, same wire shape, same query key (`[...QUERY_KEYS.journal, "search", params]`), so cache hits across navigation are preserved.
+- **Mutation invalidation already works.** `useCreateJournalEntry`, `useUpdateJournalEntry`, and `useDeleteJournalEntry` already invalidate `[...QUERY_KEYS.journal, "search"]` (`useJournal.ts:90, 118, 143`), so post-mutation freshness in search mode will continue to work via auto-refetch once `enabled` is `true`.
+
+The fix corrects a behavioral asymmetry (default mode auto-refetches; search mode does not) without introducing a new pattern.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ JournalList.tsx (page component)                                     │
+│                                                                      │
+│  state: searchTextFilter, isSearchMode, pageNumber, pageSize,        │
+│         sortBy, sortDescending                                       │
+│                                                                      │
+│   ┌─────────────────────────────┐    ┌────────────────────────────┐  │
+│   │ useJournalEntries(params)   │    │ useSearchJournalEntries(   │  │
+│   │   enabled = true (implicit) │    │     params, isSearchMode)  │  │
+│   │                             │    │   enabled = isSearchMode   │  │
+│   └──────────────┬──────────────┘    └─────────────┬──────────────┘  │
+│                  │                                  │                 │
+│                  └────────── currentQuery ──────────┘                 │
+│                  (selected by isSearchMode)                           │
+│                  │                                                    │
+│                  ▼                                                    │
+│   table render, pagination footer, SortableHeader                     │
+└──────────────────────────────────────────────────────────────────────┘
+                  │
+                  ▼ key change → React Query auto-refetch (when enabled)
+┌──────────────────────────────────────────────────────────────────────┐
+│ Backend: journal_GetJournalEntries / journal_SearchJournalEntries    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The fix removes the asymmetry: both branches of `currentQuery` are now driven by React Query's `queryKey`-change auto-refetch mechanism. The conditional `enabled = isSearchMode` ensures only one of the two queries is live at a time.
+
+### Key Design Decisions
+
+#### Decision 1: Parameterize `enabled` rather than hardcode `enabled: true`
+
+**Options considered:**
+- **A.** Always-on (`enabled: true` or removing the line). Simplest, but fires an unwanted search request on mount when `searchTextFilter` is empty (it would call `journal_SearchJournalEntries(undefined, ...)`, returning unfiltered results that are then discarded). Wastes a backend round trip on every page load.
+- **B.** Parameterize `enabled` with `false` default, bind to `isSearchMode` at the call site. Preserves the "no request on mount" guarantee; matches the existing repo pattern.
+- **C.** Collapse `useJournalEntries` + `useSearchJournalEntries` into a single mode-aware hook. Cleaner conceptually but explicitly out of scope per the spec, and would be a much larger change.
+
+**Chosen approach:** B — exactly as the spec proposes.
+
+**Rationale:** Preserves backwards compatibility for any caller that opts out (none exist today, but the default protects future callers). Matches `useInvoiceDetails`, `useManufactureOrderDetailQuery`, `useTransportBoxQuery`, etc. The two-hook pattern stays, which keeps the diff surgical.
+
+#### Decision 2: Keep the explicit `searchQuery.refetch()` in `handleApplyFilters`
+
+**Options considered:**
+- **A.** Remove it once auto-refetch is in place. Cleaner code, but breaks the UX contract when a user clicks **Filtrovat** without changing the input text (the query key is unchanged, so no auto-refetch fires).
+- **B.** Keep it. Accepts a redundant request on the "text changed" path (auto-refetch + explicit refetch fire near-simultaneously; React Query coalesces in-flight requests with the same key, so the user-visible effect is still one render).
+
+**Chosen approach:** B.
+
+**Rationale:** "Click button → something visibly happens" is a stronger product invariant than the small efficiency win. React Query's in-flight de-duplication mitigates the cost in the common case. The spec captures this correctly in FR-6.
+
+#### Decision 3: Do not memoize the `params` object
+
+**Options considered:** Wrap `params` in `useMemo` to stabilize identity across renders.
+
+**Chosen approach:** Pass a fresh object each render, as today.
+
+**Rationale:** React Query serializes the query key for comparison; new object identity with structurally equal contents does not trigger a refetch. Adding `useMemo` would add ceremony without behavior change. Confirmed out of scope by the spec.
+
+#### Decision 4: Pagination/sort handlers stay state-only
+
+**Options considered:** Make `handlePageChange`/`handlePageSizeChange`/`handleSort` also call `searchQuery.refetch()` directly.
+
+**Chosen approach:** Leave them as pure state setters. Refetch is driven entirely by `useQuery`'s key-change behavior once `enabled` is `true`.
+
+**Rationale:** Single mechanism for data freshness (key-driven refetch) reduces the chance of regressing the same bug in a new handler later. It also keeps the handlers indistinguishable from their behavior in non-search mode, where they already work correctly.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+
+No new files. Two existing files are touched:
+
+| File | Change |
+|------|--------|
+| `frontend/src/api/hooks/useJournal.ts` | Add `enabled: boolean = false` parameter to `useSearchJournalEntries`; forward to `useQuery({ enabled })`. Remove the hardcoded `enabled: false`. |
+| `frontend/src/components/pages/Journal/JournalList.tsx` | Pass `isSearchMode` as the second argument at the existing call site (`line 189`). Nothing else changes. |
+
+Tests:
+
+| File | Change |
+|------|--------|
+| `frontend/src/api/hooks/__tests__/useJournal.test.ts` | Update the existing search test (`line 181`+) to either pass `enabled = true` or invoke `refetch()` (existing behavior). Add tests per NFR-4: (a) default `enabled` → no fetch on mount, (b) `enabled = true` → fetch on mount, (c) `enabled = true` + params change → auto-refetch. |
+| `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` | Add tests that simulate search mode → page change / sort click / page-size change and assert the search query mock is re-invoked with new params (or that the rendered rows reflect the new mock response). The existing `mockUseJournalHooks.useSearchJournalEntries.mockReturnValue(...)` pattern at lines 118/238/269/310 still applies; the new test will need to re-`mockReturnValue` between interactions to simulate the new page's data and assert the table re-renders. |
+
+### Interfaces and Contracts
+
+**Hook signature (the only public-API change):**
+
+```ts
+// frontend/src/api/hooks/useJournal.ts
+export const useSearchJournalEntries = (
+  params: SearchJournalParams,
+  enabled?: boolean,    // default false — preserves current "no request on mount" semantics
+) => UseQueryResult<...>
+```
+
+**Invariants the implementation must preserve:**
+
+1. `queryKey: [...QUERY_KEYS.journal, "search", params]` — unchanged. Cache-by-params behavior is preserved.
+2. When `enabled === false`, the hook does not run on mount and does not auto-refetch on key change. `.refetch()` is the only trigger. (Matches today's behavior, retained for backwards compatibility.)
+3. When `enabled === true`, standard React Query semantics apply: runs on mount, auto-refetches on key change, integrates with `invalidateQueries` from sibling mutation hooks.
+4. The `enabled` argument flows to `useQuery({ enabled })` literally — no AND-ing with other guards (unlike `useInvoiceDetails`, which additionally requires `!!invoiceId`). `SearchJournalParams.searchText` is allowed to be empty (the backend treats it as "no text filter"), so guarding on it would change semantics.
+
+### Data Flow
+
+**Search-mode pagination (the bug being fixed):**
+
+```
+user clicks "Page 2"
+    └─> handlePageChange(2)
+        └─> setPageNumber(2)
+            └─> JournalList re-renders with pageNumber = 2
+                └─> useSearchJournalEntries({ ..., pageNumber: 2 }, isSearchMode=true)
+                    └─> queryKey changes (params is part of the key)
+                        └─> React Query detects key change + enabled=true
+                            └─> queryFn fires → journal_SearchJournalEntries(..., pageNumber=2, ...)
+                                └─> isLoading flips → spinner (existing UI)
+                                    └─> response arrives → data prop updates
+                                        └─> table re-renders with page-2 rows
+```
+
+The same flow applies symmetrically to page-size changes and sort changes (each updates state that is part of `params`, which is part of the query key).
+
+**Mode toggling:**
+
+```
+empty search + click "Filtrovat"   → isSearchMode stays false → entriesQuery active, searchQuery dormant
+non-empty search + click "Filtrovat" → isSearchMode = true → searchQuery activates (auto-fetch)
+click "Vymazat"                       → isSearchMode = false → searchQuery deactivates, entriesQuery shows
+```
+
+The transition between the two queries is observable via `currentQuery = isSearchMode ? searchQuery : entriesQuery` (`JournalList.tsx:197`) — unchanged.
+
+**Mutation → invalidation → auto-refetch:**
+
+```
+user edits an entry → useUpdateJournalEntry.mutateAsync
+    └─> onSuccess → queryClient.invalidateQueries([..., "search"])  (already in place)
+        └─> with enabled=true, React Query refetches the active search query
+            └─> table reflects the edit
+```
+
+(Today this only works via the explicit `searchQuery.refetch()` in `handleCloseModal`; after the fix, both mechanisms work, which is harmless.)
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Loading flicker on every pagination/sort click in search mode. | Low | Existing UI returns early on `loading` (`JournalList.tsx:287–296`), so each refetch will briefly show the spinner. This is consistent with non-search mode behavior. If perceived as regression, switch to a row-level skeleton or use `isFetching` instead of `isLoading` to keep the table visible during background refetch — out of scope for this fix. |
+| Double-fire on **Filtrovat** when search text changed (auto-refetch + explicit `.refetch()`). | Low | React Query coalesces in-flight requests with the same query key, so at most one network request is in flight even if both triggers fire concurrently. Documented as acceptable in FR-6. |
+| Empty-string `searchText` after clearing input would briefly run an unfiltered search if `isSearchMode` is still `true`. | Low | `handleClearFilters` sets `isSearchMode = false` before any re-render uses the new state. React batches state updates within the handler, so `searchQuery` is deactivated in the same commit that clears the filter. No spurious request. |
+| Existing hook test (`useJournal.test.ts:181`) currently calls `result.current.refetch()` and will keep working, but the new default makes some assertions vacuous. | Low | Update the test alongside the implementation per NFR-4. New tests must include the negative case (`enabled = false` → no fetch on mount) to prevent regression of the original "no request on mount" intent. |
+| Future call site of `useSearchJournalEntries` omits `enabled` and silently never fires. | Low | Default `false` was chosen specifically to preserve today's semantics for unaware callers. Add a one-line JSDoc comment on the hook explaining the flag's purpose so future callers see it. |
+| Bug recurs if someone later adds a new param-driving state setter (e.g., a date filter) and again hardcodes `enabled: false`. | Low | The new tests at the component level (page change / sort / size → new data renders) act as a regression net. Recommend a brief note in `docs/architecture/development_guidelines.md` capturing the rule: "React Query hooks must rely on query-key changes for refetch; avoid `enabled: false` unless paired with a parameter that the call site can flip on." (Optional — not strictly required to merge.) |
+
+## Specification Amendments
+
+None required. The spec is internally consistent and matches the architectural constraints of the codebase. Two minor clarifications worth folding into the implementation PR description (not the spec):
+
+1. **Test-file update required, not just additions.** The existing test at `useJournal.test.ts:181` will need its comment and explicit `refetch()` call adjusted (it can stay if the new default `enabled = false` is honored, but the comment "Search queries are disabled by default" should be updated to reflect that this is now a default, not a hardcoded constant).
+2. **JSDoc on the new parameter** is recommended (one line) since the `false` default is unusual relative to peer hooks (`useInvoiceDetails`, `useManufactureDifficulty`, etc. all default to `true`). Without the comment, a developer scanning the signature could reasonably misread the default.
+
+## Prerequisites
+
+None. No migrations, config, infrastructure, feature flags, or backend changes. The fix can land in a single frontend PR.
+
+- No `@tanstack/react-query` version bump (relies only on documented `enabled` semantics that have been stable since v3).
+- No regeneration of the OpenAPI client.
+- No environment variables.
+- No Key Vault secrets.

--- a/artifacts/feat-arch-review-journal-search-mode-paginati/brief.md
+++ b/artifacts/feat-arch-review-journal-search-mode-paginati/brief.md
@@ -1,0 +1,61 @@
+## Module
+Journal
+
+## Finding
+`useSearchJournalEntries` is configured with `enabled: false`:
+
+```ts
+// frontend/src/api/hooks/useJournal.ts, line 62
+enabled: false, // Only run when explicitly called
+```
+
+React Query therefore never re-runs the search query automatically when the query key changes. In `JournalList.tsx`, the pagination and sorting handlers only update state — they never call `.refetch()`:
+
+```tsx
+// Lines 247–255 — no refetch, so search results don't update
+const handlePageChange = (newPage: number) => {
+  if (newPage >= 1 && newPage <= totalPages) {
+    setPageNumber(newPage);
+  }
+};
+
+const handlePageSizeChange = (newPageSize: number) => {
+  setPageSize(newPageSize);
+  setPageNumber(1);
+};
+
+// Lines 237–243 — same issue for sorting
+const handleSort = (column: string) => { ... setSortBy(column); ... };
+```
+
+**Consequence**: while in search mode (after clicking "Filtrovat"), clicking a different page, changing page size, or clicking a sort column header updates the visible page indicator and sort arrow — but the data on screen does not change. It remains the first page of the original search, silently.
+
+The only way to get updated data is to click "Filtrovat" again. This means a user who searches, then navigates to page 2, is reading stale page-1 results without knowing it.
+
+## Why it matters
+Pagination and sorting are broken in a visible, user-facing feature. The bug is invisible in tests because the hook is typically tested in isolation (where `refetch` can be called directly), and the `enabled: false` pattern looks intentional at first glance.
+
+## Suggested fix
+Pass an `enabled` flag to the hook so React Query can auto-refetch when the query key changes:
+
+```ts
+// useJournal.ts
+export const useSearchJournalEntries = (params: SearchJournalParams, enabled = false) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.journal, "search", params],
+    queryFn: async () => { ... },
+    enabled,
+  });
+};
+```
+
+In `JournalList.tsx`, bind it to `isSearchMode`:
+
+```tsx
+const searchQuery = useSearchJournalEntries({ ...params }, isSearchMode);
+```
+
+This preserves the original intent (no search request on initial mount when `searchTextFilter` is empty and `isSearchMode` is false) and makes pagination/sorting work automatically when in search mode.
+
+---
+_Filed by daily arch-review routine on 2026-06-04._

--- a/artifacts/feat-arch-review-journal-search-mode-paginati/impl/main.r1.md
+++ b/artifacts/feat-arch-review-journal-search-mode-paginati/impl/main.r1.md
@@ -1,0 +1,64 @@
+Final code review: **APPROVED**. Writing the output summary.
+
+---
+
+# Implementation: Fix Journal search pagination & sorting (auto-refetch on query-key change)
+
+## What was implemented
+
+Surgical two-file fix that eliminates a silent data-staleness bug: in journal search mode, changing the page number, page size, or sort column updated UI affordances but did not refetch data — users silently kept seeing page 1 of the original search.
+
+**Root cause:** `useSearchJournalEntries` had `enabled: false` hardcoded, which prevented React Query's automatic key-change refetch. Pagination/sort handlers in `JournalList` were correct (pure state setters), but the query never reacted to those state changes in search mode.
+
+**Fix:** Parameterized `enabled` on the hook (default `false`, preserving backwards compatibility), then passed `isSearchMode` at the single call site so the query becomes live exactly when — and only when — the user has applied a non-empty search filter.
+
+## Files created/modified
+
+- `frontend/src/api/hooks/useJournal.ts` — Added `enabled: boolean = false` parameter to `useSearchJournalEntries`; forwarded to `useQuery({ enabled })`; added JSDoc explaining the default and key-change refetch semantics
+- `frontend/src/components/pages/Journal/JournalList.tsx` — Passed `isSearchMode` as second arg to `useSearchJournalEntries`; no other change
+- `frontend/src/api/hooks/__tests__/useJournal.test.ts` — 3 new tests (no-fetch-on-mount guard, fetch-on-mount with `enabled=true`, auto-refetch on params change) + comment update on the existing explicit-refetch test
+- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — 3 new component regression tests (pagination, sort, page-size in search mode) + lint fixes (`no-wait-for-multiple-assertions`)
+
+## Tests
+
+- `useJournal.test.ts` — 17 tests, all passing; 4 cover `useSearchJournalEntries` (including 3 new tests for the `enabled` parameter behavior)
+- `JournalList.test.tsx` — 21 tests, all passing; 3 new regression tests assert that changing page, sort, or page-size in search mode causes the hook to be re-invoked with the new params and `enabled=true`
+- Overall journal test suite: **38/38 PASS**
+
+## How to verify
+
+```bash
+cd frontend
+# Hook tests
+CI=true npm test -- --testPathPattern="src/api/hooks/__tests__/useJournal" --no-coverage
+
+# Component tests (includes 3 regression tests)
+CI=true npm test -- --testPathPattern="src/components/pages/Journal/__tests__/JournalList" --no-coverage
+
+# Build
+npm run build
+```
+
+## Notes
+
+- `handleApplyFilters` retains its explicit `searchQuery.refetch()` call (FR-6 — so re-clicking Filtrovat with unchanged text still refreshes data). With `enabled=true` in place, an identical-text re-filter causes both auto-refetch + explicit refetch; React Query coalesces them.
+- `handleCloseModal` and all pagination/sort handlers are untouched (FR-7, Decision 4 in arch review).
+- 144 pre-existing lint warnings in the project; none introduced by this change.
+- The `positional-index` approach in the auto-refetch test (`lastCallArgs[6]`) is noted as brittle if the API signature changes, but matches codebase conventions.
+
+## PR Summary
+
+Fixed a silent data-staleness bug where changing page, page size, or sort column while in journal search mode updated UI affordances but left the table showing stale page-1 data.
+
+The root cause was `enabled: false` hardcoded on `useSearchJournalEntries`, which blocked React Query's automatic key-change refetch. The fix parameterizes `enabled` (default `false` to preserve backwards compatibility for any caller that omits it) and passes `isSearchMode` at the sole call site in `JournalList.tsx` — so the query is live only when the user has applied a non-empty filter, and React Query auto-refetches on every pagination/sort/page-size state change.
+
+All existing handlers (`handleApplyFilters`, `handleCloseModal`) are untouched. Three new component-level regression tests directly cover the three bug scenarios (page change, sort change, page-size change in search mode).
+
+### Changes
+- `frontend/src/api/hooks/useJournal.ts` — parameterized `enabled` on `useSearchJournalEntries` with JSDoc
+- `frontend/src/components/pages/Journal/JournalList.tsx` — pass `isSearchMode` as second arg at call site
+- `frontend/src/api/hooks/__tests__/useJournal.test.ts` — 3 new hook-level tests + comment update
+- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — 3 new component regression tests + lint fixes
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-journal-search-mode-paginati/spec.r1.md
+++ b/artifacts/feat-arch-review-journal-search-mode-paginati/spec.r1.md
@@ -1,0 +1,172 @@
+# Specification: Fix Journal search pagination & sorting (auto-refetch on query key change)
+
+## Summary
+While viewing journal entries in search mode, changing the page number, page size, or sort column updates the UI affordances but does not refresh the displayed data — the user silently keeps reading page 1 of the original search. This spec covers a surgical fix that enables React Query's automatic refetch-on-key-change behavior for the search hook while preserving the original "no request on mount" intent.
+
+## Background
+`JournalList.tsx` uses two React Query hooks to back the same grid:
+
+- `useJournalEntries` — default browse mode; runs automatically on mount and on key change.
+- `useSearchJournalEntries` — search mode (active once the user clicks **Filtrovat** with non-empty search text); hardcoded with `enabled: false` at `frontend/src/api/hooks/useJournal.ts:62`.
+
+The `enabled: false` flag was introduced so the search query would not fire on initial render. Side-effect: React Query also stops auto-refetching when the query key changes. In `frontend/src/components/pages/Journal/JournalList.tsx`, the pagination handlers `handlePageChange` (lines 247–251), `handlePageSizeChange` (lines 253–256), and the sorting handler `handleSort` (lines 237–244) only update local state — they never call `searchQuery.refetch()`. The only paths that do refetch the search query are `handleApplyFilters` (clicking **Filtrovat**) and `handleCloseModal`.
+
+**Consequence (user-visible bug):** in search mode, clicking page 2/3/…, changing page size, or clicking a sortable header updates the pagination indicator and sort arrows but leaves the underlying data on screen as page 1 of the originally searched result set — a silent data-staleness bug. Default (non-search) mode is unaffected because `useJournalEntries` has no `enabled: false` and React Query auto-refetches it whenever the params/key change.
+
+The bug was not caught by tests because the hook is exercised in isolation (where `refetch()` can always be invoked directly), and the `enabled: false` pattern reads as intentional.
+
+## Functional Requirements
+
+### FR-1: Search hook accepts an `enabled` flag
+`useSearchJournalEntries` must accept an optional `enabled` parameter (default `false`, to preserve the current "no request on mount" guarantee for any existing/future caller that does not opt in) and forward it to React Query's `enabled` option.
+
+**Acceptance criteria:**
+- Hook signature becomes `useSearchJournalEntries(params: SearchJournalParams, enabled?: boolean)`.
+- When `enabled` is omitted or `false`, the hook behaves exactly as today: it does not run on mount and does not auto-refetch on query-key change; an explicit `.refetch()` is the only way to fire the request.
+- When `enabled` is `true`, the hook runs immediately and auto-refetches when any value in `params` (and hence the query key) changes.
+- The `queryKey` is unchanged (`[...QUERY_KEYS.journal, "search", params]`), so cached results keyed by prior params are still reused on back-navigation.
+
+### FR-2: `JournalList` binds the `enabled` flag to `isSearchMode`
+The page must pass `isSearchMode` to the hook so the search query becomes active iff the user has applied a non-empty search filter.
+
+**Acceptance criteria:**
+- `useSearchJournalEntries({ ...params }, isSearchMode)` is called from `JournalList.tsx`.
+- Initial mount with empty search text and `isSearchMode === false`: no search request is issued (matches today's behavior).
+- After the user clicks **Filtrovat** with non-empty text, `isSearchMode` flips to `true`, the search query becomes active, and the data renders.
+- After the user clicks **Vymazat filtry** (or applies an empty filter), `isSearchMode` flips back to `false`, the search query becomes inactive, and the default `useJournalEntries` data is shown.
+
+### FR-3: Pagination updates data in search mode
+When in search mode, clicking a different page number or pressing the prev/next chevron must trigger a backend request with the new `pageNumber` and render the new page's data.
+
+**Acceptance criteria:**
+- In search mode, calling `handlePageChange(newPage)` causes `params.pageNumber` to change → the query key changes → React Query refetches → the table renders the new page.
+- The pagination indicator and the visible rows are consistent (no silent staleness).
+- Existing guard `newPage >= 1 && newPage <= totalPages` remains in place.
+- Behavior is identical in default (non-search) mode (no regression).
+
+### FR-4: Page-size change updates data in search mode
+When in search mode, choosing a different page size must reset to page 1 and fetch fresh data with the new page size.
+
+**Acceptance criteria:**
+- `handlePageSizeChange(newPageSize)` sets `pageSize` and resets `pageNumber` to 1.
+- In search mode, the resulting query-key change triggers a refetch; the table shows the first page at the new size.
+- In default mode, behavior is unchanged.
+
+### FR-5: Sorting updates data in search mode
+When in search mode, clicking a sortable column header must trigger a backend re-query with the new sort column / direction and render the re-sorted data.
+
+**Acceptance criteria:**
+- `handleSort(column)` continues to (a) toggle direction if the same column is clicked, or (b) switch column and reset direction to ascending.
+- In search mode, the resulting `sortBy` / `sortDescending` state change feeds into `params`, the query key changes, React Query refetches, and the displayed rows reflect the new order.
+- Sort-arrow indicator in `SortableHeader` remains consistent with the actually-rendered data.
+- In default mode, behavior is unchanged.
+
+### FR-6: `handleApplyFilters` no longer needs an explicit refetch in the search path
+With FR-1+FR-2 in place, calling `searchQuery.refetch()` inside `handleApplyFilters` becomes redundant whenever the new `searchTextInput` differs from the prior `searchTextFilter` (the key changes and React Query auto-fetches). However, when the user types the same text and clicks **Filtrovat** again (key unchanged), an explicit `.refetch()` is still required to fulfill the implicit "the button does something" UX contract.
+
+**Acceptance criteria:**
+- `handleApplyFilters` retains the explicit `await searchQuery.refetch()` call in the search-text branch so that re-clicking **Filtrovat** with unchanged text still refreshes the data.
+- When `searchTextInput` differs from `searchTextFilter`, the auto-refetch (FR-1) and the explicit `.refetch()` together still produce a single coherent rendered result; an extra request on this path is acceptable.
+- The non-search branch (`await entriesQuery.refetch()`) is unchanged.
+
+### FR-7: Existing modal-close refetch behavior preserved
+`handleCloseModal` (lines 275–284) calls `searchQuery.refetch()` or `entriesQuery.refetch()` after the edit modal closes. This behavior is independently useful (force-refresh after an edit even if params didn't change) and must be preserved.
+
+**Acceptance criteria:**
+- No change to `handleCloseModal`.
+- After the fix, closing the modal still triggers a fresh fetch of the current view.
+
+### FR-8: Loading and error states cover the new auto-refetch paths
+`currentQuery.isLoading` and `currentQuery.error` already drive the page-level spinner and error banner (lines 287–308). These must continue to work for auto-refetches triggered by pagination/sort/page-size changes in search mode.
+
+**Acceptance criteria:**
+- The existing loading/error UI fires for refetches triggered by query-key change in search mode (React Query default behavior).
+- No new top-level error or empty-state branches are introduced; surgical change only.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- One additional backend request per pagination/page-size/sort interaction in search mode is expected and desired; no batching, debouncing, or request-coalescing is required for this fix.
+- React Query's existing caching by query key must remain — repeated visits to a previously-fetched page (e.g., navigating page 2 → page 3 → page 2) reuse cached data per default React Query behavior.
+- No measurable regression in default-mode rendering (the default-mode code path is untouched).
+
+### NFR-2: Security
+- No new endpoints, no new data exposure, no auth changes. The fix only affects when an existing authenticated endpoint is called from the frontend.
+
+### NFR-3: Backwards compatibility (hook API)
+- The new `enabled` parameter is optional with a `false` default, preserving the existing semantics for any caller (current or future) that does not pass it. Current call sites other than `JournalList` (if any) must be unaffected.
+
+### NFR-4: Testability
+- The change must be covered by frontend unit tests that detect the original bug (i.e., assert that changing `pageNumber`, `pageSize`, `sortBy`, or `sortDescending` while in search mode causes a new request and updates the rendered rows).
+- Tests for the hook in isolation must cover: (a) `enabled = false` does not fire on mount, (b) `enabled = true` fires on mount, (c) `enabled = true` auto-refetches when `params` changes.
+
+## Data Model
+No data-model changes. The fix is frontend-only and does not alter the wire contract, request shape, response shape, or any persisted entity.
+
+## API / Interface Design
+
+### Hook signature (changed)
+File: `frontend/src/api/hooks/useJournal.ts`
+
+```ts
+export const useSearchJournalEntries = (
+  params: SearchJournalParams,
+  enabled: boolean = false,
+) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.journal, "search", params],
+    queryFn: async () => {
+      const client = await getAuthenticatedApiClient();
+      return await client.journal_SearchJournalEntries(
+        params.searchText || undefined,
+        params.dateFrom || undefined,
+        params.dateTo || undefined,
+        params.productCodePrefix || undefined,
+        params.tagIds || undefined,
+        params.createdByUserId || undefined,
+        params.pageNumber,
+        params.pageSize,
+        params.sortBy,
+        params.sortDirection,
+      );
+    },
+    enabled,
+  });
+};
+```
+
+### Call site (changed)
+File: `frontend/src/components/pages/Journal/JournalList.tsx`
+
+```tsx
+const searchQuery = useSearchJournalEntries(
+  {
+    searchText: searchTextFilter,
+    pageNumber,
+    pageSize,
+    sortBy,
+    sortDirection: sortDescending ? "DESC" : "ASC",
+  },
+  isSearchMode,
+);
+```
+
+No other UI or controller code is touched. Backend endpoints (`journal_SearchJournalEntries`, `journal_GetJournalEntries`) are unchanged.
+
+## Dependencies
+- React Query (`@tanstack/react-query`) — already a project dependency; relies on its standard `enabled` flag and query-key-based refetch behavior. No version bump.
+- Generated API client (`SearchJournalEntryDto`, `journal_SearchJournalEntries`) — unchanged.
+
+## Out of Scope
+- Backend changes to the journal search endpoint.
+- Adding new filter fields beyond `searchText` to the page UI (date range, tags, user, product code prefix are already on the hook param shape but not all are wired to UI — keeping that scope as-is).
+- Refactoring the dual-hook pattern (`useJournalEntries` + `useSearchJournalEntries`) into a single hook.
+- Memoization of the `params` object passed to the hook. React Query serializes the query key, so a new object identity each render is fine.
+- Restructuring the loading/error UI, redesigning pagination, or any visual changes.
+- Removing the explicit `searchQuery.refetch()` call inside `handleApplyFilters` (kept per FR-6 so re-clicking **Filtrovat** with unchanged text still does something visible).
+- Any related "stale on mutation" concerns in non-search mode (existing `invalidateQueries` in the mutation hooks already covers that).
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-journal-search-mode-paginati/task-plan.r1.md
+++ b/artifacts/feat-arch-review-journal-search-mode-paginati/task-plan.r1.md
@@ -1,0 +1,10 @@
+Plan saved to `docs/superpowers/plans/2026-06-04-journal-search-mode-pagination-sort-refetch.md`.
+
+**Summary:** 8-task TDD implementation plan covering the two-file surgical fix:
+- Tasks 1–3: hook-level TDD — pin the `enabled=false` default, add failing tests for the `enabled=true` paths, then parameterize `useSearchJournalEntries(params, enabled = false)`.
+- Tasks 4–5: component-level RED/GREEN for the actual user-visible bug — failing pagination-in-search-mode test, then bind `isSearchMode` at the `JournalList.tsx` call site.
+- Task 6: regression tests for sort + page-size in search mode (FR-4, FR-5).
+- Task 7: comment refresh on the existing search test (per arch-review's spec-amendment note).
+- Task 8: lint + build + full journal test sweep.
+
+Each task includes exact file paths, complete code blocks, exact commands, expected pass/fail outcomes, and a single conventional-commit step. Self-review confirms full FR/NFR coverage with no placeholders and consistent types.

--- a/docs/superpowers/plans/2026-06-04-journal-search-mode-pagination-sort-refetch.md
+++ b/docs/superpowers/plans/2026-06-04-journal-search-mode-pagination-sort-refetch.md
@@ -1,0 +1,672 @@
+# Fix Journal Search Pagination & Sorting (Auto-Refetch on Query-Key Change) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the silent data-staleness bug where changing page, page size, or sort while in journal search mode updates UI affordances but does not refetch data — by parameterizing the `enabled` flag of `useSearchJournalEntries` and binding it to `isSearchMode` at the only call site.
+
+**Architecture:** Frontend-only, two-file change. Replace the hardcoded `enabled: false` on the search hook with an optional `enabled` parameter (default `false`, preserving "no request on mount" semantics for unaware callers). In `JournalList.tsx`, pass `isSearchMode` as the second argument so the query becomes live only when the user has applied a non-empty search filter — at which point React Query's standard query-key-change auto-refetch handles pagination, page-size, and sort updates. No new files, no schema/contract change, no backend touch.
+
+**Tech Stack:** React 18 + TypeScript, `@tanstack/react-query` v5 (`useQuery` `enabled` semantics), Jest + React Testing Library.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `frontend/src/api/hooks/useJournal.ts` | Modify (lines 44–64) | Add optional `enabled?: boolean` (default `false`) parameter to `useSearchJournalEntries`; forward to `useQuery({ enabled })`. JSDoc the default. |
+| `frontend/src/components/pages/Journal/JournalList.tsx` | Modify (lines 189–195) | Pass `isSearchMode` as the second argument to `useSearchJournalEntries`. No other change. |
+| `frontend/src/api/hooks/__tests__/useJournal.test.ts` | Modify + extend | Update existing search test to honor the new default; add NFR-4 hook-level tests (enabled-false-no-mount-fetch, enabled-true-mount-fetch, enabled-true-key-change-auto-refetch). |
+| `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` | Extend | Add component-level regression tests that simulate search-mode pagination, page-size change, and sort click; assert the search hook is re-invoked with the new params. |
+
+No other files, no new modules.
+
+---
+
+## Task 1: Add failing hook-level test for `enabled: false` default (no fetch on mount)
+
+This test pins down the backwards-compatibility guarantee from FR-1: when `enabled` is omitted, the hook must not fire on mount. It will fail today because the existing implementation already has `enabled: false` hardcoded — but after Task 3 strips the hardcoded value in favor of a parameter default, this test guards the equivalent behavior.
+
+**Files:**
+- Test: `frontend/src/api/hooks/__tests__/useJournal.test.ts`
+
+- [ ] **Step 1: Open the file and append a new test inside the existing `describe("useSearchJournalEntries", ...)` block**
+
+Insert this test immediately after the existing `it("should search journal entries successfully", ...)` test (which ends around line 217). Use the same `mockGetAuthenticatedApiClient` pattern.
+
+```ts
+    it("should not fetch on mount when enabled is omitted (default false)", async () => {
+      const searchMock = jest.fn().mockResolvedValue({
+        success: true,
+        entries: [],
+        totalCount: 0,
+      });
+
+      mockGetAuthenticatedApiClient.mockReturnValue({
+        journal_SearchJournalEntries: searchMock,
+        baseUrl: "http://localhost:5001",
+      } as any);
+
+      renderHook(
+        () =>
+          useSearchJournalEntries({
+            searchText: "test",
+            pageNumber: 1,
+            pageSize: 20,
+          }),
+        { wrapper: createWrapper },
+      );
+
+      // Wait long enough for any queued microtasks; the query must remain disabled.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(searchMock).not.toHaveBeenCalled();
+    });
+```
+
+- [ ] **Step 2: Run the new test in isolation to confirm it passes today**
+
+Run:
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useJournal.test.ts -t "should not fetch on mount when enabled is omitted" --no-coverage
+```
+
+Expected: PASS (because today the hook is hardcoded `enabled: false`). This is the **guard** test — it must continue to pass after Task 3 changes the implementation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/hooks/__tests__/useJournal.test.ts
+git commit -m "test: pin no-fetch-on-mount default for useSearchJournalEntries"
+```
+
+---
+
+## Task 2: Add failing hook-level tests for `enabled: true` (fetch on mount; auto-refetch on params change)
+
+These tests assert the new behavior from FR-1 (enabled=true fires on mount) and FR-3/FR-4/FR-5 (enabled=true auto-refetches when `params` change). They will **fail** today because the implementation hardcodes `enabled: false` and ignores any second argument — that's the RED step in TDD.
+
+**Files:**
+- Test: `frontend/src/api/hooks/__tests__/useJournal.test.ts`
+
+- [ ] **Step 1: Append two more tests inside `describe("useSearchJournalEntries", ...)` after the test from Task 1**
+
+```ts
+    it("should fetch on mount when enabled is true", async () => {
+      const mockSearchResponse = {
+        ...mockJournalEntriesResponse,
+        entries: [mockJournalEntriesResponse.entries[0]],
+        totalCount: 1,
+      };
+
+      const searchMock = jest.fn().mockResolvedValue(mockSearchResponse);
+      mockGetAuthenticatedApiClient.mockReturnValue({
+        journal_SearchJournalEntries: searchMock,
+        baseUrl: "http://localhost:5001",
+      } as any);
+
+      const { result } = renderHook(
+        () =>
+          useSearchJournalEntries(
+            {
+              searchText: "test",
+              pageNumber: 1,
+              pageSize: 20,
+            },
+            true,
+          ),
+        { wrapper: createWrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(searchMock).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toEqual(mockSearchResponse);
+    });
+
+    it("should auto-refetch when params change while enabled is true", async () => {
+      const searchMock = jest.fn().mockResolvedValue({
+        success: true,
+        entries: [],
+        totalCount: 0,
+      });
+
+      mockGetAuthenticatedApiClient.mockReturnValue({
+        journal_SearchJournalEntries: searchMock,
+        baseUrl: "http://localhost:5001",
+      } as any);
+
+      const { result, rerender } = renderHook(
+        ({ pageNumber }: { pageNumber: number }) =>
+          useSearchJournalEntries(
+            {
+              searchText: "test",
+              pageNumber,
+              pageSize: 20,
+            },
+            true,
+          ),
+        {
+          wrapper: createWrapper,
+          initialProps: { pageNumber: 1 },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(searchMock).toHaveBeenCalledTimes(1);
+
+      // Change the page number → query key changes → React Query refetches.
+      rerender({ pageNumber: 2 });
+
+      await waitFor(() => {
+        expect(searchMock).toHaveBeenCalledTimes(2);
+      });
+
+      // The most recent call should reflect the new page number (positional arg #7).
+      const lastCallArgs = searchMock.mock.calls[searchMock.mock.calls.length - 1];
+      expect(lastCallArgs[6]).toBe(2); // pageNumber is the 7th positional arg
+    });
+```
+
+- [ ] **Step 2: Run the new tests and confirm they FAIL (RED)**
+
+Run:
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useJournal.test.ts -t "useSearchJournalEntries" --no-coverage
+```
+
+Expected: The two new tests (`should fetch on mount when enabled is true`, `should auto-refetch when params change while enabled is true`) FAIL because the hook currently has `enabled: false` hardcoded and ignores any second argument — so the mock is never called and `result.current.isSuccess` never becomes `true`.
+
+The first new test (`should not fetch on mount when enabled is omitted`) and the existing `should search journal entries successfully` test should still PASS.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add frontend/src/api/hooks/__tests__/useJournal.test.ts
+git commit -m "test: add failing tests for enabled flag on useSearchJournalEntries"
+```
+
+---
+
+## Task 3: Add `enabled` parameter to `useSearchJournalEntries` (turn RED to GREEN)
+
+Implements FR-1: the hook accepts an optional `enabled` (default `false`) and forwards it to React Query. The default preserves today's "no request on mount" semantics for any unaware caller (NFR-3).
+
+**Files:**
+- Modify: `frontend/src/api/hooks/useJournal.ts:44-64`
+
+- [ ] **Step 1: Edit `useJournal.ts`**
+
+Replace the existing `useSearchJournalEntries` definition with the new signature. Use the Edit tool.
+
+Replace this block (current lines 44–64):
+
+```ts
+export const useSearchJournalEntries = (params: SearchJournalParams) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.journal, "search", params],
+    queryFn: async () => {
+      const client = await getAuthenticatedApiClient();
+      return await client.journal_SearchJournalEntries(
+        params.searchText || undefined,
+        params.dateFrom || undefined,
+        params.dateTo || undefined,
+        params.productCodePrefix || undefined,
+        params.tagIds || undefined,
+        params.createdByUserId || undefined,
+        params.pageNumber,
+        params.pageSize,
+        params.sortBy,
+        params.sortDirection,
+      );
+    },
+    enabled: false, // Only run when explicitly called
+  });
+};
+```
+
+with:
+
+```ts
+/**
+ * Searches journal entries. The query is gated by `enabled` so that the page
+ * controlling search mode can opt in only when the user has applied a non-empty
+ * filter. Default is `false` to preserve the "no request on mount" behavior for
+ * any future caller that does not explicitly enable the query.
+ *
+ * When `enabled` is `true`, React Query auto-refetches on every change to
+ * `params` (pagination, page size, sort), so callers should rely on key-change
+ * refetch rather than calling `.refetch()` manually after changing state.
+ */
+export const useSearchJournalEntries = (
+  params: SearchJournalParams,
+  enabled: boolean = false,
+) => {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.journal, "search", params],
+    queryFn: async () => {
+      const client = await getAuthenticatedApiClient();
+      return await client.journal_SearchJournalEntries(
+        params.searchText || undefined,
+        params.dateFrom || undefined,
+        params.dateTo || undefined,
+        params.productCodePrefix || undefined,
+        params.tagIds || undefined,
+        params.createdByUserId || undefined,
+        params.pageNumber,
+        params.pageSize,
+        params.sortBy,
+        params.sortDirection,
+      );
+    },
+    enabled,
+  });
+};
+```
+
+- [ ] **Step 2: Run the failing hook tests; they should now PASS (GREEN)**
+
+Run:
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useJournal.test.ts -t "useSearchJournalEntries" --no-coverage
+```
+
+Expected: All four `useSearchJournalEntries` tests PASS, including:
+- `should search journal entries successfully` (still calls `result.current.refetch()` explicitly — works with `enabled: false` default)
+- `should not fetch on mount when enabled is omitted (default false)` (preserved guard)
+- `should fetch on mount when enabled is true` (new — now passes)
+- `should auto-refetch when params change while enabled is true` (new — now passes)
+
+If the existing `should search journal entries successfully` test fails, do **not** weaken it — the explicit `refetch()` call is still expected to work. Investigate the failure and adjust the implementation, not the test.
+
+- [ ] **Step 3: Run the full hooks test file to confirm no regressions**
+
+Run:
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useJournal.test.ts --no-coverage
+```
+
+Expected: All tests in the file pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/hooks/useJournal.ts
+git commit -m "feat: parameterize enabled flag on useSearchJournalEntries"
+```
+
+---
+
+## Task 4: Add failing component-level test for pagination refetch in search mode
+
+This is the **regression test** for the actual user-visible bug (FR-3). It will fail today because the call site at `JournalList.tsx:189` does not pass `enabled`, so changing `pageNumber` state does not trigger a refetch in search mode.
+
+**Files:**
+- Test: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx`
+
+- [ ] **Step 1: Append a new test inside `describe("JournalList", ...)` after the last test (around line 484)**
+
+The test enters search mode, then clicks a different page, and asserts that the search hook is **re-invoked with the new `pageNumber`** as part of its params argument (matching how the existing "Datum" header test on line 467 asserts hook-call shapes).
+
+```tsx
+  it("re-invokes the search hook with the new pageNumber when paginating in search mode", async () => {
+    // Search returns 25 entries across 2 pages so page-2 button is visible.
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 25,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 2,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(screen.getByText("Filtrovat"));
+
+    // Wait until search mode is active (page-2 button is rendered in the pagination footer).
+    const page2Button = await screen.findByRole("button", { name: "2" });
+
+    // Click page 2.
+    fireEvent.click(page2Button);
+
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const params = lastCall?.[0];
+      const enabled = lastCall?.[1];
+
+      expect(enabled).toBe(true);
+      expect(params).toMatchObject({
+        searchText: "skincare",
+        pageNumber: 2,
+      });
+    });
+  });
+```
+
+- [ ] **Step 2: Run the new test and confirm it FAILS (RED)**
+
+Run:
+```bash
+cd frontend && npx jest src/components/pages/Journal/__tests__/JournalList.test.tsx -t "re-invokes the search hook with the new pageNumber" --no-coverage
+```
+
+Expected: FAIL. The most likely failure mode is `expect(enabled).toBe(true)` fails with `received: undefined`, because the current call site passes only one argument to `useSearchJournalEntries`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+git commit -m "test: add failing test for search-mode pagination refetch"
+```
+
+---
+
+## Task 5: Bind `isSearchMode` to the search hook at the `JournalList` call site (turn RED to GREEN)
+
+Implements FR-2 (and unlocks FR-3/FR-4/FR-5). The only change is adding `isSearchMode` as the second argument to the existing hook call. No other lines in `JournalList.tsx` are touched.
+
+**Files:**
+- Modify: `frontend/src/components/pages/Journal/JournalList.tsx:189-195`
+
+- [ ] **Step 1: Edit `JournalList.tsx`**
+
+Replace this block (current lines 189–195):
+
+```tsx
+  const searchQuery = useSearchJournalEntries({
+    searchText: searchTextFilter,
+    pageNumber: pageNumber,
+    pageSize: pageSize,
+    sortBy: sortBy,
+    sortDirection: sortDescending ? "DESC" : "ASC",
+  });
+```
+
+with:
+
+```tsx
+  const searchQuery = useSearchJournalEntries(
+    {
+      searchText: searchTextFilter,
+      pageNumber: pageNumber,
+      pageSize: pageSize,
+      sortBy: sortBy,
+      sortDirection: sortDescending ? "DESC" : "ASC",
+    },
+    isSearchMode,
+  );
+```
+
+Do not change `handlePageChange`, `handlePageSizeChange`, `handleSort`, `handleApplyFilters`, or `handleCloseModal`. Per FR-6, the explicit `searchQuery.refetch()` inside `handleApplyFilters` stays (so re-clicking **Filtrovat** with unchanged text still does something visible). Per FR-7, `handleCloseModal` stays. Per Decision 4 in the arch review, pagination/sort handlers remain pure state setters.
+
+- [ ] **Step 2: Run the failing pagination test; it should now PASS (GREEN)**
+
+Run:
+```bash
+cd frontend && npx jest src/components/pages/Journal/__tests__/JournalList.test.tsx -t "re-invokes the search hook with the new pageNumber" --no-coverage
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full `JournalList.test.tsx` to confirm no regressions**
+
+Run:
+```bash
+cd frontend && npx jest src/components/pages/Journal/__tests__/JournalList.test.tsx --no-coverage
+```
+
+Expected: All tests pass, including the existing "should handle search input and apply search", "should handle Enter key press", "should clear search and return to normal mode", and "clicking the Datum header" tests. The existing `searchQuery.refetch()` call in `handleApplyFilters` is preserved by Task 5, so those tests continue to observe `mockSearchRefetch` being called.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/pages/Journal/JournalList.tsx
+git commit -m "fix: bind isSearchMode to useSearchJournalEntries in JournalList"
+```
+
+---
+
+## Task 6: Add component-level regression tests for sort and page-size in search mode
+
+Covers FR-4 (page-size) and FR-5 (sort) as component-level regression tests against the same bug class. Both follow the pattern established in Task 4: enter search mode, perform the interaction, assert the hook was re-invoked with the new params.
+
+**Files:**
+- Test: `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx`
+
+- [ ] **Step 1: Append two more tests after the test from Task 4**
+
+```tsx
+  it("re-invokes the search hook with the new sortBy when sorting in search mode", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 1,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(screen.getByText("Filtrovat"));
+
+    // Click "Datum" header to switch sortBy to "entryDate".
+    const dateHeader = await screen.findByRole("columnheader", { name: /Datum/i });
+    fireEvent.click(dateHeader);
+
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const params = lastCall?.[0];
+      const enabled = lastCall?.[1];
+
+      expect(enabled).toBe(true);
+      expect(params).toMatchObject({
+        searchText: "skincare",
+        sortBy: "entryDate",
+        sortDirection: "ASC",
+      });
+    });
+  });
+
+  it("re-invokes the search hook with the new pageSize and resets to page 1 in search mode", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 100,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 5,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(screen.getByText("Filtrovat"));
+
+    // Change page size to 50 via the <select> in the pagination footer.
+    const pageSizeSelect = await screen.findByRole("combobox");
+    fireEvent.change(pageSizeSelect, { target: { value: "50" } });
+
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const params = lastCall?.[0];
+      const enabled = lastCall?.[1];
+
+      expect(enabled).toBe(true);
+      expect(params).toMatchObject({
+        searchText: "skincare",
+        pageSize: 50,
+        pageNumber: 1, // page-size change must reset to page 1
+      });
+    });
+  });
+```
+
+- [ ] **Step 2: Run the two new tests**
+
+Run:
+```bash
+cd frontend && npx jest src/components/pages/Journal/__tests__/JournalList.test.tsx -t "re-invokes the search hook" --no-coverage
+```
+
+Expected: All three "re-invokes the search hook" tests PASS (the one from Task 4 plus the two new ones), because Task 5 has already enabled key-change refetch in search mode.
+
+- [ ] **Step 3: Run the full component test file**
+
+Run:
+```bash
+cd frontend && npx jest src/components/pages/Journal/__tests__/JournalList.test.tsx --no-coverage
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+git commit -m "test: add search-mode regression tests for sort and page-size"
+```
+
+---
+
+## Task 7: Update the existing search test comment to reflect the new default semantics
+
+The existing test at `useJournal.test.ts:181` is still valid (it explicitly calls `result.current.refetch()`), but its inline comment "Search queries are disabled by default (enabled: false in useSearchJournalEntries)" now reads as if the value is hardcoded. Per the architecture review's "Specification Amendments" note, update the comment so future readers understand `enabled = false` is now a default, not a constant.
+
+**Files:**
+- Modify: `frontend/src/api/hooks/__tests__/useJournal.test.ts:206-207`
+
+- [ ] **Step 1: Edit the comment**
+
+Replace:
+
+```ts
+      // Search queries are disabled by default (enabled: false in useSearchJournalEntries)
+      // We need to manually trigger the query
+      result.current.refetch();
+```
+
+with:
+
+```ts
+      // useSearchJournalEntries defaults to enabled=false; the only way to fire
+      // the query without opting in via the second arg is an explicit refetch().
+      result.current.refetch();
+```
+
+- [ ] **Step 2: Run the hooks test file**
+
+Run:
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useJournal.test.ts --no-coverage
+```
+
+Expected: All tests pass (this is a comment-only change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/hooks/__tests__/useJournal.test.ts
+git commit -m "docs: update useSearchJournalEntries test comment for new default"
+```
+
+---
+
+## Task 8: Final validation — lint, build, and full frontend test suite
+
+Per the project's `CLAUDE.md` validation gate ("FE: `npm run build` + `npm run lint`; all tests touched by the change must pass"). NFR-1 (no measurable regression in default-mode rendering) is implicitly covered because the default-mode code path is untouched, and the full test suite includes the prior `clicking the "Datum" header` test against `useJournalEntries`.
+
+- [ ] **Step 1: Run lint**
+
+Run:
+```bash
+cd frontend && npm run lint
+```
+
+Expected: no errors. (Warnings unrelated to the two touched files are acceptable but should not increase relative to `main`.)
+
+- [ ] **Step 2: Run the production build**
+
+Run:
+```bash
+cd frontend && npm run build
+```
+
+Expected: build completes successfully. The OpenAPI client is regenerated on build per `CLAUDE.md`; this is expected and should be a no-op for this change (no backend contract touched).
+
+- [ ] **Step 3: Run the full frontend test suite touching journal**
+
+Run:
+```bash
+cd frontend && npx jest src/api/hooks/__tests__/useJournal.test.ts src/components/pages/Journal --no-coverage
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: No commit needed if no files changed**
+
+If lint or build produced any auto-formatted output, stage and commit it:
+
+```bash
+git status
+# if there are changes:
+git add -A
+git commit -m "chore: apply lint/format fixes after journal search fix"
+```
+
+If `git status` is clean, skip the commit — the validation has passed without modifications.
+
+---
+
+## Self-Review
+
+**Spec coverage** — each FR/NFR maps to a task:
+
+| Requirement | Covered by |
+|------------|------------|
+| FR-1 (hook accepts `enabled` flag, default `false`) | Tasks 1, 2, 3 |
+| FR-2 (`JournalList` binds `enabled` to `isSearchMode`) | Tasks 4, 5 |
+| FR-3 (pagination refetches in search mode) | Tasks 4, 5 |
+| FR-4 (page-size refetches + resets to page 1 in search mode) | Task 6 (second new test) |
+| FR-5 (sort refetches in search mode) | Task 6 (first new test) |
+| FR-6 (`handleApplyFilters` keeps explicit refetch) | Task 5 Step 1 explicitly leaves the handler untouched |
+| FR-7 (`handleCloseModal` unchanged) | Task 5 Step 1 explicitly leaves the handler untouched |
+| FR-8 (loading/error states cover new auto-refetches) | No code change needed; existing `currentQuery.isLoading` / `currentQuery.error` paths fire on every refetch by React Query default. Manually verified by reading lines 287–308 of `JournalList.tsx`. |
+| NFR-1 (performance: one extra request per interaction, cache preserved) | No code path adds batching/debouncing; cache preserved because `queryKey` is unchanged (Task 3 keeps `[...QUERY_KEYS.journal, "search", params]`). |
+| NFR-2 (security: no new endpoint or data exposure) | No backend touched. |
+| NFR-3 (backwards compat: optional flag with `false` default) | Task 3 sets `enabled: boolean = false`. |
+| NFR-4 (testability: hook + component tests) | Tasks 1, 2 (hook); Tasks 4, 6 (component). |
+
+**Placeholder scan** — searched for "TBD", "TODO", "implement later", "appropriate error handling", "similar to Task N", "Write tests for the above". No occurrences. Every code-changing step contains full code blocks.
+
+**Type consistency** — the hook signature `useSearchJournalEntries(params: SearchJournalParams, enabled: boolean = false)` is used identically in Task 3 (implementation), Task 2 (hook tests), and Task 5 (call site). The call sites in the component tests (Tasks 4 and 6) read the second arg as `lastCall?.[1]` and assert it equals `true`, matching the runtime value of `isSearchMode` after the user clicks **Filtrovat** with non-empty text. `searchText`, `pageNumber`, `pageSize`, `sortBy`, `sortDirection` field names match the `SearchJournalParams` interface defined at `useJournal.ts:16-27`.
+
+No issues found; plan is consistent.

--- a/frontend/src/api/hooks/__tests__/useJournal.test.ts
+++ b/frontend/src/api/hooks/__tests__/useJournal.test.ts
@@ -242,6 +242,85 @@ describe("useJournal hooks", () => {
 
       expect(searchMock).not.toHaveBeenCalled();
     });
+
+    it("should fetch on mount when enabled is true", async () => {
+      const mockSearchResponse = {
+        ...mockJournalEntriesResponse,
+        entries: [mockJournalEntriesResponse.entries[0]],
+        totalCount: 1,
+      };
+
+      const searchMock = jest.fn().mockResolvedValue(mockSearchResponse);
+      mockGetAuthenticatedApiClient.mockReturnValue({
+        journal_SearchJournalEntries: searchMock,
+        baseUrl: "http://localhost:5001",
+      } as any);
+
+      const { result } = renderHook(
+        () =>
+          useSearchJournalEntries(
+            {
+              searchText: "test",
+              pageNumber: 1,
+              pageSize: 20,
+            },
+            true,
+          ),
+        { wrapper: createWrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(searchMock).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toEqual(mockSearchResponse);
+    });
+
+    it("should auto-refetch when params change while enabled is true", async () => {
+      const searchMock = jest.fn().mockResolvedValue({
+        success: true,
+        entries: [],
+        totalCount: 0,
+      });
+
+      mockGetAuthenticatedApiClient.mockReturnValue({
+        journal_SearchJournalEntries: searchMock,
+        baseUrl: "http://localhost:5001",
+      } as any);
+
+      const { result, rerender } = renderHook(
+        ({ pageNumber }: { pageNumber: number }) =>
+          useSearchJournalEntries(
+            {
+              searchText: "test",
+              pageNumber,
+              pageSize: 20,
+            },
+            true,
+          ),
+        {
+          wrapper: createWrapper,
+          initialProps: { pageNumber: 1 },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(searchMock).toHaveBeenCalledTimes(1);
+
+      // Change the page number → query key changes → React Query refetches.
+      rerender({ pageNumber: 2 });
+
+      await waitFor(() => {
+        expect(searchMock).toHaveBeenCalledTimes(2);
+      });
+
+      // The most recent call should reflect the new page number (positional arg #7).
+      const lastCallArgs = searchMock.mock.calls[searchMock.mock.calls.length - 1];
+      expect(lastCallArgs[6]).toBe(2); // pageNumber is the 7th positional arg
+    });
   });
 
   describe("useCreateJournalEntry", () => {

--- a/frontend/src/api/hooks/__tests__/useJournal.test.ts
+++ b/frontend/src/api/hooks/__tests__/useJournal.test.ts
@@ -214,6 +214,34 @@ describe("useJournal hooks", () => {
       expect(result.current.data).toEqual(mockSearchResponse);
       expect(result.current.data?.entries).toHaveLength(1);
     });
+
+    it("should not fetch on mount when enabled is omitted (default false)", async () => {
+      const searchMock = jest.fn().mockResolvedValue({
+        success: true,
+        entries: [],
+        totalCount: 0,
+      });
+
+      mockGetAuthenticatedApiClient.mockReturnValue({
+        journal_SearchJournalEntries: searchMock,
+        baseUrl: "http://localhost:5001",
+      } as any);
+
+      renderHook(
+        () =>
+          useSearchJournalEntries({
+            searchText: "test",
+            pageNumber: 1,
+            pageSize: 20,
+          }),
+        { wrapper: createWrapper },
+      );
+
+      // Wait long enough for any queued microtasks; the query must remain disabled.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(searchMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("useCreateJournalEntry", () => {

--- a/frontend/src/api/hooks/__tests__/useJournal.test.ts
+++ b/frontend/src/api/hooks/__tests__/useJournal.test.ts
@@ -203,8 +203,8 @@ describe("useJournal hooks", () => {
         { wrapper: createWrapper },
       );
 
-      // Search queries are disabled by default (enabled: false in useSearchJournalEntries)
-      // We need to manually trigger the query
+      // useSearchJournalEntries defaults to enabled=false; the only way to fire
+      // the query without opting in via the second arg is an explicit refetch().
       result.current.refetch();
 
       await waitFor(() => {

--- a/frontend/src/api/hooks/useJournal.ts
+++ b/frontend/src/api/hooks/useJournal.ts
@@ -41,7 +41,20 @@ export const useJournalEntries = (params: JournalEntriesParams = {}) => {
   });
 };
 
-export const useSearchJournalEntries = (params: SearchJournalParams) => {
+/**
+ * Searches journal entries. The query is gated by `enabled` so that the page
+ * controlling search mode can opt in only when the user has applied a non-empty
+ * filter. Default is `false` to preserve the "no request on mount" behavior for
+ * any future caller that does not explicitly enable the query.
+ *
+ * When `enabled` is `true`, React Query auto-refetches on every change to
+ * `params` (pagination, page size, sort), so callers should rely on key-change
+ * refetch rather than calling `.refetch()` manually after changing state.
+ */
+export const useSearchJournalEntries = (
+  params: SearchJournalParams,
+  enabled: boolean = false,
+) => {
   return useQuery({
     queryKey: [...QUERY_KEYS.journal, "search", params],
     queryFn: async () => {
@@ -59,7 +72,7 @@ export const useSearchJournalEntries = (params: SearchJournalParams) => {
         params.sortDirection,
       );
     },
-    enabled: false, // Only run when explicitly called
+    enabled,
   });
 };
 

--- a/frontend/src/components/pages/Journal/JournalList.tsx
+++ b/frontend/src/components/pages/Journal/JournalList.tsx
@@ -186,13 +186,16 @@ const JournalList: React.FC = () => {
     sortDirection: sortDescending ? "DESC" : "ASC",
   });
 
-  const searchQuery = useSearchJournalEntries({
-    searchText: searchTextFilter,
-    pageNumber: pageNumber,
-    pageSize: pageSize,
-    sortBy: sortBy,
-    sortDirection: sortDescending ? "DESC" : "ASC",
-  });
+  const searchQuery = useSearchJournalEntries(
+    {
+      searchText: searchTextFilter,
+      pageNumber: pageNumber,
+      pageSize: pageSize,
+      sortBy: sortBy,
+      sortDirection: sortDescending ? "DESC" : "ASC",
+    },
+    isSearchMode,
+  );
 
   const currentQuery = isSearchMode ? searchQuery : entriesQuery;
   const entries = currentQuery.data?.entries || [];

--- a/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+++ b/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
@@ -481,4 +481,46 @@ describe("JournalList", () => {
       });
     });
   });
+
+  it("re-invokes the search hook with the new pageNumber when paginating in search mode", async () => {
+    // Search returns 25 entries across 2 pages so page-2 button is visible.
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 25,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 2,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(screen.getByText("Filtrovat"));
+
+    // Wait until search mode is active (page-2 button is rendered in the pagination footer).
+    const page2Button = await screen.findByRole("button", { name: "2" });
+
+    // Click page 2.
+    fireEvent.click(page2Button);
+
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const params = lastCall?.[0];
+      const enabled = lastCall?.[1];
+
+      expect(enabled).toBe(true);
+      expect(params).toMatchObject({
+        searchText: "skincare",
+        pageNumber: 2,
+      });
+    });
+  });
 });

--- a/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+++ b/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
@@ -523,4 +523,84 @@ describe("JournalList", () => {
       });
     });
   });
+
+  it("re-invokes the search hook with the new sortBy when sorting in search mode", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 1,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 1,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(screen.getByText("Filtrovat"));
+
+    // Click "Datum" header to switch sortBy to "entryDate".
+    const dateHeader = await screen.findByRole("columnheader", { name: /Datum/i });
+    fireEvent.click(dateHeader);
+
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const params = lastCall?.[0];
+      const enabled = lastCall?.[1];
+
+      expect(enabled).toBe(true);
+      expect(params).toMatchObject({
+        searchText: "skincare",
+        sortBy: "entryDate",
+        sortDirection: "ASC",
+      });
+    });
+  });
+
+  it("re-invokes the search hook with the new pageSize and resets to page 1 in search mode", async () => {
+    mockUseJournalHooks.useSearchJournalEntries.mockReturnValue({
+      data: {
+        entries: [mockJournalEntries[0]],
+        totalCount: 100,
+        currentPage: 1,
+        pageSize: 20,
+        totalPages: 5,
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn().mockResolvedValue({}),
+    } as any);
+
+    render(<JournalList />, { wrapper: createWrapper });
+
+    // Enter search mode.
+    const searchInput = screen.getByPlaceholderText("Hledat v záznamech...");
+    fireEvent.change(searchInput, { target: { value: "skincare" } });
+    fireEvent.click(screen.getByText("Filtrovat"));
+
+    // Change page size to 50 via the <select> in the pagination footer.
+    const pageSizeSelect = await screen.findByRole("combobox");
+    fireEvent.change(pageSizeSelect, { target: { value: "50" } });
+
+    await waitFor(() => {
+      const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const params = lastCall?.[0];
+      const enabled = lastCall?.[1];
+
+      expect(enabled).toBe(true);
+      expect(params).toMatchObject({
+        searchText: "skincare",
+        pageSize: 50,
+        pageNumber: 1, // page-size change must reset to page 1
+      });
+    });
+  });
 });

--- a/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
+++ b/frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx
@@ -510,17 +510,20 @@ describe("JournalList", () => {
     // Click page 2.
     fireEvent.click(page2Button);
 
+    let paginationParams: any;
+    let paginationEnabled: any;
     await waitFor(() => {
       const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
       const lastCall = calls[calls.length - 1];
-      const params = lastCall?.[0];
-      const enabled = lastCall?.[1];
+      paginationParams = lastCall?.[0];
+      paginationEnabled = lastCall?.[1];
 
-      expect(enabled).toBe(true);
-      expect(params).toMatchObject({
-        searchText: "skincare",
-        pageNumber: 2,
-      });
+      expect(paginationEnabled).toBe(true);
+    });
+
+    expect(paginationParams).toMatchObject({
+      searchText: "skincare",
+      pageNumber: 2,
     });
   });
 
@@ -549,18 +552,21 @@ describe("JournalList", () => {
     const dateHeader = await screen.findByRole("columnheader", { name: /Datum/i });
     fireEvent.click(dateHeader);
 
+    let sortParams: any;
+    let sortEnabled: any;
     await waitFor(() => {
       const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
       const lastCall = calls[calls.length - 1];
-      const params = lastCall?.[0];
-      const enabled = lastCall?.[1];
+      sortParams = lastCall?.[0];
+      sortEnabled = lastCall?.[1];
 
-      expect(enabled).toBe(true);
-      expect(params).toMatchObject({
-        searchText: "skincare",
-        sortBy: "entryDate",
-        sortDirection: "ASC",
-      });
+      expect(sortEnabled).toBe(true);
+    });
+
+    expect(sortParams).toMatchObject({
+      searchText: "skincare",
+      sortBy: "entryDate",
+      sortDirection: "ASC",
     });
   });
 
@@ -589,18 +595,21 @@ describe("JournalList", () => {
     const pageSizeSelect = await screen.findByRole("combobox");
     fireEvent.change(pageSizeSelect, { target: { value: "50" } });
 
+    let pageSizeParams: any;
+    let pageSizeEnabled: any;
     await waitFor(() => {
       const calls = (mockUseJournalHooks.useSearchJournalEntries as jest.Mock).mock.calls;
       const lastCall = calls[calls.length - 1];
-      const params = lastCall?.[0];
-      const enabled = lastCall?.[1];
+      pageSizeParams = lastCall?.[0];
+      pageSizeEnabled = lastCall?.[1];
 
-      expect(enabled).toBe(true);
-      expect(params).toMatchObject({
-        searchText: "skincare",
-        pageSize: 50,
-        pageNumber: 1, // page-size change must reset to page 1
-      });
+      expect(pageSizeEnabled).toBe(true);
+    });
+
+    expect(pageSizeParams).toMatchObject({
+      searchText: "skincare",
+      pageSize: 50,
+      pageNumber: 1, // page-size change must reset to page 1
     });
   });
 });


### PR DESCRIPTION

Fixed a silent data-staleness bug where changing page, page size, or sort column while in journal search mode updated UI affordances but left the table showing stale page-1 data.

The root cause was `enabled: false` hardcoded on `useSearchJournalEntries`, which blocked React Query's automatic key-change refetch. The fix parameterizes `enabled` (default `false` to preserve backwards compatibility for any caller that omits it) and passes `isSearchMode` at the sole call site in `JournalList.tsx` — so the query is live only when the user has applied a non-empty filter, and React Query auto-refetches on every pagination/sort/page-size state change.

All existing handlers (`handleApplyFilters`, `handleCloseModal`) are untouched. Three new component-level regression tests directly cover the three bug scenarios (page change, sort change, page-size change in search mode).

### Changes
- `frontend/src/api/hooks/useJournal.ts` — parameterized `enabled` on `useSearchJournalEntries` with JSDoc
- `frontend/src/components/pages/Journal/JournalList.tsx` — pass `isSearchMode` as second arg at call site
- `frontend/src/api/hooks/__tests__/useJournal.test.ts` — 3 new hook-level tests + comment update
- `frontend/src/components/pages/Journal/__tests__/JournalList.test.tsx` — 3 new component regression tests + lint fixes

---

Closes #2503

### Tokens used
16369030
