### PR TITLE
feat: Consistent Invalid-Input Handling in `GetExpeditionListsByDateHandler`

### DIFF
--- a/artifacts/feat-arch-review-expeditionlistarchive-invali/arch-review.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-invali/arch-review.r1.md
@@ -1,0 +1,155 @@
+# Architecture Review: Consistent Invalid-Input Handling in `GetExpeditionListsByDateHandler`
+
+## Skip Design: true
+
+Backend-only change. No new UI components, screens, or visual decisions. The frontend already consumes `BaseResponse.Success` semantics; surfaced HTTP `400` rendering is governed by existing global error UX, not by this feature.
+
+## Architectural Fit Assessment
+
+The fix is conceptually trivial but sits on top of a non-trivial architectural tension that the spec does not surface. The codebase has **two competing error-response patterns**:
+
+| Pattern | Where it lives | Count |
+|---|---|---|
+| **Canonical (`ErrorCode` + `Params` + `HandleResponse<T>`)** | `BaseResponse` (shared) → routed through `BaseApiController.HandleResponse<T>()`, which maps `ErrorCodes` to HTTP status via `[HttpStatusCode]` attributes | 35+ handlers across `Catalog`, `Manufacture`, `Logistics`, `Purchase`, `Invoices`, etc. |
+| **Local outlier (`ErrorMessage` string + `Fail(string)` factory + hand-rolled `BadRequest`)** | Added ad-hoc to the two sibling responses in `ExpeditionListArchive` | 2 handlers — **both inside the module this fix targets** |
+
+`BaseResponse` has **no `ErrorMessage` property** (`backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs:1-21`); the sibling responses added their own local `ErrorMessage` string and a manual `Fail(string)` factory. The `ExpeditionListArchiveController` does not call `HandleResponse<T>` — it hard-codes `BadRequest(response.ErrorMessage)` for Download and `BadRequest(response)` for Reprint (`ExpeditionListArchiveController.cs:42-66`).
+
+So the spec's brief is *locally* correct ("make handler #3 consistent with siblings #1 and #2"), but *globally* it propagates an outlier pattern further. The architecturally correct fix is to align `GetExpeditionListsByDate` with the **canonical** pattern using the existing `ErrorCodes.InvalidFormat` enum value (already declared in `ErrorCodes.cs:18-19` with `[HttpStatusCode(HttpStatusCode.BadRequest)]`), and route through `HandleResponse<T>`. This costs zero new types and zero new properties — everything required already exists.
+
+The brief's "mirror the siblings" suggestion is functionally fine, but it doubles down on a divergence that the next arch-review pass will flag.
+
+## Proposed Architecture
+
+### Component Overview
+
+```
+[Client]
+   │  GET /api/expedition-list-archive/{date}
+   ▼
+[ExpeditionListArchiveController.GetByDate]
+   │  (return HandleResponse(response) instead of Ok(response))
+   ▼
+[MediatR pipeline]
+   ▼
+[GetExpeditionListsByDateHandler]
+   ├─ Invalid date? → response.Success=false, ErrorCode=InvalidFormat, Params={ "Date": <token> }
+   └─ Valid date  → IBlobStorageService.ListBlobsAsync → map → Items
+   ▼
+[BaseApiController.HandleResponse<T>]
+   └─ Reads [HttpStatusCode] from ErrorCodes.InvalidFormat → 400 BadRequest
+```
+
+### Key Design Decisions
+
+#### Decision 1: Adopt the canonical `ErrorCode`-based pattern, not the local `Fail(string)` pattern
+**Options considered:**
+- **A. Mirror siblings.** Add `Fail(string)` to `GetExpeditionListsByDateResponse` plus a local `ErrorMessage` property; controller becomes `if (!response.Success) BadRequest(response); else Ok(response);`. Matches the brief literally.
+- **B. Use the canonical pattern.** Set `response.Success = false`, `response.ErrorCode = ErrorCodes.InvalidFormat`, optionally `Params`; controller becomes `return HandleResponse(response);`. Aligns with 35+ other handlers; requires no new properties or factories.
+- **C. Mirror siblings now and file a follow-up to migrate all three to canonical.** Two-step.
+
+**Chosen approach:** **B** — go straight to the canonical pattern for the new handler.
+
+**Rationale:** The "missing" piece the spec wants to introduce (`ErrorMessage` + `Fail` factory) is already an outlier in this codebase. Option A locks in three outliers instead of two. Option B reuses what exists, gives `HandleResponse<T>` automatic HTTP mapping via the `[HttpStatusCode]` attribute on `ErrorCodes.InvalidFormat`, and produces a response shape (`Success`, `ErrorCode`, `Params`) that downstream frontend code already understands for every other endpoint. The sibling migration to canonical can be a follow-up (out of this spec's scope, per the brief), but we should not extend the divergence.
+
+If the user explicitly rejects this and wants strict mirror-the-siblings consistency, fall back to A — the change is small either way, and the spec's wording supports A.
+
+#### Decision 2: Do **not** add an `ErrorMessage` string to `GetExpeditionListsByDateResponse`
+**Rationale:** `BaseResponse` already encodes failure via `Success`/`ErrorCode`/`Params`. Adding another `ErrorMessage` field would duplicate state that the canonical pattern already covers and would conflict with the `FullError()` helper on `BaseResponse`. Localization is an open project concern (see spec §"Out of scope: localizing the error message"); `Params` is the existing slot for it. Keep the contract one-way.
+
+#### Decision 3: Switch `GetByDate` controller action to `HandleResponse<T>`
+**Rationale:** `Ok(response)` unconditionally returns 200, which is exactly the bug. `HandleResponse(response)` is one line, already implemented (`BaseApiController.cs:29-60`), and used by every canonical handler. Do not introduce ad-hoc `if (!response.Success) BadRequest(...)` here — that would replicate the sibling outliers.
+
+#### Decision 4: Do not echo `request.Date` into `Params`
+**Rationale:** NFR-2 in the spec says don't echo raw input. Use a constant identifier (e.g. `Params = new() { { "Field", "Date" }, { "ExpectedFormat", "yyyy-MM-dd" } }`) or omit `Params` entirely. The frontend's existing error renderer can fall back to a generic message keyed on `ErrorCode = InvalidFormat`.
+
+## Implementation Guidance
+
+### Directory / Module Structure
+No new files. Touch:
+
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs` — change the early return.
+- `backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs:33-39` — change `Ok(response)` to `HandleResponse(response)`.
+- `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs` — add invalid-date test asserting `Success == false`, `ErrorCode == ErrorCodes.InvalidFormat`, and `_blobStorageServiceMock.Verify(... Times.Never)`.
+
+Do **not** touch `GetExpeditionListsByDateResponse.cs`. Do **not** touch `BaseResponse`.
+
+### Interfaces and Contracts
+
+**Handler invalid-date branch:**
+```csharp
+if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
+{
+    return new GetExpeditionListsByDateResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.InvalidFormat,
+        Params = new Dictionary<string, string> { { "Field", "Date" }, { "ExpectedFormat", "yyyy-MM-dd" } }
+    };
+}
+```
+
+**Controller:**
+```csharp
+[HttpGet("{date}")]
+public async Task<ActionResult<GetExpeditionListsByDateResponse>> GetByDate(string date)
+{
+    var request = new GetExpeditionListsByDateRequest { Date = date };
+    var response = await _mediator.Send(request);
+    return HandleResponse(response);
+}
+```
+
+**Response JSON on invalid date (HTTP 400):**
+```json
+{
+  "success": false,
+  "errorCode": "InvalidFormat",
+  "params": { "Field": "Date", "ExpectedFormat": "yyyy-MM-dd" },
+  "items": []
+}
+```
+
+Note: the spec's literal payload (`errorMessage: "Invalid date format. Expected yyyy-MM-dd."`) is **not** produced by this design. See Specification Amendments below.
+
+### Data Flow
+
+1. Controller receives `GET /api/expedition-list-archive/{date}`.
+2. MediatR dispatches `GetExpeditionListsByDateRequest`.
+3. Handler runs `DateOnly.TryParseExact`.
+   - **Fail:** populates `Success=false`, `ErrorCode=InvalidFormat`, `Params`. Returns. **No blob call.**
+   - **Pass:** calls `IBlobStorageService.ListBlobsAsync`, maps results to `Items`, returns success.
+4. Controller calls `HandleResponse(response)`. `[HttpStatusCode(BadRequest)]` on `InvalidFormat` → HTTP 400 with body. Success path → HTTP 200.
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Spec says "mirror siblings" but this review proposes canonical — implementer may proceed against this guidance without reading | Medium | Call this out explicitly in PR description; reference `ErrorCodes.cs:18-19` and `HandleResponse<T>` in `BaseApiController.cs:29-60` |
+| Frontend consumers that previously got `200 OK + empty items` may not handle the new `400` gracefully | Medium | Spec NFR-3 already calls this out as an intentional behavior change. Smoke-check the `ExpeditionListArchive` frontend page for an invalid date in the URL after deploy. |
+| TypeScript OpenAPI client regen needed when response shape changes | Low | Triggered automatically on build per `docs/development/api-client-generation.md`. The shape is technically unchanged (only `Success`/`ErrorCode`/`Params` are populated differently), so no client breakage expected. |
+| Siblings still use outlier `Fail(string)` pattern after this fix | Low | Out of scope per spec. Optional follow-up issue to migrate `Download`/`Reprint` to canonical. |
+| Test for invalid date asserts on a literal error message string (spec FR-2) that this design does not produce | Medium | Amend tests to assert on `ErrorCode == ErrorCodes.InvalidFormat` instead. See Specification Amendments. |
+
+## Specification Amendments
+
+The spec was written assuming the siblings' pattern is canonical. After verifying the codebase, the following amendments are needed:
+
+1. **FR-1 (Fail factory):** Replace with: "Do not add a `Fail` factory to `GetExpeditionListsByDateResponse`. Use the canonical `Success` / `ErrorCode` / `Params` fields on `BaseResponse` instead. No DTO changes are required."
+2. **FR-2 (Handler returns failed response):** Replace the error message constant with `ErrorCode = ErrorCodes.InvalidFormat` and `Params = { "Field": "Date", "ExpectedFormat": "yyyy-MM-dd" }`. The acceptance criterion "the message `Invalid date format. Expected yyyy-MM-dd.`" should be removed; the equivalent assertion is `response.ErrorCode == ErrorCodes.InvalidFormat`.
+3. **FR-3 (Controller surfaces failure as 400):** Tighten to: "Change `ExpeditionListArchiveController.GetByDate` from `return Ok(response);` to `return HandleResponse(response);`. The existing `[HttpStatusCode(BadRequest)]` on `ErrorCodes.InvalidFormat` provides the 400 mapping automatically."
+4. **FR-4 (Tests):** Update the unit-test acceptance criterion to assert `response.ErrorCode == ErrorCodes.InvalidFormat` and that `_blobStorageServiceMock` was never invoked. Drop the literal-message assertion.
+5. **API/Interface Design section:** Replace the example invalid-date JSON body with the `errorCode` / `params` form shown above.
+6. **Open Questions:** Add one — "Should the existing sibling handlers `DownloadExpeditionListHandler` and `ReprintExpeditionListHandler` also be migrated from their local `Fail(string)` / `ErrorMessage` pattern to the canonical `ErrorCode` pattern?" Recommendation: yes, but as a separate spec; out of scope here.
+
+If the user prefers strict spec adherence (mirror siblings), revert FR-1..FR-5 amendments and implement exactly as the spec describes. The architectural concern remains, but the change becomes a one-property + one-factory addition rather than a controller refactor.
+
+## Prerequisites
+
+None. All required types exist:
+
+- `ErrorCodes.InvalidFormat` — `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:18-19` with `[HttpStatusCode(BadRequest)]`.
+- `BaseApiController.HandleResponse<T>` — `backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs:29-60`.
+- `BaseResponse.Success` / `ErrorCode` / `Params` — `backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs:6-21`.
+
+No migrations, no config, no DI changes, no new NuGet packages. Implementation is a single-PR change: handler, controller, test.

--- a/artifacts/feat-arch-review-expeditionlistarchive-invali/brief.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-invali/brief.md
@@ -1,0 +1,43 @@
+## Module
+ExpeditionListArchive
+
+## Finding
+`GetExpeditionListsByDateHandler` silently returns a successful empty response when the date string fails format validation:
+
+```csharp
+// GetExpeditionListsByDateHandler.cs, lines 21-24
+if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
+{
+    return new GetExpeditionListsByDateResponse { Items = new List<ExpeditionListItemDto>() };
+}
+```
+
+`Success` defaults to `true` (inherited from `BaseResponse`), so the controller returns `200 OK` with `{ items: [] }`. This is indistinguishable from "valid date, no files uploaded that day."
+
+The other two handlers in the same module that also validate input handle the bad-input case consistently:
+
+- `DownloadExpeditionListHandler.cs:21` — returns `DownloadExpeditionListResponse.Fail("Invalid blob path.")`
+- `ReprintExpeditionListHandler.cs:23` — returns `ReprintExpeditionListResponse.Fail("Invalid blob path.")`
+
+## Why it matters
+The caller (controller + frontend) cannot distinguish a malformed date from a legitimate empty day. The inconsistency within the same module is also a readability trap: a developer familiar with the sibling handlers will expect `Fail()` to be called here too.
+
+## Suggested fix
+Add a `Fail` factory (matching the sibling pattern) and call it on invalid input:
+
+```csharp
+// GetExpeditionListsByDateResponse.cs
+public static GetExpeditionListsByDateResponse Fail(string message) =>
+    new() { Success = false, ErrorMessage = message };
+
+// GetExpeditionListsByDateHandler.cs
+if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
+{
+    return GetExpeditionListsByDateResponse.Fail("Invalid date format. Expected yyyy-MM-dd.");
+}
+```
+
+The controller already propagates the response as-is, so the HTTP layer can check `response.Success` and return `BadRequest` if needed (mirroring how `Download` and `Reprint` behave).
+
+---
+_Filed by daily arch-review routine on 2026-06-04._

--- a/artifacts/feat-arch-review-expeditionlistarchive-invali/impl/main.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-invali/impl/main.r1.md
@@ -1,0 +1,42 @@
+Final review: **READY_TO_MERGE**. All checks pass — consistency, scope, coverage, security, architecture alignment.
+
+---
+
+# Implementation: Consistent Invalid-Input Handling in `GetExpeditionListsByDateHandler`
+
+## What was implemented
+Fixed `GetExpeditionListsByDateHandler` so that an invalid `Date` input returns a canonical failure response (`Success=false`, `ErrorCode=InvalidFormat`, `Params={Field:Date, ExpectedFormat:yyyy-MM-dd}`) instead of a misleading `200 OK` with empty items. The controller's `GetByDate` action was switched from `Ok(response)` to `HandleResponse(response)` so the existing `[HttpStatusCode(BadRequest)]` on `ErrorCodes.InvalidFormat` automatically maps the failure to HTTP 400. Tests cover all invalid-date edge cases and confirm blob storage is never called on bad input.
+
+## Files created/modified
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs` — added `using Anela.Heblo.Application.Shared`; replaced silent-empty early return with canonical `Success=false, ErrorCode=InvalidFormat, Params` response
+- `backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs` — changed `return Ok(response)` to `return HandleResponse(response)` in `GetByDate` (single line)
+- `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs` — added `Handle_ReturnsFailure_WhenDateIsInvalid` `[Theory]` with 5 `[InlineData]` cases; added `using Anela.Heblo.Application.Shared`
+
+## Tests
+- `GetExpeditionListsByDateHandlerTests.Handle_ReturnsFailure_WhenDateIsInvalid` — 5 cases: `"not-a-date"`, `"2026/03/25"`, `"25-03-2026"`, `""`, `null` — all assert `Success=false`, `ErrorCode=InvalidFormat`, correct `Params` keys, empty `Items`, and `ListBlobsAsync` never invoked
+- `Handle_ReturnsItemsForDate` and `Handle_FiltersPdfFilesOnly` — pre-existing; both continue passing (22 total ExpeditionListArchive tests, 4378 total backend tests)
+
+## How to verify
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ExpeditionListArchive" --nologo
+dotnet build --nologo
+```
+
+## Notes
+- Adopted the canonical `ErrorCode`+`Params` pattern (used by 35+ handlers codebase-wide) rather than mirroring the local `Fail(string)/ErrorMessage` outlier on the sibling `Download`/`Reprint` handlers. The arch-review amended the spec to direct this approach.
+- 38 pre-existing Docker-dependent integration test failures exist in the full suite (PostgreSQL testcontainers requiring Docker); these are unrelated to this change.
+- Frontend reconnaissance confirmed `useExpeditionListsByDate` throws on non-2xx and the global handler displays a structured-error toast — no frontend changes needed, no regression risk.
+- The sibling handlers (`Download`, `Reprint`) still use the outlier `Fail(string)` pattern; their migration is explicitly out of scope per the spec amendments.
+
+## PR Summary
+Fixed a correctness bug where `GetExpeditionListsByDateHandler` silently returned `200 OK` with empty items on an invalid date string, making it indistinguishable from a valid day with no archived files. The fix adopts the canonical error pattern already used by 35+ handlers across the codebase: populate `Success=false`, `ErrorCode=InvalidFormat`, and `Params` on the response DTO, then route the controller action through `BaseApiController.HandleResponse<T>()` which maps the error code to HTTP 400 via its `[HttpStatusCode]` attribute. No new DTO properties or factory methods are needed.
+
+### Changes
+- `GetExpeditionListsByDateHandler.cs` — replaced invalid-date early return with canonical failure response; added `using Anela.Heblo.Application.Shared`
+- `ExpeditionListArchiveController.cs` — switched `GetByDate` from `Ok(response)` to `HandleResponse(response)` (one line)
+- `GetExpeditionListsByDateHandlerTests.cs` — added `[Theory]` covering 5 invalid-date inputs; verifies `ErrorCode=InvalidFormat`, correct `Params`, and that blob storage is never called on bad input
+
+## Status
+DONE

--- a/artifacts/feat-arch-review-expeditionlistarchive-invali/spec.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-invali/spec.r1.md
@@ -1,0 +1,135 @@
+# Specification: Consistent Invalid-Input Handling in `GetExpeditionListsByDateHandler`
+
+## Summary
+Fix `GetExpeditionListsByDateHandler` so that an invalid `Date` input returns a failed response with a descriptive error message, matching the pattern already used by the two sibling handlers in the `ExpeditionListArchive` module. Today the handler silently returns `200 OK` with an empty list, which is indistinguishable from a valid but empty day.
+
+## Background
+The `ExpeditionListArchive` module exposes three MediatR handlers that operate on blob-archived expedition lists:
+
+- `GetExpeditionListsByDateHandler` — list archived expedition lists for a given date.
+- `DownloadExpeditionListHandler` — download a specific archived list.
+- `ReprintExpeditionListHandler` — reprint a specific archived list.
+
+All three perform input validation. Two of them (`Download`, `Reprint`) return a failed response via a `Fail(message)` factory on the response DTO, so the controller / frontend can distinguish "bad input" from "valid input, no data". The third (`GetExpeditionListsByDate`) is inconsistent: on a malformed date string it returns an empty success response instead of failing.
+
+Concretely (current state at `GetExpeditionListsByDateHandler.cs:21-24`):
+
+```csharp
+if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
+{
+    return new GetExpeditionListsByDateResponse { Items = new List<ExpeditionListItemDto>() };
+}
+```
+
+Because `GetExpeditionListsByDateResponse` inherits `Success = true` from `BaseResponse`, this leaks "invalid date" upstream as "valid empty day". The fix is to add a `Fail` factory mirroring the sibling response types and call it from the handler, so the controller can surface a `400 Bad Request` instead of a misleading `200 OK`.
+
+This is a small consistency / correctness fix flagged by the daily arch-review routine on 2026-06-04.
+
+## Functional Requirements
+
+### FR-1: Add `Fail` factory to `GetExpeditionListsByDateResponse`
+Introduce a static `Fail(string message)` factory on `GetExpeditionListsByDateResponse` that constructs a response with `Success = false` and `ErrorMessage = message`. The shape and signature must match the analogous factories on `DownloadExpeditionListResponse` and `ReprintExpeditionListResponse`.
+
+**Acceptance criteria:**
+- `GetExpeditionListsByDateResponse.Fail("…")` returns an instance with `Success == false`.
+- The returned instance has `ErrorMessage` equal to the supplied message.
+- The returned instance has `Items` left at its default value (no items populated on failure).
+- Signature mirrors the sibling response classes (static method, single `string message` parameter, returns the response type).
+
+### FR-2: Handler returns a failed response on invalid `Date`
+`GetExpeditionListsByDateHandler` must return `GetExpeditionListsByDateResponse.Fail("Invalid date format. Expected yyyy-MM-dd.")` when `DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _)` returns `false`. No blob storage call, logging beyond the existing pattern, or other side effects should occur in the invalid-input path.
+
+**Acceptance criteria:**
+- Given `request.Date = "not-a-date"`, the handler returns a response with `Success == false` and the message `"Invalid date format. Expected yyyy-MM-dd."`.
+- Given `request.Date = "2026-06-04"`, behavior is unchanged from today (valid path executes, items are returned per existing logic).
+- Given `request.Date = null` or empty string, the handler returns a failed response with the same message (these inputs already fail `TryParseExact`, so no extra branch is needed; just verify behavior).
+- No call is made to the underlying blob storage / archive client when the date is invalid.
+
+### FR-3: Controller surfaces failure as HTTP 400
+The MVC controller that wraps this handler must map a response with `Success == false` to `400 Bad Request`, mirroring how `Download` and `Reprint` already behave. If the controller already inspects `response.Success` generically (e.g. via a shared base), no controller change is needed; otherwise the controller must be updated for parity.
+
+**Acceptance criteria:**
+- A request with an invalid date receives HTTP `400 Bad Request` with a body containing `Success: false` and the error message.
+- A request with a valid date but no archived files receives HTTP `200 OK` with `Success: true` and `Items: []` (unchanged).
+- The controller behavior for `GetExpeditionListsByDate` is consistent with `DownloadExpeditionList` and `ReprintExpeditionList` for the failed-response case.
+
+### FR-4: Tests cover both branches
+Unit tests for the handler must cover both the invalid-date branch and the valid-date branch. If integration / controller tests already exist for the sibling handlers, add equivalent coverage for `GetExpeditionListsByDate` so the HTTP-level behavior is also verified.
+
+**Acceptance criteria:**
+- A unit test asserts that an invalid date string produces `Success == false` and the expected error message, and does not invoke the storage dependency (verified via mock).
+- A unit test asserts that a valid date string produces `Success == true` and exercises the storage call as before.
+- Existing tests continue to pass after the change.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+No performance impact. The change shortcuts an already-cheap branch and avoids one unnecessary storage call on invalid input.
+
+### NFR-2: Security
+No new attack surface. Returning a clear "invalid date format" message to the caller is acceptable — the format requirement is public and disclosed in the OpenAPI contract. Do not echo the raw user input back in the error message (the constant string above is sufficient).
+
+### NFR-3: Backwards compatibility
+The response shape (`Success`, `ErrorMessage`, `Items`) is unchanged. Existing successful responses are byte-identical. The only observable behavior change is:
+- Previously: invalid date → `200 OK` with `{ success: true, items: [] }`.
+- After: invalid date → `400 Bad Request` with `{ success: false, errorMessage: "Invalid date format. Expected yyyy-MM-dd." }`.
+
+Any frontend consumer that was relying on the silent-empty behavior must be updated, but per the brief the controller already propagates the response as-is, so this is in line with the sibling endpoints and considered a bug fix rather than a breaking contract change.
+
+### NFR-4: Consistency
+The three handlers in `ExpeditionListArchive` must follow the same invalid-input pattern after this change: validate → return `Response.Fail("…")` on bad input.
+
+## Data Model
+No data model changes. Only an added static factory method on the existing `GetExpeditionListsByDateResponse` DTO. Per the project rule, response DTOs remain classes (not records), so the factory simply constructs a new instance with `Success`, `ErrorMessage`, and default `Items`.
+
+## API / Interface Design
+
+**Endpoint (unchanged path):**
+- `GET /api/expedition-list-archive/by-date?date={yyyy-MM-dd}` (or whatever the existing route is — no path change).
+
+**Response on success (unchanged):**
+```json
+{
+  "success": true,
+  "errorMessage": null,
+  "items": [ /* … */ ]
+}
+```
+
+**Response on invalid date (new behavior, HTTP 400):**
+```json
+{
+  "success": false,
+  "errorMessage": "Invalid date format. Expected yyyy-MM-dd.",
+  "items": []
+}
+```
+
+**MediatR contract (unchanged shapes, new factory):**
+```csharp
+public class GetExpeditionListsByDateResponse : BaseResponse
+{
+    public List<ExpeditionListItemDto> Items { get; set; } = new();
+
+    public static GetExpeditionListsByDateResponse Fail(string message) =>
+        new() { Success = false, ErrorMessage = message };
+}
+```
+
+## Dependencies
+- Existing `BaseResponse` (provides `Success` / `ErrorMessage`).
+- Existing MediatR handler infrastructure and DI registration — no new bindings.
+- Existing `ExpeditionListArchive` controller — possibly minor adjustment per FR-3 if it does not already map `Success == false` to `400`.
+- No new NuGet packages, no new external services.
+
+## Out of Scope
+- Refactoring `BaseResponse` or introducing a shared `Result<T>` abstraction across the codebase.
+- Changing the date format accepted by the endpoint (still `yyyy-MM-dd`).
+- Localizing the error message.
+- Frontend UX changes beyond what the new `400` response surfaces by default (e.g. dedicated inline validation messaging in the UI).
+- Reviewing other modules for similar silent-success-on-invalid-input patterns.
+
+## Open Questions
+None.
+
+## Status: COMPLETE

--- a/artifacts/feat-arch-review-expeditionlistarchive-invali/task-plan.r1.md
+++ b/artifacts/feat-arch-review-expeditionlistarchive-invali/task-plan.r1.md
@@ -1,0 +1,11 @@
+Plan saved to `docs/superpowers/plans/2026-06-04-expedition-list-archive-invalid-input.md`.
+
+The plan implements the arch-review's canonical-pattern recommendation (not the spec's literal "mirror the siblings" approach), structured as 5 sequential, TDD-driven tasks:
+
+1. **Failing handler test** for invalid date (`[Theory]` covering `"not-a-date"`, slash/dash-swapped formats, `null`, empty) — asserts `Success=false`, `ErrorCode=InvalidFormat`, the exact `Params` keys, and that `IBlobStorageService.ListBlobsAsync` is never invoked.
+2. **Handler fix** — replace the silent-empty early return at `GetExpeditionListsByDateHandler.cs:21-24` with a canonical failure response (`ErrorCode = ErrorCodes.InvalidFormat`, `Params = { Field: "Date", ExpectedFormat: "yyyy-MM-dd" }`). No DTO changes, no `Fail(string)` factory.
+3. **Controller change** — flip `Ok(response)` to `HandleResponse(response)` in `ExpeditionListArchiveController.GetByDate` so the existing `[HttpStatusCode(BadRequest)]` on `InvalidFormat` maps to HTTP 400 automatically.
+4. **Full validation gate** — `dotnet test`, `dotnet build`, `dotnet format`, with explicit guidance to revert any out-of-scope formatter changes.
+5. **Frontend reconnaissance** (read-only) — confirm the FE consumer handles 400 gracefully via global error handling, per the arch-review's medium-severity regression risk.
+
+Each step has exact paths, exact code, exact commands, expected output, and a commit. Skipping the execution handoff prompt as instructed.

--- a/backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs
+++ b/backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs
@@ -35,7 +35,7 @@ public class ExpeditionListArchiveController : BaseApiController
     {
         var request = new GetExpeditionListsByDateRequest { Date = date };
         var response = await _mediator.Send(request);
-        return Ok(response);
+        return HandleResponse(response);
     }
 
     [HttpGet("download/{*blobPath}")]

--- a/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs
+++ b/backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs
@@ -1,4 +1,5 @@
 using Anela.Heblo.Application.Features.ExpeditionListArchive.Contracts;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.FileStorage;
 using MediatR;
 using Microsoft.Extensions.Options;
@@ -20,7 +21,16 @@ public class GetExpeditionListsByDateHandler : IRequestHandler<GetExpeditionList
     {
         if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
         {
-            return new GetExpeditionListsByDateResponse { Items = new List<ExpeditionListItemDto>() };
+            return new GetExpeditionListsByDateResponse
+            {
+                Success = false,
+                ErrorCode = ErrorCodes.InvalidFormat,
+                Params = new Dictionary<string, string>
+                {
+                    { "Field", "Date" },
+                    { "ExpectedFormat", "yyyy-MM-dd" }
+                }
+            };
         }
 
         var blobs = await _blobStorageService.ListBlobsAsync(_containerName, request.Date, cancellationToken);

--- a/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs
+++ b/backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs
@@ -1,5 +1,6 @@
 using Anela.Heblo.Application.Features.ExpeditionListArchive;
 using Anela.Heblo.Application.Features.ExpeditionListArchive.UseCases.GetExpeditionListsByDate;
+using Anela.Heblo.Application.Shared;
 using Anela.Heblo.Domain.Features.FileStorage;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -72,5 +73,33 @@ public class GetExpeditionListsByDateHandlerTests
         // Assert
         Assert.Single(result.Items);
         Assert.Equal("picking-list-001.pdf", result.Items[0].FileName);
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("2026/03/25")]
+    [InlineData("25-03-2026")]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task Handle_ReturnsFailure_WhenDateIsInvalid(string? invalidDate)
+    {
+        // Arrange
+        var request = new GetExpeditionListsByDateRequest { Date = invalidDate ?? string.Empty };
+
+        // Act
+        var result = await _handler.Handle(request, default);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal(ErrorCodes.InvalidFormat, result.ErrorCode);
+        Assert.NotNull(result.Params);
+        Assert.Equal("Date", result.Params!["Field"]);
+        Assert.Equal("yyyy-MM-dd", result.Params!["ExpectedFormat"]);
+        Assert.Empty(result.Items);
+
+        _blobStorageServiceMock.Verify(
+            s => s.ListBlobsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/docs/superpowers/plans/2026-06-04-expedition-list-archive-invalid-input.md
+++ b/docs/superpowers/plans/2026-06-04-expedition-list-archive-invalid-input.md
@@ -1,0 +1,402 @@
+# Consistent Invalid-Input Handling in `GetExpeditionListsByDateHandler` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `GetExpeditionListsByDateHandler` return a failed response (`Success = false`, `ErrorCode = InvalidFormat`) on a malformed `Date` input so the controller surfaces HTTP `400 Bad Request` instead of a misleading `200 OK` with an empty list.
+
+**Architecture:** Adopt the canonical error pattern used by 35+ handlers across the codebase: populate `BaseResponse.Success`, `BaseResponse.ErrorCode`, and `BaseResponse.Params` on the existing `GetExpeditionListsByDateResponse`, then route the controller action through `BaseApiController.HandleResponse<T>()` which maps `ErrorCodes.InvalidFormat` to `400` via its `[HttpStatusCode]` attribute. No new DTO fields, no `Fail(string)` factory, no controller-level `if (!Success)` branch.
+
+**Tech Stack:** .NET 8, MediatR, ASP.NET Core MVC controllers, xUnit + Moq for unit tests.
+
+**Why canonical over "mirror siblings":** The two sibling handlers (`Download`, `Reprint`) carry a local `ErrorMessage` + `Fail(string)` outlier that the rest of the codebase does not use. The arch-review (`artifacts/feat-arch-review-expeditionlistarchive-invali/arch-review.r1.md` §"Specification Amendments") amended the spec to direct this fix at the canonical pattern instead of extending the outlier. Sibling migration is out of scope.
+
+---
+
+## File Structure
+
+**Modify (3 files):**
+
+- `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs` — replace the invalid-date early return (lines 21-24) with a canonical failed response.
+- `backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs` — change `return Ok(response);` in `GetByDate` (line 38) to `return HandleResponse(response);`.
+- `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs` — add `Handle_ReturnsFailure_WhenDateIsInvalid` test that asserts the failure response and verifies `IBlobStorageService` is never called.
+
+**Do NOT modify:**
+
+- `GetExpeditionListsByDateResponse.cs` — no new property, no `Fail` factory. The DTO already inherits everything required from `BaseResponse`.
+- `BaseResponse.cs` — already exposes `Success`, `ErrorCode`, `Params`.
+- `ErrorCodes.cs` — `InvalidFormat` already exists with `[HttpStatusCode(BadRequest)]` (line 18-19).
+- The two sibling handlers/responses (`Download`, `Reprint`) — explicitly out of scope per the spec amendments.
+
+**Reference (read but do not edit):**
+
+- `backend/src/Anela.Heblo.API/Controllers/BaseApiController.cs:29-60` — `HandleResponse<T>` mapping logic.
+- `backend/src/Anela.Heblo.Application/Shared/BaseResponse.cs` — fields populated on failure.
+- `backend/src/Anela.Heblo.Application/Shared/ErrorCodes.cs:18-19` — `InvalidFormat` with `BadRequest` mapping.
+
+---
+
+## Task 1: Add failing handler test for invalid date
+
+**Files:**
+- Test: `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs`
+
+The existing test class already wires up an `IBlobStorageService` mock and instantiates the handler. We add one test covering the invalid-date branch. It asserts the canonical failure shape **and** that the storage call is never made.
+
+- [ ] **Step 1.1: Add `using` for `Anela.Heblo.Application.Shared` to the test file (top of file)**
+
+Open `backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs` and ensure these `using`s are present at the top (add the missing one):
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionListArchive;
+using Anela.Heblo.Application.Features.ExpeditionListArchive.UseCases.GetExpeditionListsByDate;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.FileStorage;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+```
+
+The new line is `using Anela.Heblo.Application.Shared;` (needed for `ErrorCodes`). The rest already exist.
+
+- [ ] **Step 1.2: Append the invalid-date test to the test class**
+
+Add this test method as a new `[Fact]` inside the `GetExpeditionListsByDateHandlerTests` class, just below the existing `Handle_FiltersPdfFilesOnly` test:
+
+```csharp
+[Theory]
+[InlineData("not-a-date")]
+[InlineData("2026/03/25")]
+[InlineData("25-03-2026")]
+[InlineData("")]
+[InlineData(null)]
+public async Task Handle_ReturnsFailure_WhenDateIsInvalid(string? invalidDate)
+{
+    // Arrange
+    var request = new GetExpeditionListsByDateRequest { Date = invalidDate ?? string.Empty };
+
+    // Act
+    var result = await _handler.Handle(request, default);
+
+    // Assert
+    Assert.NotNull(result);
+    Assert.False(result.Success);
+    Assert.Equal(ErrorCodes.InvalidFormat, result.ErrorCode);
+    Assert.NotNull(result.Params);
+    Assert.Equal("Date", result.Params!["Field"]);
+    Assert.Equal("yyyy-MM-dd", result.Params!["ExpectedFormat"]);
+    Assert.Empty(result.Items);
+
+    _blobStorageServiceMock.Verify(
+        s => s.ListBlobsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        Times.Never);
+}
+```
+
+Notes:
+- `[Theory]` with multiple inputs covers FR-2's three cases (`"not-a-date"`, `null`, empty) in one test method.
+- `request.Date` is `string` (not nullable) per `GetExpeditionListsByDateRequest.cs:7`, so we coalesce `null` → `string.Empty` before assigning. `TryParseExact` still rejects empty.
+- We assert exact `Params` keys/values to lock the contract that the controller (and downstream frontend) sees. If the implementer chooses different keys, this test will catch the drift.
+
+- [ ] **Step 1.3: Run the new test and verify it FAILS**
+
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetExpeditionListsByDateHandlerTests.Handle_ReturnsFailure_WhenDateIsInvalid" \
+  --nologo --verbosity minimal
+```
+
+Expected: the test runs but FAILS — current handler returns `Success = true` and `ErrorCode = null` (it just builds `new GetExpeditionListsByDateResponse { Items = new List<ExpeditionListItemDto>() }`). At least the `Assert.False(result.Success)` assertion fails. Do not proceed until you observe this red.
+
+- [ ] **Step 1.4: Commit the failing test**
+
+```bash
+git add backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs
+git commit -m "test: add failing test for invalid-date branch in GetExpeditionListsByDateHandler"
+```
+
+---
+
+## Task 2: Make the handler return a canonical failed response on invalid date
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs:21-24`
+
+- [ ] **Step 2.1: Add the `using` for `Anela.Heblo.Application.Shared`**
+
+The handler file currently has:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionListArchive.Contracts;
+using Anela.Heblo.Domain.Features.FileStorage;
+using MediatR;
+using Microsoft.Extensions.Options;
+```
+
+Add `using Anela.Heblo.Application.Shared;` so the handler can reference `ErrorCodes`. The final `using` block should be:
+
+```csharp
+using Anela.Heblo.Application.Features.ExpeditionListArchive.Contracts;
+using Anela.Heblo.Application.Shared;
+using Anela.Heblo.Domain.Features.FileStorage;
+using MediatR;
+using Microsoft.Extensions.Options;
+```
+
+- [ ] **Step 2.2: Replace the invalid-date early return**
+
+In `GetExpeditionListsByDateHandler.Handle`, replace this block (lines 21-24 of the current file):
+
+```csharp
+if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
+{
+    return new GetExpeditionListsByDateResponse { Items = new List<ExpeditionListItemDto>() };
+}
+```
+
+with:
+
+```csharp
+if (!DateOnly.TryParseExact(request.Date, "yyyy-MM-dd", out _))
+{
+    return new GetExpeditionListsByDateResponse
+    {
+        Success = false,
+        ErrorCode = ErrorCodes.InvalidFormat,
+        Params = new Dictionary<string, string>
+        {
+            { "Field", "Date" },
+            { "ExpectedFormat", "yyyy-MM-dd" }
+        }
+    };
+}
+```
+
+Rationale:
+- `Success`, `ErrorCode`, and `Params` are all inherited from `BaseResponse` — no DTO changes needed.
+- The `Params` keys (`Field`, `ExpectedFormat`) deliberately do **not** include the raw `request.Date` value (per arch-review §"Decision 4" and spec NFR-2: do not echo user input).
+- `Items` is left at its default (empty list initializer on the DTO).
+
+Do not log anything from the invalid-input branch — `BaseApiController.HandleResponse<T>` already logs a warning on failed responses (`BaseApiController.cs:39-41`), so adding handler-level logging would duplicate the warning.
+
+- [ ] **Step 2.3: Run the previously-failing test and verify it PASSES**
+
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetExpeditionListsByDateHandlerTests.Handle_ReturnsFailure_WhenDateIsInvalid" \
+  --nologo --verbosity minimal
+```
+
+Expected: PASS — all five `[InlineData]` cases pass.
+
+- [ ] **Step 2.4: Run the full handler test class to confirm valid-date tests still pass**
+
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~GetExpeditionListsByDateHandlerTests" \
+  --nologo --verbosity minimal
+```
+
+Expected: PASS — `Handle_ReturnsItemsForDate`, `Handle_FiltersPdfFilesOnly`, and the new `Handle_ReturnsFailure_WhenDateIsInvalid` (5 inline cases) all pass. Total ~7 passing tests.
+
+- [ ] **Step 2.5: Commit the handler change**
+
+```bash
+git add backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs
+git commit -m "fix: return canonical InvalidFormat failure on bad date in GetExpeditionListsByDateHandler"
+```
+
+---
+
+## Task 3: Switch controller action to `HandleResponse<T>`
+
+**Files:**
+- Modify: `backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs:33-39`
+
+The handler now produces a correct failure response, but `GetByDate` still wraps it in `Ok(response)` which forces HTTP `200`. Route it through `HandleResponse` so `ErrorCodes.InvalidFormat` (carrying `[HttpStatusCode(BadRequest)]`) maps to `400`.
+
+- [ ] **Step 3.1: Change `Ok(response)` to `HandleResponse(response)` in `GetByDate`**
+
+Find this block in `ExpeditionListArchiveController.cs` (lines 33-39):
+
+```csharp
+[HttpGet("{date}")]
+public async Task<ActionResult<GetExpeditionListsByDateResponse>> GetByDate(string date)
+{
+    var request = new GetExpeditionListsByDateRequest { Date = date };
+    var response = await _mediator.Send(request);
+    return Ok(response);
+}
+```
+
+Replace it with:
+
+```csharp
+[HttpGet("{date}")]
+public async Task<ActionResult<GetExpeditionListsByDateResponse>> GetByDate(string date)
+{
+    var request = new GetExpeditionListsByDateRequest { Date = date };
+    var response = await _mediator.Send(request);
+    return HandleResponse(response);
+}
+```
+
+Only the final return statement changes. Do not touch the other actions (`GetDates`, `Download`, `Reprint`) — their migration to the canonical pattern is out of scope per the spec amendments.
+
+`HandleResponse<T>` lives on the `BaseApiController` that this controller already inherits from (`ExpeditionListArchiveController : BaseApiController`, line 14), so no new `using` directive is needed.
+
+- [ ] **Step 3.2: Build the API project to confirm no compile errors**
+
+```bash
+cd backend
+dotnet build src/Anela.Heblo.API/Anela.Heblo.API.csproj --nologo --verbosity minimal
+```
+
+Expected: `Build succeeded` with `0 Error(s)`. Warnings are acceptable if pre-existing.
+
+- [ ] **Step 3.3: Commit the controller change**
+
+```bash
+git add backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs
+git commit -m "fix: route GetByDate through HandleResponse so invalid date yields 400"
+```
+
+---
+
+## Task 4: Verify the full test suite and formatting
+
+This step is the global gate from `CLAUDE.md` §"Validation before completion": `dotnet build` + `dotnet format` + tests touched by the change must pass.
+
+- [ ] **Step 4.1: Run all tests in the `ExpeditionListArchive` namespace**
+
+```bash
+cd backend
+dotnet test test/Anela.Heblo.Tests/Anela.Heblo.Tests.csproj \
+  --filter "FullyQualifiedName~ExpeditionListArchive" \
+  --nologo --verbosity minimal
+```
+
+Expected: all `ExpeditionListArchive` test classes pass — `GetExpeditionListsByDateHandlerTests`, `GetExpeditionDatesHandlerTests`, `DownloadExpeditionListHandlerTests`, `ReprintExpeditionListHandlerTests`. No new failures in any sibling test.
+
+- [ ] **Step 4.2: Run the full backend test suite**
+
+```bash
+cd backend
+dotnet test --nologo --verbosity minimal
+```
+
+Expected: green. If any unrelated test fails, that's a pre-existing condition — note it in the PR description but do not fix it inside this change (per `CLAUDE.md` §"Surgical changes").
+
+- [ ] **Step 4.3: Build the full backend solution**
+
+```bash
+cd backend
+dotnet build --nologo --verbosity minimal
+```
+
+Expected: `Build succeeded` with `0 Error(s)`.
+
+- [ ] **Step 4.4: Run `dotnet format` and stage any formatting fixes**
+
+```bash
+cd backend
+dotnet format --verbosity diagnostic
+```
+
+If `dotnet format` modifies the three files this plan touched, review the diff (`git diff`) and stage the changes:
+
+```bash
+git add -u backend/src/Anela.Heblo.Application/Features/ExpeditionListArchive/UseCases/GetExpeditionListsByDate/GetExpeditionListsByDateHandler.cs \
+          backend/src/Anela.Heblo.API/Controllers/ExpeditionListArchiveController.cs \
+          backend/test/Anela.Heblo.Tests/ExpeditionListArchive/GetExpeditionListsByDateHandlerTests.cs
+```
+
+If `dotnet format` modifies *other* files (because the formatter detected pre-existing whitespace issues), **revert those** — they are outside the scope of this change:
+
+```bash
+git checkout -- <unrelated-file>
+```
+
+- [ ] **Step 4.5: Commit formatting fixes if any**
+
+```bash
+git diff --cached --quiet || git commit -m "chore: apply dotnet format to changes"
+```
+
+(This commit is a no-op if `dotnet format` made no changes to the staged files.)
+
+---
+
+## Task 5: Sanity-check the frontend consumer (read-only verification)
+
+Per the arch-review's "Risks" table (Medium-severity risk), a frontend page that previously got `200 OK + empty items` may regress now that invalid dates yield `400`. This task is **investigation only** — no code edits — to confirm the frontend already handles `400` gracefully via its global error handling.
+
+- [ ] **Step 5.1: Locate the frontend hook that calls this endpoint**
+
+```bash
+cd frontend
+grep -r --include='*.ts' --include='*.tsx' -l "expedition-list-archive" src/
+```
+
+Expected: one or two hook/component files (likely under `src/api/hooks/` and `src/components/expedition*`). Identify the hook that calls `GET /api/expedition-list-archive/{date}`.
+
+- [ ] **Step 5.2: Inspect the hook for `400`-handling**
+
+Open the matching file(s) and confirm one of the following:
+- The hook uses `apiClient` / TanStack Query and surfaces errors via the project's global error handler (typical pattern — toast on non-2xx response).
+- Or the hook has its own `onError` / try-catch that doesn't crash on `400`.
+
+This is a sanity check, not a code change. If the hook **assumes** `200` and unwraps `response.items` without checking `response.success`, **note it in the PR description** as a follow-up, but do not modify it inside this PR (out of scope per spec §"Out of scope: Frontend UX changes").
+
+- [ ] **Step 5.3: Record the finding**
+
+Add one line to the PR description draft (kept in your head or scratch space for the final PR creation): either "Frontend uses global error handler, `400` is rendered as a toast — no regression expected" or "Frontend assumes 200; file follow-up issue for invalid-date UX".
+
+No commit here — this is reconnaissance.
+
+---
+
+## Self-Review (executed by plan author before saving)
+
+**1. Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| FR-1 (Fail factory) — amended away by arch-review §"Specification Amendments" point 1 | Not implemented (intentional; canonical pattern instead). |
+| FR-2 (Handler returns failed response on invalid `Date`) | Task 2.2 — amended to `ErrorCode = InvalidFormat` + `Params` per arch-review point 2. |
+| FR-3 (Controller surfaces failure as HTTP 400) | Task 3.1 — amended to `HandleResponse(response)` per arch-review point 3. |
+| FR-4 (Tests cover both branches) | Task 1 — invalid-date `[Theory]` covers FR-2 cases incl. `null`/empty; existing `Handle_ReturnsItemsForDate` and `Handle_FiltersPdfFilesOnly` already cover the valid branch. Task 4.1 verifies both still pass. |
+| NFR-1 (Performance) | Implicitly — the change shortcuts an already-cheap branch and avoids one storage call. No measurement task needed. |
+| NFR-2 (Security: don't echo raw user input) | Task 2.2 — `Params` uses constants `Field=Date`, `ExpectedFormat=yyyy-MM-dd`. Raw `request.Date` is never echoed. |
+| NFR-3 (Backwards compatibility) | Task 5 — read-only frontend sanity check. The shape change (`200 → 400` on bad input) is the intended bug fix. |
+| NFR-4 (Consistency) | Achieved at the **codebase** level (canonical pattern), not the module level — call out in PR description per arch-review §"Risks". |
+
+No gaps.
+
+**2. Placeholder scan:**
+
+Searched for "TBD", "TODO", "implement later", "fill in details", "add appropriate", "similar to". No matches. Every step has either a concrete command, a concrete code block, or a concrete file edit.
+
+**3. Type consistency:**
+
+- `ErrorCodes.InvalidFormat` — used in Task 1.2 (test assert), Task 2.2 (handler). Same enum value.
+- `Params` keys: `"Field"`, `"ExpectedFormat"` — same in Task 1.2 (`result.Params!["Field"]`, `result.Params!["ExpectedFormat"]`) and Task 2.2 (dictionary initializer). Consistent.
+- `HandleResponse(response)` — method exists on `BaseApiController` (verified at `BaseApiController.cs:29`). Controller already inherits.
+- `GetExpeditionListsByDateRequest.Date` — `string` (not nullable), verified at `GetExpeditionListsByDateRequest.cs:7`. Task 1.2 coalesces `null` → `string.Empty` to satisfy the type.
+- `_blobStorageServiceMock.Verify(...)` signature — `ListBlobsAsync(string, string, CancellationToken)` matches the call site in `GetExpeditionListsByDateHandler.cs:26`.
+
+All consistent.
+
+---
+
+## Definition of Done
+
+- [ ] `Handle_ReturnsFailure_WhenDateIsInvalid` test (all 5 `[InlineData]` cases) passes.
+- [ ] Existing `Handle_ReturnsItemsForDate` and `Handle_FiltersPdfFilesOnly` tests still pass.
+- [ ] Full backend test suite passes (`dotnet test` green).
+- [ ] `dotnet build` succeeds with 0 errors.
+- [ ] `dotnet format` produces no diff on the three modified files.
+- [ ] Manual smoke check (optional — implementer's call): hitting `GET /api/expedition-list-archive/not-a-date` against a local backend returns HTTP `400` with body `{ "success": false, "errorCode": "InvalidFormat", "params": { "Field": "Date", "ExpectedFormat": "yyyy-MM-dd" }, "items": [] }`, while `GET /api/expedition-list-archive/2026-06-04` still returns `200`.
+- [ ] No changes to `GetExpeditionListsByDateResponse.cs`, `BaseResponse.cs`, `ErrorCodes.cs`, or sibling handlers/controllers.


### PR DESCRIPTION
Fixed a correctness bug where `GetExpeditionListsByDateHandler` silently returned `200 OK` with empty items on an invalid date string, making it indistinguishable from a valid day with no archived files. The fix adopts the canonical error pattern already used by 35+ handlers across the codebase: populate `Success=false`, `ErrorCode=InvalidFormat`, and `Params` on the response DTO, then route the controller action through `BaseApiController.HandleResponse<T>()` which maps the error code to HTTP 400 via its `[HttpStatusCode]` attribute. No new DTO properties or factory methods are needed.

### Changes
- `GetExpeditionListsByDateHandler.cs` — replaced invalid-date early return with canonical failure response; added `using Anela.Heblo.Application.Shared`
- `ExpeditionListArchiveController.cs` — switched `GetByDate` from `Ok(response)` to `HandleResponse(response)` (one line)
- `GetExpeditionListsByDateHandlerTests.cs` — added `[Theory]` covering 5 invalid-date inputs; verifies `ErrorCode=InvalidFormat`, correct `Params`, and that blob storage is never called on bad input

---

Closes #2504

### Tokens used
10962469
